### PR TITLE
crimson: rework request pipeline to allow for per-object processing

### DIFF
--- a/doc/dev/crimson/pipeline.rst
+++ b/doc/dev/crimson/pipeline.rst
@@ -2,96 +2,34 @@
 The ``ClientRequest`` pipeline
 ==============================
 
-In crimson, exactly like in the classical OSD, a client request has data and
-ordering dependencies which must be satisfied before processing (actually
-a particular phase of) can begin. As one of the goals behind crimson is to
-preserve the compatibility with the existing OSD incarnation, the same semantic
-must be assured. An obvious example of such data dependency is the fact that
-an OSD needs to have a version of OSDMap that matches the one used by the client
-(``Message::get_min_epoch()``).
+RADOS requires writes on each object to be ordered.  If a client
+submits a sequence of concurrent writes (doesn't want for the prior to
+complete before submitting the next), that client may rely on the
+writes being completed in the order in which they are submitted.
 
-If a dependency is not satisfied, the processing stops. It is crucial to note
-the same must happen to all other requests that are sequenced-after (due to
-their ordering requirements).
+As a result, the client->osd communication and queueing mechanisms on
+both sides must take care to ensure that writes on a (connection,
+object) pair remain ordered for the entire process.
 
-There are a few cases when the blocking of a client request can happen.
+crimson-osd enforces this ordering via Pipelines and Stages
+(crimson/osd/osd_operation.h).  Upon arrival at the OSD, messages
+enter the ConnectionPipeline::AwaitActive stage and proceed
+through a sequence of pipeline stages:
 
+* ConnectionPipeline: per-connection stages representing the message handling
+  path prior to being handed off to the target PG
+* PerShardPipeline: intermediate Pipeline representing the hand off from the
+  receiving shard to the shard with the target PG.
+* CommonPGPipeline: represents processing on the target PG prior to obtaining
+  the ObjectContext for the target of the operation.
+* CommonOBCPipeline: represents the actual processing of the IO on the target
+  object
 
-  ``ClientRequest::ConnectionPipeline::await_map``
-    wait for particular OSDMap version is available at the OSD level
-  ``ClientRequest::ConnectionPipeline::get_pg``
-    wait a particular PG becomes available on OSD
-  ``ClientRequest::PGPipeline::await_map``
-    wait on a PG being advanced to particular epoch
-  ``ClientRequest::PGPipeline::wait_for_active``
-    wait for a PG to become *active* (i.e. have ``is_active()`` asserted)
-  ``ClientRequest::PGPipeline::recover_missing``
-    wait on an object to be recovered (i.e. leaving the ``missing`` set)
-  ``ClientRequest::PGPipeline::get_obc``
-    wait on an object to be available for locking. The ``obc`` will be locked
-    before this operation is allowed to continue
-  ``ClientRequest::PGPipeline::process``
-    wait if any other ``MOSDOp`` message is handled against this PG
+Because CommonOBCPipeline is per-object rather than per-connection or
+per-pg, multiple requests on different objects may be in the same
+CommonOBCPipeline stage concurrently.  This allows us to serve
+multiple reads in the same PG concurrently.  We can also process
+writes on multiple objects concurrently up to the point at which the
+write is actually submitted.
 
-At any moment, a ``ClientRequest`` being served should be in one and only one
-of the phases described above. Similarly, an object denoting particular phase
-can host not more than a single ``ClientRequest`` the same time. At low-level
-this is achieved with a combination of a barrier and an exclusive lock.
-They implement the semantic of a semaphore with a single slot for these exclusive
-phases.
-
-As the execution advances, request enters next phase and leaves the current one
-freeing it for another ``ClientRequest`` instance. All these phases form a pipeline
-which assures the order is preserved.
-
-These pipeline phases are divided into two ordering domains: ``ConnectionPipeline``
-and ``PGPipeline``. The former ensures order across a client connection while
-the latter does that across a PG. That is, requests originating from the same
-connection are executed in the same order as they were sent by the client.
-The same applies to the PG domain: when requests from multiple connections reach
-a PG, they are executed in the same order as they entered a first blocking phase
-of the ``PGPipeline``.
-
-Comparison with the classical OSD
-----------------------------------
-As the audience of this document are Ceph Developers, it seems reasonable to
-match the phases of crimson's ``ClientRequest`` pipeline with the blocking
-stages in the classical OSD. The names in the right column are names of
-containers (lists and maps) used to implement these stages. They are also
-already documented in the ``PG.h`` header.
-
-+----------------------------------------+--------------------------------------+
-| crimson                                | ceph-osd waiting list		|
-+========================================+======================================+
-|``ConnectionPipeline::await_map``       | ``OSDShardPGSlot::waiting`` and	|
-|``ConnectionPipeline::get_pg``          | ``OSDShardPGSlot::waiting_peering``	|
-+----------------------------------------+--------------------------------------+
-|``PGPipeline::await_map``               | ``PG::waiting_for_map``		|
-+----------------------------------------+--------------------------------------+
-|``PGPipeline::wait_for_active``         | ``PG::waiting_for_peered``		|
-|                                        +--------------------------------------+
-|                                        | ``PG::waiting_for_flush``		|
-|                                        +--------------------------------------+
-|                                        | ``PG::waiting_for_active``		|
-+----------------------------------------+--------------------------------------+
-|To be done (``PG_STATE_LAGGY``)         | ``PG::waiting_for_readable``		|
-+----------------------------------------+--------------------------------------+
-|To be done                              | ``PG::waiting_for_scrub``		|
-+----------------------------------------+--------------------------------------+
-|``PGPipeline::recover_missing``         | ``PG::waiting_for_unreadable_object``|
-|                                        +--------------------------------------+
-|                                        | ``PG::waiting_for_degraded_object``	|
-+----------------------------------------+--------------------------------------+
-|To be done (proxying)                   | ``PG::waiting_for_blocked_object``	|
-+----------------------------------------+--------------------------------------+
-|``PGPipeline::get_obc``                 | *obc rwlocks*			|
-+----------------------------------------+--------------------------------------+
-|``PGPipeline::process``                 | ``PG::lock`` (roughly)		|
-+----------------------------------------+--------------------------------------+
-
-
-As the last word it might be worth to emphasize that the ordering implementations
-in both classical OSD and in crimson are stricter than a theoretical minimum one
-required by the RADOS protocol. For instance, we could parallelize read operations
-targeting the same object at the price of extra complexity but we don't -- the
-simplicity has won.
+See crimson/osd/osd_operations/client_request.(h|cc) for details.

--- a/src/common/intrusive_lru.h
+++ b/src/common/intrusive_lru.h
@@ -94,6 +94,8 @@ public:
   friend void intrusive_ptr_add_ref<>(intrusive_lru_base<Config> *);
   friend void intrusive_ptr_release<>(intrusive_lru_base<Config> *);
 
+  unsigned get_use_count() const { return use_count; }
+
   virtual ~intrusive_lru_base() {}
 };
 

--- a/src/common/intrusive_lru.h
+++ b/src/common/intrusive_lru.h
@@ -178,6 +178,25 @@ class intrusive_lru {
     evict(lru_target_size);
   }
 
+  /// clear [from, to) invoking f upon and invalidating any live references
+  template <typename F>
+  void clear_range(
+    typename lru_set_t::iterator from, typename lru_set_t::iterator to,
+    F &&f) {
+    while (from != to) {
+      if (!(*from).lru) {
+	unreferenced_list.erase(lru_list_t::s_iterator_to(*from));
+	from = lru_set.erase_and_dispose(from, [](auto *p) { delete p; } );
+      } else {
+	std::invoke(f, static_cast<T&>(*from));
+	from->lru = nullptr;
+	assert(from->is_invalidated());
+	from = lru_set.erase_and_dispose(
+	  from, [](auto *p) { assert(p->use_count > 0); });
+      }
+    }
+  }
+
 public:
   /**
    * Returns the TRef corresponding to k if it exists or
@@ -200,38 +219,28 @@ public:
     }
   }
 
-  /*
-   * Clears unreferenced elements from the lru set [from, to]
+  /**
+   * clear_range
+   *
+   * Clears elements from the lru set in [from, to] invoking F upon and
+   * invalidating any with outstanding references
    */
-  void clear_range(
-    const K& from,
-    const K& to) {
-      auto from_iter = lru_set.lower_bound(from);
-      auto to_iter = lru_set.upper_bound(to);
-      for (auto i = from_iter; i != to_iter; ) {
-        if (!(*i).lru) {
-          unreferenced_list.erase(lru_list_t::s_iterator_to(*i));
-          i = lru_set.erase_and_dispose(i, [](auto *p)
-            { delete p; } );
-        } else {
-          i++;
-        }
-      }
+  template <typename F>
+  void clear_range(const K& from, const K& to, F &&f) {
+    auto from_iter = lru_set.lower_bound(from);
+    auto to_iter = lru_set.upper_bound(to);
+    clear_range(from_iter, to_iter, std::forward<F>(f));
   }
 
-  /// drop all elements from lru, invoke f on any with outstanding references
+  /**
+   * clear
+   *
+   * Clears all elements from the lru set invoking F upon and
+   * invalidating any with outstanding references
+   */
   template <typename F>
   void clear(F &&f) {
-    evict(0);
-    assert(unreferenced_list.empty());
-    for (auto &i: lru_set) {
-      std::invoke(f, static_cast<T&>(i));
-      i.lru = nullptr;
-      assert(i.is_invalidated());
-    }
-    lru_set.clear_and_dispose([](auto *i){
-      assert(i->use_count > 0); /* don't delete, still has a ref count */
-    });
+    clear_range(lru_set.begin(), lru_set.end(), std::forward<F>(f));
   }
 
   template <class F>

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -129,14 +129,14 @@ public:
   }
 
   bool is_valid() const {
-    return !invalidated_by_interval_change;
+    return !invalidated;
   }
 
 private:
   boost::intrusive::list_member_hook<> obc_accessing_hook;
   uint64_t list_link_cnt = 0;
   bool fully_loaded = false;
-  bool invalidated_by_interval_change = false;
+  bool invalidated = false;
 
   friend class ObjectContextRegistry;
   friend class ObjectContextLoader;
@@ -196,12 +196,14 @@ public:
 
   void clear_range(const hobject_t &from,
                    const hobject_t &to) {
-    obc_lru.clear_range(from, to);
+    obc_lru.clear_range(from, to, [](auto &obc) {
+      obc.invalidated = true;
+    });
   }
 
   void invalidate_on_interval_change() {
     obc_lru.clear([](auto &obc) {
-      obc.invalidated_by_interval_change = true;
+      obc.invalidated = true;
     });
   }
 

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -9,6 +9,7 @@
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include "common/fmt_common.h"
 #include "common/intrusive_lru.h"
 #include "osd/object_state.h"
 #include "crimson/common/exception.h"
@@ -154,6 +155,15 @@ public:
     if (--list_link_cnt == 0) {
       list.erase(std::decay_t<ListType>::s_iterator_to(*this));
     }
+  }
+
+  template <typename FormatContext>
+  auto fmt_print_ctx(FormatContext & ctx) const {
+    return fmt::format_to(
+      ctx.out(), "ObjectContext({}, oid={}, refcount={})",
+      (void*)this,
+      get_oid(),
+      get_use_count());
   }
 
   using obc_accessing_option_t = boost::intrusive::member_hook<

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -145,9 +145,7 @@ public:
       if (s.is_empty()) return;
 
       s.release_lock();
-      SUBDEBUGDPP(
-	osd, "released object {}, {}",
-	loader.dpp, s.obc->get_oid(), s.obc->obs);
+      SUBDEBUGDPP(osd, "releasing obc {}, {}", loader.dpp, *(s.obc), s.obc->obs);
       s.obc->remove_from(loader.obc_set_accessing);
       s = state_t();
     }
@@ -200,6 +198,11 @@ public:
     CommonOBCPipeline &obc_pp() {
       ceph_assert(orderer_obc);
       return orderer_obc->obc_pipeline;
+    }
+
+    ~Orderer() {
+      LOG_PREFIX(ObjectContextLoader::~Orderer);
+      SUBDEBUG(osd, "releasing obc {}, {}", *(orderer_obc));
     }
   };
 

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -2,9 +2,11 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/util/defer.hh>
+#include "crimson/common/coroutine.h"
 #include "crimson/common/errorator.h"
 #include "crimson/common/log.h"
 #include "crimson/osd/object_context.h"
+#include "crimson/osd/osd_operation.h"
 #include "crimson/osd/pg_backend.h"
 #include "osd/object_state_fmt.h"
 
@@ -165,11 +167,13 @@ public:
 
     ObjectContextRef &get_obc() {
       ceph_assert(!target_state.is_empty());
+      ceph_assert(target_state.obc->is_loaded());
       return target_state.obc;
     }
 
     ObjectContextRef &get_head_obc() {
       ceph_assert(!head_state.is_empty());
+      ceph_assert(head_state.obc->is_loaded());
       return head_state.obc;
     }
 
@@ -188,9 +192,34 @@ public:
       release();
     }
   };
-  Manager get_obc_manager(hobject_t oid, bool resolve_clone = true) {
+
+  class Orderer {
+    friend ObjectContextLoader;
+    ObjectContextRef orderer_obc;
+  public:
+    CommonOBCPipeline &obc_pp() {
+      ceph_assert(orderer_obc);
+      return orderer_obc->obc_pipeline;
+    }
+  };
+
+  Orderer get_obc_orderer(const hobject_t &oid) {
+    Orderer ret;
+    std::tie(ret.orderer_obc, std::ignore) =
+      obc_registry.get_cached_obc(oid.get_head());
+    return ret;
+  }
+
+  Manager get_obc_manager(const hobject_t &oid, bool resolve_clone = true) {
     Manager ret(*this, oid);
     ret.options.resolve_clone = resolve_clone;
+    return ret;
+  }
+
+  Manager get_obc_manager(
+    Orderer &orderer, const hobject_t &oid, bool resolve_clone = true) {
+    Manager ret = get_obc_manager(oid, resolve_clone);
+    ret.set_state_obc(ret.head_state, orderer.orderer_obc);
     return ret;
   }
 
@@ -200,7 +229,7 @@ public:
   using load_and_lock_fut = load_and_lock_iertr::future<>;
 private:
   load_and_lock_fut load_and_lock_head(Manager &, RWState::State);
-  load_and_lock_fut load_and_lock_clone(Manager &, RWState::State);
+  load_and_lock_fut load_and_lock_clone(Manager &, RWState::State, bool lock_head=true);
 public:
   load_and_lock_fut load_and_lock(Manager &, RWState::State);
 
@@ -244,7 +273,7 @@ public:
     // locks on head as part of this call.
     manager.head_state.obc = head;
     manager.head_state.obc->append_to(obc_set_accessing);
-    co_await load_and_lock(manager, State);
+    co_await load_and_lock_clone(manager, State, false);
     co_await std::invoke(func, head, manager.get_obc());
   }
 

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -465,7 +465,6 @@ template <class Func>
 auto OpsExecuter::do_write_op(Func&& f, OpsExecuter::modified_by m) {
   ++num_write;
   if (!osd_op_params) {
-    osd_op_params.emplace();
     fill_op_params(m);
   }
   return std::forward<Func>(f)(pg->get_backend(), obc->obs, txn);
@@ -824,6 +823,7 @@ OpsExecuter::do_execute_op(OSDOp& osd_op)
 
 void OpsExecuter::fill_op_params(OpsExecuter::modified_by m)
 {
+  osd_op_params.emplace();
   osd_op_params->req_id = msg->get_reqid();
   osd_op_params->mtime = msg->get_mtime();
   osd_op_params->at_version = pg->get_next_version();

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -904,7 +904,12 @@ void OpsExecuter::execute_clone(
   osd_op_params->at_version.version++;
 
   // make clone
-  backend.clone(clone_obc->obs.oi, initial_obs, clone_obc->obs, txn);
+  backend.clone_for_write(soid, coid, txn);
+  backend.set_metadata(
+    coid,
+    clone_obc->obs.oi,
+    nullptr /* snapset */,
+    txn);
 
   delta_stats.num_objects++;
   if (clone_obc->obs.oi.is_omap()) {

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -393,11 +393,18 @@ public:
     const std::vector<OSDOp>& ops,
     SnapMapper& snap_mapper,
     OSDriver& osdriver);
-  void fill_op_params(modified_by m);
   pg_log_entry_t prepare_head_update(
     const std::vector<OSDOp>& ops,
     ceph::os::Transaction &txn);
 
+  void check_init_op_params(OpsExecuter::modified_by m) {
+    if (!osd_op_params) {
+      osd_op_params.emplace();
+      osd_op_params->req_id = msg->get_reqid();
+      osd_op_params->mtime = msg->get_mtime();
+      osd_op_params->user_modify = (m == modified_by::user);
+    }
+  }
 
   ObjectContextRef get_obc() const {
     return obc;

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -400,7 +400,7 @@ public:
   using rep_op_fut_t =
     interruptible_future<rep_op_fut_tuple>;
   template <typename MutFunc>
-  rep_op_fut_t flush_changes_n_do_ops_effects(
+  rep_op_fut_t flush_changes_and_submit(
     const std::vector<OSDOp>& ops,
     SnapMapper& snap_mapper,
     OSDriver& osdriver,
@@ -486,7 +486,7 @@ auto OpsExecuter::with_effect_on_obc(
 
 template <typename MutFunc>
 OpsExecuter::rep_op_fut_t
-OpsExecuter::flush_changes_n_do_ops_effects(
+OpsExecuter::flush_changes_and_submit(
   const std::vector<OSDOp>& ops,
   SnapMapper& snap_mapper,
   OSDriver& osdriver,

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -205,7 +205,6 @@ private:
   };
   std::unique_ptr<CloningContext> cloning_ctx;
 
-
   /**
    * execute_clone
    *
@@ -227,7 +226,7 @@ private:
    * @param backend [in,out] interface for generating mutations
    * @param txn [out] transaction for the operation
    */
-  std::unique_ptr<CloningContext> execute_clone(
+  void execute_clone(
     const SnapContext& snapc,
     const ObjectState& initial_obs,
     const SnapSet& initial_snapset,

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -198,10 +198,6 @@ private:
     SnapSet new_snapset;
     pg_log_entry_t log_entry;
     ObjectContextRef clone_obc;
-
-    void apply_to(
-      std::vector<pg_log_entry_t>& log_entries,
-      ObjectContext& processed_obc);
   };
   std::unique_ptr<CloningContext> cloning_ctx;
 
@@ -262,12 +258,6 @@ private:
   * part of the head object for each write operation.
   */
   void update_clone_overlap();
-
-  std::vector<pg_log_entry_t> flush_clone_metadata(
-    std::vector<pg_log_entry_t>&& log_entries,
-    SnapMapper& snap_mapper,
-    OSDriver& osdriver,
-    ceph::os::Transaction& txn);
 
 private:
   // this gizmo could be wrapped in std::optional for the sake of lazy
@@ -403,9 +393,11 @@ public:
     const std::vector<OSDOp>& ops,
     SnapMapper& snap_mapper,
     OSDriver& osdriver);
-  std::vector<pg_log_entry_t> prepare_transaction(
-    const std::vector<OSDOp>& ops);
   void fill_op_params(modified_by m);
+  pg_log_entry_t prepare_head_update(
+    const std::vector<OSDOp>& ops,
+    ceph::os::Transaction &txn);
+
 
   ObjectContextRef get_obc() const {
     return obc;

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -50,24 +50,6 @@ struct PGPeeringPipeline {
 };
 
 struct CommonPGPipeline {
-  struct WaitForActive : OrderedExclusivePhaseT<WaitForActive> {
-    static constexpr auto type_name = "CommonPGPipeline:::wait_for_active";
-  } wait_for_active;
-  struct RecoverMissing : OrderedConcurrentPhaseT<RecoverMissing> {
-    static constexpr auto type_name = "CommonPGPipeline::recover_missing";
-  } recover_missing;
-  struct CheckAlreadyCompleteGetObc : OrderedExclusivePhaseT<CheckAlreadyCompleteGetObc> {
-    static constexpr auto type_name = "CommonPGPipeline::check_already_complete_get_obc";
-  } check_already_complete_get_obc;
-  struct LockOBC : OrderedConcurrentPhaseT<LockOBC> {
-    static constexpr auto type_name = "CommonPGPipeline::lock_obc";
-  } lock_obc;
-  struct Process : OrderedExclusivePhaseT<Process> {
-    static constexpr auto type_name = "CommonPGPipeline::process";
-  } process;
-  struct WaitRepop : OrderedConcurrentPhaseT<WaitRepop> {
-    static constexpr auto type_name = "ClientRequest::PGPipeline::wait_repop";
-  } wait_repop;
   struct WaitPGReady : OrderedConcurrentPhaseT<WaitPGReady> {
     static constexpr auto type_name = "CommonPGPipeline:::wait_pg_ready";
   } wait_pg_ready;

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -76,6 +76,12 @@ struct CommonPGPipeline {
   } get_obc;
 };
 
+struct PGRepopPipeline {
+  struct Process : OrderedExclusivePhaseT<Process> {
+    static constexpr auto type_name = "PGRepopPipeline::process";
+  } process;
+};
+
 struct CommonOBCPipeline {
   struct Process : OrderedExclusivePhaseT<Process> {
     static constexpr auto type_name = "CommonOBCPipeline::process";

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -70,6 +70,18 @@ struct CommonPGPipeline {
   } wait_repop;
 };
 
+struct CommonOBCPipeline {
+  struct Process : OrderedExclusivePhaseT<Process> {
+    static constexpr auto type_name = "CommonOBCPipeline::process";
+  } process;
+  struct WaitRepop : OrderedConcurrentPhaseT<WaitRepop> {
+    static constexpr auto type_name = "CommonOBCPipeline::wait_repop";
+  } wait_repop;
+  struct SendReply : OrderedExclusivePhaseT<SendReply> {
+    static constexpr auto type_name = "CommonOBCPipeline::send_reply";
+  } send_reply;
+};
+
 
 enum class OperationTypeCode {
   client_request = 0,

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -68,6 +68,12 @@ struct CommonPGPipeline {
   struct WaitRepop : OrderedConcurrentPhaseT<WaitRepop> {
     static constexpr auto type_name = "ClientRequest::PGPipeline::wait_repop";
   } wait_repop;
+  struct WaitPGReady : OrderedConcurrentPhaseT<WaitPGReady> {
+    static constexpr auto type_name = "CommonPGPipeline:::wait_pg_ready";
+  } wait_pg_ready;
+  struct GetOBC : OrderedExclusivePhaseT<GetOBC> {
+    static constexpr auto type_name = "CommonPGPipeline:::get_obc";
+  } get_obc;
 };
 
 struct CommonOBCPipeline {

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -30,21 +30,9 @@ struct LttngBackend
     CommonPGPipeline::GetOBC::BlockingEvent::Backend,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
     PGMap::PGCreationBlockingEvent::Backend,
-    ClientRequest::PGPipeline::AwaitMap::BlockingEvent::Backend,
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::WaitForActive::BlockingEvent::Backend,
     PGActivationBlocker::BlockingEvent::Backend,
     scrub::PGScrubber::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissing::
-      BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::SendReply::BlockingEvent::Backend,
     ClientRequest::CompletionEvent::Backend,
     CommonOBCPipeline::Process::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
@@ -99,19 +87,9 @@ struct LttngBackend
               const PGMap::PGCreationBlocker&) override {
   }
 
-  void handle(ClientRequest::PGPipeline::AwaitMap::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::AwaitMap& blocker) override {
-  }
-
   void handle(PG_OSDMapGate::OSDMapBlocker::BlockingEvent&,
               const Operation&,
               const PG_OSDMapGate::OSDMapBlocker&) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::WaitForActive::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::WaitForActive& blocker) override {
   }
 
   void handle(PGActivationBlocker::BlockingEvent& ev,
@@ -122,49 +100,6 @@ struct LttngBackend
   void handle(scrub::PGScrubber::BlockingEvent& ev,
               const Operation& op,
               const scrub::PGScrubber& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::RecoverMissing& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::ExitBarrierEvent& ev,
-	      const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc& blocker) override {
-  }
-
-
-  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::LockOBC& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::Process::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::Process& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::WaitRepop::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::WaitRepop& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::SendReply::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::SendReply& blocker) override {
   }
 
   void handle(CommonOBCPipeline::Process::BlockingEvent& ev,
@@ -207,21 +142,9 @@ struct HistoricBackend
     CommonPGPipeline::GetOBC::BlockingEvent::Backend,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
     PGMap::PGCreationBlockingEvent::Backend,
-    ClientRequest::PGPipeline::AwaitMap::BlockingEvent::Backend,
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::WaitForActive::BlockingEvent::Backend,
     PGActivationBlocker::BlockingEvent::Backend,
     scrub::PGScrubber::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissing::
-      BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::SendReply::BlockingEvent::Backend,
     ClientRequest::CompletionEvent::Backend,
     CommonOBCPipeline::Process::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
@@ -276,19 +199,9 @@ struct HistoricBackend
               const PGMap::PGCreationBlocker&) override {
   }
 
-  void handle(ClientRequest::PGPipeline::AwaitMap::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::AwaitMap& blocker) override {
-  }
-
   void handle(PG_OSDMapGate::OSDMapBlocker::BlockingEvent&,
               const Operation&,
               const PG_OSDMapGate::OSDMapBlocker&) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::WaitForActive::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::WaitForActive& blocker) override {
   }
 
   void handle(PGActivationBlocker::BlockingEvent& ev,
@@ -299,48 +212,6 @@ struct HistoricBackend
   void handle(scrub::PGScrubber::BlockingEvent& ev,
               const Operation& op,
               const scrub::PGScrubber& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::RecoverMissing& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::LockOBC& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::Process::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::Process& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::WaitRepop::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::WaitRepop& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::SendReply::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::SendReply& blocker) override {
   }
 
   static const ClientRequest& to_client_request(const Operation& op) {

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -42,7 +42,11 @@ struct LttngBackend
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::SendReply::BlockingEvent::Backend,
-    ClientRequest::CompletionEvent::Backend
+    ClientRequest::CompletionEvent::Backend,
+    CommonOBCPipeline::Process::BlockingEvent::Backend,
+    CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
+    CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
+    CommonOBCPipeline::SendReply::BlockingEvent::Backend
 {
   void handle(ClientRequest::StartEvent&,
               const Operation&) override {}
@@ -145,8 +149,29 @@ struct LttngBackend
               const ClientRequest::PGPipeline::SendReply& blocker) override {
   }
 
+  void handle(CommonOBCPipeline::Process::BlockingEvent& ev,
+              const Operation& op,
+              const CommonOBCPipeline::Process& blocker) override {
+  }
+
+  void handle(CommonOBCPipeline::WaitRepop::BlockingEvent& ev,
+              const Operation& op,
+              const CommonOBCPipeline::WaitRepop& blocker) override {
+  }
+
+  void handle(CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
+  }
+
+  void handle(CommonOBCPipeline::SendReply::BlockingEvent& ev,
+              const Operation& op,
+              const CommonOBCPipeline::SendReply& blocker) override {
+  }
+
+
   void handle(ClientRequest::CompletionEvent&,
               const Operation&) override {}
+
 };
 
 struct HistoricBackend
@@ -172,7 +197,11 @@ struct HistoricBackend
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::SendReply::BlockingEvent::Backend,
-    ClientRequest::CompletionEvent::Backend
+    ClientRequest::CompletionEvent::Backend,
+    CommonOBCPipeline::Process::BlockingEvent::Backend,
+    CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
+    CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
+    CommonOBCPipeline::SendReply::BlockingEvent::Backend
 {
   void handle(ClientRequest::StartEvent&,
               const Operation&) override {}
@@ -280,6 +309,25 @@ struct HistoricBackend
 #else
     return dynamic_cast<const ClientRequest&>(op);
 #endif
+  }
+
+  void handle(CommonOBCPipeline::Process::BlockingEvent& ev,
+              const Operation& op,
+              const CommonOBCPipeline::Process& blocker) override {
+  }
+
+  void handle(CommonOBCPipeline::WaitRepop::BlockingEvent& ev,
+              const Operation& op,
+              const CommonOBCPipeline::WaitRepop& blocker) override {
+  }
+
+  void handle(CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
+  }
+
+  void handle(CommonOBCPipeline::SendReply::BlockingEvent& ev,
+              const Operation& op,
+              const CommonOBCPipeline::SendReply& blocker) override {
   }
 
   void handle(ClientRequest::CompletionEvent&, const Operation& op) override {

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -49,7 +49,8 @@ struct LttngBackend
     CommonOBCPipeline::Process::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
-    CommonOBCPipeline::SendReply::BlockingEvent::Backend
+    CommonOBCPipeline::SendReply::BlockingEvent::Backend,
+    PGRepopPipeline::Process::BlockingEvent::Backend
 {
   void handle(ClientRequest::StartEvent&,
               const Operation&) override {}
@@ -185,6 +186,10 @@ struct LttngBackend
               const CommonOBCPipeline::SendReply& blocker) override {
   }
 
+  void handle(PGRepopPipeline::Process::BlockingEvent& ev,
+              const Operation& op,
+              const PGRepopPipeline::Process& blocker) override {
+  }
 
   void handle(ClientRequest::CompletionEvent&,
               const Operation&) override {}
@@ -221,7 +226,8 @@ struct HistoricBackend
     CommonOBCPipeline::Process::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
-    CommonOBCPipeline::SendReply::BlockingEvent::Backend
+    CommonOBCPipeline::SendReply::BlockingEvent::Backend,
+    PGRepopPipeline::Process::BlockingEvent::Backend
 {
   void handle(ClientRequest::StartEvent&,
               const Operation&) override {}
@@ -362,6 +368,11 @@ struct HistoricBackend
   void handle(CommonOBCPipeline::SendReply::BlockingEvent& ev,
               const Operation& op,
               const CommonOBCPipeline::SendReply& blocker) override {
+  }
+
+  void handle(PGRepopPipeline::Process::BlockingEvent& ev,
+              const Operation& op,
+              const PGRepopPipeline::Process& blocker) override {
   }
 
   void handle(ClientRequest::CompletionEvent&, const Operation& op) override {

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -25,6 +25,9 @@ struct LttngBackend
     ConnectionPipeline::AwaitMap::BlockingEvent::Backend,
     ConnectionPipeline::GetPGMapping::BlockingEvent::Backend,
     PerShardPipeline::CreateOrWaitPG::BlockingEvent::Backend,
+    CommonPGPipeline::WaitPGReady::BlockingEvent::Backend,
+    CommonPGPipeline::WaitPGReady::BlockingEvent::ExitBarrierEvent::Backend,
+    CommonPGPipeline::GetOBC::BlockingEvent::Backend,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
     PGMap::PGCreationBlockingEvent::Backend,
     ClientRequest::PGPipeline::AwaitMap::BlockingEvent::Backend,
@@ -74,6 +77,20 @@ struct LttngBackend
   void handle(PerShardPipeline::CreateOrWaitPG::BlockingEvent& ev,
               const Operation& op,
               const PerShardPipeline::CreateOrWaitPG& blocker) override {
+  }
+
+  void handle(CommonPGPipeline::WaitPGReady::BlockingEvent& ev,
+              const Operation& op,
+              const CommonPGPipeline::WaitPGReady& blocker) override {
+  }
+
+  void handle(CommonPGPipeline::WaitPGReady::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
+  }
+
+  void handle(CommonPGPipeline::GetOBC::BlockingEvent& ev,
+              const Operation& op,
+              const CommonPGPipeline::GetOBC& blocker) override {
   }
 
   void handle(PGMap::PGCreationBlockingEvent&,
@@ -180,6 +197,9 @@ struct HistoricBackend
     ConnectionPipeline::AwaitMap::BlockingEvent::Backend,
     ConnectionPipeline::GetPGMapping::BlockingEvent::Backend,
     PerShardPipeline::CreateOrWaitPG::BlockingEvent::Backend,
+    CommonPGPipeline::WaitPGReady::BlockingEvent::Backend,
+    CommonPGPipeline::WaitPGReady::BlockingEvent::ExitBarrierEvent::Backend,
+    CommonPGPipeline::GetOBC::BlockingEvent::Backend,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent::Backend,
     PGMap::PGCreationBlockingEvent::Backend,
     ClientRequest::PGPipeline::AwaitMap::BlockingEvent::Backend,
@@ -229,6 +249,20 @@ struct HistoricBackend
   void handle(PerShardPipeline::CreateOrWaitPG::BlockingEvent& ev,
               const Operation& op,
               const PerShardPipeline::CreateOrWaitPG& blocker) override {
+  }
+
+  void handle(CommonPGPipeline::WaitPGReady::BlockingEvent& ev,
+              const Operation& op,
+              const CommonPGPipeline::WaitPGReady& blocker) override {
+  }
+
+  void handle(CommonPGPipeline::WaitPGReady::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
+  }
+
+  void handle(CommonPGPipeline::GetOBC::BlockingEvent& ev,
+              const Operation& op,
+              const CommonPGPipeline::GetOBC& blocker) override {
   }
 
   void handle(PGMap::PGCreationBlockingEvent&,

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -268,9 +268,10 @@ seastar::future<> ClientRequest::with_pg_process(
 	       *pgref, *this, this_instance_id, eptr);
     }, pgref, pgref->get_osdmap_epoch()).finally(
       [this, FNAME, opref=std::move(opref), pgref,
-       this_instance_id, instance_handle=std::move(instance_handle), &ihref] {
+       this_instance_id, instance_handle=std::move(instance_handle), &ihref]() mutable {
 	DEBUGDPP("{}.{}: exit", *pgref, *this, this_instance_id);
-	ihref.handle.exit();
+	return ihref.handle.complete(
+	).finally([instance_handle=std::move(instance_handle)] {});
     });
 }
 

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -101,7 +101,7 @@ PerShardPipeline &ClientRequest::get_pershard_pipeline(
   return shard_services.get_client_request_pipeline();
 }
 
-ClientRequest::PGPipeline &ClientRequest::client_pp(PG &pg)
+CommonPGPipeline &ClientRequest::client_pp(PG &pg)
 {
   return pg.request_pg_pipeline;
 }
@@ -140,6 +140,15 @@ ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptib
 
   DEBUGDPP("{} start", *pgref, *this);
   PG &pg = *pgref;
+
+  DEBUGDPP("{}.{}: entering wait_pg_ready stage",
+	   *pgref, *this, this_instance_id);
+  // The prior stage is OrderedExclusive (PerShardPipeline::create_or_wait_pg)
+  // and wait_pg_ready is OrderedConcurrent.  This transition, therefore, cannot
+  // block and using enter_stage_sync is legal and more efficient than
+  // enter_stage.
+  ihref.enter_stage_sync(client_pp(pg).wait_pg_ready, *this);
+
   if (!m->get_hobj().get_key().empty()) {
     // There are no users of locator. It was used to ensure that multipart-upload
     // parts would end up in the same PG so that they could be clone_range'd into
@@ -156,27 +165,21 @@ ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptib
     DEBUGDPP("{}: discarding {}", *pgref, *this, this_instance_id);
     co_return;
   }
-  DEBUGDPP("{}.{}: entering await_map stage",
-	   *pgref, *this, this_instance_id);
-  co_await ihref.enter_stage<interruptor>(client_pp(pg).await_map, *this);
-  DEBUGDPP("{}.{}: entered await_map stage, waiting for map",
-	   pg, *this, this_instance_id);
+
   auto map_epoch = co_await interruptor::make_interruptible(
     ihref.enter_blocker(
       *this, pg.osdmap_gate, &decltype(pg.osdmap_gate)::wait_for_map,
       m->get_min_epoch(), nullptr));
 
-  DEBUGDPP("{}.{}: map epoch got {}, entering wait_for_active",
+  DEBUGDPP("{}.{}: waited for epoch {}, waiting for active",
 	   pg, *this, this_instance_id, map_epoch);
-  co_await ihref.enter_stage<interruptor>(client_pp(pg).wait_for_active, *this);
-
-  DEBUGDPP("{}.{}: entered wait_for_active stage, waiting for active",
-	   pg, *this, this_instance_id);
   co_await interruptor::make_interruptible(
     ihref.enter_blocker(
       *this,
       pg.wait_for_active_blocker,
       &decltype(pg.wait_for_active_blocker)::wait));
+
+  co_await ihref.enter_stage<interruptor>(client_pp(pg).get_obc, *this);
 
   if (int res = op_info.set_from_op(&*m, *pg.get_osdmap());
       res != 0) {
@@ -345,7 +348,13 @@ ClientRequest::process_op(
   instance_handle_t &ihref, Ref<PG> pg, unsigned this_instance_id)
 {
   LOG_PREFIX(ClientRequest::process_op);
-  ihref.enter_stage_sync(client_pp(*pg).recover_missing, *this);
+  ihref.obc_orderer = pg->obc_loader.get_obc_orderer(m->get_hobj());
+  auto obc_manager = pg->obc_loader.get_obc_manager(
+    *(ihref.obc_orderer),
+    m->get_hobj());
+  co_await ihref.enter_stage<interruptor>(
+    ihref.obc_orderer->obc_pp().process, *this);
+
   if (!pg->is_primary()) {
     DEBUGDPP(
       "Skipping recover_missings on non primary pg for soid {}",
@@ -365,16 +374,6 @@ ClientRequest::process_op(
     }
   }
 
-  /**
-   * The previous stage of recover_missing is a concurrent phase.
-   * Checking for already_complete requests must done exclusively.
-   * Since get_obc is also an exclusive stage, we can merge both stages into
-   * a single stage and avoid stage switching overhead.
-   */
-  DEBUGDPP("{}.{}: entering check_already_complete_get_obc",
-	   *pg, *this, this_instance_id);
-  co_await ihref.enter_stage<interruptor>(
-    client_pp(*pg).check_already_complete_get_obc, *this);
   DEBUGDPP("{}.{}: checking already_complete",
 	   *pg, *this, this_instance_id);
   auto completed = co_await pg->already_complete(m->get_reqid());
@@ -402,12 +401,6 @@ ClientRequest::process_op(
   DEBUGDPP("{}.{}: past scrub blocker, getting obc",
 	   *pg, *this, this_instance_id);
 
-  auto obc_manager = pg->obc_loader.get_obc_manager(m->get_hobj());
-
-  // initiate load_and_lock in order, but wait concurrently
-  ihref.enter_stage_sync(
-      client_pp(*pg).lock_obc, *this);
-
   int load_err = co_await pg->obc_loader.load_and_lock(
     obc_manager, pg->get_lock_type(op_info)
   ).si_then([]() -> int {
@@ -425,13 +418,8 @@ ClientRequest::process_op(
     co_return;
   }
 
-  DEBUGDPP("{}.{}: got obc {}, entering process stage",
+  DEBUGDPP("{}.{}: obc {} loaded and locked, calling do_process",
 	   *pg, *this, this_instance_id, obc_manager.get_obc()->obs);
-  co_await ihref.enter_stage<interruptor>(
-    client_pp(*pg).process, *this);
-
-  DEBUGDPP("{}.{}: in process stage, calling do_process",
-	   *pg, *this, this_instance_id);
   co_await do_process(
     ihref, pg, obc_manager.get_obc(), this_instance_id
   );
@@ -553,12 +541,14 @@ ClientRequest::do_process(
 	std::move(ox), m->ops);
       co_await std::move(submitted);
     }
-    co_await ihref.enter_stage<interruptor>(client_pp(*pg).wait_repop, *this);
+    co_await ihref.enter_stage<interruptor>(
+      ihref.obc_orderer->obc_pp().wait_repop, *this);
 
     co_await std::move(all_completed);
   }
 
-  co_await ihref.enter_stage<interruptor>(client_pp(*pg).send_reply, *this);
+  co_await ihref.enter_stage<interruptor>(
+    ihref.obc_orderer->obc_pp().send_reply, *this);
 
   if (ret) {
     int err = -ret->value();

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -11,6 +11,7 @@
 #include "osd/osd_op_util.h"
 #include "crimson/net/Connection.h"
 #include "crimson/osd/object_context.h"
+#include "crimson/osd/object_context_loader.h"
 #include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/osd_operations/client_request_common.h"
@@ -93,20 +94,18 @@ public:
     // don't leave any references on the source core, so we just bypass it by using
     // intrusive_ptr instead.
     using ref_t = boost::intrusive_ptr<instance_handle_t>;
+    std::optional<ObjectContextLoader::Orderer> obc_orderer;
     PipelineHandle handle;
 
     std::tuple<
-      PGPipeline::AwaitMap::BlockingEvent,
+      CommonPGPipeline::WaitPGReady::BlockingEvent,
       PG_OSDMapGate::OSDMapBlocker::BlockingEvent,
-      PGPipeline::WaitForActive::BlockingEvent,
       PGActivationBlocker::BlockingEvent,
-      PGPipeline::RecoverMissing::BlockingEvent,
+      CommonPGPipeline::GetOBC::BlockingEvent,
+      CommonOBCPipeline::Process::BlockingEvent,
       scrub::PGScrubber::BlockingEvent,
-      PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent,
-      PGPipeline::LockOBC::BlockingEvent,
-      PGPipeline::Process::BlockingEvent,
-      PGPipeline::WaitRepop::BlockingEvent,
-      PGPipeline::SendReply::BlockingEvent,
+      CommonOBCPipeline::WaitRepop::BlockingEvent,
+      CommonOBCPipeline::SendReply::BlockingEvent,
       CompletionEvent
       > pg_tracking_events;
 
@@ -293,7 +292,7 @@ private:
       unsigned this_instance_id);
   bool is_pg_op() const;
 
-  PGPipeline &client_pp(PG &pg);
+  CommonPGPipeline &client_pp(PG &pg);
 
   template <typename Errorator>
   using interruptible_errorator =

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -42,22 +42,6 @@ class ClientRequest final : public PhasedOperationT<ClientRequest>,
   unsigned instance_id = 0;
 
 public:
-  class PGPipeline : public CommonPGPipeline {
-    public:
-    struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
-      static constexpr auto type_name = "ClientRequest::PGPipeline::await_map";
-    } await_map;
-    struct SendReply : OrderedExclusivePhaseT<SendReply> {
-      static constexpr auto type_name = "ClientRequest::PGPipeline::send_reply";
-    } send_reply;
-    friend class ClientRequest;
-    friend class LttngBackend;
-    friend class HistoricBackend;
-    friend class ReqRequest;
-    friend class LogMissingRequest;
-    friend class LogMissingRequestReply;
-  };
-
   /**
    * instance_handle_t
    *

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -148,7 +148,7 @@ seastar::future<> InternalClientRequest::start()
     return seastar::now();
   }).finally([this] {
     logger().debug("{}: exit", *this);
-    handle.exit();
+    return handle.complete();
   });
 }
 

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "crimson/common/type_helpers.h"
+#include "crimson/osd/object_context_loader.h"
 #include "crimson/osd/osd_operation.h"
 #include "crimson/osd/osd_operations/client_request_common.h"
 #include "crimson/osd/pg.h"
@@ -48,6 +49,7 @@ private:
   Ref<PG> pg;
   epoch_t start_epoch;
   OpInfo op_info;
+  std::optional<ObjectContextLoader::Orderer> obc_orderer;
   PipelineHandle handle;
 
 public:
@@ -55,12 +57,8 @@ public:
 
   std::tuple<
     StartEvent,
-    CommonPGPipeline::WaitForActive::BlockingEvent,
-    PGActivationBlocker::BlockingEvent,
-    CommonPGPipeline::RecoverMissing::BlockingEvent,
-    CommonPGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent,
-    CommonPGPipeline::LockOBC::BlockingEvent,
-    CommonPGPipeline::Process::BlockingEvent,
+    CommonOBCPipeline::Process::BlockingEvent,
+    CommonOBCPipeline::WaitRepop::BlockingEvent,
     CompletionEvent
   > tracking_events;
 };

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -45,8 +45,6 @@ private:
     crimson::osd::ObjectContextRef obc,
     std::vector<OSDOp> &osd_ops);
 
-  seastar::future<> do_process();
-
   Ref<PG> pg;
   epoch_t start_epoch;
   OpInfo op_info;

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -58,9 +58,9 @@ PerShardPipeline &LogMissingRequest::get_pershard_pipeline(
   return shard_services.get_replicated_request_pipeline();
 }
 
-ClientRequest::PGPipeline &LogMissingRequest::client_pp(PG &pg)
+PGRepopPipeline &LogMissingRequest::repop_pipeline(PG &pg)
 {
-  return pg.request_pg_pipeline;
+  return pg.repop_pipeline;
 }
 
 seastar::future<> LogMissingRequest::with_pg(
@@ -73,7 +73,7 @@ seastar::future<> LogMissingRequest::with_pg(
   return interruptor::with_interruption([this, pg] {
     LOG_PREFIX(LogMissingRequest::with_pg);
     DEBUGI("{}: pg present", *this);
-    return this->template enter_stage<interruptor>(client_pp(*pg).await_map
+    return this->template enter_stage<interruptor>(repop_pipeline(*pg).process
     ).then_interruptible([this, pg] {
       return this->template with_blocking_event<
         PG_OSDMapGate::OSDMapBlocker::BlockingEvent

--- a/src/crimson/osd/osd_operations/logmissing_request.h
+++ b/src/crimson/osd/osd_operations/logmissing_request.h
@@ -77,14 +77,14 @@ public:
     ConnectionPipeline::AwaitMap::BlockingEvent,
     ConnectionPipeline::GetPGMapping::BlockingEvent,
     PerShardPipeline::CreateOrWaitPG::BlockingEvent,
-    ClientRequest::PGPipeline::AwaitMap::BlockingEvent,
+    PGRepopPipeline::Process::BlockingEvent,
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent,
     PGMap::PGCreationBlockingEvent,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent
   > tracking_events;
 
 private:
-  ClientRequest::PGPipeline &client_pp(PG &pg);
+  PGRepopPipeline &repop_pipeline(PG &pg);
 
   crimson::net::ConnectionRef l_conn;
   crimson::net::ConnectionXcoreRef r_conn;

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.cc
@@ -56,11 +56,6 @@ PerShardPipeline &LogMissingRequestReply::get_pershard_pipeline(
   return shard_services.get_replicated_request_pipeline();
 }
 
-ClientRequest::PGPipeline &LogMissingRequestReply::client_pp(PG &pg)
-{
-  return pg.request_pg_pipeline;
-}
-
 seastar::future<> LogMissingRequestReply::with_pg(
   ShardServices &shard_services, Ref<PG> pg)
 {

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.h
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.h
@@ -82,8 +82,6 @@ public:
   > tracking_events;
 
 private:
-  ClientRequest::PGPipeline &client_pp(PG &pg);
-
   crimson::net::ConnectionRef l_conn;
   crimson::net::ConnectionXcoreRef r_conn;
 

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -58,9 +58,9 @@ PerShardPipeline &RepRequest::get_pershard_pipeline(
   return shard_services.get_replicated_request_pipeline();
 }
 
-ClientRequest::PGPipeline &RepRequest::client_pp(PG &pg)
+PGRepopPipeline &RepRequest::repop_pipeline(PG &pg)
 {
-  return pg.request_pg_pipeline;
+  return pg.repop_pipeline;
 }
 
 seastar::future<> RepRequest::with_pg(
@@ -72,7 +72,7 @@ seastar::future<> RepRequest::with_pg(
   return interruptor::with_interruption([this, pg] {
     LOG_PREFIX(RepRequest::with_pg);
     DEBUGI("{}: pg present", *this);
-    return this->template enter_stage<interruptor>(client_pp(*pg).await_map
+    return this->template enter_stage<interruptor>(repop_pipeline(*pg).process
     ).then_interruptible([this, pg] {
       return this->template with_blocking_event<
         PG_OSDMapGate::OSDMapBlocker::BlockingEvent

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -77,14 +77,14 @@ public:
     ConnectionPipeline::AwaitMap::BlockingEvent,
     ConnectionPipeline::GetPGMapping::BlockingEvent,
     PerShardPipeline::CreateOrWaitPG::BlockingEvent,
-    ClientRequest::PGPipeline::AwaitMap::BlockingEvent,
+    PGRepopPipeline::Process::BlockingEvent,
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent,
     PGMap::PGCreationBlockingEvent,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent
   > tracking_events;
 
 private:
-  ClientRequest::PGPipeline &client_pp(PG &pg);
+  PGRepopPipeline &repop_pipeline(PG &pg);
 
   crimson::net::ConnectionRef l_conn;
   crimson::net::ConnectionXcoreRef r_conn;

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -388,20 +388,24 @@ SnapTrimObjSubEvent::remove_or_update(
 SnapTrimObjSubEvent::snap_trim_obj_subevent_ret_t
 SnapTrimObjSubEvent::start()
 {
+  obc_orderer = pg->obc_loader.get_obc_orderer(
+    coid);
+
   ceph_assert(pg->is_active_clean());
 
-  auto exit_handle = seastar::defer([this] {
-    logger().debug("{}: exit", *this);
-    handle.exit();
+  auto exit_handle = seastar::defer([this, opref = IRef(this)] {
+    logger().debug("{}: exit", *opref);
+    std::ignore = handle.complete().then([opref = std::move(opref)] {});
   });
 
   co_await enter_stage<interruptor>(
-    client_pp().check_already_complete_get_obc);
+    obc_orderer->obc_pp().process);
 
   logger().debug("{}: getting obc for {}", *this, coid);
 
 
   auto obc_manager = pg->obc_loader.get_obc_manager(
+    *obc_orderer,
     coid, false /* resolve_oid */);
 
   co_await pg->obc_loader.load_and_lock(
@@ -413,7 +417,6 @@ SnapTrimObjSubEvent::start()
 
   logger().debug("{}: got obc={}", *this, obc_manager.get_obc()->get_oid());
 
-  co_await enter_stage<interruptor>(client_pp().process);
   auto all_completed = interruptor::now();
   {
     // as with PG::submit_executer, we need to build the pg log entries
@@ -440,12 +443,11 @@ SnapTrimObjSubEvent::start()
     co_await std::move(submitted);
   }
 
-  co_await enter_stage<interruptor>(client_pp().wait_repop);
+  co_await enter_stage<interruptor>(obc_orderer->obc_pp().wait_repop);
 
   co_await std::move(all_completed);
 
   logger().debug("{}: completed", *this);
-  co_await interruptor::make_interruptible(handle.complete());
 }
 
 void SnapTrimObjSubEvent::print(std::ostream &lhs) const

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -112,10 +112,6 @@ public:
 private:
   object_stat_sum_t delta_stats;
 
-  ObjectContextLoader::load_obc_iertr::future<> process_and_submit(
-    ObjectContextRef head_obc,
-    ObjectContextRef clone_obc);
-
   snap_trim_obj_subevent_ret_t remove_clone(
     ObjectContextRef obc,
     ObjectContextRef head_obc,

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <seastar/core/future.hh>
 
+#include "crimson/osd/object_context_loader.h"
 #include "crimson/osd/osdmap_gate.h"
 #include "crimson/osd/osd_operation.h"
 #include "crimson/common/subop_blocker.h"
@@ -154,6 +155,7 @@ private:
   }
 
   Ref<PG> pg;
+  std::optional<ObjectContextLoader::Orderer> obc_orderer;
   PipelineHandle handle;
   osd_op_params_t osd_op_p;
   const hobject_t coid;
@@ -165,9 +167,8 @@ public:
 
   std::tuple<
     StartEvent,
-    CommonPGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent,
-    CommonPGPipeline::Process::BlockingEvent,
-    CommonPGPipeline::WaitRepop::BlockingEvent,
+    CommonOBCPipeline::Process::BlockingEvent,
+    CommonOBCPipeline::WaitRepop::BlockingEvent,
     CompletionEvent
   > tracking_events;
 };

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1175,22 +1175,8 @@ PG::submit_executer_fut PG::submit_executer(
   ).flush_changes_and_submit(
     ops,
     snap_mapper,
-    osdriver,
-    [FNAME, this](auto&& txn,
-		  auto&& obc,
-		  auto&& osd_op_p,
-		  auto&& log_entries,
-                  auto&& new_clone) {
-      DEBUGDPP("object {} submitting txn", *this, obc->get_oid());
-      mutate_object(obc, txn, osd_op_p);
-      return submit_transaction(
-	std::move(obc),
-        std::move(new_clone),
-	std::move(txn),
-	std::move(osd_op_p),
-	std::move(log_entries));
-    });
-
+    osdriver
+  );
   co_return std::make_tuple(
     std::move(submitted).then_interruptible([unlocker=std::move(unlocker)] {}),
     std::move(completed));

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1172,7 +1172,7 @@ PG::submit_executer_fut PG::submit_executer(
 
   auto [submitted, completed] = co_await std::move(
     ox
-  ).flush_changes_n_do_ops_effects(
+  ).flush_changes_and_submit(
     ops,
     snap_mapper,
     osdriver,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1354,13 +1354,13 @@ void PG::log_operation(
 
 void PG::replica_clear_repop_obc(
   const std::vector<pg_log_entry_t> &logv) {
-    logger().debug("{} clearing {} entries", __func__, logv.size());
-    for (auto &&e: logv) {
-      logger().debug(" {} get_object_boundary(from): {} "
-                     " head version(to): {}",
-                     e.soid,
-                     e.soid.get_object_boundary(),
-                     e.soid.get_head());
+  logger().debug("{} clearing {} entries", __func__, logv.size());
+  for (auto &&e: logv) {
+    logger().debug(" {} get_object_boundary(from): {} "
+		   " head version(to): {}",
+		   e.soid,
+		   e.soid.get_object_boundary(),
+		   e.soid.get_head());
     /* Have to blast all clones, they share a snapset */
     obc_registry.clear_range(
       e.soid.get_object_boundary(), e.soid.get_head());

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1039,8 +1039,9 @@ PG::interruptible_future<eversion_t> PG::submit_error_log(
   const std::error_code e,
   ceph_tid_t rep_tid)
 {
-  logger().debug("{}: {} rep_tid: {} error: {}",
-                 __func__, *m, rep_tid, e);
+  LOG_PREFIX(PG::submit_error_log);
+  DEBUGDPP("{} rep_tid: {} error: {}",
+	   *this, *m, rep_tid, e);
   const osd_reqid_t &reqid = m->get_reqid();
   mempool::osd_pglog::list<pg_log_entry_t> log_entries;
   log_entries.push_back(pg_log_entry_t(pg_log_entry_t::ERROR,
@@ -1080,9 +1081,8 @@ PG::interruptible_future<eversion_t> PG::submit_error_log(
       peering_state.get_pg_committed_to());
     waiting_on.insert(peer);
 
-    logger().debug("submit_error_log: sending log"
-		   "missing_request (rep_tid: {} entries: {})"
-		   " to osd {}", rep_tid, log_entries, peer.osd);
+    DEBUGDPP("sending log missing_request (rep_tid: {} entries: {}) to osd {}",
+	     *this, rep_tid, log_entries, peer.osd);
     co_await interruptor::make_interruptible(
       shard_services.send_to_osd(
 	peer.osd,
@@ -1090,7 +1090,7 @@ PG::interruptible_future<eversion_t> PG::submit_error_log(
 	get_osdmap_epoch()));
   }
   waiting_on.insert(pg_whoami);
-  logger().debug("submit_error_log: inserting rep_tid {}", rep_tid);
+  DEBUGDPP("inserting rep_tid {}", *this, rep_tid);
   log_entry_update_waiting_on.insert(
     std::make_pair(rep_tid,
 		   log_update_t{std::move(waiting_on)}));

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -78,6 +78,7 @@ class PG : public boost::intrusive_ref_counter<
   using cached_map_t = OSDMapService::cached_map_t;
 
   ClientRequest::PGPipeline request_pg_pipeline;
+  PGRepopPipeline repop_pipeline;
   PGPeeringPipeline peering_request_pg_pipeline;
 
   ClientRequest::Orderer client_request_orderer;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -676,6 +676,8 @@ private:
   struct do_osd_ops_params_t;
 
   interruptible_future<MURef<MOSDOpReply>> do_pg_ops(Ref<MOSDOp> m);
+
+public:
   interruptible_future<
     std::tuple<interruptible_future<>, interruptible_future<>>>
   submit_transaction(
@@ -684,6 +686,8 @@ private:
     ceph::os::Transaction&& txn,
     osd_op_params_t&& oop,
     std::vector<pg_log_entry_t>&& log_entries);
+
+private:
   interruptible_future<> repair_object(
     const hobject_t& oid,
     eversion_t& v);
@@ -892,10 +896,12 @@ private:
     const hobject_t &obj,
     const eversion_t &v,
     const std::vector<pg_shard_t> &peers);
+public:
   void mutate_object(
     ObjectContextRef& obc,
     ceph::os::Transaction& txn,
     osd_op_params_t& osd_op_p);
+private:
   bool can_discard_replica_op(const Message& m, epoch_t m_map_epoch) const;
   bool can_discard_op(const MOSDOp& m) const;
   void context_registry_on_change();

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -896,12 +896,6 @@ private:
     const hobject_t &obj,
     const eversion_t &v,
     const std::vector<pg_shard_t> &peers);
-public:
-  void mutate_object(
-    ObjectContextRef& obc,
-    ceph::os::Transaction& txn,
-    osd_op_params_t& osd_op_p);
-private:
   bool can_discard_replica_op(const Message& m, epoch_t m_map_epoch) const;
   bool can_discard_op(const MOSDOp& m) const;
   void context_registry_on_change();

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -663,6 +663,7 @@ private:
     const OpInfo &op_info,
     std::vector<OSDOp>& ops);
 
+  seastar::shared_mutex submit_lock;
   using submit_executer_ret = std::tuple<
     interruptible_future<>,
     interruptible_future<>>;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -77,7 +77,7 @@ class PG : public boost::intrusive_ref_counter<
   using ec_profile_t = std::map<std::string,std::string>;
   using cached_map_t = OSDMapService::cached_map_t;
 
-  ClientRequest::PGPipeline request_pg_pipeline;
+  CommonPGPipeline request_pg_pipeline;
   PGRepopPipeline repop_pipeline;
   PGPeeringPipeline peering_request_pg_pipeline;
 

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -308,11 +308,6 @@ public:
     ObjectState& os,
     const OSDOp& osd_op,
     ceph::os::Transaction& trans);
-  void clone(
-    /* const */object_info_t& snap_oi,
-    const ObjectState& os,
-    const ObjectState& d_os,
-    ceph::os::Transaction& trans);
   interruptible_future<struct stat> stat(
     CollectionRef c,
     const ghobject_t& oid) const;
@@ -411,6 +406,20 @@ public:
     ceph::os::Transaction& trans,
     osd_op_params_t& osd_op_params,
     object_stat_sum_t& delta_stats);
+
+  /// sets oi and (for head) ss attrs
+  void set_metadata(
+    const hobject_t &obj,
+    object_info_t &oi,
+    const SnapSet *ss /* non-null iff head */,
+    ceph::os::Transaction& trans);
+
+  /// clone from->to and clear ss attribute on to
+  void clone_for_write(
+    const hobject_t &from,
+    const hobject_t &to,
+    ceph::os::Transaction& trans);
+
   virtual rep_op_fut_t
   submit_transaction(const std::set<pg_shard_t> &pg_shards,
 		     const hobject_t& hoid,

--- a/src/test/common/test_intrusive_lru.cc
+++ b/src/test/common/test_intrusive_lru.cc
@@ -177,9 +177,9 @@ TEST(LRU, clear_range) {
   auto [live_ref2, existed2] = cache.add(5, 4);
   ASSERT_FALSE(existed2);
 
-  cache.clear_range(0,4);
+  cache.clear_range(0, 4, [](auto&){});
 
-  // Should not exists (Unreferenced):
+  // Should not exist
   {
     auto [ref, existed] = cache.add(1, 4);
     ASSERT_FALSE(existed);
@@ -192,21 +192,27 @@ TEST(LRU, clear_range) {
     auto [ref, existed] = cache.add(3, 4);
     ASSERT_FALSE(existed);
   }
-  // Should exist (Still being referenced):
   {
     auto [ref, existed] = cache.add(4, 4);
-    ASSERT_TRUE(existed);
+    ASSERT_FALSE(existed);
   }
-  // Should exists (Still being referenced and wasn't removed)
+  ASSERT_TRUE(live_ref1->is_invalidated());
+  // Should exist, wasn't removed)
   {
     auto [ref, existed] = cache.add(5, 4);
     ASSERT_TRUE(existed);
   }
-  // Test out of bound deletion:
+  ASSERT_FALSE(live_ref2->is_invalidated());
+  // Test clear_range with right bound past last entry
+  cache.clear_range(3, 8, [](auto&){});
+  ASSERT_TRUE(live_ref2->is_invalidated());
   {
-    cache.clear_range(3,8);
     auto [ref, existed] = cache.add(4, 4);
-    ASSERT_TRUE(existed);
+    ASSERT_FALSE(existed);
+  }
+  {
+    auto [ref, existed] = cache.add(5, 4);
+    ASSERT_FALSE(existed);
   }
   {
     auto [ref, existed] = cache.add(3, 4);


### PR DESCRIPTION
This PR reworks the client IO pipeline to allow one request per object to be processed concurrently.  Writes still need to serialize at submission time.

For random reads with high concurrency, this seems to be good for a ~8-10% throughput increase on a single OSD with seastore in my environment.  Further refinement may well improve things further, but this branch has gotten large as is.

Teuthology run looks good, all tests passed: https://pulpito.ceph.com/sjust-2024-12-06_21:24:24-crimson-rados-wip-sjust-crimson-testing-2024-12-06-distro-default-smithi/

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
