### PR TITLE
cephadm: orch upgrade status to return output according to the format specified

### DIFF
--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1069,6 +1069,39 @@ class UpgradeStatusSpec(object):
             'is_paused': self.is_paused,
         }
 
+    def to_dict(self) -> Dict:
+        out: Dict[str, Any] = {}
+        out['in_progress'] = self.in_progress
+        out['target_image'] = self.target_image
+        out['services_complete'] = self.services_complete
+        out['which'] = self.which
+        out['progress'] = self.progress
+        out['message'] = self.message
+        out['is_paused'] = self.is_paused
+        return out
+
+    @classmethod
+    def from_json(cls, data: dict) -> 'UpgradeStatusSpec':
+        if not isinstance(data, dict):
+            raise ValueError(f'Expected a dictionary, but got {type(data)}')
+        instance = cls()
+        instance.in_progress = data.get('in_progress', False)
+        instance.target_image = data.get('target_image', None)
+        instance.services_complete = data.get('services_complete', [])
+        instance.which = data.get('which', '<unknown>')
+        instance.progress = data.get('progress', None)
+        instance.message = data.get('message', "")
+        instance.is_paused = data.get('is_paused', False)
+
+        return instance
+
+    @staticmethod
+    def yaml_representer(dumper: 'yaml.Dumper', data: 'UpgradeStatusSpec') -> yaml.Node:
+        return dumper.represent_dict(cast(Mapping, data.to_json().items()))
+
+
+yaml.add_representer(UpgradeStatusSpec, UpgradeStatusSpec.yaml_representer)
+
 
 def handle_type_error(method: FuncT) -> FuncT:
     @wraps(method)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -49,6 +49,7 @@ from ._interface import (
     MgmtGatewaySpec,
     OAuth2ProxySpec,
     ServiceDescription,
+    UpgradeStatusSpec,
     TunedProfileSpec,
     _cli_read_command,
     _cli_write_command,
@@ -2367,21 +2368,24 @@ Usage:
         return HandleCommandResult(stdout=out)
 
     @_cli_write_command('orch upgrade status')
-    def _upgrade_status(self) -> HandleCommandResult:
+    def _upgrade_status(self, format: Optional[str] = None) -> HandleCommandResult:
         """Check the status of any potential ongoing upgrade operation"""
         completion = self.upgrade_status()
         status = raise_if_exception(completion)
-        r = {
-            'target_image': status.target_image,
-            'in_progress': status.in_progress,
-            'which': status.which,
-            'services_complete': status.services_complete,
-            'progress': status.progress,
-            'message': status.message,
-            'is_paused': status.is_paused,
-        }
-        out = json.dumps(r, indent=4)
-        if r.get('in_progress'):
+        upgrade_status = UpgradeStatusSpec()
+        upgrade_status.target_image = status.target_image
+        upgrade_status.in_progress = status.in_progress
+        upgrade_status.which = status.which
+        upgrade_status.services_complete = status.services_complete
+        upgrade_status.progress = status.progress
+        upgrade_status.message = status.message
+        upgrade_status.is_paused = status.is_paused
+        if format is not None:
+            format = Format(format)
+            out = to_format(upgrade_status, format, many=False, cls=UpgradeStatusSpec)
+        else:
+            out = json.dumps(upgrade_status.to_dict(), indent=4)
+        if upgrade_status.in_progress:
             return HandleCommandResult(stdout=out)
         return HandleCommandResult(stdout="There are no upgrades in progress currently.")
 


### PR DESCRIPTION
cephadm: orch upgrade status to return output according to the format specified

Fixes: https://tracker.ceph.com/issues/69122

Testing logs:
```
[ceph: root@ceph-node-0 ~]# ceph orch upgrade status
{
    "in_progress": false,
    "target_image": null,
    "services_complete": [],
    "which": "<unknown>",
    "progress": null,
    "message": "",
    "is_paused": false
}
[ceph: root@ceph-node-0 ~]# ceph orch upgrade status --format json

{"in_progress": false, "is_paused": false, "message": "", "progress": null, "services_complete": [], "target_image": null, "which": "<unknown>"}

[ceph: root@ceph-node-0 ~]# ceph orch upgrade status --format yaml
in_progress: false
target_image: null
which: <unknown>
services_complete: []
progress: null
message: ''
is_paused: false

```
```
> tox -e py39 -- cephadm     
================= 1243 passed, 1 skipped, 7 warnings in 294.03s (0:04:54) ===================================
  py39: OK (295.86=setup[0.07]+cmd[295.79] seconds)
  congratulations :) (295.93 seconds)
```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
