### PR TITLE
mgr/cephadm: Ceph orch apply command does not give error if 'placement' is passed as both positional and keyword argument

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1122,6 +1122,9 @@ def store_arg(desc: argdesc, args: Sequence[ValidatedArg], d: ValidatedArgs):
         # prefixes' values should be a space-joined concatenation
         d[desc.name] += ' ' + desc.instance.val
     else:
+        # did we already get this argument
+        if desc.name in d:
+            raise ArgumentError(f"Duplicate argument '{desc.name}' found.")
         # if first CephPrefix or any other type, just set it
         d[desc.name] = desc.instance.val
 


### PR DESCRIPTION
Ceph orch apply command does not give error if 'placement' is passed as both positional and keyword argument, It uses keyword argument value for configuration

Fixes: https://tracker.ceph.com/issues/69174
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph orch apply nfs mynfs --port 9090 nfs-ganesha-pool --placement='2'
Invalid command: Duplicate argument 'placement' found.
orch apply nfs <svc_id> [<placement>] [--format {plain|json|json-pretty|yaml|xml-pretty|xml}] [--port <int>] [--dry-run] [--unmanaged] [--no-overwrite] :  Scale an NFS service
Error EINVAL: invalid command
[ceph: root@ceph-node-0 /]# 


[ceph: root@ceph-node-0 /]# ceph orch apply nfs mynfs --port 9090 nfs-ganesha-pool                
Error EINVAL: Cannot place <NFSServiceSpec for service_name=nfs.mynfs> on nfs-ganesha-pool: Unknown hosts
[ceph: root@ceph-node-0 /]# 


[ceph: root@ceph-node-0 /]# ceph orch apply nfs mynfs --port 9090 --placement='2'
Scheduled nfs.mynfs update...
[ceph: root@ceph-node-0 /]# 

```



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
