### PR TITLE
test/objectstore: extend `#ifdef WITH_BLUESTORE`

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -199,6 +199,7 @@ protected:
   }
 };
 
+#ifdef WITH_BLUESTORE
 
 class MultiLabelTest : public StoreTestDeferredSetup {
   public:
@@ -273,6 +274,8 @@ class MultiLabelTest : public StoreTestDeferredSetup {
     StoreTest::TearDown();
   }
 };
+
+#endif // WITH_BLUESTORE
 
 class StoreTestSpecificAUSize : public StoreTestDeferredSetup {
 
@@ -7198,13 +7201,14 @@ INSTANTIATE_TEST_SUITE_P(
   StoreTestDeferredSetup,
   ::testing::Values(
     "bluestore"));
-#endif
 
 INSTANTIATE_TEST_SUITE_P(
   ObjectStore,
   MultiLabelTest,
   ::testing::Values(
     "bluestore"));
+
+#endif // WITH_BLUESTORE
 
 struct deferred_test_t {
   uint32_t bdev_block_size;
@@ -7218,6 +7222,8 @@ void PrintTo(const deferred_test_t& t, ::std::ostream* os)
   *os << t.bdev_block_size << "/" << t.min_alloc_size << "/"
       << t.max_blob_size << "/" << t.prefer_deferred_size;
 }
+
+#ifdef WITH_BLUESTORE
 
 class DeferredWriteTest : public StoreTestFixture,
 		          public ::testing::WithParamInterface<deferred_test_t> {
@@ -7309,7 +7315,6 @@ TEST_P(DeferredWriteTest, NewData) {
   }
 }
 
-#if defined(WITH_BLUESTORE)
 INSTANTIATE_TEST_SUITE_P(
   BlueStore,
   DeferredWriteTest,
@@ -10970,6 +10975,8 @@ TEST_P(StoreTest, mergeRegionTest) {
   }
 }
 
+#ifdef WITH_BLUESTORE
+
 TEST_P(MultiLabelTest, MultiSelectableOff) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "false");
   g_conf().apply_changes(nullptr);
@@ -11291,6 +11298,8 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithObjects) {
   ASSERT_NE(it, label.meta.end());
   ASSERT_EQ(label.meta["multi"], "yes");
 }
+
+#endif // WITH_BLUESTORE
 
 TEST_P(StoreTestSpecificAUSize, BluestoreEnforceHWSettingsHdd) {
   if (string(GetParam()) != "bluestore")


### PR DESCRIPTION
Cover all Bluestore specific code.  Fixes build failures with `WITH_BLUESTORE=no`.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
