### PR TITLE
squid: qa/rgw: bump keystone/barbican from 2023.1 to 2024.1

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -27,7 +27,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      force-branch: stable/2023.1
+      force-branch: stable/2024.1
       services:
         - name: swift
           type: object-store
@@ -68,7 +68,7 @@ tasks:
           project: s3
 - barbican:
     client.0:
-      force-branch: stable/2023.1
+      force-branch: stable/2024.1
       use-keystone-role: client.0
       keystone_authtoken:
         auth_plugin: password

--- a/qa/suites/rgw/tempest/0-install.yaml
+++ b/qa/suites/rgw/tempest/0-install.yaml
@@ -4,7 +4,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      force-branch: stable/2023.1
+      force-branch: stable/2024.1
       services:
         - name: swift
           type: object-store


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69181

---

backport of https://github.com/ceph/ceph/pull/60968
parent tracker: https://tracker.ceph.com/issues/69134

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh