### PR TITLE
ops_replayer: fix signed/unsigned warning and add parameter range checking.

### DIFF
--- a/src/test/objectstore/allocsim/ops_replayer.cc
+++ b/src/test/objectstore/allocsim/ops_replayer.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <functional>
 #include <boost/program_options/value_semantic.hpp>
 #include <cassert>
 #include <cctype>
@@ -23,6 +24,7 @@
 #include <string>
 #include <iostream>
 #include <vector>
+#include <format>
 
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/parsers.hpp>
@@ -32,6 +34,23 @@ namespace po = boost::program_options;
 
 using namespace std;
 using namespace ceph;
+
+namespace settings {
+
+// Returns a function which restricts a value to a specified range by throwing if it is not in range:
+// (Note: std::clamp() does not throw.)
+auto clamp_or_throw(auto min, auto max)
+{
+ return [=](auto& x) { 
+		if(std::less<>{}(x, min) or std::greater<>{}(x, max)) {
+		 throw std::out_of_range(std::format("value expected between {} and {}, but got {}", min, max, x));
+		}
+
+		return x;	
+ 	};
+}
+
+} // namespace settings
 
 // compare shared_ptr<string>
 struct StringPtrCompare
@@ -338,8 +357,8 @@ int main(int argc, char** argv) {
 
   // options
   uint64_t io_depth = 8;
-  uint64_t nparser_threads = 16;
-  uint64_t nworker_threads = 16;
+  int nparser_threads = 16;
+  int nworker_threads = 16;
   string file("input.txt");
   string ceph_conf_path("./ceph.conf");
   string pool("test_pool");
@@ -351,8 +370,8 @@ int main(int argc, char** argv) {
     ("input-files,i", po::value<vector<string>>()->multitoken(), "List of input files (output of op_scraper.py). Multiple files will be merged and sorted by time order")
     ("ceph-conf", po::value<string>(&ceph_conf_path)->default_value("ceph.conf"), "Path to ceph conf")
     ("io-depth", po::value<uint64_t>(&io_depth)->default_value(64), "I/O depth")
-    ("parser-threads", po::value<uint64_t>(&nparser_threads)->default_value(16), "Number of parser threads")
-    ("worker-threads", po::value<uint64_t>(&nworker_threads)->default_value(16), "Number of I/O worker threads")
+    ("parser-threads", po::value<int>(&nparser_threads)->default_value(16)->notifier(settings::clamp_or_throw(1, 256)), "Number of parser threads")
+    ("worker-threads", po::value<int>(&nworker_threads)->default_value(16)->notifier(settings::clamp_or_throw(1, 256)), "Number of I/O worker threads")
     ("pool", po::value<string>(&pool)->default_value("test_pool"), "Pool to use for I/O")
     ("skip-do-ops", po::bool_switch(&skip_do_ops)->default_value(false), "Skip doing operations")
     ;


### PR DESCRIPTION
ops_replayer

Fixes signedness warning and adds range checking to related worker thread parameters.

Signed-off-by: Jesse F. Williamson <1643380+chardan@users.noreply.github.com>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
