### PR TITLE
common/config: make `legacy_values` static

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -68,6 +68,20 @@ const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config,/etc/ceph/$cluster.conf,$
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
 
+// Populate list of legacy_values according to the OPTION() definitions
+// Note that this is just setting up our map of name->member ptr.  The
+// default values etc will get loaded in along with new-style data,
+// as all loads write to both the values map, and the legacy
+// members if present.
+const std::map<std::string_view, md_config_t::member_ptr_t> md_config_t::legacy_values = {
+#define OPTION(name, type) \
+  {STRINGIFY(name), &ConfigValues::name},
+#define SAFE_OPTION(name, type) OPTION(name, type)
+#include "options/legacy_config_opts.h"
+#undef OPTION
+#undef SAFE_OPTION
+};
+
 const char *ceph_conf_level_name(int level)
 {
   switch (level) {
@@ -169,20 +183,6 @@ md_config_t::md_config_t(ConfigValues& values,
   for (auto& opt : subsys_options) {
     schema.emplace(opt.name, opt);
   }
-
-  // Populate list of legacy_values according to the OPTION() definitions
-  // Note that this is just setting up our map of name->member ptr.  The
-  // default values etc will get loaded in along with new-style data,
-  // as all loads write to both the values map, and the legacy
-  // members if present.
-  legacy_values = {
-#define OPTION(name, type) \
-    {STRINGIFY(name), &ConfigValues::name},
-#define SAFE_OPTION(name, type) OPTION(name, type)
-#include "options/legacy_config_opts.h"
-#undef OPTION
-#undef SAFE_OPTION
-  };
 
   validate_schema();
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -91,7 +91,7 @@ public:
   /*
    * Mapping from legacy config option names to class members
    */
-  std::map<std::string_view, member_ptr_t> legacy_values;
+  static const std::map<std::string_view, member_ptr_t> legacy_values;
 
   /**
    * The configuration schema, in the form of Option objects describing


### PR DESCRIPTION
This field is `const` and we need only one global instance, and not one copy per `md_config_t` instance.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
