### PR TITLE
quincy: qa/tasks/nvme_loop: update task to work with new nvme list format

### DIFF
--- a/qa/tasks/nvme_loop.py
+++ b/qa/tasks/nvme_loop.py
@@ -66,7 +66,7 @@ def task(ctx, config):
             while proceed():
                 p = remote.run(args=['sudo', 'nvme', 'list', '-o', 'json'], stdout=StringIO())
                 new_devs = []
-                # `nvme list -o json` will return the following output:
+                # `nvme list -o json` will return one of the following output:
                 '''{
                      "Devices" : [
                        {
@@ -87,12 +87,110 @@ def task(ctx, config):
                        }
                      ]
                    }'''
+                '''{
+                  "Devices":[
+                    {
+                      "HostNQN":"nqn.2014-08.org.nvmexpress:uuid:00000000-0000-0000-0000-0cc47ada6ba4",
+                      "HostID":"898a0e10-da2d-4a42-8017-d9c445089d0c",
+                      "Subsystems":[
+                        {
+                          "Subsystem":"nvme-subsys0",
+                          "SubsystemNQN":"nqn.2014.08.org.nvmexpress:80868086CVFT623300LN400BGN  INTEL SSDPEDMD400G4",
+                          "Controllers":[
+                            {
+                              "Controller":"nvme0",
+                              "Cntlid":"0",
+                              "SerialNumber":"CVFT623300LN400BGN",
+                              "ModelNumber":"INTEL SSDPEDMD400G4",
+                              "Firmware":"8DV101H0",
+                              "Transport":"pcie",
+                              "Address":"0000:02:00.0",
+                              "Slot":"2",
+                              "Namespaces":[
+                                {
+                                  "NameSpace":"nvme0n1",
+                                  "Generic":"ng0n1",
+                                  "NSID":1,
+                                  "UsedBytes":400088457216,
+                                  "MaximumLBA":781422768,
+                                  "PhysicalSize":400088457216,
+                                  "SectorSize":512
+                                }
+                              ],
+                              "Paths":[
+                              ]
+                            }
+                          ],
+                          "Namespaces":[
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                '''
+                '''{
+                  "Devices":[
+                    {
+                      "HostNQN":"nqn.2014-08.org.nvmexpress:uuid:00000000-0000-0000-0000-0cc47ada6ba4",
+                      "HostID":"898a0e10-da2d-4a42-8017-d9c445089d0c",
+                      "Subsystems":[
+                        {
+                          "Subsystem":"nvme-subsys0",
+                          "SubsystemNQN":"nqn.2014.08.org.nvmexpress:80868086CVFT534400C2400BGN  INTEL SSDPEDMD400G4",
+                          "Controllers":[
+                            {
+                              "Controller":"nvme0",
+                              "Cntlid":"0",
+                              "SerialNumber":"CVFT534400C2400BGN",
+                              "ModelNumber":"INTEL SSDPEDMD400G4",
+                              "Firmware":"8DV101H0",
+                              "Transport":"pcie",
+                              "Address":"0000:02:00.0",
+                              "Slot":"2",
+                              "Namespaces":[
+                                {
+                                  "NameSpace":"nvme0n1",
+                                  "Generic":"ng0n1",
+                                  "NSID":1,
+                                  "UsedBytes":400088457216,
+                                  "MaximumLBA":781422768,
+                                  "PhysicalSize":400088457216,
+                                  "SectorSize":512
+                                }
+                              ],
+                              "Paths":[
+                              ]
+                            }
+                          ],
+                          "Namespaces":[
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                '''
                 nvme_list = json.loads(p.stdout.getvalue())
                 for device in nvme_list['Devices']:
-                    dev = device['DevicePath']
-                    vendor = device['ModelNumber']
-                    if dev.startswith('/dev/') and vendor == 'Linux':
-                        new_devs.append(dev)
+                    try:
+                        # first try format 1 / older format
+                        dev = device['DevicePath']
+                        vendor = device['ModelNumber']
+                        if dev.startswith('/dev/') and vendor == 'Linux':
+                            new_devs.append(dev)
+                    except KeyError:
+                        for subsystem in device['Subsystems']:
+                            # format 2
+                            if 'Namespaces' in subsystem and subsystem['Namespaces']:
+                                dev = '/dev/' + subsystem['Namespaces'][0]['NameSpace']
+                            # try format 3 last
+                            else:
+                                dev = '/dev/' + subsystem['Controllers'][0]['Namespaces'][0]['NameSpace']
+                            # vendor is the same for format 2 and 3
+                            vendor = subsystem['Controllers'][0]['ModelNumber']
+                            if vendor == 'Linux':
+                                new_devs.append(dev)
                 log.info(f'new_devs {new_devs}')
                 assert len(new_devs) <= len(devs)
                 if len(new_devs) == len(devs):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69185

---

backport of https://github.com/ceph/ceph/pull/60928
parent tracker: https://tracker.ceph.com/issues/69067

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh