### PR TITLE
test/fio: remove assign-only variable

### DIFF
--- a/src/test/fio/fio_librgw.cc
+++ b/src/test/fio/fio_librgw.cc
@@ -300,8 +300,6 @@ namespace {
  */
   static void fio_librgw_cleanup(struct thread_data *td)
   {
-    int r = 0;
-
     dprint(FD_IO, "fio_librgw_cleanup\n");
 
     /* cleanup specific data */
@@ -312,9 +310,9 @@ namespace {
       data->release_handles();
 
       if (data->bucket_fh) {
-	r = rgw_fh_rele(data->fs, data->bucket_fh, 0 /* flags */);
+	rgw_fh_rele(data->fs, data->bucket_fh, 0 /* flags */);
       }
-      r = rgw_umount(data->fs, RGW_UMOUNT_FLAG_NONE);
+      rgw_umount(data->fs, RGW_UMOUNT_FLAG_NONE);
       librgw_shutdown(data->rgw_h);
       td->io_ops_data = nullptr;
       delete data;


### PR DESCRIPTION
This variable in the unit test gets flagged by -Werror which is enabled by default when compiling the unit tests in a container based environment. Examining the code the warning appears correct and it ought to be OK to simply remove this variable.





## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Is a test

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
