### PR TITLE
os/bluestore: Make some unittest_bluefs runs lighter on jenkins

### DIFF
--- a/qa/suites/rados/objectstore/backends/ceph_test_bluefs.yaml
+++ b/qa/suites/rados/objectstore/backends/ceph_test_bluefs.yaml
@@ -1,0 +1,8 @@
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, client.0]
+tasks:
+- install:
+- exec:
+    client.0:
+      - mkdir $TESTDIR/ceph_test_bluefs && cd $TESTDIR/ceph_test_bluefs && ceph_test_bluefs --log-file $TESTDIR/archive/ceph_test_bluefs.log --debug-bluefs 5/20 --gtest_catch_exceptions=0
+      - rm -rf $TESTDIR/ceph_test_bluefs

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -591,6 +591,7 @@ if(NOT WIN32)
   ceph_snappy
   cls_lock
   ceph_test_objectstore
+  ceph_test_bluefs
   ceph_erasure_code_non_regression
   cython_modules
   crushtool

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -48,6 +48,18 @@ add_executable(unittest_rocksdb_option
 add_ceph_unittest(unittest_rocksdb_option)
 target_link_libraries(unittest_rocksdb_option global os ${BLKID_LIBRARIES})
 
+# ceph_test_bluefs (a clone of unittest_bluefs)
+add_executable(ceph_test_bluefs
+  test_bluefs.cc
+  )
+target_link_libraries(ceph_test_bluefs
+  os
+  global
+  ${UNITTEST_LIBS}
+  )
+install(TARGETS ceph_test_bluefs
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 if(WITH_EVENTTRACE)
   add_dependencies(os eventtrace_tp)
 endif()

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -23,6 +23,11 @@
 
 using namespace std;
 
+// some test should not be executed on jenkins make check
+#define SKIP_JENKINS() \
+  if (getenv("JENKINS_HOME") != nullptr) GTEST_SKIP_("test disabled on jenkins");
+
+
 std::unique_ptr<char[]> gen_buffer(uint64_t size)
 {
     std::unique_ptr<char[]> buffer = std::make_unique<char[]>(size);
@@ -174,6 +179,7 @@ TEST(BlueFS, small_appends) {
 }
 
 TEST(BlueFS, very_large_write) {
+  SKIP_JENKINS();
   // we'll write a ~5G file, so allocate more than that for the whole fs
   uint64_t size = 1048576 * 1024 * 6ull;
   TempBdev bdev{size};
@@ -248,6 +254,7 @@ TEST(BlueFS, very_large_write) {
 }
 
 TEST(BlueFS, very_large_write2) {
+  SKIP_JENKINS();
   // we'll write a ~5G file, so allocate more than that for the whole fs
   uint64_t size_full = 1048576 * 1024 * 6ull;
   uint64_t size = 1048576 * 1024 * 5ull;


### PR DESCRIPTION
The idea of this PR is to make it more lightweight for jenkins to run "very_large_write" tests.
Jenkins runner often crashes doing it.

It turned out that unittest_bluefs was clone into ceph_test_bluefs
1) unittest_bluefs is run on jenkins, with exclusion of "very_large_write" tests.
2) ceph_test_bluefs is now part of packaging and gets into builds. This one is run on teuthology, including "very_large_write" tests.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
