### PR TITLE
rgw/rgw_admin.cc : Make restore attrs readable in admin cli

### DIFF
--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8822,9 +8822,19 @@ next:
       } else if (iter->first == RGW_ATTR_SOURCE_ZONE) {
         handled = decode_dump<uint32_t>("source_zone", bl, formatter.get());
       } else if (iter->first == RGW_ATTR_RESTORE_EXPIRY_DATE) {
-        handled = decode_dump<utime_t>("restore_expiry_date", bl, formatter.get());
+        handled = decode_dump<ceph::real_time>("restore_expiry_date", bl, formatter.get());
       } else if (iter->first == RGW_ATTR_RESTORE_TIME) {
-        handled = decode_dump<utime_t>("restore_time", bl, formatter.get());
+        handled = decode_dump<ceph::real_time>("restore_time", bl, formatter.get());
+      } else if (iter->first == RGW_ATTR_RESTORE_TYPE) {
+        rgw::sal::RGWRestoreType rt;
+        decode(rt, bl);
+        formatter->dump_string("RestoreType", rgw::sal::rgw_restore_type_dump(rt));
+        handled = true;
+      } else if (iter->first == RGW_ATTR_RESTORE_STATUS) {
+        rgw::sal::RGWRestoreStatus rs;
+        decode(rs, bl);
+        formatter->dump_string("RestoreStatus", rgw::sal::rgw_restore_status_dump(rs));
+        handled = true;
       }
 
       if (!handled)
@@ -8840,6 +8850,8 @@ next:
       bufferlist& bl = iter->second;
       if (iter->first == RGW_ATTR_OBJ_REPLICATION_TIMESTAMP) {
         decode_dump<ceph::real_time>("user.rgw.replicated-at", bl, formatter.get());
+      } else if (iter->first == RGW_ATTR_RESTORE_TIME) {
+        decode_dump<ceph::real_time>("user.rgw.restore-at", bl, formatter.get());
       } else {
         dump_string(iter->first.c_str(), iter->second, formatter.get());
       }

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -415,4 +415,38 @@ int Object::range_to_ofs(uint64_t obj_size, int64_t &ofs, int64_t &end)
   }
   return 0;
 }
+
+
+std::string_view rgw_restore_status_dump(rgw::sal::RGWRestoreStatus status)
+{
+  switch (status)
+  {
+  case RGWRestoreStatus::None:
+    return "None";
+  case RGWRestoreStatus::RestoreAlreadyInProgress:
+    return "RestoreAlreadyInProgress";
+  case RGWRestoreStatus::CloudRestored:
+    return "CloudRestored";
+  case RGWRestoreStatus::RestoreFailed:
+    return "RestoreFailed";
+  default:
+    return "";
+  }
+}
+
+std::string_view rgw_restore_type_dump(rgw::sal::RGWRestoreType type)
+{
+  switch (type)
+  {
+  case RGWRestoreType::None:
+    return "None";
+  case RGWRestoreType::Temporary:
+    return "Temporary";
+  case RGWRestoreType::Permanent:
+    return "Permanent";
+  default:
+    return "";
+  }
+}
+
 } // namespace rgw::sal

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -160,6 +160,7 @@ enum RGWRestoreStatus : uint8_t {
   RestoreFailed = 3
 };
 
+std::string_view rgw_restore_status_dump(rgw::sal::RGWRestoreStatus status);
 
 enum class RGWRestoreType : uint8_t {
   None = 0,
@@ -167,6 +168,7 @@ enum class RGWRestoreType : uint8_t {
   Permanent = 2
 };
 
+std::string_view rgw_restore_type_dump(rgw::sal::RGWRestoreType type);
 
 // a simple streaming data processing abstraction
 /**


### PR DESCRIPTION
The restore attrs directly stored at the backend which make it difficult to understand via `radosgw-admin object stat` cli. Make it more human readable form.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
