### PR TITLE
squid: mgr/dashboard: add a custom warning message when enabling feature

### DIFF
--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -59,6 +59,13 @@ class PortAlreadyInUse(Exception):
     pass
 
 
+# helper function for showing a warning text in
+# the terminal
+class CLIWarning(str):
+    def __new__(cls, content: str) -> "CLIWarning":
+        return super().__new__(cls, f"WARNING: {content}")
+
+
 class CephfsConnectionException(Exception):
     def __init__(self, error_code: int, error_message: str):
         self.errno = error_code


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69195

---

backport of https://github.com/ceph/ceph/pull/60749
parent tracker: https://tracker.ceph.com/issues/68969

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh