### PR TITLE
mgr/module: Smb module check

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/smb.py
+++ b/src/pybind/mgr/dashboard/controllers/smb.py
@@ -15,7 +15,7 @@ from dashboard.exceptions import DashboardException
 
 from .. import mgr
 from ..security import Scope
-from . import APIDoc, APIRouter, ReadPermission, RESTController
+from . import APIDoc, APIRouter, Endpoint, ReadPermission, RESTController, UIRouter
 
 logger = logging.getLogger('controllers.smb')
 
@@ -184,3 +184,18 @@ class SMBShare(RESTController):
         resource['share_id'] = share_id
         resource['intent'] = Intent.REMOVED
         return mgr.remote('smb', 'apply_resources', json.dumps(resource)).one().to_simplified()
+
+
+@UIRouter('/smb')
+class SMBStatus(RESTController):
+    @EndpointDoc("Get SMB feature status")
+    @Endpoint()
+    @ReadPermission
+    def status(self):
+        status = {'available': False, 'message': None}
+        try:
+            mgr.remote('smb', 'show', ['ceph.smb.cluster'])
+            status['available'] = True
+        except (ImportError, RuntimeError):
+            status['message'] = 'SMB module is not enabled'
+        return status

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -433,7 +433,15 @@ const routes: Routes = [
           },
           {
             path: 'smb',
+            canActivateChild: [ModuleStatusGuardService],
             data: {
+              moduleStatusGuardConfig: {
+                uiApiPath: 'smb',
+                redirectTo: 'error',
+                header: 'SMB module is not enabled',
+                button_to_enable_module: 'smb',
+                navigate_to: 'cephfs/smb'
+              },
               breadcrumbs: 'File/SMB'
             },
             children: [{ path: '', component: SmbClusterListComponent }]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-details/mgr-module-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-details/mgr-module-details.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { MgrModuleDetailsComponent } from './mgr-module-details.component';
+import { ToastrModule } from 'ngx-toastr';
 
 describe('MgrModuleDetailsComponent', () => {
   let component: MgrModuleDetailsComponent;
@@ -11,7 +12,7 @@ describe('MgrModuleDetailsComponent', () => {
 
   configureTestBed({
     declarations: [MgrModuleDetailsComponent],
-    imports: [HttpClientTestingModule, SharedModule]
+    imports: [HttpClientTestingModule, SharedModule, ToastrModule.forRoot()]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.ts
@@ -57,7 +57,7 @@ export class SmbClusterListComponent extends ListWithDetails implements OnInit {
 
     this.smbClusters$ = this.subject$.pipe(
       switchMap(() =>
-        this.smbService.listClusters().pipe(
+        this.smbService.listClusters()?.pipe(
           catchError(() => {
             this.context.error();
             return of(null);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/error/error.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/error/error.component.html
@@ -59,9 +59,19 @@
 </ng-template>
 
 <ng-template #dashboardButton>
-  <div class="mt-4 text-center">
+  <div class="mt-4 text-center"
+       *ngIf="!buttonToEnableModule; else enableButton">
     <button class="btn btn-primary"
             [routerLink]="'/dashboard'"
             i18n>Go To Dashboard</button>
+  </div>
+</ng-template>
+
+<ng-template #enableButton>
+  <div class="mt-4 text-center"
+       *ngIf="buttonToEnableModule && !(buttonName && buttonRoute)">
+    <button class="btn btn-primary"
+            (click)="enableModule()"
+            i18n>Enable {{ buttonToEnableModule | upperFirst }} module</button>
   </div>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/error/error.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/error/error.component.ts
@@ -4,6 +4,7 @@ import { NavigationEnd, Router, RouterEvent } from '@angular/router';
 
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
+import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { DocService } from '~/app/shared/services/doc.service';
@@ -31,13 +32,16 @@ export class ErrorComponent implements OnDestroy, OnInit {
   secondaryButtonRoute: string;
   secondaryButtonName: string;
   secondaryButtonTitle: string;
+  buttonToEnableModule: string;
+  navigateTo: string;
   component: string;
 
   constructor(
     private router: Router,
     private docService: DocService,
     private http: HttpClient,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private mgrModuleService: MgrModuleService
   ) {}
 
   ngOnInit() {
@@ -87,6 +91,8 @@ export class ErrorComponent implements OnDestroy, OnInit {
       this.secondaryButtonRoute = history.state.secondary_button_route;
       this.secondaryButtonName = history.state.secondary_button_name;
       this.secondaryButtonTitle = history.state.secondary_button_title;
+      this.buttonToEnableModule = history.state.button_to_enable_module;
+      this.navigateTo = history.state.navigate_to;
       this.component = history.state.component;
       this.docUrl = this.docService.urlGenerator(this.section);
     } catch (error) {
@@ -98,5 +104,14 @@ export class ErrorComponent implements OnDestroy, OnInit {
     if (this.routerSubscription) {
       this.routerSubscription.unsubscribe();
     }
+  }
+
+  enableModule(): void {
+    this.mgrModuleService.updateModuleState(
+      this.buttonToEnableModule,
+      false,
+      null,
+      this.navigateTo
+    );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
@@ -1,15 +1,22 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { of as observableOf, throwError as observableThrowError } from 'rxjs';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { MgrModuleService } from './mgr-module.service';
+import { CdTableSelection } from '../models/cd-table-selection';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { MgrModuleListComponent } from '~/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component';
+import { ToastrModule } from 'ngx-toastr';
+import { SharedModule } from '../shared.module';
 
 describe('MgrModuleService', () => {
   let service: MgrModuleService;
   let httpTesting: HttpTestingController;
 
   configureTestBed({
-    imports: [HttpClientTestingModule],
+    declarations: [MgrModuleListComponent],
+    imports: [HttpClientTestingModule, SharedModule, ToastrModule.forRoot()],
     providers: [MgrModuleService]
   });
 
@@ -62,5 +69,82 @@ describe('MgrModuleService', () => {
     service.getOptions('foo').subscribe();
     const req = httpTesting.expectOne('api/mgr/module/foo/options');
     expect(req.request.method).toBe('GET');
+  });
+
+  describe('should update module state', () => {
+    let component: MgrModuleListComponent;
+    let notificationService: NotificationService;
+    let fixture: ComponentFixture<MgrModuleListComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MgrModuleListComponent);
+      component = fixture.componentInstance;
+      notificationService = TestBed.inject(NotificationService);
+
+      component.selection = new CdTableSelection();
+      spyOn(notificationService, 'suspendToasties');
+      spyOn(service.blockUI, 'start');
+      spyOn(service.blockUI, 'stop');
+    });
+
+    it('should enable module', fakeAsync(() => {
+      spyOn(service, 'enable').and.returnValue(observableThrowError('y'));
+      spyOn(service, 'list').and.returnValues(observableThrowError('z'), observableOf([]));
+      component.selection.add({
+        name: 'foo',
+        enabled: false,
+        always_on: false
+      });
+      const selected = component.selection.first();
+      service.updateModuleState(selected.name, selected.enabled);
+      tick(service.REFRESH_INTERVAL);
+      tick(service.REFRESH_INTERVAL);
+      expect(service.enable).toHaveBeenCalledWith('foo');
+      expect(service.list).toHaveBeenCalledTimes(2);
+      expect(notificationService.suspendToasties).toHaveBeenCalledTimes(2);
+      expect(service.blockUI.start).toHaveBeenCalled();
+      expect(service.blockUI.stop).toHaveBeenCalled();
+    }));
+
+    it('should disable module', fakeAsync(() => {
+      spyOn(service, 'disable').and.returnValue(observableThrowError('x'));
+      spyOn(service, 'list').and.returnValue(observableOf([]));
+      component.selection.add({
+        name: 'bar',
+        enabled: true,
+        always_on: false
+      });
+      const selected = component.selection.first();
+      service.updateModuleState(selected.name, selected.enabled);
+      tick(service.REFRESH_INTERVAL);
+      expect(service.disable).toHaveBeenCalledWith('bar');
+      expect(service.list).toHaveBeenCalledTimes(1);
+      expect(notificationService.suspendToasties).toHaveBeenCalledTimes(2);
+      expect(service.blockUI.start).toHaveBeenCalled();
+      expect(service.blockUI.stop).toHaveBeenCalled();
+    }));
+
+    it('should not disable module without selecting one', () => {
+      expect(component.getTableActionDisabledDesc()).toBeTruthy();
+    });
+
+    it('should not disable dashboard module', () => {
+      component.selection.selected = [
+        {
+          name: 'dashboard'
+        }
+      ];
+      expect(component.getTableActionDisabledDesc()).toBeTruthy();
+    });
+
+    it('should not disable an always-on module', () => {
+      component.selection.selected = [
+        {
+          name: 'bar',
+          always_on: true
+        }
+      ];
+      expect(component.getTableActionDisabledDesc()).toBe('This Manager module is always on.');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -9,6 +9,8 @@ import { of as observableOf, throwError } from 'rxjs';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { MgrModuleService } from '../api/mgr-module.service';
 import { ModuleStatusGuardService } from './module-status-guard.service';
+import { ToastrModule } from 'ngx-toastr';
+import { CdDatePipe } from '../pipes/cd-date.pipe';
 
 describe('ModuleStatusGuardService', () => {
   let service: ModuleStatusGuardService;
@@ -53,8 +55,12 @@ describe('ModuleStatusGuardService', () => {
   };
 
   configureTestBed({
-    imports: [RouterTestingModule.withRoutes(routes)],
-    providers: [ModuleStatusGuardService, { provide: HttpClient, useValue: fakeService }],
+    imports: [RouterTestingModule.withRoutes(routes), ToastrModule.forRoot()],
+    providers: [
+      ModuleStatusGuardService,
+      { provide: HttpClient, useValue: fakeService },
+      CdDatePipe
+    ],
     declarations: [FooComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.ts
@@ -86,6 +86,8 @@ export class ModuleStatusGuardService implements CanActivate, CanActivateChild {
               secondary_button_name: config.secondary_button_name,
               secondary_button_route: config.secondary_button_route,
               secondary_button_title: config.secondary_button_title,
+              button_to_enable_module: config.button_to_enable_module,
+              navigate_to: config.navigate_to,
               uiConfig: config.uiConfig,
               uiApiPath: config.uiApiPath,
               icon: Icons.wrench,


### PR DESCRIPTION
This PR intorduces the SMB module status check to check and display the missing smb module frontend page where is displayed a button to enable the smb module. As can be seen in the video below.
To do this, to two new options are added to the `error.component`; `button_to_enable_module` to add the button to enable the specified module in this variable, and also `navigate_to` which allows to redirect to the specifed path.

[screen-capture (35).webm](https://github.com/user-attachments/assets/f0b6b8c1-d14b-464e-82de-812b730a3297)

Fixes: https://tracker.ceph.com/issues/69202

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
