### PR TITLE
mgr/vol: allow disabling clone progress bar

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -312,6 +312,10 @@
   DeleteBucket will start returning 409 BucketNotEmpty errors until empty
   on all zones when sync policy is enabled.
 
+* CephFS: Printing of progress bars for clone jobs in the output of ``ceph
+  status`` command can now be enabled or disabled using the config option
+  ``mgr/volumes/disable_clone_progress_bars``.
+
 * RADOS: A performance botteneck in the balancer mgr module has been fixed.
   Related Tracker: https://tracker.ceph.com/issues/68657
 

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -1110,6 +1110,13 @@ following command.
 
    ceph config get mgr mgr/volumes/snapshot_clone_no_wait
 
+Configure whether the progress bars for the asynchronous clone jobs should be
+printed in the output of ``ceph status`` command:
+
+.. prompt:: bash #
+
+    ceph config set mgr/volumes/disable_clone_progress_bars true
+
 
 .. _subvol-pinning:
 

--- a/qa/suites/fs/volumes/tasks/volumes/test/clone-progress.yaml
+++ b/qa/suites/fs/volumes/tasks/volumes/test/clone-progress.yaml
@@ -4,3 +4,4 @@ tasks:
       modules:
         - tasks.cephfs.volumes.test_clone_stats.TestCloneProgressReporter
         - tasks.cephfs.volumes.test_clone_stats.TestOngoingClonesCounter
+        - tasks.cephfs.volumes.test_clone_stats.TestDisableCloneProgressBars

--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -326,12 +326,14 @@ class Cloner(AsyncJobs):
     this relies on a simple state machine (which mimics states from SubvolumeOpSm class) as
     the driver. file types supported are directories, symbolic links and regular files.
     """
-    def __init__(self, volume_client, tp_size, snapshot_clone_delay, clone_no_wait):
+    def __init__(self, volume_client, tp_size, snapshot_clone_delay, clone_no_wait,
+                 disable_clone_progress_bars):
         super(Cloner, self).__init__(volume_client, "cloner", tp_size)
 
         self.vc = volume_client
         self.snapshot_clone_delay = snapshot_clone_delay
         self.snapshot_clone_no_wait = clone_no_wait
+        self.disable_clone_progress_bars = disable_clone_progress_bars
         self.state_table = {
             SubvolumeStates.STATE_PENDING      : handle_clone_pending,
             SubvolumeStates.STATE_INPROGRESS   : handle_clone_in_progress,
@@ -348,6 +350,9 @@ class Cloner(AsyncJobs):
 
     def reconfigure_reject_clones(self, clone_no_wait):
         self.snapshot_clone_no_wait = clone_no_wait
+
+    def reconfigure_disable_clone_progress_bars(self, disable_clone_progress_bars):
+        self.disable_clone_progress_bars = disable_clone_progress_bars
 
     def is_clone_cancelable(self, clone_state):
         return not (SubvolumeOpSm.is_complete_state(clone_state) or SubvolumeOpSm.is_failed_state(clone_state))

--- a/src/pybind/mgr/volumes/fs/stats_util.py
+++ b/src/pybind/mgr/volumes/fs/stats_util.py
@@ -147,6 +147,11 @@ class CloneProgressReporter:
         self.ongoing_clones_count = 0
 
     def initiate_reporting(self):
+        if self.volclient.cloner.disable_clone_progress_bars:
+            log.debug('mgr/vol/disable_clone_progress_bars is true, not '
+                      'printing of clone progress bars.')
+            return
+
         if self.update_task.is_alive():
             log.info('progress reporting thread is already alive, not '
                      'initiating it again')
@@ -276,6 +281,12 @@ class CloneProgressReporter:
         '''
         clones = self._get_info_for_all_clones()
         if not clones:
+            self.finish()
+            return
+
+        if self.volclient.cloner.disable_clone_progress_bars:
+            log.debug('mgr/vol/disable_clone_progress_bars is true, clone '
+                      'progress bars won\'t be printed.')
             self.finish()
             return
 

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -64,7 +64,7 @@ class VolumeClient(CephfsClient["Module"]):
         # volume specification
         self.volspec = VolSpec(mgr.rados.conf_get('client_snapdir'))
         self.cloner = Cloner(self, self.mgr.max_concurrent_clones, self.mgr.snapshot_clone_delay,
-                             self.mgr.snapshot_clone_no_wait)
+                             self.mgr.snapshot_clone_no_wait, self.mgr.disable_clone_progress_bars)
         self.clone_progress_reporter = CloneProgressReporter(self,
                                                              self.volspec)
         self.purge_queue = ThreadPoolPurgeQueueMixin(self, 4)

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -669,7 +669,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'pause_cloning',
             type='bool',
             default=False,
-            desc='Pause asynchronous cloner threads')
+            desc='Pause asynchronous cloner threads'),
+        Option(
+            'disable_clone_progress_bars',
+            type='bool',
+            default=False,
+            desc=' Disable ongoing and ongoing+pending progress bars.')
     ]
 
     def __init__(self, *args, **kwargs):
@@ -681,6 +686,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         self.snapshot_clone_no_wait = None
         self.pause_purging = False
         self.pause_cloning = False
+        self.disable_clone_progress_bars = False
         self.lock = threading.Lock()
         super(Module, self).__init__(*args, **kwargs)
         # Initialize config option members
@@ -727,7 +733,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                             self.vc.cloner.pause()
                         else:
                             self.vc.cloner.resume()
-
+                    elif opt['name'] == "disable_clone_progress_bars":
+                        self.vc.cloner.reconfigure_disable_clone_progress_bars(self.disable_clone_progress_bars)
 
     def handle_command(self, inbuf, cmd):
         handler_name = "_cmd_" + cmd['prefix'].replace(" ", "_")


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67989


TODO:
[ ] Once PR #61046 is merged, "no ongoing clone left" progress bar message will be printed when disable_clone_progress_bars is set to True, since this PR calls CloneProgressReporter.finish() to disable progress bars. Modify this PR to modify CloneProgressReporter.finish() so that progress bars for ongoing and ongoing + pending clones are removed  without printing "no ongoing clones left" and "no ongoing or pending clones left" progress bars.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>