### PR TITLE
reef: rgw: fix bucket link operation

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -177,7 +177,8 @@ int RGWBucket::init(rgw::sal::Driver* _driver, RGWBucketAdminOpState& op_state,
 
   driver = _driver;
 
-  std::string bucket_name = op_state.get_bucket_name();
+  auto bucket_name = op_state.get_bucket_name();
+  auto bucket_id = op_state.get_bucket_id();
 
   if (bucket_name.empty() && op_state.get_user_id().empty())
     return -EINVAL;
@@ -192,7 +193,8 @@ int RGWBucket::init(rgw::sal::Driver* _driver, RGWBucketAdminOpState& op_state,
     bucket_name = bucket_name.substr(pos + 1);
   }
 
-  int r = driver->get_bucket(dpp, user.get(), tenant, bucket_name, &bucket, y);
+  int r = driver->get_bucket(dpp, user.get(), rgw_bucket(tenant, bucket_name, bucket_id),
+                              &bucket, y);
   if (r < 0) {
       set_err_msg(err_msg, "failed to fetch bucket info for bucket=" + bucket_name);
       return r;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69212

---

backport of https://github.com/ceph/ceph/pull/60845
parent tracker: https://tracker.ceph.com/issues/69060

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh