### PR TITLE
reef: qa/rgw: fix s3 java tests by forcing gradle to run on Java 8

### DIFF
--- a/qa/tasks/s3tests_java.py
+++ b/qa/tasks/s3tests_java.py
@@ -284,6 +284,7 @@ class S3tests_java(Task):
             args = ['cd',
                     '{tdir}/s3-tests-java'.format(tdir=testdir),
                     run.Raw('&&'),
+                    run.Raw('JAVA_HOME=$(alternatives --list | grep jre_1.8.0 | head -n 1 | awk \'{print $3}\')'),
                     '/opt/gradle/gradle/bin/gradle', 'clean', 'test',
                     '--rerun-tasks', '--no-build-cache',
                     ]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69211

---

backport of https://github.com/ceph/ceph/pull/61010
parent tracker: https://tracker.ceph.com/issues/69204

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh