### PR TITLE
quincy: doc/cephfs: edit first 3rd of mount-using-kernel-driver

### DIFF
--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -2,32 +2,32 @@
  Mount CephFS using Kernel Driver
 =================================
 
-The CephFS kernel driver is part of the Linux kernel. It allows mounting
-CephFS as a regular file system with native kernel performance. It is the
-client of choice for most use-cases.
+The CephFS kernel driver is part of the Linux kernel. It makes possible the
+mounting of CephFS as a regular file system with native kernel performance. It
+is the client of choice for most use-cases.
 
-.. note:: CephFS mount device string now uses a new (v2) syntax. The mount
-          helper (and the kernel) is backward compatible with the old syntax.
-          This means that the old syntax can still be used for mounting with
-          newer mount helpers and kernel. However, it is recommended to use
-          the new syntax whenever possible.
+.. note:: The CephFS mount device string now uses a new syntax ("v2"). The
+   mount helper is backward compatible with the old syntax. The kernel is
+   backward-compatible with the old syntax. This means that the old syntax can
+   still be used for mounting with newer mount helpers and with the kernel.
 
 Prerequisites
 =============
 
 Complete General Prerequisites
 ------------------------------
-Go through the prerequisites required by both, kernel as well as FUSE mounts,
-in `Mount CephFS: Prerequisites`_ page.
+Go through the prerequisites required by both kernel and FUSE mounts,
+as described on the `Mount CephFS: Prerequisites`_ page.
 
 Is mount helper present?
 ------------------------
-``mount.ceph`` helper is installed by Ceph packages. The helper passes the
+The ``mount.ceph`` helper is installed by Ceph packages. The helper passes the
 monitor address(es) and CephX user keyrings, saving the Ceph admin the effort
 of passing these details explicitly while mounting CephFS. If the helper is not
 present on the client machine, CephFS can still be mounted using the kernel
-driver, but only by passing these details explicitly to the ``mount`` command.
-To check whether ``mount.ceph`` is present on your system, run the following command:
+driver but only by passing these details explicitly to the ``mount`` command.
+To check whether ``mount.ceph`` is present on your system, run the following
+command:
 
 .. prompt:: bash #
 
@@ -36,23 +36,23 @@ To check whether ``mount.ceph`` is present on your system, run the following com
 Which Kernel Version?
 ---------------------
 
-Because the kernel client is distributed as part of the linux kernel (not
-as part of packaged ceph releases), you will need to consider which kernel
+Because the kernel client is distributed as part of the Linux kernel (and not
+as part of the packaged Ceph releases), you will need to consider which kernel
 version to use on your client nodes. Older kernels are known to include buggy
-ceph clients, and may not support features that more recent Ceph clusters
+Ceph clients and may not support features that more recent Ceph clusters
 support.
 
-Remember that the "latest" kernel in a stable linux distribution is likely
-to be years behind the latest upstream linux kernel where Ceph development
+Remember that the "latest" kernel in a stable Linux distribution is likely
+to be years behind the latest upstream Linux kernel where Ceph development
 takes place (including bug fixes).
 
 As a rough guide, as of Ceph 10.x (Jewel), you should be using a least a 4.x
 kernel. If you absolutely have to use an older kernel, you should use the
 fuse client instead of the kernel client.
 
-This advice does not apply if you are using a linux distribution that
-includes CephFS support, as in this case the distributor will be responsible
-for backporting fixes to their stable kernel: check with your vendor.
+This advice does not apply if you are using a Linux distribution that includes
+CephFS support. In that case, the distributor is responsible for backporting
+fixes to their stable kernel. Check with your vendor.
 
 Synopsis
 ========


### PR DESCRIPTION
Edit the first third of doc/cephfs/mount-using-kernel-driver.rst in preparation for correcting mount commands that may not work in Reef as described in this documentation.

This commit is a cherry-pick from a branch that targeted the Reef release branch. After some thought I realized that there was no reason that the Engliish grammar shouldn't be clean in this branch too.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 7fc0ead36cadb7a10e57c50b2064b71124c9e288)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
