### PR TITLE
quincy: doc/cephfs: edit 2nd 3rd of mount-using-kernel-driver

### DIFF
--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -56,50 +56,68 @@ for backporting fixes to their stable kernel: check with your vendor.
 
 Synopsis
 ========
-In general, the command to mount CephFS via kernel driver looks like this::
+This is the general form of the command for mounting CephFS via the kernel driver:
 
-  mount -t ceph {device-string}={path-to-mounted} {mount-point} -o {key-value-args} {other-args}
+.. prompt:: bash #
+
+   mount -t ceph {device-string}={path-to-mounted} {mount-point} -o {key-value-args} {other-args}
 
 Mounting CephFS
 ===============
-On Ceph clusters, CephX is enabled by default. Use ``mount`` command to
-mount CephFS with the kernel driver::
+CephX authentication is enabled by default in Ceph clusters. Use the ``mount``
+command to use the kernel driver to mount CephFS:
 
-  mkdir /mnt/mycephfs
-  mount -t ceph <name>@<fsid>.<fs_name>=/ /mnt/mycephfs
+.. prompt:: bash #
 
-``name`` is the username of the CephX user we are using to mount CephFS.
-``fsid`` is the FSID of the ceph cluster which can be found using
-``ceph fsid`` command. ``fs_name`` is the file system to mount. The kernel
-driver requires MON's socket and the secret key for the CephX user, e.g.::
+   mkdir /mnt/mycephfs
+   mount -t ceph <name>@<fsid>.<fs_name>=/ /mnt/mycephfs
 
-  mount -t ceph cephuser@b3acfc0d-575f-41d3-9c91-0e7ed3dbb3fa.cephfs=/ -o mon_addr=192.168.0.1:6789,secret=AQATSKdNGBnwLhAAnNDKnH65FmVKpXZJVasUeQ==
+#. ``name`` is the username of the CephX user we are using to mount CephFS.
+#. ``fsid`` is the FSID of the Ceph cluster, which can be found using the
+   ``ceph fsid`` command. ``fs_name`` is the file system to mount. The kernel
+   driver requires a ceph Monitor's address and the secret key of the CephX
+   user. For example:
 
-When using the mount helper, monitor hosts and FSID are optional. ``mount.ceph``
-helper figures out these details automatically by finding and reading ceph conf
-file, .e.g::
+   .. prompt:: bash #
 
-  mount -t ceph cephuser@.cephfs=/ -o secret=AQATSKdNGBnwLhAAnNDKnH65FmVKpXZJVasUeQ==
+      mount -t ceph cephuser@b3acfc0d-575f-41d3-9c91-0e7ed3dbb3fa.cephfs=/ -o mon_addr=192.168.0.1:6789,secret=AQATSKdNGBnwLhAAnNDKnH65FmVKpXZJVasUeQ==
 
-.. note:: Note that the dot (``.``) still needs to be a part of the device string.
+When using the mount helper, monitor hosts and FSID are optional. The
+``mount.ceph`` helper discovers these details by finding and reading the ceph
+conf file. For example:
 
-A potential problem with the above command is that the secret key is left in your
-shell's command history. To prevent that you can copy the secret key inside a file
-and pass the file by using the option ``secretfile`` instead of ``secret``::
+.. prompt:: bash #
 
-  mount -t ceph cephuser@.cephfs=/ /mnt/mycephfs -o secretfile=/etc/ceph/cephuser.secret
+   mount -t ceph cephuser@.cephfs=/ -o secret=AQATSKdNGBnwLhAAnNDKnH65FmVKpXZJVasUeQ==
 
-Ensure the permissions on the secret key file are appropriate (preferably, ``600``).
+.. note:: Note that the dot (``.`` in the string ``cephuser@.cephfs``) must  be
+   a part of the device string.
 
-Multiple monitor hosts can be passed by separating each address with a ``/``::
+A weakness of this method is that it will leave the secret key in your shell's
+command history. To avoid this, copy the secret key inside a file and pass the
+file by using the option ``secretfile`` instead of ``secret``. For example:
 
-  mount -t ceph cephuser@.cephfs=/ /mnt/mycephfs -o mon_addr=192.168.0.1:6789/192.168.0.2:6789,secretfile=/etc/ceph/cephuser.secret
+.. prompt:: bash #
 
-In case CephX is disabled, you can omit any credential related options::
+   mount -t ceph cephuser@.cephfs=/ /mnt/mycephfs -o secretfile=/etc/ceph/cephuser.secret
 
-  mount -t ceph cephuser@.cephfs=/ /mnt/mycephfs
+Ensure that the permissions on the secret key file are appropriate (preferably,
+``600``).
 
-.. note:: The ceph user name still needs to be passed as part of the device string.
+Multiple monitor hosts can be passed by separating addresses with a ``/``:
+
+.. prompt:: bash #
+
+   mount -t ceph cephuser@.cephfs=/ /mnt/mycephfs -o
+   mon_addr=192.168.0.1:6789/192.168.0.2:6789,secretfile=/etc/ceph/cephuser.secret
+
+If CephX is disabled, omit any credential-related options. For example:
+
+.. prompt:: bash #
+
+   mount -t ceph cephuser@.cephfs=/ /mnt/mycephfs
+
+.. note:: The Ceph user name must be passed as part of the device string.
 
 To mount a subtree of the CephFS root, append the path to the device string::
 


### PR DESCRIPTION
Edit the second third of doc/cephfs/mount-using-kernel-driver.rst in preparation for correcting mount commands that may not work in Reef as described in this documentation.

This commit edits only English-language strings in doc/cephfs/mount-using-kernel-driver.rst. No technical content (that is, no commands and no settings) have been altered in this commit.

Technical alterations to this file will be made only after the English is unambiguous.

Co-authored-by: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 0526124b60500f97f536060ba372d2753b936c9e)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
