### PR TITLE
squid: mon/LogMonitor: Use generic cluster log level config

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -104,6 +104,10 @@
   of POOL_APP_NOT_ENABLED health warning for that pool.
   The user might temporarily mute this warning using
   ``ceph health mute POOL_APP_NOT_ENABLED``.
+* The `mon_cluster_log_file_level` and `mon_cluster_log_to_syslog_level` options
+  have been removed. Henceforth, users should use the new generic option
+  `mon_cluster_log_level` to control the cluster log level verbosity for the cluster
+  log file as well as for all external entities.
 CephFS: Disallow delegating preallocated inode ranges to clients. Config
   `mds_client_delegate_inos_pct` defaults to 0 which disables async dirops
   in the kclient.

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1744,6 +1744,22 @@ function test_wait_for_peered() {
     teardown $dir || return 1
 }
 
+function wait_for_string() {
+    local logfile=$1
+    local searchstr=$2
+
+    status=1
+    for ((i=0; i < $TIMEOUT; i++)); do
+        echo $i
+        if ! grep "$searchstr" $logfile; then
+            sleep 1
+        else
+            status=0
+            break
+        fi
+    done
+    return $status
+}
 
 #######################################################################
 

--- a/qa/standalone/mon/mon-cluster-log.sh
+++ b/qa/standalone/mon/mon-cluster-log.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 Red Hat <contact@redhat.com>
+#
+# Author: Prashant D <pdhange@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7156" # git grep '\<7156\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_cluster_log_level() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+
+    ceph config set mon.a mon_cluster_log_level debug
+    ceph osd pool create replicated1 8 8
+    ceph osd pool set replicated1 size 1 --yes-i-really-mean-it
+    ceph osd pool set replicated1 min_size 1
+
+    WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
+    ERRORS=0
+    truncate $dir/log -s 0
+    ceph pg deep-scrub 1.0
+    search_str="cluster [[]DBG[]] 1.0 deep-scrub"
+    TIMEOUT=60 wait_for_string $dir/log "$search_str"
+    grep -q "$search_str" $dir/log
+    return_code=$?
+    if [ $return_code -ne 0 ]; then
+      echo "Failed : Could not find DBG log in the cluster log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph osd down 0
+    TIMEOUT=20 wait_for_osd up 0 || return 1
+    grep -q "cluster [[]INF[]] osd.0.*boot" $dir/log
+    return_code=$?
+    if [ $return_code -ne 0 ]; then
+      echo "Failed : Could not find INF log in the cluster log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph config set mon.a mon_cluster_log_level info
+    ceph pg deep-scrub 1.1
+    search_str="cluster [[]DBG[]] 1.1 deep-scrub"
+    TIMEOUT=60 wait_for_string $dir/log "$search_str"
+    grep -q "$search_str" $dir/log
+    return_code=$?
+    if [ $return_code -eq 0 ]; then
+      echo "Failed : Found DBG log in the cluster log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph config set mon.a mon_cluster_log_level warn
+    ceph osd set noup
+    ceph osd down osd.0
+    ceph osd unset noup
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    search_str="cluster [[]WRN[]] Health check failed: noup flag(s) set (OSDMAP_FLAGS)"
+    grep -q "$search_str" $dir/log
+    return_code=$?
+    if [ $return_code -ne 0 ]; then
+      echo "Failed : No WRN entries found in the cluster log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph osd out 0
+    ceph osd in 0
+    WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
+    search_str="cluster [[]INF[]] Client client.admin marked osd.0 out, while it was still marked up"
+    ceph log last 1000 | grep -q "$search_str" || return 1
+    TIMEOUT=60 wait_for_string $dir/log "$search_str"
+    grep -q "$search_str" $dir/log
+    return_code=$?
+    if [ $return_code -eq 0 ]; then
+      echo "Failed : Found INF log in the cluster log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    if [ $ERRORS -gt 0 ]; then
+        echo "TEST FAILED WITH $ERRORS ERRORS"
+        return 1
+    fi
+
+    echo "TEST PASSED"
+    return 0
+}
+
+function TEST_journald_cluster_log_level() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+
+    ceph config set mon.a mon_cluster_log_level debug
+    ceph osd pool create replicated1 8 8
+    ceph osd pool set replicated1 size 1 --yes-i-really-mean-it
+    ceph osd pool set replicated1 min_size 1
+
+    WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
+    ERRORS=0
+    ceph config set mon.a mon_cluster_log_to_journald true
+
+    ceph pg deep-scrub 1.0
+    search_str="1.0 deep-scrub"
+    TIMEOUT=60
+    sleep $TIMEOUT
+    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=7 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    grep -q "$search_str" $dir/journal.log
+    return_code=$?
+    if [ $return_code -ne 0 ]; then
+      echo "Failed : Could not find DBG log in the journalctl log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph osd down 0
+    TIMEOUT=20 wait_for_osd up 0 || return 1
+    search_str="osd.0.*boot"
+    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=6 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    grep -q "$search_str" $dir/journal.log
+    return_code=$?
+    if [ $return_code -ne 0 ]; then
+      echo "Failed : Could not find INF log in the journalctl log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph config set mon.a mon_cluster_log_level info
+    ceph pg deep-scrub 1.1
+    TIMEOUT=60
+    sleep $TIMEOUT
+    search_str="1.1 deep-scrub"
+    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=7 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    grep -q "$search_str" $dir/journal.log
+    return_code=$?
+    if [ $return_code -eq 0 ]; then
+      echo "Failed : Found $clog_entries DBG log entries in the journalctl log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph config set mon.a mon_cluster_log_level warn
+    ceph osd set noup
+    ceph osd down osd.0
+    ceph osd unset noup
+    TIMEOUT=60 wait_for_osd up 0 || return 1
+    search_str="Health check failed: noup flag(s) set (OSDMAP_FLAGS)"
+    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=4 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    grep -q "$search_str" $dir/journal.log
+    return_code=$?
+    if [ $return_code -ne 0 ]; then
+      echo "Failed : No WRN entries found in the journalctl log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    ceph osd out 0
+    ceph osd in 0
+    WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
+    search_str="Client client.admin marked osd.0 out, while it was still marked up"
+    ceph log last | grep -q "$search_str" || return 1
+    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=6 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    grep -q "$search_str" $dir/journal.log
+    return_code=$?
+    if [ $return_code -eq 0 ]; then
+      echo "Failed : Found $clog_entries INF log entries in the journalctl log file"
+      ERRORS=$(($ERRORS + 1))
+    fi
+
+    if [ $ERRORS -gt 0 ]; then
+        echo "TEST FAILED WITH $ERRORS ERRORS"
+        return 1
+    fi
+
+    echo "TEST PASSED"
+    return 0
+}
+
+main mon-cluster-log "$@"

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -121,18 +121,6 @@ options:
   flags:
   - runtime
   with_legacy: true
-- name: mon_cluster_log_to_syslog_level
-  type: str
-  level: advanced
-  desc: Syslog level for cluster log messages
-  default: info
-  services:
-  - mon
-  see_also:
-  - mon_cluster_log_to_syslog
-  flags:
-  - runtime
-  with_legacy: true
 - name: mon_cluster_log_to_syslog_facility
   type: str
   level: advanced
@@ -181,10 +169,12 @@ options:
   flags:
   - runtime
   with_legacy: true
-- name: mon_cluster_log_file_level
+- name: mon_cluster_log_level
   type: str
   level: advanced
-  desc: Lowest level to include is cluster log file
+  desc: Lowest level to include in cluster log file and/or in external log server
+  long_desc: Log level to control the cluster log message verbosity for the cluster
+    log file as well as for all external entities.
   default: debug
   services:
   - mon

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -57,11 +57,10 @@ private:
   struct log_channel_info {
 
     std::map<std::string,std::string> log_to_syslog;
-    std::map<std::string,std::string> syslog_level;
     std::map<std::string,std::string> syslog_facility;
     std::map<std::string,std::string> log_file;
     std::map<std::string,std::string> expanded_log_file;
-    std::map<std::string,std::string> log_file_level;
+    std::map<std::string,std::string> log_level;
     std::map<std::string,std::string> log_to_graylog;
     std::map<std::string,std::string> log_to_graylog_host;
     std::map<std::string,std::string> log_to_graylog_port;
@@ -84,9 +83,8 @@ private:
      */
     void expand_channel_meta() {
       expand_channel_meta(log_to_syslog);
-      expand_channel_meta(syslog_level);
       expand_channel_meta(syslog_facility);
-      expand_channel_meta(log_file_level);
+      expand_channel_meta(log_level);
     }
     void expand_channel_meta(std::map<std::string,std::string> &m);
     std::string expand_channel_meta(const std::string &input,
@@ -99,15 +97,10 @@ private:
                              &CLOG_CONFIG_DEFAULT_KEY);
     }
 
-    std::string get_level(const std::string &channel) {
-      return get_str_map_key(syslog_level, channel,
-                             &CLOG_CONFIG_DEFAULT_KEY);
-    }
-
     std::string get_log_file(const std::string &channel);
 
-    std::string get_log_file_level(const std::string &channel) {
-      return get_str_map_key(log_file_level, channel,
+    std::string get_log_level(const std::string &channel) {
+      return get_str_map_key(log_level, channel,
                              &CLOG_CONFIG_DEFAULT_KEY);
     }
 
@@ -192,10 +185,9 @@ private:
   const char **get_tracked_conf_keys() const override {
     static const char* KEYS[] = {
       "mon_cluster_log_to_syslog",
-      "mon_cluster_log_to_syslog_level",
       "mon_cluster_log_to_syslog_facility",
       "mon_cluster_log_file",
-      "mon_cluster_log_file_level",
+      "mon_cluster_log_level",
       "mon_cluster_log_to_graylog",
       "mon_cluster_log_to_graylog_host",
       "mon_cluster_log_to_graylog_port",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68690

---

backport of https://github.com/ceph/ceph/pull/47502
parent tracker: https://tracker.ceph.com/issues/57061

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh