### PR TITLE
doc/cephfs: edit 3rd 3rd of mount-using-kernel-driver

### DIFF
--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -129,29 +129,40 @@ Backward Compatibility
 ======================
 The old syntax is supported for backward compatibility.
 
-To mount CephFS with the kernel driver::
+To mount CephFS with the kernel driver, run the following commands:
 
-    mkdir /mnt/mycephfs
-    mount -t ceph :/ /mnt/mycephfs -o name=admin
+.. prompt:: bash #
 
-The key-value argument right after option ``-o`` is CephX credential;
-``name`` is the username of the CephX user we are using to mount CephFS.
+   mkdir /mnt/mycephfs
+   mount -t ceph :/ /mnt/mycephfs -o name=admin
 
-To mount a non-default FS ``cephfs2``, in case the cluster has multiple FSs::
+The key-value argument right after the option ``-o`` is the CephX credential.
+``name`` is the username of the CephX user that is mounting CephFS.
 
-    mount -t ceph :/ /mnt/mycephfs -o name=admin,fs=cephfs2
+To mount a non-default FS (in this example, ``cephfs2``), run commands of the following form. These commands are to be used in cases in which the cluster
+has multiple file systems:
 
-    or
+.. prompt:: bash #
 
-    mount -t ceph :/ /mnt/mycephfs -o name=admin,mds_namespace=cephfs2
+   mount -t ceph :/ /mnt/mycephfs -o name=admin,fs=cephfs2
 
-.. note:: The option ``mds_namespace`` is deprecated. Use ``fs=`` instead when using the old syntax for mounting.
+or
+
+.. prompt:: bash #
+
+   mount -t ceph :/ /mnt/mycephfs -o name=admin,mds_namespace=cephfs2
+
+.. note:: The option ``mds_namespace`` is deprecated. Use ``fs=`` instead when
+   using the old syntax for mounting.
 
 Unmounting CephFS
 =================
-To unmount the Ceph file system, use the ``umount`` command as usual::
+To unmount the Ceph file system, use the ``umount`` command, as in this
+example:
 
-    umount /mnt/mycephfs
+.. prompt:: bash #
+
+   umount /mnt/mycephfs
 
 .. tip:: Ensure that you are not within the file system directories before
    executing this command.
@@ -168,11 +179,12 @@ For example::
 
   cephuser@.cephfs=/     /mnt/ceph    ceph    mon_addr=192.168.0.1:6789,noatime,_netdev    0       0
 
-If the ``secret`` or ``secretfile`` options are not specified then the mount helper
-will attempt to find a secret for the given ``name`` in one of the configured keyrings.
+If the ``secret`` or ``secretfile`` options are not specified, the mount
+helper will attempt to find a secret for the given ``name`` in one of the
+configured keyrings.
 
-See `User Management`_ for details on CephX user management and mount.ceph_
-manual for more options it can take. For troubleshooting, see
+See `User Management`_ for details on CephX user management and the mount.ceph_
+manual for a list of the options it recognizes. For troubleshooting, see
 :ref:`kernel_mount_debugging`.
 
 .. _fstab: ../fstab/#kernel-driver


### PR DESCRIPTION
Edit the third third of doc/cephfs/mount-using-kernel-driver.rst in preparation for correcting mount commands that may not work in Reef as described in this documentation.

This commit edits only English-language strings in doc/cephfs/mount-using-kernel-driver.rst. No technical content (that is, no commands and no settings) have been altered in this commit.

Technical alterations to this file will be made only after the English is unambiguous.

This PR follows the following two PRs:
https://github.com/ceph/ceph/pull/61048 - 1st 3rd
https://github.com/ceph/ceph/pull/61049 - 2nd 3rd





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
