### PR TITLE
squid: librbd/migration/HttpClient: avoid reusing ssl_stream after shut down

### DIFF
--- a/qa/suites/rbd/migration/6-prepare/qcow2-https.yaml
+++ b/qa/suites/rbd/migration/6-prepare/qcow2-https.yaml
@@ -1,0 +1,8 @@
+tasks:
+  - exec:
+      client.0:
+        - mkdir /home/ubuntu/cephtest/migration
+        - qemu-img create -f qcow2 /home/ubuntu/cephtest/migration/empty.qcow2 1G
+        - echo '{"type":"qcow","stream":{"type":"http","url":"https://download.ceph.com/qa/ubuntu-12.04.qcow2"}}' | rbd migration prepare --import-only --source-spec-path - client.0.0
+        - rbd migration prepare --import-only --source-spec '{"type":"qcow","stream":{"type":"file","file_path":"/home/ubuntu/cephtest/migration/empty.qcow2"}}' client.0.1
+        - rbd migration prepare --import-only --source-spec '{"type":"qcow","stream":{"type":"file","file_path":"/home/ubuntu/cephtest/migration/empty.qcow2"}}' client.0.2

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -445,10 +445,10 @@ private:
         ldout(cct, 5) << "remote peer stream closed, retrying request" << dendl;
         m_receive_queue.push_front(work);
       } else if (ec == boost::beast::error::timeout) {
-        lderr(cct) << "timed-out while issuing request" << dendl;
+        lderr(cct) << "timed-out while receiving response" << dendl;
         work->complete(-ETIMEDOUT, {});
       } else {
-        lderr(cct) << "failed to issue request: " << ec.message() << dendl;
+        lderr(cct) << "failed to receive response: " << ec.message() << dendl;
         work->complete(-ec.value(), {});
       }
 
@@ -473,7 +473,7 @@ private:
       r = -EACCES;
     } else if (boost::beast::http::to_status_class(result) !=
                  boost::beast::http::status_class::successful) {
-      lderr(cct) << "failed to retrieve size: HTTP " << result << dendl;
+      lderr(cct) << "failed to retrieve resource: HTTP " << result << dendl;
       r = -EIO;
     }
 

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -229,7 +229,6 @@ private:
     auto cct = m_http_client->m_cct;
     ldout(cct, 15) << dendl;
 
-    shutdown_socket();
     m_resolver.async_resolve(
       m_http_client->m_url_spec.host, m_http_client->m_url_spec.port,
       [this, on_finish](boost::system::error_code ec, auto results) {
@@ -601,6 +600,7 @@ protected:
     auto cct = http_client->m_cct;
     ldout(cct, 15) << dendl;
 
+    ceph_assert(!m_stream.socket().is_open());
     m_stream.async_connect(
       results,
       [on_finish](boost::system::error_code ec, const auto& endpoint) {
@@ -645,6 +645,7 @@ protected:
     auto cct = http_client->m_cct;
     ldout(cct, 15) << dendl;
 
+    ceph_assert(!boost::beast::get_lowest_layer(m_stream).socket().is_open());
     boost::beast::get_lowest_layer(m_stream).async_connect(
       results,
       [this, on_finish](boost::system::error_code ec, const auto& endpoint) {

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -663,11 +663,6 @@ protected:
     auto cct = http_client->m_cct;
     ldout(cct, 15) << dendl;
 
-    if (!m_ssl_enabled) {
-      on_finish->complete(0);
-      return;
-    }
-
     m_stream.async_shutdown(
       asio::util::get_callback_adapter([this, on_finish](int r) {
         shutdown(r, on_finish); }));
@@ -686,7 +681,6 @@ protected:
 
 private:
   boost::beast::ssl_stream<boost::beast::tcp_stream> m_stream;
-  bool m_ssl_enabled = false;
 
   void handle_connect(int r, Context* on_finish) {
     auto http_client = this->m_http_client;
@@ -761,7 +755,6 @@ private:
       return;
     }
 
-    m_ssl_enabled = true;
     on_finish->complete(0);
   }
 

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -514,14 +514,17 @@ private:
         return;
       }
     } else if (current_state == STATE_SHUTTING_DOWN) {
+      ceph_assert(m_on_shutdown != nullptr);
       if (next_state == STATE_READY) {
         // shut down requested while connecting/resetting
         disconnect(new LambdaContext([this](int r) { handle_shut_down(r); }));
         return;
       } else if (next_state == STATE_UNINITIALIZED ||
-                 next_state == STATE_SHUTDOWN ||
                  next_state == STATE_RESET_CONNECTING) {
-        ceph_assert(m_on_shutdown != nullptr);
+        shutdown_socket();
+        m_on_shutdown->complete(r);
+        return;
+      } else if (next_state == STATE_SHUTDOWN) {
         m_on_shutdown->complete(r);
         return;
       }

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -63,14 +63,13 @@ public:
     m_on_shutdown = on_finish;
 
     auto current_state = m_state;
+    m_state = STATE_SHUTTING_DOWN;
+
     if (current_state == STATE_UNINITIALIZED) {
       // never initialized or resolve/connect failed
       on_finish->complete(0);
       return;
-    }
-
-    m_state = STATE_SHUTTING_DOWN;
-    if (current_state != STATE_READY) {
+    } else if (current_state != STATE_READY) {
       // delay shutdown until current state transition completes
       return;
     }
@@ -501,7 +500,10 @@ private:
                    << "next_state=" << next_state << ", "
                    << "r=" << r << dendl;
 
-    m_state = next_state;
+    if (current_state != STATE_SHUTTING_DOWN) {
+      m_state = next_state;
+    }
+
     if (current_state == STATE_CONNECTING) {
       if (next_state == STATE_UNINITIALIZED) {
         shutdown_socket();

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -118,7 +118,7 @@ public:
     ceph_assert(m_http_client->m_strand.running_in_this_thread());
 
     auto cct = m_http_client->m_cct;
-    ldout(cct, 20) << "work=" << work.get() << ", r=" << -ec.value() << dendl;
+    ldout(cct, 20) << "work=" << work.get() << ", ec=" << ec.what() << dendl;
 
     ceph_assert(m_in_flight_requests > 0);
     --m_in_flight_requests;
@@ -414,7 +414,7 @@ private:
   void handle_receive(boost::system::error_code ec,
                       std::shared_ptr<Work>&& work) {
     auto cct = m_http_client->m_cct;
-    ldout(cct, 15) << "work=" << work.get() << ", r=" << -ec.value() << dendl;
+    ldout(cct, 15) << "work=" << work.get() << ", ec=" << ec.what() << dendl;
 
     ceph_assert(m_in_flight_requests > 0);
     --m_in_flight_requests;

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -757,8 +757,7 @@ private:
     if (r < 0) {
       lderr(cct) << "failed to complete handshake: " << cpp_strerror(r)
                  << dendl;
-      disconnect(new LambdaContext([r, on_finish](int) {
-        on_finish->complete(r); }));
+      on_finish->complete(r);
       return;
     }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69243

---

backport of https://github.com/ceph/ceph/pull/61079
parent tracker: https://tracker.ceph.com/issues/69178