### PR TITLE
Containerfile: Add `libcephfs-daemon` package

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1187,7 +1187,6 @@ Obsoletes:	ceph-libs < %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	ceph-libcephfs < %{_epoch_prefix}%{version}-%{release}
 %endif
 Recommends: libcephfs-proxy2 = %{_epoch_prefix}%{version}-%{release}
-Requires:   libcephfs-daemon
 %description -n libcephfs2
 Ceph is a distributed network file system designed to provide excellent
 performance, reliability, and scalability. This is a shared library

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -128,6 +128,7 @@ ceph-volume \
 cephfs-mirror \
 cephfs-top \
 kmod \
+libcephfs-daemon \
 libradosstriper1 \
 rbd-mirror" \
 >> packages.txt


### PR DESCRIPTION
#58376 is merged and **libcephfs proxy** is now available with the development branch. We had a temporary change https://github.com/ceph/ceph/commit/517a3458af887defafa5e98481dc1f83a6fa1889 inside rpm spec file to get `libcephfs-daemon` installed within container builds. Given the nature of the package, it is not a strict requirement but would be preferable going forward. Replacing `Requires` with `Recommends` may not help in container build process where `--setopt=install_weak_deps=False` is commonly used. Therefore we specifically add `libcephfs-daemon` to the list of packages to be installed in containers.

Also see https://github.com/ceph/ceph-container/issues/2240.