### PR TITLE
rgw/posix: std::ignore return value of write()

### DIFF
--- a/src/rgw/driver/posix/notify.h
+++ b/src/rgw/driver/posix/notify.h
@@ -212,7 +212,7 @@ namespace file::listing {
 
     void signal_shutdown() {
       uint64_t msg{sig_shutdown};
-      (void) write(efd, &msg, sizeof(uint64_t));
+      std::ignore = write(efd, &msg, sizeof(uint64_t));
     }
 
     friend class Notify;


### PR DESCRIPTION
```
/ceph/src/rgw/driver/posix/notify.h: In member function 'void file::listing::Inotify::signal_shutdown()': /ceph/src/rgw/driver/posix/notify.h:215:19: error: ignoring return value of 'ssize_t write(int, const void*, size_t)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
  215 |       (void) write(efd, &msg, sizeof(uint64_t));
      |              ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```
Fixes: https://tracker.ceph.com/issues/69241

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
