### PR TITLE
squid: qa/suites/crimson-rados/perf: add ssh keys

### DIFF
--- a/qa/suites/crimson-rados/perf/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/perf/deploy/ceph.yaml
@@ -10,3 +10,4 @@ tasks:
       osd:
         debug monc: 20
     flavor: crimson
+- ssh_keys:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68972

---

backport of https://github.com/ceph/ceph/pull/60161
parent tracker: https://tracker.ceph.com/issues/68421

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh