### PR TITLE
squid: qa/standalone/scrub: fix TEST_periodic_scrub_replicated

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -5831,7 +5831,7 @@ function TEST_periodic_scrub_replicated() {
 
     flush_pg_stats
     # Request a regular scrub and it will be done
-    pg_schedule_scrub $pg
+    pg_scrub $pg
     grep -q "Regular scrub request, deep-scrub details will be lost" $dir/osd.${primary}.log || return 1
 
     # deep-scrub error is no longer present


### PR DESCRIPTION
A bogus change introduced as part of PR#54363 (commit fbb7d73) changed multiple 'scrub' commands to 'scheduled-scrub'. In this one instance - that was wrong.

Backport of https://github.com/ceph/ceph/pull/61115.

Original tracker: https://tracker.ceph.com/issues/69276
Backport tracker: https://tracker.ceph.com/issues/69279


Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit ca189fb511f18fc82c62702bf904201b6347395b)
