### PR TITLE
reef: qa/rgw: force Hadoop to run under Java 1.8

### DIFF
--- a/qa/tasks/s3a_hadoop.py
+++ b/qa/tasks/s3a_hadoop.py
@@ -204,6 +204,7 @@ def run_s3atest(client, maven_version, testdir, test_options):
             run.Raw('&&'),
             run.Raw(rm_test),
             run.Raw('&&'),
+            run.Raw('JAVA_HOME=$(alternatives --list | grep jre_1.8.0 | head -n 1 | awk \'{print $3}\')'),
             run.Raw(run_test),
             run.Raw(test_options)
         ]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69270

---

backport of https://github.com/ceph/ceph/pull/61106
parent tracker: https://tracker.ceph.com/issues/68992

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh