### PR TITLE
Revert "ops_replayer: fix signed/unsigned warning and add parameter range checking."

### DIFF
--- a/src/test/objectstore/allocsim/ops_replayer.cc
+++ b/src/test/objectstore/allocsim/ops_replayer.cc
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <functional>
 #include <boost/program_options/value_semantic.hpp>
 #include <cassert>
 #include <cctype>
@@ -24,7 +23,6 @@
 #include <string>
 #include <iostream>
 #include <vector>
-#include <format>
 
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/parsers.hpp>
@@ -34,23 +32,6 @@ namespace po = boost::program_options;
 
 using namespace std;
 using namespace ceph;
-
-namespace settings {
-
-// Returns a function which restricts a value to a specified range by throwing if it is not in range:
-// (Note: std::clamp() does not throw.)
-auto clamp_or_throw(auto min, auto max)
-{
- return [=](auto& x) { 
-		if(std::less<>{}(x, min) or std::greater<>{}(x, max)) {
-		 throw std::out_of_range(std::format("value expected between {} and {}, but got {}", min, max, x));
-		}
-
-		return x;	
- 	};
-}
-
-} // namespace settings
 
 // compare shared_ptr<string>
 struct StringPtrCompare
@@ -357,8 +338,8 @@ int main(int argc, char** argv) {
 
   // options
   uint64_t io_depth = 8;
-  int nparser_threads = 16;
-  int nworker_threads = 16;
+  uint64_t nparser_threads = 16;
+  uint64_t nworker_threads = 16;
   string file("input.txt");
   string ceph_conf_path("./ceph.conf");
   string pool("test_pool");
@@ -370,8 +351,8 @@ int main(int argc, char** argv) {
     ("input-files,i", po::value<vector<string>>()->multitoken(), "List of input files (output of op_scraper.py). Multiple files will be merged and sorted by time order")
     ("ceph-conf", po::value<string>(&ceph_conf_path)->default_value("ceph.conf"), "Path to ceph conf")
     ("io-depth", po::value<uint64_t>(&io_depth)->default_value(64), "I/O depth")
-    ("parser-threads", po::value<int>(&nparser_threads)->default_value(16)->notifier(settings::clamp_or_throw(1, 256)), "Number of parser threads")
-    ("worker-threads", po::value<int>(&nworker_threads)->default_value(16)->notifier(settings::clamp_or_throw(1, 256)), "Number of I/O worker threads")
+    ("parser-threads", po::value<uint64_t>(&nparser_threads)->default_value(16), "Number of parser threads")
+    ("worker-threads", po::value<uint64_t>(&nworker_threads)->default_value(16), "Number of I/O worker threads")
     ("pool", po::value<string>(&pool)->default_value("test_pool"), "Pool to use for I/O")
     ("skip-do-ops", po::bool_switch(&skip_do_ops)->default_value(false), "Skip doing operations")
     ;


### PR DESCRIPTION
Reverts ceph/ceph#61024

from build log https://jenkins.ceph.com/job/ceph-dev-new-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos9,DIST=centos9,MACHINE_SIZE=gigantic/85258//consoleFull
```
src/test/objectstore/allocsim/ops_replayer.cc:46:47: error: ‘format’ is not a member of ‘std’; did you mean ‘fmt::v11::format’?
   46 |                  throw std::out_of_range(std::format("value expected between {} and {}, but got {}", min, max, x));
      |                                               ^~~~~~
In file included from src/test/objectstore/allocsim/ops_replayer.cc:20:
src/fmt/include/fmt/format.h:4376:13: note: ‘fmt::v11::format’ declared here
 4376 | inline auto format(const Locale& loc, format_string<T...> fmt, T&&... args)
      |             ^~~~~~
```