### PR TITLE
MonClient: Add auxiliary connections and enhance quorum handling

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1375,6 +1375,13 @@ options:
   desc: Hexdump message to debug log on message send
   default: false
   with_legacy: true
+- name: ms_inject_drop_mon_forward_msgs
+  type: float
+  level: dev
+  desc: Inject drop of forwarded mon messages with given probability (0=disabled, 1=drop all)
+  default: 0
+  min: 0
+  max: 1
 - name: ms_dump_corrupt_message_level
   type: int
   level: advanced
@@ -2310,6 +2317,13 @@ options:
   level: advanced
   default: 3
   with_legacy: true
+# how many mons connections are we keeping in the aux list
+- name: mon_aux_list_connections
+  type: uint
+  level: advanced
+  default: 0
+  min: 0
+  with_legacy: false
 - name: mon_client_target_rank
   type: int
   level: advanced

--- a/src/messages/MMonSubscribe.h
+++ b/src/messages/MMonSubscribe.h
@@ -39,6 +39,10 @@ public:
   std::map<std::string, ceph_mon_subscribe_item> what;
 
   MMonSubscribe() : Message{CEPH_MSG_MON_SUBSCRIBE, HEAD_VERSION, COMPAT_VERSION} { }
+  MMonSubscribe(std::string hname, std::map<std::string, ceph_mon_subscribe_item> w)
+    : Message{CEPH_MSG_MON_SUBSCRIBE, HEAD_VERSION, COMPAT_VERSION},
+      hostname(std::move(hname)), what(std::move(w)) {
+  }
 private:
   ~MMonSubscribe() final {}
 

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -549,9 +549,16 @@ void Elector::ping_check(int peer)
   utime_t now = ceph_clock_now();
   utime_t& acked_ping = peer_acked_ping[peer];
   utime_t& newest_ping = peer_sent_ping[peer];
-  if (!acked_ping.is_zero() && acked_ping < now - ping_timeout) {
-    dout(20) << "peer " << peer << " has not acked a ping in "
-       << now - acked_ping << " seconds" << dendl;
+  utime_t timeout_adjusted;
+  timeout_adjusted.set_from_double(ping_timeout);  // Convert seconds to utime_t
+  dout(20) << __func__ << " peer: " << peer << " now: " << now
+    << " acked_ping: " << acked_ping << " newest_ping: " << newest_ping
+    << " ping_timeout: " << ping_timeout << " now - ping_timeout: "
+    << now - timeout_adjusted << dendl;
+  if (!acked_ping.is_zero() && acked_ping < now - timeout_adjusted) {
+    dout(20) << __func__ << " peer " << peer << " didn't acked ping for "
+      << ping_timeout << " seconds" << dendl;
+    mon->check_quorum_subs_and_send_updates();
     peer_tracker.report_dead_connection(peer, now - acked_ping);
     acked_ping = now;
     begin_dead_ping(peer);
@@ -580,7 +587,8 @@ void Elector::ping_check(int peer)
 
 void Elector::begin_dead_ping(int peer)
 {
-  dout(20) << __func__ << " to peer " << peer << dendl;  
+  dout(20) << __func__ << " to peer " << peer << " current dead_pinging: "
+    << dead_pinging << dendl;
   if (dead_pinging.count(peer)) {
     dout(20) << peer << " already in dead_pinging ... return" << dendl;
     return;

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -22,6 +22,7 @@
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm_ext/copy_n.hpp>
+#include "common/admin_finisher.h"
 #include "common/weighted_shuffle.h"
 
 #include "include/random.h"
@@ -30,7 +31,6 @@
 
 #include "messages/MMonGetMap.h"
 #include "messages/MMonGetVersion.h"
-#include "messages/MMonGetMap.h"
 #include "messages/MMonGetVersionReply.h"
 #include "messages/MMonMap.h"
 #include "messages/MConfig.h"
@@ -71,6 +71,7 @@ using namespace std::literals;
 MonClient::MonClient(CephContext *cct_, boost::asio::io_context& service) :
   Dispatcher(cct_),
   AuthServer(cct_),
+  quorum(cct_),
   messenger(NULL),
   timer(cct_, monc_lock),
   service(service),
@@ -275,7 +276,9 @@ int MonClient::ping_monitor(const string &mon_id, string *result_reply)
   ldout(cct, 10) << __func__ << " ping mon." << new_mon_id
                  << " " << con->get_peer_addr() << dendl;
 
-  pinger->mc.reset(new MonConnection(cct, con, 0, &auth_registry));
+  pinger->mc.reset(new MonConnection(
+    cct, con, 0, 
+    &auth_registry, new_mon_id));
   pinger->mc->start(monmap.get_epoch(), entity_name);
   con->send_message(new MPing);
 
@@ -329,14 +332,35 @@ bool MonClient::ms_dispatch(Message *m)
     if (_hunting()) {
       auto p = _find_pending_con(m->get_connection());
       if (p == pending_cons.end()) {
-	// ignore any messages outside hunting sessions
-	ldout(cct, 10) << "discarding stray monitor message " << *m << dendl;
-	m->put();
-	return true;
+        if (active_con && active_con->get_con() != m->get_connection()
+          && (m->get_type() == CEPH_MSG_MON_MAP)) {
+          if (std::ranges::any_of(aux_list, [&con = m->get_connection()](const auto& p) {
+                return p.second.is_con(con.get());
+              })) {
+            // don't ignore aux connections monmaps quorums
+            ldout(cct, 10) << __func__ << " not ignoring aux connection monmap " << *m << dendl;
+            handle_quorum_not_active(static_cast<MMonMap*>(m));
+            m->put();
+            return true;
+          }
+        }
+        // ignore any messages outside hunting sessions
+        ldout(cct, 10) << "1 discarding stray monitor message " << *m << " "
+          << m->get_connection()->get_peer_addr()
+          << " pending size " << pending_cons.size()
+          << " aux size " << aux_list.size() << dendl;
+        m->put();
+        return true;
       }
     } else if (!active_con || active_con->get_con() != m->get_connection()) {
-      // ignore any messages outside our session(s)
-      ldout(cct, 10) << "discarding stray monitor message " << *m << dendl;
+      // ignore any messages outside our session(s) unless it's a quorum message
+      if (m->get_type() == CEPH_MSG_MON_MAP) {
+        handle_quorum_not_active(static_cast<MMonMap*>(m));
+        m->put();
+        return true;
+      }
+      ldout(cct, 10) << "2 discarding stray monitor message " << *m << " "
+           << m->get_connection()->get_peer_addr() << dendl;
       m->put();
       return true;
     }
@@ -408,6 +432,23 @@ void MonClient::flush_log()
   send_log();
 }
 
+void MonClient::handle_quorum_not_active(MMonMap *m) {
+  auto con_addrs = m->get_source_addrs();
+  auto mon_name = monmap.get_name(con_addrs);
+
+  const auto old_epoch = monmap.get_epoch();
+  if (old_epoch == 0 || old_epoch < m->monmap_epoch) {
+    auto p = m->monmapbl.cbegin();
+    decode(monmap, p);
+  }
+  ldout(cct, 10) << __func__ << " handle_monmap - quorum is "
+    << m->quorum << " from mon."
+    << mon_name << dendl;
+  if (m->get_header().version >= 2) {
+    quorum.add_quorum(con_addrs, m->monmap_epoch, m->quorum);
+  }
+}
+
 /* Unlike all the other message-handling functions, we don't put away a reference
 * because we want to support MMonMap passthrough to other Dispatchers. */
 void MonClient::handle_monmap(MMonMap *m)
@@ -416,17 +457,24 @@ void MonClient::handle_monmap(MMonMap *m)
   auto con_addrs = m->get_source_addrs();
   string old_name = monmap.get_name(con_addrs);
   const auto old_epoch = monmap.get_epoch();
+  if (old_epoch == 0 || old_epoch < m->monmap_epoch) {
+    auto p = m->monmapbl.cbegin();
+    decode(monmap, p);
+  }
 
-  auto p = m->monmapbl.cbegin();
-  decode(monmap, p);
-
-  ldout(cct, 10) << " got monmap " << monmap.epoch
-		 << " from mon." << old_name
-		 << " (according to old e" << monmap.get_epoch() << ")"
- 		 << dendl;
+  ldout(cct, 10) << __func__ << " got monmap " << monmap.epoch
+		<< " from mon." << old_name
+		<< " (according to old e" << monmap.get_epoch() << ")"
+    << " quorum is " << m->quorum
+    << " active con " << (active_con ? active_con->get_con() : nullptr)
+    << " from con " << m->get_connection() << dendl;
   ldout(cct, 10) << "dump:\n";
   monmap.print(*_dout);
   *_dout << dendl;
+  auto mon_name = monmap.get_name(con_addrs);
+  if (m->get_header().version >= 2) {
+    quorum.add_quorum(monmap.get_addrs(mon_name), monmap.epoch, m->quorum);
+  }
 
   if (old_epoch != monmap.get_epoch()) {
     tried.clear();
@@ -448,6 +496,11 @@ void MonClient::handle_monmap(MMonMap *m)
 		   << monmap.get_addrs(new_name) << " but i'm connected to "
 		   << con_addrs << ", reconnecting" << dendl;
       _reopen_session();
+    } else if (active_con && !quorum.in_quorum(monmap.get_rank(active_con->get_con()->get_peer_addr()))) {
+      ldout(cct, 10) << "mon." << old_name << " at " << con_addrs
+         << " is no longer in quorum, agreed_quorum: " << quorum.get_agreed_quorum()
+         << " reopening session." << dendl;
+      return _reopen_session();
     }
   }
 
@@ -561,6 +614,7 @@ void MonClient::shutdown()
 
   active_con.reset();
   pending_cons.clear();
+  aux_list.clear();
 
   auth.reset();
   global_id = 0;
@@ -582,7 +636,7 @@ int MonClient::authenticate(double timeout)
   std::unique_lock lock{monc_lock};
 
   if (active_con) {
-    ldout(cct, 5) << "already authenticated" << dendl;
+    ldout(cct, 5) << __func__ << " : already authenticated" << dendl;
     return 0;
   }
   sub.want("monmap", monmap.get_epoch() ? monmap.get_epoch() + 1 : 0, 0);
@@ -593,12 +647,12 @@ int MonClient::authenticate(double timeout)
   auto until = ceph::mono_clock::now();
   until += ceph::make_timespan(timeout);
   if (timeout > 0.0)
-    ldout(cct, 10) << "authenticate will time out at " << until << dendl;
+    ldout(cct, 10) << __func__ << " will time out at " << until << dendl;
   while (!active_con && authenticate_err >= 0) {
     if (timeout > 0.0) {
       auto r = auth_cond.wait_until(lock, until);
       if (r == std::cv_status::timeout && !active_con) {
-	ldout(cct, 0) << "authenticate timed out after " << timeout << dendl;
+	ldout(cct, 0) << __func__ << " timed out after " << timeout << dendl;
 	authenticate_err = -ETIMEDOUT;
       }
     } else {
@@ -661,7 +715,7 @@ void MonClient::handle_auth(MAuthReply *m)
 				  CEPH_ENTITY_TYPE_MON,
 				  rotating_secrets.get());
 	(void)ret; // we don't care
-	break;
+        break;
       }
     }
     m->put();
@@ -669,6 +723,11 @@ void MonClient::handle_auth(MAuthReply *m)
   }
 
   if (!_hunting()) {
+    ldout(cct, 20) << __func__ << " not hunting, ignoring stray auth reply "
+       << m->get_connection()->get_peer_addr() 
+       << " exist active connection: " << active_con->get_con()->get_peer_addr()
+       << dendl;
+
     std::swap(active_con->get_auth(), auth);
     int ret = active_con->authenticate(m);
     m->put();
@@ -680,6 +739,8 @@ void MonClient::handle_auth(MAuthReply *m)
     if (ret != -EAGAIN) {
       _finish_auth(ret);
     }
+    ldout(cct, 20) << __func__ << " done - active connection: " 
+      << active_con->get_con()->get_peer_addr() << dendl;
     return;
   }
 
@@ -687,7 +748,7 @@ void MonClient::handle_auth(MAuthReply *m)
   auto found = _find_pending_con(m->get_connection());
   ceph_assert(found != pending_cons.end());
   int auth_err = found->second.handle_auth(m, entity_name, want_keys,
-					   rotating_secrets.get());
+                                  rotating_secrets.get());
   m->put();
   if (auth_err == -EAGAIN) {
     return;
@@ -703,7 +764,17 @@ void MonClient::handle_auth(MAuthReply *m)
     auto& mc = found->second;
     ceph_assert(mc.have_session());
     active_con.reset(new MonConnection(std::move(mc)));
-    pending_cons.clear();
+    pending_cons.erase(found);
+    auto keep = cct->_conf.get_val<uint64_t>("mon_aux_list_connections");
+    for (auto it_other = pending_cons.begin(); it_other != pending_cons.end(); ) {
+      if (aux_list.size() < keep) {
+        _add_aux_connection(it_other->first, std::make_unique<MonConnection>(std::move(it_other->second)));
+      }
+      it_other = pending_cons.erase(it_other);
+    }
+    for (auto& c : aux_list) {
+      c.second.send_subscribe(monmap.get_epoch());
+    }
   }
 
   _finish_hunting(auth_err);
@@ -757,6 +828,7 @@ void MonClient::_reopen_session(int rank)
 
   active_con.reset();
   pending_cons.clear();
+  aux_list.clear();
 
   authenticate_err = 1;  // == in progress
 
@@ -798,7 +870,8 @@ void MonClient::_add_conn(unsigned rank)
 {
   auto peer = monmap.get_addrs(rank);
   auto conn = messenger->connect_to_mon(peer);
-  MonConnection mc(cct, conn, global_id, &auth_registry);
+  MonConnection mc(cct, conn, global_id, &auth_registry,
+    monmap.get_name(rank));
   if (auth) {
     mc.get_auth().reset(auth->clone());
   }
@@ -812,20 +885,24 @@ void MonClient::_add_conn(unsigned rank)
 void MonClient::_add_conns()
 {
   // collect the next batch of candidates who are listed right next to the ones
-  // already tried
-  auto get_next_batch = [this]() -> std::vector<unsigned> {
+  // already tried and are in the quorum.
+  ldout(cct, 20) << __func__ << " quorum agreed:" << quorum.get_agreed_quorum()
+     << " tried:" << tried << " quorums:" << quorum.get_quorums() << dendl;
+  auto get_next_batch = [this](bool filter_by_quorum = true) -> std::vector<unsigned> {
     std::multimap<uint16_t, unsigned> ranks_by_priority;
     boost::copy(
       monmap.mon_info | boost::adaptors::filtered(
-        [this](auto& info) {
+        [this, filter_by_quorum](auto& info) {
           auto rank = monmap.get_rank(info.first);
-          return tried.count(rank) == 0;
+          return tried.count(rank) == 0 &&
+            (!filter_by_quorum || quorum.empty() || quorum.in_quorum(rank));
         }) | boost::adaptors::transformed(
           [this](auto& info) {
             auto rank = monmap.get_rank(info.first);
             return std::make_pair(info.second.priority, rank);
           }), std::inserter(ranks_by_priority, end(ranks_by_priority)));
     if (ranks_by_priority.empty()) {
+      ldout(cct, 10) << __func__ << " no more monitors to try" << dendl;
       return {};
     }
     // only choose the monitors with lowest priority
@@ -839,7 +916,7 @@ void MonClient::_add_conns()
   auto ranks = get_next_batch();
   if (ranks.empty()) {
     tried.clear();  // start over
-    ranks = get_next_batch();
+    ranks = get_next_batch(/*filter_by_quorum=*/false);
   }
   ceph_assert(!ranks.empty());
   if (ranks.size() > 1) {
@@ -905,6 +982,7 @@ bool MonClient::ms_handle_reset(Connection *con)
     } else {
       ldout(cct, 10) << "ms_handle_reset stray mon " << con->get_peer_addrs()
 		     << dendl;
+      aux_list.erase(con->get_peer_addrs());
       return true;
     }
   }
@@ -1004,6 +1082,13 @@ void MonClient::tick()
 	_renew_subs();
       }
     }
+    auto cur_rank = monmap.get_rank(cur_con->get_peer_addr());
+    if (!quorum.in_quorum(cur_rank)) {
+      ldout(cct, 10) << "mon out of quorum, reopening session."
+                    << " cur_rank: " << cur_rank
+                    << " agreed_quorum: " << quorum.get_agreed_quorum() << dendl;
+      return _reopen_session();
+    }
 
     if (now > last_keepalive + cct->_conf->mon_client_ping_interval) {
       cur_con->send_keepalive();
@@ -1028,6 +1113,7 @@ void MonClient::tick()
       last_send_log = now;
     }
   }
+  ldout(cct, 10) << "tick done" << dendl;
 }
 
 void MonClient::_un_backoff()
@@ -1236,7 +1322,7 @@ void MonClient::_send_command(MonCommand *r)
       }
 
       r->target_session.reset(new MonConnection(cct, r->target_con, 0,
-						&auth_registry));
+						&auth_registry, r->target_name));
       r->target_session->start(monmap.get_epoch(), entity_name);
       r->last_send_attempt = ceph_clock_now();
 
@@ -1532,7 +1618,7 @@ int MonClient::get_auth_request(
     if (con->is_anon()) {
       for (auto& i : mon_commands) {
 	if (i.second->target_con == con) {
-	  return i.second->target_session->get_auth_request(
+    return i.second->target_session->get_auth_request(
 	    auth_method, preferred_modes, bl,
 	    entity_name, want_keys, rotating_secrets.get());
 	}
@@ -1543,6 +1629,13 @@ int MonClient::get_auth_request(
 	return i.second.get_auth_request(
 	  auth_method, preferred_modes, bl,
 	  entity_name, want_keys, rotating_secrets.get());
+      }
+    }
+    for (auto& i : aux_list) {
+      if (i.second.is_con(con)) {
+        return i.second.get_auth_request(
+          auth_method, preferred_modes, bl,
+          entity_name, want_keys, rotating_secrets.get());
       }
     }
     return -ENOENT;
@@ -1594,6 +1687,11 @@ int MonClient::handle_auth_reply_more(
 	return i.second.handle_auth_reply_more(auth_meta, bl, reply);
       }
     }
+    for (auto& i : aux_list) {
+      if (i.second.is_con(con)) {
+        return i.second.handle_auth_reply_more(auth_meta, bl, reply);
+      }
+    }
     return -ENOENT;
   }
 
@@ -1633,42 +1731,102 @@ int MonClient::handle_auth_done(
 	}
       }
     }
-    for (auto& i : pending_cons) {
-      if (i.second.is_con(con)) {
-	int r = i.second.handle_auth_done(
-	  auth_meta, global_id, bl,
-	  session_key, connection_secret);
-	if (r) {
-	  pending_cons.erase(i.first);
-	  if (!pending_cons.empty()) {
-	    return r;
-	  }
-	} else {
-	  active_con.reset(new MonConnection(std::move(i.second)));
-	  pending_cons.clear();
-	  ceph_assert(active_con->have_session());
-	}
+    for (auto it = pending_cons.begin(); it != pending_cons.end(); ) {
+      if (it->second.is_con(con)) {
+        int r = it->second.handle_auth_done(
+          auth_meta, global_id, bl,
+          session_key, connection_secret);
 
-	_finish_hunting(r);
-	if (r || monmap.get_epoch() > 0) {
-	  _finish_auth(r);
-	}
-	return r;
+        if (r == 0) { // success
+          if (!active_con) { // we have winner for this active_con
+            active_con.reset(new MonConnection(std::move(it->second)));
+            it = pending_cons.erase(it);
+            auto keep = cct->_conf.get_val<uint64_t>("mon_aux_list_connections");
+            for (auto it_other = pending_cons.begin(); it_other != pending_cons.end(); ) {
+              if (aux_list.size() < keep) {
+                _add_aux_connection(it_other->first,
+                  std::make_unique<MonConnection>(std::move(it_other->second)));
+              }
+              it_other = pending_cons.erase(it_other);
+            }
+
+            // now that pending_cons is empty, we can making _hunting() false
+            _finish_hunting(0);
+            if (monmap.get_epoch() > 0) {
+              _finish_auth(0);
+            }
+
+            // Start background subs for everyone
+            for (auto& c : aux_list) {
+              c.second.send_subscribe(monmap.get_epoch());
+            }
+            ldout(cct, 10) << __func__ << " hunting success, active mon."
+                        << monmap.get_name(active_con->get_con()->get_peer_addr())
+                        << " addr " << active_con->get_con()->get_peer_addr() 
+                        << " aux connections: " << aux_list.size()
+                        << dendl;
+            return 0;
+          } else {
+            // active con already exists, so add this one to the aux list if we have room
+            auto keep = cct->_conf.get_val<uint64_t>("mon_aux_list_connections");
+            if (aux_list.size() < keep) {
+              ldout(cct, 10) << __func__ << " adding extra aux connection for "
+                          << monmap.get_name(it->second.get_con()->get_peer_addr())
+                          << " addr " << it->second.get_con()->get_peer_addr() 
+                          << " aux connections: " << aux_list.size()
+                          << dendl;
+              _add_aux_connection(it->first,
+                std::make_unique<MonConnection>(std::move(it->second)));
+              aux_list.at(it->first).send_subscribe(monmap.get_epoch());
+            }
+            it = pending_cons.erase(it);
+            return 0;
+          }
+        } else {
+          // r != 0 means this con failed auth, so remove it from pending_cons and try the next one
+          it = pending_cons.erase(it);
+          if (pending_cons.empty() && !active_con) {
+            ldout(cct, 10) << __func__ << " hunting failed, no more pending cons" << dendl;
+            _finish_hunting(r);
+            _finish_auth(r);
+          }
+          return r;
+        }
+      } else {
+        it++;
       }
     }
+
+    // Handle Auxiliary Connections (Updates to background sessions)
+    for (auto& i : aux_list) {
+      if (i.second.is_con(con)) {
+        auto key = i.first;
+        int r = i.second.handle_auth_done(
+          auth_meta, global_id, bl,
+          session_key, connection_secret);
+        if (r) {
+          aux_list.erase(key);
+        }
+        return r;
+      }
+    }
+    
+    // If it's a monitor but not found in any list
     return -ENOENT;
+    
   } else {
-    // verify authorizer reply
+    // Handling for Non-Monitor connections (e.g., Authorizer replies)
     auto p = bl.begin();
     if (!auth_meta->authorizer->verify_reply(p, &auth_meta->connection_secret)) {
-      ldout(cct, 0) << __func__ << " failed verifying authorizer reply"
-		    << dendl;
+      ldout(cct, 0) << __func__ << " failed verifying authorizer reply" << dendl;
       return -EACCES;
     }
+    ldout(cct, 10) << __func__ << " authorizer reply verified" << dendl;
     auth_meta->session_key = auth_meta->authorizer->session_key;
     return 0;
   }
 }
+
 
 int MonClient::handle_auth_bad_method(
   Connection *con,
@@ -1824,8 +1982,8 @@ AuthAuthorizer* MonClient::build_authorizer(int service_id) const {
 
 MonConnection::MonConnection(
   CephContext *cct, ConnectionRef con, uint64_t global_id,
-  AuthRegistry *ar)
-  : cct(cct), con(con), global_id(global_id), auth_registry(ar)
+  AuthRegistry *ar, std::string name)
+  : cct(cct), con(con), global_id(global_id), auth_registry(ar), mon_name(name)
 {}
 
 MonConnection::~MonConnection()
@@ -2100,6 +2258,44 @@ int MonConnection::authenticate(MAuthReply *m)
   }
 
   return ret;
+}
+
+void MonClientQuorum::recalc_agreed_quorum() {
+  ceph_assert(ceph_mutex_is_locked(quorum_lock));
+  if (quorums.empty()) {
+    agreed_quorum.clear();
+    return;
+  }
+  auto it = quorums.begin();
+  const std::set<int>& initial_ranks = it->second.second;
+  bool all_agree = std::all_of(
+    std::next(it), quorums.end(),
+    [&initial_ranks](const auto& entry) {
+      return entry.second.second == initial_ranks;
+    });
+
+  if (all_agree) {
+    agreed_quorum = initial_ranks;
+  } else {
+    std::set<int> intersection = initial_ranks;
+    for (const auto& entry : quorums) {
+      std::set<int> tmp;
+      std::set_intersection(
+        intersection.begin(), intersection.end(),
+        entry.second.second.begin(), entry.second.second.end(),
+        std::inserter(tmp, tmp.begin()));
+      intersection.swap(tmp);
+      if (intersection.empty()) break;
+    }
+    agreed_quorum = intersection;
+  }
+}
+
+
+void AuxConnection::send_subscribe(epoch_t start_epoch) {
+  sub.want("monmap", start_epoch, 0);
+  conn_ptr->get_con()->send_message2(
+    ceph::make_message<MMonSubscribe>(ceph_get_short_hostname(), sub.get_subs()));
 }
 
 void MonClient::register_config_callback(md_config_t::config_callback fn) {

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -32,6 +32,7 @@
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/post.hpp>
 
+#include "include/types.h"
 #include "msg/Messenger.h"
 
 #include "MonMap.h"
@@ -45,13 +46,13 @@
 
 #include "auth/AuthClient.h"
 #include "auth/AuthServer.h"
+#include "auth/AuthClientHandler.h"
 
 class MMonMap;
 class MConfig;
 class MMonGetVersionReply;
 class MMonCommandAck;
 class LogClient;
-class AuthClientHandler;
 class AuthRegistry;
 class KeyRing;
 class RotatingKeyRing;
@@ -61,7 +62,8 @@ public:
   MonConnection(CephContext *cct,
 		ConnectionRef conn,
 		uint64_t global_id,
-		AuthRegistry *auth_registry);
+		AuthRegistry *auth_registry,
+                std::string mon_name);
   ~MonConnection();
   MonConnection(MonConnection&& rhs) = default;
   MonConnection& operator=(MonConnection&&) = default;
@@ -83,6 +85,10 @@ public:
   }
   std::unique_ptr<AuthClientHandler>& get_auth() {
     return auth;
+  }
+
+  std::string get_mon_name() const {
+    return mon_name;
   }
 
   int get_auth_request(
@@ -145,8 +151,59 @@ private:
   MessageRef pending_tell_command;
 
   AuthRegistry *auth_registry;
+  std::string mon_name;
 };
 
+class MonClientQuorum {
+private:
+  CephContext *cct;
+  std::set<int> agreed_quorum;
+  mutable ceph::mutex quorum_lock = ceph::make_mutex("MonClientQuorum");
+  std::map<entity_addrvec_t, std::pair<version_t, std::set<int>>> quorums;
+
+  void recalc_agreed_quorum();
+
+public:
+
+  MonClientQuorum(CephContext *cct_ = nullptr) : cct(cct_) {}
+
+  void set_cct(CephContext *cct_) { cct = cct_; }
+
+  bool in_quorum(const int rank) const {
+    std::lock_guard l{quorum_lock};
+    // first time connection
+    if (quorums.empty()) {
+      return true;
+    }
+    return agreed_quorum.count(rank) > 0;
+  }
+  bool empty() const {
+    std::lock_guard l{quorum_lock};
+    return quorums.empty();
+  }
+  void add_quorum(const entity_addrvec_t& addrs,
+      const version_t epoch,
+      const std::set<int>& quorum) {
+    std::lock_guard l{quorum_lock};
+    if (quorum.empty()) {
+      quorums.erase(addrs);
+      recalc_agreed_quorum();
+      return;
+    }
+    quorums[addrs] = std::make_pair(epoch, quorum);
+    recalc_agreed_quorum();
+  }
+
+  std::set<int> get_agreed_quorum() const {
+    std::lock_guard l{quorum_lock};
+    return agreed_quorum;
+  }
+
+  std::map<entity_addrvec_t, std::pair<version_t, std::set<int>>> get_quorums() const {
+    std::lock_guard l{quorum_lock};
+    return quorums;
+  }
+};
 
 struct MonClientPinger : public Dispatcher,
 			 public AuthClient {
@@ -248,6 +305,71 @@ struct MonClientPinger : public Dispatcher,
   }
 };
 
+enum class ConnectionStatus {
+  UNKNOWN,          // Initial state
+  HEALTHY,          // Responding and in quorum
+  OUT_OF_QUORUM,    // Responding but not in quorum
+  UNRESPONSIVE      // Not responding
+};
+
+// Class for individual auxiliary connections
+class AuxConnection {
+public:
+  AuxConnection(const std::string& name, std::unique_ptr<MonConnection> connection_ptr)
+    : mon_name(name), conn_ptr(std::move(connection_ptr)), status(ConnectionStatus::UNKNOWN) {}
+
+  AuxConnection(AuxConnection&&) = default;
+  AuxConnection& operator=(AuxConnection&&) = default;
+  AuxConnection(const AuxConnection&) = delete;
+  AuxConnection& operator=(const AuxConnection&) = delete;
+
+  void set_status(ConnectionStatus new_status) { status = new_status; }
+
+  bool is_con(Connection *c) const {
+    return conn_ptr->is_con(c);
+  }
+
+  int handle_auth_done(
+    AuthConnectionMeta *auth_meta,
+    uint64_t global_id,
+    const ceph::buffer::list& bl,
+    CryptoKey *session_key,
+    std::string *connection_secret) {
+    return conn_ptr->handle_auth_done(auth_meta, global_id, bl, session_key, connection_secret);
+  }
+
+  int get_auth_request(
+    uint32_t *method,
+    std::vector<uint32_t> *preferred_modes,
+    ceph::buffer::list *out,
+    const EntityName& entity_name,
+    uint32_t want_keys,
+    RotatingKeyRing* keyring) {
+    return conn_ptr->get_auth_request(method, preferred_modes, out, entity_name, want_keys, keyring);
+  }
+
+  int handle_auth_reply_more(
+    AuthConnectionMeta *auth_meta,
+    const ceph::buffer::list& bl,
+    ceph::buffer::list *reply) {
+    return conn_ptr->handle_auth_reply_more(auth_meta, bl, reply);
+  }
+
+  bool empty() const {
+    return !conn_ptr;
+  }
+
+
+  void send_subscribe(epoch_t start_epoch);
+
+private:
+  std::string mon_name;
+  std::unique_ptr<MonConnection> conn_ptr;
+  ConnectionStatus status;            // Status of the connection
+  MonSub sub;
+};
+
+
 const boost::system::error_category& monc_category() noexcept;
 
 enum class monc_errc {
@@ -296,11 +418,13 @@ public:
   std::map<std::string,std::string> config_mgr;
 
 private:
+  MonClientQuorum quorum;
   Messenger *messenger;
 
   std::unique_ptr<MonConnection> active_con;
   std::map<entity_addrvec_t, MonConnection> pending_cons;
   std::set<unsigned> tried;
+  std::map<entity_addrvec_t, AuxConnection> aux_list;
 
   EntityName entity_name;
 
@@ -324,6 +448,7 @@ private:
   bool ms_handle_refused(Connection *con) override { return false; }
 
   void handle_monmap(MMonMap *m);
+  void handle_quorum_not_active(MMonMap *m);
   void handle_config(MConfig *m);
 
   void handle_auth(MAuthReply *m);
@@ -384,6 +509,17 @@ private:
       }
     }
     return pending_cons.end();
+  }
+
+  void _erase_pending_cons(const entity_addrvec_t &addr) {
+    pending_cons.erase(addr);
+  }
+
+  void _add_aux_connection(const entity_addrvec_t& addr, std::unique_ptr<MonConnection> mc) {
+    if (aux_list.find(addr) == aux_list.end()) {
+      auto name = mc->get_mon_name();
+      aux_list.emplace(addr, AuxConnection(name, std::move(mc)));
+    }
   }
 
 public:

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -255,7 +255,8 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
 
   admin_hook(NULL),
   routed_request_tid(0),
-  op_tracker(cct, g_conf().get_val<bool>("mon_enable_op_tracker"), 1)
+  op_tracker(cct, g_conf().get_val<bool>("mon_enable_op_tracker"), 1),
+  ms_inject_drop_mon_forward_msgs(cct, "mon_inject_drop_mon_forward_msgs", 0)
 {
   clog = log_client.create_channel(CLOG_CHANNEL_CLUSTER);
   audit_clog = log_client.create_channel(CLOG_CHANNEL_AUDIT);
@@ -4227,6 +4228,14 @@ void Monitor::forward_request_leader(MonOpRequestRef op)
   } else if (session->proxy_con) {
     dout(10) << "forward_request won't double fwd request " << *req << dendl;
   } else if (!session->closed) {
+    // ms_inject_drop_mon_forward_msgs - if negative drop any mon forward messages
+    // if positive drop random percentage of mon forward messages
+    if (ms_inject_drop_mon_forward_msgs > 0.0 &&
+      rand() % 10000 < 10000 * ms_inject_drop_mon_forward_msgs) {
+      dout(20) << __func__ << " inject drop mon forward request " << *req << dendl;
+      req->put();
+      return;
+    }
     RoutedRequest *rr = new RoutedRequest;
     rr->tid = ++routed_request_tid;
     rr->con = req->get_connection();
@@ -4470,6 +4479,14 @@ void Monitor::resend_routed_requests()
       auto q = rr->request_bl.cbegin();
       PaxosServiceMessage *req =
 	(PaxosServiceMessage *)decode_message(cct, 0, q);
+      // ms_inject_drop_mon_forward_msgs - if negative drop any mon forward messages
+      // if positive drop random percentage of mon forward messages
+      if (ms_inject_drop_mon_forward_msgs > 0.0 &&
+        rand() % 10000 < 10000 * ms_inject_drop_mon_forward_msgs) {
+        dout(20) << __func__ << " inject drop mon forward request " << *req << dendl;
+        req->put();
+        continue;
+      }
       rr->op->mark_event("resend forwarded message to leader");
       dout(10) << " resend to mon." << mon << " tid " << rr->tid << " " << *req
 	       << dendl;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -256,7 +256,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   admin_hook(NULL),
   routed_request_tid(0),
   op_tracker(cct, g_conf().get_val<bool>("mon_enable_op_tracker"), 1),
-  ms_inject_drop_mon_forward_msgs(cct, "mon_inject_drop_mon_forward_msgs", 0)
+  ms_inject_drop_mon_forward_msgs(cct->_conf , "ms_inject_drop_mon_forward_msgs")
 {
   clog = log_client.create_channel(CLOG_CHANNEL_CLUSTER);
   audit_clog = log_client.create_channel(CLOG_CHANNEL_AUDIT);
@@ -2505,6 +2505,8 @@ void Monitor::finish_election()
     authmon()->_set_mon_num_rank(monmap->size(), rank);
   }
 
+  check_quorum_subs_and_send_updates();
+
   // am i named and located properly?
   string cur_name = monmap->get_name(messenger->get_myaddrs());
   const auto my_infop = monmap->mon_info.find(cur_name);
@@ -4230,8 +4232,8 @@ void Monitor::forward_request_leader(MonOpRequestRef op)
   } else if (!session->closed) {
     // ms_inject_drop_mon_forward_msgs - if negative drop any mon forward messages
     // if positive drop random percentage of mon forward messages
-    if (ms_inject_drop_mon_forward_msgs > 0.0 &&
-      rand() % 10000 < 10000 * ms_inject_drop_mon_forward_msgs) {
+    if (*ms_inject_drop_mon_forward_msgs > 0.0 &&
+      rand() % 10000 < 10000 * *ms_inject_drop_mon_forward_msgs) {
       dout(20) << __func__ << " inject drop mon forward request " << *req << dendl;
       req->put();
       return;
@@ -4481,8 +4483,8 @@ void Monitor::resend_routed_requests()
 	(PaxosServiceMessage *)decode_message(cct, 0, q);
       // ms_inject_drop_mon_forward_msgs - if negative drop any mon forward messages
       // if positive drop random percentage of mon forward messages
-      if (ms_inject_drop_mon_forward_msgs > 0.0 &&
-        rand() % 10000 < 10000 * ms_inject_drop_mon_forward_msgs) {
+      if (*ms_inject_drop_mon_forward_msgs > 0.0 &&
+        rand() % 10000 < 10000 * *ms_inject_drop_mon_forward_msgs) {
         dout(20) << __func__ << " inject drop mon forward request " << *req << dendl;
         req->put();
         continue;
@@ -4698,7 +4700,7 @@ void Monitor::_ms_dispatch(Message *m)
 void Monitor::dispatch_op(MonOpRequestRef op)
 {
   op->mark_event("mon:dispatch_op");
-
+  dout(20) << "dispatch_op: " << op << " " << *op->get_req() << dendl;
   MonSession *s = op->get_session();
   ceph_assert(s);
   if (s->closed) {
@@ -5439,6 +5441,8 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
   for (map<string,ceph_mon_subscribe_item>::iterator p = m->what.begin();
        p != m->what.end();
        ++p) {
+    dout(20) << __func__ << " " << p->first << " start " << p->second.start
+             << " flags " << p->second.flags << dendl;
     if (p->first == "monmap" || p->first == "config") {
       // these require no caps
     } else if (!s->is_capable("mon", MON_CAP_R)) {
@@ -5458,6 +5462,7 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
 	   it != s->sub_map.end(); ) {
 	if (it->first != p->first && logmon()->sub_name_to_id(it->first) >= 0) {
 	  std::lock_guard l(session_map_lock);
+          dout(20) << __func__ << " removing conflicting sub " << it->first << dendl;
 	  session_map.remove_sub((it++)->second);
 	} else {
 	  ++it;
@@ -5606,8 +5611,29 @@ bool Monitor::ms_handle_refused(Connection *con)
 void Monitor::send_latest_monmap(Connection *con)
 {
   bufferlist bl;
+  dout(10) << __func__ << " sending latest monmap and quorum to "
+    << con->get_peer_entity_name().get_type_name()
+    << " type:" << con->get_peer_type()
+    << " id:" << con->get_peer_id()
+    << " quorum: " << get_quorum()
+    << dendl;
   monmap->encode(bl, con->get_features());
-  con->send_message(new MMonMap(bl));
+  con->send_message(new MMonMap(bl, monmap->get_epoch(), get_quorum()));
+}
+
+void Monitor::check_quorum_subs_and_send_updates()
+{
+  dout(10) << __func__ << dendl;
+  const string quorum_type = "monmap";
+  with_session_map([this, &quorum_type]
+    (const MonSessionMap& session_map) {
+      auto subs = session_map.subs.find(quorum_type);
+      if (subs != session_map.subs.end()) {
+        for (auto sub : *subs->second) {
+          send_latest_monmap(sub->session->con.get());
+        }
+      }
+    });
 }
 
 void Monitor::handle_mon_get_map(MonOpRequestRef op)

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -740,6 +740,7 @@ public:
     std::forward<Func>(func)(session_map);
   }
   void send_latest_monmap(Connection *con);
+  void check_quorum_subs_and_send_updates();
 
   // messages
   void handle_get_version(MonOpRequestRef op);

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -53,6 +53,7 @@
 #include <boost/smart_ptr/shared_ptr.hpp>
 
 #include "mon/MonOpRequest.h"
+#include "common/config_cacher.h"
 #include "common/WorkQueue.h"
 
 struct health_check_map_t;
@@ -998,7 +999,7 @@ private:
   void write_features(MonitorDBStore::TransactionRef t);
 
   OpTracker op_tracker;
-
+  md_config_cacher_t<double> ms_inject_drop_mon_forward_msgs;
  public:
   Monitor(CephContext *cct_, std::string nm, MonitorDBStore *s,
 	  Messenger *m, Messenger *mgr_m, MonMap *map);

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -1473,7 +1473,7 @@ void MonmapMonitor::check_sub(Subscription *sub)
   const auto epoch = mon.monmap->get_epoch();
   dout(10) << __func__
 	   << " monmap next " << sub->next
-	   << " have " << epoch << dendl;
+	   << " have " << epoch << " session:" << sub->session->name << " addr:" << sub->session->addrs << dendl;
   if (sub->next <= epoch) {
     mon.send_latest_monmap(sub->session->con.get());
     if (sub->onetime) {

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -504,7 +504,6 @@ Message *decode_message(CephContext *cct,
   case CEPH_MSG_MON_GET_VERSION_REPLY:
     m = make_message<MMonGetVersionReply>();
     break;
-
   case MSG_OSD_BOOT:
     m = make_message<MOSDBoot>();
     break;


### PR DESCRIPTION
This commit introduces auxiliary connections (aux_list) in MonClient
to improve the robustness of monitor connectivity and quorum detection.

Key changes:
 * Added support for multiple auxiliary connections, enabling MonClient
   to fetch MonMaps and validate quorum status independently of the active connection.
 * Improved handling of half-dead monitors (monitors that appear responsive but are
   out of quorum) by leveraging auxiliary connections to verify their quorum state.
 * Subscribed to quorum change events, ensuring prompt updates and better cluster responsiveness.
 * Transitioned from relying on a single active connection to utilizing multiple monitor connections,
   reducing the risk of cluster misbehavior due to a faulty monitor.

These changes address scenarios where a half-dead monitor caused disruptions and make MonClient more
resilient in dynamic cluster environments by not relay just on active
connection.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
