### PR TITLE
squid: rgw/lc: Fix lifecycle not working while bucket versioning is suspended

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1183,7 +1183,7 @@ public:
 		       << " " << oc.wq->thr_name() << dendl;
     } else {
       /* ! o.is_delete_marker() */
-      r = remove_expired_obj(oc.dpp, oc, !oc.bucket->versioned(),
+      r = remove_expired_obj(oc.dpp, oc, !oc.bucket->versioning_enabled(),
                              {rgw::notify::ObjectExpirationCurrent,
                               rgw::notify::LifecycleExpirationDelete});
       if (r < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69308

---

backport of https://github.com/ceph/ceph/pull/59449
parent tracker: https://tracker.ceph.com/issues/65772

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh