### PR TITLE
rgw-admin: allow switching between sync states for bucket

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -833,7 +833,7 @@ public:
   unsigned get_subsys() const override;
   std::ostream& gen_prefix(std::ostream& out) const override;
 
-  int init_sync_status(const DoutPrefixProvider *dpp);
+  int init_sync_status(const DoutPrefixProvider *dpp, BucketSyncState state);
   tl::expected<std::map<int, rgw_bucket_shard_sync_info>, int> read_sync_status(
     const DoutPrefixProvider *dpp);
   int run(const DoutPrefixProvider *dpp);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -42,6 +42,9 @@
     bucket sync checkpoint           poll a bucket's sync status until it catches up to its remote
     bucket sync disable              disable bucket sync
     bucket sync enable               enable bucket sync
+    bucket sync init                 reset the bucket sync state to init to restore consistency of a bucket
+    bucket sync batch-replicate      reset the bucket sync state to full-sync to perform a full sync of a bucket (replicate existing objects)
+    bucket sync skip-full-sync       reset the bucket sync state to incremental-sync to perform an incremental sync of a bucket (skip existing objects)
     bucket radoslist                 list rados objects backing bucket's objects
     bucket logging flush             flush pending log records object of source bucket to the log bucket to bucket
     bi get                           retrieve bucket index object entries


### PR DESCRIPTION
As part of the recent update in https://github.com/ceph/ceph/pull/61003, a new command `bucket sync batch-replicate` has been introduced to allow a bucket to perform batch replication when it is initially set to start with incremental replication.

Additionally, a `bucket sync skip-full-sync` command has been introduced, enabling the switch from full sync to incremental sync. However, this command applies only to buckets where the source and destination names differ, as symmetry must be maintained when the names are the same.

Fixes: https://tracker.ceph.com/issues/69309

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
