### PR TITLE
Rgw chain replication

### DIFF
--- a/doc/radosgw/zone-features.rst
+++ b/doc/radosgw/zone-features.rst
@@ -9,15 +9,17 @@ On creation of new zones and zonegroups, all known features are supported and so
 Supported Features
 ------------------
 
-+-----------------------------------+---------+----------+
-| Feature                           | Release | Default  |
-+===================================+=========+==========+
-| :ref:`feature_resharding`         | Reef    | Enabled  |
-+-----------------------------------+---------+----------+
-| :ref:`feature_compress_encrypted` | Reef    | Disabled |
-+-----------------------------------+---------+----------+
-| :ref:`feature_notification_v2`    | Squid   | Enabled  |
-+-----------------------------------+---------+----------+
++----------------------------------------------------+-----------+----------+
+| Feature                                            | Release   | Default  |
++====================================================+===========+==========+
+| :ref:`feature_resharding`                          | Reef      | Enabled  |
++----------------------------------------------------+-----------+----------+
+| :ref:`feature_compress_encrypted`                  | Reef      | Disabled |
++----------------------------------------------------+-----------+----------+
+| :ref:`feature_notification_v2`                     | Squid     | Enabled  |
++----------------------------------------------------+-----------+----------+
+| :ref:`feature_data_sync_disable_chain_replication` | Tentacle  | Enabled  |
++----------------------------------------------------+-----------+----------+
 
 .. _feature_resharding:
 
@@ -63,6 +65,23 @@ scale to many topics.
 
 Once this feature is enabled on all zonegroups in the realm, a background process
 will convert existing v1 topics and bucket notifications into their v2 format.
+
+
+.. _feature_data_sync_disable_chain_replication:
+
+data-sync-disable-chain-replication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This feature controls whether the replication of already replicated objects (chain replication)
+is permitted. When disabled, objects replicated to a destination zone can be further replicated
+to other zones.
+Enabling this option prevents chain replication, mitigating potential performance issues and
+redundant logging caused by circular replication between zones. This feature is particularly
+useful in scenarios where chain replication is unnecessary or undesirable, helping to optimize
+synchronization operations and reduce overhead.
+
+Since AWS does not support chain replication, this feature is enabled by default for new
+deployments but requires existing deployments to opt-in manually.
 
 
 Commands

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4501,7 +4501,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
   //erase the append attr
   cb.get_attrs().erase(RGW_ATTR_APPEND_PART_NUM);
 
-  { // add x-amz-replication-status=REPLICA
+  if (data_sync) { // add x-amz-replication-status=REPLICA only if it's data sync
     auto& bl = cb.get_attrs()[RGW_ATTR_OBJ_REPLICATION_STATUS];
     bl.clear(); // overwrite source's status
     bl.append("REPLICA");

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1167,6 +1167,7 @@ public:
                        bool stat_follow_olh,
                        const rgw_obj& stat_dest_obj,
                        const rgw_zone_set_entry& source_trace_entry,
+                       bool data_sync,
                        rgw_zone_set *zones_trace = nullptr,
                        std::optional<uint64_t>* bytes_transferred = 0);
   /**

--- a/src/rgw/rgw_zone_features.h
+++ b/src/rgw/rgw_zone_features.h
@@ -16,12 +16,14 @@ namespace rgw::zone_features {
 inline constexpr std::string_view resharding = "resharding";
 inline constexpr std::string_view compress_encrypted = "compress-encrypted";
 inline constexpr std::string_view notification_v2 = "notification_v2";
+inline constexpr std::string_view data_sync_disable_chain_replication = "data-sync-disable-chain-replication";
 
 // static list of features supported by this release
 inline constexpr std::initializer_list<std::string_view> supported = {
     resharding,
     compress_encrypted,
     notification_v2,
+    data_sync_disable_chain_replication,
 };
 
 inline constexpr bool supports(std::string_view feature) {
@@ -37,6 +39,7 @@ inline constexpr bool supports(std::string_view feature) {
 inline constexpr std::initializer_list<std::string_view> enabled = {
     resharding,
     notification_v2,
+    data_sync_disable_chain_replication,
 };
 
 


### PR DESCRIPTION
When chain replication is enabled, an object that has been replicated to a destination zone can be further replicated to other zones. Disabling this option prevents chain replication, avoiding potential performance issues and redundant logging caused by circular replication patterns between zones. This can be useful in scenarios where chain replication is unnecessary or undesirable for optimizing sync operations.

Introduced a new zonegroup feature called "data-sync-disable-chain-replication" to disable this type of replication for the new deployments. Currently AWS also doesn't support such a replication: https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-what-is-isnot-replicated.html

Fixes: https://tracker.ceph.com/issues/69310