### PR TITLE
crimson/os/seastore/cache: improve committing allocations by backref entries

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1142,8 +1142,7 @@ SegmentCleaner::do_reclaim_space(
             pin->get_key(),
             pin->get_val(),
             pin->get_length(),
-            pin->get_type(),
-            JOURNAL_SEQ_NULL);
+            pin->get_type());
         }
         for (auto &cached_backref : cached_backref_entries) {
           if (cached_backref.laddr == L_ADDR_NULL) {

--- a/src/crimson/os/seastore/backref_entry.h
+++ b/src/crimson/os/seastore/backref_entry.h
@@ -1,0 +1,127 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <memory>
+#include <iostream>
+
+#if FMT_VERSION >= 90000
+#include <fmt/ostream.h>
+#endif
+
+#include <boost/intrusive/set.hpp>
+
+#include "crimson/os/seastore/seastore_types.h"
+
+namespace crimson::os::seastore {
+
+struct backref_entry_t {
+  using ref_t = std::unique_ptr<backref_entry_t>;
+
+  backref_entry_t(
+    const paddr_t& paddr,
+    const laddr_t& laddr,
+    extent_len_t len,
+    extent_types_t type)
+    : paddr(paddr),
+      laddr(laddr),
+      len(len),
+      type(type) {
+    assert(len > 0);
+  }
+  paddr_t paddr = P_ADDR_NULL;
+  laddr_t laddr = L_ADDR_NULL;
+  extent_len_t len = 0;
+  extent_types_t type = extent_types_t::NONE;
+  friend bool operator< (
+    const backref_entry_t &l,
+    const backref_entry_t &r) {
+    return l.paddr < r.paddr;
+  }
+  friend bool operator> (
+    const backref_entry_t &l,
+    const backref_entry_t &r) {
+    return l.paddr > r.paddr;
+  }
+  friend bool operator== (
+    const backref_entry_t &l,
+    const backref_entry_t &r) {
+    return l.paddr == r.paddr;
+  }
+
+  using set_hook_t =
+    boost::intrusive::set_member_hook<
+      boost::intrusive::link_mode<
+	boost::intrusive::auto_unlink>>;
+  set_hook_t backref_set_hook;
+  using backref_set_member_options = boost::intrusive::member_hook<
+    backref_entry_t,
+    set_hook_t,
+    &backref_entry_t::backref_set_hook>;
+  using multiset_t = boost::intrusive::multiset<
+    backref_entry_t,
+    backref_set_member_options,
+    boost::intrusive::constant_time_size<false>>;
+
+  struct cmp_t {
+    using is_transparent = paddr_t;
+    bool operator()(
+      const backref_entry_t &l,
+      const backref_entry_t &r) const {
+      return l.paddr < r.paddr;
+    }
+    bool operator()(const paddr_t l, const backref_entry_t &r) const {
+      return l < r.paddr;
+    }
+    bool operator()(const backref_entry_t &l, const paddr_t r) const {
+      return l.paddr < r;
+    }
+  };
+
+  static ref_t create_alloc(
+      const paddr_t& paddr,
+      const laddr_t& laddr,
+      extent_len_t len,
+      extent_types_t type) {
+    assert(is_backref_mapped_type(type));
+    assert(laddr != L_ADDR_NULL);
+    return std::make_unique<backref_entry_t>(
+      paddr, laddr, len, type);
+  }
+
+  static ref_t create_retire(
+      const paddr_t& paddr,
+      extent_len_t len,
+      extent_types_t type) {
+    assert(is_backref_mapped_type(type) ||
+	   is_retired_placeholder_type(type));
+    return std::make_unique<backref_entry_t>(
+      paddr, L_ADDR_NULL, len, type);
+  }
+
+  static ref_t create(const alloc_blk_t& delta) {
+    return std::make_unique<backref_entry_t>(
+      delta.paddr, delta.laddr, delta.len, delta.type);
+  }
+};
+
+inline std::ostream &operator<<(std::ostream &out, const backref_entry_t &ent) {
+  return out << "backref_entry_t{"
+	     << ent.paddr << "~0x" << std::hex << ent.len << std::dec << ", "
+	     << "laddr: " << ent.laddr << ", "
+	     << "type: " << ent.type
+	     << "}";
+}
+
+using backref_entry_ref = backref_entry_t::ref_t;
+using backref_entry_mset_t = backref_entry_t::multiset_t;
+using backref_entry_refs_t = std::vector<backref_entry_ref>;
+using backref_entryrefs_by_seq_t = std::map<journal_seq_t, backref_entry_refs_t>;
+using backref_entry_query_set_t = std::set<backref_entry_t, backref_entry_t::cmp_t>;
+
+} // namespace crimson::os::seastore
+
+#if FMT_VERSION >= 90000
+template <> struct fmt::formatter<crimson::os::seastore::backref_entry_t> : fmt::ostream_formatter {};
+#endif

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -28,14 +28,6 @@ SET_SUBSYS(seastore_cache);
 
 namespace crimson::os::seastore {
 
-std::ostream &operator<<(std::ostream &out, const backref_entry_t &ent) {
-  return out << "backref_entry_t{"
-	     << ent.paddr << "~0x" << std::hex << ent.len << std::dec << ", "
-	     << "laddr: " << ent.laddr << ", "
-	     << "type: " << ent.type
-	     << "}";
-}
-
 Cache::Cache(
   ExtentPlacementManager &epm)
   : epm(epm),

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1421,7 +1421,7 @@ record_t Cache::prepare_record(
 	alloc_laddr = i->cast<lba_manager::btree::LBANode>()->get_node_meta().begin;
       } else {
 	assert(i->get_type() == extent_types_t::TEST_BLOCK_PHYSICAL);
-	alloc_laddr = L_ADDR_NULL;
+	alloc_laddr = L_ADDR_MIN;
       }
       alloc_delta.alloc_blk_ranges.emplace_back(
 	i->get_paddr(),
@@ -1708,7 +1708,7 @@ void Cache::complete_commit(
 	alloc_laddr = i->cast<lba_manager::btree::LBANode>()->get_node_meta().begin;
       } else {
 	assert(i->get_type() == extent_types_t::TEST_BLOCK_PHYSICAL);
-	alloc_laddr = L_ADDR_NULL;
+	alloc_laddr = L_ADDR_MIN;
       }
       backref_entries.emplace_back(
 	std::make_unique<backref_entry_t>(

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -32,8 +32,7 @@ std::ostream &operator<<(std::ostream &out, const backref_entry_t &ent) {
   return out << "backref_entry_t{"
 	     << ent.paddr << "~0x" << std::hex << ent.len << std::dec << ", "
 	     << "laddr: " << ent.laddr << ", "
-	     << "type: " << ent.type << ", "
-	     << "seq: " << ent.seq << ", "
+	     << "type: " << ent.type
 	     << "}";
 }
 
@@ -1697,8 +1696,7 @@ void Cache::complete_commit(
 	    ? i->cast<lba_manager::btree::LBANode>()->get_node_meta().begin
 	    : L_ADDR_NULL),
 	  i->get_length(),
-	  i->get_type(),
-	  start_seq));
+	  i->get_type()));
     } else if (is_backref_node(i->get_type())) {
 	add_backref_extent(
 	  i->get_paddr(),
@@ -1762,8 +1760,7 @@ void Cache::complete_commit(
 	  extent->get_paddr(),
 	  L_ADDR_NULL,
 	  extent->get_length(),
-	  extent->get_type(),
-	  start_seq));
+	  extent->get_type()));
     } else if (is_backref_node(extent->get_type())) {
       remove_backref_extent(extent->get_paddr());
     } else {
@@ -1795,8 +1792,7 @@ void Cache::complete_commit(
 	  i->get_paddr(),
 	  i->cast<LogicalCachedExtent>()->get_laddr(),
 	  i->get_length(),
-	  i->get_type(),
-	  start_seq));
+	  i->get_type()));
       add_extent(i);
       const auto t_src = t.get_src();
       if (i->is_dirty()) {
@@ -1944,8 +1940,7 @@ Cache::replay_delta(
 	  alloc_blk.paddr,
 	  alloc_blk.laddr,
 	  alloc_blk.len,
-	  alloc_blk.type,
-	  journal_seq));
+	  alloc_blk.type));
     }
     if (!backref_list.empty()) {
       backref_batch_update(std::move(backref_list), journal_seq);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1355,8 +1355,8 @@ record_t Cache::prepare_record(
     retire_stat.increment(extent->get_length());
     DEBUGT("retired and remove extent -- {}", t, *extent);
     commit_retire_extent(t, extent);
-    if (is_backref_mapped_extent_node(extent) ||
-        is_retired_placeholder_type(extent->get_type())) {
+    if (is_backref_mapped_type(extent->get_type()) ||
+	is_retired_placeholder_type(extent->get_type())) {
       rel_delta.alloc_blk_ranges.emplace_back(
 	extent->get_paddr(),
 	L_ADDR_NULL,
@@ -1413,7 +1413,7 @@ record_t Cache::prepare_record(
       },
       modify_time);
     if (i->is_valid() &&
-	is_backref_mapped_extent_node(i)) {
+	is_backref_mapped_type(i->get_type())) {
       laddr_t alloc_laddr;
       if (i->is_logical()) {
 	alloc_laddr = i->cast<LogicalCachedExtent>()->get_laddr();
@@ -1438,7 +1438,7 @@ record_t Cache::prepare_record(
     get_by_ext(efforts.fresh_ool_by_ext,
                i->get_type()).increment(i->get_length());
     i->prepare_commit();
-    if (is_backref_mapped_extent_node(i)) {
+    if (is_backref_mapped_type(i->get_type())) {
       laddr_t alloc_laddr;
       if (i->is_logical()) {
         alloc_laddr = i->cast<LogicalCachedExtent>()->get_laddr();
@@ -1696,7 +1696,7 @@ void Cache::complete_commit(
     const auto t_src = t.get_src();
     touch_extent(*i, &t_src);
     epm.commit_space_used(i->get_paddr(), i->get_length());
-    if (is_backref_mapped_extent_node(i)) {
+    if (is_backref_mapped_type(i->get_type())) {
       DEBUGT("backref_entry alloc {} len 0x{:x}",
 	     t,
 	     i->get_paddr(),
@@ -1768,7 +1768,7 @@ void Cache::complete_commit(
   for (auto &i: t.retired_set) {
     auto &extent = i.extent;
     extent->dirty_from_or_retired_at = start_seq;
-    if (is_backref_mapped_extent_node(extent) ||
+    if (is_backref_mapped_type(extent->get_type()) ||
         is_retired_placeholder_type(extent->get_type())) {
       DEBUGT("backref_entry free {} len 0x{:x}",
 	     t,

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1826,9 +1826,23 @@ private:
   seastar::metrics::metric_group metrics;
   void register_metrics();
 
+  void apply_backref_mset(
+      backref_entry_refs_t& backref_entries) {
+    for (auto& entry : backref_entries) {
+      backref_entry_mset.insert(*entry);
+    }
+  }
+
+  void apply_backref_byseq(
+      backref_entry_refs_t&& backref_entries,
+      const journal_seq_t& seq);
+
   void commit_backref_entries(
-    backref_entry_refs_t&& backref_entries,
-    const journal_seq_t& seq);
+      backref_entry_refs_t&& backref_entries,
+      const journal_seq_t& seq) {
+    apply_backref_mset(backref_entries);
+    apply_backref_byseq(std::move(backref_entries), seq);
+  }
 
   /// Add extent to extents handling dirty and refcounting
   ///

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -40,26 +40,18 @@ class SegmentProvider;
 
 struct backref_entry_t {
   backref_entry_t(
-    const paddr_t paddr,
-    const laddr_t laddr,
-    const extent_len_t len,
-    const extent_types_t type)
+    const paddr_t& paddr,
+    const laddr_t& laddr,
+    extent_len_t len,
+    extent_types_t type)
     : paddr(paddr),
       laddr(laddr),
       len(len),
-      type(type)
-  {}
-  backref_entry_t(alloc_blk_t alloc_blk)
-    : paddr(alloc_blk.paddr),
-      laddr(alloc_blk.laddr),
-      len(alloc_blk.len),
-      type(alloc_blk.type)
-  {}
+      type(type) {}
   paddr_t paddr = P_ADDR_NULL;
   laddr_t laddr = L_ADDR_NULL;
   extent_len_t len = 0;
-  extent_types_t type =
-    extent_types_t::ROOT;
+  extent_types_t type = extent_types_t::NONE;
   friend bool operator< (
     const backref_entry_t &l,
     const backref_entry_t &r) {
@@ -112,8 +104,7 @@ using backref_entry_ref = std::unique_ptr<backref_entry_t>;
 using backref_entry_mset_t = backref_entry_t::multiset_t;
 using backref_entry_refs_t = std::vector<backref_entry_ref>;
 using backref_entryrefs_by_seq_t = std::map<journal_seq_t, backref_entry_refs_t>;
-using backref_entry_query_set_t = std::set<
-    backref_entry_t, backref_entry_t::cmp_t>;
+using backref_entry_query_set_t = std::set<backref_entry_t, backref_entry_t::cmp_t>;
 
 /**
  * Cache
@@ -1905,7 +1896,7 @@ private:
   void register_metrics();
 
   void backref_batch_update(
-    std::vector<backref_entry_ref> &&,
+    backref_entry_refs_t &&,
     const journal_seq_t &);
 
   /// Add extent to extents handling dirty and refcounting

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -3,14 +3,13 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "seastar/core/shared_future.hh"
 
 #include "include/buffer.h"
 
 #include "crimson/common/errorator.h"
 #include "crimson/common/errorator-loop.h"
+#include "crimson/os/seastore/backref_entry.h"
 #include "crimson/os/seastore/cached_extent.h"
 #include "crimson/os/seastore/extent_placement_manager.h"
 #include "crimson/os/seastore/logging.h"
@@ -37,104 +36,6 @@ template <
 class FixedKVBtree;
 class BackrefManager;
 class SegmentProvider;
-
-struct backref_entry_t {
-  using ref_t = std::unique_ptr<backref_entry_t>;
-
-  backref_entry_t(
-    const paddr_t& paddr,
-    const laddr_t& laddr,
-    extent_len_t len,
-    extent_types_t type)
-    : paddr(paddr),
-      laddr(laddr),
-      len(len),
-      type(type) {
-    assert(len > 0);
-  }
-  paddr_t paddr = P_ADDR_NULL;
-  laddr_t laddr = L_ADDR_NULL;
-  extent_len_t len = 0;
-  extent_types_t type = extent_types_t::NONE;
-  friend bool operator< (
-    const backref_entry_t &l,
-    const backref_entry_t &r) {
-    return l.paddr < r.paddr;
-  }
-  friend bool operator> (
-    const backref_entry_t &l,
-    const backref_entry_t &r) {
-    return l.paddr > r.paddr;
-  }
-  friend bool operator== (
-    const backref_entry_t &l,
-    const backref_entry_t &r) {
-    return l.paddr == r.paddr;
-  }
-
-  using set_hook_t =
-    boost::intrusive::set_member_hook<
-      boost::intrusive::link_mode<
-	boost::intrusive::auto_unlink>>;
-  set_hook_t backref_set_hook;
-  using backref_set_member_options = boost::intrusive::member_hook<
-    backref_entry_t,
-    set_hook_t,
-    &backref_entry_t::backref_set_hook>;
-  using multiset_t = boost::intrusive::multiset<
-    backref_entry_t,
-    backref_set_member_options,
-    boost::intrusive::constant_time_size<false>>;
-
-  struct cmp_t {
-    using is_transparent = paddr_t;
-    bool operator()(
-      const backref_entry_t &l,
-      const backref_entry_t &r) const {
-      return l.paddr < r.paddr;
-    }
-    bool operator()(const paddr_t l, const backref_entry_t &r) const {
-      return l < r.paddr;
-    }
-    bool operator()(const backref_entry_t &l, const paddr_t r) const {
-      return l.paddr < r;
-    }
-  };
-
-  static ref_t create_alloc(
-      const paddr_t& paddr,
-      const laddr_t& laddr,
-      extent_len_t len,
-      extent_types_t type) {
-    assert(is_backref_mapped_type(type));
-    assert(laddr != L_ADDR_NULL);
-    return std::make_unique<backref_entry_t>(
-      paddr, laddr, len, type);
-  }
-
-  static ref_t create_retire(
-      const paddr_t& paddr,
-      extent_len_t len,
-      extent_types_t type) {
-    assert(is_backref_mapped_type(type) ||
-	   is_retired_placeholder_type(type));
-    return std::make_unique<backref_entry_t>(
-      paddr, L_ADDR_NULL, len, type);
-  }
-
-  static ref_t create(const alloc_blk_t& delta) {
-    return std::make_unique<backref_entry_t>(
-      delta.paddr, delta.laddr, delta.len, delta.type);
-  }
-};
-
-std::ostream &operator<<(std::ostream &out, const backref_entry_t &ent);
-
-using backref_entry_ref = backref_entry_t::ref_t;
-using backref_entry_mset_t = backref_entry_t::multiset_t;
-using backref_entry_refs_t = std::vector<backref_entry_ref>;
-using backref_entryrefs_by_seq_t = std::map<journal_seq_t, backref_entry_refs_t>;
-using backref_entry_query_set_t = std::set<backref_entry_t, backref_entry_t::cmp_t>;
 
 /**
  * Cache

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -43,13 +43,11 @@ struct backref_entry_t {
     const paddr_t paddr,
     const laddr_t laddr,
     const extent_len_t len,
-    const extent_types_t type,
-    const journal_seq_t seq)
+    const extent_types_t type)
     : paddr(paddr),
       laddr(laddr),
       len(len),
-      type(type),
-      seq(seq)
+      type(type)
   {}
   backref_entry_t(alloc_blk_t alloc_blk)
     : paddr(alloc_blk.paddr),
@@ -62,7 +60,6 @@ struct backref_entry_t {
   extent_len_t len = 0;
   extent_types_t type =
     extent_types_t::ROOT;
-  journal_seq_t seq;
   friend bool operator< (
     const backref_entry_t &l,
     const backref_entry_t &r) {
@@ -984,7 +981,7 @@ private:
     for (auto it = start_iter;
 	 it != end_iter;
 	 it++) {
-      res.emplace(it->paddr, it->laddr, it->len, it->type, it->seq);
+      res.emplace(it->paddr, it->laddr, it->len, it->type);
     }
     return res;
   }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1925,9 +1925,9 @@ private:
   seastar::metrics::metric_group metrics;
   void register_metrics();
 
-  void backref_batch_update(
-    backref_entry_refs_t &&,
-    const journal_seq_t &);
+  void commit_backref_entries(
+    backref_entry_refs_t&& backref_entries,
+    const journal_seq_t& seq);
 
   /// Add extent to extents handling dirty and refcounting
   ///

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -38,12 +38,6 @@ void intrusive_ptr_release(CachedExtent *ptr)
 
 #endif
 
-bool is_backref_mapped_extent_node(const CachedExtentRef &extent) {
-  return extent->is_logical()
-    || is_lba_node(extent->get_type())
-    || extent->get_type() == extent_types_t::TEST_BLOCK_PHYSICAL;
-}
-
 std::ostream &operator<<(std::ostream &out, CachedExtent::extent_state_t state)
 {
   switch (state) {

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1097,8 +1097,6 @@ protected:
 std::ostream &operator<<(std::ostream &, CachedExtent::extent_state_t);
 std::ostream &operator<<(std::ostream &, const CachedExtent&);
 
-bool is_backref_mapped_extent_node(const CachedExtentRef &extent);
-
 /// Compare extents by paddr
 struct paddr_cmp {
   bool operator()(paddr_t lhs, const CachedExtent &rhs) const {

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -59,13 +59,13 @@ public:
     crimson::ct_error::erange,
     crimson::ct_error::input_output_error
     >;
-  using submit_record_ret = submit_record_ertr::future<
-    record_locator_t
-    >;
-  virtual submit_record_ret submit_record(
+  using on_submission_func_t = std::function<
+    void(record_locator_t)>;
+  virtual submit_record_ertr::future<> submit_record(
     record_t &&record,
-    OrderingHandle &handle
-  ) = 0;
+    OrderingHandle &handle,
+    transaction_type_t t_src,
+    on_submission_func_t &&on_submission) = 0;
 
   /**
    * flush
@@ -100,9 +100,6 @@ public:
       sea_time_point modify_time)>;
   virtual replay_ret replay(
     delta_handler_t &&delta_handler) = 0;
-
-  virtual seastar::future<> finish_commit(
-    transaction_type_t type) = 0;
 
   virtual ~Journal() {}
 

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -80,9 +80,11 @@ public:
     return backend_type_t::RANDOM_BLOCK;
   }
 
-  submit_record_ret submit_record(
+  submit_record_ertr::future<> submit_record(
     record_t &&record,
-    OrderingHandle &handle
+    OrderingHandle &handle,
+    transaction_type_t t_src,
+    on_submission_func_t &&on_submission
   ) final;
 
   seastar::future<> flush(
@@ -148,8 +150,6 @@ public:
     return cjs.get_records_start();
   }
 
-  seastar::future<> finish_commit(transaction_type_t type) final;
-
   using cbj_delta_handler_t = std::function<
   replay_ertr::future<bool>(
     const record_locator_t&,
@@ -160,7 +160,10 @@ public:
     cbj_delta_handler_t &&delta_handler,
     journal_seq_t tail);
 
-  submit_record_ret do_submit_record(record_t &&record, OrderingHandle &handle);
+  submit_record_ertr::future<> do_submit_record(
+    record_t &&record,
+    OrderingHandle &handle,
+    on_submission_func_t &&on_submission);
 
   void try_read_rolled_header(scan_valid_records_cursor &cursor) {
     paddr_t addr = convert_abs_addr_to_paddr(

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -44,9 +44,11 @@ public:
 
   close_ertr::future<> close() final;
 
-  submit_record_ret submit_record(
+  submit_record_ertr::future<> submit_record(
     record_t &&record,
-    OrderingHandle &handle) final;
+    OrderingHandle &handle,
+    transaction_type_t t_src,
+    on_submission_func_t &&on_submission) final;
 
   seastar::future<> flush(OrderingHandle &handle) final;
 
@@ -59,9 +61,6 @@ public:
   backend_type_t get_type() final {
     return backend_type_t::SEGMENTED;
   }
-  seastar::future<> finish_commit(transaction_type_t type) {
-    return seastar::now();
-  }
 
   bool is_checksum_needed() final {
     // segmented journal always requires checksum
@@ -69,10 +68,10 @@ public:
   }
 
 private:
-  submit_record_ret do_submit_record(
+  submit_record_ertr::future<> do_submit_record(
     record_t &&record,
-    OrderingHandle &handle
-  );
+    OrderingHandle &handle,
+    on_submission_func_t &&on_submission);
 
   SegmentSeqAllocatorRef segment_seq_allocator;
   SegmentAllocator journal_segment_allocator;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1965,7 +1965,9 @@ struct alloc_blk_t {
     const laddr_t& laddr,
     extent_len_t len,
     extent_types_t type)
-    : paddr(paddr), laddr(laddr), len(len), type(type) {}
+    : paddr(paddr), laddr(laddr), len(len), type(type) {
+    assert(len > 0);
+  }
 
   explicit alloc_blk_t() = default;
 
@@ -1980,6 +1982,25 @@ struct alloc_blk_t {
     denc(v.len, p);
     denc(v.type, p);
     DENC_FINISH(p);
+  }
+
+  static alloc_blk_t create_alloc(
+      const paddr_t& paddr,
+      const laddr_t& laddr,
+      extent_len_t len,
+      extent_types_t type) {
+    assert(is_backref_mapped_type(type));
+    assert(laddr != L_ADDR_NULL);
+    return alloc_blk_t(paddr, laddr, len, type);
+  }
+
+  static alloc_blk_t create_retire(
+      const paddr_t& paddr,
+      extent_len_t len,
+      extent_types_t type) {
+    assert(is_backref_mapped_type(type) ||
+	   is_retired_placeholder_type(type));
+    return alloc_blk_t(paddr, L_ADDR_NULL, len, type);
   }
 };
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1468,6 +1468,23 @@ constexpr bool is_physical_type(extent_types_t type) {
   }
 }
 
+constexpr bool is_backref_mapped_type(extent_types_t type) {
+  if ((type >= extent_types_t::LADDR_INTERNAL &&
+       type <= extent_types_t::OBJECT_DATA_BLOCK) ||
+      type == extent_types_t::TEST_BLOCK ||
+      type == extent_types_t::TEST_BLOCK_PHYSICAL) {
+    assert(is_logical_type(type) ||
+	   is_lba_node(type) ||
+	   type == extent_types_t::TEST_BLOCK_PHYSICAL);
+    return true;
+  } else {
+    assert(!is_logical_type(type) &&
+	   !is_lba_node(type) &&
+	   type != extent_types_t::TEST_BLOCK_PHYSICAL);
+    return false;
+  }
+}
+
 constexpr bool is_real_type(extent_types_t type) {
   if (type <= extent_types_t::OBJECT_DATA_BLOCK ||
       (type >= extent_types_t::TEST_BLOCK &&

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1228,7 +1228,6 @@ constexpr laddr_t L_ADDR_MAX = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX);
 constexpr laddr_t L_ADDR_MIN = laddr_t::from_raw_uint(0);
 constexpr laddr_t L_ADDR_NULL = L_ADDR_MAX;
 constexpr laddr_t L_ADDR_ROOT = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX - 1);
-constexpr laddr_t L_ADDR_LBAT = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX - 2);
 
 struct __attribute__((packed)) laddr_le_t {
   ceph_le64 laddr;
@@ -1945,12 +1944,11 @@ struct __attribute__((packed)) root_t {
 
 struct alloc_blk_t {
   alloc_blk_t(
-    paddr_t paddr,
-    laddr_t laddr,
+    const paddr_t& paddr,
+    const laddr_t& laddr,
     extent_len_t len,
     extent_types_t type)
-    : paddr(paddr), laddr(laddr), len(len), type(type)
-  {}
+    : paddr(paddr), laddr(laddr), len(len), type(type) {}
 
   explicit alloc_blk_t() = default;
 

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -39,8 +39,8 @@ struct test_block_delta_t {
 
 inline std::ostream &operator<<(
   std::ostream &lhs, const test_extent_desc_t &rhs) {
-  return lhs << "test_extent_desc_t(len=" << rhs.len
-	     << ", checksum=" << rhs.checksum << ")";
+  return lhs << "test_extent_desc_t(len=0x" << std::hex << rhs.len
+	     << ", checksum=0x" << rhs.checksum << std::dec << ")";
 }
 
 struct TestBlock : crimson::os::seastore::LogicalCachedExtent {

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -112,14 +112,22 @@ struct btree_test_base :
   seastar::future<> submit_transaction(TransactionRef t)
   {
     auto record = cache->prepare_record(*t, JOURNAL_SEQ_NULL, JOURNAL_SEQ_NULL);
-    return journal->submit_record(std::move(record), t->get_handle()).safe_then(
-      [this, t=std::move(t)](auto submit_result) mutable {
-	cache->complete_commit(
-            *t,
+    return seastar::do_with(
+	std::move(t), [this, record=std::move(record)](auto& _t) mutable {
+      auto& t = *_t;
+      return journal->submit_record(
+        std::move(record),
+        t.get_handle(),
+        t.get_src(),
+        [this, &t](auto submit_result) {
+          cache->complete_commit(
+            t,
             submit_result.record_block_base,
             submit_result.write_result.start_seq);
-	complete_commit(*t);
-      }).handle_error(crimson::ct_error::assert_all{});
+          complete_commit(t);
+        }
+      ).handle_error(crimson::ct_error::assert_all{});
+    });
   }
 
   virtual LBAManager::mkfs_ret test_structure_setup(Transaction &t) = 0;


### PR DESCRIPTION
This PR is supposed to be cleanup only, reworking https://github.com/ceph/ceph/pull/59775.

@zhscn @xxhdx1985126 

For the specific issue https://tracker.ceph.com/issues/66941, seems to me propagating remapped extents upon `prepare_record()` (PR59775) cannot address the issue, because the backref entries of fresh extents are still updated upon `complete_commit()`, and they have the same issue. And they cannot be simply moved to `prepare_record()` because their paddrs are unknown at that time.

So, IIUC a new segment state "COMMITTED" is still necessary to fix reclaiming, for both inline and ool segments.

~~TODO/Draft: still some cleanups to add.~~ Done.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
