### PR TITLE
squid: rgw/posix: std::ignore return value of write()

### DIFF
--- a/src/rgw/driver/posix/notify.h
+++ b/src/rgw/driver/posix/notify.h
@@ -212,7 +212,7 @@ namespace file::listing {
 
     void signal_shutdown() {
       uint64_t msg{sig_shutdown};
-      (void) write(efd, &msg, sizeof(uint64_t));
+      std::ignore = write(efd, &msg, sizeof(uint64_t));
     }
 
     friend class Notify;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69317

---

backport of https://github.com/ceph/ceph/pull/61107
parent tracker: https://tracker.ceph.com/issues/69241

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh