### PR TITLE
squid: rgw: relax RGWPutACLs_ObjStore::get_params read data log

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1467,7 +1467,7 @@ int RGWPutACLs_ObjStore::get_params(optional_yield y)
 {
   const auto max_size = s->cct->_conf->rgw_max_put_param_size;
   std::tie(op_ret, data) = read_all_input(s, max_size, false);
-  ldpp_dout(s, 0) << "RGWPutACLs_ObjStore::get_params read data is: " << data.c_str() << dendl;
+  ldpp_dout(s, 20) << "RGWPutACLs_ObjStore::get_params read data is: " << data.c_str() << dendl;
   return op_ret;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69136

---

backport of https://github.com/ceph/ceph/pull/60910
parent tracker: https://tracker.ceph.com/issues/69093

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh