### PR TITLE
squid: rbd: open images in read-only mode for "rbd mirror pool status --verbose"

### DIFF
--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -354,6 +354,10 @@ protected:
   virtual ~ImageRequestBase() {
   }
 
+  virtual bool open_read_only() const {
+    return false;
+  }
+
   virtual bool skip_get_info() const {
     return false;
   }
@@ -428,8 +432,13 @@ private:
     librbd::RBD rbd;
     auto aio_completion = utils::create_aio_completion<
       ImageRequestBase, &ImageRequestBase::handle_open_image>(this);
-    rbd.aio_open(m_io_ctx, m_image, m_image_name.c_str(), nullptr,
-                 aio_completion);
+    if (open_read_only()) {
+      rbd.aio_open_read_only(m_io_ctx, m_image, m_image_name.c_str(), nullptr,
+                             aio_completion);
+    } else {
+      rbd.aio_open(m_io_ctx, m_image, m_image_name.c_str(), nullptr,
+                   aio_completion);
+    }
   }
 
   void handle_open_image(int r) {
@@ -603,6 +612,10 @@ public:
   }
 
 protected:
+  bool open_read_only() const override {
+    return true;
+  }
+
   bool skip_get_info() const override {
     return true;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69334

---

backport of https://github.com/ceph/ceph/pull/61150
parent tracker: https://tracker.ceph.com/issues/69319