### PR TITLE
cephadm: Indicate orch is paused on executing operations

### DIFF
--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -36,6 +36,35 @@ These commands disable all ``ceph orch ...`` CLI commands. All
 previously deployed daemon containers continue to run and will start just as
 they were before you ran these commands.
 
+In certain scenarios, commands may still execute even when the orchestrator is paused. 
+This behavior arises because these commands bypass the orchestrator's main working loop and are not queued for asynchronous execution. 
+Instead, they invoke low-level operations directly, allowing them to proceed regardless of the orchestrator's paused state.
+
+Example: removing a Daemon
+The 'ceph orch daemon rm' command is one such example. 
+When executed, it directly interacts with the underlying infrastructure to remove the specified daemon.
+Below are log excerpts illustrating this behavior:
+
+.. prompt:: bash #
+
+   mgr.ceph-node-0.pbyqcl (mgr.15129) 139 : cephadm [INF] Paused
+   mgr.ceph-node-0.pbyqcl (mgr.15129) 168 : cephadm [INF] Remove daemons osd.5
+   mgr.ceph-node-0.pbyqcl (mgr.15129) 169 : cephadm [INF] Daemon details: osd.5, ceph-node-2
+   mgr.ceph-node-0.pbyqcl (mgr.15129) 170 : cephadm [INF] Details: osd.5 in status None on ceph-node-2
+   mgr.ceph-node-0.pbyqcl (mgr.15129) 171 : cephadm [INF] Removing daemon osd.5 from ceph-node-2 -- ports []
+   mgr.ceph-node-0.pbyqcl (mgr.15129) 173 : cephadm [INF] Directly calling post_remove for daemon type: osd
+   mgr.ceph-node-0.pbyqcl (mgr.15129) 174 : cephadm [INF] Removing key for osd.5
+
+
+Other commands that directly interact with daemons or hosts and may execute when the orchestrator is paused include:
+
+.. prompt:: bash #
+
+   ceph orch daemon add
+   ceph orch host add <host>
+   ceph orch host rm <host>
+   ceph orch tuned-profile apply
+
 See :ref:`cephadm-spec-unmanaged` for more on disabling individual services.
 
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -52,6 +52,7 @@ from ._interface import (
     TunedProfileSpec,
     _cli_read_command,
     _cli_write_command,
+    check_orchestrator_paused,
     json_to_generic_spec,
     raise_if_exception,
 )
@@ -491,6 +492,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return bool(self.get_module_option("fail_fs"))
 
     @_cli_write_command('orch host add')
+    @check_orchestrator_paused()
     def _add_host(self,
                   hostname: str,
                   addr: Optional[str] = None,
@@ -676,6 +678,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch host rm')
+    @check_orchestrator_paused()
     def _remove_host(self, hostname: str, force: bool = False, offline: bool = False, rm_crush_entry: bool = False) -> HandleCommandResult:
         """Remove a host"""
         completion = self.remove_host(hostname, force, offline, rm_crush_entry)
@@ -683,6 +686,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch host drain')
+    @check_orchestrator_paused()
     def _drain_host(self, hostname: str, force: bool = False, keep_conf_keyring: bool = False, zap_osd_devices: bool = False) -> HandleCommandResult:
         """drain all daemons from a host"""
         completion = self.drain_host(hostname, force, keep_conf_keyring, zap_osd_devices)
@@ -690,6 +694,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch host set-addr')
+    @check_orchestrator_paused()
     def _update_set_addr(self, hostname: str, addr: str) -> HandleCommandResult:
         """Update a host address"""
         completion = self.update_host_addr(hostname, addr)
@@ -768,6 +773,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=output)
 
     @_cli_write_command('orch host label add')
+    @check_orchestrator_paused()
     def _host_label_add(self, hostname: str, label: str) -> HandleCommandResult:
         """Add a host label"""
         completion = self.add_host_label(hostname, label)
@@ -775,6 +781,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch host label rm')
+    @check_orchestrator_paused()
     def _host_label_rm(self, hostname: str, label: str, force: bool = False) -> HandleCommandResult:
         """Remove a host label"""
         completion = self.remove_host_label(hostname, label, force)
@@ -789,6 +796,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch host maintenance enter')
+    @check_orchestrator_paused()
     def _host_maintenance_enter(self, hostname: str, force: bool = False, yes_i_really_mean_it: bool = False) -> HandleCommandResult:
         """
         Prepare a host for maintenance by shutting down and disabling all Ceph daemons (cephadm only)
@@ -799,6 +807,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch host maintenance exit')
+    @check_orchestrator_paused()
     def _host_maintenance_exit(self, hostname: str, force: bool = False, offline: bool = False) -> HandleCommandResult:
         """
         Return a host from maintenance, restarting all Ceph daemons (cephadm only)
@@ -1303,6 +1312,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=json.dumps(out))
 
     @_cli_write_command('orch apply osd')
+    @check_orchestrator_paused()
     def _apply_osd(self,
                    all_available_devices: bool = False,
                    format: Format = Format.plain,
@@ -1361,6 +1371,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(-errno.EINVAL, stderr='--all-available-devices is required')
 
     @_cli_write_command('orch daemon add osd')
+    @check_orchestrator_paused()
     def _daemon_add_osd(self,
                         svc_arg: Optional[str] = None,
                         method: Optional[OSDMethod] = None) -> HandleCommandResult:
@@ -1473,6 +1484,7 @@ Usage:
         return HandleCommandResult(stdout=out)
 
     @_cli_write_command('orch daemon add')
+    @check_orchestrator_paused()
     def daemon_add_misc(self,
                         daemon_type: Optional[ServiceType] = None,
                         placement: Optional[str] = None,
@@ -1499,6 +1511,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch daemon add mds')
+    @check_orchestrator_paused()
     def _mds_add(self,
                  fs_name: str,
                  placement: Optional[str] = None,
@@ -1515,6 +1528,7 @@ Usage:
         return self._daemon_add_misc(spec)
 
     @_cli_write_command('orch daemon add rgw')
+    @check_orchestrator_paused()
     def _rgw_add(self,
                  svc_id: str,
                  placement: Optional[str] = None,
@@ -1535,6 +1549,7 @@ Usage:
         return self._daemon_add_misc(spec)
 
     @_cli_write_command('orch daemon add nfs')
+    @check_orchestrator_paused()
     def _nfs_add(self,
                  svc_id: str,
                  placement: Optional[str] = None,
@@ -1550,6 +1565,7 @@ Usage:
         return self._daemon_add_misc(spec)
 
     @_cli_write_command('orch daemon add iscsi')
+    @check_orchestrator_paused()
     def _iscsi_add(self,
                    pool: str,
                    api_user: str,
@@ -1572,6 +1588,7 @@ Usage:
         return self._daemon_add_misc(spec)
 
     @_cli_write_command('orch daemon add nvmeof')
+    @check_orchestrator_paused()
     def _nvmeof_add(self,
                     pool: str,
                     group: str,
@@ -1606,6 +1623,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch daemon redeploy')
+    @check_orchestrator_paused()
     def _daemon_action_redeploy(self,
                                 name: str,
                                 image: Optional[str] = None) -> HandleCommandResult:
@@ -1617,6 +1635,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch daemon rm')
+    @check_orchestrator_paused()
     def _daemon_rm(self,
                    names: List[str],
                    force: Optional[bool] = False) -> HandleCommandResult:
@@ -1633,6 +1652,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch rm')
+    @check_orchestrator_paused()
     def _service_rm(self,
                     service_name: str,
                     force: bool = False) -> HandleCommandResult:
@@ -1644,6 +1664,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch apply')
+    @check_orchestrator_paused()
     def apply_misc(self,
                    service_type: Optional[ServiceType] = None,
                    placement: Optional[str] = None,
@@ -1755,6 +1776,7 @@ Usage:
         return HandleCommandResult(stdout=out)
 
     @_cli_write_command('orch apply mds')
+    @check_orchestrator_paused()
     def _apply_mds(self,
                    fs_name: str,
                    placement: Optional[str] = None,
@@ -1779,6 +1801,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply rgw')
+    @check_orchestrator_paused()
     def _apply_rgw(self,
                    svc_id: str,
                    placement: Optional[str] = None,
@@ -1823,6 +1846,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply nfs')
+    @check_orchestrator_paused()
     def _apply_nfs(self,
                    svc_id: str,
                    placement: Optional[str] = None,
@@ -1849,6 +1873,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply iscsi')
+    @check_orchestrator_paused()
     def _apply_iscsi(self,
                      pool: str,
                      api_user: str,
@@ -1880,6 +1905,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply mgmt-gateway')
+    @check_orchestrator_paused()
     def _apply_mgmt_gateway(self,
                             port: Optional[int] = None,
                             disable_https: Optional[bool] = False,
@@ -1908,6 +1934,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply oauth2-proxy')
+    @check_orchestrator_paused()
     def _apply_oauth2_proxy(self,
                             https_address: Optional[str] = None,
                             placement: Optional[str] = None,
@@ -1929,6 +1956,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply nvmeof')
+    @check_orchestrator_paused()
     def _apply_nvmeof(self,
                       pool: str,
                       group: str,
@@ -1956,6 +1984,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply snmp-gateway')
+    @check_orchestrator_paused()
     def _apply_snmp_gateway(self,
                             snmp_version: SNMPGatewaySpec.SNMPVersion,
                             destination: str,
@@ -1999,6 +2028,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply jaeger')
+    @check_orchestrator_paused()
     def _apply_jaeger(self,
                       es_nodes: Optional[str] = None,
                       without_query: bool = False,
@@ -2021,6 +2051,7 @@ Usage:
         return self._apply_misc(specs, dry_run, format, no_overwrite)
 
     @_cli_write_command('orch apply smb')
+    @check_orchestrator_paused()
     def _apply_smb(
         self,
         cluster_id: str,
@@ -2057,6 +2088,7 @@ Usage:
         return self._apply_misc([spec], dry_run, format, no_overwrite)
 
     @_cli_write_command('orch set-unmanaged')
+    @check_orchestrator_paused()
     def _set_unmanaged(self, service_name: str) -> HandleCommandResult:
         """Set 'unmanaged: true' for the given service name"""
         completion = self.set_unmanaged(service_name, True)
@@ -2065,6 +2097,7 @@ Usage:
         return HandleCommandResult(stdout=out)
 
     @_cli_write_command('orch set-managed')
+    @check_orchestrator_paused()
     def _set_managed(self, service_name: str) -> HandleCommandResult:
         """Set 'unmanaged: false' for the given service name"""
         completion = self.set_unmanaged(service_name, False)
@@ -2073,6 +2106,7 @@ Usage:
         return HandleCommandResult(stdout=out)
 
     @_cli_write_command('orch set backend')
+    @check_orchestrator_paused()
     def _set_backend(self, module_name: Optional[str] = None) -> HandleCommandResult:
         """
         Select orchestrator module backend
@@ -2364,6 +2398,7 @@ Usage:
         return HandleCommandResult(stdout=out)
 
     @_cli_write_command('orch upgrade start')
+    @check_orchestrator_paused()
     def _upgrade_start(self,
                        image: Optional[str] = None,
                        _end_positional_: int = 0,
@@ -2381,6 +2416,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch upgrade pause')
+    @check_orchestrator_paused()
     def _upgrade_pause(self) -> HandleCommandResult:
         """Pause an in-progress upgrade"""
         completion = self.upgrade_pause()
@@ -2388,6 +2424,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch upgrade resume')
+    @check_orchestrator_paused()
     def _upgrade_resume(self) -> HandleCommandResult:
         """Resume paused upgrade"""
         completion = self.upgrade_resume()
@@ -2395,6 +2432,7 @@ Usage:
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command('orch upgrade stop')
+    @check_orchestrator_paused()
     def _upgrade_stop(self) -> HandleCommandResult:
         """Stop an in-progress upgrade"""
         completion = self.upgrade_stop()


### PR DESCRIPTION
cephadm: Indicate orch is paused on executing operations. 

This fix introduces a decorator, `check_orchestrator_paused`, to ensure that commands executed when the orchestrator is paused provide a clear warning to the user.

Fixes: https://tracker.ceph.com/issues/69219

Test logs:

```
[ceph: root@ceph-node-0 ~]# ceph orch status
Backend: cephadm
Available: Yes
Paused: Yes

[ceph: root@ceph-node-0 ~]# ceph orch rm crash
WARNING: The following command will be deferred and executed once the orchestrator is resumed.
Removed service crash

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED   AGE  PLACEMENT  
crash                                 3/3  <deleting>  9m   *          
mgr                                   2/2  4m ago      9m   count:2    
mon                                   3/5  4m ago      9m   count:5    
osd.all-available-devices               3  4m ago      8m   *    
```      

```
[ceph: root@ceph-node-0 ~]# ceph orch status
Backend: cephadm
Available: Yes
Paused: No

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT  
mgr                                   2/2  1s ago     9m   count:2    
mon                                   3/5  1s ago     9m   count:5    
osd.all-available-devices               3  1s ago     8m   *      
    
[ceph: root@ceph-node-0 ~]# ceph orch apply crash
Scheduled crash update...
```


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
