### PR TITLE
mon/nvme: fix unused lambda capture warnings

### DIFF
--- a/src/nvmeof/NVMeofGwMonitorClient.cc
+++ b/src/nvmeof/NVMeofGwMonitorClient.cc
@@ -151,13 +151,12 @@ int NVMeofGwMonitorClient::init()
 
   // We must register our config callback before calling init(), so
   // that we see the initial configuration message
-  monc.register_config_callback([this](const std::string &k, const std::string &v){
+  monc.register_config_callback([](const std::string &k, const std::string &v){
       // leaving this for debugging purposes
       dout(10) << "nvmeof config_callback: " << k << " : " << v << dendl;
-      
       return false;
     });
-  monc.register_config_notify_callback([this]() {
+  monc.register_config_notify_callback([]() {
       dout(4) << "nvmeof monc config notify callback" << dendl;
     });
   dout(4) << "nvmeof Registered monc callback" << dendl;


### PR DESCRIPTION
Removing compiler warnings:
```

Building CXX object src/CMakeFiles/ceph-nvmeof-monitor-client.dir/nvmeof/NVMeofGwMonitorClient.cc.o
..../src/nvmeof/NVMeofGwMonitorClient.cc:154:34: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
  154 |   monc.register_config_callback([this](const std::string &k, const std::string &v){
      |                                  ^~~~
..../src/nvmeof/NVMeofGwMonitorClient.cc:160:41: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
  160 |   monc.register_config_notify_callback([this]() {
      |                                         ^~~~

```