### PR TITLE
reef: mgr/dashboard: Administration > Configuration > Some of the config options are not updatable at runtime

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -859,7 +859,19 @@ class RbdTest(DashboardTestCase):
         self.assertEqual(clone_format_version, 2)
         self.assertStatus(200)
 
+        # if empty list is sent, then the config will remain as it is
         value = []
+        res = [{'section': "global", 'value': "2"}]
+        self._post('/api/cluster_conf', {
+            'name': config_name,
+            'value': value
+        })
+        self.wait_until_equal(
+            lambda: _get_config_by_name(config_name),
+            res,
+            timeout=60)
+
+        value = [{'section': "global", 'value': ""}]
         self._post('/api/cluster_conf', {
             'name': config_name,
             'value': value

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -2,7 +2,7 @@ from ._api_router import APIRouter
 from ._auth import ControllerAuthMixin
 from ._base_controller import BaseController
 from ._crud import CRUDCollectionMethod, CRUDEndpoint, CRUDResourceMethod, SecretStr
-from ._docs import APIDoc, EndpointDoc
+from ._docs import APIDoc, EndpointDoc, Param
 from ._endpoint import Endpoint, Proxy
 from ._helpers import ENDPOINT_MAP, allow_empty_body, \
     generate_controller_routes, json_error_page, validate_ceph_type
@@ -23,6 +23,7 @@ __all__ = [
     'Task',
     'ControllerAuthMixin',
     'EndpointDoc',
+    'Param',
     'APIDoc',
     'allow_empty_body',
     'ENDPOINT_MAP',

--- a/src/pybind/mgr/dashboard/controllers/_docs.py
+++ b/src/pybind/mgr/dashboard/controllers/_docs.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type, Union
 
 from ..api.doc import SchemaInput, SchemaType
 
@@ -113,6 +113,13 @@ class EndpointDoc:  # noqa: N802
             'response': self.resp
         }
         return func
+
+
+class Param(NamedTuple):
+    type: Union[Type, List[Type]]
+    description: str
+    optional: bool = False
+    default: Optional[Any] = None
 
 
 class APIDoc(object):

--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from typing import Optional
+
 import cherrypy
 
 from .. import mgr
 from ..exceptions import DashboardException
 from ..security import Scope
 from ..services.ceph_service import CephService
-from . import APIDoc, APIRouter, EndpointDoc, RESTController
+from . import APIDoc, APIRouter, EndpointDoc, Param, RESTController
 
 FILTER_SCHEMA = [{
     "name": (str, 'Name of the config option'),
@@ -80,22 +82,33 @@ class ClusterConfiguration(RESTController):
 
         return config_options
 
-    def create(self, name, value):
+    @EndpointDoc("Create/Update Cluster Configuration",
+                 parameters={
+                     'name': Param(str, 'Config option name'),
+                     'value': (
+                         [
+                            {
+                                'section': Param(
+                                    str, 'Section/Client where config needs to be updated'
+                                ),
+                                'value': Param(str, 'Value of the config option')
+                            }
+                         ], 'Section and Value of the config option'
+                     ),
+                     'force_update': Param(bool, 'Force update the config option', False, None)
+                 }
+                 )
+    def create(self, name, value, force_update: Optional[bool] = None):
         # Check if config option is updateable at runtime
-        self._updateable_at_runtime([name])
+        self._updateable_at_runtime([name], force_update)
 
-        # Update config option
-        avail_sections = ['global', 'mon', 'mgr', 'osd', 'mds', 'client']
+        for entry in value:
+            section = entry['section']
+            entry_value = entry['value']
 
-        for section in avail_sections:
-            for entry in value:
-                if entry['value'] is None:
-                    break
-
-                if entry['section'] == section:
-                    CephService.send_command('mon', 'config set', who=section, name=name,
-                                             value=str(entry['value']))
-                    break
+            if entry_value not in (None, ''):
+                CephService.send_command('mon', 'config set', who=section, name=name,
+                                         value=str(entry_value))
             else:
                 CephService.send_command('mon', 'config rm', who=section, name=name)
 
@@ -116,11 +129,24 @@ class ClusterConfiguration(RESTController):
 
         raise cherrypy.HTTPError(404)
 
-    def _updateable_at_runtime(self, config_option_names):
+    def _updateable_at_runtime(self, config_option_names, force_update=False):
         not_updateable = []
 
         for name in config_option_names:
             config_option = self._get_config_option(name)
+
+            # making rgw configuration to be editable by bypassing 'can_update_at_runtime'
+            # as the same can be done via CLI.
+            if force_update and 'rgw' in name and not config_option['can_update_at_runtime']:
+                break
+
+            if force_update and 'rgw' not in name and not config_option['can_update_at_runtime']:
+                raise DashboardException(
+                    msg=f'Only the configuration containing "rgw" can be edited at runtime with'
+                        f' force_update flag, hence not able to update "{name}"',
+                    code='config_option_not_updatable_at_runtime',
+                    component='cluster_configuration'
+                )
             if not config_option['can_update_at_runtime']:
                 not_updateable.append(name)
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form-create-request.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form-create-request.model.ts
@@ -1,4 +1,5 @@
 export class ConfigFormCreateRequestModel {
   name: string;
   value: Array<any> = [];
+  force_update: boolean = false;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -150,7 +150,7 @@
       </div>
       <!-- Footer -->
       <div class="card-footer">
-        <cd-form-button-panel (submitActionEvent)="submit()"
+        <cd-form-button-panel (submitActionEvent)="forceUpdate ? openCriticalConfirmModal() : submit()"
                               [form]="configForm"
                               [submitText]="actionLabels.UPDATE"
                               wrappingClass="text-right"></cd-form-button-panel>
@@ -158,3 +158,4 @@
     </div>
   </form>
 </div>
+

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -13,6 +13,10 @@ import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { ConfigFormCreateRequestModel } from './configuration-form-create-request.model';
+import { CriticalConfirmationModalComponent } from '~/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
+import { ModalService } from '~/app/shared/services/modal.service';
+
+const RGW = 'rgw';
 
 @Component({
   selector: 'cd-configuration-form',
@@ -29,13 +33,15 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
   maxValue: number;
   patternHelpText: string;
   availSections = ['global', 'mon', 'mgr', 'osd', 'mds', 'client'];
+  forceUpdate: boolean;
 
   constructor(
     public actionLabels: ActionLabelsI18n,
     private route: ActivatedRoute,
     private router: Router,
     private configService: ConfigurationService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private modalService: ModalService
   ) {
     super();
     this.createForm();
@@ -95,7 +101,6 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
   setResponse(response: ConfigFormModel) {
     this.response = response;
     const validators = this.getValidators(response);
-
     this.configForm.get('name').setValue(response.name);
     this.configForm.get('desc').setValue(response.desc);
     this.configForm.get('long_desc').setValue(response.long_desc);
@@ -118,7 +123,7 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
         this.configForm.get('values').get(value.section).setValue(sectionValue);
       });
     }
-
+    this.forceUpdate = !this.response.can_update_at_runtime && response.name.includes(RGW);
     this.availSections.forEach((section) => {
       this.configForm.get('values').get(section).setValidators(validators);
     });
@@ -134,7 +139,7 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
 
     this.availSections.forEach((section) => {
       const sectionValue = this.configForm.getValue(section);
-      if (sectionValue !== null && sectionValue !== '') {
+      if (sectionValue !== null) {
         values.push({ section: section, value: sectionValue });
       }
     });
@@ -143,10 +148,26 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
       const request = new ConfigFormCreateRequestModel();
       request.name = this.configForm.getValue('name');
       request.value = values;
+      if (this.forceUpdate) {
+        request.force_update = this.forceUpdate;
+      }
       return request;
     }
 
     return null;
+  }
+
+  openCriticalConfirmModal() {
+    this.modalService.show(CriticalConfirmationModalComponent, {
+      buttonText: $localize`Force Edit`,
+      actionDescription: $localize`force edit`,
+      itemDescription: $localize`configuration`,
+      infoMessage: 'Updating this configuration might require restarting the client',
+      submitAction: () => {
+        this.modalService.dismissAll();
+        this.submit();
+      }
+    });
   }
 
   submit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -12,6 +12,8 @@ import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 import { Permission } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 
+const RGW = 'rgw';
+
 @Component({
   selector: 'cd-configuration',
   templateUrl: './configuration.component.html',
@@ -143,7 +145,9 @@ export class ConfigurationComponent extends ListWithDetails implements OnInit {
     if (selection.selected.length !== 1) {
       return false;
     }
-
-    return selection.selected[0].can_update_at_runtime;
+    if ((this.selection.selected[0].name as string).includes(RGW)) {
+      return true;
+    }
+    return this.selection.selected[0].can_update_at_runtime;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/config-option/config-option.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/config-option/config-option.model.ts
@@ -9,4 +9,5 @@ export class ConfigFormModel {
   min: any;
   max: any;
   services: Array<string>;
+  can_update_at_runtime: boolean;
 }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3885,10 +3885,27 @@ paths:
           application/json:
             schema:
               properties:
+                force_update:
+                  description: Force update the config option
+                  type: boolean
                 name:
+                  description: Config option name
                   type: string
                 value:
-                  type: string
+                  description: Section and Value of the config option
+                  items:
+                    properties:
+                      section:
+                        description: Section/Client where config needs to be updated
+                        type: string
+                      value:
+                        description: Value of the config option
+                        type: string
+                    required:
+                    - section
+                    - value
+                    type: object
+                  type: array
               required:
               - name
               - value
@@ -3915,6 +3932,7 @@ paths:
             trace.
       security:
       - jwt: []
+      summary: Create/Update Cluster Configuration
       tags:
       - ClusterConfiguration
     put:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69272

backport of: #60798

parent tracker: https://tracker.ceph.com/issues/68976

<hr style="border: 2px solid #eeeee">

Fixes: https://tracker.ceph.com/issues/68976

Fixes Includes:
1) by-passing 'can_update_at_runtime' flag for 'rgw' related configurations as the same can be updated at runtime via CLI. Also implemented a warning popup for user to make force edit to rgw related configurations.

Signed-off-by: Naman Munet <naman.munet@ibm.com>
(cherry picked from commit 3181acc223dafd04e3fc56d418389ad50c5868e4)


https://github.com/user-attachments/assets/b4eb3357-2320-41f4-9400-1fe25e168a3c





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
