### PR TITLE
osd/scrub: register for 'osd_max_scrubs' config changes

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9958,7 +9958,8 @@ const char** OSD::get_tracked_conf_keys() const
     "osd_scrub_max_interval",
     "osd_op_thread_timeout",
     "osd_op_thread_suicide_timeout",
-    NULL
+    "osd_max_scrubs",
+    nullptr
   };
   return KEYS;
 }
@@ -10002,6 +10003,10 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
     service.snap_reserver.set_max(cct->_conf->osd_max_trimming_pgs);
   }
   if (changed.count("osd_max_scrubs")) {
+    dout(0) << fmt::format(
+                   "{}: scrub concurrency max changed to {}",
+                   __func__, cct->_conf->osd_max_scrubs)
+            << dendl;
     service.scrub_reserver.set_max(cct->_conf->osd_max_scrubs);
   }
   if (changed.count("osd_op_complaint_time") ||


### PR DESCRIPTION
Since https://github.com/ceph/ceph/pull/55340, the osd_max_scrubs (also) affects the parameters of the async scrub reserver used by the replicas. Thus,
the code must notice and acknowledge changes to this config.

Fixes: https://tracker.ceph.com/issues/69362

