### PR TITLE
squid: osd/scrub: register for 'osd_max_scrubs' config changes

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9875,7 +9875,8 @@ const char** OSD::get_tracked_conf_keys() const
     "osd_scrub_max_interval",
     "osd_op_thread_timeout",
     "osd_op_thread_suicide_timeout",
-    NULL
+    "osd_max_scrubs",
+    nullptr
   };
   return KEYS;
 }
@@ -9919,6 +9920,10 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
     service.snap_reserver.set_max(cct->_conf->osd_max_trimming_pgs);
   }
   if (changed.count("osd_max_scrubs")) {
+    dout(0) << fmt::format(
+                   "{}: scrub concurrency max changed to {}",
+                   __func__, cct->_conf->osd_max_scrubs)
+            << dendl;
     service.scrub_reserver.set_max(cct->_conf->osd_max_scrubs);
   }
   if (changed.count("osd_op_complaint_time") ||


### PR DESCRIPTION
Since https://github.com/ceph/ceph/pull/55340, the osd_max_scrubs (also) affects the parameters of the async scrub reserver used by the replicas. Thus,
the code must notice and acknowledge changes to this config.

Backport of https://github.com/ceph/ceph/pull/61184.

Original tracker: https://tracker.ceph.com/issues/69362
Backport tracker: https://tracker.ceph.com/issues/RRRR <========


(cherry picked from commit 31e6bacfbf60e3e9222cae354d8527fa92282dbc)

