### PR TITLE
reef: mgr/snap_schedule: handle volume delete

### DIFF
--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -197,6 +197,15 @@ this happens, the next snapshot will be schedule as if the previous one was not
 delayed, i.e. one or more delayed snapshots will not cause drift in the overall
 schedule.
 
+If a volume is deleted while snapshot schedules are active on the volume, then
+there might be cases when Python Tracebacks are seen in the log file or on the
+command-line when commands are executed on such volumes. Although measures have
+been taken to take note of the fs_map changes and delete active timers and
+close database connections to avoid Python Tracebacks, it is not possible to
+completely mute the tracebacks due to the inherent nature of problem. In the
+event that such tracebacks are seen, the only solution to get the system to a
+stable state is the disable and re-enable the snap_schedule Manager Module.
+
 In order to somewhat limit the overall number of snapshots in a file system, the
 module will only keep a maximum of 50 snapshots per directory. If the retention
 policy results in more then 50 retained snapshots, the retention list will be

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1157,6 +1157,11 @@ class RemoveFilesystemHandler : public FileSystemCommandHandler
 
     fsmap.erase_filesystem(fs->fscid);
 
+    ss << "If there are active snapshot schedules associated with this "
+       << "file-system, you might see EIO errors in the mgr logs or at the "
+       << "snap-schedule command-line due to the missing file-system. "
+       << "However, these errors are transient and will get auto-resolved.";
+
     return 0;
   }
 };

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -133,7 +133,11 @@ def delete_volume(mgr, volname, metadata_pool, data_pools):
         r, outb, outs = remove_pool(mgr, data_pool)
         if r != 0:
             return r, outb, outs
-    result_str = "metadata pool: {0} data pool: {1} removed".format(metadata_pool, str(data_pools))
+    result_str = f"metadata pool: {metadata_pool} data pool: {str(data_pools)} removed.\n"
+    result_str += "If there are active snapshot schedules associated with this "
+    result_str += "volume, you might see EIO errors in the mgr logs or at the "
+    result_str += "snap-schedule command-line due to the missing volume. "
+    result_str += "However, these errors are transient and will get auto-resolved."
     return r, result_str, ""
 
 def rename_volume(mgr, volname: str, newvolname: str) -> Tuple[int, str, str]:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69354

---

backport of https://github.com/ceph/ceph/pull/55145
parent tracker: https://tracker.ceph.com/issues/63999

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh