### PR TITLE
doc/mgr/dashboard: Fix HAProxy TLS example

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -1296,9 +1296,9 @@ redirection on standby nodes.
     mode tcp
     option httpchk GET /
     http-check expect status 200
-    server x <HOST>:<PORT> ssl check verify none
-    server y <HOST>:<PORT> ssl check verify none
-    server z <HOST>:<PORT> ssl check verify none
+    server x <HOST>:<PORT> check check-ssl verify none
+    server y <HOST>:<PORT> check check-ssl verify none
+    server z <HOST>:<PORT> check check-ssl verify none
 
 .. _dashboard-auditing:
 


### PR DESCRIPTION
With `ssl` set on the `server` option, HAProxy strips the TLS protocol for all clients. You would need to connect to it with `http://<ip>:443`.

To have an active health check, which uses SSL, but does not strip it for clients, you'd need to add:

- `check` to enable active health checks.
- `check-ssl` to instruct the health check to use TLS
- `verify none` to skip verification on the health check requests from HAProxy
- _REMOVE_ `ssl` to stop stripping TLS

The active health checks are required to not route any requests to the inactive managers. These would redirect to any unusable IP from the active mgr.

---

Alternatively you could add another certificate in the frontend and then re-encrypt the traffic.

---

## Checklist
- Tracker (select at least one)
  - [x] Doc update (no ticket needed)
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests

