### PR TITLE
cephadm: link new OSDs to existing managed services

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -199,17 +199,19 @@ There are multiple ways to create new OSDs:
 
 .. warning:: When deploying new OSDs with ``cephadm``, ensure that the ``ceph-osd`` package is not installed on the target host. If it is installed, conflicts may arise in the management and control of the OSD that may lead to errors or unexpected behavior.
 
-* OSDs created via ``ceph orch daemon add`` are by default not added to the orchestrator's OSD service. To attach an OSD to a different, existing OSD service, issue a command of the following form:
+* New OSDs created using ``ceph orch daemon add osd`` are added under ``osd.default`` as managed OSDs with a valid spec.
 
-  .. prompt:: bash *
+  To attach an existing OSD to a different managed service, ``ceph orch osd set-spec-affinity`` command can be used:
 
-    ceph orch osd set-spec-affinity <service_name> <osd_id(s)>
+  .. prompt:: bash #
+
+     ceph orch osd set-spec-affinity <service_name> <osd_id(s)>
 
   For example:
 
   .. prompt:: bash #
-
-    ceph orch osd set-spec-affinity osd.default_drive_group 0 1
+    
+     ceph orch osd set-spec-affinity osd.default_drive_group 0 1
 
 Dry Run
 -------

--- a/qa/suites/orch/cephadm/smoke-small/start.yaml
+++ b/qa/suites/orch/cephadm/smoke-small/start.yaml
@@ -20,4 +20,4 @@ tasks:
       - ceph orch host ls
       - ceph orch device ls
       - ceph orch ls --format yaml
-      - ceph orch ls | grep '^osd '
+      - ceph orch ls | grep 'osd'

--- a/qa/suites/orch/cephadm/smoke/start.yaml
+++ b/qa/suites/orch/cephadm/smoke/start.yaml
@@ -25,4 +25,4 @@ tasks:
       - ceph orch host ls
       - ceph orch device ls
       - ceph orch ls --format yaml
-      - ceph orch ls | grep '^osd '
+      - ceph orch ls | grep 'osd'

--- a/qa/suites/orch/cephadm/upgrade/4-wait.yaml
+++ b/qa/suites/orch/cephadm/upgrade/4-wait.yaml
@@ -13,4 +13,4 @@ tasks:
       - ceph health detail
       - ceph versions | jq -e '.overall | length == 1'
       - ceph versions | jq -e '.overall | keys' | grep $sha1
-      - ceph orch ls | grep '^osd '
+      - ceph orch ls | grep 'osd'


### PR DESCRIPTION
cephadm: link new OSDs to existing managed services

Added logic for new OSDs to correctly link to existing managed services. The create_osds function now dynamically assigns service_id based on matching entries in the spec_store.

Fixes: https://tracker.ceph.com/issues/69378

Test log:
```
[ceph: root@ceph-node-0 ~]# ceph orch ls

NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT        
osd.all-available-devices               7  10m ago    23h  *            
osd.default                             1  4m ago     -    <unmanaged>  
osd.foo                                 5  10m ago    22h  *        

[ceph: root@ceph-node-0 ~]# ceph orch restart osd.all-available-devices

Scheduled to restart osd.0 on host 'ceph-node-0'
Scheduled to restart osd.8 on host 'ceph-node-0'
Scheduled to restart osd.12 on host 'ceph-node-0'
Scheduled to restart osd.1 on host 'ceph-node-1'
Scheduled to restart osd.6 on host 'ceph-node-1'
Scheduled to restart osd.2 on host 'ceph-node-2'
Scheduled to restart osd.7 on host 'ceph-node-2'

[ceph: root@ceph-node-0 ~]# ceph orch restart osd.foo

Scheduled to restart osd.5 on host 'ceph-node-0'
Scheduled to restart osd.9 on host 'ceph-node-0'
Scheduled to restart osd.4 on host 'ceph-node-1'
Scheduled to restart osd.10 on host 'ceph-node-1'
Scheduled to restart osd.3 on host 'ceph-node-2'

```

```
[ceph: root@ceph-node-0 ~]# cat osd_spec.yaml 
service_type: osd
service_id: osd_spec
placement:
  hosts:
    - ceph-node-0
data_devices:
  paths:
    - /dev/vdc
encrypted: true

[ceph: root@ceph-node-0 ~]# ceph orch apply -i osd_spec.yaml 
Scheduled osd.osd_spec update...

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT       
osd.all-available-devices               3  3m ago     23m  *            
osd.osd_spec                            1  48s ago    91s  ceph-node-0 
```

**Providing `--force` option** :
```
[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT  
osd.all-available-devices               6  77s ago    22h  *          
osd.foo                                 3  77s ago    21h  *     
     
[ceph: root@ceph-node-0 ~]# lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sr0     11:0    1  512K  0 rom  
zram0  251:0    0  5.8G  0 disk [SWAP]
vda    252:0    0  100G  0 disk 
|-vda1 252:1    0    2M  0 part 
|-vda2 252:2    0  100M  0 part 
|-vda3 252:3    0 1000M  0 part 
`-vda4 252:4    0 98.9G  0 part /var/lib/ceph/crash
                                /etc/ceph/ceph.keyring
                                /var/log/ceph
                                /etc/ceph/ceph.conf
                                /etc/hosts
                                /run/podman-init
                                /root
vdb    252:16   0   10G  0 disk 
vdc    252:32   0    5G  0 disk 
vdd    252:48   0    5G  0 disk 

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT   
osd.all-available-devices               6  97s ago    22h  *          
osd.foo                                 3  97s ago    21h  *        
  
[ceph: root@ceph-node-0 ~]# ceph orch daemon add osd ceph-node-0:/dev/vde --service-name osd.foo --force
Created osd(s) 9 on host 'ceph-node-0'

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT  
osd.all-available-devices               6  3m ago     22h  *          
osd.foo                                 4  3m ago     21h  *   
``` 

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
