### PR TITLE
dokan: fix a Y2038 bug by replacing `Int32x32To64` with multiplication

### DIFF
--- a/src/dokan/utils.cc
+++ b/src/dokan/utils.cc
@@ -15,7 +15,7 @@
 void to_filetime(time_t t, LPFILETIME pft)
 {
   // Note that LONGLONG is a 64-bit value
-  LONGLONG ll = Int32x32To64(t, 10000000) + 116444736000000000;
+  LONGLONG ll = (t * 10000000LL) + 116444736000000000LL;
   pft->dwLowDateTime = (DWORD)ll;
   pft->dwHighDateTime = ll >> 32;
 }


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
