### PR TITLE
doc: README.md - improve "Tshooting" and "Tips & Tricks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,31 +127,7 @@ To build Ceph, follow this procedure:
 
        ninja install
 
-## Tips and Tricks
-
-   * Use "debug builds" only when needed. Debugging builds are helpful for
-     development, but they can slow down performance. Use
-     `-DCMAKE_BUILD_TYPE=Release` when debugging isn't necessary.
-   * Enable Selective Daemons when testing specific components. Don't start
-     unnecessary daemons.
-   * Preserve Existing Data skip cluster reinitialization between tests by
-     using the `-n` flag.
-
-##  Troubleshooting     
- 
-    * Cluster Fails to Start: Look for errors in the logs under the `out/`
-      directory.
-    * OSD Crashes: Check the OSD logs for errors.
-    * Cluster in a `Health Error` State: Run the `ceph status` command to
-      identify the issue.
-    * RocksDB Errors: Look for RocksDB-related errors in the OSD logs.
     
-    To manage a vstart cluster, stop daemons using `./stop.sh` and start them with ./vstart.sh --daemon osd.${ID} [--nodaemonize]. 
-    Restart by stopping and restarting daemons, ensuring no stale sockets. 
-    For RocksDB performance tracking, set `export ROCKSDB_PERF=true` and start the cluster with `./vstart.sh -n -d -x --bluestore`. 
-    Build with `vstart-base` using debug flags in cmake, compile, and deploy via `./vstart.sh -d -n --bluestore`.
-    To containerize, generate configurations with `vstart.sh`, and deploy with Docker, mapping directories and configuring the network.
-    Manage containers using `docker run`, `stop`, and `rm`. For detailed setups, consult the Ceph-Container repository.
 
  
 ### CMake Options
@@ -204,6 +180,36 @@ The diagnostic colors will be visible when the following command is run:
 Other available values for `DIAGNOSTICS_COLOR` are `auto` (default) and
 `never`.
 
+## Tips and Tricks
+
+   * Use "debug builds" only when needed. Debugging builds are helpful for
+     development, but they can slow down performance. Use
+     `-DCMAKE_BUILD_TYPE=Release` when debugging isn't necessary.
+   * Enable Selective Daemons when testing specific components. Don't start
+     unnecessary daemons.
+   * Preserve Existing Data skip cluster reinitialization between tests by
+     using the `-n` flag.
+   * To manage a vstart cluster, stop daemons using `./stop.sh` and start them
+     with `./vstart.sh --daemon osd.${ID} [--nodaemonize]`. 
+   * Restart the sockets by stopping and restarting the daemons associated with
+     them. This ensures that there are no stale sockets in the cluster.
+   * To track RocksDB performance, set `export ROCKSDB_PERF=true` and start
+     the cluster by using the command `./vstart.sh -n -d -x --bluestore`. 
+   * Build with `vstart-base` using debug flags in cmake, compile, and deploy
+     via `./vstart.sh -d -n --bluestore`.
+   * To containerize, generate configurations with `vstart.sh`, and deploy with
+     Docker, mapping directories and configuring the network.
+   * Manage containers using `docker run`, `stop`, and `rm`. For detailed
+     setups, consult the Ceph-Container repository.
+
+##  Troubleshooting     
+ 
+   * Cluster Fails to Start: Look for errors in the logs under the `out/`
+     directory.
+   * OSD Crashes: Check the OSD logs for errors.
+   * Cluster in a `Health Error` State: Run the `ceph status` command to
+     identify the issue.
+   * RocksDB Errors: Look for RocksDB-related errors in the OSD logs.
 
 ## Building a source tarball
 


### PR DESCRIPTION
Improve the formatting and English language in the sections "Troubleshooting" and "Tips and Tricks", and move those sections to a place where they don't interrupt the flow of the vstart cluster installation instructions. Some of the strings in "Tips and Tricks" are not yet unambiguous sentences that will make sense to the uninitiated, but this PR represents a step in that direction.

This PR is part of a series of PRs meant to preserve the integrity of the README.md file after some recent additions that break the flow of the document.

This PR follows https://github.com/ceph/ceph/pull/61226 and https://github.com/ceph/ceph/pull/61221.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

