### PR TITLE
quincy: mds/fsmap: proper update of filesystems

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -1090,8 +1090,11 @@ std::vector<mds_gid_t> FSMap::stop(mds_gid_t who)
     if (other_info.rank == info.rank
         && other_info.state == MDSMap::STATE_STANDBY_REPLAY) {
       standbys.push_back(other_gid);
-      erase(other_gid, 0);
     }
+  }
+
+  for (const auto &other_gid : standbys) {
+    erase(other_gid, 0);
   }
 
   fs->mds_map.mds_info.erase(who);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55925

---

backport of https://github.com/ceph/ceph/pull/46371
parent tracker: https://tracker.ceph.com/issues/55620

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh