### PR TITLE
quincy: client: Fix return in removexattr for xattrs from `system.` namespace

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13086,7 +13086,9 @@ int Client::_removexattr(Inode *in, const char *name, const UserPerm& perms)
   if (strncmp(name, "user.", 5) &&
       strncmp(name, "security.", 9) &&
       strncmp(name, "trusted.", 8) &&
-      strncmp(name, "ceph.", 5))
+      strncmp(name, "ceph.", 5) &&
+      strcmp(name, ACL_EA_ACCESS) &&
+      strcmp(name, ACL_EA_DEFAULT))
     return -CEPHFS_EOPNOTSUPP;
 
   const VXattr *vxattr = _match_vxattr(in, name);
@@ -13101,6 +13103,11 @@ int Client::_removexattr(Inode *in, const char *name, const UserPerm& perms)
   req->set_inode(in);
  
   int res = make_request(req, perms);
+
+  if ((!strcmp(name, ACL_EA_ACCESS) ||
+      !strcmp(name, ACL_EA_DEFAULT)) &&
+      res == -CEPHFS_ENODATA)
+    res = 0;
 
   trim_cache();
   ldout(cct, 8) << "_removexattr(" << in->ino << ", \"" << name << "\") = " << res << dendl;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13084,7 +13084,6 @@ int Client::_removexattr(Inode *in, const char *name, const UserPerm& perms)
 
   // same xattrs supported by kernel client
   if (strncmp(name, "user.", 5) &&
-      strncmp(name, "system.", 7) &&
       strncmp(name, "security.", 9) &&
       strncmp(name, "trusted.", 8) &&
       strncmp(name, "ceph.", 5))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64564

---

backport of https://github.com/ceph/ceph/pull/55087
parent tracker: https://tracker.ceph.com/issues/64542

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh