### PR TITLE
script/ceph-backport: Remove stray `\` from grep command

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -779,7 +779,7 @@ function maybe_deduce_remote {
     else
         assert_fail "bad remote_type ->$remote_type<- in maybe_deduce_remote"
     fi
-    remote=$(git remote -v | grep --extended-regexp --ignore-case '(://|@)github.com(/|:|:/)'${url_component}'/ceph(\s|\.|\/|-)' | head -n1 | cut -f 1)
+    remote=$(git remote -v | grep --extended-regexp --ignore-case '(://|@)github.com(/|:|:/)'${url_component}'/ceph(\s|\.|/|-)' | head -n1 | cut -f 1)
     echo "$remote"
 }
 


### PR DESCRIPTION
GNU grep v3.8 [release notes](https://git.savannah.gnu.org/cgit/grep.git/tree/NEWS#n85) has the following mention about the usage of backslashes:

> Regular expressions with stray backslashes now cause warnings, as their unspecified behavior can lead to unexpected results.
 . . .
> The warnings are intended as a transition aid; they are likely to be errors in future releases.

As a result we see the warning "grep: warning: stray \ before /" during script execution. Therefore remove the extra `\` from grep command.