### PR TITLE
reef: mgr/dashboard: Fix Latency chart data units in rgw overview page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.html
@@ -60,6 +60,7 @@
         </cd-dashboard-area-chart>
         <cd-dashboard-area-chart chartTitle="Latency"
                                  dataUnits="ms"
+                                 decimals="2"
                                  [labelsArray]="['GET', 'PUT']"
                                  [dataArray]="[queriesResults.AVG_GET_LATENCY, queriesResults.AVG_PUT_LATENCY]">
         </cd-dashboard-area-chart>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.ts
@@ -162,11 +162,9 @@ export class PrometheusService {
                 checkNan
               ) {
                 queriesResults[queryName].forEach((valueArray: any[]) => {
-                  valueArray.forEach((val, index) => {
-                    if (isNaN(parseFloat(val[1]))) {
-                      valueArray[index][1] = '0';
-                    }
-                  });
+                  if (isNaN(parseFloat(valueArray[1]))) {
+                    valueArray[1] = '0';
+                  }
                 });
               }
             });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
@@ -11,8 +11,8 @@ export enum Promqls {
 
 export enum RgwPromqls {
   RGW_REQUEST_PER_SECOND = 'sum(rate(ceph_rgw_req[1m]))',
-  AVG_GET_LATENCY = 'sum(rate(ceph_rgw_get_initial_lat_sum[1m])) / sum(rate(ceph_rgw_get_initial_lat_count[1m]))',
-  AVG_PUT_LATENCY = 'sum(rate(ceph_rgw_put_initial_lat_sum[1m])) / sum(rate(ceph_rgw_put_initial_lat_count[1m]))',
+  AVG_GET_LATENCY = 'sum(rate(ceph_rgw_get_initial_lat_sum[1m])) / sum(rate(ceph_rgw_get_initial_lat_count[1m])) * 1000',
+  AVG_PUT_LATENCY = 'sum(rate(ceph_rgw_put_initial_lat_sum[1m])) / sum(rate(ceph_rgw_put_initial_lat_count[1m])) * 1000',
   GET_BANDWIDTH = 'sum(rate(ceph_rgw_get_b[1m]))',
   PUT_BANDWIDTH = 'sum(rate(ceph_rgw_put_b[1m]))'
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69291

---

backport of https://github.com/ceph/ceph/pull/60976
parent tracker: https://tracker.ceph.com/issues/69144

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh