### PR TITLE
rgw: fix radosgw-admin use after free in bucket sync status

### DIFF
--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -2540,8 +2540,8 @@ static void sync_status(Formatter *formatter)
 
 struct indented {
   int w; // indent width
-  std::string_view header;
-  indented(int w, std::string_view header = "") : w(w), header(header) {}
+  std::string header;
+  indented(int w, std::string header = "") : w(w), header(header) {}
 };
 std::ostream& operator<<(std::ostream& out, const indented& h) {
   return out << std::setw(h.w) << h.header << std::setw(1) << ' ';
@@ -2549,10 +2549,10 @@ std::ostream& operator<<(std::ostream& out, const indented& h) {
 
 struct bucket_source_sync_info {
   const RGWZone& _source;
-  std::string_view error;
+  std::string error;
   std::map<int,std::string> shards_behind;
   int total_shards;
-  std::string_view status;
+  std::string status;
   rgw_bucket bucket_source;
 
   bucket_source_sync_info(const RGWZone& source): _source(source) {}
@@ -3072,14 +3072,12 @@ static int bucket_sync_status(rgw::sal::Driver* driver, const RGWBucketInfo& inf
       }
       if (pipe.source.zone.value_or(rgw_zone_id()) == z->second.id) {
         bucket_source_sync_info source_sync_info(z->second);
-	auto ret = bucket_source_sync_status(dpp(), static_cast<rgw::sal::RadosStore*>(driver), static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone(), z->second,
+        bucket_source_sync_status(dpp(), static_cast<rgw::sal::RadosStore*>(driver), static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone(), z->second,
 				  c->second,
 				  info, pipe,
 				  source_sync_info);
 
-        if (ret == 0) {
-          bucket_sync_info.source_status_info.emplace_back(std::move(source_sync_info));
-        }
+        bucket_sync_info.source_status_info.emplace_back(std::move(source_sync_info));
       }
     }
   }


### PR DESCRIPTION
Converted `std::string_view` members to `std::string` to avoid use after free. `std::string_view` does not own the underlying data so the temporarily created strings for error/status go out of scope before it gets printed as part of the status. 

Regression was introduced in commit e84c7fcc57f6e6f453b6d6c4dbeffa7b1154d793 ([link](https://github.com/ceph/ceph/commit/e84c7fcc57f6e6f453b6d6c4dbeffa7b1154d793)).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
