### PR TITLE
reef: test/librbd/fsx: switch to netlink interface for rbd-nbd

### DIFF
--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -1254,6 +1254,7 @@ nbd_open(const char *name, struct rbd_ctx *ctx)
 			   SubProcess::KEEP);
 	process.add_cmd_arg("map");
 	process.add_cmd_arg("--io-timeout=600");
+	process.add_cmd_arg("--try-netlink");
 	std::string img;
 	img.append(pool);
 	img.append("/");


### PR DESCRIPTION
The default was flipped in commit fcbf7367d285 ("rbd-nbd: map using netlink interface by default") in squid.  This is a reef-only fixup for fsx to counter failures like "Size error: expected 0xa5cac00 stat 0x0" which seem to be quite persistent on CentOS Stream 9.

This popped up in https://tracker.ceph.com/issues/69414.
