### PR TITLE
ceph-volume: fix Zap.ensure_associated_raw()

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -119,13 +119,12 @@ class Zap:
                     osd_uuid = details.get('osd_uuid')
                     break
 
-        for osd_uuid, details in raw_report.items():
+        for _, details in raw_report.items():
             device: str = details.get('device')
             if details.get('osd_uuid') == osd_uuid:
                 raw_devices.add(device)
 
         return list(raw_devices)
-        
 
     def find_associated_devices(self) -> List[api.Volume]:
         """From an ``osd_id`` and/or an ``osd_fsid``, filter out all the Logical Volumes (LVs) in the

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/data_zap.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/data_zap.py
@@ -22,7 +22,7 @@ ceph_bluestore_tool_output = '''
         "whoami": "0"
     },
     "/dev/vdx": {
-        "osd_uuid": "d5a496bc-dcb9-4ad0-a12c-393d3200d2b6",
+        "osd_uuid": "d5a496bc-dcb9-4ad0-a12c-393d3200d2b7",
         "size": 214748364800,
         "btime": "2024-10-16T10:51:05.955279+0000",
         "description": "main",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69437

parent tracker: https://tracker.ceph.com/issues/69430

When an OSD creation fails, ceph-volume can zaps unrelated existing raw based OSD as part of the 'rollback step'.

Fixes: https://tracker.ceph.com/issues/69437

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>
(cherry picked from commit 95bdcbfd813d41aa07069cc95a5da7c321936afd)
