### PR TITLE
crimson: Revert "allow replica side write commits to pipeline"

### DIFF
--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -62,12 +62,6 @@ struct PGRepopPipeline {
   struct Process : OrderedExclusivePhaseT<Process> {
     static constexpr auto type_name = "PGRepopPipeline::process";
   } process;
-  struct WaitCommit : OrderedConcurrentPhaseT<WaitCommit> {
-    static constexpr auto type_name = "PGRepopPipeline::wait_repop";
-  } wait_commit;
-  struct SendReply : OrderedExclusivePhaseT<SendReply> {
-    static constexpr auto type_name = "PGRepopPipeline::send_reply";
-  } send_reply;
 };
 
 struct CommonOBCPipeline {

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -38,10 +38,7 @@ struct LttngBackend
     CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
     CommonOBCPipeline::SendReply::BlockingEvent::Backend,
-    PGRepopPipeline::Process::BlockingEvent::Backend,
-    PGRepopPipeline::WaitCommit::BlockingEvent::Backend,
-    PGRepopPipeline::WaitCommit::BlockingEvent::ExitBarrierEvent::Backend,
-    PGRepopPipeline::SendReply::BlockingEvent::Backend
+    PGRepopPipeline::Process::BlockingEvent::Backend
 {
   void handle(ClientRequest::StartEvent&,
               const Operation&) override {}
@@ -129,20 +126,6 @@ struct LttngBackend
               const PGRepopPipeline::Process& blocker) override {
   }
 
-  void handle(PGRepopPipeline::WaitCommit::BlockingEvent& ev,
-              const Operation& op,
-              const PGRepopPipeline::WaitCommit& blocker) override {
-  }
-
-  void handle(PGRepopPipeline::WaitCommit::BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(PGRepopPipeline::SendReply::BlockingEvent& ev,
-              const Operation& op,
-              const PGRepopPipeline::SendReply& blocker) override {
-  }
-
   void handle(ClientRequest::CompletionEvent&,
               const Operation&) override {}
 
@@ -167,10 +150,7 @@ struct HistoricBackend
     CommonOBCPipeline::WaitRepop::BlockingEvent::Backend,
     CommonOBCPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
     CommonOBCPipeline::SendReply::BlockingEvent::Backend,
-    PGRepopPipeline::Process::BlockingEvent::Backend,
-    PGRepopPipeline::WaitCommit::BlockingEvent::Backend,
-    PGRepopPipeline::WaitCommit::BlockingEvent::ExitBarrierEvent::Backend,
-    PGRepopPipeline::SendReply::BlockingEvent::Backend
+    PGRepopPipeline::Process::BlockingEvent::Backend
 {
   void handle(ClientRequest::StartEvent&,
               const Operation&) override {}
@@ -265,21 +245,6 @@ struct HistoricBackend
               const Operation& op,
               const PGRepopPipeline::Process& blocker) override {
   }
-
-  void handle(PGRepopPipeline::WaitCommit::BlockingEvent& ev,
-              const Operation& op,
-              const PGRepopPipeline::WaitCommit& blocker) override {
-  }
-
-  void handle(PGRepopPipeline::WaitCommit::BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(PGRepopPipeline::SendReply::BlockingEvent& ev,
-              const Operation& op,
-              const PGRepopPipeline::SendReply& blocker) override {
-  }
-
 
   void handle(ClientRequest::CompletionEvent&, const Operation& op) override {
     if (crimson::common::local_conf()->osd_op_history_size) {

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -82,12 +82,15 @@ seastar::future<> RepRequest::with_pg(
       });
     }).then_interruptible([this, pg] (auto) {
       return pg->handle_rep_op(req);
+    }).then_interruptible([this] {
+      logger().debug("{}: complete", *this);
+      return handle.complete();
     });
   }, [](std::exception_ptr) {
     return seastar::now();
   }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)] {
     logger().debug("{}: exit", *this);
-    return handle.complete();
+    handle.exit();
   });
 }
 

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -83,13 +83,7 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
 
   auto [commit_fut, reply] = co_await pg->handle_rep_op(req);
 
-  // Transitions from OrderedExclusive->OrderedConcurrent cannot block
-  this->template enter_stage_sync(repop_pipeline(*pg).wait_commit);
-
   co_await std::move(commit_fut);
-
-  co_await this->template enter_stage<interruptor>(
-    repop_pipeline(*pg).send_reply);
 
   co_await interruptor::make_interruptible(
     pg->shard_services.send_to_osd(

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -5,7 +5,6 @@
 
 #include "common/Formatter.h"
 
-#include "crimson/common/coroutine.h"
 #include "crimson/osd/osd.h"
 #include "crimson/osd/osd_connection_priv.h"
 #include "crimson/osd/osd_operation_external_tracking.h"
@@ -69,14 +68,17 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
 {
   LOG_PREFIX(RepRequest::with_pg_interruptible);
   DEBUGI("{}", *this);
-  co_await this->template enter_stage<interruptor>(repop_pipeline(*pg).process);
-  co_await interruptor::make_interruptible(this->template with_blocking_event<
-    PG_OSDMapGate::OSDMapBlocker::BlockingEvent
-    >([this, pg](auto &&trigger) {
-      return pg->osdmap_gate.wait_for_map(
-	std::move(trigger), req->min_epoch);
-    }));
-  co_await pg->handle_rep_op(req);
+  return this->template enter_stage<interruptor>(repop_pipeline(*pg).process
+  ).then_interruptible([this, pg] {
+    return this->template with_blocking_event<
+      PG_OSDMapGate::OSDMapBlocker::BlockingEvent
+      >([this, pg](auto &&trigger) {
+        return pg->osdmap_gate.wait_for_map(
+          std::move(trigger), req->min_epoch);
+      });
+  }).then_interruptible([this, pg] (auto) {
+    return pg->handle_rep_op(req);
+  });
 }
 
 seastar::future<> RepRequest::with_pg(

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -71,9 +71,6 @@ public:
     r_conn = make_local_shared_foreign(std::move(conn));
   }
 
-  interruptible_future<> with_pg_interruptible(
-    Ref<PG> pg);
-
   seastar::future<> with_pg(
     ShardServices &shard_services, Ref<PG> pg);
 

--- a/src/crimson/osd/osd_operations/replicated_request.h
+++ b/src/crimson/osd/osd_operations/replicated_request.h
@@ -84,8 +84,6 @@ public:
     ConnectionPipeline::GetPGMapping::BlockingEvent,
     PerShardPipeline::CreateOrWaitPG::BlockingEvent,
     PGRepopPipeline::Process::BlockingEvent,
-    PGRepopPipeline::WaitCommit::BlockingEvent,
-    PGRepopPipeline::SendReply::BlockingEvent,
     PG_OSDMapGate::OSDMapBlocker::BlockingEvent,
     PGMap::PGCreationBlockingEvent,
     OSD_OSDMapGate::OSDMapBlocker::BlockingEvent

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1215,10 +1215,13 @@ void PG::update_stats(const pg_stat_t &stat) {
   );
 }
 
-PG::handle_rep_op_fut PG::handle_rep_op(Ref<MOSDRepOp> req)
+PG::interruptible_future<> PG::handle_rep_op(Ref<MOSDRepOp> req)
 {
   LOG_PREFIX(PG::handle_rep_op);
   DEBUGDPP("{}", *this, *req);
+  if (can_discard_replica_op(*req)) {
+    co_return;
+  }
 
   ceph::os::Transaction txn;
   auto encoded_txn = req->get_data().cbegin();
@@ -1240,8 +1243,7 @@ PG::handle_rep_op_fut PG::handle_rep_op(Ref<MOSDRepOp> req)
                 txn,
                 false);
   DEBUGDPP("{} do_transaction", *this, *req);
-
-  auto commit_fut = interruptor::make_interruptible(
+  co_await interruptor::make_interruptible(
     shard_services.get_store().do_transaction(coll_ref, std::move(txn))
   );
 
@@ -1252,7 +1254,10 @@ PG::handle_rep_op_fut PG::handle_rep_op(Ref<MOSDRepOp> req)
     req.get(), pg_whoami, 0,
     map_epoch, req->get_min_epoch(), CEPH_OSD_FLAG_ONDISK);
   reply->set_last_complete_ondisk(lcod);
-  co_return handle_rep_op_ret(std::move(commit_fut), std::move(reply));
+  co_await interruptor::make_interruptible(
+    shard_services.send_to_osd(req->from.osd, std::move(reply), map_epoch)
+  );
+  co_return;
 }
 
 PG::interruptible_future<> PG::update_snap_map(

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -596,13 +596,7 @@ public:
   using with_obc_func_t =
     std::function<load_obc_iertr::future<> (ObjectContextRef, ObjectContextRef)>;
 
-  using handle_rep_op_ret = std::tuple<
-    interruptible_future<>, // resolves upon commit
-    MURef<MOSDRepOpReply>     // reply message
-    >;
-  // outer future resolves upon submission
-  using handle_rep_op_fut = interruptible_future<handle_rep_op_ret>;
-  handle_rep_op_fut handle_rep_op(Ref<MOSDRepOp> m);
+  interruptible_future<> handle_rep_op(Ref<MOSDRepOp> m);
   void update_stats(const pg_stat_t &stat);
   interruptible_future<> update_snap_map(
     const std::vector<pg_log_entry_t> &log_entries,


### PR DESCRIPTION
Seems related to 02b70a62a43c86123b196dbd478be2c3c3e272d4 as the traceback is around `RepRequest::with_pg`.
I've reverted all the dependent commits from https://github.com/ceph/ceph/pull/61086 for now until we can sort this one out.
Noticed while trying to start a 3 OSD vstart cluster locally without (--redirect-output):
```
INFO  2025-01-08 17:20:22,231 seastar - Reactor backend: linux-aio                                                                                                                                                                                            
==1764782==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!                                                                                                                               
=================================================================                                                                                                                                                                                             
=================================================================                                                                                                                                                                                             
==1764782==ERROR: AddressSanitizer: heap-use-after-free on address 0x6260000032b0 at pc 0x0000047c0964 bp 0x7fffe6e25fc0 sp 0x7fffe6e25fb0                                                                                                                    
==1762314==ERROR: AddressSanitizer: heap-use-after-free on address 0x6260000032b0 at pc 0x0000047c0964 bp 0x7ffcbb975f70 sp 0x7ffcbb975f60                                                                                                                    
READ of size 4 at 0x6260000032b0 thread T0                                                                                                                                                                                                                    
READ of size 4 at 0x6260000032b0 thread T0                                                                                                                                                                                                                    
    #0 0x47c0963 in crimson::OrderedExclusivePhaseT<crimson::osd::PGRepopPipeline::SendReply>::ExitBarrier::~ExitBarrier() /home/*/ceph/src/crimson/common/operation.h:679                                                                                
    #1 0x47c0963 in crimson::OrderedExclusivePhaseT<crimson::osd::PGRepopPipeline::SendReply>::ExitBarrier::~ExitBarrier() /home/*/ceph/src/crimson/common/operation.h:681                                                                                
    #0 0x47c0963 in crimson::OrderedExclusivePhaseT<crimson::osd::PGRepopPipeline::SendReply>::ExitBarrier::~ExitBarrier() /home/*/ceph/src/crimson/common/operation.h:679                                                                                
    #1 0x47c0963 in crimson::OrderedExclusivePhaseT<crimson::osd::PGRepopPipeline::SendReply>::ExitBarrier::~ExitBarrier() /home/*/ceph/src/crimson/common/operation.h:681                                                                                
    #2 0x277fa18 in std::default_delete<crimson::PipelineExitBarrierI>::operator()(crimson::PipelineExitBarrierI*) const /usr/include/c++/11/bits/unique_ptr.h:85                                                                                             
    #3 0x277fa18 in std::unique_ptr<crimson::PipelineExitBarrierI, std::default_delete<crimson::PipelineExitBarrierI> >::~unique_ptr() /usr/include/c++/11/bits/unique_ptr.h:361                                                                              
    #4 0x277fa18 in crimson::PipelineHandle::complete() /home/*/ceph/src/crimson/common/operation.h:638                                                                                                                                                   
    #5 0x478c274 in operator() /home/*/ceph/src/crimson/osd/osd_operations/replicated_request.cc:112                                                                                                                                                      
    #6 0x478c274 in invoke<crimson::osd::RepRequest::with_pg(crimson::osd::ShardServices&, Ref<crimson::osd::PG>)::<lambda()>&> /home/*/ceph/src/seastar/include/seastar/core/future.hh:2034                                                              
    #7 0x478c274 in futurize_invoke<crimson::osd::RepRequest::with_pg(crimson::osd::ShardServices&, Ref<crimson::osd::PG>)::<lambda()>&> /home/*/ceph/src/seastar/include/seastar/core/future.hh:2065                                                     
    #8 0x478f34c in operator() /home/*/ceph/src/seastar/include/seastar/core/future.hh:1662                                                                                                                                                               
    #9 0x478f34c in invoke<seastar::future<>::finally_body<crimson::osd::RepRequest::with_pg(crimson::osd::ShardServices&, Ref<crimson::osd::PG>)::<lambda()>, true>&, seastar::future<void> > /home/*/ceph/src/seastar/include/seastar/core/future.hh:203
4     
    
freed by thread T0 here:                                                                                                                                                                                                                                      
    #0 0x7ff9918b73cf in operator delete(void*, unsigned long) (/lib64/libasan.so.6+0xb73cf)                                                                                                                                                                  
    #21 0x121ef9ac in seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) /home/matan/ceph/src/seastar/src/core/app-template.cc:276                                                                                                  
    #22 0x121f207e in seastar::app_template::run(int, char**, std::function<seastar::future<int> ()>&&) /home/*/ceph/src/seastar/src/core/app-template.cc:167                                                                                             
    #23 0x205331a in main /home/*/ceph/src/crimson/osd/main.cc:122                                                                                                                                                                                        
    #24 0x7f5eefe2958f in __libc_start_call_main (/lib64/libc.so.6+0x2958f)                                                                                                                                                                                   
    #25 0x7f5eefe2963f in __libc_start_main_alias_1 (/lib64/libc.so.6+0x2963f)                                                                                                                                                                                
    #26 0x1d13f64 in _start (/home/*/ceph/build/bin/crimson-osd+0x1d13f64)                                                                                                                                                                                
                                                                                                                                                                                                                                                              
0x6260000032b0 is located 432 bytes inside of 10312-byte region [0x626000003100,0x626000005948)                                                                                                                                                               
freed by thread T0 here:                                                                                                                                                                                                                                      
    #0 0x7f5ef22b73cf in operator delete(void*, unsigned long) (/lib64/libasan.so.6+0xb73cf)                                                                                                                                                                  
    #1 0x2fe09f3 in crimson::osd::PG::~PG() /home/*/ceph/src/crimson/osd/pg.cc:165                                                                                                                                                                        
                                                                                                                                                                                                                                                              
previously allocated by thread T0 here:                                                                                                                                                                                                                       
    #0 0x7ff9918b6367 in operator new(unsigned long) (/lib64/libasan.so.6+0xb6367)                                                                                                                                                                            
    #1 0x2fe09f3 in crimson::osd::PG::~PG() /home/*/ceph/src/crimson/osd/pg.cc:165  
SUMMARY: AddressSanitizer: heap-use-after-free /home/*/ceph/src/crimson/common/operation.h:679 in crimson::OrderedExclusivePhaseT<crimson::osd::PGRepopPipeline::SendReply>::ExitBarrier::~ExitBarrier(
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
