### PR TITLE
crimson/.../replicated_request: fix pg lifetime in with_pg finally

### DIFF
--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -107,9 +107,10 @@ seastar::future<> RepRequest::with_pg(
     return with_pg_interruptible(pg);
   }, [](std::exception_ptr) {
     return seastar::now();
-  }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)] {
+  }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)]() mutable {
     logger().debug("{}: exit", *this);
-    return handle.complete();
+    return handle.complete(
+    ).finally([ref=std::move(ref)] {});
   });
 }
 

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -107,10 +107,11 @@ seastar::future<> RepRequest::with_pg(
     return with_pg_interruptible(pg);
   }, [](std::exception_ptr) {
     return seastar::now();
-  }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)]() mutable {
+  }, pg, pg->get_osdmap_epoch()
+  ).finally([this, pg, ref=std::move(ref)]() mutable {
     logger().debug("{}: exit", *this);
     return handle.complete(
-    ).finally([ref=std::move(ref)] {});
+    ).finally([ref=std::move(ref), pg=std::move(pg)] {});
   });
 }
 

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -70,12 +70,21 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
   LOG_PREFIX(RepRequest::with_pg_interruptible);
   DEBUGI("{}", *this);
   co_await this->template enter_stage<interruptor>(repop_pipeline(*pg).process);
-  co_await interruptor::make_interruptible(this->template with_blocking_event<
-    PG_OSDMapGate::OSDMapBlocker::BlockingEvent
-    >([this, pg](auto &&trigger) {
-      return pg->osdmap_gate.wait_for_map(
-	std::move(trigger), req->min_epoch);
-    }));
+  {
+    /* Splitting this expression into a fut and a seperate co_await
+     * works around a gcc 11 bug (observed on 11.4.1 and gcc 11.5.0)
+     * which results in the pg ref captured by the lambda being
+     * destructed twice.  We can probably remove these workarounds
+     * once we disallow gcc 11 */
+    auto fut = interruptor::make_interruptible(
+      this->template with_blocking_event<
+      PG_OSDMapGate::OSDMapBlocker::BlockingEvent
+      >([this, pg](auto &&trigger) {
+	return pg->osdmap_gate.wait_for_map(
+	  std::move(trigger), req->min_epoch);
+      }));
+    co_await std::move(fut);
+  }
 
   if (pg->can_discard_replica_op(*req)) {
     co_return;


### PR DESCRIPTION
02b70a62a4 moved the call to handle.complete() into the finally, but didn't extend the pg ref lifetime until after the complete resolved.


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
