### PR TITLE
rgw/s3: CreateBucket extension for layout type and shard count

### DIFF
--- a/examples/rgw/boto3/create_bucket_indexless.py
+++ b/examples/rgw/boto3/create_bucket_indexless.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+
+import boto3
+import sys
+
+if len(sys.argv) != 2:
+    print('Usage: ' + sys.argv[0] + ' <bucket>')
+    sys.exit(1)
+
+# bucket name as first argument
+bucketname = sys.argv[1]
+
+# endpoint and keys from vstart
+endpoint = 'http://127.0.0.1:8000'
+access_key='0555b35654ad1656d804'
+secret_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
+
+client = boto3.client('s3',
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key)
+
+client.create_bucket(
+    Bucket=bucketname,
+    CreateBucketConfiguration={
+        'BucketIndex': {
+            'Type': 'Indexless'
+        }
+    })

--- a/examples/rgw/boto3/create_bucket_shards.py
+++ b/examples/rgw/boto3/create_bucket_shards.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+import boto3
+import sys
+
+if len(sys.argv) != 3:
+    print('Usage: ' + sys.argv[0] + ' <bucket> <num-shards>')
+    sys.exit(1)
+
+# bucket name as first argument
+bucketname = sys.argv[1]
+shards = int(sys.argv[2])
+
+# endpoint and keys from vstart
+endpoint = 'http://127.0.0.1:8000'
+access_key='0555b35654ad1656d804'
+secret_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
+
+client = boto3.client('s3',
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key)
+
+client.create_bucket(
+    Bucket=bucketname,
+    CreateBucketConfiguration={
+        'BucketIndex': {
+            'Type': 'Normal',
+            'NumShards': shards
+        }
+    })

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -411,7 +411,40 @@
         },
         "ReadStats":{"type":"boolean"},
         "ObjectCount":{"type":"integer"},
-        "BytesUsed":{"type":"integer"}
+        "BytesUsed":{"type":"integer"},
+        "CreateBucketConfiguration":{
+            "type":"structure",
+            "members":{
+                "BucketIndex":{
+                    "shape":"BucketIndex",
+                    "documentation":"<p>Configuration to customize the bucket index layout.</p> <note> <p>This element is a Ceph RGW extension.</p> </note>"
+                }
+            }
+        },
+        "BucketIndex":{
+            "type":"structure",
+            "required":[
+                "Type"
+            ],
+            "members":{
+                "Type":{
+                    "shape":"BucketIndexType",
+                    "documentation":"<p>Bucket index type: Normal or Indexless.</p>"
+                },
+                "NumShards":{
+                    "shape":"BucketIndexNumShards",
+                    "documentation":"<p>Number of initial bucket index shards. Only valid for the <code>Normal</code> index type.</p>"
+                }
+            }
+        },
+        "BucketIndexType":{
+            "type":"string",
+            "enum":[
+                "Normal",
+                "Indexless"
+            ]
+        },
+        "BucketIndexNumShards":{"type":"integer"}
     },
     "documentation":"<p/>"
 }

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -2805,14 +2805,17 @@ int RGWBucketInstanceMetadataHandler::put(std::string& entry, RGWMetadataObject*
 
 void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
 				const RGWZone& zone,
-				std::optional<rgw::BucketIndexType> type) {
+				std::optional<rgw::BucketIndexType> type,
+				std::optional<uint32_t> shards) {
   layout.current_index.gen = 0;
   layout.current_index.layout.normal.hash_type = rgw::BucketHashType::Mod;
 
   layout.current_index.layout.type =
     type.value_or(rgw::BucketIndexType::Normal);
 
-  if (cct->_conf->rgw_override_bucket_index_max_shards > 0) {
+  if (shards) {
+    layout.current_index.layout.normal.num_shards = *shards;
+  } else if (cct->_conf->rgw_override_bucket_index_max_shards > 0) {
     layout.current_index.layout.normal.num_shards =
       cct->_conf->rgw_override_bucket_index_max_shards;
   } else {
@@ -2842,7 +2845,7 @@ int RGWBucketInstanceMetadataHandler::put_prepare(
       bci.info.layout = rgw::BucketLayout{};
       init_default_bucket_layout(dpp->get_cct(), bci.info.layout,
 				 svc_zone->get_zone(),
-				 std::nullopt);
+				 std::nullopt, std::nullopt);
     }
   }
 

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -44,7 +44,8 @@ extern bool rgw_bucket_object_check_filter(const std::string& oid);
 
 void init_default_bucket_layout(CephContext *cct, rgw::BucketLayout& layout,
 				const RGWZone& zone,
-				std::optional<rgw::BucketIndexType> type);
+				std::optional<rgw::BucketIndexType> type,
+				std::optional<uint32_t> shards);
 
 struct RGWBucketCompleteInfo {
   RGWBucketInfo info;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -2362,6 +2362,8 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
                             const std::optional<std::string>& swift_ver_location,
                             const std::optional<RGWQuotaInfo>& quota,
                             std::optional<ceph::real_time> creation_time,
+                            std::optional<rgw::BucketIndexType> index_type,
+                            std::optional<uint32_t> index_shards,
                             obj_version* pep_objv,
                             RGWBucketInfo& info)
 {
@@ -2392,8 +2394,11 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
     }
 
     if (zone_placement) {
+      if (!index_type) {
+        index_type = zone_placement->index_type;
+      }
       init_default_bucket_layout(cct, info.layout, svc.zone->get_zone(),
-                                 zone_placement->index_type);
+                                 index_type, index_shards);
     }
 
     info.requester_pays = false;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -643,6 +643,8 @@ public:
                     const std::optional<std::string>& swift_ver_location,
                     const std::optional<RGWQuotaInfo>& quota,
                     std::optional<ceph::real_time> creation_time,
+                    std::optional<rgw::BucketIndexType> index_type,
+                    std::optional<uint32_t> index_shards,
                     obj_version* pep_objv,
                     RGWBucketInfo& info);
 

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -174,7 +174,8 @@ int RadosBucket::create(const DoutPrefixProvider* dpp,
       dpp, y, key, params.owner, params.zonegroup_id,
       params.placement_rule, params.zone_placement, params.attrs,
       params.obj_lock_enabled, params.swift_ver_location,
-      params.quota, params.creation_time, &bucket_version, info);
+      params.quota, params.creation_time, params.index_type,
+      params.index_shards, &bucket_version, info);
 
   bool existed = false;
   if (ret == -EEXIST) {
@@ -186,6 +187,13 @@ int RadosBucket::create(const DoutPrefixProvider* dpp,
      * client about a name conflict.
      */
     if (info.owner != params.owner) {
+      return -ERR_BUCKET_EXISTS;
+    }
+    // prevent re-creation with different index type or shard count
+    if ((params.index_type && *params.index_type !=
+         info.layout.current_index.layout.type) ||
+        (params.index_shards && *params.index_shards !=
+         info.layout.current_index.layout.normal.num_shards)) {
       return -ERR_BUCKET_EXISTS;
     }
     ret = 0;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6264,6 +6264,13 @@ void RGWPutACLs::execute(optional_yield y)
 
 void RGWPutLC::execute(optional_yield y)
 {
+  if (const auto& current_index = s->bucket->get_info().layout.current_index;
+      current_index.layout.type == rgw::BucketIndexType::Indexless) {
+    s->err.message = "Indexless buckets do not support lifecycle policy";
+    op_ret = -ERR_METHOD_NOT_ALLOWED;
+    return;
+  }
+
   bufferlist bl;
   
   RGWLifecycleConfiguration_S3 config(s->cct);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3196,6 +3196,13 @@ void RGWListBucket::execute(optional_yield y)
     return;
   }
 
+  if (const auto& current_index = s->bucket->get_info().layout.current_index;
+      current_index.layout.type == rgw::BucketIndexType::Indexless) {
+    s->err.message = "Indexless buckets cannot be listed";
+    op_ret = -ERR_METHOD_NOT_ALLOWED;
+    return;
+  }
+
   if (allow_unordered && !delimiter.empty()) {
     ldpp_dout(this, 0) <<
       "ERROR: unordered bucket listing requested with a delimiter" << dendl;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -889,6 +889,8 @@ class Bucket {
       std::optional<std::string> swift_ver_location;
       std::optional<RGWQuotaInfo> quota;
       std::optional<ceph::real_time> creation_time;
+      std::optional<rgw::BucketIndexType> index_type;
+      std::optional<uint32_t> index_shards;
     };
 
     /// Create this bucket in the backing store.

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -358,6 +358,10 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
                                         const rgw::bucket_index_layout_generation& idx_layout,
                                         bool judge_support_logrecord)
 {
+  if (idx_layout.layout.type != rgw::BucketIndexType::Normal) {
+    return 0;
+  }
+
   librados::IoCtx index_pool;
 
   string dir_oid = dir_oid_prefix;
@@ -386,6 +390,10 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
 int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
                                          const rgw::bucket_index_layout_generation& idx_layout)
 {
+  if (idx_layout.layout.type != rgw::BucketIndexType::Normal) {
+    return 0;
+  }
+
   librados::IoCtx index_pool;
 
   std::string dir_oid = dir_oid_prefix;


### PR DESCRIPTION
extend s3's [CreateBucketConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#API_CreateBucket_RequestSyntax) with a custom `BucketIndex` element that can override rgw's default bucket index type and shard count

to create an indexless bucket:
```xml
  <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <BucketIndex>
      <Type>Indexless</Type>
    </BucketIndex>
  </CreateBucketConfiguration>
```
to create a normal pre-sharded bucket:
```xml
  <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <BucketIndex>
      <Type>Normal</Type>
      <NumShards>1023</NumShards>
    </BucketIndex>
  </CreateBucketConfiguration>
```
----

this also registers the extension for boto. the following output is from `aws s3api create-bucket help`:
```
       --create-bucket-configuration (structure)
          The configuration information for the bucket.

          LocationConstraint -> (string)
              ...
				 
          Location -> (structure)
              ...

          Bucket -> (structure)
              ...

          BucketIndex -> (structure)
              Configuration to customize the bucket index layout.

              NOTE:
                 This element is a Ceph RGW extension.

              Type -> (string)
                 Bucket index type: Normal or Indexless.

              NumShards -> (integer)
                 Number of initial bucket index shards.  Only  valid  for  the
                 Normal index type.

       Shorthand Syntax:

          LocationConstraint=string,Location={Type=string,Name=string},Bucket={DataRedundancy=string,Type=string},BucketIndex={Type=string,NumShards=integer}

       JSON Syntax:

          {
            "LocationConstraint": "af-south-1"|"ap-east-1"|"ap-northeast-1"|"ap-northeast-2"|"ap-northeast-3"|"ap-south-1"|"ap-south-2"|"ap-southeast-1"|"ap-southeast-2"|"ap-southeast-3"|"ca-central-1"|"cn-north-1"|"cn-northwest-1"|"EU"|"eu-central-1"|"eu-north-1"|"eu-south-1"|"eu-south-2"|"eu-west-1"|"eu-west-2"|"eu-west-3"|"me-south-1"|"sa-east-1"|"us-east-2"|"us-gov-east-1"|"us-gov-west-1"|"us-west-1"|"us-west-2",
            "Location": {
              "Type": "AvailabilityZone",
              "Name": "string"
            },
            "Bucket": {
              "DataRedundancy": "SingleAvailabilityZone",
              "Type": "Directory"
            },
            "BucketIndex": {
              "Type": "Normal"|"Indexless",
              "NumShards": integer
            }
          }
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
