### PR TITLE
squid: ceph-fuse: Improve fuse mount usage message

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -81,9 +81,10 @@ static void fuse_usage()
 void usage()
 {
   cout <<
-"usage: ceph-fuse [-n client.username] [-m mon-ip-addr:mon-port] <mount point> [OPTIONS]\n"
-"  --client_mountpoint/-r <sub_directory>\n"
-"                    use sub_directory as the mounted root, rather than the full Ceph tree.\n"
+"\nusage: ceph-fuse [-n client.username] [-m mon-ip-addr:mon-port] [--client_fs <fsname>] [--client_mountpoint/-r <sub_directory>] <mount point> [OPTIONS]\n\n"
+
+"  --client_mountpoint/-r: use sub_directory as the mounted root, rather than the full CephFS tree.\n"
+"  --client_fs: named file system to mount (default: usually the first file system created).\n"
 "\n";
   fuse_usage();
   generic_client_usage();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68940

---

backport of https://github.com/ceph/ceph/pull/58847
parent tracker: https://tracker.ceph.com/issues/67283

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh