### PR TITLE
reef: qa: increase the http.maxRequestBuffer to 100MB and enable the git debug logs

### DIFF
--- a/qa/workunits/fs/snaps/snaptest-git-ceph.sh
+++ b/qa/workunits/fs/snaps/snaptest-git-ceph.sh
@@ -8,6 +8,11 @@ sudo git config --global http.postBuffer 1024MB # default is 1MB
 sudo git config --global http.maxRequestBuffer 100M # default is 10MB
 sudo git config --global core.compression 0
 
+# enable the debug logs for git clone
+export GIT_TRACE_PACKET=1
+export GIT_TRACE=1
+export GIT_CURL_VERBOSE=1
+
 # try it again if the clone is slow and the second time
 retried=false
 trap -- 'retry' EXIT
@@ -20,6 +25,11 @@ rm -rf ceph
 timeout 1800 git clone https://git.ceph.com/ceph.git
 trap - EXIT
 cd ceph
+
+# disable the debug logs for git clone
+export GIT_TRACE_PACKET=0
+export GIT_TRACE=0
+export GIT_CURL_VERBOSE=0
 
 versions=`seq 1 90`
 

--- a/qa/workunits/fs/snaps/snaptest-git-ceph.sh
+++ b/qa/workunits/fs/snaps/snaptest-git-ceph.sh
@@ -4,7 +4,9 @@ set -e
 
 # increase the cache size
 sudo git config --global http.sslVerify false
-sudo git config --global http.postBuffer 1048576000
+sudo git config --global http.postBuffer 1024MB # default is 1MB
+sudo git config --global http.maxRequestBuffer 100M # default is 10MB
+sudo git config --global core.compression 0
 
 # try it again if the clone is slow and the second time
 retried=false


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68765

---

backport of https://github.com/ceph/ceph/pull/59072
parent tracker: https://tracker.ceph.com/issues/66991

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh