### PR TITLE
quincy: qa: increase the http.maxRequestBuffer to 100MB and enable the git debug logs

### DIFF
--- a/qa/workunits/fs/snaps/snaptest-git-ceph.sh
+++ b/qa/workunits/fs/snaps/snaptest-git-ceph.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+
+# increase the cache size
+sudo git config --global http.sslVerify false
+sudo git config --global http.postBuffer 1024MB # default is 1MB
+sudo git config --global http.maxRequestBuffer 100M # default is 10MB
+sudo git config --global core.compression 0
+
 # try it again if the clone is slow and the second time
 retried=false
 trap -- 'retry' EXIT

--- a/qa/workunits/fs/snaps/snaptest-git-ceph.sh
+++ b/qa/workunits/fs/snaps/snaptest-git-ceph.sh
@@ -9,6 +9,11 @@ sudo git config --global http.postBuffer 1024MB # default is 1MB
 sudo git config --global http.maxRequestBuffer 100M # default is 10MB
 sudo git config --global core.compression 0
 
+# enable the debug logs for git clone
+export GIT_TRACE_PACKET=1
+export GIT_TRACE=1
+export GIT_CURL_VERBOSE=1
+
 # try it again if the clone is slow and the second time
 retried=false
 trap -- 'retry' EXIT
@@ -22,7 +27,12 @@ timeout 1800 git clone https://git.ceph.com/ceph.git
 trap - EXIT
 cd ceph
 
-versions=`seq 1 21`
+# disable the debug logs for git clone
+export GIT_TRACE_PACKET=0
+export GIT_TRACE=0
+export GIT_CURL_VERBOSE=0
+
+versions=`seq 1 90`
 
 for v in $versions
 do


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68764

---

backport of https://github.com/ceph/ceph/pull/59072
parent tracker: https://tracker.ceph.com/issues/66991

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh