### PR TITLE
mgr/nfs: NFS commands to enable, disable and get QOS config for cluster and export

### DIFF
--- a/src/cephadm/cephadmlib/container_engines.py
+++ b/src/cephadm/cephadmlib/container_engines.py
@@ -14,7 +14,7 @@ from .constants import (
     MIN_PODMAN_VERSION,
     PIDS_LIMIT_UNLIMITED_PODMAN_VERSION,
 )
-from .data_utils import with_units_to_int
+from ceph.utils import with_units_to_int
 from .exceptions import Error
 
 

--- a/src/cephadm/cephadmlib/data_utils.py
+++ b/src/cephadm/cephadmlib/data_utils.py
@@ -56,51 +56,6 @@ def dict_get_join(d: Dict[str, Any], key: str) -> Any:
     return value
 
 
-def bytes_to_human(num, mode='decimal'):
-    # type: (float, str) -> str
-    """Convert a bytes value into it's human-readable form.
-
-    :param num: number, in bytes, to convert
-    :param mode: Either decimal (default) or binary to determine divisor
-    :returns: string representing the bytes value in a more readable format
-    """
-    unit_list = ['', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
-    divisor = 1000.0
-    yotta = 'YB'
-
-    if mode == 'binary':
-        unit_list = ['', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
-        divisor = 1024.0
-        yotta = 'YiB'
-
-    for unit in unit_list:
-        if abs(num) < divisor:
-            return '%3.1f%s' % (num, unit)
-        num /= divisor
-    return '%.1f%s' % (num, yotta)
-
-
-def with_units_to_int(v: str) -> int:
-    if v.endswith('iB'):
-        v = v[:-2]
-    elif v.endswith('B'):
-        v = v[:-1]
-    mult = 1
-    if v[-1].upper() == 'K':
-        mult = 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'M':
-        mult = 1024 * 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'G':
-        mult = 1024 * 1024 * 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'T':
-        mult = 1024 * 1024 * 1024 * 1024
-        v = v[:-1]
-    return int(float(v) * mult)
-
-
 def read_config(fn):
     # type: (Optional[str]) -> ConfigParser
     cp = ConfigParser()

--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -16,7 +16,7 @@ from typing import Any, cast, Dict, List, Optional, Set, Union
 
 from cephadmlib.call_wrappers import call, call_throws, CallVerbosity
 from cephadmlib.context import CephadmContext
-from cephadmlib.data_utils import bytes_to_human
+from ceph.utils import bytes_to_human
 from cephadmlib.exe_utils import find_executable
 from cephadmlib.file_utils import read_file
 from cephadmlib.net_utils import get_fqdn, get_ipv4_address, get_ipv6_address

--- a/src/cephadm/tests/test_agent.py
+++ b/src/cephadm/tests/test_agent.py
@@ -254,8 +254,8 @@ def test_agent_daemon_ls_subset(cephadm_fs, funkypatch):
         assert daemons['mgr.host1.pntmho']['container_id'] == mgr_cid
         assert daemons['crash.host1']['container_id'] == crash_cid
 
-        assert daemons['mgr.host1.pntmho']['memory_usage'] == 478570086  # 456.4 MB
-        assert daemons['crash.host1']['memory_usage'] == 7426015  # 7.082 MB
+        assert daemons['mgr.host1.pntmho']['memory_usage'] == 456400000  # 456.4 MB
+        assert daemons['crash.host1']['memory_usage'] == 7082000  # 7.082 MB
 
 
 @mock.patch("cephadm.list_daemons")

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -18,8 +18,15 @@ from .utils import (
     available_clusters,
     conf_obj_name,
     restart_nfs_service,
-    user_conf_obj_name)
-from .export import NFSRados
+    user_conf_obj_name,
+    USER_CONF_PREFIX,
+    qos_conf_obj_name)
+from .rados_utils import NFSRados
+from .ganesha_conf import format_block, GaneshaConfParser
+from .qos_conf import (
+    QOS,
+    QOSType,
+    QOSBandwidthControl)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -281,7 +288,7 @@ class NFSCluster:
         try:
             if cluster_id in available_clusters(self.mgr):
                 rados_obj = self._rados(cluster_id)
-                if rados_obj.check_user_config():
+                if rados_obj.check_config(USER_CONF_PREFIX):
                     raise NonFatalError("NFS-Ganesha User Config already exists")
                 rados_obj.write_obj(nfs_config, user_conf_obj_name(cluster_id),
                                     conf_obj_name(cluster_id))
@@ -299,7 +306,7 @@ class NFSCluster:
         try:
             if cluster_id in available_clusters(self.mgr):
                 rados_obj = self._rados(cluster_id)
-                if not rados_obj.check_user_config():
+                if not rados_obj.check_config(USER_CONF_PREFIX):
                     raise NonFatalError("NFS-Ganesha User Config does not exist")
                 rados_obj.remove_obj(user_conf_obj_name(cluster_id),
                                      conf_obj_name(cluster_id))
@@ -315,3 +322,100 @@ class NFSCluster:
     def _rados(self, cluster_id: str) -> NFSRados:
         """Return a new NFSRados object for the given cluster id."""
         return NFSRados(self.mgr.rados, cluster_id)
+
+    def get_cluster_qos_config(self, cluster_id: str) -> Optional[QOS]:
+        """Return QOS object for the given cluster id."""
+        rados_obj = self._rados(cluster_id)
+        conf = rados_obj.read_obj(qos_conf_obj_name(cluster_id))
+        if conf:
+            qos_block = GaneshaConfParser(conf).parse()
+            qos_obj = QOS.from_qos_block(qos_block[0], True)
+            return qos_obj
+        return None
+
+    def update_cluster_qos_bw(self,
+                              cluster_id: str,
+                              enable_qos: bool,
+                              bw_obj: QOSBandwidthControl,
+                              qos_type: Optional[QOSType] = None) -> None:
+        """Update cluster QOS config"""
+        qos_obj_exists = False
+        qos_obj = self.get_cluster_qos_config(cluster_id)
+        if not qos_obj:
+            log.debug(f"Creating new QOS block for cluster {cluster_id}")
+            qos_obj = QOS(True, enable_qos, qos_type, bw_obj)
+        else:
+            log.debug(f"Updating existing QOS block for cluster {cluster_id}")
+            qos_obj_exists = True
+            qos_obj.enable_qos = enable_qos
+            qos_obj.qos_type = qos_type
+            qos_obj.bw_obj = bw_obj
+
+        qos_config = format_block(qos_obj.to_qos_block())
+        rados_obj = self._rados(cluster_id)
+        if not qos_obj_exists:
+            rados_obj.write_obj(qos_config, qos_conf_obj_name(cluster_id),
+                                conf_obj_name(cluster_id))
+        else:
+            rados_obj.update_obj(qos_config, qos_conf_obj_name(cluster_id),
+                                 conf_obj_name(cluster_id), should_notify=False)
+        log.debug(f"Successfully saved {cluster_id}s QOS bandwidth control config: \n {qos_config}")
+
+    def enable_cluster_qos_bw(self,
+                              cluster_id: str,
+                              qos_type: QOSType,
+                              bw_obj: QOSBandwidthControl
+                              ) -> None:
+        """
+        There are 2 cases to consider:
+        1. If combined bandwith control is disabled
+            a. If qos_type is pershare, then export_writebw and export_readbw parameters are compulsory
+            b. If qos_type is perclient, then client_writebw and client_readbw parameters are compulsory
+            c. If qos_type is pershare_perclient then export_writebw, export_readbw, client_writebw and
+               client_readbw are compulsory parameters
+        2. If combined bandwidth control is enabled
+            a. If qos_type is pershare, then export_rw_bw parameter is compulsory
+            b. If qos_type is perclient, then client_rw_bw parameter is compulsory
+            c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory
+        """
+        try:
+            bw_obj.qos_bandwidth_checks(qos_type)
+            if cluster_id in available_clusters(self.mgr):
+                self.update_cluster_qos_bw(cluster_id, True, bw_obj, qos_type)
+                restart_nfs_service(self.mgr, cluster_id)
+                log.info(f"QOS bandwidth control has been successfully enabled for cluster {cluster_id}. "
+                         "If the qos_type is changed during this process, ensure that the bandwidth "
+                         "values for all exports are updated accordingly.")
+                return
+            raise ClusterNotFound()
+        except NotImplementedError:
+            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added Successfully for {cluster_id}")
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def get_cluster_qos(self, cluster_id: str) -> Dict[str, Any]:
+        try:
+            if cluster_id in available_clusters(self.mgr):
+                qos_obj = self.get_cluster_qos_config(cluster_id)
+                return qos_obj.to_dict() if qos_obj else {}
+            raise ClusterNotFound()
+        except Exception as e:
+            log.exception(f"Fetching NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def disable_cluster_qos_bw(self, cluster_id: str) -> None:
+        try:
+            if cluster_id in available_clusters(self.mgr):
+                self.update_cluster_qos_bw(cluster_id, False, QOSBandwidthControl())
+                restart_nfs_service(self.mgr, cluster_id)
+                log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
+                         f"cluster {cluster_id}. As a result, export-level bandwidth control will "
+                         "no longer have any effect, even if it's enabled.")
+                return
+            raise ClusterNotFound()
+        except NotImplementedError:
+            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added successfully for {cluster_id}")
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/export_utils.py
+++ b/src/pybind/mgr/nfs/export_utils.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+from .cluster import NFSCluster
+from .qos_conf import QOSType, QOSParams, QOSBandwidthControl
+
+
+def export_dict_bw_checks(cluster_id: str,
+                          mgr_obj: Any,
+                          qos_enable: bool,
+                          qos_dict: dict) -> None:
+    enable_bw_ctrl = qos_dict.get('enable_bw_control')
+    combined_bw_ctrl = qos_dict.get('combined_rw_bw_control')
+    bandwith_param_exists = any(key.endswith('bw') for key in qos_dict)
+    if enable_bw_ctrl is None:
+        if combined_bw_ctrl and bandwith_param_exists:
+            raise Exception('Bandwidth control is not enabled but associated parameters exists')
+        return
+    if combined_bw_ctrl is None:
+        combined_bw_ctrl = False
+    if not qos_enable and enable_bw_ctrl:
+        raise Exception('To enable bandwidth control, qos_enable should be true.')
+    if not (isinstance(enable_bw_ctrl, bool) and isinstance(combined_bw_ctrl, bool)):
+        raise Exception('Invalid values for the enable_bw_ctrl and combined_bw_ctrl parameters.')
+    # if qos is disabled, then bandwidths should not be set and no need to bandwidth checks
+    if not enable_bw_ctrl:
+        if bandwith_param_exists:
+            raise Exception('Bandwidths should not be passed when enable_bw_control is false.')
+        return
+    if enable_bw_ctrl and not bandwith_param_exists:
+        raise Exception('Bandwidths should be set when enable_bw_control is true.')
+    bw_obj = QOSBandwidthControl(enable_bw_ctrl,
+                                 combined_bw_ctrl,
+                                 export_writebw=qos_dict.get(QOSParams.export_writebw.value, '0'),
+                                 export_readbw=qos_dict.get(QOSParams.export_readbw.value, '0'),
+                                 client_writebw=qos_dict.get(QOSParams.client_writebw.value, '0'),
+                                 client_readbw=qos_dict.get(QOSParams.client_readbw.value, '0'),
+                                 export_rw_bw=qos_dict.get(QOSParams.export_rw_bw.value, '0'),
+                                 client_rw_bw=qos_dict.get(QOSParams.client_rw_bw.value, '0'))
+    export_qos_bw_checks(cluster_id, mgr_obj, bw_obj)
+
+
+def export_dict_qos_checks(cluster_id: str,
+                           mgr_obj: Any,
+                           qos_dict: dict) -> None:
+    """Validate the qos block of dict passed to apply_export method"""
+    qos_enable = qos_dict.get('enable_qos')
+    if qos_enable is None:
+        raise Exception('The QOS block requires at least the enable_qos parameter')
+    if not isinstance(qos_enable, bool):
+        raise Exception('Invalid value for the enable_qos parameter')
+    export_dict_bw_checks(cluster_id, mgr_obj, qos_enable, qos_dict)
+
+
+def export_qos_bw_checks(cluster_id: str,
+                         mgr_obj: Any,
+                         bw_obj: QOSBandwidthControl,
+                         nfs_clust_obj: Any = None) -> None:
+    """check cluster level qos is enabled to enable export level qos and validate bandwidths"""
+    if not nfs_clust_obj:
+        nfs_clust_obj = NFSCluster(mgr_obj)
+    clust_qos_obj = nfs_clust_obj.get_cluster_qos_config(cluster_id)
+    if not clust_qos_obj or (clust_qos_obj and not (clust_qos_obj.enable_qos)):
+        raise Exception('To configure bandwidth control for export, you must first enable bandwidth control at the cluster level.')
+    if clust_qos_obj.qos_type:
+        if clust_qos_obj.qos_type == QOSType.PerClient:
+            raise Exception('Export-level QoS bandwidth control cannot be enabled if the QoS type at the cluster level is set to PerClient.')
+        bw_obj.qos_bandwidth_checks(clust_qos_obj.qos_type)

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -5,6 +5,7 @@ from mgr_module import NFS_GANESHA_SUPPORTED_FSALS
 
 from .exception import NFSInvalidOperation, FSNotFound
 from .utils import check_fs
+from .qos_conf import QOS, RawBlock
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -51,27 +52,6 @@ def _validate_sec_type(sec_type: str) -> None:
     if not isinstance(sec_type, str) or sec_type not in valid_sec_types:
         raise NFSInvalidOperation(
             f"SecType {sec_type} invalid, valid types are {valid_sec_types}")
-
-
-class RawBlock():
-    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
-        if not values:  # workaround mutable default argument
-            values = {}
-        if not blocks:  # workaround mutable default argument
-            blocks = []
-        self.block_name = block_name
-        self.blocks = blocks
-        self.values = values
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, RawBlock):
-            return False
-        return self.block_name == other.block_name and \
-            self.blocks == other.blocks and \
-            self.values == other.values
-
-    def __repr__(self) -> str:
-        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'
 
 
 class GaneshaConfParser:
@@ -375,7 +355,8 @@ class Export:
             transports: List[str],
             fsal: FSAL,
             clients: Optional[List[Client]] = None,
-            sectype: Optional[List[str]] = None) -> None:
+            sectype: Optional[List[str]] = None,
+            qos_block: Optional[QOS] = None) -> None:
         self.export_id = export_id
         self.path = path
         self.fsal = fsal
@@ -389,6 +370,7 @@ class Export:
         self.transports = transports
         self.clients: List[Client] = clients or []
         self.sectype = sectype
+        self.qos_block = qos_block
 
     @classmethod
     def from_export_block(cls, export_block: RawBlock, cluster_id: str) -> 'Export':
@@ -397,6 +379,10 @@ class Export:
 
         client_blocks = [b for b in export_block.blocks
                          if b.block_name == "CLIENT"]
+
+        qos_block = [b for b in export_block.blocks
+                     if b.block_name == "qos_block"]
+        qos_block = QOS.from_qos_block(qos_block[0]) if qos_block else None
 
         protocols = export_block.values.get('protocols')
         if not isinstance(protocols, list):
@@ -425,7 +411,9 @@ class Export:
                    FSAL.from_fsal_block(fsal_blocks[0]),
                    [Client.from_client_block(client)
                     for client in client_blocks],
-                   sectype=sectype)
+                   sectype=sectype,
+                   qos_block=qos_block
+                   )
 
     def to_export_block(self) -> RawBlock:
         values = {
@@ -448,10 +436,16 @@ class Export:
             client.to_client_block()
             for client in self.clients
         ]
+        if self.qos_block:
+            result.blocks.append(self.qos_block.to_qos_block())
         return result
 
     @classmethod
     def from_dict(cls, export_id: int, ex_dict: Dict[str, Any]) -> 'Export':
+        if ex_dict.get('qos_block'):
+            qos_block = QOS.from_dict(ex_dict.get('qos_block', {}))
+        else:
+            qos_block = None
         return cls(export_id,
                    ex_dict.get('path', '/'),
                    ex_dict['cluster_id'],
@@ -463,7 +457,9 @@ class Export:
                    ex_dict.get('transports', ['TCP']),
                    FSAL.from_dict(ex_dict.get('fsal', {})),
                    [Client.from_dict(client) for client in ex_dict.get('clients', [])],
-                   sectype=ex_dict.get("sectype"))
+                   sectype=ex_dict.get("sectype"),
+                   qos_block=qos_block
+                   )
 
     def to_dict(self) -> Dict[str, Any]:
         values = {
@@ -481,6 +477,8 @@ class Export:
         }
         if self.sectype:
             values['sectype'] = self.sectype
+        if self.qos_block:
+            values['qos_block'] = self.qos_block.to_dict()
         return values
 
     def validate(self, mgr: 'Module') -> None:

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -11,6 +11,7 @@ from mgr_util import CephFSEarmarkResolver
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
 from .utils import available_clusters
+from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType
 
 log = logging.getLogger(__name__)
 
@@ -194,3 +195,84 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def cluster_ls(self) -> List[str]:
         return available_clusters(self)
+
+    @CLICommand('nfs export qos enable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_bw_enable(self,
+                                  cluster_id: str,
+                                  pseudo_path: str,
+                                  combined_rw_bw_ctrl: bool = False,
+                                  max_export_write_bw: str = '0',
+                                  max_export_read_bw: str = '0',
+                                  max_client_write_bw: str = '0',
+                                  max_client_read_bw: str = '0',
+                                  max_export_combined_bw: str = '0',
+                                  max_client_combined_bw: str = '0'
+                                  ) -> None:
+        """enable QOS config for NFS export and set different bandwidth"""
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_rw_bw_ctrl,
+                                         export_writebw=max_export_write_bw,
+                                         export_readbw=max_export_read_bw,
+                                         client_writebw=max_client_write_bw,
+                                         client_readbw=max_client_read_bw,
+                                         export_rw_bw=max_export_combined_bw,
+                                         client_rw_bw=max_client_combined_bw)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_bw(cluster_id=cluster_id,
+                                                    pseudo_path=pseudo_path,
+                                                    bw_obj=bw_obj)
+
+    @CLICommand('nfs export qos get', perm='r')
+    @object_format.Responder()
+    def _cmd_export_qos_get(self, cluster_id: str, pseudo_path: str) -> Dict[str, int]:
+        """Get NFS export QOS config"""
+        return self.export_mgr.get_export_qos(cluster_id, pseudo_path)
+
+    @CLICommand('nfs export qos disable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_bw_disable(self, cluster_id: str, pseudo_path: str) -> None:
+        """Disable NFS export QOS config"""
+        return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
+
+    @CLICommand('nfs cluster qos enable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_bw_enable(self,
+                                   cluster_id: str,
+                                   qos_type: UserQoSType,
+                                   combined_rw_bw_ctrl: bool = False,
+                                   max_export_write_bw: str = '0',
+                                   max_export_read_bw: str = '0',
+                                   max_client_write_bw: str = '0',
+                                   max_client_read_bw: str = '0',
+                                   max_export_combined_bw: str = '0',
+                                   max_client_combined_bw: str = '0') -> None:
+        """Enable QOS ratelimiting for NFS cluster and set default export and client max bandwidth"""
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_rw_bw_ctrl,
+                                         export_writebw=max_export_write_bw,
+                                         export_readbw=max_export_read_bw,
+                                         client_writebw=max_client_write_bw,
+                                         client_readbw=max_client_read_bw,
+                                         export_rw_bw=max_export_combined_bw,
+                                         client_rw_bw=max_client_combined_bw)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_bw(cluster_id=cluster_id,
+                                              qos_type=QOSType[qos_type.value],
+                                              bw_obj=bw_obj)
+
+    @CLICommand('nfs cluster qos disable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_bw_disable(self, cluster_id: str) -> None:
+        """Disable QOS for NFS cluster"""
+        return self.nfs.disable_cluster_qos_bw(cluster_id)
+
+    @CLICommand('nfs cluster qos get', perm='r')
+    @object_format.Responder()
+    def _cmd_cluster_qos_get(self, cluster_id: str) -> Dict[str, Any]:
+        """Get QOS configuration of NFS cluster"""
+        return self.nfs.get_cluster_qos(cluster_id)

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -1,0 +1,247 @@
+from typing import List, Dict, Any, Optional
+from enum import Enum
+
+from ceph.utils import bytes_to_human, with_units_to_int
+
+
+class RawBlock():
+    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
+        if not values:  # workaround mutable default argument
+            values = {}
+        if not blocks:  # workaround mutable default argument
+            blocks = []
+        self.block_name = block_name
+        self.blocks = blocks
+        self.values = values
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, RawBlock):
+            return False
+        return self.block_name == other.block_name and \
+            self.blocks == other.blocks and \
+            self.values == other.values
+
+    def __repr__(self) -> str:
+        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'
+
+
+class QOSParams(Enum):
+    clust_block = "QOS_DEFAULT_CONFIG"
+    export_block = "QOS_BLOCK"
+    enable_qos = "enable_qos"
+    enable_bw_ctrl = "enable_bw_control"
+    combined_bw_ctrl = "combined_rw_bw_control"
+    qos_type = "qos_type"
+    export_writebw = "max_export_write_bw"
+    export_readbw = "max_export_read_bw"
+    client_writebw = "max_client_write_bw"
+    client_readbw = "max_client_read_bw"
+    export_rw_bw = "max_export_combined_bw"
+    client_rw_bw = "max_client_combined_bw"
+
+
+class UserQoSType(Enum):
+    per_share = 'PerShare'
+    per_client = 'PerClient'
+    per_share_per_client = 'PerShare_PerClient'
+
+
+class QOSType(Enum):
+    PerShare = 1
+    PerClient = 2
+    PerShare_PerClient = 3
+
+
+def _validate_qos_bw(bandwidth: str) -> int:
+    min_bw = 1000000  # 1MB
+    max_bw = 2000000000  # 2GB
+    bw_bytes = with_units_to_int(bandwidth)
+    if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
+        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (2GB) bytes")
+    return bw_bytes
+
+
+QOS_REQ_PARAMS = {
+    'combined_bw_disabled': {
+        'PerShare': ['max_export_write_bw', 'max_export_read_bw'],
+        'PerClient': ['max_client_write_bw', 'max_client_read_bw'],
+        'PerShare_PerClient': ['max_export_write_bw', 'max_export_read_bw', 'max_client_write_bw', 'max_client_read_bw']
+    },
+    'combined_bw_enabled': {
+        'PerShare': ['max_export_combined_bw'],
+        'PerClient': ['max_client_combined_bw'],
+        'PerShare_PerClient': ['max_export_combined_bw', 'max_client_combined_bw'],
+    }
+}
+
+
+class QOSBandwidthControl(object):
+    def __init__(self,
+                 enable_bw_ctrl: bool = False,
+                 combined_bw_ctrl: bool = False,
+                 export_writebw: str = '0',
+                 export_readbw: str = '0',
+                 client_writebw: str = '0',
+                 client_readbw: str = '0',
+                 export_rw_bw: str = '0',
+                 client_rw_bw: str = '0'
+                 ) -> None:
+        self.enable_bw_ctrl = enable_bw_ctrl
+        self.combined_bw_ctrl = combined_bw_ctrl
+        try:
+            self.export_writebw: int = _validate_qos_bw(export_writebw)
+            self.export_readbw: int = _validate_qos_bw(export_readbw)
+            self.client_writebw: int = _validate_qos_bw(client_writebw)
+            self.client_readbw: int = _validate_qos_bw(client_readbw)
+            self.export_rw_bw: int = _validate_qos_bw(export_rw_bw)
+            self.client_rw_bw: int = _validate_qos_bw(client_rw_bw)
+        except Exception as e:
+            raise Exception(f"Invalid bandwidth value. {e}")
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSBandwidthControl':
+        # json has bandwidths in human readable format(str)
+        bw_kwargs = {
+            'enable_bw_ctrl': qos_dict.get(QOSParams.enable_bw_ctrl.value, False),
+            'combined_bw_ctrl': qos_dict.get(QOSParams.combined_bw_ctrl.value, False),
+            'export_writebw': qos_dict.get(QOSParams.export_writebw.value, '0'),
+            'export_readbw': qos_dict.get(QOSParams.export_readbw.value, '0'),
+            'client_writebw': qos_dict.get(QOSParams.client_writebw.value, '0'),
+            'client_readbw': qos_dict.get(QOSParams.client_readbw.value, '0'),
+            'export_rw_bw': qos_dict.get(QOSParams.export_rw_bw.value, '0'),
+            'client_rw_bw': qos_dict.get(QOSParams.client_rw_bw.value, '0')
+        }
+        return cls(**bw_kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock) -> 'QOSBandwidthControl':
+        # block has bandwidths in bytes(int)
+        bw_kwargs = {
+            'enable_bw_ctrl': qos_block.values.get(QOSParams.enable_bw_ctrl.value, False),
+            'combined_bw_ctrl': qos_block.values.get(QOSParams.combined_bw_ctrl.value, False),
+            'export_writebw': str(qos_block.values.get(QOSParams.export_writebw.value, 0)),
+            'export_readbw': str(qos_block.values.get(QOSParams.export_readbw.value, 0)),
+            'client_writebw': str(qos_block.values.get(QOSParams.client_writebw.value, 0)),
+            'client_readbw': str(qos_block.values.get(QOSParams.client_readbw.value, 0)),
+            'export_rw_bw': str(qos_block.values.get(QOSParams.export_rw_bw.value, 0)),
+            'client_rw_bw': str(qos_block.values.get(QOSParams.client_rw_bw.value, 0))
+        }
+        return cls(**bw_kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        result = RawBlock('qos_bandwidths_control')
+        result.values[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
+        result.values[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
+        if self.export_writebw:
+            result.values[QOSParams.export_writebw.value] = self.export_writebw
+        if self.export_readbw:
+            result.values[QOSParams.export_readbw.value] = self.export_readbw
+        if self.client_writebw:
+            result.values[QOSParams.client_writebw.value] = self.client_writebw
+        if self.client_readbw:
+            result.values[QOSParams.client_readbw.value] = self.client_readbw
+        if self.export_rw_bw:
+            result.values[QOSParams.export_rw_bw.value] = self.export_rw_bw
+        if self.client_rw_bw:
+            result.values[QOSParams.client_rw_bw.value] = self.client_rw_bw
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: dict[str, Any] = {}
+        r[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
+        r[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
+        if self.export_writebw:
+            r[QOSParams.export_writebw.value] = bytes_to_human(self.export_writebw)
+        if self.export_readbw:
+            r[QOSParams.export_readbw.value] = bytes_to_human(self.export_readbw)
+        if self.client_writebw:
+            r[QOSParams.client_writebw.value] = bytes_to_human(self.client_writebw)
+        if self.client_readbw:
+            r[QOSParams.client_readbw.value] = bytes_to_human(self.client_readbw)
+        if self.export_rw_bw:
+            r[QOSParams.export_rw_bw.value] = bytes_to_human(self.export_rw_bw)
+        if self.client_rw_bw:
+            r[QOSParams.client_rw_bw.value] = bytes_to_human(self.client_rw_bw)
+        return r
+
+    def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
+        """Checks for enabling qos"""
+        params = {}
+        d = vars(self)
+        for key in d:
+            if key.endswith('bw'):
+                params[QOSParams[key].value] = d[key]
+        if not self.combined_bw_ctrl:
+            req_params = QOS_REQ_PARAMS['combined_bw_disabled'][qos_type.name]
+        else:
+            req_params = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+        allowed_params = []
+        not_allowed_params = []
+        for key in params:
+            if key in req_params and params[key] == 0:
+                allowed_params.append(key)
+            elif key not in req_params and params[key] != 0:
+                not_allowed_params.append(key)
+        if allowed_params or not_allowed_params:
+            raise Exception(f"When combined_rw_bw is {'enabled' if self.combined_bw_ctrl else 'disabled'} "
+                            f"and qos_type is {qos_type.name}, "
+                            f"{'attributes ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                            f"{'attributes ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+
+
+class QOS(object):
+    def __init__(self,
+                 cluster_op: bool = False,
+                 enable_qos: bool = False,
+                 qos_type: Optional[QOSType] = None,
+                 bw_obj: Optional[QOSBandwidthControl] = None
+                 ) -> None:
+        self.cluster_op = cluster_op
+        self.enable_qos = enable_qos
+        self.qos_type = qos_type
+        self.bw_obj = bw_obj
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any], cluster_op: bool = False) -> 'QOS':
+        kwargs: dict[str, Any] = {}
+        # qos dict will have qos type as enum name
+        if cluster_op:
+            qos_type = qos_dict.get(QOSParams.qos_type.value)
+            if qos_type:
+                kwargs['qos_type'] = QOSType[qos_type]
+        kwargs['enable_qos'] = qos_dict.get(QOSParams.enable_qos.value)
+        kwargs['bw_obj'] = QOSBandwidthControl.from_dict(qos_dict)
+        return cls(cluster_op, **kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock, cluster_op: bool = False) -> 'QOS':
+        kwargs: dict[str, Any] = {}
+        # qos block will have qos type as enum value
+        if cluster_op:
+            qos_type = qos_block.values.get(QOSParams.qos_type.value)
+            if qos_type:
+                kwargs['qos_type'] = QOSType(qos_type)
+        kwargs['enable_qos'] = qos_block.values.get(QOSParams.enable_qos.value)
+        kwargs['bw_obj'] = QOSBandwidthControl.from_qos_block(qos_block)
+        return cls(cluster_op, **kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        if self.cluster_op:
+            result = RawBlock(QOSParams.clust_block.value)
+        else:
+            result = RawBlock(QOSParams.export_block.value)
+        result.values[QOSParams.enable_qos.value] = self.enable_qos
+        if self.cluster_op and self.qos_type:
+            result.values[QOSParams.qos_type.value] = self.qos_type.value
+        if self.bw_obj and (res := self.bw_obj.to_qos_block()):
+            result.values.update(res.values)
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: Dict[str, Any] = {}
+        r[QOSParams.enable_qos.value] = self.enable_qos
+        if self.cluster_op and self.qos_type:
+            r[QOSParams.qos_type.value] = self.qos_type.name
+        if self.bw_obj and (res := self.bw_obj.to_dict()):
+            r.update(res)
+        return r

--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Optional, Any
+
+from rados import TimedOut, ObjectNotFound, Rados
+from mgr_module import NFS_POOL_NAME as POOL_NAME
+from .ganesha_conf import RawBlock, format_block
+from .utils import USER_CONF_PREFIX
+
+log = logging.getLogger(__name__)
+
+
+def _check_rados_notify(ioctx: Any, obj: str) -> None:
+    try:
+        ioctx.notify(obj)
+    except TimedOut:
+        log.exception("Ganesha timed out")
+
+
+class NFSRados:
+    def __init__(self, rados: 'Rados', namespace: str) -> None:
+        self.rados = rados
+        self.pool = POOL_NAME
+        self.namespace = namespace
+
+    def _make_rados_url(self, obj: str) -> str:
+        return "rados://{}/{}/{}".format(self.pool, self.namespace, obj)
+
+    def _create_url_block(self, obj_name: str) -> RawBlock:
+        return RawBlock('%url', values={'value': self._make_rados_url(obj_name)})
+
+    def write_obj(self, conf_block: str, obj: str, config_obj: str = '') -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            ioctx.write_full(obj, conf_block.encode('utf-8'))
+            if not config_obj:
+                # Return after creating empty common config object
+                return
+            log.debug("write configuration into rados object %s/%s/%s",
+                      self.pool, self.namespace, obj)
+
+            # Add created obj url to common config obj
+            ioctx.append(config_obj, format_block(
+                         self._create_url_block(obj)).encode('utf-8'))
+            _check_rados_notify(ioctx, config_obj)
+            log.debug("Added %s url to %s", obj, config_obj)
+
+    def read_obj(self, obj: str) -> Optional[str]:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            try:
+                return ioctx.read(obj, 1048576).decode()
+            except ObjectNotFound:
+                return None
+
+    def update_obj(self, conf_block: str, obj: str, config_obj: str,
+                   should_notify: Optional[bool] = True) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            ioctx.write_full(obj, conf_block.encode('utf-8'))
+            log.debug("write configuration into rados object %s/%s/%s",
+                      self.pool, self.namespace, obj)
+            if should_notify:
+                _check_rados_notify(ioctx, config_obj)
+            log.debug("Update export %s in %s", obj, config_obj)
+
+    def remove_obj(self, obj: str, config_obj: str) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            export_urls = ioctx.read(config_obj)
+            url = '%url "{}"\n\n'.format(self._make_rados_url(obj))
+            export_urls = export_urls.replace(url.encode('utf-8'), b'')
+            ioctx.remove_object(obj)
+            ioctx.write_full(config_obj, export_urls)
+            _check_rados_notify(ioctx, config_obj)
+            log.debug("Object deleted: %s", url)
+
+    def remove_all_obj(self) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            for obj in ioctx.list_objects():
+                obj.remove()
+
+    def check_config(self, config: str = USER_CONF_PREFIX) -> bool:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            for obj in ioctx.list_objects():
+                if obj.key.startswith(config):
+                    return True
+        return False

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 EXPORT_PREFIX: str = "export-"
 CONF_PREFIX: str = "conf-nfs."
 USER_CONF_PREFIX: str = "userconf-nfs."
+QOS_CONF_PREFIX: str = "qosconf-nfs."
 
 log = logging.getLogger(__name__)
 
@@ -57,8 +58,13 @@ def conf_obj_name(cluster_id: str) -> str:
 
 
 def user_conf_obj_name(cluster_id: str) -> str:
-    """Returna a rados object name for the user config."""
+    """Return a rados object name for the user config."""
     return f"{USER_CONF_PREFIX}{cluster_id}"
+
+
+def qos_conf_obj_name(cluster_id: str) -> str:
+    """Return a rados object name for the qos config."""
+    return f"{QOS_CONF_PREFIX}{cluster_id}"
 
 
 def available_clusters(mgr: 'Module') -> List[str]:

--- a/src/python-common/ceph/utils.py
+++ b/src/python-common/ceph/utils.py
@@ -182,3 +182,51 @@ def strtobool(value: str) -> bool:
     if value.lower() in _FALSE_VALS:
         return False
     raise ValueError(f'invalid truth value {value!r}')
+
+
+def bytes_to_human(num: float, mode: str = 'decimal') -> str:
+    """Convert a bytes value into it's human-readable form.
+
+    :param num: number, in bytes, to convert
+    :param mode: Either decimal (default) or binary to determine divisor
+    :returns: string representing the bytes value in a more readable format
+    """
+    unit_list = ['', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
+    divisor = 1000.0
+    yotta = 'YB'
+
+    if mode == 'binary':
+        unit_list = ['', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
+        divisor = 1024.0
+        yotta = 'YiB'
+
+    for unit in unit_list:
+        if abs(num) < divisor:
+            return '%3.1f%s' % (num, unit)
+        num /= divisor
+    return '%.1f%s' % (num, yotta)
+
+
+def with_units_to_int(v: str) -> int:
+    if not v:
+        return 0
+    if v.endswith('iB'):
+        v = v[:-2]
+        bytes_mult = 1024
+    elif v.endswith('B'):
+        v = v[:-1]
+        bytes_mult = 1000
+    mult = 1
+    if v[-1].upper() == 'K':
+        mult = bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'M':
+        mult = bytes_mult * bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'G':
+        mult = bytes_mult * bytes_mult * bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'T':
+        mult = bytes_mult * bytes_mult * bytes_mult * bytes_mult
+        v = v[:-1]
+    return int(float(v) * mult)


### PR DESCRIPTION
NFS commands to enable, disable and get QOS ratelimiting config for cluster and export 

fixes: https://tracker.ceph.com/issues/69458
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

**Cluster commands:**
The cluster level QOS config will get store in RADOS object 'qosconf-nfs' in cluster namespace. And this object URL will be added in 'conf-nfs'. At the time of NFS cluster creation, the qos block will not present, It will get added when the qos enabled command is run for first time.  Enable and disable commands will restart NFS cluster.

Below is the example of qos block:
when enabled
```
QOS_DEFAULT_CONFIG {
    enable_qos = true;
    enable_bw_control = true;
    combined_rw_bw_control = false;
    qos_type = 1;
    max_export_write_bw = 10000;
    max_export_read_bw = 20000;
}
```
when disabled
```
QOS_DEFAULT_CONFIG {
    enable_qos = false;
    enable_bw_control = false;
    combined_rw_bw_control = false;
}

``` 
For enable command:
        1. If combined bandwith control is disabled
            a. If qos_type is pershare, then export_writebw and export_readbw parameters are compulsory
            b. If qos_type is perclient, then client_writebw and client_readbw parameters are compulsory
            c. If qos_type is pershare_perclient then export_writebw, export_readbw, client_writebw and
               client_readbw are compulsory parameters
        2. If combined bandwidth control is enabled
            a. If qos_type is pershare, then export_rw_bw parameter is compulsory
            b. If qos_type is perclient, then client_rw_bw parameter is compulsory
            c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory

we are accepting bandwidths in human readable format and storing after converting to bytes. Also for qos_type, we are accepting string, but storing as int. Get qos will show human readable format.

1. To enable qos ratelimiting
          _nfs cluster qos enable bandwidth_control <cluster_id> <qos_type:PerShare|PerClient|PerShare_PerClient> [--combined-rw-bw-ctrl] [--max_export_write_bw <value>] [--max_export_read_bw <value>] [--max_client_write_bw <value>] [--max_client_read_bw <value>] [--max_export_combined_bw <value>] [--max_client_combined_bw <value>] [--format <value>]_
3. To disable qos
        _nfs cluster qos disable bandwidth_control <cluster_id>_
4. To get qos config
        _nfs cluster qos get <cluster_id> [--format <value>]_


**Export commands**
When export is created, there will be no QOS block, it will get added when qos enable command is run for first time. This will add QOS block in existing RADOS object for export.
Below is the example of export block when qos block is present
When enabled
```
EXPORT {
    FSAL {
        name = "CEPH";
        user_id = "nfs.testnfs1.testfs.df10c343";
        filesystem = "testfs";
        secret_access_key = "AQAh1JlnyHmwExAAXyH1IqQMGji1JIBVoXinbA==";
        cmount_path = "/";
    }
    QOS_BLOCK {
        enable_qos = true;
        enable_bw_control = true;
        combined_rw_bw_control = false;
        max_export_write_bw = 10000;
        max_export_read_bw = 10000;
    }
    export_id = 1;
    path = "/";
    pseudo = "/export1";
    access_type = "RW";
    squash = "none";
    attr_expiration_time = 0;
    security_label = true;
    protocols = 3, 4;
    transports = "TCP";
}

```
when disabled
```
    QOS_BLOCK {
        enable_qos = false;
        enable_bw_control = false;
    }
```
For enable command:
        There are 2 cases to consider, based on QOS type set on cluster level
        1. If combined bandwith control is disabled
            a. If qos_type is pershare, then export_writebw and export_readbw parameters are compulsory
            b. If qos_type is perclient, then can't enable export level qos
            c. If qos_type is pershare_perclient then export_writebw, export_readbw, client_writebw and
               client_readbw are compulsory parameters
        2. If combined bandwidth control is enabled
            a. If qos_type is pershare, then export_rw_bw parameter is compulsory
            b. If qos_type is perclient, then can't enable export level qos
            c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory
- Export level qos can be enabled only when cluster level qos is enabled.

1. To enable qos ratelimiting
        _nfs export qos enable bandwidth_control <cluster_id> <pseudo_path> [--combined-rw-bw-ctrl] [--max_export_write_bw <value>] [--max_export_read_bw <value>] [--max_client_write_bw <value>] [--max_client_read_bw <value>] [--max_export_combined_bw <value>] [--max_client_combined_bw <value>]_
3. To disable qos
       _nfs export qos disable bandwidth_control <cluster_id> <pseudo_path>_
4. to get qos config
        _nfs export qos get <cluster_id> <pseudo_path> [--format <value>]_

**Existing command affected by this changes**: nfs export apply <cluster_id> [--format <value>]


Tetsing logs:
```
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos enable bandwidth_control mynfs PerShare --max_export_write_bw 10MB --max_export_read_bw 20MB                           
[
  "QOS bandwidth control has been successfully enabled. If the qos_type is changed during this process, ensure that the bandwidth values for all exports are updated accordingly."
]
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos get mynfs
{
  "combined_rw_bw_control": false,
  "enable_bw_control": true,
  "enable_qos": true,
  "max_export_read_bw": "20.0MB",
  "max_export_write_bw": "10.0MB",
  "qos_type": "PerShare"
}
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos disable bandwidth_control mynfs                                 
[
  "Cluster-level QoS bandwidth control has been successfully disabled. As a result, export-level bandwidth control will no longer have any effect, even if it's enabled."
]
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos get mynfs
{
  "combined_rw_bw_control": false,
  "enable_bw_control": false,
  "enable_qos": false
}
[ceph: root@ceph-node-0 /]#
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos enable bandwidth_control mynfs PerShare --max_export_write_bw 10MB --max_export_read_bw 10MB
[
  "QOS bandwidth control has been successfully enabled. If the qos_type is changed during this process, ensure that the bandwidth values for all exports are updated accordingly."
]
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs export qos enable bandwidth_control mynfs /export1 --max_export_write_bw=20MB --max_export_read_bw=20MB
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs export qos get mynfs /export1                                              
{
  "combined_rw_bw_control": false,
  "enable_bw_control": true,
  "enable_qos": true,
  "max_export_read_bw": "20.0MB",
  "max_export_write_bw": "20.0MB"
}
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs export info mynfs /export1   
{
  "access_type": "RW",
  "clients": [],
  "cluster_id": "mynfs",
  "export_id": 1,
  "fsal": {
    "cmount_path": "/",
    "fs_name": "myfs",
    "name": "CEPH",
    "user_id": "nfs.mynfs.myfs.126d1904"
  },
  "path": "/",
  "protocols": [
    3,
    4
  ],
  "pseudo": "/export1",
  "qos_block": {
    "combined_rw_bw_control": false,
    "enable_bw_control": true,
    "enable_qos": true,
    "max_export_read_bw": "20.0MB",
    "max_export_write_bw": "20.0MB"
  },
  "security_label": true,
  "squash": "none",
  "transports": [
    "TCP"
  ]
}
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs export qos disable bandwidth_control mynfs /export1                         
[ceph: root@ceph-node-0 /]# ceph nfs export info mynfs /export1
{
  "access_type": "RW",
  "clients": [],
  "cluster_id": "mynfs",
  "export_id": 1,
  "fsal": {
    "cmount_path": "/",
    "fs_name": "myfs",
    "name": "CEPH",
    "user_id": "nfs.mynfs.myfs.126d1904"
  },
  "path": "/",
  "protocols": [
    3,
    4
  ],
  "pseudo": "/export1",
  "qos_block": {
    "combined_rw_bw_control": false,
    "enable_bw_control": false,
    "enable_qos": false
  },
  "security_label": true,
  "squash": "none",
  "transports": [
    "TCP"
  ]
}
[ceph: root@ceph-node-0 /]# ceph nfs export qos get mynfs /export1
{
  "combined_rw_bw_control": false,
  "enable_bw_control": false,
  "enable_qos": false
}
[ceph: root@ceph-node-0 /]# 

```




## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
