### PR TITLE
doc/rgw: document UserName requirements for account migration

### DIFF
--- a/doc/radosgw/account.rst
+++ b/doc/radosgw/account.rst
@@ -174,6 +174,11 @@ An existing user can be adopted into an account with ``user modify``::
 .. note:: Account membership is permanent. Once added, users cannot be
    removed from their account.
 
+.. note:: The IAM User API imposes additional requirements on the format
+   of ``UserName``, which is enforced when migrating users into an account.
+   If migration fails with "UserName contains invalid characters", the
+   ``--display-name`` should be modified to match ``[\w+=,.@-]+``.
+
 .. warning:: Ownership of the user's notification topics will not be
    transferred to the account. Notifications will continue to work, but
    the topics will no longer be visible to SNS Topic APIs. Topics and


### PR DESCRIPTION
clarify the following error when migrating a user into an account:

> could not modify user: unable to modify user, UserName contains invalid characters

Fixes: https://tracker.ceph.com/issues/69470

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
