### PR TITLE
reef: mds: drop client metrics during recovery

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2103,6 +2103,8 @@ void MDSRank::active_start()
 {
   dout(1) << "active_start" << dendl;
 
+  m_is_active = true;
+
   if (last_state == MDSMap::STATE_CREATING ||
       last_state == MDSMap::STATE_STARTING) {
     mdcache->open_root();

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -15,6 +15,7 @@
 #ifndef MDS_RANK_H_
 #define MDS_RANK_H_
 
+#include <atomic>
 #include <string_view>
 
 #include <boost/asio/io_context.hpp>
@@ -223,6 +224,8 @@ class MDSRank {
     bool is_stopped() const { return mdsmap->is_stopped(whoami); }
     bool is_cluster_degraded() const { return cluster_degraded; }
     bool allows_multimds_snaps() const { return mdsmap->allows_multimds_snaps(); }
+
+    bool is_active_lockless() const { return m_is_active.load(); }
 
     bool is_cache_trimmable() const {
       return is_standby_replay() || is_clientreplay() || is_active() || is_stopping();
@@ -661,6 +664,8 @@ private:
 
     mono_time starttime = mono_clock::zero();
     boost::asio::io_context& ioc;
+
+    std::atomic_bool m_is_active = false; /* accessed outside mds_lock */
 };
 
 class C_MDS_RetryMessage : public MDSInternalContext {

--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -332,6 +332,11 @@ void MetricsHandler::handle_payload(Session *session, const UnknownPayload &payl
 }
 
 void MetricsHandler::handle_client_metrics(const cref_t<MClientMetrics> &m) {
+  if (!mds->is_active_lockless()) {
+    dout(20) << ": dropping metrics message during recovery" << dendl;
+    return;
+  }
+
   std::scoped_lock locker(lock);
 
   Session *session = mds->get_session(m);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66622

---

backport of https://github.com/ceph/ceph/pull/57084
parent tracker: https://tracker.ceph.com/issues/65660

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh