### PR TITLE
squid: qa/cephfs: override testing kernel with -k option

### DIFF
--- a/qa/cephfs/begin/3-kernel.yaml
+++ b/qa/cephfs/begin/3-kernel.yaml
@@ -1,0 +1,23 @@
+# When the --kernel option is given to teuthology-suite, the kernel is set for
+# all nodes (also, the kernel is "distro" when the --kernel option is not set).
+# We don't generally want to use a custom kernel for all tests, so unset it.
+# The k-testing.yaml will set it, if given, for only the client nodes.
+#
+# Allow overriding this by using a branch ending in "-all".
+
+teuthology:
+  postmerge:
+    - |
+      local branch = yaml.kernel.branch
+      if branch and not yaml.kernel.branch:find "-all$" then
+        log.debug("removing default kernel specification: %s", yaml.kernel)
+        py_attrgetter(yaml.kernel).pop('branch', nil)
+        py_attrgetter(yaml.kernel).pop('deb', nil)
+        py_attrgetter(yaml.kernel).pop('flavor', nil)
+        py_attrgetter(yaml.kernel).pop('kdb', nil)
+        py_attrgetter(yaml.kernel).pop('koji', nil)
+        py_attrgetter(yaml.kernel).pop('koji_task', nil)
+        py_attrgetter(yaml.kernel).pop('rpm', nil)
+        py_attrgetter(yaml.kernel).pop('sha1', nil)
+        py_attrgetter(yaml.kernel).pop('tag', nil)
+      end

--- a/qa/cephfs/mount/kclient/overrides/distro/testing/k-testing.yaml
+++ b/qa/cephfs/mount/kclient/overrides/distro/testing/k-testing.yaml
@@ -1,3 +1,12 @@
+teuthology:
+  premerge: |
+    log.debug("base kernel %s", base_config.kernel)
+    local kernel = base_config.kernel
+    if kernel.branch ~= "distro" then
+      log.debug("overriding testing kernel with %s", kernel)
+      yaml_fragment.kernel.client = kernel
+    end
+
 kernel:
   client:
     branch: testing

--- a/qa/suites/fs/upgrade/featureful_client/old_client/kernel.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/kernel.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/kernel.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/nofs/kernel.yaml
+++ b/qa/suites/fs/upgrade/nofs/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/upgraded_client/kernel.yaml
+++ b/qa/suites/fs/upgrade/upgraded_client/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/workload/begin/3-kernel.yaml
+++ b/qa/suites/fs/workload/begin/3-kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68722

---

backport of https://github.com/ceph/ceph/pull/60386
parent tracker: https://tracker.ceph.com/issues/68603

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh