### PR TITLE
squid: qa: ignore pg availability/degraded warnings

### DIFF
--- a/qa/cephfs/overrides/pg_health.yaml
+++ b/qa/cephfs/overrides/pg_health.yaml
@@ -9,3 +9,5 @@ overrides:
       - PG_DEGRADED
       - Reduced data availability
       - Degraded data redundancy
+      - pg .* is stuck inactive
+      - pg .* is .*degraded


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68450

---

backport of https://github.com/ceph/ceph/pull/60012
parent tracker: https://tracker.ceph.com/issues/68284

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh