### PR TITLE
squid: qa: correct daemon for warning conf 

### DIFF
--- a/qa/cephfs/conf/mgr.yaml
+++ b/qa/cephfs/conf/mgr.yaml
@@ -1,8 +1,9 @@
 overrides:
   ceph:
-    conf:
+    cluster-conf:
       mgr:
         client mount timeout: 30
         debug client: 20
         debug mgr: 20
         debug ms: 1
+        mon warn on pool no app: false

--- a/qa/cephfs/conf/mon.yaml
+++ b/qa/cephfs/conf/mon.yaml
@@ -5,4 +5,3 @@ overrides:
         mon op complaint time: 120
         # cephadm can take up to 5 minutes to bring up remaining mons
         mon down mkfs grace: 300
-        mon warn on pool no app: false


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68244

---

backport of https://github.com/ceph/ceph/pull/59467
parent tracker: https://tracker.ceph.com/issues/67737

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh