### PR TITLE
Make the PG autoscaler bulk flag default for new pools

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -160,10 +160,14 @@ The output will resemble the following::
   ``off``, or ``warn``.
 
 - **BULK** determines whether the pool is ``bulk``. It has a value of ``True``
-  or ``False``. A ``bulk`` pool is expected to be large and should initially
+  or ``False``. A pool with the ``bulk`` flag enabled
+  is expected to be large and should initially
   have a large number of PGs so that performance does not suffer]. On the other
   hand, a pool that is not ``bulk`` is expected to be small (for example, a
-  ``.mgr`` pool or a meta pool).
+  ``.mgr`` pool or a meta pool).  Additionally this flag is useful for pools
+  including RGW index and CephFS metadata that may experience low performance
+  due to their op workloads being nonlinear compared to their data size,
+  complementing the ``BIAS`` PG autoscaler value.
 
 .. note::
 

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2690,8 +2690,8 @@ options:
   type: bool
   level: advanced
   desc: set bulk flag on new pools
-  fmt_desc: Set the ``bulk`` flag on new pools. Allowing autoscaler to use scale-down mode.
-  default: false
+  fmt_desc: Set the ``bulk`` flag on new pools, allowing autoscaler to use scale-down mode.  Existing pools would need manual adjustment.
+  default: true
   services:
   - mon
   with_legacy: true


### PR DESCRIPTION
Make the PG autoscaler bulk flag default for new pools.

There is support for this in the community to address the performance impact of low PG counts especially for index pools. 

This complements https://github.com/ceph/ceph/pull/60492

The changes are tweaking docs and flipping the config option default value.  Since the existing config option applies only to newly-created pools there will be no thundering herd of PG splits at upgrade time.

Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
