### PR TITLE
mgr: add retry logic for module loading

### DIFF
--- a/qa/suites/rados/mgr/tasks/4-units/mgr_module_loading_time.yaml
+++ b/qa/suites/rados/mgr/tasks/4-units/mgr_module_loading_time.yaml
@@ -1,0 +1,13 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(CEPHADM_STRAY_DAEMON\)
+      - \(CEPHADM_STRAY_HOST\)
+      - \(MGR_DOWN\)
+      - evicting unresponsive client
+
+tasks:
+  - workunit:
+      clients:
+        client.0:
+          - mgr/test_mgr_module_loading_time.sh

--- a/qa/workunits/mgr/test_mgr_module_loading_time.sh
+++ b/qa/workunits/mgr/test_mgr_module_loading_time.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Set up orchestrator...
+# This will create CEPHADM_STRAY_HOST warnings, but we just want to be able to run an orch command.
+ceph mgr module enable cephadm
+ceph orch set backend cephadm
+
+# Check cluster status
+ceph -s
+
+# Run balancer for a bit to add upmap entires to the osdmap
+# (helps detect balancer scalability issues that affect module
+# loading time, i.e. https://tracker.ceph.com/issues/68657)
+ceph osd set-require-min-compat-client reef
+ceph balancer mode upmap-read
+for i in {1..5}; do
+    ceph balancer on
+    sleep 1
+done
+ceph osd dump
+
+# Delay loading on the balancer module
+ceph config set mgr mgr_module_load_delay_name balancer
+
+# Test case 1: Delay exceeds max load time
+echo "Testing with module load delay of 6 seconds..."
+ceph config set mgr mgr_module_load_delay 6
+
+output=$(ceph mgr fail; ceph orch status 2>&1)
+echo "$output"
+if [[ "$output" == *"Error ETIMEDOUT: Warning: due to ceph-mgr restart, some PG states may not be up to date"* ]]; then
+    echo "PASS: Expected command timeout occurred."
+else
+    echo "FAIL: Command did not fail as expected."
+    exit 1
+fi
+
+# Test case 2: Delay within acceptable load time
+echo "Testing with module load delay of 4 seconds..."
+ceph config set mgr mgr_module_load_delay 4
+
+for i in $(seq 1 100); do
+    output=$(ceph mgr fail && ceph orch status 2>&1)
+    echo "$output"
+    if [[ "$output" == *"Error ETIMEDOUT: Warning: due to ceph-mgr restart, some PG states may not be up to date"* ]]; then
+        echo "FAIL: Command failed with acceptable delay in iteration $i."
+        exit 1
+    fi
+    sleep 1
+done
+echo "PASS: All commands succeeded with acceptable delay."
+
+# Test case 3: No injected delay; testing real module loading time
+echo "Testing with module load delay of 0 seconds..."
+ceph config set mgr mgr_module_load_delay 0
+
+for i in $(seq 1 100); do
+    output=$(ceph mgr fail && ceph orch status 2>&1)
+    echo "$output"
+    if [[ "$output" == *"Error ETIMEDOUT: Warning: due to ceph-mgr restart, some PG states may not be up to date"* ]]; then
+        echo "FAIL: Command unexpectedly timed out in iteration $i."
+	exit 1
+    fi
+    sleep 1
+done
+
+echo "PASS: All tests completed successfully."

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -177,6 +177,22 @@ options:
   services:
   - mgr
   with_legacy: true
+- name: mgr_module_load_delay
+  type: uint
+  level: dev
+  default: 0
+  desc: Amount of seconds a mgr module delays loading. For testing purposes only.
+  services:
+  - mgr
+- name: mgr_module_load_delay_name
+  type: str
+  level: dev
+  desc: Choose which mgr module to inject a load delay. For testing purposes only.
+  flags:
+  - runtime
+  with_legacy: true
+  services:
+  - mgr
 - name: cephadm_path
   type: str
   level: advanced

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -159,6 +159,24 @@ options:
   flags:
   - no_mon_update
   - cluster_create
+# retry every N seconds
+- name: mgr_module_load_interval
+  type: uint
+  level: advanced
+  default: 1
+  desc: The mgr will retry loading a module every ``N`` seconds.
+  services:
+  - mgr
+  with_legacy: true
+# fail if the module fails to load in time
+- name: mgr_module_load_timeout
+  type: uint
+  level: advanced
+  default: 5
+  desc: Max length of time that the mgr should retry loading a module before issuing an error code.
+  services:
+  - mgr
+  with_legacy: true
 - name: cephadm_path
   type: str
   level: advanced

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2545,14 +2545,38 @@ bool DaemonServer::_handle_command(
     return true;
   }
 
-  // Validate that the module is active
-  auto& mod_name = py_command.module_name;
-  if (!py_modules.is_module_active(mod_name)) {
-    ss << "Module '" << mod_name << "' is not enabled/loaded (required by "
+  // Validate that the module is enabled
+  auto& py_handler_name = py_command.module_name;
+  PyModuleRef module = py_modules.get_module(py_handler_name);
+  ceph_assert(module);
+  if (!module->is_enabled()) {
+    ss << "Module '" << py_handler_name << "' is not enabled (required by "
           "command '" << prefix << "'): use `ceph mgr module enable "
-          << mod_name << "` to enable it";
+          << py_handler_name << "` to enable it";
     dout(4) << ss.str() << dendl;
     cmdctx->reply(-EOPNOTSUPP, ss);
+    return true;
+  }
+
+  // Validate that the module is active
+  auto& mod_name = py_command.module_name;
+  uint64_t interval = cct->_conf->mgr_module_load_interval;
+  uint64_t timeout = cct->_conf->mgr_module_load_timeout;
+  uint64_t retries = floor(timeout / interval);
+  while (!py_modules.is_module_active(mod_name) && (retries-- > 0)) {
+    // Retry loading...
+    dout(4) << "Module '" << mod_name << "' is not active (required by command '"
+            << prefix << "'): retrying in " << interval << " secs (" << retries
+            << " retries left)." << dendl;
+    // Sleep for the retry interval
+    std::this_thread::sleep_for(std::chrono::seconds(interval));
+  }
+
+  if (!py_modules.is_module_active(mod_name)) {
+    ss << "Module '" << mod_name << "' failed to load in time (required by "
+          "command '" << prefix << "').";
+    dout(4) << ss.str() << dendl;
+    cmdctx->reply(-ETIMEDOUT, ss);
     return true;
   }
 
@@ -2561,24 +2585,12 @@ bool DaemonServer::_handle_command(
   dout(10) << "passing through command '" << prefix << "' size " << cmdctx->cmdmap.size() << dendl;
   Finisher& mod_finisher = py_modules.get_active_module_finisher(mod_name);
 
-  mod_finisher.queue(new LambdaContext([this, cmdctx, session, py_command, prefix, op]
+  mod_finisher.queue(new LambdaContext([this, cmdctx, session, py_command, prefix, op, py_handler_name, module]
                                        (int r_) mutable {
     std::stringstream ss;
 
     dout(10) << "dispatching command '" << prefix << "' size " << cmdctx->cmdmap.size() << dendl;
 
-    // Validate that the module is enabled
-    auto& py_handler_name = py_command.module_name;
-    PyModuleRef module = py_modules.get_module(py_handler_name);
-    ceph_assert(module);
-    if (!module->is_enabled()) {
-      ss << "Module '" << py_handler_name << "' is not enabled (required by "
-            "command '" << prefix << "'): use `ceph mgr module enable "
-            << py_handler_name << "` to enable it";
-      dout(4) << ss.str() << dendl;
-      cmdctx->reply(-EOPNOTSUPP, ss);
-      return;
-    }
 
     // Hack: allow the self-test method to run on unhealthy modules.
     // Fix this in future by creating a special path for self test rather


### PR DESCRIPTION
This PR accomplishes several things:

1. Reorder "active and enabled" checks & add retry logic for module loading

    The current "active and enabled" check order can result in an ENOTSUP being
    returned when a module is enabled, but needs more time to load. In this case,
    the command should be supported, but the module timed out loading. We added
    internal retry logic to the mgr, so now the mgr retries loading the module several
    times before giving up. With that implemented, ETIMEDOUT is more appropriate.
    
    The default max time that a module can take to load is now 5 seconds. To
    adjust this time, the following command can be run:
      `ceph config set mgr mgr_module_load_timeout <uint>`
    
    The default cadence at which the mgr retries is every 1 second. To
    adjust this time, the following command can be run:
      `ceph config set mgr mgr_module_load_interval <uint>`

2. Add test coverage for slow loading module
    
    To test the above modifications, this PR adds a dev-only config
    that can inject a longer loading time into the mgr module loading
    sequence so we can simulate this scenario in a test.
    
    The config is 0 secs by default since we do not add any delay
    outside of testing scenarios. The config can be adjusted
    with the following command:
      `ceph config set mgr mgr_module_load_delay <uint>`
    
    A second dev-only config also allows you to specify which
    module you want to be delayed in loading time. You may change
    this with the following command:
      `ceph config set mgr mgr_module_load_delay_name <module name>`
    
    The workunit added here tests a simulated slow loading module
    scenario, as well as checks for any problems in the actual
    module loading time.

Latest teuthology results for the new workunit are green:
https://pulpito.ceph.com/lflores-2025-01-10_16:53:51-rados:mgr-wip-_handle_command-returns-ENOTSUP-prematurely-distro-default-smithi/

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
