### PR TITLE
squid: qa/suites/upgrade/reef-x: sync log-ignorelist with quincy-x

### DIFF
--- a/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
@@ -39,7 +39,10 @@ overrides:
       - mon down
       - MON_DOWN
       - out of quorum
+      - PG_AVAILABILITY
       - PG_DEGRADED
       - Reduced data availability
       - Degraded data redundancy
+      - pg .* is stuck inactive
+      - pg .* is .*degraded
       - OSDMAP_FLAGS

--- a/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
@@ -47,3 +47,4 @@ overrides:
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS
+      - OSD_UPGRADE_FINISHED

--- a/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
@@ -33,6 +33,7 @@ overrides:
         osd shutdown pgref assert: true
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - is down
       - OSD_DOWN
       - mons down
       - mon down

--- a/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
@@ -32,7 +32,10 @@ overrides:
       osd:
         osd shutdown pgref assert: true
     log-ignorelist:
-      - \(POOL_APP_NOT_ENABLED\)
+      - do not have an application enabled
+      - application not enabled
+      - or freeform for custom applications
+      - POOL_APP_NOT_ENABLED
       - is down
       - OSD_DOWN
       - mons down

--- a/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
@@ -45,4 +45,5 @@ overrides:
       - Degraded data redundancy
       - pg .* is stuck inactive
       - pg .* is .*degraded
+      - FS_DEGRADED
       - OSDMAP_FLAGS

--- a/qa/suites/upgrade/quincy-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/1-tasks.yaml
@@ -1,11 +1,8 @@
 overrides:
   ceph:
     log-ignorelist:
-      - mons down
-      - mon down
-      - MON_DOWN
-      - out of quorum
-      - PG_AVAILABILITY
+      - Telemetry requires re-opt-in
+      - telemetry module includes new collections
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -1,7 +1,10 @@
 overrides:
   ceph:
     log-ignorelist:
-      - \(POOL_APP_NOT_ENABLED\)
+      - do not have an application enabled
+      - application not enabled
+      - or freeform for custom applications
+      - POOL_APP_NOT_ENABLED
       - is down
       - OSD_DOWN
       - mons down

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -14,6 +14,7 @@ overrides:
       - Degraded data redundancy
       - pg .* is stuck inactive
       - pg .* is .*degraded
+      - FS_DEGRADED
       - OSDMAP_FLAGS
 tasks:
 - install:

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -8,11 +8,13 @@ overrides:
       - mon down
       - MON_DOWN
       - out of quorum
+      - PG_AVAILABILITY
       - PG_DEGRADED
       - Reduced data availability
       - Degraded data redundancy
+      - pg .* is stuck inactive
+      - pg .* is .*degraded
       - OSDMAP_FLAGS
-      - PG_AVAILABILITY
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -16,6 +16,7 @@ overrides:
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS
+      - OSD_UPGRADE_FINISHED
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - is down
       - OSD_DOWN
       - mons down
       - mon down

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -39,7 +39,10 @@ overrides:
       - mon down
       - MON_DOWN
       - out of quorum
+      - PG_AVAILABILITY
       - PG_DEGRADED
       - Reduced data availability
       - Degraded data redundancy
+      - pg .* is stuck inactive
+      - pg .* is .*degraded
       - OSDMAP_FLAGS

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -47,3 +47,4 @@ overrides:
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS
+      - OSD_UPGRADE_FINISHED

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -33,6 +33,7 @@ overrides:
         osd shutdown pgref assert: true
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - is down
       - OSD_DOWN
       - mons down
       - mon down

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -32,4 +32,13 @@ overrides:
       osd:
         osd shutdown pgref assert: true
     log-ignorelist:
-        - PG_DEGRADED
+      - \(POOL_APP_NOT_ENABLED\)
+      - OSD_DOWN
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
+      - PG_DEGRADED
+      - Reduced data availability
+      - Degraded data redundancy
+      - OSDMAP_FLAGS

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -32,7 +32,10 @@ overrides:
       osd:
         osd shutdown pgref assert: true
     log-ignorelist:
-      - \(POOL_APP_NOT_ENABLED\)
+      - do not have an application enabled
+      - application not enabled
+      - or freeform for custom applications
+      - POOL_APP_NOT_ENABLED
       - is down
       - OSD_DOWN
       - mons down

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -45,4 +45,5 @@ overrides:
       - Degraded data redundancy
       - pg .* is stuck inactive
       - pg .* is .*degraded
+      - FS_DEGRADED
       - OSDMAP_FLAGS

--- a/qa/suites/upgrade/reef-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/0-start.yaml
@@ -31,3 +31,5 @@ overrides:
     conf:
       osd:
         osd shutdown pgref assert: true
+    log-ignorelist:
+        - PG_DEGRADED

--- a/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
@@ -1,12 +1,8 @@
 overrides:
   ceph:
     log-ignorelist:
-      - mons down
-      - mon down
-      - MON_DOWN
-      - out of quorum
-      - PG_AVAILABILITY
-      - PG_DEGRADED
+      - Telemetry requires re-opt-in
+      - telemetry module includes new collections
 tasks:
 - install:
     branch: reef

--- a/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
@@ -6,6 +6,7 @@ overrides:
       - MON_DOWN
       - out of quorum
       - PG_AVAILABILITY
+      - PG_DEGRADED
 tasks:
 - install:
     branch: reef

--- a/qa/suites/upgrade/reef-x/parallel/overrides/ignorelist_health.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/overrides/ignorelist_health.yaml
@@ -1,20 +1,19 @@
 overrides:
   ceph:
     log-ignorelist:
-      - \(MDS_ALL_DOWN\)
-      - \(MDS_UP_LESS_THAN_MAX\)
-      - \(OSD_SLOW_PING_TIME
+      - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
+      - OSD_SLOW_PING_TIME
       - reached quota
+      - running out of quota
       - overall HEALTH_
-      - \(CACHE_POOL_NO_HIT_SET\)
-      - \(POOL_FULL\)
-      - \(SMALLER_PGP_NUM\)
-      - \(SLOW_OPS\)
-      - \(CACHE_POOL_NEAR_FULL\)
-      - \(POOL_APP_NOT_ENABLED\)
-      - \(PG_AVAILABILITY\)
-      - \(OBJECT_MISPLACED\)
+      - CACHE_POOL_NO_HIT_SET
+      - pool\(s\) full
+      - POOL_FULL
+      - SMALLER_PGP_NUM
+      - SLOW_OPS
+      - CACHE_POOL_NEAR_FULL
+      - OBJECT_MISPLACED
       - slow request
-      - \(MON_DOWN\)
       - noscrub
       - nodeep-scrub

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -1,7 +1,10 @@
 overrides:
   ceph:
     log-ignorelist:
-      - \(POOL_APP_NOT_ENABLED\)
+      - do not have an application enabled
+      - application not enabled
+      - or freeform for custom applications
+      - POOL_APP_NOT_ENABLED
       - is down
       - OSD_DOWN
       - mons down

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -14,6 +14,7 @@ overrides:
       - Degraded data redundancy
       - pg .* is stuck inactive
       - pg .* is .*degraded
+      - FS_DEGRADED
       - OSDMAP_FLAGS
 tasks:
 - install:

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -8,11 +8,13 @@ overrides:
       - mon down
       - MON_DOWN
       - out of quorum
+      - PG_AVAILABILITY
       - PG_DEGRADED
       - Reduced data availability
       - Degraded data redundancy
+      - pg .* is stuck inactive
+      - pg .* is .*degraded
       - OSDMAP_FLAGS
-      - PG_AVAILABILITY
 tasks:
 - install:
     branch: reef

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - is down
       - OSD_DOWN
       - mons down
       - mon down

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -1,10 +1,16 @@
 overrides:
   ceph:
     log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
+      - OSD_DOWN
       - mons down
       - mon down
       - MON_DOWN
       - out of quorum
+      - PG_DEGRADED
+      - Reduced data availability
+      - Degraded data redundancy
+      - OSDMAP_FLAGS
       - PG_AVAILABILITY
 tasks:
 - install:

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -16,6 +16,7 @@ overrides:
       - pg .* is .*degraded
       - FS_DEGRADED
       - OSDMAP_FLAGS
+      - OSD_UPGRADE_FINISHED
 tasks:
 - install:
     branch: reef

--- a/qa/suites/upgrade/reef-x/stress-split/overrides/ignorelist_health.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/overrides/ignorelist_health.yaml
@@ -1,20 +1,19 @@
 overrides:
   ceph:
     log-ignorelist:
-      - \(MDS_ALL_DOWN\)
-      - \(MDS_UP_LESS_THAN_MAX\)
-      - \(OSD_SLOW_PING_TIME
+      - MDS_ALL_DOWN
+      - MDS_UP_LESS_THAN_MAX
+      - OSD_SLOW_PING_TIME
       - reached quota
+      - running out of quota
       - overall HEALTH_
-      - \(CACHE_POOL_NO_HIT_SET\)
-      - \(POOL_FULL\)
-      - \(SMALLER_PGP_NUM\)
-      - \(SLOW_OPS\)
-      - \(CACHE_POOL_NEAR_FULL\)
-      - \(POOL_APP_NOT_ENABLED\)
-      - \(PG_AVAILABILITY\)
-      - \(OBJECT_MISPLACED\)
+      - CACHE_POOL_NO_HIT_SET
+      - pool\(s\) full
+      - POOL_FULL
+      - SMALLER_PGP_NUM
+      - SLOW_OPS
+      - CACHE_POOL_NEAR_FULL
+      - OBJECT_MISPLACED
       - slow request
-      - \(MON_DOWN\)
       - noscrub
       - nodeep-scrub


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69496

---

backport of https://github.com/ceph/ceph/pull/59045 and https://github.com/ceph/ceph/pull/60969
parent tracker: https://tracker.ceph.com/issues/69135