### PR TITLE
reef: mds: do not process client metrics message with fast dispatch

### DIFF
--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -20,15 +20,6 @@ MetricsHandler::MetricsHandler(CephContext *cct, MDSRank *mds)
     mds(mds) {
 }
 
-bool MetricsHandler::ms_can_fast_dispatch2(const cref_t<Message> &m) const {
-  return m->get_type() == CEPH_MSG_CLIENT_METRICS || m->get_type() == MSG_MDS_PING;
-}
-
-void MetricsHandler::ms_fast_dispatch2(const ref_t<Message> &m) {
-  bool handled = ms_dispatch2(m);
-  ceph_assert(handled);
-}
-
 bool MetricsHandler::ms_dispatch2(const ref_t<Message> &m) {
   if (m->get_type() == CEPH_MSG_CLIENT_METRICS &&
       m->get_connection()->get_peer_type() == CEPH_ENTITY_TYPE_CLIENT) {

--- a/src/mds/MetricsHandler.h
+++ b/src/mds/MetricsHandler.h
@@ -25,11 +25,6 @@ class MetricsHandler : public Dispatcher {
 public:
   MetricsHandler(CephContext *cct, MDSRank *mds);
 
-  bool ms_can_fast_dispatch_any() const override {
-    return true;
-  }
-  bool ms_can_fast_dispatch2(const cref_t<Message> &m) const override;
-  void ms_fast_dispatch2(const ref_t<Message> &m) override;
   bool ms_dispatch2(const ref_t<Message> &m) override;
 
   void ms_handle_connect(Connection *c) override {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69360

---

backport of https://github.com/ceph/ceph/pull/60653
parent tracker: https://tracker.ceph.com/issues/68865

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh