### PR TITLE
squid: mon/scrub: log error details of store access failures

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -5695,7 +5695,12 @@ bool Monitor::_scrub(ScrubResult *r,
 
     bufferlist bl;
     int err = store->get(k.first, k.second, bl);
-    ceph_assert(err == 0);
+    if (err != 0) {
+      derr << __func__ << " store got: " << cpp_strerror(err)
+                       << " prefix: " << k.first << " key: " << k.second
+                       << dendl;
+      ceph_abort();
+    }
     
     uint32_t key_crc = bl.crc32c(0);
     dout(30) << __func__ << " " << k << " bl " << bl.length() << " bytes"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69505

---

backport of https://github.com/ceph/ceph/pull/58472
parent tracker: https://tracker.ceph.com/issues/64824

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh