### PR TITLE
osd/scrub: increase the default scrub load limit

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -287,11 +287,10 @@ options:
   desc: Allow scrubbing when system load divided by number of CPUs is below this value
   fmt_desc: The normalized maximum load. Ceph will not initiate periodic (regular)
     scrubs when the system load (as defined by ``getloadavg() / number of online CPUs``)
-    is higher than this number.
-    Default is ``0.5``.
-  default: 0.5
+    is higher than this number. The default is set high enough to allow periodic scrubbing
+    under most load conditions.
+  default: 10.0
   with_legacy: true
-# if load is low
 - name: osd_scrub_min_interval
   type: float
   level: advanced
@@ -301,7 +300,6 @@ options:
   see_also:
   - osd_scrub_max_interval
   with_legacy: true
-# regardless of load
 - name: osd_scrub_max_interval
   type: float
   level: advanced


### PR DESCRIPTION
Modifying the default value of osd_scrub_load_threshold from 0.5 to 10.0, rendering it mostly irrelevant.

That is done following a combination of reasons:
- the new mclock scheduler, which provides a better mechanism to control scrub load under all conditions;
- the inapplicability of the existing mechanism to Crimson; and
- users` requests.
