### PR TITLE
rgw/s3: remove local variable 'uri' that shadows member variable

### DIFF
--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -200,7 +200,6 @@ bool ACLGrant_S3::xml_end(const char *el) {
   ACLURI_S3 *acl_uri;
   ACLEmail_S3 *acl_email;
   ACLDisplayName_S3 *acl_name;
-  string uri;
 
   acl_grantee = static_cast<ACLGrantee_S3 *>(find_first("Grantee"));
   if (!acl_grantee)


### PR DESCRIPTION
fixes "Invalid group uri" errors from `s3cmd setacl --acl-public s3://bucketname` introduced by account changes for squid

Fixes: https://tracker.ceph.com/issues/69527

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
