### PR TITLE
qa/cephadm: wait between starting and restarting osd in test_daemon_restart test

### DIFF
--- a/qa/tasks/cephadm_cases/test_cli.py
+++ b/qa/tasks/cephadm_cases/test_cli.py
@@ -60,6 +60,8 @@ class TestCephadmCLI(MgrTestCase):
         time.sleep(5)
         self._orch_cmd('daemon', 'start', 'osd.0')
         self.wait_for_health_clear(120)
+        # this sleep is to try and address https://tracker.ceph.com/issues/69526
+        time.sleep(5)
         self._orch_cmd('daemon', 'restart', 'osd.0')
 
     def test_device_ls_wide(self):


### PR DESCRIPTION
The test before the pause test ends with `ceph orch daemon restart osd.0`
which may temporarily cause a CEPHADM_FAILED_DAEMON warning for that
OSD. It seems to be failing with "status=219/CGROUP", logging nothing
else of note, and coming up totally fine when restarted by systemd
a second later (see the linked tracker for more info/logs). This
sleep is me thinking this may be timing related and that if we
separate the start from the restart by a few more seconds it might
avoid the error.

Fixes: https://tracker.ceph.com/issues/69526



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
