### PR TITLE
squid: test/pybind: Clean whitespace. (Doc and test fixes)

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -4,7 +4,7 @@ Ceph Dashboard Developer Documentation
 Note: The content of this file has been moved into the Ceph Developer Guide.
 
 If you're interested in helping with the development of the dashboard, please
-see ``/doc/dev/developer_guide/dash_devel.rst`` or the `online version
+see ``/doc/dev/developer_guide/dash-devel.rst`` or the `online version
 <https://ceph.readthedocs.io/en/latest/dev/developer_guide/dash-devel/>`_ for
 details on how to set up a development environment and other development-related
 topics.

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -217,7 +217,7 @@ class TestPG(TestArgparse):
     def test_pg_missing_args_output(self):
         ret, _, stderr = self._capture_output(['pg'], stderr=True)
         self.assertEqual({}, ret)
-        self.assertRegexpMatches(stderr, re.compile('no valid command found.* closest matches'))
+        self.assertRegex(stderr, re.compile('no valid command found.* closest matches'))
 
     def test_pg_wrong_arg_output(self):
         ret, _, stderr = self._capture_output(['pg', 'map', 'bad-pgid'],
@@ -416,10 +416,10 @@ class TestMDS(TestArgparse):
 
 
 class TestFS(TestArgparse):
-    
+
     def test_dump(self):
         self.check_0_or_1_natural_arg('fs', 'dump')
-    
+
     def test_fs_new(self):
         self._assert_valid_command(['fs', 'new', 'default', 'metadata', 'data'])
 
@@ -912,7 +912,7 @@ class TestOSD(TestArgparse):
                                         '1.2.3.4/567', '600.40'])
             self._assert_valid_command(['osd', 'blocklist', action,
                                         '1.2.3.4', '600.40'])
-            
+
             self._assert_valid_command(['osd', 'blocklist', action,
                                         'v1:1.2.3.4', '600.40'])
             self._assert_valid_command(['osd', 'blocklist', action,
@@ -925,7 +925,7 @@ class TestOSD(TestArgparse):
                                         'v2:[2607:f298:4:2243::5522]:0/0', '600.40'])
             self._assert_valid_command(['osd', 'blocklist', action,
                                         '[2001:0db8::85a3:0000:8a2e:0370:7334]:0/0', '600.40'])
-            
+
             self.assertEqual({}, validate_command(sigdict, ['osd', 'blocklist',
                                                             action,
                                                             'invalid',

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -148,7 +148,7 @@ def wrap(s, sl):
     """return a '+' suffixed wrapped string"""
     if len(s) < sl:
         return s
-    return f'{s[0:sl-1]}+'
+    return f'{s[0:sl - 1]}+'
 
 
 class FSTopBase(object):


### PR DESCRIPTION
Signed-off-by: Paulo E. Castro <pecastro@wormholenet.com>
(cherry picked from commit aec8ca8b2688be5b460c822cab7ae6ba47bf4c80)

test/pybind: Test method has been renamed in unittest 3.2

Signed-off-by: Paulo E. Castro <pecastro@wormholenet.com>
(cherry picked from commit 560d66e34edacef0bed3c44ff8a02be6f79b5fbe)

doc: Fix typo.

Signed-off-by: Paulo E. Castro <pecastro@wormholenet.com>
(cherry picked from commit 5a886ee6ce9e55e9f66da6cff45945fba354bd69)

tools/cephfs: fix flake8 f-string formatting for py3.12

Signed-off-by: Paulo E. Castro <pecastro@wormholenet.com>
(cherry picked from commit 2b2ce7871579252074eff7b6072890196b1e4f2c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

