### PR TITLE
squid: test/librados: fix LibRadosIoECPP.CrcZeroWrite

### DIFF
--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -832,6 +832,21 @@ TEST_F(LibRadosIoECPP, RmXattrPP) {
   ASSERT_EQ(-ENOENT, ioctx.rmxattr("foo_rmxattr", attr2));
 }
 
+TEST_F(LibRadosIoECPP, CrcZeroWrite) {
+  SKIP_IF_CRIMSON();
+  set_allow_ec_overwrites();
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+
+  ASSERT_EQ(0, ioctx.write("foo", bl, 0, 0));
+  ASSERT_EQ(0, ioctx.write("foo", bl, 0, sizeof(buf)));
+
+  ObjectReadOperation read;
+  read.read(0, bl.length(), NULL, NULL);
+  ASSERT_EQ(0, ioctx.operate("foo", &read, &bl));
+}
+
 TEST_F(LibRadosIoECPP, XattrListPP) {
   SKIP_IF_CRIMSON();
   char buf[128];

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -838,6 +838,7 @@ TEST_F(LibRadosIoECPP, CrcZeroWrite) {
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
+  bl.append(buf, sizeof(buf));
 
   ASSERT_EQ(0, ioctx.write("foo", bl, 0, 0));
   ASSERT_EQ(0, ioctx.write("foo", bl, 0, sizeof(buf)));

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -402,6 +402,16 @@ void RadosTestECPP::TearDown()
     cleanup_default_namespace(ioctx);
     cleanup_namespace(ioctx, nspace);
   }
+  if (ec_overwrites_set) {
+    ASSERT_EQ(0, destroy_one_ec_pool_pp(pool_name, s_cluster));
+    ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
+    ec_overwrites_set = false;
+  }
   ioctx.close();
 }
 
+void RadosTestECPP::set_allow_ec_overwrites()
+{
+  ASSERT_EQ("", set_allow_ec_overwrites_pp(pool_name, cluster, true));
+  ec_overwrites_set = true;
+}

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -3,6 +3,9 @@
 
 #include "testcase_cxx.h"
 
+#include <chrono>
+#include <thread>
+
 #include <errno.h>
 #include <fmt/format.h>
 #include "test_cxx.h"
@@ -412,6 +415,22 @@ void RadosTestECPP::TearDown()
 
 void RadosTestECPP::set_allow_ec_overwrites()
 {
-  ASSERT_EQ("", set_allow_ec_overwrites_pp(pool_name, cluster, true));
   ec_overwrites_set = true;
+  ASSERT_EQ("", set_allow_ec_overwrites_pp(pool_name, cluster, true));
+
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  const std::string objname = "RadosTestECPP::set_allow_ec_overwrites:test_obj";
+  ASSERT_EQ(0, ioctx.write(objname, bl, sizeof(buf), 0));
+  const auto end = std::chrono::steady_clock::now() + std::chrono::seconds(120);
+  while (true) {
+    if (0 == ioctx.write(objname, bl, sizeof(buf), 0)) {
+      break;
+    }
+    ASSERT_LT(std::chrono::steady_clock::now(), end);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
 }

--- a/src/test/librados/testcase_cxx.h
+++ b/src/test/librados/testcase_cxx.h
@@ -111,12 +111,14 @@ protected:
 };
 
 class RadosTestECPP : public RadosTestPP {
+  bool ec_overwrites_set = false;
 public:
   RadosTestECPP(bool c=false) : cluster(s_cluster), cleanup(c) {}
   ~RadosTestECPP() override {}
 protected:
   static void SetUpTestCase();
   static void TearDownTestCase();
+  void set_allow_ec_overwrites();
   static librados::Rados s_cluster;
   static std::string pool_name;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66533

---

backport of https://github.com/ceph/ceph/pull/57856
parent tracker: https://tracker.ceph.com/issues/66226

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh