### PR TITLE
[DON'T REVIEW] libcephfsproxy: Implement initial design for metadata caching

### DIFF
--- a/src/libcephfs_proxy/proxy_helpers.h
+++ b/src/libcephfs_proxy/proxy_helpers.h
@@ -15,6 +15,9 @@
 #define ptr_value(_ptr) ((uint64_t)(uintptr_t)(_ptr))
 #define value_ptr(_val) ((void *)(uintptr_t)(_val))
 
+#define MAX_CLIENTS 1000
+#define MAX_INODES  (50 * 1024 * 1024) / 4248
+
 typedef struct _proxy_random {
 	uint64_t mask;
 	uint64_t factor;


### PR DESCRIPTION
### Overview:
This PR introduces metadata caching to improve performance in the proxy. The cache stores inode metadata, including version information, to minimize the need for redundant daemon queries. The caching mechanism ensures consistency by validating the cache with inode version checks. Stale cache entries are invalidated and removed when detected.

### Changes:
- Added metadata_cache_entry_t for inode metadata.
- Implemented cache management functions (find_in_cache, add_to_cache, remove_from_cache).
- Registered invalidation callbacks (libcephfsd_invalidate_inode) in the daemon.
- Added schedule_invalidation to notify proxy clients of invalidations.
- Updated ceph_ll_lookup_new to use the cache and handle invalidation messages.

### Workflow:
- Daemon registers invalidation callbacks with libcephfs.
- MDS invalidation notifications trigger these callbacks.
- Proxy daemon notifies clients caching affected inodes/dentries.
- Proxy clients handle messages and remove stale cache entries.

### Next Steps:
- Discuss cache invalidation strategy with the CephFS and implement changes based on the final design.






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
