### PR TITLE
mgr/cephadm: After deploying nvmeof gateway group, the prometheus port 10008/tcp is not opened

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -481,11 +481,11 @@ timeout = 1.0\n"""
                         "image": "",
                         "deploy_arguments": [],
                         "params": {
-                            "tcp_ports": [5500, 4420, 8009]
+                            "tcp_ports": [5500, 4420, 8009, 10008]
                         },
                         "meta": {
                             "service_name": "nvmeof.testpool",
-                            "ports": [5500, 4420, 8009],
+                            "ports": [5500, 4420, 8009, 10008],
                             "ip": None,
                             "deployed_by": [],
                             "rank": None,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1550,7 +1550,7 @@ class NvmeofServiceSpec(ServiceSpec):
         self.monitor_client_log_file_dir = monitor_client_log_file_dir
 
     def get_port_start(self) -> List[int]:
-        return [self.port, 4420, self.discovery_port]
+        return [self.port, 4420, self.discovery_port, self.prometheus_port]
 
     def validate(self) -> None:
         #  TODO: what other parameters should be validated as part of this function?


### PR DESCRIPTION
mgr/cephadm: Open prometheus port 10008, as part of nvmeof gateway deployment

Fixes: https://tracker.ceph.com/issues/69541
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>


Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph osd pool create nvmeof_pool01
pool 'nvmeof_pool01' created
[ceph: root@ceph-node-0 /]#  ceph orch apply nvmeof nvmeof_pool01 grp01 --placement="*"
Scheduled nvmeof.nvmeof_pool01.grp01 update...
[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                        PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT  
crash                                                   3/3  5s ago     39m  *          
mgr                                                     2/2  5s ago     39m  count:2    
mon                                                     3/5  5s ago     39m  count:5    
nvmeof.nvmeof_pool01.grp01  ?:4420,5500,8009,10008      3/3  5s ago     2m   *          
osd.all-available-devices                                 3  5s ago     38m  *          
[ceph: root@ceph-node-0 /]# ceph orch ps --daemon_type nvmeof
NAME                                           HOST         PORTS                   STATUS          REFRESHED   AGE  MEM USE  MEM LIM  VERSION  IMAGE ID      CONTAINER ID  
nvmeof.nvmeof_pool01.grp01.ceph-node-0.uesxmb  ceph-node-0  *:5500,4420,8009,10008  running (63s)     18s ago   63s    31.0M        -  1.4.2    a09f7e144ac2  c21eb83e2567  
nvmeof.nvmeof_pool01.grp01.ceph-node-1.gwrnor  ceph-node-1  *:5500,4420,8009,10008  running (105s)    18s ago  105s    30.9M        -  1.4.2    a09f7e144ac2  68eb7985e35c  
nvmeof.nvmeof_pool01.grp01.ceph-node-2.vfdrmd  ceph-node-2  *:5500,4420,8009,10008  running (22s)     18s ago   22s    30.9M        -  1.4.2    a09f7e144ac2  a7fc20b45c4f  
[ceph: root@ceph-node-0 /]# 

[root@ceph-node-0 ~]# firewall-cmd --list-port
4420/tcp 5500/tcp 8009/tcp 10008/tcp
[root@ceph-node-0 ~]#

[root@ceph-node-1 ~]# firewall-cmd --list-port
4420/tcp 5500/tcp 8009/tcp 10008/tcp
[root@ceph-node-1 ~]# exit
logout
shwetabhosale:ceph-cluster-setup$ kcli ssh -u root -- ceph-node-2
Last login: Wed Jan 15 12:44:09 2025 from 192.168.100.1
[root@ceph-node-2 ~]# firewall-cmd --list-port
4420/tcp 5500/tcp 8009/tcp 10008/tcp

```


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
