### PR TITLE
mon/test_mon_osdmap_prune: Use first_pinned instead of first_committed

### DIFF
--- a/qa/workunits/mon/test_mon_osdmap_prune.sh
+++ b/qa/workunits/mon/test_mon_osdmap_prune.sh
@@ -33,7 +33,9 @@ function wait_for_trim() {
 
   for ((i=0; i < ${#delays[*]}; ++i)); do
     fc=$(ceph report | jq '.osdmap_first_committed')
-    if [[ $fc -eq $epoch ]]; then
+    manifest="$(ceph report | jq '.osdmap_manifest')"
+    first_pinned_map=$(ceph report | jq '.osdmap_manifest.first_pinned')
+    if [[ $first_pinned_map -eq $epoch ]]; then
       return 0
     fi
     sleep ${delays[$i]}


### PR DESCRIPTION
In the test, we assume the trimming of osdmaps is done if osdmap_first_committed is equal to the epoch of the map upto which we had to trim. osdmap_first_committed however returns the value of cached_first_committed which is updated before the Paxos proposal for trim goes through. Normally, this is not a problem as when a refresh() happens, cached_first_committed will be corrected to the value before the trim was proposed if the Paxos proposal failed. But for this test, we encounter a failure in this case as the osdmap_first_committed will not be equal to the osdmap_manifest.first_pinned as the trim never went through. Changing the test to verify that osdmap_manifest.first_pinned has changed to the correct value is a better way to signify that the trim is complete for the purpose of this test.

Fixes: https://tracker.ceph.com/issues/47838





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
