### PR TITLE
squid: common: fix md_config_cacher_t

### DIFF
--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -597,17 +597,16 @@ function TEST_dump_scrub_schedule() {
     declare -A expct_dmp_duration=( ['dmp_last_duration']="0" ['dmp_last_duration_neg']="not0" )
     wait_any_cond $pgid 10 $saved_last_stamp expct_dmp_duration "WaitingAfterScrub_dmp " sched_data || return 1
 
-    sleep 2
-
     #
     # step 2: set noscrub and request a "periodic scrub". Watch for the change in the 'is the scrub
     #         scheduled for the future' value
     #
 
-    ceph tell osd.* config set osd_scrub_chunk_max "3" || return 1
-    ceph tell osd.* config set osd_scrub_sleep "1.0" || return 1
     ceph osd set noscrub || return 1
     sleep 2
+    ceph tell osd.* config set osd_shallow_scrub_chunk_max "3" || return 1
+    ceph tell osd.* config set osd_scrub_sleep "2.0" || return 1
+    sleep 8
     saved_last_stamp=${sched_data['query_last_stamp']}
 
     ceph tell $pgid schedule-scrub

--- a/src/common/config_cacher.h
+++ b/src/common/config_cacher.h
@@ -40,7 +40,7 @@ class md_config_cacher_t : public md_config_obs_t {
 
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string>& changed) override {
-    if (changed.count(keys[0])) {
+    if (changed.contains(keys[0])) {
       value_cache.store(conf.get_val<ValueT>(keys[0]));
     }
   }


### PR DESCRIPTION
In its get_tracked_conf_keys() member function, the cacher (in the existing code)
initializes a static function-block variable ('keys'), and uses it for
registering the observer.

But the cacher is instantiated on the type of
the configuration value. Thus, multiple cacher
objects for which the configuration values are
of the same type - share the static 'keys'. Only
one of the observers is registered.

Backport of https://github.com/ceph/ceph/pull/61289

Original tracker: https://tracker.ceph.com/issues/69236
Backport tracker: https://tracker.ceph.com/issues/69530
