### PR TITLE
cephfs-mirror: incremental sync should consider current snapshot for syncing instead of current state

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1481,19 +1481,19 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       if ("." == nname || ".." == nname)
         continue;
       // create path for the newly found entry
-      npath = entry_diff_path(epath, nname);
-      nabs_path = entry_diff_path(dir_root, npath);
+      npath = entry_path(epath, nname);
 
-      r = ceph_statx(sd_info.cmount, nabs_path.c_str(), &cstx,
-                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                     CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+      r = ceph_statxat(m_local_mount, fh.c_fd, npath.c_str(), &cstx,
+                       CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                           CEPH_STATX_SIZE | CEPH_STATX_ATIME |
+                           CEPH_STATX_MTIME,
+                       AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
       if (r < 0) {
         // can't stat, so it's a deleted entry.
         if (DT_DIR == sd_entry.dir_entry.d_type) { // is a directory
           r = cleanup_remote_dir(dir_root, npath, fh);
           if (r < 0) {
-            derr << ": failed to remove directory=" << nabs_path << dendl;
+            derr << ": failed to remove directory=" << npath << dendl;
             break;
           }
         }
@@ -1506,17 +1506,18 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       } else {
         // stat success, update the existing entry
         struct ceph_statx tstx;
-        int rstat_r = ceph_statx(m_remote_mount, nabs_path.c_str(), &tstx,
-                                 CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                                 CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                                 AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+        int rstat_r = ceph_statxat(
+            m_remote_mount, fh.r_fd_dir_root, npath.c_str(), &tstx,
+            CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+            AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
         if (S_ISDIR(cstx.stx_mode)) { // is a directory
           //cleanup if it's a file in the remotefs
           if ((0 == rstat_r) && !S_ISDIR(tstx.stx_mode)) {
             r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), 0);
             if (r < 0) {
               derr << ": Error in directory sync. Failed to remove file="
-                   << nabs_path << dendl;
+                   << npath << dendl;
               break;
             }
           }
@@ -1541,7 +1542,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
               r = cleanup_remote_dir(dir_root, npath, fh);
               if (r < 0) {
                 derr << ": Error in file sync. Failed to remove remote directory="
-                     << nabs_path << dendl;
+                     << npath << dendl;
                 break;
               }
             }


### PR DESCRIPTION


Fixes: https://tracker.ceph.com/issues/69190
Signed-off-by: Md Mahamudur Rahaman Sajib <mahamudur.sajib@croit.io>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
