### PR TITLE
client: Use custom fscrypt cli in fs/fscrypt suite

### DIFF
--- a/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-common.yaml
+++ b/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-common.yaml
@@ -1,12 +1,16 @@
 overrides:
   install:
+    # Remove package manager installation of fscrypt
     extra_system_packages:
-      rpm:
-        - fscrypt
-      deb:
-        - fscrypt
+      rpm: []
+      deb: []
 tasks:
+  - workunit:
+      clients:
+        all:
+          - fs/fscrypt_cli_setup.sh
   - cephfs_test_runner:
       fail_on_skip: false
       modules:
         - tasks.cephfs.test_fscrypt
+ 

--- a/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-dbench.yaml
+++ b/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-dbench.yaml
@@ -3,5 +3,6 @@ tasks:
     timeout: 6h
     clients:
       client.0:
+        - fs/fscrypt_cli_setup.sh
         - fs/fscrypt.sh none dbench
         - fs/fscrypt.sh unlocked dbench

--- a/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-ffsb.yaml
+++ b/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-ffsb.yaml
@@ -3,5 +3,6 @@ tasks:
     timeout: 6h
     clients:
       client.0:
+        - fs/fscrypt_cli_setup.sh
         - fs/fscrypt.sh none ffsb
         - fs/fscrypt.sh unlocked ffsb

--- a/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-iozone.yaml
+++ b/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-iozone.yaml
@@ -3,5 +3,6 @@ tasks:
     timeout: 6h
     clients:
       client.0:
+        - fs/fscrypt_cli_setup.sh
         - fs/fscrypt.sh none iozone
         - fs/fscrypt.sh unlocked iozone

--- a/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-pjd.yaml
+++ b/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-pjd.yaml
@@ -3,5 +3,6 @@ tasks:
     timeout: 6h
     clients:
       client.0:
+        - fs/fscrypt_cli_setup.sh
         - fs/fscrypt.sh none pjd
         - fs/fscrypt.sh unlocked pjd

--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -22,17 +22,17 @@ class FSCryptTestCase(CephFSTestCase):
 
         self.mount_a.run_shell_payload("sudo fscrypt --help")
         self.mount_a.run_shell_payload("sudo fscrypt setup --help")
-        self.mount_a.run_shell_payload("sudo fscrypt setup --force --quiet")
-        self.mount_a.run_shell_payload("sudo fscrypt status")
-        self.mount_a.run_shell_payload(f"sudo fscrypt setup --quiet {self.mount_a.hostfs_mntpt}")
-        self.mount_a.run_shell_payload("sudo fscrypt status")
+        self.mount_a.run_shell_payload("sudo fscrypt setup --force --verbose")
+        self.mount_a.run_shell_payload("sudo fscrypt status --verbose")
+        self.mount_a.run_shell_payload(f"sudo fscrypt setup {self.mount_a.hostfs_mntpt} --verbose")
+        self.mount_a.run_shell_payload("sudo fscrypt status --verbose")
         self.mount_a.run_shell_payload(f"sudo dd if=/dev/urandom of={self.key_file} bs=32 count=1")
         self.mount_a.run_shell_payload(f"mkdir -p {self.path}")
-        self.mount_a.run_shell_payload(f"sudo fscrypt encrypt --quiet --source=raw_key --name={self.protector} --no-recovery --skip-unlock --key={self.key_file} {self.path}")
-        self.mount_a.run_shell_payload(f"sudo fscrypt unlock --quiet --key=/tmp/key {self.path}")
+        self.mount_a.run_shell_payload(f"sudo fscrypt encrypt --verbose --source=raw_key --name={self.protector} --no-recovery --skip-unlock --key={self.key_file} {self.path}")
+        self.mount_a.run_shell_payload(f"sudo fscrypt unlock --verbose --key=/tmp/key {self.path}")
 
     def tearDown(self):
-        self.mount_a.run_shell_payload(f"sudo fscrypt purge --force --quiet {self.mount_a.hostfs_mntpt}")
+        self.mount_a.run_shell_payload(f"sudo fscrypt purge --force --verbose {self.mount_a.hostfs_mntpt}")
 
         super().tearDown()
 

--- a/qa/workunits/fs/fscrypt_cli_setup.sh
+++ b/qa/workunits/fs/fscrypt_cli_setup.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+echo "Custom fscrypt CLI setup begin"
+WORK_DIR=$(pwd)
+set -xe
+
+# Check and print kernel encryption support
+zgrep -h ENCRYPTION /proc/config.gz /boot/config-$(uname -r) | sort | uniq || true
+cat /proc/mounts || true
+
+# Update the package manager cache
+if command -v apt-get &>/dev/null; then
+    sudo apt-get update -y
+elif command -v yum &>/dev/null; then
+    sudo yum makecache --refresh -y
+else
+    echo "Unsupported package manager. Exiting."
+    exit 1
+fi
+
+# Remove any pre-installed fscrypt packages
+if command -v apt-get &>/dev/null; then
+    sudo apt-get remove --purge -y fscrypt || true
+elif command -v yum &>/dev/null; then
+    sudo yum remove -y fscrypt || true
+fi
+
+# Check if /tmp/fscrypt exists
+if [ -d "$WORK_DIR/fscrypt" ]; then
+    echo "$WORK_DIR/fscrypt exists. Cleaning up..."
+
+    # Navigate to the folder
+    cd "$WORK_DIR/fscrypt" || { echo "Failed to navigate to $WORK_DIR/fscrypt"; exit 1; }
+
+    # Uninstall the existing installation
+    if [ -f "Makefile" ]; then
+        echo "Running 'sudo make uninstall'..."
+        sudo make uninstall || echo "Uninstall failed or no uninstall target defined."
+    else
+        echo "Makefile not found. Skipping 'make uninstall'."
+    fi
+
+    # Navigate back
+    cd || { echo "Failed to navigate back to home directory"; exit 1; }
+
+    # Delete the directory
+    echo "Deleting $WORK_DIR/fscrypt..."
+    rm -rf "$WORK_DIR/fscrypt"
+    echo "$WORK_DIR/fscrypt cleanup complete."
+else
+    echo "$WORK_DIR/fscrypt does not exist. No action needed."
+fi
+
+# Install required dependencies for building fscrypt
+if command -v apt-get &>/dev/null; then
+    sudo apt-get install -y build-essential libpam0g-dev libtinfo-dev golang
+elif command -v yum &>/dev/null; then
+    sudo yum install -y gcc make pam-devel ncurses-devel golang
+fi
+
+# Clone the custom fscrypt repository, build, and install
+git clone https://git.ceph.com/fscrypt.git -b wip-ceph-fuse "$WORK_DIR/fscrypt"
+cd "$WORK_DIR/fscrypt"
+make
+sudo make install PREFIX=/usr/local
+
+# Add /usr/local/bin to secure_path in sudoers
+if ! sudo grep -q "/usr/local/bin" /etc/sudoers; then
+    echo "Adding /usr/local/bin to secure_path in /etc/sudoers"
+    if sudo grep -q 'Defaults\s*secure_path="[^"]*"' /etc/sudoers; then
+        # If secure_path is quoted
+        sudo sed -i.bak 's|\(Defaults\s*secure_path="[^"]*\)"|\1:/usr/local/bin"|' /etc/sudoers
+    else
+        # If secure_path is unquoted
+        sudo sed -i.bak 's|\(Defaults\s*secure_path\s*=\s*\)\(.*\)|\1\2:/usr/local/bin|' /etc/sudoers
+    fi
+fi
+
+# Verify installation
+sudo fscrypt --help || echo "fscrypt installation or configuration failed."
+
+echo "Custom fscrypt CLI setup done"


### PR DESCRIPTION
This PR addresses the folliowing case:

**Currently, fuse cannot use ioctls defined in the kernel because they have incorrect input/output definitions and are restricted. This affects the set|get policy ioctls[1](https://tracker.ceph.com/issues/68776?tab=history#fn1). Now we are using custom ioctls defined only in userspace to handle these operations. These new ioctls are defined in custom fscrypt commands.**

The fix contains 3 parts:
 - new script `fscrypt_cli_setup.sh` which installs our custom fscrypt branch
 - updated `fscrypt.sh` workunit, which initializes the fscrypt instead of xfsdev
 - updated `fscrypt-common.yaml` that runs the `fscrypt_cli_setup.sh` on the client machines when running tests

The current state of the teuthology tests for the fs/fscrypt suite:
This branch fails exactly as the main branch

Known issues:
In the `fscrypt.sh` the mount point is hard coded, please suggest how to find it programatically

Fixes https://tracker.ceph.com/issues/68776


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
