### PR TITLE
rgw: set dest bucket id in bucket sync checkpoint

### DIFF
--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -1061,7 +1061,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
 
     if (!pipe.dest.bucket) {
       /* Uh oh, something went wrong */
-      ldpp_dout(this, 20) << "ERROR: RGWOp_BILog_Status::execute(optional_yield y): BUG: pipe.dest.bucket was not initialized" << pipe << dendl;
+      ldpp_dout(this, 0) << "ERROR: RGWOp_BILog_Status::execute(optional_yield y): BUG: pipe.dest.bucket was not initialized" << pipe << dendl;
       op_ret = -EIO;
       return;
     }

--- a/src/rgw/radosgw-admin/sync_checkpoint.cc
+++ b/src/rgw/radosgw-admin/sync_checkpoint.cc
@@ -228,6 +228,7 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
     }
     auto& entry = sources.emplace_back();
     entry.pipe = pipe;
+    entry.pipe.dest.bucket = info.bucket; // so it contains the bucket key (+bucket id)
 
     // fetch remote markers
     boost::asio::spawn(ioctx, [&] (boost::asio::yield_context yield) {


### PR DESCRIPTION
`bucket_source_sync_checkpoint()` requires bucket id to lookup for full-sync object and the dest pipe doesn't have it. by replcaning the bucket key in the pipe with the bucket info we will ensure the bucket id is set.

Fixes: https://tracker.ceph.com/issues/69548