### PR TITLE
squid: mgr/vol: show progress and stats for the subvolume snapshot clones

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -360,6 +360,15 @@ CephFS: Disallow delegating preallocated inode ranges to clients. Config
   exposed via the new `--snap-id` option for `rbd clone` command.
 * RBD: The output of `rbd snap ls --all` command now includes the original
   type for trashed snapshots.
+* CephFS: "ceph fs clone status" command will now print statistics about clone
+  progress in terms of how much data has been cloned (in both percentage as
+  well as bytes) and how many files have been cloned.
+* CephFS: "ceph status" command will now print a progress bar when cloning is
+  ongoing. If clone jobs are more than the cloner threads, it will print one
+  more progress bar that shows total amount of progress made by both ongoing
+  as well as pending clones. Both progress are accompanied by messages that
+  show number of clone jobs in the respective categories and the amount of
+  progress made by each of them.
 
 * CephFS: Command "ceph mds fail" and "ceph fs fail" now requires a
   confirmation flag when some MDSs exhibit health warning MDS_TRIM or

--- a/qa/suites/fs/volumes/tasks/volumes/test/clone-progress.yaml
+++ b/qa/suites/fs/volumes/tasks/volumes/test/clone-progress.yaml
@@ -1,0 +1,5 @@
+tasks:
+  - cephfs_test_runner:
+      fail_on_skip: false
+      modules:
+        - tasks.cephfs.test_volumes.TestCloneProgressReporter

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -781,6 +781,10 @@ class CephFSMountBase(object):
 
         return self.client_remote.run(args=args, **kwargs)
 
+    def get_shell_stdout(self, args, timeout=300, **kwargs):
+        return self.run_shell(args=args, timeout=timeout, **kwargs).stdout.\
+            getvalue().strip()
+
     def run_shell_payload(self, payload, wait=True, timeout=900, **kwargs):
         kwargs.setdefault('cwd', self.mountpoint)
         kwargs.setdefault('omit_sudo', False)

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -35,7 +35,10 @@ class TestVolumesHelper(CephFSTestCase):
     def _raw_cmd(self, *args):
         return self.get_ceph_cmd_stdout(args)
 
-    def __check_clone_state(self, state, clone, clone_group=None, timo=120):
+    def __check_clone_state(self, states, clone, clone_group=None, timo=120):
+        if isinstance(states, str):
+            states = (states, )
+
         check = 0
         args = ["clone", "status", self.volname, clone]
         if clone_group:
@@ -43,7 +46,7 @@ class TestVolumesHelper(CephFSTestCase):
         args = tuple(args)
         while check < timo:
             result = json.loads(self._fs_cmd(*args))
-            if result["status"]["state"] == state:
+            if result["status"]["state"] in states:
                 break
             check += 1
             time.sleep(1)
@@ -56,6 +59,23 @@ class TestVolumesHelper(CephFSTestCase):
         args = tuple(args)
         result = json.loads(self._fs_cmd(*args))
         return result
+
+    def _wait_for_clone_to_be_pending(self, clone, clone_group=None,
+                                      timo=120):
+        # check for "in-progress" state too along with "pending" state, because
+        # if former has occurred it means latter has occured before (which can
+        # happen for such a small time that it is easy to miss) and it won't
+        # occur again.
+        states = ('pending', 'in-progress')
+        self.__check_clone_state(states, clone, clone_group, timo)
+
+    def _wait_for_clone_to_be_canceled(self, clone, clone_group=None,
+                                          timo=120):
+        # check for "cancelled" state too along with "complete" state, because
+        # it takes some time for a clone job to be cancelled and in that time
+        # a clone job might finish.
+        states = ('canceled', 'complete')
+        self.__check_clone_state(states, clone, clone_group, timo)
 
     def _wait_for_clone_to_complete(self, clone, clone_group=None, timo=120):
         self.__check_clone_state("complete", clone, clone_group, timo)

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -18,6 +18,13 @@ from teuthology.exceptions import CommandFailedError
 
 log = logging.getLogger(__name__)
 
+
+class RsizeDoesntMatch(Exception):
+
+    def __init__(self, msg):
+        self.msg = msg
+
+
 class TestVolumesHelper(CephFSTestCase):
     """Helper class for testing FS volume, subvolume group and subvolume operations."""
     TEST_FILE_NAME_PREFIX="subvolume_file"
@@ -53,7 +60,7 @@ class TestVolumesHelper(CephFSTestCase):
                 result = json.loads(self._fs_cmd(*args))
                 current_state = result["status"]["state"]
 
-                log.info(f'current clone state = {current_state}')
+                log.debug(f'current clone state = {current_state}')
                 if current_state in states:
                     return
 
@@ -8277,6 +8284,711 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
 
         # verify trash dir is clean
         self._wait_for_trash_empty()
+
+
+# NOTE: these tests consumes considerable amount of CPU and RAM due generation
+# random of files and due to multiple cloning jobs that are run simultaneously.
+#
+# NOTE: mgr/vol code generates progress bars for cloning jobs and these tests
+# capture them through "ceph status --format json-pretty" and checks if they
+# are as expected. If cloning happens too fast, these tests will fail to
+# capture progress bars, at least in desired state. Thus, these tests are
+# slightly racy by their very nature.
+#
+# Two measure can be taken to avoid this (and thereby inconsistent results in
+# testing) -
+# 1. Slow down cloning. This was done by adding a sleep after every file is
+# copied. However, this method was rejected since a new config for this would
+# have to be added.
+# 2. Amount of data that will cloned is big enough so that cloning takes enough
+# time for test code to capture the progress bar in desired state and finish
+# running. This is method that has been currently employed. This consumes
+# significantly more time, CPU and RAM in comparison.
+class TestCloneProgressReporter(TestVolumesHelper):
+    '''
+    This class contains tests for features that show how much progress cloning
+    jobs have made.
+    '''
+
+    CLIENTS_REQUIRED = 1
+
+    def setUp(self):
+        super(TestCloneProgressReporter, self).setUp()
+
+        # save this config value so that it can be set again at the end of test
+        # and therefore other tests that might depend on this won't be
+        # disturbed unnecessarily.
+        self.num_of_cloner_threads_def = self.get_ceph_cmd_stdout(
+            'config get mgr mgr/volumes/max_concurrent_clones').strip()
+
+        # set number of cloner threads to 4, tests in this class depend on this.
+        self.run_ceph_cmd('config set mgr mgr/volumes/max_concurrent_clones 4')
+
+    def tearDown(self):
+        v = self.volname
+        o = self.get_ceph_cmd_stdout('fs volume ls')
+        if self.volname not in o:
+            super(TestCloneProgressReporter, self).tearDown()
+            return
+
+        subvols = self.get_ceph_cmd_stdout(f'fs subvolume ls {v} --format '
+                                           'json')
+        subvols = json.loads(subvols)
+        for i in subvols:
+            sv = tuple(i.values())[0]
+            if 'clone' in sv:
+                self.run_ceph_cmd(f'fs subvolume rm --force {v} {sv}')
+                continue
+
+            p = self.run_ceph_cmd(f'fs subvolume snapshot ls {v} {sv} '
+                                   '--format json', stdout=StringIO())
+            snaps = p.stdout.getvalue().strip()
+            snaps = json.loads(snaps)
+            for j in snaps:
+                ss = tuple(j.values())[0]
+                self.run_ceph_cmd('fs subvolume snapshot rm --force '
+                                  f'--format json {v} {sv} {ss}')
+
+            self.run_ceph_cmd(f'fs subvolume rm {v} {sv}')
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
+        self.run_ceph_cmd('config set mgr mgr/volumes/max_concurrent_clones '
+                          f'{self.num_of_cloner_threads_def}')
+
+        # this doesn't work as expected because cleanup is not done when a
+        # volume is deleted.
+        #
+        # delete volumes so that all async purge threads, async cloner
+        # threads, progress bars, etc. associated with it are removed from
+        # Ceph cluster.
+        #self.run_ceph_cmd(f'fs volume rm {self.volname} --yes-i-really-mean-it')
+
+        super(self.__class__, self).tearDown()
+
+    # XXX: it is important to wait for rbytes value to catch up to actual size of
+    # subvolume so that progress bar shows sensible amount of progress
+    def wait_till_rbytes_is_right(self, v_name, sv_name, exp_size,
+                                  grp_name=None, sleep=2, max_count=60):
+        getpath_cmd = f'fs subvolume getpath {v_name} {sv_name}'
+        if grp_name:
+            getpath_cmd += f' {grp_name}'
+        sv_path = self.get_ceph_cmd_stdout(getpath_cmd)
+        sv_path = sv_path[1:]
+
+        for i in range(max_count):
+            r_size = self.mount_a.get_shell_stdout(
+                f'getfattr -n ceph.dir.rbytes {sv_path}').split('rbytes=')[1]
+            r_size = int(r_size.replace('"', '').replace('"', ''))
+            log.info(f'r_size = {r_size} exp_size = {exp_size}')
+            if exp_size == r_size:
+                break
+
+            time.sleep(sleep)
+        else:
+            msg = ('size reported by rstat is not the expected size.\n'
+                   f'expected size = {exp_size}\n'
+                   f'size reported by rstat = {r_size}')
+            raise RsizeDoesntMatch(msg)
+
+    def test_progress_is_printed_in_clone_status_output(self):
+        '''
+        Test that the command "ceph fs clone status" prints progress stats
+        for the clone.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        # "clone" must be part of clone name for sake of tearDown()
+        c = 'ss1clone1'
+
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {c}')
+        self._wait_for_clone_to_be_in_progress(c)
+
+        with safe_while(tries=120, sleep=1) as proceed:
+            while proceed():
+                o = self.get_ceph_cmd_stdout(f'fs clone status {v} {c}')
+                o = json.loads(o)
+
+                try:
+                    p = o['status']['progress_report']['percentage cloned']
+                    log.debug(f'percentage cloned = {p}')
+                except KeyError:
+                    # if KeyError is caught, either progress_report is present
+                    # or clone is complete
+                    if 'progress_report' in ['status']:
+                        self.assertEqual(o['status']['state'], 'complete')
+                    break
+
+        self._wait_for_clone_to_complete(c)
+
+    def filter_in_only_clone_pevs(self, progress_events):
+        '''
+        Progress events dictionary in output of "ceph status --format json"
+        has the progress bars and message associated with each progress bar.
+        Sometimes during testing of clone progress bars, and sometimes
+        otherwise too, an extra progress bar is seen with message "Global
+        Recovery Event". This extra progress bar interferes with testing of
+        progress bars for cloning.
+
+        This helper methods goes through this dictionary and picks only
+        (filters in) clone events.
+        '''
+        clone_pevs = {}
+
+        for k, v in progress_events.items():
+            if 'mgr-vol-ongoing-clones' in k or 'mgr-vol-total-clones' in k:
+                clone_pevs[k] = v
+
+        return clone_pevs
+
+    def get_pevs_from_ceph_status(self, clones=None, check=True):
+        o = self.get_ceph_cmd_stdout('status --format json-pretty')
+        o = json.loads(o)
+
+        try:
+            pevs = o['progress_events'] # pevs = progress events
+        except KeyError as e:
+            try:
+                if check and clones:
+                    self.__check_clone_state('completed', clone=clones, timo=1)
+            except:
+                msg = ('Didn\'t find expected entries in dictionary '
+                       '"progress_events" which is obtained from the '
+                       'output of command "ceph status".\n'
+                       f'Exception - {e}\npev -\n{pevs}')
+                raise Exception(msg)
+
+        pevs = self.filter_in_only_clone_pevs(pevs)
+
+        return pevs
+
+    def test_clones_less_than_cloner_threads(self):
+        '''
+        Test that one progress bar is printed in output of "ceph status" output
+        when number of clone jobs is less than number of cloner threads.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        # XXX: "clone" must be part of clone name for sake of tearDown()
+        c = 'ss1clone1'
+
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+        size = self._do_subvolume_io(sv, None, None, 10, 1024)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {c}')
+
+        with safe_while(tries=10, sleep=1) as proceed:
+            while proceed():
+                pev = self.get_pevs_from_ceph_status(c)
+
+                if len(pev) < 1:
+                   continue
+                elif len(pev) > 1:
+                    raise RuntimeError('For 1 clone "ceph status" output has 2 '
+                                       'progress bars, it should have only 1 '
+                                       f'progress bar.\npev -\n{pev}')
+
+                # ensure that exactly 1 progress bar for cloning is present in
+                # "ceph status" output
+                msg = ('"progress_events" dict in "ceph status" output must have '
+                       f'exactly one entry.\nprogress_event dict -\n{pev}')
+                self.assertEqual(len(pev), 1, msg)
+
+                pev_msg = tuple(pev.values())[0]['message']
+                self.assertIn('1 ongoing clones', pev_msg)
+                break
+
+        # allowing clone jobs to finish will consume too much time and space
+        # and not cancelling these clone doesnt affect this test case.
+        self.cancel_clones_and_ignore_if_finished(c)
+
+    def test_clone_to_diff_group_and_less_than_cloner_threads(self):
+        '''
+        Initiate cloning where clone subvolume and source subvolume are located
+        in different groups and then test that when this clone is in progress,
+        one progress bar is printed in output of command "ceph status" that
+        shows progress of this clone.
+        '''
+        v = self.volname
+        group = 'group1'
+        sv = 'sv1'
+        ss = 'ss1'
+        # XXX: "clone" must be part of clone name for sake of tearDown()
+        c = 'ss1clone1'
+
+        self.run_ceph_cmd(f'fs subvolumegroup create {v} {group}')
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} {group} --mode=777')
+        size = self._do_subvolume_io(sv, group, None, 10, 1024)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss} {group}')
+        self.wait_till_rbytes_is_right(v, sv, size, group)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {c} '
+                          f'--group-name {group}')
+
+        with safe_while(tries=10, sleep=1) as proceed:
+            while proceed():
+                pev = self.get_pevs_from_ceph_status(c)
+
+                if len(pev) < 1:
+                   continue
+                elif len(pev) > 1:
+                    raise RuntimeError('For 1 clone "ceph status" output has 2 '
+                                       'progress bars, it should have only 1 '
+                                       f'progress bar.\npev -\n{pev}')
+
+                # ensure that exactly 1 progress bar for cloning is present in
+                # "ceph status" output
+                msg = ('"progress_events" dict in "ceph status" output must have '
+                       f'exactly one entry.\nprogress_event dict -\n{pev}')
+                self.assertEqual(len(pev), 1, msg)
+
+                pev_msg = tuple(pev.values())[0]['message']
+                self.assertIn('1 ongoing clones', pev_msg)
+                break
+
+        # allowing clone jobs to finish will consume too much time and space
+        # and not cancelling these clone doesnt affect this test case.
+        self.cancel_clones_and_ignore_if_finished(c)
+
+    def test_clones_equal_to_cloner_threads(self):
+        '''
+        Test that one progress bar is printed in output of "ceph status" output
+        when number of clone jobs is equal to number of cloner threads.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        c = self._gen_subvol_clone_name(4)
+
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+        size = self._do_subvolume_io(sv, None, None, 10, 1024)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        for i in c:
+            self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {i}')
+
+        with safe_while(tries=10, sleep=1) as proceed:
+            while proceed():
+                pev = self.get_pevs_from_ceph_status(c)
+
+                if len(pev) < 1:
+                    time.sleep(1)
+                    continue
+                elif len(pev) > 1:
+                    raise RuntimeError('For 1 clone "ceph status" output has 2 '
+                                       'progress bars, it should have only 1 '
+                                       f'progress bar.\npev -\n{pev}')
+
+                # ensure that exactly 1 progress bar for cloning is present in
+                # "ceph status" output
+                msg = ('"progress_events" dict in "ceph status" output must have '
+                       f'exactly one entry.\nprogress_event dict -\n{pev}')
+                self.assertEqual(len(pev), 1, msg)
+
+                pev_msg = tuple(pev.values())[0]['message']
+                self.assertIn('ongoing clones', pev_msg)
+                break
+
+        # allowing clone jobs to finish will consume too much time and space
+        # and not cancelling these clone doesnt affect this test case.
+        self.cancel_clones_and_ignore_if_finished(c)
+
+    def wait_for_both_progress_bars_to_appear(self, sleep=1, iters=20):
+        pevs = []
+        msg = (f'Waited for {iters*sleep} seconds but couldn\'t 2 progress '
+                'bars in output of "ceph status" command.')
+        with safe_while(tries=iters, sleep=sleep, action=msg) as proceed:
+            while proceed():
+                o = self.get_ceph_cmd_stdout('status --format json-pretty')
+                o = json.loads(o)
+                pevs = o['progress_events']
+                pevs = self.filter_in_only_clone_pevs(pevs)
+                if len(pevs) == 2:
+                    v = tuple(pevs.values())
+                    if 'ongoing+pending' in v[1]['message']:
+                        self.assertIn('ongoing', v[0]['message'])
+                    else:
+                        self.assertIn('ongoing', v[1]['message'])
+                        self.assertIn('ongoing+pending', v[0]['message'])
+                    break
+
+    def test_clones_more_than_cloner_threads(self):
+        '''
+        Test that 2 progress bars are printed in output of "ceph status"
+        command when number of clone jobs is greater than number of cloner
+        threads.
+
+        Also, test that one of these progress bars is for ongoing clones and
+        other progress bar for ongoing+pending clones.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        c = self._gen_subvol_clone_name(7)
+
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', 'false')
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        for i in c:
+            self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {i}')
+
+        msg = ('messages for progress bars for snapshot cloning are not how '
+               'they were expected')
+        with safe_while(tries=20, sleep=1, action=msg) as proceed:
+            while proceed():
+                pevs = self.get_pevs_from_ceph_status(c)
+
+                if len(pevs) <= 1:
+                    continue # let's wait for second progress bar to appear
+                elif len(pevs) > 2:
+                    raise RuntimeError(
+                        'More than 2 progress bars were found in the output '
+                        'of "ceph status" command.\nprogress events -'
+                        f'\n{pevs}')
+
+                msg = ('"progress_events" dict in "ceph -s" output must have '
+                       f'only two entries.\n{pevs}')
+                self.assertEqual(len(pevs), 2, msg)
+                pev1, pev2 = pevs.values()
+                if ('ongoing clones' in pev1['message'].lower() and
+                    'total ' in pev2['message'].lower()):
+                    break
+                elif ('ongoing clones' in pev2['message'].lower() or
+                    'total ' in pev1['message'].lower()):
+                    break
+                else:
+                    raise RuntimeError(msg)
+
+        # allowing clone jobs to finish will consume too much time, space and
+        # CPU and not cancelling these clone doesnt affect this test case.
+        self.cancel_clones_and_ignore_if_finished(c)
+
+    def get_onpen_count(self, pev):
+        '''
+        Return number of clones reported in the message of progress bar for
+        ongoing+pending clones.
+        '''
+        i = pev['message'].find('ongoing+pending')
+        if i == -1:
+            return
+        count = pev['message'][:i]
+        count = count[:-1] # remomve trailing space
+        count = int(count)
+        return count
+
+    def get_both_progress_fractions_and_onpen_count(self):
+        '''
+        Go through output of "ceph status --format json-pretty" and return
+        progress made by both clones (that is progress fractions) and return
+        number of clones in reported in message of ongoing+pending progress
+        bar.
+        '''
+        msg = 'Expected 2 progress bars but found ' # rest continued in loop
+        with safe_while(tries=20, sleep=1, action=msg) as proceed:
+            while proceed():
+                o = self.get_ceph_cmd_stdout('status --format json-pretty')
+                o = json.loads(o)
+                pevs = o['progress_events']
+                pevs = self.filter_in_only_clone_pevs(pevs)
+                if len(pevs.values()) == 2:
+                    break
+                else:
+                    msg += f'{len(pevs)} instead'
+
+        log.info(f'pevs -\n{pevs}')
+        # on_p - progress fraction for ongoing clone jobs
+        # onpen_p - progress fraction for ongoing+pending clone jobs
+        pev1, pev2 = tuple(pevs.values())
+        if 'ongoing+pending' in pev1['message']:
+            onpen_p = pev1['progress']
+            onpen_count = self.get_onpen_count(pev1)
+            on_p = pev2['progress']
+        else:
+            onpen_p = pev2['progress']
+            onpen_count = self.get_onpen_count(pev2)
+            on_p = pev1['progress']
+
+        on_p = float(on_p)
+        onpen_p = float(onpen_p)
+
+        return on_p, onpen_p, onpen_count
+
+    # "ceph fs clone cancel" command takes considerable time to finish running.
+    # test cases where more than 4 clones are being cancelled, this error is
+    # seen, and can be safely ignored since it only implies that cloning has
+    # been finished.
+    def cancel_clones_and_ignore_if_finished(self, clones):
+        if isinstance(clones, str):
+            clones = (clones, )
+
+        for c in clones:
+            cmdargs = f'fs clone cancel {self.volname} {c}'
+            proc = self.run_ceph_cmd(args=cmdargs, stderr=StringIO(),
+                                     check_status=False)
+
+            stderr = proc.stderr.getvalue().strip().lower()
+            if proc.exitstatus == 0:
+                continue
+            elif proc.exitstatus == 22 and 'clone finished' in stderr:
+                continue
+            else:
+                cmdargs = './bin/ceph ' + cmdargs
+                raise CommandFailedError(cmdargs, proc.exitstatus)
+
+    def cancel_clones(self, clones, check_status=True):
+        v = self.volname
+        if not isinstance(clones, (tuple, list)):
+            clones = (clones, )
+
+        for i in clones:
+            self.run_ceph_cmd(f'fs clone cancel {v} {i}',
+                               check_status=check_status)
+            time.sleep(2)
+
+    # check status is False since this method is meant to cleanup clones at
+    # the end of a test case and some clones might already be complete.
+    def cancel_clones_and_confirm(self, clones, check_status=False):
+        if not isinstance(clones, (tuple, list)):
+            clones = (clones, )
+
+        self.cancel_clones(clones, check_status)
+
+        for i in clones:
+            self._wait_for_clone_to_be_canceled(i)
+
+    def cancel_clones_and_assert(self, clones):
+        v = self.volname
+        if not isinstance(clones, (tuple, list)):
+            clones = (clones, )
+
+        self.cancel_clones(clones, True)
+
+        for i in clones:
+            o = self.get_ceph_cmd_stdout(f'fs clone status {v} {i}')
+            try:
+                self.assertIn('canceled', o)
+            except AssertionError:
+                self.assertIn('complete', o)
+
+    def test_progress_drops_when_new_jobs_are_added(self):
+        '''
+        Test that progress indicated by progress bar for ongoing+pending clones
+        drops when more clone jobs are launched.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        c = self._gen_subvol_clone_name(20)
+
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', 'false')
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        for i in c[:5]:
+            self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {i}')
+
+        tuple_ = self.get_both_progress_fractions_and_onpen_count()
+        if isinstance(tuple_, (list, tuple)) and len(tuple_) == 3:
+            on_p, onpen_p, onpen_count = tuple_
+
+        # this should cause onpen progress bar to go back
+        for i in c[5:]:
+            self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {i}')
+        time.sleep(2)
+
+        with safe_while(tries=30, sleep=0.5) as proceed:
+            while proceed():
+                tuple_ = self.get_both_progress_fractions_and_onpen_count()
+                new_on_p, new_onpen_p, new_onpen_count = tuple_
+                if new_onpen_p < onpen_p:
+                    log.info('new_onpen_p is less than onpen_p.')
+                    log.info(f'new_onpen_p = {new_onpen_p}; onpen_p = {onpen_p}')
+                    break
+                log.info(f'on_p = {on_p} new_on_p = {new_on_p}')
+                log.info(f'onpen_p = {onpen_p} new_onpen_p = {new_onpen_p}')
+                log.info(f'onpen_count = {onpen_count} new_onpen_count = '
+                         f'{new_onpen_count}')
+            else:
+                self.cancel_clones_and_ignore_if_finished(c)
+                raise RuntimeError('Test failed: it was expected for '
+                                   '"new_onpen_p < onpen_p" to be true.')
+
+        # average progress for "ongoing + pending" clone jobs must
+        # reduce since a new job was added to penidng state
+        self.assertLess(new_onpen_p, onpen_p)
+
+        # allowing clone jobs to finish will consume too much time and space
+        # and not cancelling these clone doesnt affect this test case.
+        self.cancel_clones_and_ignore_if_finished(c)
+
+    def _wait_for_clone_progress_bars_to_be_removed(self):
+        with safe_while(tries=10, sleep=0.5) as proceed:
+            while proceed():
+                o = self.get_ceph_cmd_stdout('status --format json-pretty')
+                o = json.loads(o)
+
+                pevs = o['progress_events'] # pevs = progress events
+                pevs = self.filter_in_only_clone_pevs(pevs)
+                if not pevs:
+                    break
+
+    def test_when_clones_cancelled_are_less_than_cloner_threads(self):
+        '''
+        Test that the progress bar that is printed for 1 ongoing clone job is
+        removed from the output of "ceph status" command when a clone is
+        cancelled.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        # "clone" must be part of clone name for sake of tearDown()
+        c = 'ss1clone1'
+
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+
+        sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
+        sv_path = sv_path[1:]
+
+        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {c}')
+        time.sleep(1)
+        self.cancel_clones_and_ignore_if_finished(c)
+        self._wait_for_clone_to_be_canceled(c)
+        self._wait_for_clone_progress_bars_to_be_removed()
+
+        # test that cloning had begun but didn't finish.
+        try:
+            sv_path = sv_path.replace(sv, c)
+            o = self.mount_a.run_shell(f'ls -lh {sv_path}')
+            o = o.stdout.getvalue().strip()
+            # ensure that all files were not copied. 'ls -lh' will print 1 file
+            # per line with an extra line for  summary, so this command must
+            # print less than 4 lines
+            self.assertLess(len(o.split('\n')), 4)
+        except CommandFailedError as cfe:
+            # if command failed due to errno 2 (no such file or dir), this
+            # means cloning hadn't begun yet. that too is fine
+            if cfe.exitstatus == 2:
+                pass
+            else:
+                raise
+
+    def test_when_clones_cancelled_are_equal_to_cloner_threads(self):
+        '''
+        Test that progress bars, that printed for 3 ongoing clone jobs, are
+        removed from the output of "ceph status" command when all 3 clone jobs
+        are cancelled.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        c = self._gen_subvol_clone_name(3)
+
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+
+        sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
+        sv_path = sv_path[1:]
+
+        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        for i in c:
+            self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {i}')
+        time.sleep(1)
+        self.cancel_clones_and_ignore_if_finished(c)
+        for i in c:
+            self._wait_for_clone_to_be_canceled(i)
+        self._wait_for_clone_progress_bars_to_be_removed()
+
+        try:
+            sv_path = sv_path.replace(sv, c[0])
+            o = self.mount_a.run_shell(f'ls -lh {sv_path}')
+            o = o.stdout.getvalue().strip()
+            log.info(o)
+            # ensure that all files were not copied. 'ls -lh' will print 1 file
+            # per line with an extra line for  summary, so this command must
+            # print less than 4 lines
+            self.assertLess(len(o.split('\n')), 4)
+        except CommandFailedError as cfe:
+            # if command failed due to errno 2 (no such file or dir), this
+            # means cloning hadn't begun yet. that too is fine
+            if cfe.exitstatus == errno.ENOENT:
+                pass
+            else:
+                raise
+
+    def test_when_clones_cancelled_are_more_than_cloner_threads(self):
+        '''
+        Test that both the progress bars, that are printed for all 7 clone
+        jobs, are removed from the output of "ceph status" command when all
+        these clones are cancelled.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        c = self._gen_subvol_clone_name(7)
+
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', 'false')
+
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+
+        sv_path = self.get_ceph_cmd_stdout(f'fs subvolume getpath {v} {sv}')
+        sv_path = sv_path[1:]
+
+        size = self._do_subvolume_io(sv, None, None, 3, 1024)
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        for i in c:
+            self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {i}')
+        time.sleep(1)
+        self.cancel_clones_and_ignore_if_finished(c)
+        for i in c:
+            self._wait_for_clone_to_be_canceled(i)
+        self._wait_for_clone_progress_bars_to_be_removed()
+
+        try:
+            sv_path = sv_path.replace(sv, c[0])
+            o = self.mount_a.run_shell(f'ls -lh {sv_path}')
+            o = o.stdout.getvalue().strip()
+            log.info(o)
+            # ensure that all files were not copied. 'ls -lh' will print 1 file
+            # per line with an extra line for  summary, so this command must
+            # print less than 4 lines
+            self.assertLess(len(o.split('\n')), 4)
+        except CommandFailedError as cfe:
+            # if command failed due to errno 2 (no such file or dir), this
+            # means cloning hadn't begun yet. that too is fine
+            if cfe.exitstatus == errno.ENOENT:
+                pass
+            else:
+                raise
 
 
 class TestMisc(TestVolumesHelper):

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -302,6 +302,8 @@ class TestVolumesHelper(CephFSTestCase):
             filename = "{0}.{1}".format(TestVolumes.TEST_FILE_NAME_PREFIX, i)
             self.mount_a.write_n_mb(os.path.join(io_path, filename), file_size)
 
+        return number_of_files * file_size * 1024 * 1024
+
     def _do_subvolume_io_mixed(self, subvolume, subvolume_group=None):
         subvolpath = self._get_subvolume_path(self.volname, subvolume, group_name=subvolume_group)
 

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -6444,7 +6444,7 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
 
         # insert delay at the beginning of snapshot clone
-        self.config_set('mgr', 'mgr/volumes/snapshot_clone_delay', 5)
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_delay', 15)
 
         # disable "capped" clones
         self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', False)

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -8349,7 +8349,22 @@ class TestCloneProgressReporter(TestVolumesHelper):
                 self.run_ceph_cmd('fs subvolume snapshot rm --force '
                                   f'--format json {v} {sv} {ss}')
 
-            self.run_ceph_cmd(f'fs subvolume rm {v} {sv}')
+            try:
+                self.run_ceph_cmd(f'fs subvolume rm {v} {sv}')
+            except CommandFailedError as e:
+                if e.exitstatus == errno.ENOENT:
+                    log.info(
+                        'ignoring this error, perhaps subvolume was deleted '
+                        'during the test and snapshot deleted above is a '
+                        'retained snapshot. when a retained snapshot (which is '
+                        'snapshot retained despite of subvolume deletion) is '
+                        'deleted, the subvolume directory is also deleted '
+                        'along. and before retained snapshot deletion, the '
+                        'subvolume is reported by "subvolume ls" command, which'
+                        'is what probably caused confusion here')
+                    pass
+                else:
+                    raise
 
         # verify trash dir is clean
         self._wait_for_trash_empty()
@@ -8539,6 +8554,58 @@ class TestCloneProgressReporter(TestVolumesHelper):
                           f'--group-name {group}')
 
         with safe_while(tries=10, sleep=1) as proceed:
+            while proceed():
+                pev = self.get_pevs_from_ceph_status(c)
+
+                if len(pev) < 1:
+                   continue
+                elif len(pev) > 1:
+                    raise RuntimeError('For 1 clone "ceph status" output has 2 '
+                                       'progress bars, it should have only 1 '
+                                       f'progress bar.\npev -\n{pev}')
+
+                # ensure that exactly 1 progress bar for cloning is present in
+                # "ceph status" output
+                msg = ('"progress_events" dict in "ceph status" output must have '
+                       f'exactly one entry.\nprogress_event dict -\n{pev}')
+                self.assertEqual(len(pev), 1, msg)
+
+                pev_msg = tuple(pev.values())[0]['message']
+                self.assertIn('1 ongoing clones', pev_msg)
+                break
+
+        # allowing clone jobs to finish will consume too much time and space
+        # and not cancelling these clone doesnt affect this test case.
+        self.cancel_clones_and_ignore_if_finished(c)
+
+    def test_clone_after_subvol_is_removed(self):
+        '''
+        Initiate cloning after source subvolume has been deleted but with
+        snapshots retained and then test that, when this clone is in progress,
+        one progress bar is printed in output of command "ceph status" that
+        shows progress of this clone.
+        '''
+        v = self.volname
+        sv = 'sv1'
+        ss = 'ss1'
+        # XXX: "clone" must be part of clone name for sake of tearDown()
+        c = 'ss1clone1'
+
+        # XXX: without setting mds_snap_rstat to true rstats are not updated on
+        # a subvolume snapshot and therefore clone progress bar will not show
+        # any progress.
+        self.config_set('mds', 'mds_snap_rstat', 'true')
+
+        self.run_ceph_cmd(f'fs subvolume create {v} {sv} --mode=777')
+        size = self._do_subvolume_io(sv, None, None, 10, 1024)
+
+        self.run_ceph_cmd(f'fs subvolume snapshot create {v} {sv} {ss}')
+        self.wait_till_rbytes_is_right(v, sv, size)
+
+        self.run_ceph_cmd(f'fs subvolume rm {v} {sv} --retain-snapshots')
+        self.run_ceph_cmd(f'fs subvolume snapshot clone {v} {sv} {ss} {c}')
+
+        with safe_while(tries=15, sleep=10) as proceed:
             while proceed():
                 pev = self.get_pevs_from_ceph_status(c)
 

--- a/src/pybind/mgr/volumes/fs/async_job.py
+++ b/src/pybind/mgr/volumes/fs/async_job.py
@@ -44,8 +44,8 @@ class JobThread(threading.Thread):
                             return
                         timo = self.async_job.wakeup_timeout
                         if timo is not None:
-                            vols = [e['name'] for e in list_volumes(self.vc.mgr)]
-                            missing = set(vols) - set(self.async_job.q)
+                            volnames = list_volumes(self.vc.mgr)
+                            missing = set(volnames) - set(self.async_job.q)
                             for m in missing:
                                 self.async_job.jobs[m] = []
                                 self.async_job.q.append(m)

--- a/src/pybind/mgr/volumes/fs/operations/clone_index.py
+++ b/src/pybind/mgr/volumes/fs/operations/clone_index.py
@@ -8,14 +8,16 @@ import cephfs
 
 from .index import Index
 from ..exception import IndexException, VolumeException
-from ..fs_util import list_one_entry_at_a_time
+from ..fs_util import list_one_entry_at_a_time, listdir
 
 log = logging.getLogger(__name__)
 
 
+PATH_MAX = 4096
+
+
 class CloneIndex(Index):
     SUB_GROUP_NAME = "clone"
-    PATH_MAX = 4096
 
     @property
     def path(self):
@@ -47,6 +49,26 @@ class CloneIndex(Index):
         except cephfs.Error as e:
             raise IndexException(-e.args[0], e.args[1])
 
+    def list_entries_by_ctime_order(self):
+        entry_names = listdir(self.fs, self.path, filter_files=False)
+        if not entry_names:
+            return []
+
+        # clone entries with ctime obtained by statig them. basically,
+        # following is a list of tuples where each tuple has 2 memebers.
+        ens_with_ctime = []
+        for en in entry_names:
+            d_path = os.path.join(self.path, en)
+            stb = self.fs.lstat(d_path)
+
+            # add ctime next to clone entry
+            ens_with_ctime.append((en, stb.st_ctime))
+
+        ens_with_ctime.sort(key=lambda ctime: en[1])
+
+        # remove ctime and return list of clone entries sorted by ctime.
+        return [i[0] for i in ens_with_ctime]
+
     def get_oldest_clone_entry(self, exclude=[]):
         try:
             min_ctime_entry = None
@@ -61,7 +83,7 @@ class CloneIndex(Index):
                         min_ctime_entry = (dname, st)
             if min_ctime_entry:
                 linklen = min_ctime_entry[1].st_size
-                sink_path = self.fs.readlink(os.path.join(self.path, min_ctime_entry[0]), CloneIndex.PATH_MAX)
+                sink_path = self.fs.readlink(os.path.join(self.path, min_ctime_entry[0]), PATH_MAX)
                 return (min_ctime_entry[0], sink_path[:linklen])
             return None
         except cephfs.Error as e:
@@ -76,7 +98,7 @@ class CloneIndex(Index):
                 dpath = os.path.join(self.path, dname)
                 st = self.fs.lstat(dpath)
                 if stat.S_ISLNK(st.st_mode):
-                    target_path = self.fs.readlink(dpath, CloneIndex.PATH_MAX)
+                    target_path = self.fs.readlink(dpath, PATH_MAX)
                     if sink_path == target_path[:st.st_size]:
                         return dname
             return None

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -235,15 +235,14 @@ def rename_volume(mgr, volname: str, newvolname: str) -> Tuple[int, str, str]:
 
 def list_volumes(mgr):
     """
-    list all filesystem volumes.
+    Get name of all volumes/file systems.
 
-    :param: None
-    :return: None
+    :param: mgr
+    :return: list of volume/file system names
     """
     result = []
-    fs_map = mgr.get("fs_map")
-    for f in fs_map['filesystems']:
-        result.append({'name': f['mdsmap']['fs_name']})
+    for fs in mgr.get("fs_map")['filesystems']:
+        result.append(fs['mdsmap']['fs_name'])
     return result
 
 

--- a/src/pybind/mgr/volumes/fs/stats_util.py
+++ b/src/pybind/mgr/volumes/fs/stats_util.py
@@ -1,0 +1,56 @@
+'''
+This module contains classes, methods & helpers that are used to get statistics
+(specifically number of files and total size of data present under the source
+and destination directory for the copy operation that is performed for snapshot
+cloning) and pass, print, log and convert them to human readable format
+conveniently.
+'''
+from typing import Optional
+
+from mgr_util import format_bytes, format_dimless
+
+
+def get_size_ratio_str(size1, size2):
+    size1, size2 = format_bytes(size1, 4), format_bytes(size2, 4)
+
+    size_string =  f'{size1}/{size2}'
+    size_string = size_string.replace(' ', '')
+    return size_string
+
+
+def get_num_ratio_str(num1, num2):
+    num1, num2 = format_dimless(num1, 4), format_dimless(num2, 4)
+
+    num_string = f'{num1}/{num2}'
+    num_string = num_string.replace(' ', '')
+    return num_string
+
+
+def get_amount_copied(src_path, dst_path, fs_handle):
+    rbytes = 'ceph.dir.rbytes'
+
+    size_t = int(fs_handle.getxattr(src_path, rbytes))
+    size_c = int(fs_handle.getxattr(dst_path, rbytes))
+
+    percent: Optional[float]
+    if size_t == 0 or size_c == 0:
+        percent = 0
+    else:
+        percent = ((size_c/size_t) * 100)
+        percent = round(percent, 3)
+
+    return size_t, size_c, percent
+
+
+def get_stats(src_path, dst_path, fs_handle):
+    rentries = 'ceph.dir.rentries'
+    rentries_t = int(fs_handle.getxattr(src_path, rentries))
+    rentries_c = int(fs_handle.getxattr(dst_path, rentries))
+
+    size_t, size_c, percent = get_amount_copied(src_path, dst_path, fs_handle)
+
+    return {
+        'percentage cloned': percent,
+        'amount cloned': get_size_ratio_str(size_c, size_t),
+        'files cloned': get_num_ratio_str(rentries_c, rentries_t),
+    }

--- a/src/pybind/mgr/volumes/fs/stats_util.py
+++ b/src/pybind/mgr/volumes/fs/stats_util.py
@@ -5,9 +5,22 @@ and destination directory for the copy operation that is performed for snapshot
 cloning) and pass, print, log and convert them to human readable format
 conveniently.
 '''
+from os.path import join as os_path_join
 from typing import Optional
+from logging import getLogger
 
-from mgr_util import format_bytes, format_dimless
+from .operations.volume import open_volume_lockless, list_volumes
+from .operations.subvolume import open_clone_subvol_pair_in_vol, open_subvol_in_vol
+from .operations.template import SubvolumeOpType
+from .operations.clone_index import open_clone_index, PATH_MAX
+from .operations.resolver import resolve_group_and_subvolume_name
+from .exception import VolumeException
+
+from mgr_util import RTimer, format_bytes, format_dimless
+from cephfs import ObjectNotFound
+
+
+log = getLogger(__name__)
 
 
 def get_size_ratio_str(size1, size2):
@@ -42,6 +55,11 @@ def get_amount_copied(src_path, dst_path, fs_handle):
     return size_t, size_c, percent
 
 
+def get_percent_copied(src_path, dst_path, fs_handle):
+    _, _, percent = get_amount_copied(src_path, dst_path, fs_handle)
+    return percent
+
+
 def get_stats(src_path, dst_path, fs_handle):
     rentries = 'ceph.dir.rentries'
     rentries_t = int(fs_handle.getxattr(src_path, rentries))
@@ -54,3 +72,240 @@ def get_stats(src_path, dst_path, fs_handle):
         'amount cloned': get_size_ratio_str(size_c, size_t),
         'files cloned': get_num_ratio_str(rentries_c, rentries_t),
     }
+
+
+class CloneInfo:
+
+    def __init__(self, volname):
+        self.volname = volname
+
+        self.src_group_name = None
+        self.src_subvol_name = None
+        self.src_path = None
+
+        self.dst_group_name = None
+        self.dst_subvol_name = None
+        self.dst_path = None
+
+
+class CloneProgressReporter:
+
+    def __init__(self, volclient, vol_spec):
+        self.vol_spec = vol_spec
+
+        # instance of VolumeClient is needed here so that call to
+        # LibCephFS.getxattr() can be made.
+        self.volclient = volclient
+
+        # need to figure out how many progress bars should be printed. print 1
+        # progress bar if number of ongoing clones is less than this value,
+        # else print 2.
+        self.max_concurrent_clones = self.volclient.mgr.max_concurrent_clones
+
+        # Creating an RTimer instance in advance so that we can check if clone
+        # reporting has already been initiated by calling RTimer.is_alive().
+        self.update_task = RTimer(1, self._update_progress_bars)
+
+    def initiate_reporting(self):
+        if self.update_task.is_alive():
+            log.info('progress reporting thread is already alive, not '
+                     'initiating it again')
+            return
+
+        log.info('initiating progress reporting for clones...')
+        # progress event ID for ongoing clone jobs
+        self.on_pev_id: Optional[str] = 'mgr-vol-ongoing-clones'
+        # progress event ID for ongoing+pending clone jobs
+        self.onpen_pev_id: Optional[str] = 'mgr-vol-total-clones'
+
+        self.update_task = RTimer(1, self._update_progress_bars)
+        self.update_task.start()
+        log.info('progress reporting for clones has been initiated')
+
+    def _get_clone_dst_info(self, fs_handle, ci, clone_entry,
+                            clone_index_path):
+        log.debug('collecting info for cloning destination')
+
+        ce_path = os_path_join(clone_index_path, clone_entry)
+        # XXX: This may raise ObjectNotFound exception. As soon as cloning is
+        # finished, clone entry is deleted by cloner thread. This exception is
+        # handled in _get_info_for_all_clones().
+        dst_subvol_base_path = fs_handle.readlink(ce_path, PATH_MAX).\
+            decode('utf-8')
+
+        ci.dst_group_name, ci.dst_subvol_name = \
+            resolve_group_and_subvolume_name(self.vol_spec, dst_subvol_base_path)
+        with open_subvol_in_vol(self.volclient, self.vol_spec, ci.volname,
+                                ci.dst_group_name, ci.dst_subvol_name,
+                                SubvolumeOpType.CLONE_INTERNAL) \
+                                as (_, _, dst_subvol):
+            ci.dst_path = dst_subvol.path
+            log.debug(f'destination subvolume path for clone - {ci.dst_path}')
+
+        log.debug('finished collecting info for cloning destination')
+
+    def _get_clone_src_info(self, fs_handle, ci):
+        log.debug('collecting info for cloning source')
+
+        with open_clone_subvol_pair_in_vol(self.volclient, self.vol_spec,
+                                           ci.volname, ci.dst_group_name,
+                                           ci.dst_subvol_name) as \
+                                           (dst_subvol, src_subvol, snap_name):
+            ci.src_group_name = src_subvol.group_name
+            ci.src_subvol_name = src_subvol.subvolname
+            ci.src_path = src_subvol.snapshot_data_path(snap_name)
+            log.debug(f'source subvolume path for clone - {ci.src_path}')
+
+        log.debug('finished collecting info for cloning source')
+
+    def _get_info_for_all_clones(self):
+        clones:list[CloneInfo] = []
+
+        log.debug('collecting all entries in clone index...')
+        volnames = list_volumes(self.volclient.mgr)
+        for volname in volnames:
+            with open_volume_lockless(self.volclient, volname) as fs_handle:
+                with open_clone_index(fs_handle, self.vol_spec) as clone_index:
+                    clone_index_path = clone_index.path
+                    # get clone in order in which they were launched, this
+                    # should be same as the ctime on clone entry.
+                    clone_index_entries = clone_index.list_entries_by_ctime_order()
+                    log.debug('finished collecting all clone index entries, '
+                              f'found {len(clones)} clone index entries')
+
+                log.debug('collecting info for clones found through clone index '
+                         'entries...')
+                for ce in clone_index_entries:
+                    ci = CloneInfo(volname)
+
+                    try:
+                        self._get_clone_dst_info(fs_handle, ci, ce,
+                                                 clone_index_path)
+                        self._get_clone_src_info(fs_handle, ci)
+                    except ObjectNotFound as e:
+                        log.info('Exception ObjectNotFound was raised. Apparently '
+                                 'entry in clone index was removed because one of '
+                                 'the clone job(s) has completed/cancelled, '
+                                 'therefore ignoring and proceeding. '
+                                 f'Printing the exception: {e}')
+                        continue
+                    except VolumeException as e:
+                        if e.error_str != 'error fetching subvolume metadata':
+                            raise
+                        log.info('Exception VolumeException was raised. Apparently '
+                                 'an entry from the metadata file of clone source '
+                                 'was removed because one of the clone job(s) has '
+                                 'completed/cancelled. Therefore ignoring and '
+                                 f'proceeding Printing the exception: {e}')
+                        continue
+
+                    if not ci.src_path or not ci.dst_path:
+                        continue
+
+                    clones.append(ci)
+
+        log.debug('finished collecting info on all clones, found '
+                  f'{len(clones)} clones')
+        return clones
+
+    def _update_progress_bar_event(self, ev_id, ev_msg, ev_progress_fraction):
+        log.debug(f'ev_id = {ev_id} ev_progress_fraction = {ev_progress_fraction}')
+        log.debug(f'ev_msg = {ev_msg}')
+        log.debug('calling update() from mgr/update module')
+
+        self.volclient.mgr.remote('progress', 'update', ev_id=ev_id,
+                                  ev_msg=ev_msg,
+                                  ev_progress=ev_progress_fraction,
+                                  refs=['mds', 'clone'], add_to_ceph_s=True)
+
+        log.debug('call to update() from mgr/update module was successful')
+
+    def _update_progress_bars(self):
+        '''
+        Look for amount of progress made by all cloning operations and prints
+        progress bars, in "ceph -s" output, for average progress made
+        accordingly.
+
+        This method is supposed to be run only by instance of class RTimer
+        present in this class.
+        '''
+        clones = self._get_info_for_all_clones()
+        if not clones:
+            self.finish()
+            return
+
+        # onpen bar (that is progress bar for clone jobs in ongoing and pending
+        # state) is printed when clones are in pending state. it is kept in
+        # printing until all clone jobs finish.
+        show_onpen_bar = True if len(clones) > self.max_concurrent_clones \
+            else False
+
+        percent = 0.0
+
+        assert self.on_pev_id is not None
+        sum_percent_ongoing = 0.0
+        avg_percent_ongoing = 0.0
+        total_ongoing_clones = min(len(clones), self.max_concurrent_clones)
+
+        if show_onpen_bar:
+            assert self.onpen_pev_id is not None
+            sum_percent_onpen = 0.0
+            avg_percent_onpen = 0.0
+            total_onpen_clones = len(clones)
+
+        for clone in clones:
+            with open_volume_lockless(self.volclient, clone.volname) as \
+                    fs_handle:
+                percent = get_percent_copied(clone.src_path, clone.dst_path,
+                                             fs_handle)
+                if clone in clones[:total_ongoing_clones]:
+                    sum_percent_ongoing += percent
+                if show_onpen_bar:
+                    sum_percent_onpen += percent
+
+        avg_percent_ongoing = round(sum_percent_ongoing / total_ongoing_clones, 3)
+        # progress module takes progress as a fraction between 0.0 to 1.0.
+        avg_progress_fraction = avg_percent_ongoing / 100
+        msg = (f'{total_ongoing_clones} ongoing clones - average progress is '
+               f'{avg_percent_ongoing}%')
+        self._update_progress_bar_event(ev_id=self.on_pev_id, ev_msg=msg,
+            ev_progress_fraction=avg_progress_fraction)
+        log.debug('finished updating progress bar for ongoing clones with '
+                  f'following message - {msg}')
+
+        if show_onpen_bar:
+            avg_percent_onpen = round(sum_percent_onpen / total_onpen_clones, 3)
+            # progress module takes progress as a fraction between 0.0 to 1.0.
+            avg_progress_fraction = avg_percent_onpen / 100
+            msg = (f'Total {total_onpen_clones} clones - average progress is '
+                   f'{avg_percent_onpen}%')
+            self._update_progress_bar_event(ev_id=self.onpen_pev_id, ev_msg=msg,
+                                        ev_progress_fraction=avg_progress_fraction)
+            log.debug('finished updating progress bar for ongoing+pending '
+                      f'clones with following message - {msg}')
+
+    def _finish_progress_events(self):
+        '''
+        Remove progress bars from "ceph status" output.
+        '''
+        log.info('removing progress bars from "ceph status" output')
+
+        assert self.on_pev_id is not None
+        assert self.onpen_pev_id is not None
+
+        self.volclient.mgr.remote('progress', 'complete', self.on_pev_id)
+        self.on_pev_id = None
+
+        self.volclient.mgr.remote('progress', 'complete', self.onpen_pev_id)
+        self.onpen_pev_id = None
+
+        log.info('finished removing progress bars from "ceph status" output')
+
+    def finish(self):
+        '''
+        All cloning jobs have been completed. Terminate this RTimer thread.
+        '''
+        self._finish_progress_events()
+
+        log.info(f'marking this RTimer thread as finished; thread object ID - {self}')
+        self.update_task.finished.set()

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -146,7 +146,9 @@ class VolumeClient(CephfsClient["Module"]):
         return delete_volume(self.mgr, volname, metadata_pool, data_pools)
 
     def list_fs_volumes(self):
-        volumes = list_volumes(self.mgr)
+        volnames = list_volumes(self.mgr)
+        # since we report in json format, make a dict of volnames.
+        volumes = [{'name': vn} for vn in volnames]
         return 0, json.dumps(volumes, indent=4, sort_keys=True), ""
 
     def rename_fs_volume(self, volname, newvolname, sure):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69561, https://tracker.ceph.com/issues/69562

backport of https://github.com/ceph/ceph/pull/54620, https://github.com/ceph/ceph/pull/59712
parent tracker: https://tracker.ceph.com/issues/61904, https://tracker.ceph.com/issues/67988

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh


---

updated using ceph-backport.sh version 16.0.0.6848
