### PR TITLE
rgw: handle destination bucket as an ARN in ReplicationConfiguration

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1315,8 +1315,14 @@ struct ReplicationConfiguration {
       // Here we are sure that s->owner.id is of type rgw_user
       const auto& tenant_owner = std::get_if<rgw_user>(&s->owner.id)->tenant;
 
+      auto dest_bk_arn = ARN::parse(destination.bucket);
+      if (!dest_bk_arn || dest_bk_arn->service != rgw::Service::s3 || dest_bk_arn->resource.empty()) {
+        s->err.message = "Invalid bucket ARN";
+        return -EINVAL;
+      }
+
       rgw_bucket_key dest_bk(tenant_owner,
-                             destination.bucket);
+                             dest_bk_arn->resource);
 
       if (source && !source->zone_names.empty()) {
         pipe->source.zones = get_zone_ids_from_names(driver, source->zone_names);
@@ -1383,7 +1389,7 @@ struct ReplicationConfiguration {
       }
 
       if (pipe.dest.bucket) {
-        destination.bucket = pipe.dest.bucket->get_key();
+        destination.bucket = ARN(*pipe.dest.bucket).to_string();
       }
 
       filter.emplace();


### PR DESCRIPTION
The S3 ReplicationConfiguration's destination bucket must be treated as an ARN, per the AWS S3 documentation:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_Destination.html#AmazonS3-Type-Destination-Bucket

Fixes: https://tracker.ceph.com/issues/69568