### PR TITLE
reef: mds: Fix invalid access of mdr->dn[0].back()

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4073,7 +4073,7 @@ void Server::handle_client_getattr(MDRequestRef& mdr, bool is_lookup)
 
     if (r < 0) {
       // fall-thru. let rdlock_path_pin_ref() check again.
-    } else if (is_lookup) {
+    } else if (is_lookup && mdr->dn[0].size()) {
       CDentry* dn = mdr->dn[0].back();
       mdr->pin(dn);
       auto em = dn->batch_ops.emplace(std::piecewise_construct, std::forward_as_tuple(mask), std::forward_as_tuple());
@@ -4179,7 +4179,7 @@ void Server::handle_client_getattr(MDRequestRef& mdr, bool is_lookup)
   // reply
   dout(10) << "reply to stat on " << *req << dendl;
   mdr->tracei = ref;
-  if (is_lookup)
+  if (is_lookup && mdr->dn[0].size())
     mdr->tracedn = mdr->dn[0].back();
   respond_to_request(mdr, 0);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69555

---

backport of https://github.com/ceph/ceph/pull/60889
parent tracker: https://tracker.ceph.com/issues/69059

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh