### PR TITLE
reef: doc/cephfs: edit grammar in snapshots.rst

### DIFF
--- a/doc/cephfs/snapshots.rst
+++ b/doc/cephfs/snapshots.rst
@@ -2,12 +2,13 @@
 CephFS Snapshots
 ================
 
-CephFS snapshots create an immutable view of the file system at the point
-in time they are taken. CephFS support snapshots which is managed in a 
-special hidden subdirectory named ``.snap`` .Snapshots are created using
-``mkdir`` inside this directory.
+CephFS snapshots create an immutable view of the file system at the point in
+time they are taken. CephFS snapshots are managed in a special hidden
+subdirectory named ``.snap``. Snapshots are created using ``mkdir`` inside the
+``.snap`` directory.
 
-Snapshots can be exposed with a different name by changing the following client configurations.
+Snapshots can be exposed with different names by changing the following client
+configurations:
 
 - ``snapdirname`` which is a mount option for kernel clients
 - ``client_snapdir`` which is a mount option for ceph-fuse.
@@ -15,19 +16,20 @@ Snapshots can be exposed with a different name by changing the following client 
 Snapshot Creation
 ==================
 
-CephFS snapshot feature is enabled by default on new file systems. To enable 
-it on existing file systems, use the command below.
+The CephFS snapshot feature is enabled by default on new file systems. To
+enable the CephFS snapshot feature on existing file systems, use the command
+below.
 
 .. code-block:: bash
     
     $ ceph fs set <fs_name> allow_new_snaps true
 
-When snapshots are enabled, all directories in CephFS will have a special ``.snap``
-directory. (You may configure a different name with the client snapdir setting if 
-you wish.)
-To create a CephFS snapshot, create a subdirectory under ``.snap`` with a name of 
-your choice. 
-For example, to create a snapshot on directory ``/file1/``, invoke ``mkdir /file1/.snap/snapshot-name``
+When snapshots are enabled, all directories in CephFS will have a special
+``.snap`` directory. (You may configure a different name with the client's
+``snapdir`` setting if you wish.) To create a CephFS snapshot, create a
+subdirectory under ``.snap`` with a name of your choice.  For example, to
+create a snapshot on directory ``/file1/``, run the command ``mkdir
+/file1/.snap/snapshot-name``:
 
 .. code-block:: bash
 
@@ -35,10 +37,10 @@ For example, to create a snapshot on directory ``/file1/``, invoke ``mkdir /file
     $ cd .snap
     $ mkdir my_snapshot
 
-Using snapshot to recover data
+Using Snapshots to Recover Data
 ===============================
 
-Snapshots can also be used to recover some deleted files.
+Snapshots can also be used to recover deleted files:
 
 - ``create a file1 and create snapshot snap1``
 
@@ -75,9 +77,9 @@ Snapshots can also be used to recover some deleted files.
 Snapshot Deletion
 ==================
 
-Snapshots are deleted by invoking ``rmdir`` on the ``.snap`` directory they are
-rooted in. (Attempts to delete a directory which roots the snapshots will fail; 
-you must delete the snapshots first.)
+Snapshots are deleted by running ``rmdir`` on the ``.snap`` directory that they
+are rooted in. (Attempts to delete a directory that roots the snapshots will
+fail. You must delete the snapshots first.)
 
 .. code-block:: bash
 


### PR DESCRIPTION
This commit improves the grammar in doc/cephfs/snapshots.rst. The PR associated with this commit follows from
https://github.com/ceph/ceph/pull/61240, the PR raised by Neeraj Pratap Singh to introduce information about snapshots into the CephFS documentation.

See also https://tracker.ceph.com/issues/68974.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 9a34ae55ede6dea5bb784a3e6cd45b9e60d4475d)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

