### PR TITLE
erasure-code: clay wrong d calculation

### DIFF
--- a/qa/workunits/rados/test-clay-profiles.sh
+++ b/qa/workunits/rados/test-clay-profiles.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Ceph CLI commands and validation script for CLAY profile corner cases
+
+# Variables
+PROFILE_NAME="test_clay_profile"
+
+expect_false()
+{
+  if "$@"; then
+    echo "+++++ expected failure, but got success! cmd: $@"
+    exit 1
+  else
+    echo "+++++ expected failure"
+    echo -e "\n\n"
+  fi
+}
+
+expect_true()
+{
+  if "$@"; then
+    ceph osd erasure-code-profile rm "$PROFILE_NAME" > /dev/null 2>&1 || true
+    echo -e "\n\n"
+  else
+    echo "+++++ function returned non-zero, we failed"
+    exit 1
+  fi
+}
+
+ecp_create_test() {
+  local k=$1
+  local m=$2
+  local d=$3
+  local description=$4
+
+  echo "Testing with k=$k, m=$m, d=$d: $description"
+  ceph osd erasure-code-profile set "$PROFILE_NAME" \
+    plugin=clay \
+    k=$k \
+    m=$m \
+    d=$d
+  local result=$?
+  if [ $result -ne 0 ]; then
+    echo "Failed to create profile with k=$k, m=$m, d=$d"
+  fi
+  return $result
+}
+
+# 1. Boundary Values for d
+expect_false ecp_create_test 3 2 3 "Lower boundary (should fail)"
+expect_true ecp_create_test 3 2 4 "Exact lower bound (should succeed)"
+expect_false ecp_create_test 3 2 5 "Exact upper bound (should failed)"
+
+# 2. Invalid d Values
+expect_false ecp_create_test 3 2 -1 "Negative d (should fail)"
+expect_false ecp_create_test 3 2 0 "Zero d (should fail)"
+expect_false ecp_create_test 3 2 10 "Unreasonably large d (should fail)"
+
+# 3. Invalid Total Number of Chunks
+expect_false ecp_create_test 250 5 255 "Exceeds total chunk limit (should fail)"
+
+# 4. Valid but Edge Cases
+expect_false ecp_create_test 1 1 2 "Minimum viable configuration (should fail)"
+expect_false ecp_create_test 253 1 252 "Maximum viable configuration (should fail)"
+expect_true ecp_create_test 10 2 11 "Highly imbalanced configuration (should succeed)"
+
+# 5. Invalid Techniques expected to fail
+expect_false ceph osd erasure-code-profile set "$PROFILE_NAME" \
+  plugin=clay \
+  k=3 \
+  m=2 \
+  d=4 \
+  scalar_mds=isa \
+  technique=liber8tion
+
+# 6. Mixed Valid/Invalid Configurations
+expect_false ecp_create_test 3 2 0 "Invalid d with valid k and m (should fail)"
+expect_false ecp_create_test 0 2 3 "Valid d with invalid k (should fail)"
+expect_false ecp_create_test 3 0 4 "Valid d with invalid m (should fail)"
+
+
+expect_true ecp_create_test 10 5 13 "Valid configuration with padding (should succeed)"
+expect_false ecp_create_test 250 4 253 "Invalid configuration exceeding chunk limit (should fail)"
+expect_true ecp_create_test 12 3 14 "Configuration without padding (should succeed)"

--- a/src/erasure-code/clay/ErasureCodeClay.cc
+++ b/src/erasure-code/clay/ErasureCodeClay.cc
@@ -261,9 +261,9 @@ int ErasureCodeClay::parse(ErasureCodeProfile &profile,
       }
     }
   }
-  if ((d < k) || (d > k + m - 1)) {
+  if ((d < k + 1) || (d > k + m - 1)) {
     *ss << "value of d " << d
-        << " must be within [ " << k << "," << k+m-1 << "]" << std::endl;
+        << " must be within [" << k + 1 << "," << k + m - 1 << "]" << std::endl;
     err = -EINVAL;
     return err;
   }


### PR DESCRIPTION
Fix validation logic for `d` in CLAY erasure code profiles
Updated validation to ensure `d` satisfies `k + 1 <= d <= k + m - 1`.
This change aligns the implementation with the documented constraints
for CLAY erasure code profiles, ensuring consistent behavior and avoiding
undefined scenarios.

Fixes: https://tracker.ceph.com/issues/69506



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
