### PR TITLE
ceph-crash: Do not skip other directories if there is no done file

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -77,7 +77,7 @@ def scrape_path(path):
                 # or the daemon crashed before finishing it
                 time.sleep(1)
                 if not os.path.isfile(donepath):
-                    return
+                    continue
             # ok, we can process this one
             rc = post_crash(crashpath)
             if rc == 0:


### PR DESCRIPTION

Hello,
Please consider the pull request.

It contains a little fix for ceph-crash utility.

The utility scrapes /var/lib/ceph/crash/ and looks for crash subdirectories, then posts them to the cluster storage for investigation. To be posted, crash subdirectory should contain files 'done' and 'meta'.
The ceph-crash utility contains a bug, causing skipping other directories if current one doesn't contain the 'done' file.
This PR fixes it.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
