### PR TITLE
squid: test: ceph daemon command with asok path

### DIFF
--- a/qa/standalone/osd/pg-split-merge.sh
+++ b/qa/standalone/osd/pg-split-merge.sh
@@ -103,7 +103,7 @@ function TEST_import_after_merge_and_gap() {
 
     ceph osd pool set foo pg_num 1
     sleep 5
-    while ceph daemon osd.0 perf dump | jq '.osd.numpg' | grep 2 ; do sleep 1 ; done
+    while CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) perf dump | jq '.osd.numpg' | grep 2 ; do sleep 1 ; done
     wait_for_clean || return 1
 
     #
@@ -176,7 +176,7 @@ function TEST_import_after_split() {
 
     ceph osd pool set foo pg_num 2
     sleep 5
-    while ceph daemon osd.0 perf dump | jq '.osd.numpg' | grep 1 ; do sleep 1 ; done
+    while CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) perf dump | jq '.osd.numpg' | grep 1 ; do sleep 1 ; done
     wait_for_clean || return 1
 
     kill_daemons $dir TERM osd.0 || return 1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69623

---

backport of https://github.com/ceph/ceph/pull/57201
parent tracker: https://tracker.ceph.com/issues/65737

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh