### PR TITLE
reef: rgw/lc: make lc worker thread name shorter

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2326,7 +2326,7 @@ void RGWLC::start_processor()
   for (int ix = 0; ix < maxw; ++ix) {
     auto worker  =
       std::make_unique<RGWLC::LCWorker>(this /* dpp */, cct, this, ix);
-    worker->create((string{"lifecycle_thr_"} + to_string(ix)).c_str());
+    worker->create((string{"rgw_lc_"} + to_string(ix)).c_str());
     workers.emplace_back(std::move(worker));
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69564

---

backport of https://github.com/ceph/ceph/pull/61277
parent tracker: https://tracker.ceph.com/issues/69459

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh