### PR TITLE
container/build.sh: fix up org vs. repo naming

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -2,7 +2,7 @@
 # vim: ts=4 sw=4 expandtab
 
 # repo auth with write perms must be present (this script does not log into
-# CONTAINER_REPO_HOSTNAME and CONTAINER_REPO_ORGANIZATION).
+# repos named by CONTAINER_REPO_*).
 # If NO_PUSH is set, no login is necessary
 
 
@@ -20,6 +20,7 @@ CEPH_SHA1 (of Ceph)
 ARCH (of build host, and resulting container)
 CONTAINER_REPO_HOSTNAME (quay.ceph.io, for CI, for instance)
 CONTAINER_REPO_ORGANIZATION (ceph-ci, for CI, for instance)
+CONTAINER_REPO (ceph, for CI, or prerelease-<arch> for release, for instance)
 CONTAINER_REPO_USERNAME
 CONTAINER_REPO_PASSWORD
 PRERELEASE_USERNAME for download.ceph.com:/prerelease/ceph
@@ -50,10 +51,12 @@ fi
 
 if [[ ${CI_CONTAINER} == "true" ]] ; then
     CONTAINER_REPO_HOSTNAME=${CONTAINER_REPO_HOSTNAME:-quay.ceph.io}
-    CONTAINER_REPO_ORGANIZATION=${CONTAINER_REPO_ORGANIZATION:-ceph-ci/ceph}
+    CONTAINER_REPO_ORGANIZATION=${CONTAINER_REPO_ORGANIZATION:-ceph-ci}
+    CONTAINER_REPO=${CONTAINER_REPO:-ceph}
 else
     CONTAINER_REPO_HOSTNAME=${CONTAINER_REPO_HOSTNAME:-quay.ceph.io}
-    CONTAINER_REPO_ORGANIZATION=${CONTAINER_REPO_ORGANIZATION:-ceph/prerelease-${REPO_ARCH}}
+    CONTAINER_REPO_ORGANIZATION=${CONTAINER_REPO_ORGANIZATION:-ceph}
+    CONTAINER_REPO=${CONTAINER_REPO:-prerelease-${REPO_ARCH}}
     # default: most-recent annotated tag
     VERSION=${VERSION:-$(git describe --abbrev=0)}
 fi
@@ -71,13 +74,13 @@ fi
 if [[ ${CI_CONTAINER} != "true" ]] ; then : "${VERSION:?}"; fi
 
 # check for valid repo auth (if pushing)
-ORGURL=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
-MINIMAL_IMAGE=${ORGURL}/ceph:minimal-test
+repopath=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/${CONTAINER_REPO}
+MINIMAL_IMAGE=${repopath}:minimal-test
 if [[ ${NO_PUSH} != "true" ]] ; then
     podman rmi ${MINIMAL_IMAGE} || true
     echo "FROM scratch" | podman build -f - -t ${MINIMAL_IMAGE}
     if ! podman push ${MINIMAL_IMAGE} ; then
-        echo "Not authenticated to ${ORGURL}; need docker/podman login?"
+        echo "Not authenticated to ${repopath}; need docker/podman login?"
         exit 1
     fi
     podman rmi ${MINIMAL_IMAGE} | true
@@ -145,14 +148,14 @@ fromtag=${fromtag/:/-}
 builddate=$(date -u +%Y%m%d)
 local_tag=${fromtag}-${CEPH_CONTAINER_CEPH_REF}-${CEPH_CONTAINER_ARCH}-${builddate}
 
-repopath=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}
+repopath=${CONTAINER_REPO_HOSTNAME}/${CONTAINER_REPO_ORGANIZATION}/${CONTAINER_REPO}
 
 if [[ ${CI_CONTAINER} == "true" ]] ; then
     # ceph-ci conventions for remote tags:
     # requires ARCH, BRANCH, CEPH_SHA1, FLAVOR
-    full_repo_tag=$repopath/ceph:${BRANCH}-${fromtag}-${ARCH}-devel
-    branch_repo_tag=$repopath/ceph:${BRANCH}
-    sha1_repo_tag=$repopath/ceph:${CEPH_SHA1}
+    full_repo_tag=${repopath}:${BRANCH}-${fromtag}-${ARCH}-devel
+    branch_repo_tag=${repopath}:${BRANCH}
+    sha1_repo_tag=${repopath}:${CEPH_SHA1}
 
     if [[ "${ARCH}" == "arm64" ]] ; then
         branch_repo_tag=${branch_repo_tag}-arm64
@@ -182,7 +185,7 @@ else
     # non-CI build.  Tags are like v19.1.0-20240701
     # push to quay.ceph.io/ceph/prerelease-$REPO_ARCH
     #
-    version_tag=${repopath}/prerelease-${REPO_ARCH}:v${VERSION}-${builddate}
+    version_tag=${repopath}:v${VERSION}-${builddate}
 
     podman tag ${image_id} ${version_tag}
     if [[ -z "${NO_PUSH}" ]] ; then


### PR DESCRIPTION
release builds were using the wrong container repo name because of confused variable naming and inadequate separation.  Keep the hostname, org name, and repo name in separate variables, and assemble the full path with a version when tagging is done.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
