### PR TITLE
crimson: Provide an options to configure several seastar parameters

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -51,6 +51,35 @@ options:
   - startup
   min: 0
   max: 32
+- name: crimson_reactor_task_quota_ms
+  type: float
+  level: advanced
+  default: 0.5
+  desc: The maximum time (ms) Seastar reactors will wait between polls.
+  long_desc: The maximum time (ms) Seastar reactors will wait between polls.
+             Shorter time between pools will result in larger CPU utilization.
+  flags:
+  - startup
+- name: crimson_reactor_idle_poll_time_us
+  type: uint
+  level: advanced
+  default: 200
+  desc: Seastar's reactor idle polling time (ms) before going back to sleep.
+  long_desc: Seastar's reactor idle polling time (ms) before going back to sleep.
+             Longer reactor poll time will result in larger CPU utilization.
+  flags:
+  - startup
+- name: crimson_reactor_io_latency_goal_ms
+  type: float
+  level: advanced
+  default: 0
+  desc: The maximum time (ms) Seastar's reactor IO operations must take.
+        If not set(0 mean not set), defaults to 1.5 * crimson_reactor_task_quota_ms
+  long_desc: The maximum time (ms) Seastar's reactor IO operations must take.
+             If not set, defaults to 1.5 * crimson_reactor_task_quota_ms.
+             Increasing this value will allow more IO requests to be dispatched concurrently.
+  flags:
+  - startup
 - name: crimson_osd_stat_interval
   type: int
   level: advanced

--- a/src/crimson/osd/main_config_bootstrap_helpers.cc
+++ b/src/crimson/osd/main_config_bootstrap_helpers.cc
@@ -84,6 +84,41 @@ seastar::future<> populate_config_from_mon()
   });
 }
 
+struct SeastarOption {
+  std::string option_name;  // Command-line option name
+  std::string config_key;   // Configuration key
+  Option::type_t value_type ;   // Type of configuration value
+};
+
+// Define a list of Seastar options
+const std::vector<SeastarOption> seastar_options = {
+  {"--task-quota-ms", "crimson_reactor_task_quota_ms", Option::TYPE_FLOAT},
+  {"--io-latency-goal-ms", "crimson_reactor_io_latency_goal_ms", Option::TYPE_FLOAT},
+  {"--idle-poll-time-us", "crimson_reactor_idle_poll_time_us", Option::TYPE_UINT}
+};
+
+// Function to get the option value as a string
+std::optional<std::string> get_option_value(const SeastarOption& option) {
+  switch (option.value_type) {
+    case Option::TYPE_FLOAT: {
+      if (auto value = crimson::common::get_conf<double>(option.config_key)) {
+        return std::to_string(value);
+      }
+      break;
+    }
+    case Option::TYPE_UINT: {
+      if (auto value = crimson::common::get_conf<uint64_t>(option.config_key)) {
+        return std::to_string(value);
+      }
+      break;
+    }
+    default:
+      logger().warn("get_option_value --option_name {} encountered unknown type", option.config_key);
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
+
 static tl::expected<early_config_t, int>
 _get_early_config(int argc, const char *argv[])
 {
@@ -143,6 +178,14 @@ _get_early_config(int argc, const char *argv[])
 	  std::begin(early_args),
 	  std::end(early_args));
 
+        for (const auto& option : seastar_options) {
+          auto option_value = get_option_value(option);
+          if (option_value) {
+            logger().info("Configure option_name {} with value : {}", option.config_key, option_value);
+            ret.early_args.emplace_back(option.option_name);
+            ret.early_args.emplace_back(*option_value);
+          }
+        }
 	if (auto found = std::find_if(
 	      std::begin(early_args),
 	      std::end(early_args),


### PR DESCRIPTION
Implement a new mechanism to introduce a new seastar parameter in future and add options to configure parameters like task_quota_ms, io_latency_goal_ms and idle_poll_time_us.

Fixes: https://tracker.ceph.com/issues/69595





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
