### PR TITLE
squid: qa/workunits/mon: ensure election strategy is "connectivity" for stretch mode

### DIFF
--- a/qa/suites/rados/singleton/all/stretch-mode-5-mons-8-osds.yaml
+++ b/qa/suites/rados/singleton/all/stretch-mode-5-mons-8-osds.yaml
@@ -26,7 +26,6 @@ overrides:
   ceph:
     conf:
       global:
-        mon election default strategy: 3
         osd pool default size: 3
         osd pool default min size: 2
       mon:

--- a/qa/workunits/mon/mon-stretch-mode-5-mons-8-osds.sh
+++ b/qa/workunits/mon/mon-stretch-mode-5-mons-8-osds.sh
@@ -9,6 +9,10 @@ if [ $NUM_OSDS_UP -lt 8 ]; then
     exit 1
 fi
 
+# ensure election strategy is set to "connectivity"
+# See https://tracker.ceph.com/issues/69107
+ceph mon set election_strategy connectivity
+
 for dc in dc1 dc2
     do
       ceph osd crush add-bucket $dc datacenter


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69168

---

backport of https://github.com/ceph/ceph/pull/60927
parent tracker: https://tracker.ceph.com/issues/69107

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh