### PR TITLE
reef: doc/cephfs: edit disaster-recovery-experts (5 of x)

### DIFF
--- a/doc/cephfs/disaster-recovery-experts.rst
+++ b/doc/cephfs/disaster-recovery-experts.rst
@@ -234,126 +234,130 @@ recovery since the existing metadata pool would not be modified.
    contents of the data pool while this is the case. After recovery is
    complete, archive or delete the damaged metadata pool.
 
-To begin, the existing file system should be taken down to prevent further
-modification of the data pool. Unmount all clients and then use the following
-command to mark the file system failed:
+#. To begin, the existing file system should be taken down to prevent further
+   modification of the data pool. Unmount all clients and then use the
+   following command to mark the file system failed:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   ceph fs fail <fs_name>
+      ceph fs fail <fs_name>
 
-.. note::
+   .. note::
 
-   ``<fs_name>`` here and below refers to the original, damaged file system.
+      ``<fs_name>`` here and below refers to the original, damaged file system.
 
-Next, create a recovery file system in which we will populate a new metadata pool
-that is backed by the original data pool:
+#. Next, create a recovery file system in which we will populate a new metadata
+   pool that is backed by the original data pool:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   ceph osd pool create cephfs_recovery_meta
-   ceph fs new cephfs_recovery cephfs_recovery_meta <data_pool> --recover --allow-dangerous-metadata-overlay
+      ceph osd pool create cephfs_recovery_meta
+      ceph fs new cephfs_recovery cephfs_recovery_meta <data_pool> --recover --allow-dangerous-metadata-overlay
 
-.. note::
+   .. note::
 
-   You may rename the recovery metadata pool and file system at a future time.
-   The ``--recover`` flag prevents any MDS daemon from joining the new file
-   system.
+      You may rename the recovery metadata pool and file system at a future time.
+      The ``--recover`` flag prevents any MDS daemon from joining the new file
+      system.
 
-Next, we will create the intial metadata for the fs:
+#. Next, we will create the intial metadata for the fs:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   cephfs-table-tool cephfs_recovery:0 reset session
+      cephfs-table-tool cephfs_recovery:0 reset session
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   cephfs-table-tool cephfs_recovery:0 reset snap
+      cephfs-table-tool cephfs_recovery:0 reset snap
 
-.. prompt:: bash #
+   .. prompt:: bash #
    
-   cephfs-table-tool cephfs_recovery:0 reset inode
+      cephfs-table-tool cephfs_recovery:0 reset inode
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   cephfs-journal-tool --rank cephfs_recovery:0 journal reset --force --yes-i-really-really-mean-it
+      cephfs-journal-tool --rank cephfs_recovery:0 journal reset --force --yes-i-really-really-mean-it
 
-Now perform the recovery of the metadata pool from the data pool:
+#. Now perform the recovery of the metadata pool from the data pool:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   cephfs-data-scan init --force-init --filesystem cephfs_recovery --alternate-pool cephfs_recovery_meta
+      cephfs-data-scan init --force-init --filesystem cephfs_recovery --alternate-pool cephfs_recovery_meta
 
-.. prompt:: bash #
+   .. prompt:: bash #
    
-   cephfs-data-scan scan_extents --alternate-pool cephfs_recovery_meta --filesystem <fs_name>
+      cephfs-data-scan scan_extents --alternate-pool cephfs_recovery_meta --filesystem <fs_name>
 
-.. prompt:: bash #
+   .. prompt:: bash #
    
-   cephfs-data-scan scan_inodes --alternate-pool cephfs_recovery_meta --filesystem <fs_name> --force-corrupt
+      cephfs-data-scan scan_inodes --alternate-pool cephfs_recovery_meta --filesystem <fs_name> --force-corrupt
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   cephfs-data-scan scan_links --filesystem cephfs_recovery
+      cephfs-data-scan scan_links --filesystem cephfs_recovery
 
-.. note::
+   .. note::
 
-   Each of the scan procedures above scans through the entire data pool. This
-   may take a long time. See the previous section on how to distribute this
-   task among workers.
+      Each of the scan procedures above scans through the entire data pool.
+      This may take a long time. See the previous section on how to distribute
+      this task among workers.
 
-If the damaged file system contains dirty journal data, it may be recovered next
-with a command of the following form:
+   If the damaged file system contains dirty journal data, it may be recovered
+   next with a command of the following form:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   cephfs-journal-tool --rank=<fs_name>:0 event recover_dentries list --alternate-pool cephfs_recovery_meta
+      cephfs-journal-tool --rank=<fs_name>:0 event recover_dentries list --alternate-pool cephfs_recovery_meta
 
-After recovery, some recovered directories will have incorrect statistics.
-Ensure that the parameters ``mds_verify_scatter`` and ``mds_debug_scatterstat``
-are set to false (the default) to prevent the MDS from checking the statistics:
+#. After recovery, some recovered directories will have incorrect statistics.
+   Ensure that the parameters ``mds_verify_scatter`` and
+   ``mds_debug_scatterstat`` are set to false (the default) to prevent the MDS
+   from checking the statistics:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   ceph config rm mds mds_verify_scatter
+      ceph config rm mds mds_verify_scatter
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   ceph config rm mds mds_debug_scatterstat
+      ceph config rm mds mds_debug_scatterstat
 
-.. note::
+   .. note::
 
-   Verify that the config has not been set globally or with a local ``ceph.conf`` file.
+      Verify that the config has not been set globally or with a local
+      ``ceph.conf`` file.
 
-Now, allow an MDS daemon to join the recovery file system:
+#. Now, allow an MDS daemon to join the recovery file system:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   ceph fs set cephfs_recovery joinable true
+      ceph fs set cephfs_recovery joinable true
 
-Finally, run a forward :doc:`scrub </cephfs/scrub>` to repair recursive statistics.
-Ensure that you have an MDS daemon running and issue the following command:
+#. Finally, run a forward :doc:`scrub </cephfs/scrub>` to repair recursive
+   statistics.  Ensure that you have an MDS daemon running and issue the
+   following command:
 
-.. prompt:: bash #
+   .. prompt:: bash #
 
-   ceph tell mds.cephfs_recovery:0 scrub start / recursive,repair,force
+      ceph tell mds.cephfs_recovery:0 scrub start / recursive,repair,force
 
-.. note::
+   .. note::
 
-   The `Symbolic link recovery <https://tracker.ceph.com/issues/46166>`_ is
-   supported starting in the Quincy release.
+      The `Symbolic link recovery <https://tracker.ceph.com/issues/46166>`_ is
+      supported starting in the Quincy release.
 
-   Symbolic links were recovered as empty regular files before.
+      Symbolic links were recovered as empty regular files before.
 
-It is recommended that you migrate any data from the recovery file system as
-soon as possible. Do not restore the old file system while the recovery file
-system is operational.
+   It is recommended that you migrate any data from the recovery file system as
+   soon as possible. Do not restore the old file system while the recovery file
+   system is operational.
 
-.. note::
+   .. note::
 
-    If the data pool is also corrupt, some files may not be restored because
-    the backtrace information associated with them is lost. If any data objects
-    are missing (due to issues like lost Placement Groups on the data pool),
-    the recovered files will contain holes in place of the missing data.
+       If the data pool is also corrupt, some files may not be restored because
+       the backtrace information associated with them is lost. If any data
+       objects are missing (due to issues like lost Placement Groups on the
+       data pool), the recovered files will contain holes in place of the
+       missing data.
 
 .. _Symbolic link recovery: https://tracker.ceph.com/issues/46166


### PR DESCRIPTION
Put the procedure in the section called "Using an alternate metadata pool for recovery" into an ordered list, so that it is in a proper procedure format.

This commit is meant only to break the procedure into steps. The English language in each of these steps could be improved, but that improvement will be done after this formatting has been merged and backported.

Follows https://github.com/ceph/ceph/pull/61462.

https://tracker.ceph.com/issues/69557

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 9af7d9786a11e2b07a095c95ae911dfb13e4a61b)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

