### PR TITLE
Fix EventTrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,11 +623,6 @@ endif()
 # -lz link into kv
 find_package(ZLIB REQUIRED)
 
-#option for EventTrace
-CMAKE_DEPENDENT_OPTION(
-  WITH_EVENTTRACE "Event tracing support, requires WITH_LTTNG"
-  OFF "USE_LTTNG" OFF)
-
 #option for LTTng
 option(WITH_LTTNG "LTTng tracing is enabled" ON)
 if(${WITH_LTTNG})
@@ -638,6 +633,11 @@ if(${WITH_LTTNG})
     message(FATAL_ERROR "Can't find lttng-gen-tp.")
   endif()
 endif(${WITH_LTTNG})
+
+#option for EventTrace
+CMAKE_DEPENDENT_OPTION(
+  WITH_EVENTTRACE "Event tracing support, requires WITH_LTTNG"
+  OFF "WITH_LTTNG" OFF)
 
 option(WITH_OSD_INSTRUMENT_FUNCTIONS OFF)
 

--- a/src/common/EventTrace.cc
+++ b/src/common/EventTrace.cc
@@ -43,7 +43,7 @@ void EventTrace::init_tp(CephContext *_ctx)
   }
 }
 
-void EventTrace::set_message_attrs(const Message *m, string& oid, string& context, bool incl_oid)
+void EventTrace::set_message_attrs(const Message *m, std::string& oid, std::string& context, bool incl_oid)
 {
   // arg1 = oid, arg2 = message type, arg3 = source!source_addr!tid!sequence
   if (m && (m->get_type() == CEPH_MSG_OSD_OP || m->get_type() == CEPH_MSG_OSD_OPREPLY)) {
@@ -54,7 +54,7 @@ void EventTrace::set_message_attrs(const Message *m, string& oid, string& contex
         oid = ((MOSDOpReply *)m)->get_oid().name;
     }
 
-    ostringstream buf;
+    std::ostringstream buf;
     buf << m->get_source() << "!" << m->get_source_addr() << "!"
         << m->get_tid() << "!" << m->get_seq() << "!" << m->get_type();
     context = buf.str();
@@ -87,7 +87,7 @@ EventTrace::~EventTrace()
 void EventTrace::log_event_latency(const char *event)
 {
   utime_t now = ceph_clock_now();
-  double usecs = (now.to_nsec()-last_ts.to_nsec())/1000;
+  double usecs = (now.to_nsec()-last_ts.to_nsec())/1000.0;
   OID_ELAPSED("", usecs, event);
   last_ts = now;
 }
@@ -104,7 +104,7 @@ void EventTrace::trace_oid_event(const char *oid, const char *event, const char 
 void EventTrace::trace_oid_event(const Message *m, const char *event, const char *file,
   const char *func, int line, bool incl_oid)
 {
-  string oid, context;
+  std::string oid, context;
   set_message_attrs(m, oid, context, incl_oid);
   trace_oid_event(oid.c_str(), event, context.c_str(), file, func, line);
 }
@@ -121,7 +121,7 @@ void EventTrace::trace_oid_elapsed(const char *oid, const char *event, const cha
 void EventTrace::trace_oid_elapsed(const Message *m, const char *event, double elapsed,
   const char *file, const char *func, int line, bool incl_oid)
 {
-  string oid, context;
+  std::string oid, context;
   set_message_attrs(m, oid, context, incl_oid);
   trace_oid_elapsed(oid.c_str(), event, context.c_str(), elapsed, file, func, line);
 }

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -35,6 +35,11 @@ if(WITH_CEPH_DEBUG_MUTEX)
     ${PROJECT_SOURCE_DIR}/src/common/condition_variable_debug.cc
     ${PROJECT_SOURCE_DIR}/src/common/shared_mutex_debug.cc)
 endif()
+if(WITH_EVENTTRACE)
+  list(APPEND crimson_alien_common_srcs
+    ${PROJECT_SOURCE_DIR}/src/common/TracepointProvider.cc
+    ${PROJECT_SOURCE_DIR}/src/common/EventTrace.cc)
+endif()
 add_library(crimson-alien-common STATIC
   ${crimson_alien_common_srcs})
 

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1453,7 +1453,7 @@ CtPtr ProtocolV2::handle_message() {
     utime_t ltt_processed_stamp = ceph_clock_now();
     double usecs_elapsed =
       ((double)(ltt_processed_stamp.to_nsec() - recv_stamp.to_nsec())) / 1000;
-    ostringstream buf;
+    std::ostringstream buf;
     if (message->get_type() == CEPH_MSG_OSD_OP)
       OID_ELAPSED_WITH_MSG(message, usecs_elapsed, "TIME_TO_DECODE_OSD_OP",
                            false);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18718,7 +18718,7 @@ mono_clock::duration BlueStore::BlueStoreThrottle::log_state_latency(
   if (txc.tracing &&
       state >= l_bluestore_state_prepare_lat &&
       state <= l_bluestore_state_done_lat) {
-    OID_ELAPSED("", lat.to_nsec() / 1000.0, txc.get_state_latency_name(state));
+    OID_ELAPSED("", lat.count() / 1000.0, txc.get_state_latency_name(state));
     tracepoint(
       bluestore,
       transaction_state_duration,


### PR DESCRIPTION
Fix a CMake build dependency and compiler errors to get EventTrace to build again.

With this I was able use EventTrace when building with `DWITH_EVENTTRACE=YES`:


```
$ ceph-osd -i 0 -c /compile2/ceph/wip/build/ceph.conf --osd_tracing=true --event-tracing=true

$ sudo bpftrace -l 'usdt:*:eventtrace:*' -p $(pgrep ceph-osd | head -1) 2>/dev/null
usdt:/proc/1115537/root/compile2/ceph/wip/build/bin/ceph-osd:eventtrace:func_enter
usdt:/proc/1115537/root/compile2/ceph/wip/build/bin/ceph-osd:eventtrace:func_exit
usdt:/proc/1115537/root/compile2/ceph/wip/build/bin/ceph-osd:eventtrace:oid_elapsed
usdt:/proc/1115537/root/compile2/ceph/wip/build/bin/ceph-osd:eventtrace:oid_event

$ sudo bpftrace -p $(pgrep ceph-osd | head -1) -e 'usdt:/compile2/ceph/wip/build/bin/ceph-osd:*:oid_event { printf("oid:%s ev:%s ctx:%s f:%s fn:%s line:%d\n", str(arg0), str(arg1), str(arg2), str(arg3), str(arg4), arg5); }' 2>/dev/null

Attaching 1 probe...
oid: ev:MS_FAST_DISPATCH_END ctx:client.4484!192.168.101.23:0/601074448!3536!929!42 f:/compile2/ceph/wip/src/osd/OSD.cc fn:ms_fast_dispatch line:7751
oid: ev:DEQUEUE_OP_BEGIN ctx:client.4484!192.168.101.23:0/601074448!3536!929!42 f:/compile2/ceph/wip/src/osd/OSD.cc fn:dequeue_op line:9907
oid: ev:MS_FAST_DISPATCH_END ctx:client.4484!192.168.101.23:0/601074448!3537!930!42 f:/compile2/ceph/wip/src/osd/OSD.cc fn:ms_fast_dispatch line:7751
oid: ev:DEQUEUE_OP_BEGIN ctx:client.4484!192.168.101.23:0/601074448!3537!930!42 f:/compile2/ceph/wip/src/osd/OSD.cc fn:dequeue_op line:9907
oid:notify.3 ev:SEND_MSG_OSD_OPREPLY_BEGIN ctx:osd.1!192.168.101.23:0/601074448!3536!0!43 f:/compile2/ceph/wip/src/msg/async/AsyncConnection.cc fn:send_message line:567
...

```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
