### PR TITLE
examples/rgw: add type to HeadBucketOutput for old boto

### DIFF
--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -391,6 +391,7 @@
             }
         },
         "HeadBucketOutput":{
+            "type":"structure",
             "members":{
                 "ObjectCount":{
                     "shape":"ObjectCount",


### PR DESCRIPTION
0f55c1759d4f959f4de448289b5f31fc95ae88d5 added an override for the "HeadBucketOutput" shape, but that didn't exist until botocore 1.33.2. s3-tests is pinned to botocore <1.28.0

Fixes: https://tracker.ceph.com/issues/69582

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
