### PR TITLE
osd/scrub: use ObjectSection & ArraySection

### DIFF
--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -65,9 +65,8 @@ void OsdScrub::dump_scrubs(ceph::Formatter* f) const
 void OsdScrub::dump_scrub_reservations(ceph::Formatter* f) const
 {
   m_resource_bookkeeper.dump_scrub_reservations(f);
-  f->open_object_section("remote_scrub_reservations");
+  Formatter::ObjectSection rmt_section{*f, "remote_scrub_reservations"sv};
   m_osd_svc.get_scrub_reserver().dump(f);
-  f->close_section();
 }
 
 void OsdScrub::log_fwd(std::string_view text)

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -141,10 +141,10 @@ void ScrubQueue::dump_scrubs(ceph::Formatter* f) const
 {
   ceph_assert(f != nullptr);
   const auto query_time = ceph_clock_now();
-  f->open_array_section("scrubs");
+  Formatter::ArraySection all_scrubs_section{*f, "scrubs"};
   for_each_job(
       [&f, query_time](const Scrub::SchedEntry& e) {
-	f->open_object_section("scrub");
+        Formatter::ObjectSection job_section{*f, "scrub"sv};
 	f->dump_stream("pgid") << e.pgid;
 	f->dump_stream("sched_time") << e.schedule.not_before;
 	f->dump_stream("orig_sched_time") << e.schedule.scheduled_at;
@@ -160,11 +160,8 @@ void ScrubQueue::dump_scrubs(ceph::Formatter* f) const
         f->dump_bool("eligible", e.schedule.not_before <= query_time);
         f->dump_bool("overdue", e.schedule.deadline < query_time);
         f->dump_stream("last_issue") << fmt::format("{}", e.last_issue);
-
-	f->close_section();
       },
       std::numeric_limits<int>::max());
-  f->close_section();
 }
 
 // ////////////////////////////////////////////////////////////////////////// //

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -726,11 +726,10 @@ void asok_response_section(
     scrub_level_t scrub_level,
     utime_t stamp = utime_t{})
 {
-  f->open_object_section("result");
+  Formatter::ObjectSection asok_resp_section{*f, "result"sv};
   f->dump_bool("deep", (scrub_level == scrub_level_t::deep));
   f->dump_bool("must", !is_periodic);
   f->dump_stream("stamp") << stamp;
-  f->close_section();
 }
 }  // namespace
 
@@ -2355,7 +2354,7 @@ Scrub::schedule_result_t PgScrubber::start_scrub_session(
 void PgScrubber::dump_scrubber(
     ceph::Formatter* f) const
 {
-  f->open_object_section("scrubber");
+  Formatter::ObjectSection scrubber_section{*f, "scrubber"sv};
 
   if (m_active_target) {
     f->dump_bool("active", true);
@@ -2382,8 +2381,6 @@ void PgScrubber::dump_scrubber(
     // The 'test_sequence' is an ever-increasing number used by tests.
     f->dump_int("test_sequence", m_sessions_counter);
   }
-
-  f->close_section();
 }
 
 
@@ -2407,11 +2404,10 @@ void PgScrubber::dump_active_scrubber(ceph::Formatter* f) const
   f->dump_int("deep_errors", m_deep_errors);
   f->dump_int("fixed", m_fixed_count);
   {
-    f->open_array_section("waiting_on_whom");
+    Formatter::ArraySection waiting_on_whom{*f, "waiting_on_whom"sv};
     for (const auto& p : m_maps_status.get_awaited()) {
       f->dump_stream("shard") << p;
     }
-    f->close_section();
   }
   if (m_scrub_job->blocked) {
     f->dump_string("schedule", "blocked");
@@ -2537,7 +2533,7 @@ void PgScrubber::handle_query_state(ceph::Formatter* f)
 {
   dout(15) << __func__ << dendl;
 
-  f->open_object_section("scrub");
+  Formatter::ObjectSection scrub_section{*f, "scrub"sv};
   f->dump_stream("scrubber.epoch_start") << m_interval_start;
   f->dump_bool("scrubber.active", m_active);
   f->dump_stream("scrubber.start") << m_start;
@@ -2546,16 +2542,13 @@ void PgScrubber::handle_query_state(ceph::Formatter* f)
   f->dump_stream("scrubber.subset_last_update") << m_subset_last_update;
   f->dump_bool("scrubber.deep", m_is_deep);
   {
-    f->open_array_section("scrubber.waiting_on_whom");
+    Formatter::ArraySection waiting_on_whom{*f, "waiting_on_whom"sv};
     for (const auto& p : m_maps_status.get_awaited()) {
       f->dump_stream("shard") << p;
     }
-    f->close_section();
   }
 
   f->dump_string("comment", "DEPRECATED - may be removed in the next release");
-
-  f->close_section();
 }
 
 PgScrubber::~PgScrubber()

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -377,13 +377,12 @@ void ScrubJob::dump(ceph::Formatter* f) const
 {
   const auto& entry = earliest_target().sched_info;
   const auto& sch = entry.schedule;
-  f->open_object_section("scrub");
+  Formatter::ObjectSection scrubjob_section{*f, "scrub"sv};
   f->dump_stream("pgid") << pgid;
   f->dump_stream("sched_time") << get_sched_time();
   f->dump_stream("orig_sched_time") << sch.scheduled_at;
   f->dump_stream("deadline") << sch.deadline;
   f->dump_bool("forced", entry.urgency >= urgency_t::operator_requested);
-  f->close_section();
 }
 
 // a set of static functions to determine, given a scheduling target's urgency,


### PR DESCRIPTION
Use the RAII wrappers for the dump Formatters,
instead of manually opening and closing sections.
