### PR TITLE
reef: qa/multisite: add extra checkpoints in datalog_autotrim testcase

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1017,6 +1017,9 @@ def test_datalog_autotrim():
     # wait for metadata and data sync to catch up
     zonegroup_meta_checkpoint(zonegroup)
     zonegroup_data_checkpoint(zonegroup_conns)
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+    time.sleep(config.checkpoint_delay)
+    zonegroup_data_checkpoint(zonegroup_conns)
 
     # trim each datalog
     for zone, _ in zone_bucket:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69130

---

backport of https://github.com/ceph/ceph/pull/60591
parent tracker: https://tracker.ceph.com/issues/67207

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh