### PR TITLE
container: add label ceph=True back

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -36,6 +36,7 @@ LABEL org.opencontainers.image.authors="Ceph Release Team <ceph-maintainers@ceph
       org.opencontainers.image.documentation="https://docs.ceph.com/"
 
 LABEL \
+ceph=True \
 FROM_IMAGE=${FROM_IMAGE} \
 CEPH_REF=${CEPH_REF} \
 CEPH_SHA1=${CEPH_SHA1} \


### PR DESCRIPTION
Add a label used by cephadm internally that was always set by ceph-container [1] back to the new containerfile. This should prevent issues with cephadm shell command thinking official ceph images are not official ceph images.

[1] https://github.com/ceph/ceph-container/blob/30dc8b9a55f70a40983fd2da6ac31e1b9e977143/src/__DOCKERFILE_TRACEABILITY_LABELS__#L5





## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; <s>references commit where it was introduced</s> introduced by new continerfile
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
