### PR TITLE
reef: doc/rados: pool and namespace are independent osdcap restrictions

### DIFF
--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -134,7 +134,7 @@ Capability syntax follows this form::
 
     osd 'allow {access-spec} [{match-spec}] [network {network/prefix}]'
 
-    osd 'profile {name} [pool={pool-name} [namespace={namespace-name}]] [network {network/prefix}]'
+    osd 'profile {name} [pool={pool-name}] [namespace={namespace-name}] [network {network/prefix}]'
 
   There are two alternative forms of the ``{access-spec}`` syntax: ::
 
@@ -142,9 +142,13 @@ Capability syntax follows this form::
 
         class {class name} [{method name}]
 
-  There are two alternative forms of the optional ``{match-spec}`` syntax::
+  There are four alternative forms of the optional ``{match-spec}`` syntax::
 
         pool={pool-name} [namespace={namespace-name}] [object_prefix {prefix}]
+
+        [pool={pool-name}] namespace={namespace-name} [object_prefix {prefix}]
+
+        [pool={pool-name}] [namespace={namespace-name}] object_prefix {prefix}
 
         [namespace={namespace-name}] tag {application} {key}={value}
 


### PR DESCRIPTION
For the "profile {name}" syntax, pool and namespace restrictions are independent of each other (i.e. specifying namespace doesn't also require specifying pool like is currently suggested).  A cap can look like "profile rbd namespace=myns", signifying that the RBD profile is to be allowed in myns namespace of any pool.

For the "allow {access-spec}" syntax, pool restriction is optional. A cap can look like "allow r namespace=myns", "allow w object_prefix myprefix" or "allow rw namespace=myns object_prefix myprefix", for example.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>
(cherry picked from commit 67f5769ce6e110b89362763cfb41a0e00e595cdf)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

