### PR TITLE
squid: librbd: clear ctx before initiating close in Image::{aio_,}close()

### DIFF
--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1630,8 +1630,8 @@ namespace librbd {
       ImageCtx *ictx = (ImageCtx *)ctx;
       tracepoint(librbd, close_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str());
 
+      ctx = NULL;  // before initiating close
       r = ictx->state->close();
-      ctx = NULL;
 
       tracepoint(librbd, close_image_exit, r);
     }
@@ -1647,9 +1647,9 @@ namespace librbd {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, aio_close_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), c->pc);
 
+    ctx = NULL;  // before initiating close
     ictx->state->close(new C_AioCompletion(ictx, librbd::io::AIO_TYPE_CLOSE,
                                            get_aio_completion(c)));
-    ctx = NULL;
 
     tracepoint(librbd, aio_close_image_exit, 0);
     return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69653

---

backport of https://github.com/ceph/ceph/pull/61492
parent tracker: https://tracker.ceph.com/issues/69619