### PR TITLE
mgr/dashboard: Multi-site replication wizard breaks when a default realm is already present in the secondary cluster.

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -1294,7 +1294,7 @@ class RgwZone(RESTController):
 
     @Endpoint()
     @ReadPermission
-    def get_user_list(self, zoneName=None):
+    def get_user_list(self, zoneName=None, realmName=None):
         multisite_instance = RgwMultisite()
-        result = multisite_instance.get_user_list(zoneName)
+        result = multisite_instance.get_user_list(zoneName, realmName)
         return result

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -13292,6 +13292,11 @@ paths:
         name: zoneName
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: realmName
+        schema:
+          type: string
       responses:
         '200':
           content:


### PR DESCRIPTION
When a default realm is already present in a secondary cluster, the multi-site automation wizard breaks and shows the progress as 0% again. This happens because the last step of the wizard is to confirm the presence of replication user created as a part of the wizard to be present in the secondary cluster and then do the further processing. We fetch the user list from the secondary cluster using get_user_list method which takes the zoneName as input param. In case there is a default realm in the secondary cluster, we need this method to take the realm name as input param as well.

Fixes: https://tracker.ceph.com/issues/69670

Signed-off-by: Aashish Sharma <aasharma@redhat.com>


https://github.com/user-attachments/assets/7d2d5ee5-ca98-4227-a621-6263f9da1cc7






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
