### PR TITLE
nvmeofgw* : fix duplicated optimized host's pathes

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -557,61 +557,6 @@ void  NVMeofGwMap::find_failover_candidate(
   }
 }
 
-void  NVMeofGwMap::handle_gw_performing_fast_reboot(const NvmeGwId &gw_id,
-     const NvmeGroupKey& group_key, bool &map_modified)
-{
-  for (auto& state_itr: created_gws[group_key][gw_id].sm_state ) {
-    fsm_handle_gw_fast_reboot(gw_id,group_key, state_itr.first, map_modified);
-  }
-}
-
-void NVMeofGwMap::fsm_handle_gw_fast_reboot(const NvmeGwId &gw_id,
-    const NvmeGroupKey& group_key, NvmeAnaGrpId grpid, bool &map_modified)
-{
-  // GW that appears in the internal map as Available, performed reboot,
-  // need to re-apply this GW: to load proper states for all active ANA groups
-  auto& gw_state = created_gws[group_key][gw_id];
-  map_modified = true;
-  gw_states_per_group_t  state = gw_state.sm_state[grpid];
-  dout(10) << "GW " << gw_id  << " ANA groupId: " << grpid << " state "
-        << state << dendl;
-  switch (state){
-  case gw_states_per_group_t::GW_IDLE_STATE:
-  case gw_states_per_group_t::GW_STANDBY_STATE:
-  case gw_states_per_group_t::GW_ACTIVE_STATE:
-    break;
-
-  case gw_states_per_group_t::GW_WAIT_FAILBACK_PREPARED:
-  {
-    //restart timeout
-    start_timer(gw_id, group_key, grpid, 3);
-  }
-  break;
-
-  case gw_states_per_group_t::GW_OWNER_WAIT_FAILBACK_PREPARED:
-  {
-    // since owner was reseted for this group, wait for the background process
-    // to choose it again
-    gw_state.standby_state(grpid);
-  }
-  break;
-
-  case gw_states_per_group_t::GW_WAIT_BLOCKLIST_CMPL:
-  {
-    //restart timer
-    // The blocklist was started, need to wait for the epoch in the GW
-    start_timer(gw_id, group_key, grpid, 30);
-  }
-  break;
-
-  default:
-  {
-    dout(4) << "Warning: GW " << gw_id  << " Invalid state " << state << dendl;
-  }
-  }
-  validate_gw_map(group_key);
-}
-
 void NVMeofGwMap::fsm_handle_gw_alive(
   const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
   NvmeGwMonState & gw_state, gw_states_per_group_t state,
@@ -866,11 +811,11 @@ void NVMeofGwMap::fsm_handle_to_expired(
     }
   } else if (fbp_gw_state.sm_state[grpid] ==
 	     gw_states_per_group_t::GW_WAIT_BLOCKLIST_CMPL) {
-    dout(4) << "Warning: Expired GW_WAIT_FAILOVER_PREPARED timer "
+    dout(4) << "Warning: Expired GW_WAIT_BLOCKLIST_CMPL timer "
 	    << "from GW, Force exit the GW " << gw_id
 	    << " ANA groupId: "<< grpid << dendl;
-    fbp_gw_state.set_unavailable_state();
-    map_modified = true;
+    //another Trigger for GW down (failover)
+    process_gw_map_gw_down(gw_id, group_key, map_modified);
   }
   if (map_modified) validate_gw_map(group_key);
 }

--- a/src/mon/NVMeofGwMap.h
+++ b/src/mon/NVMeofGwMap.h
@@ -96,9 +96,6 @@ private:
   void fsm_handle_to_expired(
     const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
     NvmeAnaGrpId grpid,  bool &map_modified);
-  void fsm_handle_gw_fast_reboot(const NvmeGwId &gw_id,
-      const NvmeGroupKey& group_key, NvmeAnaGrpId grpid,
-      bool &map_modified);
   void find_failover_candidate(
     const NvmeGwId &gw_id, const NvmeGroupKey& group_key,
     NvmeAnaGrpId grpid, bool &propose_pending);

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -553,7 +553,7 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
 	dout(4) << " Warning :GW marked as Available in the NVmeofGwMon "
 		<< "database, performed full startup - Apply GW!"
 		<< gw_id << dendl;
-	 pending_map.handle_gw_performing_fast_reboot(gw_id, group_key, propose);
+	 process_gw_down(gw_id, group_key, propose, avail);
 	 LastBeacon lb = {gw_id, group_key};
 	 last_beacon[lb] = now; //Update last beacon
       } else if (


### PR DESCRIPTION
 1. fix duplicated optimized host's pathes - trigger process_gw_down upon fast-gw reboot, removed old fast-reboot handlers
 2. fix GW startup - trigger process_gw_down when expired WAIT_BLOCKLIST timer





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
