### PR TITLE
cephfs_mirror: avoid latest changes on the source fs to enable mirroring

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1625,3 +1625,53 @@ class TestMirroring(CephFSTestCase):
                    expected_snap_count == res[dir_name]['snaps_synced']):
                     break
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_sync_already_existing_snapshots(self):
+        """
+        That mirroring syncs the already existing snapshot correctly.
+        """
+        log.debug('reconfigure client auth caps')
+        self.get_ceph_cmd_result(
+            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
+                'mds', 'allow rw',
+                'mon', 'allow r',
+                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
+                    self.backup_fs.get_data_pool_name(),
+                    self.backup_fs.get_data_pool_name()))
+
+        log.debug(f'mounting filesystem {self.secondary_fs_name}')
+        self.mount_b.umount_wait()
+        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+
+        dir_name = 'dir'
+
+        # make some change in the fs and take a snapshot
+        snap_a = "snap_a"
+        self.mount_a.run_shell(['mkdir', '-p', f'{dir_name}/d1'])
+        self.mount_a.write_n_mb(os.path.join(f'{dir_name}/d1', 'file1'), 1)
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_a}'])
+
+        # make some more changes in the fs and take another snapshot
+        snap_b = "snap_b"
+        self.mount_a.write_n_mb(os.path.join(f'{dir_name}/d1', 'file2'), 1)
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_b}'])
+
+        # make another change in the fs and don't take snapshot
+        self.mount_a.run_shell(['rm', f'{dir_name}/d1/file2'])
+
+        # add the directory for mirroring
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        time.sleep(60)
+
+        # confirm snapshot synced and status 'idle'
+        expected_snap_count = 2
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap_b, expected_snap_count)
+        self.verify_snapshot(dir_name, snap_a)
+        self.verify_snapshot(dir_name, snap_b)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -70,12 +70,6 @@ std::string entry_path(const std::string &dir, const std::string &name) {
   return dir + "/" + name;
 }
 
-std::string entry_diff_path(const std::string &dir, const std::string &name) {
-  if (dir == ".")
-    return name;
-  return dir + "/" + name;
-}
-
 std::map<std::string, std::string> decode_snap_metadata(snap_metadata *snap_metadata,
                                                         size_t nr_snap_metadata) {
   std::map<std::string, std::string> metadata;
@@ -1448,7 +1442,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   std::queue<SyncEntry> sync_queue;
 
   //start with initial/default entry
-  std::string epath = ".", npath = "", nabs_path = "", nname = "";
+  std::string epath = ".", npath = "", nname = "";
   sync_queue.emplace(SyncEntry(epath, cstx));
 
   while (!sync_queue.empty()) {
@@ -1483,19 +1477,17 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       if ("." == nname || ".." == nname)
         continue;
       // create path for the newly found entry
-      npath = entry_diff_path(epath, nname);
-      nabs_path = entry_diff_path(dir_root, npath);
-
-      r = ceph_statx(sd_info.cmount, nabs_path.c_str(), &cstx,
-                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                     CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+      npath = entry_path(epath, nname);
+      r = ceph_statxat(m_local_mount, fh.c_fd, npath.c_str(), &cstx,
+                       CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                       CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                       AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
       if (r < 0) {
         // can't stat, so it's a deleted entry.
         if (DT_DIR == sd_entry.dir_entry.d_type) { // is a directory
           r = cleanup_remote_dir(dir_root, npath, fh);
           if (r < 0) {
-            derr << ": failed to remove directory=" << nabs_path << dendl;
+            derr << ": failed to remove directory=" << npath << dendl;
             break;
           }
         }
@@ -1508,17 +1500,17 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       } else {
         // stat success, update the existing entry
         struct ceph_statx tstx;
-        int rstat_r = ceph_statx(m_remote_mount, nabs_path.c_str(), &tstx,
-                                 CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                                 CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                                 AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+        int rstat_r = ceph_statxat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), &tstx,
+                                   CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                                   CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                                   AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
         if (S_ISDIR(cstx.stx_mode)) { // is a directory
           //cleanup if it's a file in the remotefs
           if ((0 == rstat_r) && !S_ISDIR(tstx.stx_mode)) {
             r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), 0);
             if (r < 0) {
               derr << ": Error in directory sync. Failed to remove file="
-                   << nabs_path << dendl;
+                   << npath << dendl;
               break;
             }
           }
@@ -1543,7 +1535,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
               r = cleanup_remote_dir(dir_root, npath, fh);
               if (r < 0) {
                 derr << ": Error in file sync. Failed to remove remote directory="
-                     << nabs_path << dendl;
+                     << npath << dendl;
                 break;
               }
             }

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -310,6 +310,7 @@ private:
   int pre_sync_check_and_open_handles(const std::string &dir_root, const Snapshot &current,
                                       boost::optional<Snapshot> prev, FHandles *fh);
 
+  int validate_source(const std::string &dir_root, boost::optional<Snapshot> prev, FHandles *fh);
   int do_synchronize(const std::string &dir_root, const Snapshot &current,
                      boost::optional<Snapshot> prev);
 


### PR DESCRIPTION
This avoids considering latest changes from the source filesystem for
the mirroring of already existing snapshots. Thus the destination filesystem 
and snapshots would be created based only on the source snapshots. 
The destination fs would be a replica of the last snapshot taken.

To check this, do:

```
$ sudo ./bin/mount.ceph admin@.a=/ /mnt/cephfs1 -o conf=$(pwd)/ceph.conf;
$ sudo ./bin/mount.ceph admin@.remotefs=/ /mnt/cephfs2 -o conf=$(pwd)/ceph.conf;
```

Make some changes and take a snapshot:
```
$ mkdir -p /mnt/cephfs1/dir/d1
$ touch /mnt/cephfs1/dir/d1/file1
$ mkdir -p /mnt/cephfs1/dir/.snap/snap1; 
```

Make some more changes & take another snapshot:
```
$ touch /mnt/cephfs1/dir/d1/file2
$ mkdir -p /mnt/cephfs1/dir/.snap/snap2;
```

Make a change and don't take snapshot:
`
$ rm /mnt/cephfs1/dir/d1/file2
`

Add `dir` for mirroring:
$ `./bin/ceph fs snapshot mirror add a /dir
`

Results:
```
$ tree /mnt/cephfs1/dir/.snap
/mnt/cephfs1/dir/.snap
├── snap1
│   └── d1
│       └── file1
└── snap2
    └── d1
        ├── file1
        └── file2
```

```
$ tree /mnt/cephfs2/dir/.snap
/mnt/cephfs2/dir/.snap
├── snap1
│   └── d1
│       └── file1
└── snap2
    └── d1
        ├── file1
        └── file2
```

```
$ tree /mnt/cephfs1/dir
/mnt/cephfs1/dir
└── d1
    └── file1
```

```
$ tree /mnt/cephfs2/dir
/mnt/cephfs2/dir
└── d1
    ├── file1
    └── file2
```

Fixes: https://tracker.ceph.com/issues/68567
Fixes: https://tracker.ceph.com/issues/69671






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>