### PR TITLE
rgw: add missing last_modified field to swift api

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1263,6 +1263,7 @@ struct RGWBucketEnt {
   size_t size;
   size_t size_rounded;
   ceph::real_time creation_time;
+  ceph::real_time modification_time;
   uint64_t count;
 
   /* The placement_rule is necessary to calculate per-storage-policy statics

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -327,7 +327,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_data(rgw::sal::BucketList& buc
   }
 }
 
-void RGWListBuckets_ObjStore_SWIFT::dump_bucket_entry(const rgw::sal::Bucket& bucket)
+void RGWListBuckets_ObjStore_SWIFT::dump_bucket_entry(rgw::sal::Bucket& bucket)
 {
   s->formatter->open_object_section("container");
   s->formatter->dump_string("name", bucket.get_name());
@@ -335,6 +335,7 @@ void RGWListBuckets_ObjStore_SWIFT::dump_bucket_entry(const rgw::sal::Bucket& bu
   if (need_stats) {
     s->formatter->dump_int("count", bucket.get_count());
     s->formatter->dump_int("bytes", bucket.get_size());
+    dump_time(s, "last_modified", bucket.get_modification_time());
   }
 
   s->formatter->close_section();

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -57,7 +57,7 @@ public:
   void send_response_begin(bool has_buckets) override;
   void send_response_data(rgw::sal::BucketList& buckets) override;
   void send_response_data_reversed(rgw::sal::BucketList& buckets);
-  void dump_bucket_entry(const rgw::sal::Bucket& obj);
+  void dump_bucket_entry(rgw::sal::Bucket& obj);
   void send_response_end() override;
 
   bool should_get_stats() override { return need_stats; }

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -88,6 +88,7 @@ class StoreBucket : public Bucket {
       info.bucket = ent.bucket;
       info.placement_rule = ent.placement_rule;
       info.creation_time = ent.creation_time;
+      mtime = ent.modification_time;
     }
     StoreBucket(const RGWBucketInfo& _i) : info(_i) {
       ent.bucket = info.bucket;
@@ -100,6 +101,7 @@ class StoreBucket : public Bucket {
       info.bucket = ent.bucket;
       info.placement_rule = ent.placement_rule;
       info.creation_time = ent.creation_time;
+      mtime = ent.modification_time;
     }
     StoreBucket(const RGWBucketInfo& _i, User* _u) : info(_i), owner(_u) {
       ent.bucket = info.bucket;

--- a/src/rgw/services/svc_bucket_sobj.cc
+++ b/src/rgw/services/svc_bucket_sobj.cc
@@ -617,7 +617,7 @@ int RGWSI_Bucket_SObj::read_bucket_stats(RGWSI_Bucket_X_Ctx& ctx,
                                          const DoutPrefixProvider *dpp)
 {
   RGWBucketInfo bucket_info;
-  int ret = read_bucket_info(ctx, bucket, &bucket_info, nullptr, nullptr, boost::none, y, dpp);
+  int ret = read_bucket_info(ctx, bucket, &bucket_info, &ent->modification_time, nullptr, boost::none, y, dpp);
   if (ret < 0) {
     return ret;
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/69587

Upstream PR: https://github.com/ceph/ceph/pull/61157

Upstream issue: https://tracker.ceph.com/issues/68195

This PR is a backport of mentioned upstream PR. 

It adds `last_modified` JSON field to the Swift bucket listing response.

It is present in [Swift API spec](https://docs.openstack.org/api-ref/object-store/), but currently is missing in the RGW response.

Result looks the following way
```bash
# PR affects output of this request, last_modified field is added
curl -v -XGET 127.0.0.1:8080/swift/v1/AUTH_2421cecf177b41f683bdcd09338f1ebd -H "X-Auth-Token: ${OS_AUTH_TOKEN}" -H "Accept: application/json" 
…
[{"name":"bucket1","count":1,"bytes":2814,"last_modified":"2024-12-11T13:44:15.761Z"}]

# A request on concrete bucket is listed to show consistency
curl -v -XGET 127.0.0.1:8080/swift/v1/AUTH_2421cecf177b41f683bdcd09338f1ebd/bucket1 -H "X-Auth- Token: ${OS_AUTH_TOKEN}" -H "Accept: application/json" 
…
Last-Modified: Wed, 11 Dec 2024 13:44:15 GMT 
…
```

Changes to the original cherry-picked commit were required due to following reasons

1. `read_bucket_info` function signatures differ. Method in `reef` has `RGWSI_Bucket_X_Ctx&` argument, while method in `main` doesn't.

In [main](https://github.com/ceph/ceph/blob/main/src/rgw/services/svc_bucket_sobj.cc#L323).
```
int RGWSI_Bucket_SObj::read_bucket_info(const rgw_bucket& bucket,
                                        RGWBucketInfo *info,
                                        real_time *pmtime,
                                        map<string, bufferlist> *pattrs,
                                        boost::optional<obj_version> refresh_version,
                                        optional_yield y,
                                        const DoutPrefixProvider *dpp)
```

In [reef](https://github.com/ceph/ceph/blob/reef/src/rgw/services/svc_bucket_sobj.cc#L374)
```
int RGWSI_Bucket_SObj::read_bucket_info(RGWSI_Bucket_X_Ctx& ctx,
                                        const rgw_bucket& bucket,
                                        RGWBucketInfo *info,
                                        real_time *pmtime,
                                        map<string, bufferlist> *pattrs,
                                        boost::optional<obj_version> refresh_version,
                                        optional_yield y,
                                        const DoutPrefixProvider *dpp)
```

2. `dump_bucket_entry` in `main` accepts `RGWBucketEnt` as an argument, while one in `reef` accepts `rgw::sal::Bucket`

In [main](https://github.com/ceph/ceph/blob/main/src/rgw/rgw_rest_swift.h#L53)
```
  void dump_bucket_entry(const RGWBucketEnt& ent);
```

In [reef](https://github.com/ceph/ceph/blob/reef/src/rgw/rgw_rest_swift.h#L60)
```
void dump_bucket_entry(const rgw::sal::Bucket& obj);
```

3. `dump_bucket_entry` in reef accepts `rgw::sal::Bucket` as `const`, therefore it is not possible to call `get_modification_time` on it, because it returns the reference.

In [reef](https://github.com/ceph/ceph/blob/reef/src/rgw/rgw_rest_swift.h#L60)

```
void dump_bucket_entry(const rgw::sal::Bucket& obj);
```

Changed to 

```
void dump_bucket_entry(rgw::sal::Bucket& obj);
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
