### PR TITLE
cephfs,mon: don't disallow "mds/fs fail" when other MDS/FS has health warning

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -165,11 +165,18 @@ class TestAdminCommands(CephFSTestCase):
         if overwrites:
             self.run_ceph_cmd('osd', 'pool', 'set', n+"-data", 'allow_ec_overwrites', 'true')
 
-    def gen_health_warn_mds_cache_oversized(self):
+    def gen_health_warn_mds_cache_oversized(self, mds_id=None):
         health_warn = 'MDS_CACHE_OVERSIZED'
 
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
+        # cs_name = config section name
+        cs_name = None   # declaring here in case no if/elif condition is true
+        if mds_id:
+            cs_name = f'mds.{mds_id}'
+        elif not mds_id:
+            cs_name = 'mds'
+
+        self.config_set(cs_name, 'mds_cache_memory_limit', '1K')
+        self.config_set(cs_name, 'mds_health_cache_threshold', '1.00000')
         self.mount_a.open_n_background('.', 400)
 
         self.wait_for_health(health_warn, 30)

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -165,15 +165,21 @@ class TestAdminCommands(CephFSTestCase):
         if overwrites:
             self.run_ceph_cmd('osd', 'pool', 'set', n+"-data", 'allow_ec_overwrites', 'true')
 
-    def gen_health_warn_mds_cache_oversized(self, mds_id=None):
+    def gen_health_warn_mds_cache_oversized(self, mds_id=None, fs=None):
         health_warn = 'MDS_CACHE_OVERSIZED'
 
         # cs_name = config section name
         cs_name = None   # declaring here in case no if/elif condition is true
-        if mds_id:
+        if mds_id and not fs:
             cs_name = f'mds.{mds_id}'
-        elif not mds_id:
+        elif not mds_id and fs:
+            mds_id = self.fs.get_active_names()[0]
+            cs_name = f'mds.{mds_id}'
+        elif not mds_id and not fs:
             cs_name = 'mds'
+        elif mds_id and fs:
+            raise RuntimeError('Makes no sense to pass both, mds_id as well as '
+                               'FS object')
 
         self.config_set(cs_name, 'mds_cache_memory_limit', '1K')
         self.config_set(cs_name, 'mds_health_cache_threshold', '1.00000')

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -2613,7 +2613,7 @@ class TestFSFail(TestAdminCommands):
 class TestMDSFail(TestAdminCommands):
 
     MDSS_REQUIRED = 2
-    CLIENTS_REQUIRED = 1
+    CLIENTS_REQUIRED = 2
 
     def test_with_health_warn_cache_oversized(self):
         '''
@@ -2690,6 +2690,51 @@ class TestMDSFail(TestAdminCommands):
                               errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {mds1_id} --yes-i-really-mean-it')
         self.run_ceph_cmd(f'mds fail {mds2_id} --yes-i-really-mean-it')
+
+    def test_when_other_MDS_has_warn_TRIM(self):
+        '''
+        Test that "mds fail" runs successfully for a MDS when a MDS which is
+        active for a different FS has health warning MDS_TRIM.
+        '''
+        self.fs1 = self.fs
+
+        self.fs2 = self.fs.newfs(name='cephfs2', create=True)
+        self.mount_b.remount(fsname=self.fs2.name)
+        self.mount_b.wait_until_mounted()
+
+        # generates health warning for self.fs1
+        self.gen_health_warn_mds_trim()
+
+        active_mds_id = self.fs2.get_active_names()[0]
+        # actual testing begins now.
+        self.run_ceph_cmd(f'mds fail {active_mds_id}')
+
+        # Bring and wait for MDS to be up since it is needed for unmounting
+        # of CephFS in CephFSTestCase.tearDown() to be successful.
+        self.fs.set_joinable()
+        self.fs.wait_for_daemons()
+
+    def test_when_other_MDS_has_warn_CACHE_OVERSIZED(self):
+        '''
+        Test that "mds fail" runs successfully for a MDS when a MDS which is
+        active for a different FS has health warning MDS_CACHE_OVERSIZED.
+        '''
+        self.fs1 = self.fs
+
+        self.fs2 = self.fs.newfs(name='cephfs2', create=True)
+        self.mount_b.remount(fsname=self.fs2.name)
+        self.mount_b.wait_until_mounted()
+
+        # actual testing begins now.
+        mds_id_for_fs1 = self.fs1.get_active_names()[0]
+        self.gen_health_warn_mds_cache_oversized(mds_id=mds_id_for_fs1)
+        mds_id_for_fs2 = self.fs2.get_active_names()[0]
+        self.run_ceph_cmd(f'mds fail {mds_id_for_fs2}')
+
+        # Bring and wait for MDS to be up since it is needed for unmounting
+        # of CephFS in CephFSTestCase.tearDown() to be successful.
+        self.fs.set_joinable()
+        self.fs.wait_for_daemons()
 
 
 class TestFSSetMaxMDS(TestAdminCommands):
@@ -2928,3 +2973,4 @@ class TestToggleVolumes(CephFSTestCase):
         # plugin is reported properly by "ceph mgr module ls" command, check if
         # it is also working fine.
         self.run_ceph_cmd('fs volume ls')
+

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -2554,7 +2554,7 @@ class TestPermErrMsg(CephFSTestCase):
 class TestFSFail(TestAdminCommands):
 
     MDSS_REQUIRED = 2
-    CLIENTS_REQUIRED = 1
+    CLIENTS_REQUIRED = 2
 
     def test_with_health_warn_cache_oversized(self):
         '''
@@ -2609,6 +2609,48 @@ class TestFSFail(TestAdminCommands):
         self.negtest_ceph_cmd(args=f'fs fail {self.fs.name}',
                               retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'fs fail {self.fs.name} --yes-i-really-mean-it')
+
+        # Bring and wait for MDS to be up since it is needed for unmounting
+        # of CephFS in CephFSTestCase.tearDown() to be successful.
+        self.fs.set_joinable()
+        self.fs.wait_for_daemons()
+
+    def test_when_other_FS_has_warn_TRIM(self):
+        '''
+        Test that "fs fail" runs successfully for an FS when a MDS which is
+        active for a different FS has health warning MDS_TRIM.
+        '''
+        self.fs1 = self.fs
+
+        self.fs2 = self.fs.newfs(name='cephfs2', create=True)
+        self.mount_b.remount(fsname=self.fs2.name)
+        self.mount_b.wait_until_mounted()
+
+        # generates health warning for self.fs1
+        self.gen_health_warn_mds_trim()
+
+        # actual testing begins now.
+        self.run_ceph_cmd(f'fs fail {self.fs2.name}')
+
+        # Bring and wait for MDS to be up since it is needed for unmounting
+        # of CephFS in CephFSTestCase.tearDown() to be successful.
+        self.fs.set_joinable()
+        self.fs.wait_for_daemons()
+
+    def test_when_other_FS_has_warn_CACHE_OVERSIZED(self):
+        '''
+        Test that "fs fail" runs successfully for an FS when a MDS which is
+        active for a different FS) has health warning MDS_CACHE_OVERSIZED.
+        '''
+        self.fs1 = self.fs
+
+        self.fs2 = self.fs.newfs(name='cephfs2', create=True)
+        self.mount_b.remount(fsname=self.fs2.name)
+        self.mount_b.wait_until_mounted()
+
+        # actual testing begins now.
+        self.gen_health_warn_mds_cache_oversized(fs=self.fs1)
+        self.run_ceph_cmd(f'fs fail {self.fs2.name}')
 
         # Bring and wait for MDS to be up since it is needed for unmounting
         # of CephFS in CephFSTestCase.tearDown() to be successful.
@@ -2979,4 +3021,3 @@ class TestToggleVolumes(CephFSTestCase):
         # plugin is reported properly by "ceph mgr module ls" command, check if
         # it is also working fine.
         self.run_ceph_cmd('fs volume ls')
-

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -108,14 +108,14 @@ class FailHandler : public FileSystemCommandHandler
       return -ENOENT;
     }
 
-  bool confirm = false;
-  cmd_getval(cmdmap, "yes_i_really_mean_it", confirm);
-  if (!confirm &&
-      mon->mdsmon()->has_health_warnings({
-	MDS_HEALTH_TRIM, MDS_HEALTH_CACHE_OVERSIZED})) {
-    ss << errmsg_for_unhealthy_mds;
-    return -EPERM;
-  }
+    bool confirm = false;
+    cmd_getval(cmdmap, "yes_i_really_mean_it", confirm);
+    if (!confirm &&
+	mon->mdsmon()->has_health_warnings({
+	  MDS_HEALTH_TRIM, MDS_HEALTH_CACHE_OVERSIZED})) {
+      ss << errmsg_for_unhealthy_mds;
+      return -EPERM;
+    }
 
     auto f = [](auto&& fs) {
       fs.get_mds_map().set_flag(CEPH_MDSMAP_NOT_JOINABLE);

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -122,15 +122,15 @@ class FailHandler : public FileSystemCommandHandler
     };
     fsmap.modify_filesystem(fsp->get_fscid(), std::move(f));
 
-    vector<mds_gid_t> to_fail;
+    vector<mds_gid_t> mds_gids_to_fail;
     for (const auto& p : fsp->get_mds_map().get_mds_info()) {
-      to_fail.push_back(p.first);
+      mds_gids_to_fail.push_back(p.first);
     }
 
-    for (const auto& gid : to_fail) {
+    for (const auto& gid : mds_gids_to_fail) {
       mon->mdsmon()->fail_mds_gid(fsmap, gid);
     }
-    if (!to_fail.empty()) {
+    if (!mds_gids_to_fail.empty()) {
       mon->osdmon()->propose_pending();
     }
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1548,7 +1548,7 @@ out:
   }
 }
 
-bool MDSMonitor::has_health_warnings(vector<mds_metric_t> warnings, const mds_gid_t& gid)
+bool MDSMonitor::has_health_warnings(const vector<mds_metric_t>& warnings, const mds_gid_t& gid)
 {
   for (auto& [_gid, health] : pending_daemon_health) {
     if (gid != MDS_GID_NONE) {

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1548,7 +1548,7 @@ out:
   }
 }
 
-bool MDSMonitor::has_health_warnings(vector<mds_metric_t> warnings, mds_gid_t gid)
+bool MDSMonitor::has_health_warnings(vector<mds_metric_t> warnings, const mds_gid_t& gid)
 {
   for (auto& [_gid, health] : pending_daemon_health) {
     if (gid != MDS_GID_NONE) {
@@ -1568,6 +1568,17 @@ bool MDSMonitor::has_health_warnings(vector<mds_metric_t> warnings, mds_gid_t gi
     }
   }
 
+  return false;
+}
+
+bool MDSMonitor::has_health_warnings(const vector<mds_metric_t>& warnings,
+				     const std::vector<mds_gid_t>& gids)
+{
+  for (auto& gid : gids) {
+    if (has_health_warnings(warnings, gid)) {
+      return true;
+    }
+  }
   return false;
 }
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1548,9 +1548,15 @@ out:
   }
 }
 
-bool MDSMonitor::has_health_warnings(vector<mds_metric_t> warnings)
+bool MDSMonitor::has_health_warnings(vector<mds_metric_t> warnings, mds_gid_t gid)
 {
-  for (auto& [gid, health] : pending_daemon_health) {
+  for (auto& [_gid, health] : pending_daemon_health) {
+    if (gid != MDS_GID_NONE) {
+      if (gid != mds_gid_t(_gid)) {
+	continue;
+      }
+    }
+
     for (auto& metric : health.metrics) {
       // metric.type here is the type of health warning. We are only
       // looking for types of health warnings passed to this func member
@@ -1631,7 +1637,7 @@ int MDSMonitor::filesystem_command(
     }
 
     if (!confirm &&
-        has_health_warnings({MDS_HEALTH_TRIM, MDS_HEALTH_CACHE_OVERSIZED})) {
+        has_health_warnings({MDS_HEALTH_TRIM, MDS_HEALTH_CACHE_OVERSIZED}, gid)) {
       ss << errmsg_for_unhealthy_mds;
       return -EPERM;
     }

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -52,7 +52,7 @@ class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHand
   bool preprocess_query(MonOpRequestRef op) override;  // true if processed.
   bool prepare_update(MonOpRequestRef op) override;
   bool should_propose(double& delay) override;
-  bool has_health_warnings(std::vector<mds_metric_t> warnings,
+  bool has_health_warnings(const std::vector<mds_metric_t>& warnings,
 			   const mds_gid_t& gid=MDS_GID_NONE);
   bool has_health_warnings(const std::vector<mds_metric_t>& warnings,
 			   const std::vector<mds_gid_t>& gids);

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -53,7 +53,9 @@ class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHand
   bool prepare_update(MonOpRequestRef op) override;
   bool should_propose(double& delay) override;
   bool has_health_warnings(std::vector<mds_metric_t> warnings,
-			   mds_gid_t gid=MDS_GID_NONE);
+			   const mds_gid_t& gid=MDS_GID_NONE);
+  bool has_health_warnings(const std::vector<mds_metric_t>& warnings,
+			   const std::vector<mds_gid_t>& gids);
   bool has_any_health_warning();
 
   bool should_print_status() const {

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -52,7 +52,8 @@ class MDSMonitor : public PaxosService, public PaxosFSMap, protected CommandHand
   bool preprocess_query(MonOpRequestRef op) override;  // true if processed.
   bool prepare_update(MonOpRequestRef op) override;
   bool should_propose(double& delay) override;
-  bool has_health_warnings(std::vector<mds_metric_t> warnings);
+  bool has_health_warnings(std::vector<mds_metric_t> warnings,
+			   mds_gid_t gid=MDS_GID_NONE);
   bool has_any_health_warning();
 
   bool should_print_status() const {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/69694
Fixes: https://tracker.ceph.com/issues/69707

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>