### PR TITLE
rgw/lua: Fix Lua background thread execution timing and config updates

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -24,6 +24,10 @@ An execution of a script in a context can use up to 500K byte of memory. This in
 To change this default value, use the ``rgw_lua_max_memory_per_state`` configuration parameter. Note that the basic overhead of Lua with its standard libraries is ~32K bytes. To disable the limit, use zero.
 By default, the execution of a Lua script is limited to a maximum runtime of 1000 milliseconds. This limit can be changed using the ``rgw_lua_max_runtime_per_state`` configuration parameter. If a Lua script exceeds this runtime, it will be terminated. To disable the runtime limit, use zero.
 
+.. warning:: Be cautious when modifying the memory limit. If the current memory usage exceeds the newly set limit, all previously stored data in the background state will be lost.
+
+.. warning:: Disabling the runtime limit may result in unbounded script execution, which can lead to excessive resource consumption and potentially impact the RADOS gateway's availability.
+
 By default, all Lua standard libraries are available in the script, however, in order to allow for additional Lua modules to be used in the script, we support adding packages to an allowlist:
 
   - Adding a Lua package to the allowlist, or removing a packge from it does not install or remove it. For the changes to take affect a "reload" command should be called.

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -107,6 +107,30 @@ int Background::read_script() {
   return rgw::lua::read_script(&dp, lua_manager, tenant, null_yield, rgw::lua::context::background, rgw_script);
 }
 
+std::unique_ptr<lua_state_guard> Background::initialize_lguard_state() {
+  auto lguard = std::make_unique<lua_state_guard>(
+      cct->_conf->rgw_lua_max_memory_per_state,
+      cct->_conf->rgw_lua_max_runtime_per_state, &dp);
+  lua_State* L = lguard->get();
+  if (!L) {
+    ldpp_dout(&dp, 1) << "Failed to create state for Lua background thread"
+                      << dendl;
+    return nullptr;
+  }
+  try {
+    open_standard_libs(L);
+    set_package_path(L, lua_manager->luarocks_path());
+    create_debug_action(L, cct);
+    create_background_metatable(L);
+  } catch (const std::runtime_error& e) {
+    ldpp_dout(&dp, 1)
+        << "Failed to create initial setup of Lua background thread. error "
+        << e.what() << dendl;
+    return nullptr;
+  }
+  return lguard;
+}
+
 const BackgroundMapValue Background::empty_table_value;
 
 const BackgroundMapValue& Background::get_table_value(const std::string& key) const {
@@ -124,21 +148,8 @@ const BackgroundMapValue& Background::get_table_value(const std::string& key) co
 void Background::run() {
   ceph_pthread_setname("lua_background");
   const DoutPrefixProvider* const dpp = &dp;
-  lua_state_guard lguard(cct->_conf->rgw_lua_max_memory_per_state,
-                         cct->_conf->rgw_lua_max_runtime_per_state, dpp);
-  auto L = lguard.get();
-  if (!L) {
-    ldpp_dout(dpp, 1) << "Failed to create state for Lua background thread" << dendl;
-    return;
-  }
-  try {
-    open_standard_libs(L);
-  set_package_path(L, lua_manager->luarocks_path());
-    create_debug_action(L, cct);
-    create_background_metatable(L);
-  } catch (const std::runtime_error& e) { 
-    ldpp_dout(dpp, 1) << "Failed to create initial setup of Lua background thread. error " 
-      << e.what() << dendl;
+  std::unique_ptr<lua_state_guard> lguard = initialize_lguard_state();
+  if (!lguard) {
     return;
   }
 
@@ -153,8 +164,20 @@ void Background::run() {
       }
       ldpp_dout(dpp, 10) << "Lua background thread resumed" << dendl;
     }
-    
-    lguard.reset_start_time();
+    const std::size_t max_memory = cct->_conf->rgw_lua_max_memory_per_state;
+    const std::uint64_t max_runtime = cct->_conf->rgw_lua_max_runtime_per_state;
+    auto res = lguard->set_max_memory(max_memory);
+    if (!res) {
+      ldpp_dout(dpp, 10)
+          << "Lua state required reset due to memory limit change" << dendl;
+      lguard = initialize_lguard_state();
+      if (!lguard) {
+        return;
+      }
+      ldpp_dout(dpp, 10) << "Lua state restarted seccessfully." << dendl;
+    }
+    lguard->set_max_runtime(max_runtime);
+    lguard->reset_start_time();
     const auto rc = read_script();
     if (rc == -ENOENT || rc == -EAGAIN) {
       // either no script or paused, nothing to do
@@ -162,6 +185,7 @@ void Background::run() {
       ldpp_dout(dpp, 1) << "WARNING: failed to read background script. error " << rc << dendl;
     } else {
       auto failed = false;
+      auto L = lguard->get();
       try {
         //execute the background lua script
         if (luaL_dostring(L, rgw_script.c_str()) != LUA_OK) {

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -154,6 +154,7 @@ void Background::run() {
       ldpp_dout(dpp, 10) << "Lua background thread resumed" << dendl;
     }
     
+    lguard.reset_start_time();
     const auto rc = read_script();
     if (rc == -ENOENT || rc == -EAGAIN) {
       // either no script or paused, nothing to do

--- a/src/rgw/rgw_lua_background.h
+++ b/src/rgw/rgw_lua_background.h
@@ -155,8 +155,9 @@ private:
 
   std::string rgw_script;
   int read_script();
+  std::unique_ptr<lua_state_guard> initialize_lguard_state();
 
-public:
+ public:
   Background(rgw::sal::Driver* _driver,
       CephContext* _cct,
       rgw::sal::LuaManager* _lua_manager,

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -70,7 +70,7 @@ void stack_dump(lua_State* L);
 class lua_state_guard {
   const std::size_t max_memory;
   const std::chrono::milliseconds max_runtime;
-  const ceph::real_clock::time_point start_time;
+  ceph::real_clock::time_point start_time;
   const DoutPrefixProvider* const dpp;
   lua_State* const state;
 
@@ -82,6 +82,7 @@ class lua_state_guard {
                   const DoutPrefixProvider* _dpp);
   ~lua_state_guard();
   lua_State* get() { return state; }
+  void reset_start_time() { start_time = ceph::real_clock::now(); }
 };
 
 int dostring(lua_State* L, const char* str);

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -68,8 +68,9 @@ inline void unsetglobal(lua_State* L, const char* name)
 void stack_dump(lua_State* L);
 
 class lua_state_guard {
-  const std::size_t max_memory;
-  const std::chrono::milliseconds max_runtime;
+  std::size_t max_memory;
+  std::size_t mem_in_use;
+  std::chrono::milliseconds max_runtime;
   ceph::real_clock::time_point start_time;
   const DoutPrefixProvider* const dpp;
   lua_State* const state;
@@ -83,6 +84,13 @@ class lua_state_guard {
   ~lua_state_guard();
   lua_State* get() { return state; }
   void reset_start_time() { start_time = ceph::real_clock::now(); }
+
+  std::size_t get_max_memory() const { return max_memory; }
+  std::size_t get_mem_in_use() const { return mem_in_use; }
+  std::chrono::milliseconds get_max_runtime() const { return max_runtime; }
+  bool set_max_memory(std::size_t _max_memory);
+  void set_mem_in_use(std::size_t _mem_in_use);
+  void set_max_runtime(std::uint64_t _max_runtime);
 };
 
 int dostring(lua_State* L, const char* str);


### PR DESCRIPTION
This PR includes two fixes for the Lua background thread in RADOS Gateway:

1. **Reset start time for accurate execution time limit:**  
   - Fixed an issue where the execution time limit was incorrectly applied across multiple runs.  
   - Introduced `reset_start_time()` in `rgw_lua_utils.h`.  
   - Updated `rgw_lua_background.cc` to call `reset_start_time()` before each script execution.  

2. **Ensure background thread updates config changes dynamically:**  
   - Added setters/getters for max memory and runtime limits in `lua_state_guard`.  
   - Implemented logic to update limits when configuration changes.  
   - Apply the new memory limit within the same Lua state when possible; otherwise, reset Lua state with new memory limit.

3. **memory leak check:**  
   - Added a memory leak check after Lua cleanup to ensure proper resource deallocation.

References commit: #61282 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
