### PR TITLE
rgw/cloudtier: Correct option ordering in RGWZoneGroupPlacementTier

### DIFF
--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -548,26 +548,27 @@ struct RGWZoneGroupPlacementTier {
   std::string tier_type;
   std::string storage_class;
   bool retain_head_object = false;
-  bool allow_read_through = false;
-  uint64_t read_through_restore_days = 1;
 
   struct _tier {
     RGWZoneGroupPlacementTierS3 s3;
   } t;
 
+  bool allow_read_through = false;
+  uint64_t read_through_restore_days = 1;
+
   int update_params(const JSONFormattable& config);
   int clear_params(const JSONFormattable& config);
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(tier_type, bl);
     encode(storage_class, bl);
     encode(retain_head_object, bl);
-    encode(allow_read_through, bl);
-    encode(read_through_restore_days, bl);
     if (tier_type == "cloud-s3") {
       encode(t.s3, bl);
     }
+    encode(allow_read_through, bl);
+    encode(read_through_restore_days, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -576,12 +577,22 @@ struct RGWZoneGroupPlacementTier {
     decode(tier_type, bl);
     decode(storage_class, bl);
     decode(retain_head_object, bl);
-    if (struct_v >= 2) {
+    if (struct_v == 1) {
+      if (tier_type == "cloud-s3") {
+        decode(t.s3, bl);
+      }
+    } else if (struct_v == 2) {
       decode(allow_read_through, bl);
       decode(read_through_restore_days, bl);
-    }
-    if (tier_type == "cloud-s3") {
-      decode(t.s3, bl);
+      if (tier_type == "cloud-s3") {
+        decode(t.s3, bl);
+      }
+    } else if (struct_v >= 3) {
+      if (tier_type == "cloud-s3") {
+        decode(t.s3, bl);
+      }
+      decode(allow_read_through, bl);
+      decode(read_through_restore_days, bl);
     }
     DECODE_FINISH(bl);
   }


### PR DESCRIPTION
Two tier-config options (related to `cloud-restore`) were incorrectly added in the middle of the encoding and decoding methods of RGWZoneGroupPlacementTier. This modification can cause compatibility issues with older decoders when attempting to read v2-encoded REST objects.

The fix is to correct the option order and update the decode() function to properly interpret the structure based on the encoded version.

Fixes: https://tracker.ceph.com/issues/69713
Signed-off-by: Soumya Koduri <skoduri@redhat.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
