### PR TITLE
pybind/mgr/cephadm: fix issue with multiple nfs clusters on the same port

### DIFF
--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -97,11 +97,14 @@ class NFSService(CephService):
         # create the rados config object
         self.create_rados_config_obj(spec)
 
+        port = daemon_spec.ports[0] if daemon_spec.ports else 2049
+
         # create the RGW keyring
         rgw_user = f'{rados_user}-rgw'
         rgw_keyring = self.create_rgw_keyring(daemon_spec)
         if spec.virtual_ip:
             bind_addr = spec.virtual_ip
+            daemon_spec.port_ips = {str(port): spec.virtual_ip}
         else:
             bind_addr = daemon_spec.ip if daemon_spec.ip else ''
         if not bind_addr:
@@ -119,7 +122,7 @@ class NFSService(CephService):
                 "rgw_user": rgw_user,
                 "url": f'rados://{POOL_NAME}/{spec.service_id}/{spec.rados_config_name()}',
                 # fall back to default NFS port if not present in daemon_spec
-                "port": daemon_spec.ports[0] if daemon_spec.ports else 2049,
+                "port": port,
                 "monitoring_port": spec.monitoring_port if spec.monitoring_port else 9587,
                 "bind_addr": bind_addr,
                 "haproxy_hosts": [],


### PR DESCRIPTION
## Intro
Currently even if ingress and virtual_ip are used, the port_in_use check in cephadm fails when the same port is used. This PR fixes the issue by ensuring that the daemon spec includes the virtual ip address for the endpoint to be checked is included so it doesn't default to checking `0.0.0.0:port` only.

Fixes: https://tracker.ceph.com/issues/69744
Signed-off-by: Omid Yoosefi <omidyoosefi@ibm.com>



## Testing
```
nfs.nfs0.0.0.ceph-1.pathwr                                     ceph-1  *:2049   running (26s)     1s ago  25s    50.7M        -  5.7               b8cbbe39e657  2d821b2ab87f
nfs.nfs0.1.0.ceph-2.rwqvnb                                     ceph-2  *:2049   running (24s)     1s ago  24s    52.7M        -  5.7               b8cbbe39e657  af0e33576754
nfs.nfs0.2.0.ceph-3.ygcgnf                                     ceph-3  *:2049   running (22s)     1s ago  22s    52.7M        -  5.7               b8cbbe39e657  5102888cc279
nfs.nfs1.0.0.ceph-1.djihxv                                     ceph-1  *:2049   running (12s)     1s ago  12s    50.6M        -  5.7               b8cbbe39e657  7f1f4684697f
nfs.nfs1.1.0.ceph-2.wdsijn                                     ceph-2  *:2049   running (10s)     1s ago  10s    50.7M        -  5.7               b8cbbe39e657  1f93e78ba7f0
nfs.nfs1.2.0.ceph-3.uclfeg                                     ceph-3  *:2049   running (9s)      1s ago   8s    50.6M        -  5.7               b8cbbe39e657  1492b5765ca1
```

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
