### PR TITLE
rgw: log request_id on start new request

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -274,8 +274,10 @@ int process_request(const RGWProcessEnv& penv,
                     int* http_ret)
 {
   int ret = client_io->init(g_ceph_context);
+  rgw::sal::Driver* driver = penv.driver;
+  auto trans_id = driver->zone_unique_trans_id(req->id);
   dout(1) << "====== starting new request req=" << hex << req << dec
-	  << " =====" << dendl;
+          << " request_id=" << trans_id << " =====" << dendl;
   perfcounter->inc(l_rgw_req);
 
   RGWEnv& rgw_env = client_io->get_env();
@@ -285,7 +287,6 @@ int process_request(const RGWProcessEnv& penv,
 
   s->ratelimit_data = penv.ratelimiting->get_active();
 
-  rgw::sal::Driver* driver = penv.driver;
   std::unique_ptr<rgw::sal::User> u = driver->get_user(rgw_user());
   s->set_user(u);
 
@@ -296,11 +297,9 @@ int process_request(const RGWProcessEnv& penv,
   }
 
   s->req_id = driver->zone_unique_id(req->id);
-  s->trans_id = driver->zone_unique_trans_id(req->id);
+  s->trans_id = trans_id;
   s->host_id = driver->get_host_id();
   s->yield = yield;
-
-  ldpp_dout(s, 2) << "initializing for trans_id = " << s->trans_id << dendl;
 
   RGWOp* op = nullptr;
   int init_error = 0;


### PR DESCRIPTION
The log entry for "starting new request" may display the same hexadecimal value across multiple requests, making it difficult to pinpoint the exact start time of a request. Including the request ID in this log would facilitate easier identification of individual request start times.

Fixes: https://tracker.ceph.com/issues/69715