### PR TITLE
cephadm: move three functions out of cephadm.py

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -93,7 +93,7 @@ from cephadmlib.container_engines import (
 )
 from cephadmlib.data_utils import (
     dict_get_join,
-    get_legacy_config_fsid,
+    get_legacy_daemon_fsid,
     is_fsid,
     normalize_image_digest,
     try_convert_datetime,
@@ -736,27 +736,6 @@ def lookup_unit_name_by_daemon_name(ctx: CephadmContext, fsid: str, name: str) -
         return daemon['systemd_unit']
     except KeyError:
         raise Error('Failed to get unit name for {}'.format(daemon))
-
-
-def get_legacy_daemon_fsid(ctx, cluster,
-                           daemon_type, daemon_id, legacy_dir=None):
-    # type: (CephadmContext, str, str, Union[int, str], Optional[str]) -> Optional[str]
-    fsid = None
-    if daemon_type == 'osd':
-        try:
-            fsid_file = os.path.join(ctx.data_dir,
-                                     daemon_type,
-                                     'ceph-%s' % daemon_id,
-                                     'ceph_fsid')
-            if legacy_dir is not None:
-                fsid_file = os.path.abspath(legacy_dir + fsid_file)
-            with open(fsid_file, 'r') as f:
-                fsid = f.read().strip()
-        except IOError:
-            pass
-    if not fsid:
-        fsid = get_legacy_config_fsid(cluster, legacy_dir=legacy_dir)
-    return fsid
 
 
 def create_daemon_dirs(

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1633,7 +1633,6 @@ class CephadmAgent(DaemonForm):
         # not changed for any daemon, we assume our cached info is good.
         daemons: Dict[str, Dict[str, Any]] = {}
         data_dir = self.ctx.data_dir
-        seen_memusage = {}  # type: Dict[str, int]
         seen_memusage_cid_len, seen_memusage = parsed_container_mem_usage(self.ctx)
         # we need a mapping from container names to ids. Later we will convert daemon
         # names to container names to get daemons container id to see if it has changed
@@ -3446,8 +3445,6 @@ def list_daemons(
     seen_digests = {}   # type: Dict[str, List[str]]
 
     # keep track of memory and cpu usage we've seen
-    seen_memusage = {}  # type: Dict[str, int]
-    seen_cpuperc = {}  # type: Dict[str, str]
     seen_memusage_cid_len, seen_memusage = parsed_container_mem_usage(ctx)
     seen_cpuperc_cid_len, seen_cpuperc = parsed_container_cpu_perc(ctx)
 

--- a/src/cephadm/cephadmlib/data_utils.py
+++ b/src/cephadm/cephadmlib/data_utils.py
@@ -9,9 +9,10 @@ import logging
 
 from configparser import ConfigParser
 
-from typing import Dict, Any, Optional, Iterable, List
+from typing import Dict, Any, Optional, Iterable, List, Union
 
 from .constants import DATEFMT, DEFAULT_REGISTRY
+from .context import CephadmContext
 from .exceptions import Error
 
 
@@ -203,6 +204,30 @@ def get_legacy_config_fsid(
         ):
             return config.get('global', 'fsid')
     return None
+
+
+def get_legacy_daemon_fsid(
+    ctx: CephadmContext,
+    cluster: str,
+    daemon_type: str,
+    daemon_id: Union[int, str],
+    legacy_dir: Optional[str] = None,
+) -> Optional[str]:
+    fsid = None
+    if daemon_type == 'osd':
+        try:
+            fsid_file = os.path.join(
+                ctx.data_dir, daemon_type, 'ceph-%s' % daemon_id, 'ceph_fsid'
+            )
+            if legacy_dir is not None:
+                fsid_file = os.path.abspath(legacy_dir + fsid_file)
+            with open(fsid_file, 'r') as f:
+                fsid = f.read().strip()
+        except IOError:
+            pass
+    if not fsid:
+        fsid = get_legacy_config_fsid(cluster, legacy_dir=legacy_dir)
+    return fsid
 
 
 def _extract_host_info_from_applied_spec(

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -1,3 +1,4 @@
+import contextlib
 import mock
 import os
 import pytest
@@ -163,25 +164,24 @@ def with_cephadm_ctx(
         hostname = 'host1'
 
     _cephadm = import_cephadm()
-    with mock.patch('cephadmlib.net_utils.attempt_bind'), \
-         mock.patch('cephadmlib.call_wrappers.call', return_value=('', '', 0)), \
-         mock.patch('cephadmlib.call_wrappers.call_timeout', return_value=0), \
-         mock.patch('cephadm.call', return_value=('', '', 0)), \
-         mock.patch('cephadm.call_timeout', return_value=0), \
-         mock.patch('cephadmlib.exe_utils.find_executable', return_value='foo'), \
-         mock.patch('cephadm.get_container_info', return_value=None), \
-         mock.patch('cephadm.is_available', return_value=True), \
-         mock.patch('cephadm.json_loads_retry', return_value={'epoch' : 1}), \
-         mock.patch('cephadm.logger'), \
-         mock.patch('cephadm.FileLock'), \
-         mock.patch('socket.gethostname', return_value=hostname):
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch('cephadmlib.net_utils.attempt_bind'))
+        stack.enter_context(mock.patch('cephadmlib.call_wrappers.call', return_value=('', '', 0)))
+        stack.enter_context(mock.patch('cephadmlib.call_wrappers.call_timeout', return_value=0))
+        stack.enter_context(mock.patch('cephadm.call', return_value=('', '', 0)))
+        stack.enter_context(mock.patch('cephadm.call_timeout', return_value=0))
+        stack.enter_context(mock.patch('cephadmlib.exe_utils.find_executable', return_value='foo'))
+        stack.enter_context(mock.patch('cephadm.get_container_info', return_value=None))
+        stack.enter_context(mock.patch('cephadm.is_available', return_value=True))
+        stack.enter_context(mock.patch('cephadm.json_loads_retry', return_value={'epoch' : 1}))
+        stack.enter_context(mock.patch('cephadm.logger'))
+        stack.enter_context(mock.patch('cephadm.FileLock'))
+        stack.enter_context(mock.patch('socket.gethostname', return_value=hostname))
+        if list_networks is not None:
+            stack.enter_context(mock.patch('cephadm.list_networks', return_value=list_networks))
         ctx: _cephadm.CephadmContext = _cephadm.cephadm_init_ctx(cmd)
         ctx.container_engine = mock_podman()
-        if list_networks is not None:
-            with mock.patch('cephadm.list_networks', return_value=list_networks):
-                yield ctx
-        else:
-            yield ctx
+        yield ctx
 
 
 @pytest.fixture()

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -154,6 +154,8 @@ def with_cephadm_ctx(
     cmd: List[str],
     list_networks: Optional[Dict[str, Dict[str, List[str]]]] = None,
     hostname: Optional[str] = None,
+    *,
+    mock_cephadm_call_fn: bool = True,
 ):
     """
     :param cmd: cephadm command argv
@@ -166,10 +168,6 @@ def with_cephadm_ctx(
     _cephadm = import_cephadm()
     with contextlib.ExitStack() as stack:
         stack.enter_context(mock.patch('cephadmlib.net_utils.attempt_bind'))
-        stack.enter_context(mock.patch('cephadmlib.call_wrappers.call', return_value=('', '', 0)))
-        stack.enter_context(mock.patch('cephadmlib.call_wrappers.call_timeout', return_value=0))
-        stack.enter_context(mock.patch('cephadm.call', return_value=('', '', 0)))
-        stack.enter_context(mock.patch('cephadm.call_timeout', return_value=0))
         stack.enter_context(mock.patch('cephadmlib.exe_utils.find_executable', return_value='foo'))
         stack.enter_context(mock.patch('cephadm.get_container_info', return_value=None))
         stack.enter_context(mock.patch('cephadm.is_available', return_value=True))
@@ -177,6 +175,11 @@ def with_cephadm_ctx(
         stack.enter_context(mock.patch('cephadm.logger'))
         stack.enter_context(mock.patch('cephadm.FileLock'))
         stack.enter_context(mock.patch('socket.gethostname', return_value=hostname))
+        if mock_cephadm_call_fn:
+            stack.enter_context(mock.patch('cephadmlib.call_wrappers.call', return_value=('', '', 0)))
+            stack.enter_context(mock.patch('cephadmlib.call_wrappers.call_timeout', return_value=0))
+            stack.enter_context(mock.patch('cephadm.call', return_value=('', '', 0)))
+            stack.enter_context(mock.patch('cephadm.call_timeout', return_value=0))
         if list_networks is not None:
             stack.enter_context(mock.patch('cephadm.list_networks', return_value=list_networks))
         ctx: _cephadm.CephadmContext = _cephadm.cephadm_init_ctx(cmd)

--- a/src/cephadm/tests/test_agent.py
+++ b/src/cephadm/tests/test_agent.py
@@ -3,7 +3,12 @@ import copy, datetime, json, os, socket, threading
 
 import pytest
 
-from tests.fixtures import with_cephadm_ctx, cephadm_fs, import_cephadm
+from tests.fixtures import (
+    cephadm_fs,
+    funkypatch,
+    import_cephadm,
+    with_cephadm_ctx,
+)
 
 from typing import Optional
 
@@ -182,7 +187,7 @@ def test_agent_ceph_volume(_ceph_volume):
             out, _ = agent._ceph_volume(False)
 
 
-def test_agent_daemon_ls_subset(cephadm_fs):
+def test_agent_daemon_ls_subset(cephadm_fs, funkypatch):
     # Basing part of this test on some actual sample output
 
     # Some sample "podman stats --format '{{.ID}},{{.MemUsage}}' --no-stream" output
@@ -225,10 +230,11 @@ def test_agent_daemon_ls_subset(cephadm_fs):
     cephadm_fs.create_dir(f'/var/lib/ceph/{FSID}/mgr.host1.pntmho')  # cephadm daemon
     cephadm_fs.create_dir(f'/var/lib/ceph/{FSID}/crash.host1')  # cephadm daemon
 
-    with with_cephadm_ctx([]) as ctx:
+    with with_cephadm_ctx([], mock_cephadm_call_fn=False) as ctx:
         ctx.fsid = FSID
         agent = _cephadm.CephadmAgent(ctx, FSID, AGENT_ID)
-        _cephadm.call.side_effect = _fake_call
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call')
+        _call.side_effect = _fake_call
         daemons = agent._daemon_ls_subset()
 
         assert 'agent.host1' in daemons

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -226,7 +226,9 @@ class TestCephAdm(object):
 
     @mock.patch('cephadm.logger')
     def test_parse_mem_usage(self, _logger):
-        len, summary = _cephadm._parse_mem_usage(0, 'c6290e3f1489,-- / --')
+        from cephadmlib.container_engines import _parse_mem_usage
+
+        len, summary = _parse_mem_usage(0, 'c6290e3f1489,-- / --')
         assert summary == {}
 
     def test_CustomValidation(self):
@@ -1665,7 +1667,9 @@ class TestBootstrap(object):
 
 class TestShell(object):
 
-    def test_fsid(self, cephadm_fs):
+    def test_fsid(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
         fsid = '00000000-0000-0000-0000-0000deadbeef'
 
         cmd = ['shell', '--fsid', fsid]
@@ -1699,7 +1703,10 @@ class TestShell(object):
                 assert retval == 1
                 assert ctx.fsid == None
 
-    def test_name(self, cephadm_fs):
+    def test_name(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = ['shell', '--name', 'foo']
         with with_cephadm_ctx(cmd) as ctx:
             retval = _cephadm.command_shell(ctx)
@@ -1718,7 +1725,10 @@ class TestShell(object):
             retval = _cephadm.command_shell(ctx)
             assert retval == 0
 
-    def test_config(self, cephadm_fs):
+    def test_config(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = ['shell']
         with with_cephadm_ctx(cmd) as ctx:
             retval = _cephadm.command_shell(ctx)
@@ -1737,7 +1747,10 @@ class TestShell(object):
             assert retval == 0
             assert ctx.config == 'foo'
 
-    def test_keyring(self, cephadm_fs):
+    def test_keyring(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = ['shell']
         with with_cephadm_ctx(cmd) as ctx:
             retval = _cephadm.command_shell(ctx)
@@ -1756,24 +1769,33 @@ class TestShell(object):
             assert retval == 0
             assert ctx.keyring == 'foo'
 
-    @mock.patch('cephadm.CephContainer')
-    def test_mount_no_dst(self, _ceph_container, cephadm_fs):
+    def test_mount_no_dst(self, cephadm_fs, funkypatch):
+        _ceph_container = funkypatch.patch('cephadm.CephContainer')
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = ['shell', '--mount', '/etc/foo']
         with with_cephadm_ctx(cmd) as ctx:
             retval = _cephadm.command_shell(ctx)
             assert retval == 0
             assert _ceph_container.call_args.kwargs['volume_mounts']['/etc/foo'] == '/mnt/foo'
 
-    @mock.patch('cephadm.CephContainer')
-    def test_mount_with_dst_no_opt(self, _ceph_container, cephadm_fs):
+    def test_mount_with_dst_no_opt(self, cephadm_fs, funkypatch):
+        _ceph_container = funkypatch.patch('cephadm.CephContainer')
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = ['shell', '--mount', '/etc/foo:/opt/foo/bar']
         with with_cephadm_ctx(cmd) as ctx:
             retval = _cephadm.command_shell(ctx)
             assert retval == 0
             assert _ceph_container.call_args.kwargs['volume_mounts']['/etc/foo'] == '/opt/foo/bar'
 
-    @mock.patch('cephadm.CephContainer')
-    def test_mount_with_dst_and_opt(self, _ceph_container, cephadm_fs):
+    def test_mount_with_dst_and_opt(self, cephadm_fs, funkypatch):
+        _ceph_container = funkypatch.patch('cephadm.CephContainer')
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = ['shell', '--mount', '/etc/foo:/opt/foo/bar:Z']
         with with_cephadm_ctx(cmd) as ctx:
             retval = _cephadm.command_shell(ctx)
@@ -1790,7 +1812,10 @@ class TestCephVolume(object):
             '--', 'inventory', '--format', 'json'
         ]
 
-    def test_noop(self, cephadm_fs):
+    def test_noop(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = self._get_cmd()
         with with_cephadm_ctx(cmd) as ctx:
             _cephadm.command_ceph_volume(ctx)
@@ -1799,7 +1824,10 @@ class TestCephVolume(object):
             assert ctx.keyring == None
             assert ctx.config_json == None
 
-    def test_fsid(self, cephadm_fs):
+    def test_fsid(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         fsid = '00000000-0000-0000-0000-0000deadbeef'
 
         cmd = self._get_cmd('--fsid', fsid)
@@ -1830,7 +1858,10 @@ class TestCephVolume(object):
                 _cephadm.command_ceph_volume(ctx)
                 assert ctx.fsid == None
 
-    def test_config(self, cephadm_fs):
+    def test_config(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = self._get_cmd('--config', 'foo')
         with with_cephadm_ctx(cmd) as ctx:
             err = r'No such file or directory'
@@ -1843,7 +1874,10 @@ class TestCephVolume(object):
             _cephadm.command_ceph_volume(ctx)
             assert ctx.config == 'bar'
 
-    def test_keyring(self, cephadm_fs):
+    def test_keyring(self, cephadm_fs, funkypatch):
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
+        _call.side_effect = lambda *args, **kwargs: ('', '', 0)
+
         cmd = self._get_cmd('--keyring', 'foo')
         with with_cephadm_ctx(cmd) as ctx:
             err = r'No such file or directory'
@@ -2260,7 +2294,7 @@ class TestPull:
         funkypatch.patch('cephadm.logger')
         _giifi = funkypatch.patch('cephadm.get_image_info_from_inspect')
         _giifi.return_value = {}
-        _call = funkypatch.patch('cephadmlib.call_wrappers.call')
+        _call = funkypatch.patch('cephadmlib.call_wrappers.call', force=True)
         ctx = _cephadm.CephadmContext()
         ctx.container_engine = mock_podman()
         ctx.insecure = False


### PR DESCRIPTION
There were three functions I recently noticed were good candidates for moving out of cephadm.py as they didn't have complex dependencies:
* get_legacy_daemon_fsid
* _parse_mem_usage  (and the command that gets called to generate the output)
* _parse_cpu_perc  (and the command that gets called to generate the output)

The first one was easy. The others needed a bunch of test updates to make them work properly (applied when _parse_mem_usage is replaced).

This work is in preparation for a bigger refactor of the list_daemons function.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Updates tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
