### PR TITLE
squid: container/Containerfile: replace CEPH_VERSION label for backward compat

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -212,6 +212,7 @@ RUN rpm -q $(cat packages.txt) && rm -f /var/lib/rpm/__db* && rm -f *packages.tx
 # Set some envs in the container for quickly inspecting details about the build at runtime
 ENV CEPH_IS_DEVEL="${CI_CONTAINER}" \
     CEPH_REF="${CEPH_REF}" \
+    CEPH_VERSION="${CEPH_REF}" \
     CEPH_OSD_FLAVOR="${OSD_FLAVOR}" \
     FROM_IMAGE="${FROM_IMAGE}"
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69721

---

backport of https://github.com/ceph/ceph/pull/61218
parent tracker: https://tracker.ceph.com/issues/69698

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh