### PR TITLE
squid: container/build.sh: don't require repo creds on NO_PUSH

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -64,10 +64,12 @@ fi
 : "${BRANCH:?}"
 : "${CEPH_SHA1:?}"
 : "${ARCH:?}"
-: "${CONTAINER_REPO_HOSTNAME:?}"
-: "${CONTAINER_REPO_ORGANIZATION:?}"
-: "${CONTAINER_REPO_USERNAME:?}"
-: "${CONTAINER_REPO_PASSWORD:?}"
+if [[ ${NO_PUSH} != "true" ]] ; then
+    : "${CONTAINER_REPO_HOSTNAME:?}"
+    : "${CONTAINER_REPO_ORGANIZATION:?}"
+    : "${CONTAINER_REPO_USERNAME:?}"
+    : "${CONTAINER_REPO_PASSWORD:?}"
+fi
 if [[ ${CI_CONTAINER} != "true" ]] ; then : "${VERSION:?}"; fi
 
 # check for valid repo auth (if pushing)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69717

---

backport of https://github.com/ceph/ceph/pull/61510
parent tracker: https://tracker.ceph.com/issues/69700

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh