### PR TITLE
Display comma separated ports for RGW services

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2375,6 +2375,7 @@ Then run the following:
                 virtual_ip=spec.get_virtual_ip(),
                 ports=spec.get_port_start(),
             )
+
             if spec.service_type == 'ingress':
                 # ingress has 2 daemons running per host
                 # but only if it's the full ingress service, not for keepalive-only

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1067,7 +1067,11 @@ class RgwService(CephService):
             # this is a redeploy of older instance that doesn't have an explicitly
             # assigned port, in which case we can assume there is only 1 per host
             # and it matches the spec.
-            port = spec.get_port()
+            ports = spec.get_port()
+            if spec.ssl:
+                port = ports[1] if len(ports) > 1 else ports[0]
+            else:
+                port = ports[0]
 
         if spec.generate_cert:
             cert, key = self.mgr.cert_mgr.generate_cert(

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -749,9 +749,13 @@ class RookCluster(object):
             port = None
             secure_port = None
             if spec.ssl:
-                secure_port = spec.get_port()
+                _secure_port = spec.get_port()
+                if len(_secure_port) > 1:
+                    secure_port = _secure_port[1]
+                else:
+                    secure_port = _secure_port[0]
             else:
-                port = spec.get_port()
+                port = spec.get_port()[0]
             object_store = cos.CephObjectStore(
                     apiVersion=self.rook_env.api_name,
                     metadata=dict(


### PR DESCRIPTION
Cephadm: Display comma separated ports for RGW services

In this change, `get_port` has been modified  to return both frontend and SSL ports when applicable, ensuring that `ceph orch ls` correctly displays both ports.

Fixes: https://tracker.ceph.com/issues/69664

Test logs:
```
> cat rgw_spec.yaml

service_type: rgw
service_id: foo
placement:
  label: rgw
  count_per_host: 1
spec:
  ssl: true  # Required for SSL
  generate_cert: true  
  rgw_frontend_port: 8080  # Regular HTTP port
  rgw_frontend_extra_args:
    - ssl_port=9443

> ceph orch apply -i rgw_spec.yaml
```

```
> ceph orch host ls

HOST         ADDR             LABELS      STATUS
ceph-node-0  192.168.100.100  _admin,rgw           
ceph-node-1  192.168.100.101  rgw                  
ceph-node-2  192.168.100.102  
```

```
> ceph config dump | grep rgw

client.rgw.foo.ceph-node-0.pyqfuc   basic rgw_frontends beast ssl_port=8080 ssl_certificate=config://rgw/cert/rgw.foo.ceph-node-0.pyqfuc ssl_port=9443  *  
client.rgw.foo.ceph-node-1.rsyvun   basic rgw_frontends beast ssl_port=8080 ssl_certificate=config://rgw/cert/rgw.foo.ceph-node-1.rsyvun ssl_port=9443  *  
```

```
> ss -tuln | grep LISTEN

tcp   LISTEN 0      4096           0.0.0.0:9443       0.0.0.0:*           
tcp   LISTEN 0      4096           0.0.0.0:8080       0.0.0.0:*  
```         

```
> netstat -tulnp | grep 9443
tcp   LISTEN 0      4096           0.0.0.0:9443       0.0.0.0:*    users:(("radosgw",pid=103522,fd=65))      
tcp   LISTEN 0      4096              [::]:9443          [::]:*    users:(("radosgw",pid=103522,fd=66))     

> netstat -tulnp | grep 8080
tcp   LISTEN 0      4096           0.0.0.0:8080       0.0.0.0:*    users:(("radosgw",pid=103522,fd=63))      
tcp   LISTEN 0      4096              [::]:8080          [::]:*    users:(("radosgw",pid=103522,fd=64))      

``` 
```
> ps -p 103522 -o pid,comm,cmd

PID     COMMAND  CMD
103522  radosgw  /usr/bin/radosgw -n client.rgw.foo.ceph-node-0.vtpvqa -f --setuser ceph --setgroup ceph --default-log-to-file=false --default-log-to-journald=true --default-log-to-stderr=false
```
```
ceph orch ls

NAME      PORTS        RUNNING  REFRESHED  AGE  PLACEMENT
rgw.foo   ?:8080,9443    2/2     1s ago    3s   count-per-host:1;label:rgw
```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
