### PR TITLE
osd/scrub: discard repair_oinfo_oid()

### DIFF
--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -703,8 +703,6 @@ class PgScrubber : public ScrubPgIF,
   epoch_t m_interval_start{0};	///< interval's 'from' of when scrubbing was
 				///< first scheduled
 
-  void repair_oinfo_oid(ScrubMap& smap);
-
   /*
    * the exact epoch when the scrubbing actually started (started here - cleared
    * checks for no-scrub conf). Incoming events are verified against this, with

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -717,10 +717,17 @@ shard_as_auth_t ScrubBackend::possible_auth_shard(const hobject_t& obj,
         return shard_as_auth_t{errstream.str()};
       }
     }
-  }
 
-  // This is automatically corrected in repair_oinfo_oid()
-  ceph_assert(oi.soid == obj);
+    if (!dup_error_cond(err,
+                        false,
+                        (oi.soid != obj),
+                        shard_info,
+                        &shard_info_wrapper::set_info_corrupted,
+                        "candidate info oid mismatch"sv,
+                        errstream)) {
+      return shard_as_auth_t{errstream.str()};
+    }
+  }
 
   if (test_error_cond(smap_obj.size != logical_to_ondisk_size(oi.size),
                       shard_info,


### PR DESCRIPTION
`repair_oinfo_oid()`, called every scrub, has a very specific functionality:
fix the object ID specified in the Object Info attribute, if different from the ID of the owning object.

This fix was added in 2017, as a response to a unique failure scenario that was observed in Sepia -
probably following a filesystem bug.
See https://tracker.ceph.com/issues/18409 & https://tracker.ceph.com/issues/20471.

The limited functionality of `repair_oinfo_oid()` -
only repairing this one specific issue, and only if the OI_ATTR exists and is decodable -
does not justify the overhead of running it every scrub.

