### PR TITLE
qa/rgw: fix user cleanup in s3tests task

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -281,6 +281,7 @@ def create_users(ctx, config, s3tests_conf):
                             '--cluster', cluster_name,
                             'account', 'rm',
                             '--account-id', account_id,
+                            '--purge-data',
                             ])
 
 

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -251,7 +251,7 @@ def create_users(ctx, config, s3tests_conf):
         for client in config.keys():
             for section, user in users.items():
                 # don't need to delete keystone users
-                if not user in keystone_users:
+                if section in keystone_users:
                     continue
                 uid = '{user}.{client}'.format(user=user, client=client)
                 cluster_name, daemon_type, client_id = teuthology.split_role(client)

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -11904,6 +11904,7 @@ next:
       .max_groups = max_groups,
       .max_access_keys = max_access_keys,
       .max_buckets = max_buckets,
+      .purge_data = static_cast<bool>(purge_data),
     };
 
     std::string err_msg;

--- a/src/rgw/rgw_account.h
+++ b/src/rgw/rgw_account.h
@@ -53,6 +53,7 @@ struct AdminOpState {
   std::optional<int64_t> quota_max_size;
   std::optional<int64_t> quota_max_objects;
   std::optional<bool> quota_enabled;
+  bool purge_data = false;
 };
 
 /// create an account


### PR DESCRIPTION
the if condition was backwards, preventing non-keystone users from being removed after the s3tests task runs

with the addition of user accounts for squid, any created buckets were no longer cleaned up by `user rm --purge-data` because the buckets are owned by the account instead. this caused the `account rm` command to fail with:
> The account cannot be deleted until all buckets are removed.

added a `account rm --purge-data` to handle this cleanup for account buckets

Fixes: https://tracker.ceph.com/issues/69741

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
