### PR TITLE
mgr/dashboard: namespace update route robustness

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any, Dict, Optional
 
+import cherrypy
 from orchestrator import OrchestratorError
 
 from .. import mgr
@@ -386,7 +387,7 @@ else:
             },
         )
         @NvmeofCLICommand("nvmeof ns update")
-        @empty_response
+        @map_model(model.Namespace, first="namespaces")
         @handle_nvmeof_error
         def update(
             self,
@@ -400,34 +401,32 @@ else:
             w_mbytes_per_second: Optional[int] = None,
             gw_group: Optional[str] = None
         ):
+            contains_failure = False
+
             if rbd_image_size:
                 mib = 1024 * 1024
                 new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
-                response = NVMeoFClient(gw_group=gw_group).stub.namespace_resize(
+                resp = NVMeoFClient(gw_group=gw_group).stub.namespace_resize(
                     NVMeoFClient.pb2.namespace_resize_req(
                         subsystem_nqn=nqn, nsid=int(nsid), new_size=new_size_mib
                     )
                 )
-                if response.status != 0:
-                    return response
+                if resp.status != 0:
+                    contains_failure = True
 
             if load_balancing_group:
-                response = NVMeoFClient().stub.namespace_change_load_balancing_group(
+                resp = NVMeoFClient().stub.namespace_change_load_balancing_group(
                     NVMeoFClient.pb2.namespace_change_load_balancing_group_req(
                         subsystem_nqn=nqn, nsid=int(nsid), anagrpid=load_balancing_group
                     )
                 )
-                if response.status != 0:
-                    return response
+                if resp.status != 0:
+                    contains_failure = True
 
-            if (
-                rw_ios_per_second
-                or rw_mbytes_per_second
-                or r_mbytes_per_second
-                or w_mbytes_per_second
-            ):
-                response = NVMeoFClient().stub.namespace_set_qos_limits(
+            if rw_ios_per_second or rw_mbytes_per_second or r_mbytes_per_second \
+               or w_mbytes_per_second:
+                resp = NVMeoFClient().stub.namespace_set_qos_limits(
                     NVMeoFClient.pb2.namespace_set_qos_req(
                         subsystem_nqn=nqn,
                         nsid=int(nsid),
@@ -437,9 +436,13 @@ else:
                         w_mbytes_per_second=w_mbytes_per_second,
                     )
                 )
-                if response.status != 0:
-                    return response
-
+                if resp.status != 0:
+                    contains_failure = True
+            response = NVMeoFClient(gw_group=gw_group).stub.list_namespaces(
+                NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn, nsid=int(nsid))
+            )
+            if contains_failure:
+                cherrypy.response.status = 202
             return response
 
         @EndpointDoc(


### PR DESCRIPTION
Made sure the namespace update endpoint will fail if no action was requested or if more than one action was requested, as well as made it not suppress errors but let them propagate.

It seems like the current behavior implicitly allows only one update operation executed(update operations available: resize, change lb group, set qos limits). if the user requested more than 1, it will succeed although only 1 operation was executed which might be very confusing. Also, I let it return also responses with status != so the `@handle_nvmeof_error` will catch error cases. I hope it makes sense :) 

I will be glad to hear your thoughts :)
Thanks!

fixes: https://tracker.ceph.com/issues/62705

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
