### PR TITLE
doc/rbd: use https links in live import examples

### DIFF
--- a/doc/rbd/rbd-live-migration.rst
+++ b/doc/rbd/rbd-live-migration.rst
@@ -239,7 +239,7 @@ source. Its ``source-spec`` JSON is encoded as follows::
         }
 
 For example, to import a raw-format image from a file located at
-"/mnt/image.raw", its ``source-spec`` JSON is encoded as follows::
+`/mnt/image.raw`, its ``source-spec`` JSON is encoded as follows::
 
         {
             "type": "raw",
@@ -261,14 +261,14 @@ server. Its ``source-spec`` JSON is encoded as follows::
         }
 
 For example, to import a raw-format image from a file located at
-``http://download.ceph.com/image.raw``, its ``source-spec`` JSON is encoded
+`https://download.ceph.com/image.raw`, its ``source-spec`` JSON is encoded
 as follows::
 
         {
             "type": "raw",
             "stream": {
                 "type": "http",
-                "url": "http://download.ceph.com/image.raw"
+                "url": "https://download.ceph.com/image.raw"
             }
         }
 
@@ -286,14 +286,14 @@ The ``s3`` stream can be used to import from a remote S3 bucket. Its
         }
 
 For example, to import a raw-format image from a file located at
-`http://s3.ceph.com/bucket/image.raw`, its ``source-spec`` JSON is encoded
+`https://s3.ceph.com/bucket/image.raw`, its ``source-spec`` JSON is encoded
 as follows::
 
         {
             "type": "raw",
             "stream": {
                 "type": "s3",
-                "url": "http://s3.ceph.com/bucket/image.raw",
+                "url": "https://s3.ceph.com/bucket/image.raw",
                 "access_key": "NX5QOQKC6BH2IDN8HC7A",
                 "secret_key": "LnEsqNNqZIpkzauboDcLXLcYaWwLQ3Kop0zAnKIn"
             }


### PR DESCRIPTION
Even though it's explicitly said that "http" stream can be used to import via both HTTP and HTTPS, it can still be confusing that "type": "http" is expected to go with "url": "https://...".  Switch example URLs from HTTP to HTTPS to make it more obvious.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
