### PR TITLE
cephadm: move a few other small things out of cephadm.py

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -85,6 +85,7 @@ from cephadmlib.call_wrappers import (
     concurrent_tasks,
 )
 from cephadmlib.container_engines import (
+    ContainerInfo,
     Podman,
     check_container_engine,
     find_container_engine,
@@ -196,30 +197,6 @@ FuncT = TypeVar('FuncT', bound=Callable)
 
 logger = logging.getLogger()
 
-
-##################################
-
-
-class ContainerInfo:
-    def __init__(self, container_id: str,
-                 image_name: str,
-                 image_id: str,
-                 start: str,
-                 version: str) -> None:
-        self.container_id = container_id
-        self.image_name = image_name
-        self.image_id = image_id
-        self.start = start
-        self.version = version
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, ContainerInfo):
-            return NotImplemented
-        return (self.container_id == other.container_id
-                and self.image_name == other.image_name
-                and self.image_id == other.image_id
-                and self.start == other.start
-                and self.version == other.version)
 
 ##################################
 

--- a/src/cephadm/cephadmlib/container_engines.py
+++ b/src/cephadm/cephadmlib/container_engines.py
@@ -3,7 +3,7 @@
 import os
 import logging
 
-from typing import Tuple, List, Optional, Dict
+from typing import Tuple, List, Optional, Dict, Any
 
 from .call_wrappers import call_throws, call, CallVerbosity
 from .context import CephadmContext
@@ -302,3 +302,30 @@ def parsed_container_cpu_perc(
         ctx, container_path=container_path, verbosity=verbosity
     )
     return _parse_cpu_perc(code, out)
+
+
+class ContainerInfo:
+    def __init__(
+        self,
+        container_id: str,
+        image_name: str,
+        image_id: str,
+        start: str,
+        version: str,
+    ) -> None:
+        self.container_id = container_id
+        self.image_name = image_name
+        self.image_id = image_id
+        self.start = start
+        self.version = version
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, ContainerInfo):
+            return NotImplemented
+        return (
+            self.container_id == other.container_id
+            and self.image_name == other.image_name
+            and self.image_id == other.image_id
+            and self.start == other.start
+            and self.version == other.version
+        )

--- a/src/cephadm/cephadmlib/container_types.py
+++ b/src/cephadm/cephadmlib/container_types.py
@@ -10,7 +10,12 @@ from typing import Dict, List, Optional, Any, Union, Tuple, Iterable, cast
 from .call_wrappers import call, call_throws, CallVerbosity
 from .constants import DEFAULT_TIMEOUT
 from ceph.cephadm.images import DefaultImages
-from .container_engines import Docker, Podman
+from .container_engines import (
+    ContainerInfo,
+    Docker,
+    Podman,
+    parsed_container_stats,
+)
 from .context import CephadmContext
 from .daemon_identity import DaemonIdentity, DaemonSubIdentity
 from .exceptions import Error
@@ -670,3 +675,15 @@ def get_mgr_images() -> dict:
         f'{mgr_prefix}{image.key}': image.image_ref for image in DefaultImages
     }
     return mgr_images
+
+
+def get_container_stats(
+    ctx: CephadmContext, identity: DaemonIdentity, *, container_path: str = ''
+) -> Optional[ContainerInfo]:
+    """returns container id, image name, image id, created time, and ceph version if available"""
+    c = CephContainer.for_daemon(ctx, identity, 'bash')
+    for name in (c.cname, c.old_cname):
+        ci = parsed_container_stats(ctx, name, container_path=container_path)
+        if ci is not None:
+            return ci
+    return None

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -650,9 +650,8 @@ class TestCephAdm(object):
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                     {'name': 'mgr.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972,registry.hub.docker.com/rkachach/ceph:custom-v0.5,666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4,2022-04-19 13:45:20.97146228 +0000 UTC,",
-                 "",
-                 0),
+                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972", "registry.hub.docker.com/rkachach/ceph:custom-v0.5", "666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4", "2022-04-19 13:45:20.97146228 +0000 UTC", ""
+                 ),
                 _cephadm.ContainerInfo('935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972',
                                  'registry.hub.docker.com/rkachach/ceph:custom-v0.5',
                                  '666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4',
@@ -667,9 +666,8 @@ class TestCephAdm(object):
                     {'name': 'mgr.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972,registry.hub.docker.com/rkachach/ceph:custom-v0.5,666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4,2022-04-19 13:45:20.97146228 +0000 UTC,",
-                 "",
-                 0),
+                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972", "registry.hub.docker.com/rkachach/ceph:custom-v0.5", "666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4", "2022-04-19 13:45:20.97146228 +0000 UTC", ""
+                 ),
                 _cephadm.ContainerInfo('935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972',
                                  'registry.hub.docker.com/rkachach/ceph:custom-v0.5',
                                  '666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4',
@@ -684,9 +682,8 @@ class TestCephAdm(object):
                     {'name': 'mon.ceph-node-0', 'fsid': '10000000-0000-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972,registry.hub.docker.com/rkachach/ceph:custom-v0.5,666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4,2022-04-19 13:45:20.97146228 +0000 UTC,",
-                 "",
-                 0),
+                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972", "registry.hub.docker.com/rkachach/ceph:custom-v0.5", "666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4", "2022-04-19 13:45:20.97146228 +0000 UTC", ""
+                 ),
                 _cephadm.ContainerInfo('935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972',
                                  'registry.hub.docker.com/rkachach/ceph:custom-v0.5',
                                  '666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4',
@@ -701,9 +698,7 @@ class TestCephAdm(object):
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-FFFF-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("",
-                 "",
-                 127),
+                None,
                 None
             ),
             # get container info by name (bad container stats: 127 code)
@@ -714,9 +709,7 @@ class TestCephAdm(object):
                     {'name': 'mgr.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("",
-                 "",
-                 127),
+                None,
                 None
             ),
             # get container info by invalid name (doens't contain '.')
@@ -727,9 +720,8 @@ class TestCephAdm(object):
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972,registry.hub.docker.com/rkachach/ceph:custom-v0.5,666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4,2022-04-19 13:45:20.97146228 +0000 UTC,",
-                 "",
-                 0),
+                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972", "registry.hub.docker.com/rkachach/ceph:custom-v0.5", "666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4", "2022-04-19 13:45:20.97146228 +0000 UTC", ""
+                 ),
                 None
             ),
             # get container info by invalid name (empty)
@@ -740,9 +732,8 @@ class TestCephAdm(object):
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972,registry.hub.docker.com/rkachach/ceph:custom-v0.5,666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4,2022-04-19 13:45:20.97146228 +0000 UTC,",
-                 "",
-                 0),
+                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972", "registry.hub.docker.com/rkachach/ceph:custom-v0.5", "666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4", "2022-04-19 13:45:20.97146228 +0000 UTC", ""
+                 ),
                 None
             ),
             # get container info by invalid type (empty)
@@ -753,9 +744,8 @@ class TestCephAdm(object):
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-0000-0000-0000-0000deadbeef'},
                 ],
-                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972,registry.hub.docker.com/rkachach/ceph:custom-v0.5,666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4,2022-04-19 13:45:20.97146228 +0000 UTC,",
-                 "",
-                 0),
+                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972", "registry.hub.docker.com/rkachach/ceph:custom-v0.5", "666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4", "2022-04-19 13:45:20.97146228 +0000 UTC", ""
+                 ),
                 None
             ),
             # get container info by name: no match (invalid fsid)
@@ -766,9 +756,8 @@ class TestCephAdm(object):
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-1111-0000-0000-0000deadbeef'},
                     {'name': 'mon.ceph-node-0', 'fsid': '00000000-2222-0000-0000-0000deadbeef'},
                 ],
-                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972,registry.hub.docker.com/rkachach/ceph:custom-v0.5,666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4,2022-04-19 13:45:20.97146228 +0000 UTC,",
-                 "",
-                 0),
+                ("935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972", "registry.hub.docker.com/rkachach/ceph:custom-v0.5", "666bbfa87e8df05702d6172cae11dd7bc48efb1d94f1b9e492952f19647199a4", "2022-04-19 13:45:20.97146228 +0000 UTC", ""
+                ),
                 None
             ),
             # get container info by name: no match
@@ -788,19 +777,36 @@ class TestCephAdm(object):
                 None
             ),
         ])
-    @mock.patch('cephadm.logger')
-    def test_get_container_info(self, _logger, daemon_filter, by_name, daemon_list, container_stats, output):
+    def test_get_container_info(
+        self,
+        daemon_filter,
+        by_name,
+        daemon_list,
+        container_stats,
+        output,
+        funkypatch,
+    ):
         ctx = _cephadm.CephadmContext()
         ctx.fsid = '00000000-0000-0000-0000-0000deadbeef'
         ctx.container_engine = mock_podman()
-        with mock.patch('cephadm.list_daemons', return_value=daemon_list):
-            with mock.patch('cephadm.get_container_stats', return_value=container_stats):
-                assert _cephadm.get_container_info(ctx, daemon_filter, by_name) == output
+        funkypatch.patch('cephadm.list_daemons').return_value = daemon_list
+        cinfo = (
+            _cephadm.ContainerInfo(*container_stats)
+            if container_stats
+            else None
+        )
+        funkypatch.patch(
+            'cephadmlib.container_types.get_container_stats'
+        ).return_value = cinfo
+        assert (
+            _cephadm.get_container_info(ctx, daemon_filter, by_name) == output
+        )
 
-    @mock.patch('cephadm.list_daemons')
-    @mock.patch('cephadm.get_container_stats')
-    @mock.patch('cephadm.get_container_stats_by_image_name')
-    def test_get_container_info_daemon_down(self, _get_stats_by_name, _get_stats, _list_daemons):
+    def test_get_container_info_daemon_down(self, funkypatch):
+        _get_stats_by_name = funkypatch.patch('cephadm.get_container_stats_by_image_name')
+        _get_stats = funkypatch.patch('cephadmlib.container_types.get_container_stats')
+        _list_daemons = funkypatch.patch('cephadm.list_daemons')
+
         ctx = _cephadm.CephadmContext()
         ctx.fsid = '5e39c134-dfc5-11ee-a344-5254000ee071'
         ctx.container_engine = mock_podman()
@@ -859,7 +865,7 @@ class TestCephAdm(object):
         # than it partially being taken from the list_daemons output
         up_osd_json = copy.deepcopy(down_osd_json)
         up_osd_json['state'] = 'running'
-        _get_stats.return_value = (('container_id,image_name,image_id,the_past,'), '', 0)
+        _get_stats.return_value = _cephadm.ContainerInfo('container_id', 'image_name','image_id','the_past','')
         _list_daemons.return_value = [down_osd_json, up_osd_json]
 
         expected_container_info = _cephadm.ContainerInfo(

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -803,7 +803,7 @@ class TestCephAdm(object):
         )
 
     def test_get_container_info_daemon_down(self, funkypatch):
-        _get_stats_by_name = funkypatch.patch('cephadm.get_container_stats_by_image_name')
+        _get_stats_by_name = funkypatch.patch('cephadmlib.container_engines.parsed_container_image_stats')
         _get_stats = funkypatch.patch('cephadmlib.container_types.get_container_stats')
         _list_daemons = funkypatch.patch('cephadm.list_daemons')
 
@@ -845,9 +845,6 @@ class TestCephAdm(object):
                 "configured": "2024-03-11T17:37:28.494075Z"
         }
         _list_daemons.return_value = [down_osd_json]
-        _get_stats_by_name.return_value = (('a03c201ff4080204949932f367545cd381c4acee0d48dbc15f2eac1e35f22318,'
-                                   '2023-11-28 21:34:38.045413692 +0000 UTC,'),
-                                   '', 0)
 
         expected_container_info = _cephadm.ContainerInfo(
             container_id='',
@@ -855,6 +852,10 @@ class TestCephAdm(object):
             image_id='a03c201ff4080204949932f367545cd381c4acee0d48dbc15f2eac1e35f22318',
             start='2023-11-28 21:34:38.045413692 +0000 UTC',
             version='')
+        # refactoring get_container_stats_by_image_name into
+        # parsed_container_image_stats has made this part of the test somewhat
+        # redundant
+        _get_stats_by_name.return_value = expected_container_info
 
         assert _cephadm.get_container_info(ctx, 'osd.2', by_name=True) == expected_container_info
         assert not _get_stats.called, 'only get_container_stats_by_image_name should have been called'


### PR DESCRIPTION
Depends on #61579

Move the ContainerInfo class, and the get_container_stats and the (equivalent of) get_container_stats_by_image_name functions out of cephadm.py.

This reduces the size of cephadm.py. As part of the move I refactored the functions so that the commands are run and parsed as a unit. Note that parsing code in the libraries are kept seperate and could be tested alone in unit tests.  But the current tests mix all the things together and I wasn't trying to resolve that situation, just keep thing working while reorganizing a bit.


This work is in preparation for a bigger refactor of the list_daemons function.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Updates tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
