### PR TITLE
squid: mon/OSDMonitor: relax cap enforcement for unmanaged snapshots

### DIFF
--- a/qa/workunits/rbd/permissions.sh
+++ b/qa/workunits/rbd/permissions.sh
@@ -49,8 +49,13 @@ create_users() {
     ceph auth get-or-create client.snap_none mon 'allow r' >> $KEYRING
     ceph auth get-or-create client.snap_all mon 'allow r' osd 'allow w' >> $KEYRING
     ceph auth get-or-create client.snap_pool mon 'allow r' osd 'allow w pool=images' >> $KEYRING
+    ceph auth get-or-create client.snap_pool_namespace mon 'allow r' osd 'allow w pool=images namespace=foo' >> $KEYRING
+    ceph auth get-or-create client.snap_namespace mon 'allow r' osd 'allow w namespace=foo' >> $KEYRING
+    ceph auth get-or-create client.snap_tag mon 'allow r' osd 'allow w tag fooapp *=*' >> $KEYRING
     ceph auth get-or-create client.snap_profile_all mon 'allow r' osd 'profile rbd' >> $KEYRING
     ceph auth get-or-create client.snap_profile_pool mon 'allow r' osd 'profile rbd pool=images' >> $KEYRING
+    ceph auth get-or-create client.snap_profile_pool_namespace mon 'allow r' osd 'profile rbd pool=images namespace=foo' >> $KEYRING
+    ceph auth get-or-create client.snap_profile_namespace mon 'allow r' osd 'profile rbd namespace=foo' >> $KEYRING
 
     ceph auth get-or-create client.mon_write mon 'allow *' >> $KEYRING
 }
@@ -208,11 +213,26 @@ test_remove_self_managed_snapshots() {
     create_self_managed_snapshot snap_pool images
     expect 1 create_self_managed_snapshot snap_pool volumes
 
+    create_self_managed_snapshot snap_pool_namespace images
+    expect 1 create_self_managed_snapshot snap_pool_namespace volumes
+
+    create_self_managed_snapshot snap_namespace images
+    create_self_managed_snapshot snap_namespace volumes
+
+    expect 1 create_self_managed_snapshot snap_tag images
+    expect 1 create_self_managed_snapshot snap_tag volumes
+
     create_self_managed_snapshot snap_profile_all images
     create_self_managed_snapshot snap_profile_all volumes
 
     create_self_managed_snapshot snap_profile_pool images
     expect 1 create_self_managed_snapshot snap_profile_pool volumes
+
+    create_self_managed_snapshot snap_profile_pool_namespace images
+    expect 1 create_self_managed_snapshot snap_profile_pool_namespace volumes
+
+    create_self_managed_snapshot snap_profile_namespace images
+    create_self_managed_snapshot snap_profile_namespace volumes
 
     # Ensure users cannot delete self-managed snapshots w/o permissions
     expect 1 remove_self_managed_snapshot snap_none images
@@ -224,11 +244,26 @@ test_remove_self_managed_snapshots() {
     remove_self_managed_snapshot snap_pool images
     expect 1 remove_self_managed_snapshot snap_pool volumes
 
+    remove_self_managed_snapshot snap_pool_namespace images
+    expect 1 remove_self_managed_snapshot snap_pool_namespace volumes
+
+    remove_self_managed_snapshot snap_namespace images
+    remove_self_managed_snapshot snap_namespace volumes
+
+    expect 1 remove_self_managed_snapshot snap_tag images
+    expect 1 remove_self_managed_snapshot snap_tag volumes
+
     remove_self_managed_snapshot snap_profile_all images
     remove_self_managed_snapshot snap_profile_all volumes
 
     remove_self_managed_snapshot snap_profile_pool images
     expect 1 remove_self_managed_snapshot snap_profile_pool volumes
+
+    remove_self_managed_snapshot snap_profile_pool_namespace images
+    expect 1 remove_self_managed_snapshot snap_profile_pool_namespace volumes
+
+    remove_self_managed_snapshot snap_profile_namespace images
+    remove_self_managed_snapshot snap_profile_namespace volumes
 }
 
 test_rbd_support() {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -270,10 +270,14 @@ bool is_osd_writable(const OSDCapGrant& grant, const std::string* pool_name) {
     auto& match = grant.match;
     if (match.is_match_all()) {
       return true;
-    } else if (pool_name != nullptr &&
-               !match.pool_namespace.pool_name.empty() &&
-               match.pool_namespace.pool_name == *pool_name) {
-      return true;
+    } else if (pool_name != nullptr) {
+      if (!match.pool_namespace.pool_name.empty()) {
+        if (match.pool_namespace.pool_name == *pool_name) {
+          return true;
+        }
+      } else if (match.pool_tag.is_match_all()) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -445,7 +445,7 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
 	       >> (lit('=') | spaces)
 	       >> estr >> -char_('*'));
 
-    // match := [pool[=]<poolname> [namespace[=]<namespace>]] [object_prefix <prefix>]
+    // match := [pool[=]<poolname>] [namespace[=]<namespace>] [object_prefix <prefix>]
     object_prefix %= -(spaces >> lit("object_prefix") >> spaces >> str);
     pooltag %= (spaces >> lit("tag")
 		>> spaces >> str // application
@@ -478,7 +478,7 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
       (rwxa)                      [_val = phoenix::construct<OSDCapSpec>(_1)] |
       (class_name >> method_name) [_val = phoenix::construct<OSDCapSpec>(_1, _2)]);
 
-    // profile := profile <name> [pool[=]<pool> [namespace[=]<namespace>]]
+    // profile := profile <name> [pool[=]<pool>] [namespace[=]<namespace>]
     profile_name %= (lit("profile") >> (lit('=') | spaces) >> str);
     profile = (
       (profile_name >> pool_name >> nspace) [_val = phoenix::construct<OSDCapProfile>(_1, _2, _3)] |


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69729

---

backport of https://github.com/ceph/ceph/pull/61540
parent tracker: https://tracker.ceph.com/issues/69679