### PR TITLE
mon: include cleanup

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -30,12 +30,14 @@
 #include <utility>
 
 #include "auth/KeyRing.h"
+#include "common/ceph_context.h"
 #include "common/errno.h"
 #include "common/Formatter.h"
 #include "common/module.h"
 #include "common/run_cmd.h"
 #include "common/safe_io.h"
 #include "common/secret.h"
+#include "common/strtol.h" // for strict_strtoll()
 #include "common/TextTable.h"
 #include "common/Thread.h"
 #include "include/ceph_assert.h"

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -1,15 +1,17 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <boost/algorithm/string/split.hpp>
-
 #include "ConfigMap.h"
 #include "crush/CrushWrapper.h"
 #include "common/entity_name.h"
 
+#include <boost/algorithm/string/split.hpp>
+
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #include "common/dout.h"
+
+#include <iomanip>
 
 using namespace std::literals;
 

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <list>
 #include <map>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <string>
 
+#include "include/types.h" // for version_t
 #include "include/utime.h"
 #include "common/options.h"
 #include "common/entity_name.h"

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -1,10 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <boost/algorithm/string/predicate.hpp>
-
-#include "mon/Monitor.h"
 #include "mon/ConfigMonitor.h"
+#include "mon/Monitor.h"
 #include "mon/KVMonitor.h"
 #include "mon/MgrMonitor.h"
 #include "mon/OSDMonitor.h"
@@ -15,6 +13,9 @@
 #include "common/TextTable.h"
 #include "common/cmdparse.h"
 #include "include/stringify.h"
+#include "crush/CrushWrapper.h"
+
+#include <boost/algorithm/string/predicate.hpp>
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
-#include <optional>
-
 #include "ConfigMap.h"
 #include "mon/PaxosService.h"
+
+#include <map>
+#include <optional>
+#include <string>
 
 class MonSession;
 

--- a/src/mon/ElectionLogic.cc
+++ b/src/mon/ElectionLogic.cc
@@ -17,6 +17,11 @@
 #include "include/ceph_assert.h"
 #include "common/dout.h"
 
+#include <iomanip>
+#include <ostream>
+#include <sstream>
+#include <string>
+
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, epoch, elector)

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -17,6 +17,7 @@
 #define CEPH_ELECTIONLOGIC_H
 
 #include <map>
+#include <memory>
 #include <set>
 #include "include/types.h"
 #include "ConnectionTracker.h"

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -12,13 +12,14 @@
  * 
  */
 
-
-#include "OSDMonitor.h"
-
 #include "FSCommands.h"
+#include "OSDMonitor.h"
 #include "MDSMonitor.h"
 #include "MgrStatMonitor.h"
 #include "mds/cephfs_features.h"
+#include "mds/FSMap.h"
+#include "osd/OSDMap.h"
+#include "common/strtol.h" // for strict_strtoll()
 
 using TOPNSPC::common::cmd_getval;
 

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -19,11 +19,14 @@
 #include "Monitor.h"
 #include "CommandHandler.h"
 
-#include "osd/OSDMap.h"
-#include "mds/FSMap.h"
-
+#include <iosfwd>
+#include <memory>
 #include <string>
-#include <ostream>
+#include <variant>
+
+class Filesystem;
+class FSMap;
+class OSDMap;
 
 class FileSystemCommandHandler : protected CommandHandler
 {

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -39,6 +39,7 @@
 #include "include/ceph_assert.h"
 #include "include/str_list.h"
 #include "include/stringify.h"
+#include "mds/cephfs_features.h"
 #include "mds/mdstypes.h"
 #include "Session.h"
 

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -14,11 +14,14 @@
 #ifndef MGR_MAP_H_
 #define MGR_MAP_H_
 
-#include <sstream>
+#include <map>
 #include <set>
+#include <string>
+#include <vector>
 
 #include "msg/msg_types.h"
 #include "include/encoding.h"
+#include "include/types.h" // for epoch_t
 #include "include/utime.h"
 #include "common/ceph_json.h"
 #include "common/Formatter.h"

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -33,6 +33,7 @@
 
 #include "common/admin_socket.h"
 #include "common/async/completion.h"
+#include "common/strtol.h" // for strict_strtoll()
 #include "common/Timer.h"
 #include "common/config.h"
 #include "messages/MMonGetVersion.h"

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -21,12 +21,15 @@
 
 #include "common/config_fwd.h"
 #include "common/ceph_releases.h"
+#include "include/uuid.h" // for uuid_d
 
-#include "include/err.h"
-#include "include/types.h"
+#include "mon/mon_types.h" // for mon_feature_t
 
-#include "mon/mon_types.h"
-#include "msg/Message.h"
+#include <iosfwd>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
 
 class health_check_map_t;
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -12,7 +12,9 @@
  * 
  */
 
+#include "Monitor.h"
 
+#include <iomanip> // for std::setw()
 #include <iterator>
 #include <sstream>
 #include <tuple>
@@ -26,11 +28,11 @@
 #include "json_spirit/json_spirit_reader.h"
 #include "json_spirit/json_spirit_writer.h"
 
-#include "Monitor.h"
 #include "common/version.h"
 #include "common/blkdev.h"
 #include "common/cmdparse.h"
 #include "common/signal.h"
+#include "crush/CrushWrapper.h"
 
 #include "osd/OSDMap.h"
 
@@ -93,6 +95,12 @@
 #include "perfglue/heap_profiler.h"
 
 #include "auth/none/AuthNoneClientHandler.h"
+
+#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#include "crimson/common/perf_counters_collection.h"
+#else
+#include "common/perf_counters_collection.h"
+#endif
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -23,6 +23,7 @@
 #include <sstream>
 #include "common/config.h"
 #include "common/cmdparse.h"
+#include "crush/CrushWrapper.h"
 
 #include "include/ceph_assert.h"
 #include "include/stringify.h"

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1,22 +1,30 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <boost/algorithm/string.hpp>
+#include "PGMap.h"
+#include "mon/health_check.h"
+#include "common/ceph_context.h"
 
 #include "include/rados.h"
-#include "PGMap.h"
 
 #define dout_subsys ceph_subsys_mon
 #include "common/debug.h"
 #include "common/Clock.h"
 #include "common/Formatter.h"
+#include "common/TextTable.h"
 #include "global/global_context.h"
 #include "include/ceph_features.h"
+#include "include/health.h"
 #include "include/stringify.h"
 
 #include "osd/osd_types.h"
 #include "osd/OSDMap.h"
+
+#include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/reversed.hpp>
+
+#include <iomanip> // for std::setw()
+#include <sstream>
 
 #define dout_context g_ceph_context
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -21,15 +21,22 @@
 #ifndef CEPH_PGMAP_H
 #define CEPH_PGMAP_H
 
-#include "include/health.h"
-#include "common/debug.h"
-#include "common/TextTable.h"
+#include "include/buffer.h"
+#include "common/debug.h" // for cmdmap_t
+#include "common/cmdparse.h"
+#include "common/Formatter.h"
 #include "osd/osd_types.h"
 #include "include/mempool.h"
-#include "mon/health_check.h"
-#include <sstream>
 
+#include <cstdint>
+#include <iosfwd>
+#include <map>
+#include <set>
+#include <string>
+
+struct health_check_map_t;
 namespace ceph { class Formatter; }
+class TextTable;
 
 class PGMapDigest {
 public:

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -12,7 +12,6 @@
  * 
  */
 
-#include <sstream>
 #include "Paxos.h"
 #include "Monitor.h"
 #include "messages/MMonPaxos.h"
@@ -23,6 +22,12 @@
 #include "include/stringify.h"
 #include "common/Timer.h"
 #include "messages/PaxosServiceMessage.h"
+
+#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#include "crimson/common/perf_counters_collection.h"
+#else
+#include "common/perf_counters_collection.h"
+#endif
 
 using std::string;
 using std::unique_lock;

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -15,13 +15,18 @@
 #ifndef CEPH_MON_SESSION_H
 #define CEPH_MON_SESSION_H
 
+#include <map>
+#include <set>
 #include <string>
 #include <string_view>
 
+#include "common/Clock.h" // for ceph_clock_now()
+#include "common/RefCountedObj.h"
 #include "include/utime.h"
 #include "include/xlist.h"
 
 #include "global/global_context.h"
+#include "msg/Connection.h" // for ConnectionRef
 #include "msg/msg_types.h"
 #include "mon/mon_types.h"
 

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -15,14 +15,19 @@
 #ifndef CEPH_MON_TYPES_H
 #define CEPH_MON_TYPES_H
 
+#include <iomanip>
+#include <list>
 #include <map>
+#include <sstream>
+#include <string>
 
-#include "include/Context.h"
+#include "include/ceph_features.h" // for CEPH_FEATURE_*
 #include "include/util.h"
 #include "include/utime.h"
 #include "common/Formatter.h"
 #include "common/bit_str.h"
 #include "common/ceph_releases.h"
+#include "msg/msg_types.h" // for entity_addrvec_t
 
 // use as paxos_service index
 enum {


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490; this time the "mon" subsystem.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
