### PR TITLE
squid: container: add label ceph=True back

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -36,6 +36,7 @@ LABEL org.opencontainers.image.authors="Ceph Release Team <ceph-maintainers@ceph
       org.opencontainers.image.documentation="https://docs.ceph.com/"
 
 LABEL \
+ceph=True \
 FROM_IMAGE=${FROM_IMAGE} \
 CEPH_REF=${CEPH_REF} \
 CEPH_SHA1=${CEPH_SHA1} \


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/61511

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
