### PR TITLE
rgw: replace obsolete get_tracked_conf_keys()

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -886,12 +886,10 @@ void rgw::auth::ImplicitTenants::recompute_value(const ConfigProxy& c)
   saved = v;
 }
 
-const char **rgw::auth::ImplicitTenants::get_tracked_conf_keys() const
+std::vector<std::string> rgw::auth::ImplicitTenants::get_tracked_keys()
+    const noexcept
 {
-  static const char *keys[] = {
-    "rgw_keystone_implicit_tenants",
-  nullptr };
-  return keys;
+  return {"rgw_keystone_implicit_tenants"s};
 }
 
 void rgw::auth::ImplicitTenants::handle_conf_change(const ConfigProxy& c,

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -550,7 +550,7 @@ public:
     return ImplicitTenantValue(saved);
   }
 private:
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
     const std::set <std::string> &changed) override;
 };

--- a/src/rgw/rgw_dmclock_async_scheduler.cc
+++ b/src/rgw/rgw_dmclock_async_scheduler.cc
@@ -5,6 +5,8 @@
 #include "rgw_dmclock_async_scheduler.h"
 #include "rgw_dmclock_scheduler.h"
 
+using namespace std::literals;
+
 namespace rgw::dmclock {
 
 AsyncScheduler::~AsyncScheduler()
@@ -15,15 +17,13 @@ AsyncScheduler::~AsyncScheduler()
   }
 }
 
-const char** AsyncScheduler::get_tracked_conf_keys() const
+std::vector<std::string> AsyncScheduler::get_tracked_keys() const noexcept
 {
   if (observer) {
-    return observer->get_tracked_conf_keys();
+    return observer->get_tracked_keys();
   }
-  static const char* keys[] = { "rgw_max_concurrent_requests", nullptr };
-  return keys;
+  return {"rgw_max_concurrent_requests"s};;
 }
-
 void AsyncScheduler::handle_conf_change(const ConfigProxy& conf,
                                         const std::set<std::string>& changed)
 {

--- a/src/rgw/rgw_dmclock_async_scheduler.h
+++ b/src/rgw/rgw_dmclock_async_scheduler.h
@@ -64,7 +64,7 @@ class AsyncScheduler : public md_config_obs_t, public Scheduler {
   /// handler with an operation_aborted error and default-constructed result
   void cancel(const client_id& client);
 
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string>& changed) override;
 

--- a/src/rgw/rgw_dmclock_scheduler_ctx.cc
+++ b/src/rgw/rgw_dmclock_scheduler_ctx.cc
@@ -13,6 +13,8 @@
  */
 #include "rgw_dmclock_scheduler_ctx.h"
 
+using namespace std::literals;
+
 namespace rgw::dmclock {
 
 ClientConfig::ClientConfig(CephContext *cct)
@@ -25,25 +27,23 @@ ClientInfo* ClientConfig::operator()(client_id client)
   return &clients[static_cast<size_t>(client)];
 }
 
-const char** ClientConfig::get_tracked_conf_keys() const
+std::vector<std::string> ClientConfig::get_tracked_keys() const noexcept
 {
-  static const char* keys[] = {
-    "rgw_dmclock_admin_res",
-    "rgw_dmclock_admin_wgt",
-    "rgw_dmclock_admin_lim",
-    "rgw_dmclock_auth_res",
-    "rgw_dmclock_auth_wgt",
-    "rgw_dmclock_auth_lim",
-    "rgw_dmclock_data_res",
-    "rgw_dmclock_data_wgt",
-    "rgw_dmclock_data_lim",
-    "rgw_dmclock_metadata_res",
-    "rgw_dmclock_metadata_wgt",
-    "rgw_dmclock_metadata_lim",
-    "rgw_max_concurrent_requests",
-    nullptr
+  return {
+    "rgw_dmclock_admin_res"s,
+    "rgw_dmclock_admin_wgt"s,
+    "rgw_dmclock_admin_lim"s,
+    "rgw_dmclock_auth_res"s,
+    "rgw_dmclock_auth_wgt"s,
+    "rgw_dmclock_auth_lim"s,
+    "rgw_dmclock_data_res"s,
+    "rgw_dmclock_data_wgt"s,
+    "rgw_dmclock_data_lim"s,
+    "rgw_dmclock_metadata_res"s,
+    "rgw_dmclock_metadata_wgt"s,
+    "rgw_dmclock_metadata_lim"s,
+    "rgw_max_concurrent_requests"s
   };
-  return keys;
 }
 
 void ClientConfig::update(const ConfigProxy& conf)

--- a/src/rgw/rgw_dmclock_scheduler_ctx.h
+++ b/src/rgw/rgw_dmclock_scheduler_ctx.h
@@ -92,7 +92,7 @@ public:
 
   ClientInfo* operator()(client_id client);
 
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string>& changed) override;
 };


### PR DESCRIPTION
... with get_tracked_keys().

This PR is but one of a set. Following https://github.com/ceph/ceph/pull/61394, all
uses of the deprecated interface will be updated, and that old interface will be
removed.
