### PR TITLE
mon: Add nvmeof group/gateway name in  "ceph -s"

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3106,15 +3106,19 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f,
     {
       size_t maxlen = 3;
       auto& service_map = mgrstatmon()->get_service_map();
-      std::map<std::string, std::set<std::string>> nvmeof_groups;
+      std::map<NvmeGroupKey, std::set<std::string>> nvmeof_services;
       for (auto& p : service_map.services) {
         if (p.first == "nvmeof") {
           auto daemons = p.second.daemons;
           for (auto& d : daemons) {
             auto group = d.second.metadata.find("group");
-            auto gw_id = d.second.metadata.find("id"); 
-            nvmeof_groups[group->second].insert(gw_id->second);
-            maxlen = std::max(maxlen, p.first.size() + group->second.size() + 3); 
+            auto pool = d.second.metadata.find("pool_name"); 
+            auto gw_id = d.second.metadata.find("id");
+            NvmeGroupKey group_key = std::make_pair(pool->second,  group->second); 
+            nvmeof_services[group_key].insert(gw_id->second);
+            maxlen = std::max(maxlen, 
+                p.first.size() + group->second.size() + pool->second.size() + 4
+              ); // nvmeof (pool.group):
           }
         } else {
           maxlen = std::max(maxlen, p.first.size());
@@ -3165,12 +3169,20 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f,
           continue;
         }
         if (p.first == "nvmeof") {
-          for (auto& group : nvmeof_groups) {
-            ss << "    " << p.first << " (" << group.first << "): ";
-            ss << string(maxlen - p.first.size() - group.first.size() - 3, ' ');
-            ss << group.second.size() << " gateway" << (group.second.size() ? "s" : "") << " active (";
-            for (auto gw = group.second.begin(); gw != group.second.end(); ++gw){
-              if (gw != group.second.begin()) {
+          auto created_gws = nvmegwmon()->get_map().created_gws;
+          for (const auto& created_map_pair: created_gws) {
+            const auto& group_key = created_map_pair.first;
+            const NvmeGwMonStates& gw_created_map = created_map_pair.second;
+            const int total = gw_created_map.size();
+            auto& active_gws = nvmeof_services[group_key];
+
+            ss << "    " << p.first << " (" << group_key.first << "." << group_key.second << "): ";
+            ss << string(maxlen - p.first.size() - group_key.first.size() 
+                    - group_key.second.size() - 4, ' ');
+            ss << total << " gateway" << (total > 1 ? "s" : "") << ": " 
+               << active_gws.size() << " active (";
+            for (auto gw = active_gws.begin(); gw != active_gws.end(); ++gw){
+              if (gw != active_gws.begin()) {
 	              ss << ", ";
               }
               ss << *gw; 

--- a/src/mon/NVMeofGwMon.h
+++ b/src/mon/NVMeofGwMon.h
@@ -82,6 +82,8 @@ public:
   void check_subs(bool type);
   void check_sub(Subscription *sub);
   void check_sub_unconditional(Subscription *sub);
+ 
+  const NVMeofGwMap& get_map() const { return map; }
 
   std::map<NvmeGroupKey, std::map<NvmeGwId, utime_t>> gws_deleting_time;
 


### PR DESCRIPTION
In "ceph status" command output, show gateway
group names and gateway names.

Before:
```
  services:
    mon:    4 daemons, quorum ceph-nvme-vm8,ceph-nvme-vm1,ceph-nvme-vm7,ceph-nvme-vm6 (age 71m)
    mgr:    ceph-nvme-vm8.tgytdq(active, since 73m), standbys: ceph-nvme-vm6.tequqo, ceph-nvme-vm1.pxrofr, ceph-nvme-vm7.lbxrea
    osd:    4 osds: 4 up (since 70m), 4 in (since 70m)
    nvmeof: 4 gateways active (4 hosts)
```

After:
```
  services:
    mon:                      4 daemons, quorum ceph-nvme-vm31,ceph-nvme-vm28,ceph-nvme-vm30,ceph-nvme-vm29 (age 16m)
    mgr:                      ceph-nvme-vm31.wnfclf(active, since 18m), standbys: ceph-nvme-vm29.iuwqin, ceph-nvme-vm28.lnnyui, ceph-nvme-vm30.fitwnw
    osd:                      4 osds: 4 up (since 14m), 4 in (since 15m)
    nvmeof (mypool.mygroup1): 2 gateways: 1 active (ceph-nvme-vm30.kkcfux)
    nvmeof (mypool.mygroup2): 2 gateways: 2 active (ceph-nvme-vm28.mfqucr, ceph-nvme-vm29.hrizzl)
```


Ticket: https://jsw.ibm.com/browse/ISCE-1807

Depends on: https://github.com/ceph/ceph-nvmeof/pull/1080

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
