### PR TITLE
squid: Backport two commits to the Squid branch

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -94,6 +94,29 @@ configuration across the entire cluster. Conversely, opt for a ``stretch pool``
 when you need a particular pool to be replicated across ``more than two data centers``,
 providing a more granular level of control and a larger cluster size.
 
+Limitations
+-----------
+
+Individual Stretch Pools do not support I/O operations during a netsplit
+scenario between two or more zones. While the cluster remains accessible for
+basic Ceph commands, I/O usage remains unavailable until the netsplit is
+resolved. This is different from ``stretch mode``, where the tiebreaker monitor
+can isolate one zone of the cluster and continue I/O operations in degraded
+mode during a netsplit. See :ref:`stretch_mode1`
+
+Ceph is designed to tolerate multiple host failures. However, if more than 25% of
+the OSDs in the cluster go down, Ceph may stop marking OSDs as out which will prevent rebalancing
+and some PGs might go inactive. This behavior is controlled by the ``mon_osd_min_in_ratio`` parameter.
+By default, mon_osd_min_in_ratio is set to 0.75, meaning that at least 75% of the OSDs
+in the cluster must remain ``active`` before any additional OSDs can be marked out.
+This setting prevents too many OSDs from being marked out as this might lead to significant
+data movement. The data movement can cause high client I/O impact and long recovery times when
+the OSDs are returned to service. If Ceph stops marking OSDs as out, some PGs may fail to
+rebalance to surviving OSDs, potentially leading to ``inactive`` PGs.
+See https://tracker.ceph.com/issues/68338 for more information.
+
+.. _stretch_mode1:
+
 Stretch Mode
 ============
 Stretch mode is designed to handle deployments in which you cannot guarantee the


### PR DESCRIPTION
This backports two commits to the squid branch that were not properly backported before. This is done to ensure that the Squid documentation can be updated with the standard backport procedure.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

