### PR TITLE
mgr/cephadm/nvmeof: Add max_hosts field to NVMeOF configuration

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -30,6 +30,7 @@ enable_monitor_client = {{ spec.enable_monitor_client }}
 max_hosts_per_namespace = {{ spec.max_hosts_per_namespace }}
 max_namespaces_with_netmask = {{ spec.max_namespaces_with_netmask }}
 max_subsystems = {{ spec.max_subsystems }}
+max_hosts = {{ spec.max_hosts }}
 max_namespaces = {{ spec.max_namespaces }}
 max_namespaces_per_subsystem = {{ spec.max_namespaces_per_subsystem }}
 max_hosts_per_subsystem = {{ spec.max_hosts_per_subsystem }}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -379,9 +379,10 @@ enable_monitor_client = True
 max_hosts_per_namespace = 8
 max_namespaces_with_netmask = 1000
 max_subsystems = 128
+max_hosts = 2048
 max_namespaces = 1024
 max_namespaces_per_subsystem = 256
-max_hosts_per_subsystem = 32
+max_hosts_per_subsystem = 128
 
 [gateway-logs]
 log_level = INFO

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1361,9 +1361,10 @@ class NvmeofServiceSpec(ServiceSpec):
                  max_hosts_per_namespace: Optional[int] = 8,
                  max_namespaces_with_netmask: Optional[int] = 1000,
                  max_subsystems: Optional[int] = 128,
+                 max_hosts: Optional[int] = 2048,
                  max_namespaces: Optional[int] = 1024,
                  max_namespaces_per_subsystem: Optional[int] = 256,
-                 max_hosts_per_subsystem: Optional[int] = 32,
+                 max_hosts_per_subsystem: Optional[int] = 128,
                  server_key: Optional[str] = None,
                  server_cert: Optional[str] = None,
                  client_key: Optional[str] = None,
@@ -1471,6 +1472,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.max_namespaces_with_netmask = max_namespaces_with_netmask
         #: ``max_subsystems`` max number of subsystems
         self.max_subsystems = max_subsystems
+        #: ``max_hosts`` max number of hosts on all subsystems
+        self.max_hosts = max_hosts
         #: ``max_namespaces`` max number of namespaces on all subsystems
         self.max_namespaces = max_namespaces
         #: ``max_namespaces_per_subsystem`` max number of namespaces per one subsystem
@@ -1618,6 +1621,7 @@ class NvmeofServiceSpec(ServiceSpec):
         verify_non_negative_int(self.max_hosts_per_namespace, "Max hosts per namespace")
         verify_non_negative_int(self.max_namespaces_with_netmask, "Max namespaces with netmask")
         verify_positive_int(self.max_subsystems, "Max subsystems")
+        verify_positive_int(self.max_hosts, "Max hosts")
         verify_positive_int(self.max_namespaces, "Max namespaces")
         verify_positive_int(self.max_namespaces_per_subsystem, "Max namespaces per subsystem")
         verify_positive_int(self.max_hosts_per_subsystem, "Max hosts per subsystem")


### PR DESCRIPTION
mgr/cephadm/nvmeof: Add max_hosts field to NVMeOF configuration and update default values

Fixes https://tracker.ceph.com/issues/69759
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>