### PR TITLE
qa: do not install ceph-selinux

### DIFF
--- a/qa/suites/fs/nfs/tasks/nfs.yaml
+++ b/qa/suites/fs/nfs/tasks/nfs.yaml
@@ -1,5 +1,7 @@
 overrides:
   install:
+    exclude_packages:
+      - ceph-selinux
     extra_system_packages:
       rpm:
         - fio


### PR DESCRIPTION
reads are failing with v4.2 in smithi machines. dmesg logs point to SELinux:
SELinux: inode_doinit_use_xattr:  getxattr returned 2 for dev=0:134 ino=1

This happens because the dirs are skipped while installing ceph-selinux:
2025-02-03T16:59:58.233 INFO:teuthology.orchestra.run.smithi110.stdout:  Installing       : ceph-selinux-2:19.3.0-7103.gb257c5b2.el9.x86_64    101/135
2025-02-03T17:00:11.001 INFO:teuthology.orchestra.run.smithi110.stdout:  Running scriptlet: ceph-selinux-2:19.3.0-7103.gb257c5b2.el9.x86_64    101/135
2025-02-03T17:00:11.001 INFO:teuthology.orchestra.run.smithi110.stdout:skipping the directory /sys
2025-02-03T17:00:11.001 INFO:teuthology.orchestra.run.smithi110.stdout:skipping the directory /proc
2025-02-03T17:00:11.001 INFO:teuthology.orchestra.run.smithi110.stdout:skipping the directory /mnt
2025-02-03T17:00:11.002 INFO:teuthology.orchestra.run.smithi110.stdout:skipping the directory /var/tmp
2025-02-03T17:00:11.002 INFO:teuthology.orchestra.run.smithi110.stdout:skipping the directory /home
2025-02-03T17:00:11.002 INFO:teuthology.orchestra.run.smithi110.stdout:skipping the directory /root
2025-02-03T17:00:11.002 INFO:teuthology.orchestra.run.smithi110.stdout:skipping the directory /tmp

It looks like this misconfiguration leads to read xattrs retrieval to fail and the read is not allowed, audit logs suggest the same: ino=393233 scontext=system_u:system_r:syslogd_t:s0 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=dir permissive=1 type=AVC msg=audit(1738667402.210:7628): avc:  denied  { search } for  pid=4562 comm=72733A6D61696E20513A526567 name="cephtest" dev="sda1" ino=393233 scontext=system_u:system_r:syslogd_t:s0 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=dir permissive=1

Interesting obersation is this workload passes with v3 or v4.1 mounts. So there is something v4.2 specific combined with SELinux that's doing some mishap. The same workload on other machines work fine (probably SELinux labelling is properly done there).





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
