### PR TITLE
os/bluestore: Improved algorithm for "fragmentation score" calculation

### DIFF
--- a/src/include/intarith.h
+++ b/src/include/intarith.h
@@ -111,6 +111,38 @@ constexpr inline T p2roundup(T x, T align) {
   return -(-x & -align);
 }
 
+/*
+ * return log2(x) rounded up
+ * x must be of unsigned type
+ * for x == 0 gives unexpected value
+ * eg, p2log_ceil(0x1234) == 13 (2^13 = 0x2000)
+ * eg, p2log_ceil(0x1fff) == 13 (2^13 = 0x2000)
+ * eg, p2log_ceil(0x2000) == 13 (2^13 = 0x2000)
+ * eg, p2log_ceil(1)      == 0  (2^0 = 1)
+ * eg, p2log_ceil(0)      == 8 * sizeof(x)
+ */
+template<typename T>
+constexpr inline signed char p2log_ceil(T x) {
+  static_assert(std::is_unsigned_v<T> == true);
+  return 8 * sizeof(T) - std::countl_zero(T(x - 1));
+}
+
+/*
+ * return log2(x) rounded down
+ * x must be of unsigned type
+ * For x == 0 it gives unexpected value
+ * eg, p2log_floor(0x1234U)  == 12 (2^12 = 0x1000)
+ * eg, p2log_floor(0x1fffU)  == 12 (2^12 = 0x1000)
+ * eg, p2log_floor(0x2000UL) == 13 (2^13 = 0x2000)
+ * eg, p2log_floor(1)        == 0  (2^0 = 1)
+ * eg, p2log_floor(0)        == -1
+ */
+template<typename T>
+constexpr inline signed char p2log_floor(T x) {
+  static_assert(std::is_unsigned_v<T> == true);
+  return 8 * sizeof(T) - std::countl_zero(x) - 1;
+}
+
 // count bits (set + any 0's that follow)
 template<std::integral T>
 unsigned cbits(T v) {

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -295,6 +295,9 @@ public:
   {
     return 0.0;
   }
+  std::vector<double> score_scaled{1};
+  double get_score(size_t v);
+  virtual double get_fragmentation_score_raw();
   virtual double get_fragmentation_score();
   virtual void shutdown() = 0;
 

--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -365,6 +365,7 @@ AvlAllocator::AvlAllocator(CephContext* cct,
                            uint64_t max_mem,
                            std::string_view name) :
   Allocator(name, device_size, block_size),
+  FastScore(cct, this),
   cct(cct),
   range_size_alloc_threshold(
     cct->_conf.get_val<uint64_t>("bluestore_avl_alloc_bf_threshold")),

--- a/src/test/test_intarith.cc
+++ b/src/test/test_intarith.cc
@@ -38,3 +38,39 @@ TEST(intarith, p2family) {
   ASSERT_EQ(0x1300, p2roundup(0x1234, 0x100));
   ASSERT_EQ(0x5600, p2roundup(0x5600, 0x100));
 }
+
+TEST(intarith, p2log_family) {
+  ASSERT_EQ(13, p2log_ceil(0x1234U));
+  ASSERT_EQ(13, p2log_ceil(0x1234UL));
+  ASSERT_EQ(13, p2log_ceil(0x1234ULL));
+  ASSERT_EQ(13, p2log_ceil(0x1fffU));
+  ASSERT_EQ(13, p2log_ceil(0x1fffUL));
+  ASSERT_EQ(13, p2log_ceil(0x1fffULL));
+  ASSERT_EQ(13, p2log_ceil(0x2000U));
+  ASSERT_EQ(13, p2log_ceil(0x2000UL));
+  ASSERT_EQ(13, p2log_ceil(0x2000ULL));
+  ASSERT_EQ(0,  p2log_ceil(0x1U));
+  ASSERT_EQ(0,  p2log_ceil(0x1UL));
+  ASSERT_EQ(0,  p2log_ceil(0x1ULL));
+  ASSERT_EQ(8,  p2log_ceil(uint8_t(0)));
+  ASSERT_EQ(16, p2log_ceil(uint16_t(0)));
+  ASSERT_EQ(32, p2log_ceil(uint32_t(0)));
+  ASSERT_EQ(64, p2log_ceil(uint64_t(0)));
+
+  ASSERT_EQ(12, p2log_floor(0x1234U));
+  ASSERT_EQ(12, p2log_floor(0x1234UL));
+  ASSERT_EQ(12, p2log_floor(0x1234ULL));
+  ASSERT_EQ(12, p2log_floor(0x1fffU));
+  ASSERT_EQ(12, p2log_floor(0x1fffUL));
+  ASSERT_EQ(12, p2log_floor(0x1fffULL));
+  ASSERT_EQ(13, p2log_floor(0x2000U));
+  ASSERT_EQ(13, p2log_floor(0x2000UL));
+  ASSERT_EQ(13, p2log_floor(0x2000ULL));
+  ASSERT_EQ(0,  p2log_floor(0x1U));
+  ASSERT_EQ(0,  p2log_floor(0x1UL));
+  ASSERT_EQ(0,  p2log_floor(0x1ULL));
+  ASSERT_EQ(-1, p2log_floor(uint8_t(0)));
+  ASSERT_EQ(-1, p2log_floor(uint16_t(0)));
+  ASSERT_EQ(-1, p2log_floor(uint32_t(0)));
+  ASSERT_EQ(-1, p2log_floor(uint64_t(0)));
+}


### PR DESCRIPTION
Calculation of alloc->get_fragmentation_score() is slow.
It causes stall on allocator which translates to a slow op.
New method allows to get rid of this effect for most allocators.

Currently (draft) only avl is handled.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
