### PR TITLE
rgw/rados: enable object deletion at rados pool quota

### DIFF
--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -3,3 +3,9 @@ tasks:
     clients:
       client.0:
         - rgw/run-rados-pool-quota.sh
+
+overrides:
+  ceph:
+    log-ignorelist:
+      - reached quota
+      - POOL_FULL

--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rgw/run-rados-pool-quota.sh

--- a/qa/workunits/rgw/run-rados-pool-quota.sh
+++ b/qa/workunits/rgw/run-rados-pool-quota.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+
+# assume working ceph environment (radosgw-admin in path) and rgw on localhost:80
+# localhost::443 for ssl
+
+mydir=`dirname $0`
+
+python3 -m venv $mydir
+source $mydir/bin/activate
+pip install pip --upgrade
+pip install boto3
+
+## run test
+$mydir/bin/python3 $mydir/test_rgw_rados_pool_quota.py
+
+deactivate
+echo OK.
+

--- a/qa/workunits/rgw/test_rgw_rados_pool_quota.py
+++ b/qa/workunits/rgw/test_rgw_rados_pool_quota.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import logging as log
+import uuid
+import botocore
+import time
+from common import exec_cmd, create_user, boto_connect
+from botocore.config import Config
+
+"""
+Tests rgw behavior when backing rados pool is at quota
+"""
+# The test cases in this file have been annotated for inventory.
+# To extract the inventory (in csv format) use the command:
+#
+#   grep '^ *# TESTCASE' | sed 's/^ *# TESTCASE //'
+#
+#
+
+""" Constants """
+USER = 'quota-tester'
+DISPLAY_NAME = 'Quota Tester'
+ACCESS_KEY = 'LTA662PVVDTDWX6M2AB0'
+SECRET_KEY = 'pvtchqajgzqx5581t6qbddbkj0bgf3a69qdkjcea'
+BUCKET_NAME = 'quota-tester-bucket'
+DATA_POOL = 'default.rgw.buckets.data'
+
+def main():
+    """
+    execute quota tests
+    """
+    create_user(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY)
+
+    connection = boto_connect(ACCESS_KEY, SECRET_KEY, Config(retries = {
+        'total_max_attempts': 1,
+    }))
+
+    # pre-test cleanup
+    try:
+        exec_cmd(f"ceph osd pool set-quota {DATA_POOL} max_objects 0")
+    except:
+        pass
+
+    try:
+        bucket = connection.Bucket(BUCKET_NAME)
+        bucket.objects.all().delete()
+        bucket.delete()
+    except botocore.exceptions.ClientError as e:
+        if not e.response['Error']['Code'] == 'NoSuchBucket':
+            raise
+
+    bucket = connection.create_bucket(Bucket=BUCKET_NAME)
+
+    # reproducer for bug from https://tracker.ceph.com/issues/69723
+    # TESTCASE 'add objects to pool, set quota to small value, verify that we can delete objects'
+    log.debug('TEST: verify that objects can be deleted with rados pool at quota')
+    key = str(uuid.uuid4())
+
+    objects = [f"{key}.{i}" for i in range(10)]
+    for obj in objects:
+        bucket.put_object(Key=obj, Body=b"new data")
+
+    exec_cmd(f"ceph osd pool set-quota {DATA_POOL} max_objects 1")
+
+    log.debug('forcing quota to propagate')
+    # We need the monitor to notice the pool stats and set the pool flags
+    time.sleep(10)
+    # And then we need to make sure the map with the newly set pool flags
+    # has propagated to the OSDs.  rados ls should force every OSD with a
+    # pg for this pool to have the most recent map
+    exec_cmd(f'rados -p {DATA_POOL} ls')
+    log.debug('forced quota to propagate')
+
+    for obj in objects:
+        try:
+            bucket.Object(obj).delete()
+        except Exception as e:
+            log.debug(f"Got error {e} on delete of obj {obj}")
+            assert False, f'Failure to delete obj {obj} with error {e}'
+
+    (_out, ret) = exec_cmd(f'rados -p {DATA_POOL} ls | grep {key}', check_retcode=False)
+    assert ret != 0, f'some objects were not cleaned up: {_out.decode("utf-8")}'
+
+    # reset quota
+    exec_cmd(f"ceph osd pool set-quota {DATA_POOL} max_objects 0")
+
+main()
+log.info("Completed rados pool quota tests")

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -685,6 +685,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
 	  }
 
 	  ctx->locator_set_key(obj.loc);
+	  ctx->set_pool_full_try(); // allow deletion at pool quota limit
 
 	  const string& oid = obj.key.name; /* just stored raw oid there */
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6155,6 +6155,7 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
   }
 
   auto& ioctx = ref.ioctx;
+  ioctx.set_pool_full_try(); // allow deletion at pool quota limit
   version_t epoch = 0;
   r = rgw_rados_operate(dpp, ioctx, ref.obj.oid, &op, y, 0, nullptr, &epoch);
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5048,6 +5048,7 @@ done_ret:
       if (ret2 < 0) {
         continue;
       }
+      obj.ioctx.set_pool_full_try();  // allow deletion at pool quota limit
 
       ObjectWriteOperation op;
       cls_refcount_put(op, ref_tag, true);
@@ -5663,6 +5664,7 @@ void RGWRados::delete_objs_inline(const DoutPrefixProvider *dpp, cls_rgw_obj_cha
   if (ret < 0) {
     return;
   }
+  ioctx.set_pool_full_try();  // allow deletion at pool quota limit
 
   // issue deletions in parallel, up to max_aio at a time
   auto aio = rgw::make_throttle(cct->_conf->rgw_multi_obj_del_max_aio, y);


### PR DESCRIPTION
adds the `librados::OPERATION_FULL_TRY` flag via `IoCtx::set_pool_full_try()` to object delete operations so that Objecter sends them even if the rados pool has reached its quota. this covers both the initial head object deletion and the deletion/garbage collection of tail objects

Fixes: https://tracker.ceph.com/issues/69723

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
