### PR TITLE
mgr/dashboard: Modify default Prometheus rule to take device classes into account

### DIFF
--- a/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
+++ b/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
@@ -195,11 +195,21 @@ tests:
    promql_expr_test:
      - expr: |
          abs(
-           (
-             (ceph_osd_numpg > 0) - on (job) group_left avg(ceph_osd_numpg > 0)
-             by (job)
-           ) / on (job) group_left avg(ceph_osd_numpg > 0) by (job)
-         ) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata > 0.30
+              (
+                (
+                  (ceph_osd_numpg > 0)
+                  * on (%(cluster)sjob, %(cluster)sceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                )
+                - on (%(cluster)sjob, device_class) group_left avg(
+                  (ceph_osd_numpg > 0)
+                  * on (%(cluster)sjob, %(cluster)sceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+                ) by (%(cluster)sjob, device_class)
+              )
+              / on (%(cluster)sjob, device_class) group_left avg(
+                (ceph_osd_numpg > 0)
+                * on (%(cluster)sjob, %(cluster)sceph_daemon) group_left(hostname, device_class) ceph_osd_metadata
+              ) by (%(cluster)sjob, device_class)
+            ) > 0.30
 
        eval_time: 5m
        exp_samples:


### PR DESCRIPTION
This PR updates the CephPGImbalance alert rule in Prometheus to account for device classes preventing false positives in mixed-storage clusters.

Fixes: https://tracker.ceph.com/issues/69690#change-285215

Signed-off-by:- Piyush Agarwal [piyushagarwal14.pa@gmail.com](mailto:piyushagarwal14.pa@gmail.com)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
