### PR TITLE
mgr/smb: Enable vfs_shadowcopy2 module by default

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
@@ -43,7 +43,7 @@ tasks:
             globals = ["default", "domain"]
             instance_name = "SAMBA"
             [shares.share1.options]
-            "vfs objects" = "acl_xattr ceph"
+            "vfs objects" = "acl_xattr shadow_copy2 ceph"
             path = "/"
             "acl_xattr:security_acl_name" = "user.NTACL"
             "ceph:config_file" = "/etc/ceph/ceph.conf"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
@@ -42,7 +42,7 @@ tasks:
           globals = ["default", "domain"]
           instance_name = "SAMBA"
           [shares.share1.options]
-          "vfs objects" = "acl_xattr ceph"
+          "vfs objects" = "acl_xattr shadow_copy2 ceph"
           path = "/"
           "acl_xattr:security_acl_name" = "user.NTACL"
           "ceph:config_file" = "/etc/ceph/ceph.conf"

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1186,7 +1186,7 @@ def _generate_share(
         # smb.conf options
         'options': {
             'path': path,
-            "vfs objects": f"acl_xattr {ceph_vfs}",
+            "vfs objects": f"acl_xattr shadow_copy2 {ceph_vfs}",
             'acl_xattr:security_acl_name': 'user.NTACL',
             f'{ceph_vfs}:config_file': '/etc/ceph/ceph.conf',
             f'{ceph_vfs}:filesystem': share.cephfs.volume,


### PR DESCRIPTION
With this change ceph snapshots can be accessed as Windows Volume Shadow Copies from the windows clients.

Reference: https://www.samba.org/samba/docs/4.9/man-html/vfs_shadow_copy2.8.html






## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
