### PR TITLE
mgr/nfs: nodeid should be numeric for RADOS_KV block in ganesha.conf file

### DIFF
--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -48,7 +48,7 @@ class NFSService(CephService):
                     if daemon_id is not None:
                         self.fence(daemon_id)
                 del rank_map[rank]
-                nodeid = f'{spec.service_name()}.{rank}'
+                nodeid = f'{rank}'
                 self.mgr.log.info(f'Removing {nodeid} from the ganesha grace table')
                 self.run_grace_tool(cast(NFSServiceSpec, spec), 'remove', nodeid)
                 self.mgr.spec_store.save_rank_map(spec.service_name(), rank_map)
@@ -82,7 +82,7 @@ class NFSService(CephService):
 
         deps: List[str] = []
 
-        nodeid = f'{daemon_spec.service_name}.{daemon_spec.rank}'
+        nodeid = f'{daemon_spec.rank}'
 
         nfs_idmap_conf = '/etc/ganesha/idmap.conf'
 

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -26,7 +26,7 @@ NFSv4 {
 
 RADOS_KV {
         UserId = "{{ user }}";
-        nodeid = "{{ nodeid }}";
+        nodeid = {{ nodeid }};
         pool = "{{ pool }}";
         namespace = "{{ namespace }}";
 }

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3256,7 +3256,7 @@ class TestIngressService:
             '\n'
             'RADOS_KV {\n'
             '        UserId = "nfs.foo.test.0.0";\n'
-            '        nodeid = "nfs.foo.None";\n'
+            '        nodeid = 0;\n'
             '        pool = ".nfs";\n'
             '        namespace = "foo";\n'
             '}\n'
@@ -3357,6 +3357,7 @@ class TestIngressService:
                 host='test',
                 daemon_id='foo.test.0.0',
                 service_name=nfs_service.service_name(),
+                rank=0,
             ),
         )
         assert nfs_generated_conf == nfs_expected_conf


### PR DESCRIPTION
For NFS HA changes, nodeid should be numeric for RADOS_KV block in ganesha.conf file. Refer Ganesha code change - https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1207554

Fixes: https://tracker.ceph.com/issues/69808
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[root@ceph-node-0 fe8d97b8-e3a3-11ef-af91-525400b09e9f]# cat /var/lib/ceph/fe8d97b8-e3a3-11ef-af91-525400b09e9f/nfs.mynfs.1.1.ceph-node-0.shngry/etc/ganesha/ganesha.conf | grep -i nodeid
        nodeid = 1;
[root@ceph-node-0 fe8d97b8-e3a3-11ef-af91-525400b09e9f]# 

[root@ceph-node-1 ~]# cat /var/lib/ceph/fe8d97b8-e3a3-11ef-af91-525400b09e9f/nfs.mynfs.0.1.ceph-node-1.dbtjwv/etc/ganesha/ganesha.conf | grep -i nodeid
        nodeid = 0;
[root@ceph-node-1 ~]# 



ceph.cephadm.log:480:2025-02-05T11:16:12.733412+0000 mgr.ceph-node-0.keeaak (mgr.14166) 3480 : cephadm [DBG] ['ganesha-rados-grace', '--cephconf', '/tmp/mgr-grace-conf61_sgq5s', '--userid', 'mgr.nfs.grace.nfs.mynfs', '--pool', '.nfs', '--ns', 'mynfs', 'add', '0']
ceph.cephadm.log:512:2025-02-05T11:16:14.255125+0000 mgr.ceph-node-0.keeaak (mgr.14166) 3504 : cephadm [DBG] ['ganesha-rados-grace', '--cephconf', '/tmp/mgr-grace-confsp4gogm3', '--userid', 'mgr.nfs.grace.nfs.mynfs', '--pool', '.nfs', '--ns', 'mynfs', 'add', '1']

```



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
