### PR TITLE
mgr/nfs: allow tls for nfs using stunnel as a sidecar container

### DIFF
--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-stunnel.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-stunnel.yaml
@@ -1,0 +1,55 @@
+tasks:
+- vip:
+
+# make sure cephadm notices the new IP
+- cephadm.shell:
+    host.a:
+      - ceph orch device ls --refresh
+
+# stop kernel nfs server, if running
+- vip.exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create foofs
+
+# deploy nfs + ingress
+- cephadm.apply:
+    specs:
+      - service_type: nfs
+        service_id: foo
+        placement:
+          count: 2
+        spec:
+          port: 12049
+          deploy_stunnel: true
+          stunnel_port: 20490
+          virtual_ip: "{{VIP0}}"
+      - service_type: ingress
+        service_id: nfs.foo
+        spec:
+          backend_service: nfs.foo
+          frontend_port: 2049
+          monitor_port: 9002
+          virtual_ip: "{{VIP0}}/{{VIPPREFIXLEN}}"
+- cephadm.wait_for_service:
+    service: nfs.foo
+- cephadm.wait_for_service:
+    service: ingress.nfs.foo
+
+## export and mount
+
+- cephadm.shell:
+    host.a:
+      - ceph nfs export create cephfs --fsname foofs --cluster-id foo --pseudo-path /fake
+
+- vip.exec:
+    host.a:
+      - podman run --network host quay.io/adk3798/stunnel:0.1.0.build-5 --endpoint {{VIP0}}:20490 --bind 0.0.0.0 --port 120490
+      - mkdir /mnt/foo
+      - sleep 5
+      - mount -t nfs -o port=120490 127.0.0.1:/fake /mnt/foo
+      - echo test > /mnt/foo/testfile
+      - sync

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -493,6 +493,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.container_image_jaeger_query = ''
             self.container_image_samba = ''
             self.container_image_samba_metrics = ''
+            self.container_image_stunnel = ''
             self.warn_on_stray_hosts = True
             self.warn_on_stray_daemons = True
             self.warn_on_failed_host_check = True
@@ -1646,6 +1647,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 'snmp-gateway': self.container_image_snmp_gateway,
                 'mgmt-gateway': self.container_image_nginx,
                 'oauth2-proxy': self.container_image_oauth2_proxy,
+                'stunnel': self.container_image_stunnel,
                 # The image can't be resolved here, the necessary information
                 # is only available when a container is deployed (given
                 # via spec).

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3295,6 +3295,7 @@ class TestIngressService:
                 ),
                 'user': 'nfs.foo.test.0.0-rgw',
             },
+            'stunnel': {},
             'userid': 'nfs.foo.test.0.0',
         }
 

--- a/src/python-common/ceph/cephadm/images.py
+++ b/src/python-common/ceph/cephadm/images.py
@@ -32,6 +32,7 @@ class DefaultImages(Enum):
     GRAFANA = _create_image('quay.io/ceph/grafana:10.4.8', 'grafana')
     HAPROXY = _create_image('quay.io/ceph/haproxy:2.3', 'haproxy')
     KEEPALIVED = _create_image('quay.io/ceph/keepalived:2.2.4', 'keepalived')
+    STUNNEL = _create_image('quay.io/adk3798/stunnel:0.1.0.build-5', 'stunnel')
     NVMEOF = _create_image('quay.io/ceph/nvmeof:1.4', 'nvmeof')
     SNMP_GATEWAY = _create_image('docker.io/maxwo/snmp-notifier:v1.2.1', 'snmp_gateway')
     ELASTICSEARCH = _create_image('quay.io/omrizeneva/elasticsearch:6.8.23', 'elasticsearch')


### PR DESCRIPTION
## WIP
- Image needs to be pushed to `quay.io` - not in adk namespace

## Intro
This is a new feature that give users option to deploy a stunnel container as a sidecar to NFS. The users can create the client-side of the tunnel and encrypt their NFS traffic.

- There are generated self-signed certificates in the stunnel image used that reside in `/etc/tls` within the container. 

- deploy_stunnel: defaults to false
- stunnel_tls_dir: defaults to None
-     - if specified, the directory is mounted to container under `/etc/tls`
- stunnel_port: defaults to 20490


[Reference article](https://www.linuxjournal.com/content/encrypting-nfsv4-stunnel-tls)

## Usage
Users can use the same stunnel image on a client(where they'd be mounting the share) OR run stunnel natively connecting to the stunnel server using the same certificates(can be extracted from `/etc/tls` in the image). They can use their own IP(client side of the tunnel) to mount the share and enjoy TLS encryption.

## Image
### Info
This image is based on https://github.com/flitbit/alpine-stunnel with some minor changes. This is an old repo but still works great. Some minor changes are included as part of the auto-generated config. Some other changes around usage and options are included as well in the built image in quay.io repo. 

### Sample conf
- This is a sample config that is generated by the image's entrypoint (`/opt/run-stunnel.sh`).
```
cert = /etc/tls/cert.pem
key = /etc/tls/key.pem
cafile = /etc/tls/ca.pem
verify = 2
socket = a:TCP_NODELAY=1
socket = a:SO_KEEPALIVE=1
syslog = yes
debug = 5
delay = yes
foreground=yes

sslVersion = TLSv1.3
ciphers = HIGH:!aNULL:!MD5:!3DES:!RC4:!SHA1:!SEED:!CAMELLIA
options = NO_SSLv2
options = NO_SSLv3
options = SINGLE_DH_USE
options = SINGLE_ECDH_USE
options = CIPHER_SERVER_PREFERENCE

TIMEOUTidle = 60
FIPS = no
setuid = nobody
setgid = nobody

service = stunnel-nfs
curve = secp521r1

[backend]
client = no
accept = 0.0.0.0:20490
connect = 0.0.0.0:2049
```

### Usage
```
OPTIONS:
  -e/--endpoint:
      Required; specifies the endpoint to connect to, in the form <host>:<port>.

      Examples:
        10.0.0.10:8080
        svc.local:2133

  -t/--tls-path:
      Optional; specifies the directory containing a TLS key, certificate, and CA
       certificate. The directory must be mounted into the container
       and must contain files with the following names:

         ca.pem    - the CA's certificate
         cert.pem  - the endpoint's certificate
         key.pem   - the endpoint's key

        Default: /etc/tls

  -b/--bind: 
      Optional; specifies the IP address to bind to
        Default: IP from "getent hosts ${HOSTNAME} | awk '{print $1}'"
      Examples:
        127.0.0.1
        0.0.0.0

  -x/--ca:
        Optional; specify the name of the CA certificate file
        Default: ca.pem

  -y/--cert:  
        Optional; specify the name of the certificate file
        Default: cert.pem
  
  -z/--key:
        Optional; specify the name of the key file
        Default: key.pem
  
  -c/--config-path:
        Optional; specifies path to stunnel config
        Default: /etc/stunnel.d/stunnel.conf

  -p/--port:
        Optional; specifies port for stunnel
        Default: 4442

  -d/--server:
        Optional; specifies that the connect endpoint is a daemon that this secure
        tunnel will protect. This corresponds to stunnel's "client = no" setting.
        Default: True

        Adding this flag indicates that this end of the tunnel is where TLS
        termination occurs and that the backend (connect port) is insecure.

        Leaving this flag off indicates that clients will connect to this end of
        the tunnel without TLS, and that this end of the tunnel establishes TLS
        on behalf of the accepted clients.
```

## Testing


Signed-off-by: Omid Yoosefi <omidyoosefi@ibm.com>


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [] No tests
