### PR TITLE
qa: cut squid nightlies to one-per-week

### DIFF
--- a/qa/crontab/teuthology-cronjobs
+++ b/qa/crontab/teuthology-cronjobs
@@ -62,9 +62,6 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 
 
 ## main branch runs - weekly
-## suites rados and rbd use --subset arg and must be call with schedule_subset.sh
-## see script in https://github.com/ceph/ceph/tree/main/qa/machine_types
-
 # rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
 00 20 * * 0        $CW $SS 100000 --ceph main --suite      rados -p 101 --force-priority
 08 20 * * 1        $CW $SS     64 --ceph main --suite       orch -p 950
@@ -76,25 +73,18 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 56 20 * * 6        $CW $SS      1 --ceph main --suite crimson-rados -p 101 --force-priority --flavor crimson
 
 
-## squid branch runs - twice weekly (crimson-rados is run weekly)
-## suites rados and rbd use --subset arg and must be call with schedule_subset.sh
-## see script in https://github.com/ceph/ceph/tree/main/qa/machine_types
-
+## squid branch runs - weekly
 # rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
-#                                                                 -p 94-
-00 21 * * 0        $CW $SS 100000 --ceph squid --suite      rados -p 700 --force-priority
-08 21 * * 1,5      $CW $SS     64 --ceph squid --suite       orch -p 100 --force-priority
-16 21 * * 2,6      $CW $SS    128 --ceph squid --suite        rbd -p 100 --force-priority
-24 21 * * 3,0      $CW $SS    512 --ceph squid --suite         fs -p 100 --force-priority
-32 21 * * 4,1      $CW $SS      4 --ceph squid --suite powercycle -p 100 --force-priority
-40 21 * * 5,2      $CW $SS      1 --ceph squid --suite        rgw -p 100 --force-priority
-48 21 * * 6,3      $CW $SS      4 --ceph squid --suite       krbd -p 100 --force-priority --kernel testing
-56 21 * * 6        $CW $SS      1 --ceph squid --suite crimson-rados -p 100 --force-priority --flavor crimson
+00 21 * * 0        $CW $SS 100000 --ceph squid --suite      rados -p 921
+08 21 * * 1        $CW $SS     64 --ceph squid --suite       orch -p 920
+16 21 * * 2        $CW $SS    128 --ceph squid --suite        rbd -p 920
+24 21 * * 3        $CW $SS    512 --ceph squid --suite         fs -p 920
+32 21 * * 4        $CW $SS      4 --ceph squid --suite powercycle -p 920
+40 21 * * 5        $CW $SS      1 --ceph squid --suite        rgw -p 920
+48 21 * * 6        $CW $SS      4 --ceph squid --suite       krbd -p 920 --kernel testing
+56 21 * * 6        $CW $SS      1 --ceph squid --suite crimson-rados -p 920 --flavor crimson
 
 ## reef branch runs - weekly
-## suites rados and rbd use --subset arg and must be call with schedule_subset.sh
-## see script in https://github.com/ceph/ceph/tree/main/qa/machine_types
-
 # rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
 00 22 * * 0        $CW $SS 100000 --ceph reef --suite      rados -p 931
 08 22 * * 1        $CW $SS     64 --ceph reef --suite       orch -p 930


### PR DESCRIPTION
Now that it's released, we should go back to typical release branch cadence (teuthology queue is also growing).

Also, update the priority (ahead of reef) now that it's released.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
