### PR TITLE
squid: os/bluestore: Create additional bdev labels when expanding block device.

### DIFF
--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -33,6 +33,8 @@ function TEST_bluestore() {
     CEPH_ARGS+="--bluestore_block_wal_size=536870912 "
     CEPH_ARGS+="--bluestore_block_wal_create=true "
     CEPH_ARGS+="--bluestore_fsck_on_mount=true "
+    #choosing randomly allocation from file
+    CEPH_ARGS+="--bluestore_allocation_from_file=$((RANDOM % 2)) "
 
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
@@ -465,7 +467,7 @@ function TEST_bluestore_expand() {
     total_space_after=$( ceph tell osd.0 perf dump bluefs | jq ".bluefs.slow_total_bytes" )
     free_space_after=`ceph tell osd.0 bluestore bluefs device info | grep "BDEV_SLOW" -A 2 | grep free | cut -d':' -f 2 | cut -d"," -f 1 | cut -d' ' -f 2`
 
-    if [$total_space_after != $requested_space]; then
+    if [ $total_space_after != $requested_space ]; then
 	echo "total_space_after = $total_space_after"
 	echo "requested_space   = $requested_space"
 	return 1;

--- a/qa/standalone/osd/osd-bluefs-volume-ops.sh
+++ b/qa/standalone/osd/osd-bluefs-volume-ops.sh
@@ -72,7 +72,7 @@ function TEST_bluestore() {
 
     truncate $dir/0/block -s 4294967296 # 4GB
     ceph-bluestore-tool --path $dir/0 bluefs-bdev-expand || return 1
-    truncate $dir/1/block -s 4311744512 # 4GB + 16MB
+    truncate $dir/1/block -s 11811160064 # 11GB to get bdev label at 10737418240
     ceph-bluestore-tool --path $dir/1 bluefs-bdev-expand || return 1
     truncate $dir/2/block -s 4295099392 # 4GB + 129KB
     ceph-bluestore-tool --path $dir/2 bluefs-bdev-expand || return 1

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6856,8 +6856,19 @@ int BlueStore::_check_main_bdev_label()
     return -EIO;
   }
   if (bluestore_bdev_label_require_all && r != 0) {
-    derr << __func__ << " not all labels read properly" << dendl;
-    return -EIO;
+    // We are about to complain that some labels failed.
+    // But in case if we expanded block device some labels will not be good.
+    uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+    uint32_t valid_locations = 0;
+    for (uint64_t loc : bdev_label_positions) {
+      if (loc + lsize <= bdev_label.size) {
+        ++valid_locations;
+      }
+    }
+    if (valid_locations != bdev_label_valid_locations.size()) {
+      derr << __func__ << " not all labels read properly" << dendl;
+      return -EIO;
+    }
   }
   return 0;
 }
@@ -8868,11 +8879,25 @@ int BlueStore::expand_devices(ostream& out)
     _close_db_and_around();
 
     // mount in read/write to sync expansion changes
+    if (bdev_label_multi) {
+      // We need not do fsck, because we can be broken - size is increased,
+      // but we might not have labels set.
+      cct->_conf.set_val_or_die("bluestore_fsck_on_mount", "false");
+    }
     r = _mount();
     ceph_assert(r == 0);
     if (fm && fm->is_null_manager()) {
       // we grow the allocation range, must reflect it in the allocation file
       alloc->init_add_free(size0, size - size0);
+      if (bdev_label_multi) {
+        uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+        for (uint64_t loc : bdev_label_positions) {
+          if ((loc >= size0) && (loc + lsize <= size)) {
+            bdev_label_valid_locations.push_back(loc);
+          }
+        }
+        _write_bdev_label(cct, bdev, path + "/block", bdev_label, bdev_label_valid_locations);
+      }
       need_to_destage_allocation_file = true;
     }
     umount();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6609,10 +6609,8 @@ int BlueStore::_read_bdev_label(
     decode(expected_crc, p);
   }
   catch (ceph::buffer::error& e) {
-    derr << __func__ << " unable to decode label " << path.c_str()
-         << " at offset " << p.get_off()
-	 << ": " << e.what()
-	 << dendl;
+    derr << __func__ << " " << path.c_str() << " data at " << std::hex << disk_position
+      << std::dec << ", " << "unable to decode label " << dendl;
     return -ENOENT;
   }
   if (crc != expected_crc) {


### PR DESCRIPTION
When expansion crosses potential location of multi bdev label, we need to initialize the new label.
Expanded and fixed testing.
Improved dout on bdev label decoding failure.
This is backport of #60363

Fixes:
https://tracker.ceph.com/issues/69829

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
