### PR TITLE
src: Cleanup WITH_ALIENSTORE

### DIFF
--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -5,7 +5,7 @@
 #include "common/perf_counters.h"
 #include "include/types.h" // for operator<<(std::vector)
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/common/RefCountedObj.h
+++ b/src/common/RefCountedObj.h
@@ -89,7 +89,7 @@ template<typename... Args>
   virtual ~RefCountedObjectSafe() override {}
 };
 
-#if !defined(WITH_SEASTAR)|| defined(WITH_ALIEN)
+#ifndef WITH_SEASTAR
 
 /**
  * RefCountedCond
@@ -186,7 +186,7 @@ static inline void intrusive_ptr_add_ref(RefCountedWaitObject *p) {
 static inline void intrusive_ptr_release(RefCountedWaitObject *p) {
   p->put();
 }
-#endif // !defined(WITH_SEASTAR)|| defined(WITH_ALIEN)
+#endif // ifndef WITH_SEASTAR
 
 static inline void intrusive_ptr_add_ref(const RefCountedObject *p) {
   p->get();

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -15,7 +15,7 @@
 #include "include/Context.h"
 #include "common/ThrottleInterface.h"
 #include "common/Timer.h"
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -24,7 +24,7 @@
 #include "include/spinlock.h"
 #include "msg/Message.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -15,7 +15,7 @@
 #ifndef CEPH_WORKQUEUE_H
 #define CEPH_WORKQUEUE_H
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 // for ObjectStore.h
 struct ThreadPool {
   struct TPHandle {

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -15,7 +15,7 @@
 #ifndef CEPH_COMMON_ADMIN_SOCKET_H
 #define CEPH_COMMON_ADMIN_SOCKET_H
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/admin/admin_socket.h"
 #else
 

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -48,7 +48,7 @@
 #include "common/PluginRegistry.h"
 #include "common/valgrind.h"
 #include "include/spinlock.h"
-#if !(defined(WITH_SEASTAR) && !defined(WITH_ALIEN))
+#ifndef WITH_SEASTAR
 #include "mon/MonMap.h"
 #endif
 
@@ -64,7 +64,7 @@ using ceph::bufferlist;
 using ceph::HeartbeatMap;
 
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 namespace crimson::common {
 CephContext::CephContext()
   : _conf{crimson::common::local_conf()},

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -34,7 +34,7 @@
 #include "common/cmdparse.h"
 #include "common/code_environment.h"
 #include "msg/msg_types.h"
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/config_proxy.h"
 #include "crimson/common/perf_counters_collection.h"
 #else
@@ -66,7 +66,7 @@ namespace ceph {
   }
 }
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 namespace crimson::common {
 class CephContext {
 public:
@@ -423,7 +423,7 @@ private:
 #endif
 #endif	// WITH_SEASTAR
 
-#if !(defined(WITH_SEASTAR) && !defined(WITH_ALIEN)) && defined(__cplusplus)
+#if !defined(WITH_SEASTAR) && defined(__cplusplus)
 namespace ceph::common {
 inline void intrusive_ptr_add_ref(CephContext* cct)
 {
@@ -435,5 +435,5 @@ inline void intrusive_ptr_release(CephContext* cct)
   cct->put();
 }
 }
-#endif // !(defined(WITH_SEASTAR) && !defined(WITH_ALIEN)) && defined(__cplusplus)
+#endif // !defined(WITH_SEASTAR) && defined(__cplusplus)
 #endif

--- a/src/common/ceph_mutex.h
+++ b/src/common/ceph_mutex.h
@@ -14,7 +14,7 @@
 // and make_recursive_mutex() factory methods, which take a string
 // naming the mutex for the purposes of the lockdep debug variant.
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include <seastar/core/condition-variable.hh>
 
 #include "crimson/common/log.h"
@@ -87,7 +87,7 @@ namespace ceph {
   #define ceph_mutex_is_locked_by_me(m) true
 }
 
-#else  // defined (WITH_SEASTAR) && !defined(WITH_ALIEN)
+#else  // ifdef WITH_SEASTAR
 //
 // For legacy Mutex users that passed recursive=true, use
 // ceph::make_recursive_mutex.  For legacy Mutex users that passed

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -20,7 +20,7 @@
 
 #include "include/ceph_assert.h"
 #include "include/common_fwd.h"
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include <seastar/util/log.hh>
 #include "crimson/common/log.h"
 #include "crimson/common/config_proxy.h"
@@ -139,7 +139,7 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
 // generic macros
 #define dout_prefix *_dout
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #define dout_impl(cct, sub, v)                                          \
   do {                                                                  \
     if (crimson::common::local_conf()->subsys.should_gather(sub, v)) {  \

--- a/src/common/mempool.cc
+++ b/src/common/mempool.cc
@@ -15,7 +15,7 @@
 #include "include/mempool.h"
 #include "include/demangle.h"
 
-#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR)
 #else
 // Thread local variables should save index, not &shard[index],
 // because shard[] is defined in the class
@@ -98,7 +98,7 @@ size_t mempool::pool_t::allocated_items() const
 
 void mempool::pool_t::adjust_count(ssize_t items, ssize_t bytes)
 {
-#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR)
   // the expected path: we alway pick the shard for a cpu core
   // a thread is executing on.
   const size_t shard_index = pick_a_shard_int();
@@ -128,7 +128,7 @@ void mempool::pool_t::get_stats(
     for (auto &p : type_map) {
       std::string n = ceph_demangle(p.second.type_name);
       stats_t &s = (*by_type)[n];
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
       s.bytes = 0;
       s.items = 0;
       for (size_t i = 0 ; i < num_shards; ++i) {

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -531,7 +531,7 @@ PerfCounters::PerfCounters(CephContext *cct, const std::string &name,
     m_lower_bound(lower_bound),
     m_upper_bound(upper_bound),
     m_name(name)
-#if !defined(WITH_SEASTAR) || defined(WITH_ALIEN)
+#ifndef WITH_SEASTAR
     ,
     m_lock_name(std::string("PerfCounters::") + name.c_str()),
     m_lock(ceph::make_mutex(m_lock_name))

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -305,7 +305,7 @@ private:
 
   int prio_adjust = 0;
 
-#if !defined(WITH_SEASTAR) || defined(WITH_ALIEN)
+#ifndef WITH_SEASTAR
   const std::string m_lock_name;
   /** Protects m_data */
   ceph::mutex m_lock;

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -38,10 +38,6 @@ endif()
 add_library(crimson-alien-common STATIC
   ${crimson_alien_common_srcs})
 
-target_link_libraries(crimson-alien-common
-  crimson-common
-  alien::cflags)
-
 set(alien_store_srcs
   alien_store.cc
   thread_pool.cc

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -69,6 +69,7 @@ if(WITH_LTTNG)
   add_dependencies(crimson-alienstore bluestore-tp)
 endif()
 
+# For crimson-alienstore WITH_CRIMSON is not defined
 target_link_libraries(crimson-alienstore
   PRIVATE
     alien::cflags

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -1,10 +1,5 @@
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rocksdb/include")
 
-add_library(alien::cflags INTERFACE IMPORTED)
-set_target_properties(alien::cflags PROPERTIES
-  INTERFACE_COMPILE_DEFINITIONS ""
-  INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:Seastar::seastar,INTERFACE_INCLUDE_DIRECTORIES>)
-
 set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/admin_socket.cc
   ${PROJECT_SOURCE_DIR}/src/common/url_escape.cc
@@ -38,6 +33,10 @@ endif()
 add_library(crimson-alien-common STATIC
   ${crimson_alien_common_srcs})
 
+add_library(alien::cflags INTERFACE IMPORTED)
+set_target_properties(alien::cflags PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:Seastar::seastar,INTERFACE_INCLUDE_DIRECTORIES>)
+
 set(alien_store_srcs
   alien_store.cc
   thread_pool.cc
@@ -63,11 +62,13 @@ set(alien_store_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/Writer.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueStore_debug.cc
   ${PROJECT_SOURCE_DIR}/src/os/memstore/MemStore.cc)
+
 add_library(crimson-alienstore STATIC
   ${alien_store_srcs})
 if(WITH_LTTNG)
   add_dependencies(crimson-alienstore bluestore-tp)
 endif()
+
 target_link_libraries(crimson-alienstore
   PRIVATE
     alien::cflags

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -2,7 +2,7 @@ include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rocksdb/include")
 
 add_library(alien::cflags INTERFACE IMPORTED)
 set_target_properties(alien::cflags PROPERTIES
-  INTERFACE_COMPILE_DEFINITIONS "WITH_SEASTAR;WITH_ALIEN"
+  INTERFACE_COMPILE_DEFINITIONS ""
   INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:Seastar::seastar,INTERFACE_INCLUDE_DIRECTORIES>)
 
 set(crimson_alien_common_srcs
@@ -77,5 +77,5 @@ target_link_libraries(crimson-alienstore
     crimson-alien-common
     ${BLKID_LIBRARIES}
     ${UDEV_LIBRARIES}
-    crimson
+    seastar
     blk)

--- a/src/global/global_context.cc
+++ b/src/global/global_context.cc
@@ -16,11 +16,11 @@
 
 #include <string.h>
 #include "common/ceph_context.h"
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/config_proxy.h"
 #endif
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 namespace ceph::global {
 int __attribute__((weak)) g_conf_set_val(const std::string& key, const std::string& s) {
   return 0;
@@ -38,14 +38,14 @@ int __attribute__((weak)) g_conf_rm_val(const std::string& key) {
 namespace TOPNSPC::global {
 CephContext *g_ceph_context = NULL;
 ConfigProxy& g_conf() {
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
   return crimson::common::local_conf();
 #else
   return g_ceph_context->_conf;
 #endif
 }
 
-#ifdef WITH_ALIEN
+#ifndef WITH_SEASTAR
 int g_conf_set_val(const std::string& key, const std::string& s)
 {
   if (g_ceph_context != NULL)

--- a/src/include/common_fwd.h
+++ b/src/include/common_fwd.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #define TOPNSPC crimson
 #else
 #define TOPNSPC ceph

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -26,7 +26,7 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/container/flat_map.hpp>
 
-#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR)
 #  include <sched.h>
 #endif
 
@@ -206,7 +206,7 @@ enum {
 };
 
 static size_t pick_a_shard_int() {
-#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#if defined(_GNU_SOURCE) && defined(WITH_SEASTAR)
   // a thread local storage is actually just an approximation;
   // what we truly want is a _cpu local storage_.
   //
@@ -262,7 +262,7 @@ const char *get_pool_name(pool_index_t ix);
 struct type_t {
   const char *type_name;
   size_t item_size;
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
   struct type_shard_t {
     ceph::atomic<ssize_t> items = {0}; // signed
     char __padding[128 - sizeof(ceph::atomic<ssize_t>)];
@@ -366,7 +366,7 @@ public:
     shard.bytes += total;
     shard.items += n;
     if (type) {
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
       type->shards[shid].items += n;
 #else
       type->items += n;
@@ -383,7 +383,7 @@ public:
     shard.bytes -= total;
     shard.items -= n;
     if (type) {
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
       type->shards[shid].items -= n;
 #else
       type->items -= n;
@@ -399,7 +399,7 @@ public:
     shard.bytes += total;
     shard.items += n;
     if (type) {
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
       type->shards[shid].items += n;
 #else
       type->items += n;
@@ -420,7 +420,7 @@ public:
     shard.bytes -= total;
     shard.items -= n;
     if (type) {
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
       type->shards[shid].items -= n;
 #else
       type->items -= n;

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -20,7 +20,7 @@
 #include <time.h>
 #include <errno.h>
 
-#if defined(WITH_SEASTAR)
+#ifdef WITH_SEASTAR
 #include <seastar/core/lowres_clock.hh>
 #endif
 
@@ -93,7 +93,7 @@ public:
     tv.tv_nsec = std::max<common_t>((std::chrono::duration_cast<std::chrono::nanoseconds>(dur) %
 				     std::chrono::seconds(1)).count(), 0);
   }
-#if defined(WITH_SEASTAR)
+#ifdef WITH_SEASTAR
   explicit utime_t(const seastar::lowres_system_clock::time_point& t) {
     tv.tv_sec = std::chrono::duration_cast<std::chrono::seconds>(
         t.time_since_epoch()).count();

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -35,7 +35,7 @@
 
 #include "common/debug.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -52,7 +52,7 @@ SQLITE_EXTENSION_INIT1
 #include "include/libcephsqlite.h"
 #include "SimpleRADOSStriper.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -26,7 +26,7 @@
 #include "CInode.h"
 #include "Mutation.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -96,7 +96,7 @@
 
 #include "auth/none/AuthNoneClientHandler.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -23,7 +23,7 @@
 #include "common/Timer.h"
 #include "messages/PaxosServiceMessage.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -23,7 +23,7 @@
 #include "msg/async/Event.h"
 #include "msg/msg_types.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(os
   blk
   ${FMT_LIB})
 
+target_compile_definitions(os PRIVATE -DWITH_KSTORE)
 target_link_libraries(os heap_profiler kv)
 
 if(WITH_BLUEFS)

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -21,7 +21,7 @@
 #if defined(WITH_BLUESTORE)
 #include "bluestore/BlueStore.h"
 #endif
-#ifndef WITH_SEASTAR
+#ifdef WITH_KSTORE
 #include "kstore/KStore.h"
 #endif
 
@@ -43,7 +43,6 @@ std::unique_ptr<ObjectStore> ObjectStore::create(
   return nullptr;
 }
 
-#ifndef WITH_SEASTAR
 std::unique_ptr<ObjectStore> ObjectStore::create(
   CephContext *cct,
   const string& type,
@@ -55,13 +54,15 @@ std::unique_ptr<ObjectStore> ObjectStore::create(
     lgeneric_derr(cct) << __func__ << ": FileStore has been deprecated and is no longer supported" << dendl;
     return nullptr;
   }
+  #ifdef WITH_KSTORE
   if (type == "kstore" &&
       cct->check_experimental_feature_enabled("kstore")) {
     return std::make_unique<KStore>(cct, data);
   }
+  #endif
   return create(cct, type, data);
 }
-#endif
+
 
 int ObjectStore::probe_block_device_fsid(
   CephContext *cct,

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -13,7 +13,7 @@
 #include "include/ceph_assert.h"
 #include "common/admin_socket.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -2775,7 +2775,7 @@ void PeeringState::activate(
 
       psdout(10) << "activate peer osd." << peer << " " << pi << dendl;
 
-      #if defined(WITH_SEASTAR)
+      #ifdef WITH_SEASTAR
       MURef<MOSDPGLog> m;
       #else
       MRef<MOSDPGLog> m;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -79,7 +79,7 @@ struct PeeringCtx;
 
 // [primary only] content recovery state
 struct BufferedRecoveryMessages {
-#if defined(WITH_SEASTAR)
+#ifdef WITH_SEASTAR
   std::map<int, std::vector<MessageURef>> message_map;
 #else
   std::map<int, std::vector<MessageRef>> message_map;
@@ -287,7 +287,7 @@ public:
     virtual uint64_t get_snap_trimq_size() const = 0;
 
     /// Send cluster message to osd
-    #if defined(WITH_SEASTAR)
+    #ifdef WITH_SEASTAR
     virtual void send_cluster_message(
       int osd, MessageURef m, epoch_t epoch, bool share_map_update=false) = 0;
     #else

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -13,7 +13,7 @@
 
 #include <unordered_map>
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/rgw/rgw_dmclock_scheduler_ctx.h
+++ b/src/rgw/rgw_dmclock_scheduler_ctx.h
@@ -8,7 +8,7 @@
 #include "common/config.h"
 #include "rgw_dmclock.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/rgw/rgw_dmclock_sync_scheduler.cc
+++ b/src/rgw/rgw_dmclock_sync_scheduler.cc
@@ -5,7 +5,7 @@
 #include "rgw_dmclock_sync_scheduler.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"

--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -30,7 +30,7 @@
 #include "include/ceph_assert.h" // fio.h clobbers our assert.h
 #include <algorithm>
 
-#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/perf_counters_collection.h"


### PR DESCRIPTION
* Instead of the previous ifdef of: `#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)` switch to `#ifdef WITH_SEASTAR`.

* This is now possible after not using `WITH_ALIEN` for compiling alien store targets.
   Alienstore targets won't be defined as `WITH_CRIMSON`.

~* Switch HAVE_SEASTAR to WITH_CRIMSON for single flag standardization purposes.~ Moved to other PR.

Blocked by: https://github.com/ceph/ceph-build/pull/2329
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
