### PR TITLE
erasure-code: Set reed_sol_van to be the default technique for Jerasure if none is specified.

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -2100,7 +2100,6 @@ function test_wait_for_scrub() {
 # @param plugin erasure code plugin
 # @return 0 on success, 1 on error
 #
-
 function erasure_code_plugin_exists() {
     local plugin=$1
     local status
@@ -2115,10 +2114,13 @@ function erasure_code_plugin_exists() {
     local status=$?
     if [ $status -eq 0 ]; then
         ceph osd erasure-code-profile rm TESTPROFILE
-    elif ! echo $s | grep --quiet "$grepstr" ; then
+    elif echo $s | grep --quiet "$grepstr" ; then
+        # expected error when the plugin doesn't exist
         status=1
-        # display why the string was rejected.
+    else
+        # any other error means plugin exists but can't initialize
         echo $s
+        status=0
     fi
     return $status
 }

--- a/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
@@ -39,7 +39,7 @@ int ErasureCodePluginJerasure::factory(const std::string& directory,
     std::string t;
     if (profile.find("technique") != profile.end())
       t = profile.find("technique")->second;
-    if (t == "reed_sol_van") {
+    if (t == "reed_sol_van" || t == "") { // Default!
       interface = new ErasureCodeJerasureReedSolomonVandermonde();
     } else if (t == "reed_sol_r6_op") {
       interface = new ErasureCodeJerasureReedSolomonRAID6();

--- a/src/test/erasure-code/TestErasureCodePluginJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodePluginJerasure.cc
@@ -28,8 +28,9 @@ using namespace std;
 TEST(ErasureCodePlugin, factory)
 {
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
-  ErasureCodeProfile profile;
   {
+    ErasureCodeProfile profile;
+    profile["technique"] = "doesnotexist";
     ErasureCodeInterfaceRef erasure_code;
     EXPECT_FALSE(erasure_code);
     EXPECT_EQ(-ENOENT, instance.factory("jerasure",


### PR DESCRIPTION
This PR will set the default technique for Jerasure to be reed_sol_van if none is specified as per the documentation. This used to work for jerasure because the profile would inherit the options from the osd_pool_default_erasure_code_profile conf file setting which set the default plugin to jerasure, which meant that the erasure code profile was successfully created. When the conf file setting is changed to isal this stops working because it is invalid to create a jerasure profile without specifying a technique.

This PR also makes a small change to the erasure_code_plugin_exists function, this issue highlighted the function does not properly cases where the plugin exists but the command fails for some other reason e.g. missing technique parameter. I have added a special case for this, although it should no longer be exercised now the ErasureCodePluginJerasure.cc change.

Fixes: https://tracker.ceph.com/issues/69758
Fixes: https://tracker.ceph.com/issues/69762

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
