### PR TITLE
Revert PR 60176

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -222,7 +222,7 @@ void ProtocolV1::send_message(Message *m) {
     is_prepared = true;
   }
 
-  std::unique_lock l{connection->write_lock};
+  std::lock_guard<std::mutex> l(connection->write_lock);
   // "features" changes will change the payload encoding
   if (can_fast_prepare &&
       (can_write == WriteStatus::NOWRITE || connection->get_features() != f)) {
@@ -245,11 +245,6 @@ void ProtocolV1::send_message(Message *m) {
                    << dendl;
     if (can_write != WriteStatus::REPLACING && !write_in_progress) {
       write_in_progress = true;
-
-      /* unlock the mutex now because dispatch_event_external() may
-         block waiting for another mutex */
-      l.unlock();
-
       connection->center->dispatch_event_external(connection->write_handler);
     }
   }
@@ -275,14 +270,9 @@ void ProtocolV1::prepare_send_message(uint64_t features, Message *m,
 
 void ProtocolV1::send_keepalive() {
   ldout(cct, 10) << __func__ << dendl;
-  std::unique_lock l{connection->write_lock};
+  std::lock_guard<std::mutex> l(connection->write_lock);
   if (can_write != WriteStatus::CLOSED) {
     keepalive = true;
-
-    /* unlock the mutex now because dispatch_event_external() may
-       block waiting for another mutex */
-    l.unlock();
-
     connection->center->dispatch_event_external(connection->write_handler);
   }
 }

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1643,8 +1643,8 @@ CtPtr ProtocolV2::handle_keepalive2(ceph::bufferlist &payload)
 
   ldout(cct, 30) << __func__ << " got KEEPALIVE2 tag ..." << dendl;
 
-  auto keepalive_ack_frame = KeepAliveFrameAck::Encode(keepalive_frame.timestamp());
   connection->write_lock.lock();
+  auto keepalive_ack_frame = KeepAliveFrameAck::Encode(keepalive_frame.timestamp());
   if (!append_frame(keepalive_ack_frame)) {
     connection->write_lock.unlock();
     return _fault();


### PR DESCRIPTION
PR #60176 was mistakenly merged though there had been regressions found in teuthology.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
