### PR TITLE
os/bluestore: Fix default base size for histogram

### DIFF
--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -108,20 +108,20 @@ public:
       f->dump_float("fragmentation_rating", alloc->get_fragmentation());
       f->close_section();
     } else if (command == "bluestore allocator fragmentation histogram " + name) {
-      int64_t alloc_unit = 4096;
+      int64_t alloc_unit = alloc->get_block_size();
       cmd_getval(cmdmap, "alloc_unit", alloc_unit);
       if (alloc_unit <= 0  ||
           p2align(alloc_unit, alloc->get_block_size()) != alloc_unit) {
         ss << "Invalid allocation unit: '" << alloc_unit
-           << ", to be aligned with: '" << alloc->get_block_size()
-           << std::endl;
+           << "', to be aligned with: '" << alloc->get_block_size()
+           << "'" << std::endl;
         return -EINVAL;
       }
       int64_t num_buckets = 8;
       cmd_getval(cmdmap, "num_buckets", num_buckets);
       if (num_buckets < 2) {
         ss << "Invalid amount of buckets (min=2): '" << num_buckets
-           << std::endl;
+           << "'" << std::endl;
         return -EINVAL;
       }
 


### PR DESCRIPTION
Use allocator's unit size instead of 4096 as default value. This makes "bluefs-db" and "bluefs-wal" histograms work on defaults.

+ Fixed error printout

Fixes: https://tracker.ceph.com/issues/69855





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
