### PR TITLE
mgr/cephadm: reconfig rgw and ingress daemons when certificate changes

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -996,6 +996,21 @@ class RgwService(CephService):
     def allow_colo(self) -> bool:
         return True
 
+    @classmethod
+    def get_dependencies(cls, mgr: "CephadmOrchestrator",
+                         spec: Optional[ServiceSpec] = None,
+                         daemon_type: Optional[str] = None) -> List[str]:
+
+        deps = []
+        rgw_spec = cast(RGWSpec, spec)
+        ssl_cert = getattr(rgw_spec, 'rgw_frontend_ssl_certificate', None)
+        if ssl_cert:
+            if isinstance(ssl_cert, list):
+                ssl_cert = '\n'.join(ssl_cert)
+            deps.append(f'ssl-cert:{str(utils.md5_hash(ssl_cert))}')
+
+        return sorted(deps)
+
     def set_realm_zg_zone(self, spec: RGWSpec) -> None:
         assert self.TYPE == spec.service_type
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1283,14 +1283,10 @@ class RgwService(CephService):
         self.mgr.trigger_connect_dashboard_rgw()
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
-        config, deps = super().generate_config(daemon_spec)
-        rgw_spec = cast(RGWSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
-        ssl_cert = getattr(rgw_spec, 'rgw_frontend_ssl_certificate', None)
-        if isinstance(ssl_cert, list):
-            ssl_cert = '\n'.join(ssl_cert)
-        if ssl_cert:
-            deps.append(str(utils.md5_hash(ssl_cert)))
-        return config, deps
+        svc_spec = cast(RGWSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
+        config, parent_deps = super().generate_config(daemon_spec)
+        rgw_deps = parent_deps + self.get_dependencies(self.mgr, svc_spec)
+        return config, rgw_deps
 
 
 @register_cephadm_service

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1267,6 +1267,16 @@ class RgwService(CephService):
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
         self.mgr.trigger_connect_dashboard_rgw()
 
+    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+        config, deps = super().generate_config(daemon_spec)
+        rgw_spec = cast(RGWSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
+        ssl_cert = getattr(rgw_spec, 'rgw_frontend_ssl_certificate', None)
+        if isinstance(ssl_cert, list):
+            ssl_cert = '\n'.join(ssl_cert)
+        if ssl_cert:
+            deps.append(str(utils.md5_hash(ssl_cert)))
+        return config, deps
+
 
 @register_cephadm_service
 class RbdMirrorService(CephService):

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -97,10 +97,18 @@ class IngressService(CephService):
         # sufficient to detect changes.
         if not spec:
             return []
+
         ingress_spec = cast(IngressSpec, spec)
         assert ingress_spec.backend_service
         daemons = mgr.cache.get_daemons_by_service(ingress_spec.backend_service)
-        return sorted([d.name() for d in daemons])
+        deps = [d.name() for d in daemons]
+        for attr in ['ssl_cert', 'ssl_key']:
+            ssl_cert_key = getattr(ingress_spec, attr, None)
+            if ssl_cert_key:
+                assert isinstance(ssl_cert_key, str)
+                deps.append(f'ssl-cert-key:{str(utils.md5_hash(ssl_cert_key))}')
+
+        return sorted(deps)
 
     def haproxy_generate_config(
             self,
@@ -221,11 +229,12 @@ class IngressService(CephService):
                 "haproxy.cfg": haproxy_conf,
             }
         }
+
         if spec.ssl_cert:
-            ssl_cert = spec.ssl_cert
-            if isinstance(ssl_cert, list):
-                ssl_cert = '\n'.join(ssl_cert)
-            config_files['files']['haproxy.pem'] = ssl_cert
+            config_files['files']['haproxy.pem'] = spec.ssl_cert
+
+        if spec.ssl_key:
+            config_files['files']['haproxy.pem.key'] = spec.ssl_key
 
         return config_files, self.get_haproxy_dependencies(self.mgr, spec)
 


### PR DESCRIPTION
Now updating the rgw_frontend_ssl_cert will cause us to reocnfigure rgw daemons that are part of the service. This will additionally cause us to redo the service level config operations which for rgw includes storing the cert in the config-key store where rgw will look for it. Similarly if the user changes the cert/key of ingress spec cephadm will automatically reconfigure the corresponding daemons.

Fixes: https://tracker.ceph.com/issues/69863

Co-authored by: Adam King <adking@redhat.com>
(cherry picked from commit 74ca2e71888f9b49d803a2ee0e1658b5e9acf30a)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
