### PR TITLE
osd: include cleanup

### DIFF
--- a/src/include/object.h
+++ b/src/include/object.h
@@ -17,8 +17,8 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <iomanip>
-#include <iosfwd>
+#include <list>
+#include <ostream>
 #include <string>
 #include <string>
 #include <string_view>

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -12,10 +12,10 @@
  *
  */
 
-#include <iostream>
-#include <sstream>
-
 #include "ECBackend.h"
+
+#include <iostream>
+
 #include "ECInject.h"
 #include "messages/MOSDPGPush.h"
 #include "messages/MOSDPGPushReply.h"
@@ -23,6 +23,7 @@
 #include "messages/MOSDECSubOpWriteReply.h"
 #include "messages/MOSDECSubOpRead.h"
 #include "messages/MOSDECSubOpReadReply.h"
+#include "common/debug.h"
 #include "ECMsgTypes.h"
 #include "ECTypes.h"
 #include "ECSwitch.h"

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -12,10 +12,11 @@
  *
  */
 
+#include "ECCommon.h"
+
 #include <iostream>
 #include <sstream>
 
-#include "ECCommon.h"
 #include "ECInject.h"
 #include "messages/MOSDPGPush.h"
 #include "messages/MOSDPGPushReply.h"
@@ -23,6 +24,7 @@
 #include "messages/MOSDECSubOpWriteReply.h"
 #include "messages/MOSDECSubOpRead.h"
 #include "messages/MOSDECSubOpReadReply.h"
+#include "common/debug.h"
 #include "ECMsgTypes.h"
 #include "PGLog.h"
 

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <boost/intrusive/set.hpp>
 #include <boost/intrusive/list.hpp>
 #include <fmt/format.h>
 

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -1,10 +1,13 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 
+#include "ECUtil.h"
+
+#include <sstream>
+
 #include <errno.h>
 #include "common/ceph_context.h"
 #include "global/global_context.h"
 #include "include/encoding.h"
-#include "ECUtil.h"
 
 using namespace std;
 using ceph::bufferlist;

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -14,7 +14,11 @@
 
 #pragma once
 
+#include <map>
 #include <ostream>
+#include <set>
+#include <string>
+
 #include "erasure-code/ErasureCodeInterface.h"
 #include "include/buffer_fwd.h"
 #include "include/ceph_assert.h"

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -13,10 +13,13 @@
  *
  */
 
+#include "OSD.h"
+
 #include "acconfig.h"
 
 #include <cctype>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 
@@ -45,7 +48,6 @@
 #include "include/random.h"
 #include "include/scope_guard.h"
 
-#include "OSD.h"
 #include "OSDMap.h"
 #include "Watch.h"
 #include "osdc/Objecter.h"
@@ -54,6 +56,7 @@
 #include "common/ceph_argparse.h"
 #include "common/ceph_releases.h"
 #include "common/ceph_time.h"
+#include "common/debug.h"
 #include "common/version.h"
 #include "common/async/blocked_completion.h"
 #include "common/pick_address.h"
@@ -124,6 +127,7 @@
 #include "global/pidfile.h"
 
 #include "include/color.h"
+#include "log/Log.h"
 #include "perfglue/cpu_profiler.h"
 #include "perfglue/heap_profiler.h"
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -15,15 +15,19 @@
  *
  */
 
+#include "OSDMap.h"
+
 #include <algorithm>
 #include <bit>
+#include <iomanip>
 #include <optional>
 #include <random>
+#include <sstream>
 #include <fmt/format.h>
 
 #include <boost/algorithm/string.hpp>
 
-#include "OSDMap.h"
+#include "common/ceph_context.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/Formatter.h"

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -29,16 +29,20 @@
 #include <set>
 #include <map>
 #include <memory>
+#include <random>
 
-#include <boost/smart_ptr/local_shared_ptr.hpp>
 #include "include/btree_map.h"
 #include "include/common_fwd.h"
+#include "include/fs_types.h" // for struct file_layout_t
 #include "include/types.h"
 #include "common/ceph_releases.h"
 #include "osd_types.h"
 
-//#include "include/ceph_features.h"
 #include "crush/CrushWrapper.h"
+
+#ifdef WITH_SEASTAR
+#include <boost/smart_ptr/local_shared_ptr.hpp>
+#endif
 
 // forward declaration
 class CrushWrapper;

--- a/src/osd/OSDMapMapping.cc
+++ b/src/osd/OSDMapMapping.cc
@@ -7,6 +7,7 @@
 #define dout_subsys ceph_subsys_mon
 
 #include "common/debug.h"
+#include "crush/crush.h" // for CRUSH_ITEM_NONE
 
 using std::vector;
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -15,6 +15,7 @@
 #include "PG.h"
 #include "messages/MOSDRepScrub.h"
 
+#include "common/debug.h"
 #include "common/errno.h"
 #include "common/ceph_releases.h"
 #include "common/config.h"

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -15,13 +15,15 @@
  *
  */
 
-
+#include "PGBackend.h"
+#include "common/debug.h"
 #include "common/errno.h"
 #include "common/scrub_types.h"
+#include "include/random.h" // for ceph::util::generate_random_number()
 #include "ReplicatedBackend.h"
 #include "osd/scrubber/ScrubStore.h"
+#include "ECBackend.h"
 #include "ECSwitch.h"
-#include "PGBackend.h"
 #include "OSD.h"
 #include "erasure-code/ErasureCodePlugin.h"
 #include "OSDMap.h"

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -16,13 +16,22 @@
  */
 #pragma once
 
+#include "common/ceph_context.h"
+#include "common/debug.h"
 // re-include our assert to clobber boost's
 #include "include/ceph_assert.h"
 #include "include/common_fwd.h"
 #include "osd_types.h"
 #include "os/ObjectStore.h"
+
+#include <iosfwd>
+#include <map>
+#include <memory>
 #include <list>
+#include <set>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #ifdef WITH_SEASTAR
 #include <seastar/core/future.hh>

--- a/src/osd/PGPeeringEvent.cc
+++ b/src/osd/PGPeeringEvent.cc
@@ -1,8 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "include/mempool.h"
 #include "osd/PGPeeringEvent.h"
+#include "include/mempool.h"
 #include "messages/MOSDPGLog.h"
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PGPeeringEvent, pg_peering_evt, osd);

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -3,6 +3,12 @@
 
 #pragma once
 
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include <boost/intrusive_ptr.hpp>
 #include <boost/statechart/event.hpp>
 
 #include "osd/osd_types.h"

--- a/src/osd/PGStateUtils.h
+++ b/src/osd/PGStateUtils.h
@@ -3,10 +3,12 @@
 
 #pragma once
 
+#include "include/types.h" // for epoch_t
 #include "include/utime.h"
 #include "common/Formatter.h"
 
 #include <stack>
+#include <tuple>
 #include <vector>
 #include <boost/circular_buffer.hpp>
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1,10 +1,14 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "PGPeeringEvent.h"
-#include "common/ceph_releases.h"
-#include "common/dout.h"
 #include "PeeringState.h"
+#include "PGPeeringEvent.h"
+#include "osd_perf_counters.h"
+#include "common/ceph_releases.h"
+#include "common/debug.h"
+#include "common/ostream_temp.h"
+#include "crush/crush.h" // for CRUSH_ITEM_NONE
+#include "crush/CrushWrapper.h"
 
 #include "messages/MOSDPGRemove.h"
 #include "messages/MBackfillReserve.h"

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -5,13 +5,16 @@
 
 #include <boost/statechart/custom_reaction.hpp>
 #include <boost/statechart/event.hpp>
-#include <boost/statechart/simple_state.hpp>
 #include <boost/statechart/state.hpp>
 #include <boost/statechart/state_machine.hpp>
 #include <boost/statechart/transition.hpp>
 #include <boost/statechart/event_base.hpp>
 #include <string>
 #include <atomic>
+#include <map>
+#include <optional>
+#include <ostream>
+#include <vector>
 
 #include "include/ceph_assert.h"
 #include "include/common_fwd.h"
@@ -20,13 +23,16 @@
 #include "PGStateUtils.h"
 #include "PGPeeringEvent.h"
 #include "osd_types.h"
-#include "osd_types_fmt.h"
 #include "os/ObjectStore.h"
 #include "OSDMap.h"
 #include "MissingLoc.h"
-#include "osd/osd_perf_counters.h"
+#include "msg/Message.h"
+#include "msg/MessageRef.h"
+#include "common/ceph_mutex.h"
 #include "common/config_cacher.h"
-#include "common/ostream_temp.h"
+#include "common/snap_types.h" // for class SnapContext
+
+class OstreamTemp;
 
 struct PGPool {
   epoch_t cached_epoch;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -27,6 +27,7 @@
 
 #include "cls/cas/cls_cas_ops.h"
 #include "common/CDC.h"
+#include "common/debug.h"
 #include "common/EventTrace.h"
 #include "common/ceph_crypto.h"
 #include "common/config.h"

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -11,8 +11,12 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "common/errno.h"
 #include "ReplicatedBackend.h"
+
+#include <sstream>
+
+#include "common/debug.h"
+#include "common/errno.h"
 #include "messages/MOSDOp.h"
 #include "messages/MOSDPGPCT.h"
 #include "messages/MOSDRepOp.h"

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -17,6 +17,8 @@
 #include <fmt/printf.h>
 #include <fmt/ranges.h>
 
+#include "common/ceph_context.h"
+#include "common/debug.h"
 #include "global/global_context.h"
 #include "osd/osd_types_fmt.h"
 #include "SnapMapReaderI.h"

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -16,6 +16,7 @@
 #define SNAPMAPPER_H
 
 #include <cstring>
+#include <map>
 #include <set>
 #include <string>
 #include <utility>

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+#include "Watch.h"
 #include "PG.h"
 
+#include "common/debug.h"
 #include "include/types.h"
 #include "messages/MWatchNotify.h"
 
@@ -8,7 +10,6 @@
 
 #include "OSD.h"
 #include "PrimaryLogPG.h"
-#include "Watch.h"
 #include "Session.h"
 
 #include "common/config.h"

--- a/src/osd/osd_internal_types.h
+++ b/src/osd/osd_internal_types.h
@@ -7,6 +7,7 @@
 #include "osd_types.h"
 #include "OpRequest.h"
 #include "object_state.h"
+#include "Watch.h" // for WatchRef
 
 /*
   * keep tabs on object modifications that are in flight.

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -15,6 +15,9 @@
  *
  */
 
+#include "osd_types.h"
+#include "osd_perf_counters.h"
+
 #include <algorithm>
 #include <list>
 #include <map>
@@ -31,15 +34,18 @@
 #include "include/ceph_features.h"
 #include "include/encoding.h"
 #include "include/stringify.h"
+
+#include "crush/CrushWrapper.h"
 extern "C" {
+#include "crush/crush.h" // for CRUSH_ITEM_NONE
 #include "crush/hash.h"
 }
 
+#include "common/ceph_context.h"
 #include "common/Formatter.h"
 #include "common/StackStringStream.h"
 #include "include/utime_fmt.h"
 #include "OSDMap.h"
-#include "osd_types.h"
 #include "osd_types_fmt.h"
 #include "os/Transaction.h"
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -19,38 +19,39 @@
 #define CEPH_OSD_TYPES_H
 
 #include <atomic>
-#include <sstream>
-#include <cstdio>
+#include <cstdint>
+#include <list>
+#include <map>
 #include <memory>
+#include <ostream>
+#include <set>
+#include <string>
 #include <string_view>
 
-#include <boost/scoped_ptr.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <boost/variant.hpp>
+#ifdef WITH_SEASTAR
 #include <boost/smart_ptr/local_shared_ptr.hpp>
+#endif
 
-#include "include/rados/rados_types.hpp"
 #include "include/mempool.h"
 #include "common/fmt_common.h"
 
 #include "msg/msg_types.h"
+#include "include/common_fwd.h" // for CephContext
 #include "include/compat.h"
 #include "include/types.h"
 #include "include/utime.h"
 #include "include/CompatSet.h"
-#include "common/ceph_context.h"
-#include "common/histogram.h"
+#include "common/dout.h"
+#include "common/histogram.h" // for pow2_hist_t
 #include "include/interval_set.h"
 #include "include/inline_memory.h"
 #include "common/Formatter.h"
-#include "common/bloom_filter.hpp"
 #include "common/hobject.h"
 #include "common/snap_types.h"
+#include "common/strtol.h" // for ritoa()
 #include "HitSet.h"
-#include "Watch.h"
 #include "librados/ListObjectImpl.h"
-#include "compressor/Compressor.h"
-#include "osd_perf_counters.h"
 #include "pg_features.h"
 #include "ECTypes.h"
 

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -17,7 +17,13 @@
 #include <functional>
 
 #include "osd/scheduler/mClockScheduler.h"
-#include "common/dout.h"
+#include "common/debug.h"
+
+#ifdef WITH_SEASTAR
+#include "crimson/common/perf_counters_collection.h"
+#else
+#include "common/perf_counters_collection.h"
+#endif
 
 namespace dmc = crimson::dmclock;
 using namespace std::placeholders;

--- a/src/osd/scrubber/PrimaryLogScrub.cc
+++ b/src/osd/scrubber/PrimaryLogScrub.cc
@@ -5,6 +5,7 @@
 
 #include <sstream>
 
+#include "common/debug.h"
 #include "common/scrub_types.h"
 #include "osd/PeeringState.h"
 #include "osd/PrimaryLogPG.h"

--- a/src/osd/scrubber/ScrubStore.cc
+++ b/src/osd/scrubber/ScrubStore.cc
@@ -8,7 +8,6 @@
 
 #include "pg_scrubber.h"
 
-using std::ostringstream;
 using std::string;
 using std::vector;
 

--- a/src/osd/scrubber/ScrubStore.cc
+++ b/src/osd/scrubber/ScrubStore.cc
@@ -3,6 +3,7 @@
 
 #include "./ScrubStore.h"
 #include "osd/osd_types.h"
+#include "common/debug.h"
 #include "common/scrub_types.h"
 #include "include/rados/rados_types.hpp"
 

--- a/src/osd/scrubber/ScrubStore.h
+++ b/src/osd/scrubber/ScrubStore.h
@@ -2,6 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "common/map_cacher.hpp"
 #include "osd/osd_types_fmt.h"
 #include "osd/SnapMapper.h"  // for OSDriver

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -8,6 +8,7 @@
 #include "osdc/Objecter.h"
 
 #include "pg_scrubber.h"
+#include "common/debug.h"
 
 using namespace ::std::chrono;
 using namespace ::std::chrono_literals;

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -6,6 +6,7 @@
 #include "osd/OSD.h"
 
 #include "pg_scrubber.h"
+#include "common/debug.h"
 
 using namespace ::std::chrono;
 using namespace ::std::chrono_literals;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -8,11 +8,13 @@
 #include <cmath>
 #include <iostream>
 #include <span>
+#include <sstream>
 #include <vector>
 
 #include "debug.h"
 
 #include "common/ceph_time.h"
+#include "common/debug.h"
 #include "common/errno.h"
 #include "messages/MOSDOp.h"
 #include "messages/MOSDRepScrub.h"

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -4,6 +4,7 @@
 #include "./scrub_backend.h"
 
 #include <algorithm>
+#include <sstream>
 
 #include <fmt/ranges.h>
 

--- a/src/osd/scrubber/scrub_backend.h
+++ b/src/osd/scrubber/scrub_backend.h
@@ -43,6 +43,7 @@
 #include <fmt/core.h>
 #include <fmt/format.h>
 
+#include <iosfwd>
 #include <string_view>
 
 #include "common/LogClient.h"

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -5,6 +5,8 @@
 
 #include "pg_scrubber.h"
 
+#include "common/debug.h"
+
 using must_scrub_t = Scrub::must_scrub_t;
 using sched_params_t = Scrub::sched_params_t;
 using OSDRestrictions = Scrub::OSDRestrictions;

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "scrub_machine.h"
+
 #include <chrono>
 #include <typeinfo>
 
@@ -10,7 +12,7 @@
 #include "osd/OpRequest.h"
 
 #include "ScrubStore.h"
-#include "scrub_machine.h"
+#include "common/debug.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd

--- a/src/osd/scrubber/scrub_reservations.cc
+++ b/src/osd/scrubber/scrub_reservations.cc
@@ -6,6 +6,7 @@
 #include <span>
 
 #include "common/ceph_time.h"
+#include "common/debug.h"
 #include "osd/OSD.h"
 #include "osd/PG.h"
 #include "osd/osd_types_fmt.h"

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -2,10 +2,16 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include <iosfwd>
+#include <set>
+#include <string>
+#include <string_view>
+
 #include <fmt/ranges.h>
 #include "common/ceph_time.h"
 #include "common/fmt_common.h"
 #include "common/scrub_types.h"
+#include "include/random.h" // for ceph::util::generate_random_number()
 #include "include/types.h"
 #include "messages/MOSDScrubReserve.h"
 #include "os/ObjectStore.h"


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490; this time the "osd" subsystem.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
