### PR TITLE
osdc: include cleanup

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -16,6 +16,7 @@
 #ifndef CEPH_CLIENT_H
 #define CEPH_CLIENT_H
 
+#include "common/admin_socket.h"
 #include "common/CommandTable.h"
 #include "common/Finisher.h"
 #include "common/Timer.h"
@@ -54,6 +55,8 @@
 using std::set;
 using std::map;
 using std::fstream;
+
+namespace boost::asio { class io_context; }
 
 class FSMap;
 class FSMapUser;

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -30,6 +30,25 @@ using ceph::decode_nohead;
 using ceph::encode;
 using ceph::Formatter;
 
+CrushWrapper::~CrushWrapper()
+{
+  if (crush)
+    crush_destroy(crush);
+  choose_args_clear();
+}
+
+void CrushWrapper::create()
+{
+  if (crush)
+    crush_destroy(crush);
+  crush = crush_create();
+  choose_args_clear();
+  ceph_assert(crush);
+  have_rmaps = false;
+
+  set_tunables_default();
+}
+
 bool CrushWrapper::has_non_straw2_buckets() const
 {
   for (int i=0; i<crush->max_buckets; ++i) {

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -93,25 +93,12 @@ public:
   CrushWrapper() {
     create();
   }
-  ~CrushWrapper() {
-    if (crush)
-      crush_destroy(crush);
-    choose_args_clear();
-  }
+  ~CrushWrapper();
 
   crush_map *get_crush_map() { return crush; }
 
   /* building */
-  void create() {
-    if (crush)
-      crush_destroy(crush);
-    crush = crush_create();
-    choose_args_clear();
-    ceph_assert(crush);
-    have_rmaps = false;
-
-    set_tunables_default();
-  }
+  void create();
 
   /// true if any buckets that aren't straw2
   bool has_non_straw2_buckets() const;

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -12,10 +12,9 @@
  *
  */
 
-
-#include <mutex>
-#include <algorithm>
 #include "Filer.h"
+
+#include <algorithm>
 #include "osd/OSDMap.h"
 #include "Striper.h"
 

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -26,21 +26,26 @@
  * "files" are identified by ino.
  */
 
-
-#include <mutex>
-
+#include "osd/osd_types.h"
+#include "include/fs_types.h"
 #include "include/types.h"
+#include "include/utime.h"
 
 #include "common/ceph_time.h"
 
-#include "osd/OSDMap.h"
 #include "Objecter.h"
 #include "Striper.h"
 
+#include <map>
+#include <mutex>
+#include <set>
+#include <vector>
+
 class Context;
 class Messenger;
-class OSDMap;
 class Finisher;
+struct SnapContext;
+class utime_t;
 
 
 /**** Filer interface ***/

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -12,11 +12,11 @@
  *
  */
 
+#include "osdc/Journaler.h"
 #include "common/perf_counters.h"
 #include "common/dout.h"
 #include "include/Context.h"
 #include "msg/Messenger.h"
-#include "osdc/Journaler.h"
 #include "common/errno.h"
 #include "include/ceph_assert.h"
 #include "common/Finisher.h"

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -63,7 +63,6 @@
 #include "Objecter.h"
 #include "Filer.h"
 
-#include "common/Timer.h"
 #include "common/Throttle.h"
 #include "include/common_fwd.h"
 

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -13,6 +13,12 @@
 
 #include <unordered_map>
 
+#if defined(WITH_SEASTAR) && !defined(WITH_ALIEN)
+#include "crimson/common/perf_counters_collection.h"
+#else
+#include "common/perf_counters_collection.h"
+#endif
+
 #define MAX_FLUSH_UNDER_LOCK 20  ///< max bh's we start writeback on
 #define BUFFER_MEMORY_WEIGHT CEPH_PAGE_SHIFT  // memory usage of BufferHead, count in (1<<n)
 				 /// while holding the lock

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -11,10 +11,10 @@
 
 #include "common/Cond.h"
 #include "common/Finisher.h"
+#include "common/snap_types.h" // for class SnapContext
 #include "common/Thread.h"
 #include "common/zipkin_trace.h"
 
-#include "Objecter.h"
 #include "Striper.h"
 
 #include <unordered_map>

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -12,10 +12,12 @@
  *
  */
 
-#include <algorithm>
-#include <cerrno>
-
 #include "Objecter.h"
+#include "Striper.h"
+
+#include <algorithm>
+#include <sstream>
+
 #include "osd/OSDMap.h"
 #include "osd/error_code.h"
 #include "Filer.h"

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -15,12 +15,10 @@
 #ifndef CEPH_OBJECTER_H
 #define CEPH_OBJECTER_H
 
-#include <condition_variable>
 #include <list>
 #include <map>
 #include <mutex>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -35,8 +33,6 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/post.hpp>
-
-#include <fmt/format.h>
 
 #include "include/buffer.h"
 #include "include/ceph_assert.h"
@@ -54,9 +50,11 @@
 #include "common/ceph_timer.h"
 #include "common/config_obs.h"
 #include "common/shunique_lock.h"
+#include "common/snap_types.h" // for class SnapContext
 #include "common/zipkin_trace.h"
 #include "common/tracer.h"
 #include "common/Throttle.h"
+#include "crush/crush.h" // for CRUSH_ITEM_NONE
 
 #include "mon/MonClient.h"
 

--- a/src/osdc/Striper.h
+++ b/src/osdc/Striper.h
@@ -16,10 +16,17 @@
 #define CEPH_STRIPER_H
 
 #include "include/common_fwd.h"
+#include "include/fs_types.h" // for inodeno_t
 #include "include/types.h"
 #include "osd/osd_types.h"
 #include "osdc/StriperTypes.h"
 
+#include <cstdint>
+#include <cstdio> // for snprintf()
+#include <map>
+#include <vector>
+
+struct file_layout_t;
 
 //namespace ceph {
 


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490; this time the "osdc" subsystem.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
