### PR TITLE
mgr/dashboard: (refactor)fix image size in nvmeof namespace create/update api

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -339,7 +339,7 @@ else:
                 "rbd_pool": Param(str, "RBD pool name"),
                 "rbd_image_name": Param(str, "RBD image name"),
                 "create_image": Param(bool, "Create RBD image"),
-                "size": Param(int, "RBD image size"),
+                "rbd_image_size": Param(int, "RBD image size"),
                 "block_size": Param(int, "NVMeoF namespace block size"),
                 "load_balancing_group": Param(int, "Load balancing group"),
                 "gw_group": Param(str, "NVMeoF gateway group", True, None),
@@ -354,7 +354,7 @@ else:
             rbd_image_name: str,
             rbd_pool: str = "rbd",
             create_image: Optional[bool] = True,
-            size: Optional[int] = 1024,
+            rbd_image_size: Optional[int] = 1024,
             block_size: int = 512,
             load_balancing_group: Optional[int] = None,
             gw_group: Optional[str] = None,
@@ -366,7 +366,7 @@ else:
                     rbd_pool_name=rbd_pool,
                     block_size=block_size,
                     create_image=create_image,
-                    size=size,
+                    size=rbd_image_size,
                     anagrpid=load_balancing_group,
                 )
             )

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.spec.ts
@@ -63,7 +63,7 @@ describe('NvmeofNamespacesFormComponent', () => {
       expect(nvmeofService.createNamespace).toHaveBeenCalledWith(mockSubsystemNQN, {
         rbd_image_name: image,
         rbd_pool: null,
-        size: 1073741824
+        rbd_image_size: 1073741824
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import {
   NamespaceCreateRequest,
-  NamespaceEditRequest,
+  NamespaceUpdateRequest,
   NvmeofService
 } from '~/app/shared/api/nvmeof.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
@@ -120,23 +120,41 @@ export class NvmeofNamespacesFormComponent implements OnInit {
     });
   }
 
-  buildRequest(): NamespaceCreateRequest | NamespaceEditRequest {
-    const image_size = this.nsForm.getValue('image_size');
-    const image_size_unit = this.nsForm.getValue('unit');
-    const request = {} as NamespaceCreateRequest | NamespaceEditRequest;
-    request['gw_group'] = this.group;
-    if (image_size) {
-      const key: string = this.edit ? 'rbd_image_size' : 'size';
-      const value: number = this.formatterService.toBytes(image_size + image_size_unit);
-      request[key] = value;
-    }
-    if (!this.edit) {
-      const image = this.nsForm.getValue('image');
-      const pool = this.nsForm.getValue('pool');
-      request['rbd_image_name'] = image;
-      request['rbd_pool'] = pool;
+  updateRequest(rbdImageSize: number): NamespaceUpdateRequest {
+    const request: NamespaceUpdateRequest = {
+      gw_group: this.group,
+      rbd_image_size: rbdImageSize
+    };
+    return request;
+  }
+
+  createRequest(rbdImageSize: number): NamespaceCreateRequest {
+    const image = this.nsForm.getValue('image');
+    const pool = this.nsForm.getValue('pool');
+    const request: NamespaceCreateRequest = {
+      gw_group: this.group,
+      rbd_image_name: image,
+      rbd_pool: pool
+    };
+    if (rbdImageSize) {
+      request['rbd_image_size'] = rbdImageSize;
     }
     return request;
+  }
+
+  buildRequest() {
+    const image_size = this.nsForm.getValue('image_size');
+    let rbdImageSize: number = null;
+    if (image_size) {
+      const image_size_unit = this.nsForm.getValue('unit');
+      const value: number = this.formatterService.toBytes(image_size + image_size_unit);
+      rbdImageSize = value;
+    }
+    if (this.edit) {
+      return this.updateRequest(rbdImageSize);
+    } else {
+      return this.createRequest(rbdImageSize);
+    }
   }
 
   validateSize() {
@@ -157,7 +175,7 @@ export class NvmeofNamespacesFormComponent implements OnInit {
       this.invalidSizeError = false;
       const component = this;
       const taskUrl: string = `nvmeof/namespace/${this.edit ? URLVerbs.EDIT : URLVerbs.CREATE}`;
-      const request = this.buildRequest();
+      const request: NamespaceCreateRequest | NamespaceUpdateRequest = this.buildRequest();
       let action: Observable<any>;
 
       if (this.edit) {
@@ -169,7 +187,7 @@ export class NvmeofNamespacesFormComponent implements OnInit {
           call: this.nvmeofService.updateNamespace(
             this.subsystemNQN,
             this.nsid,
-            request as NamespaceEditRequest
+            request as NamespaceUpdateRequest
           )
         });
       } else {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -159,7 +159,7 @@ describe('NvmeofService', () => {
       const mockNamespaceObj = {
         rbd_image_name: 'nvme_ns_image:12345678',
         rbd_pool: 'rbd',
-        size: 1024,
+        rbd_image_size: 1024,
         gw_group: mockGroupName
       };
       service.createNamespace(mockNQN, mockNamespaceObj).subscribe();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -7,29 +7,29 @@ import { catchError, mapTo } from 'rxjs/operators';
 
 export const MAX_NAMESPACE = 1024;
 
-export interface ListenerRequest {
+type NvmeofRequest = {
   gw_group: string;
+};
+
+export type ListenerRequest = NvmeofRequest & {
   host_name: string;
   traddr: string;
   trsvcid: number;
-}
+};
 
-export interface NamespaceCreateRequest {
+export type NamespaceCreateRequest = NvmeofRequest & {
   rbd_image_name: string;
   rbd_pool: string;
-  size: number;
-  gw_group: string;
-}
+  rbd_image_size?: number;
+};
 
-export interface NamespaceEditRequest {
+export type NamespaceUpdateRequest = NvmeofRequest & {
   rbd_image_size: number;
-  gw_group: string;
-}
+};
 
-export interface InitiatorRequest {
+export type InitiatorRequest = NvmeofRequest & {
   host_nqn: string;
-  gw_group: string;
-}
+};
 
 const API_PATH = 'api/nvmeof';
 const UI_API_PATH = 'ui-api/nvmeof';
@@ -144,7 +144,7 @@ export class NvmeofService {
     });
   }
 
-  updateNamespace(subsystemNQN: string, nsid: string, request: NamespaceEditRequest) {
+  updateNamespace(subsystemNQN: string, nsid: string, request: NamespaceUpdateRequest) {
     return this.http.patch(`${API_PATH}/subsystem/${subsystemNQN}/namespace/${nsid}`, request, {
       observe: 'response'
     });

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9012,14 +9012,14 @@ paths:
                 rbd_image_name:
                   description: RBD image name
                   type: string
+                rbd_image_size:
+                  default: 1024
+                  description: RBD image size
+                  type: integer
                 rbd_pool:
                   default: rbd
                   description: RBD pool name
                   type: string
-                size:
-                  default: 1024
-                  description: RBD image size
-                  type: integer
               required:
               - rbd_image_name
               type: object


### PR DESCRIPTION
- Different name is used in POST and PATCH for `rbd_image_size`
- Using same name in both requests
- fixing typing issues in frontend

Fixes https://tracker.ceph.com/issues/69864


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
