### PR TITLE
mgr/vol: print proper message when subvolume metadata filename is too long

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -4345,6 +4345,36 @@ class TestSubvolumes(TestVolumesHelper):
         # verify trash dir is clean.
         self._wait_for_trash_empty()
 
+    def test_create_when_subvol_name_is_too_long(self):
+        '''
+        255 chars of subvol name + 7 chars of (':', '_' and '.meta') and 0
+        chars for default group name is greater than 256 chars, therefore
+        subvol meta file issue should be tested.
+        '''
+        subvolname = 's' * 255
+        self.negtest_ceph_cmd(
+            f'fs subvolume create {self.volname} {subvolname}',
+            retval=errno.ENAMETOOLONG,
+            errmsgs='Error ENAMETOOLONG: use shorter group or subvol name, '
+                    'combination of both should be less than 249 characters')
+
+    def test_create_when_subvol_group_name_is_too_long(self):
+        '''
+        248 chars of group name + 7 chars of (':', '_' and '.meta') and 7
+        chars for subvol name is greater than 256 chars, therefore subvol
+        meta file issue should be tested.
+        '''
+        groupname = 'g' * 248
+        self.run_ceph_cmd(
+            f'fs subvolumegroup create {self.volname} {groupname}')
+        subvolname = 's' * 7
+        self.negtest_ceph_cmd(
+            f'fs subvolume create {self.volname} {subvolname} --group-name '
+            f'{groupname}',
+            retval=errno.ENAMETOOLONG,
+            errmsgs='Error ENAMETOOLONG: use shorter group or subvol name, '
+                    'combination of both should be less than 249 characters')
+
 class TestSubvolumeGroupSnapshots(TestVolumesHelper):
     """Tests for FS subvolume group snapshot operations."""
     @unittest.skip("skipping subvolumegroup snapshot tests")

--- a/src/pybind/mgr/volumes/fs/operations/versions/auth_metadata.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/auth_metadata.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import errno
 import os
 import fcntl
 import json
@@ -9,8 +10,12 @@ import uuid
 import cephfs
 
 from ..group import Group
+from ...exception import VolumeException
 
 log = logging.getLogger(__name__)
+
+
+FILE_NAME_MAX = 255
 
 
 class AuthMetadataError(Exception):
@@ -43,10 +48,17 @@ class AuthMetadataManager(object):
             return str(param).encode('utf-8')
 
     def _subvolume_metadata_path(self, group_name, subvol_name):
-        return os.path.join(self.volume_prefix, "_{0}:{1}{2}".format(
-            group_name if group_name != Group.NO_GROUP_NAME else "",
-            subvol_name,
-            self.META_FILE_EXT))
+        group_name = group_name if group_name != Group.NO_GROUP_NAME else ""
+        metadata_filename = f'_{group_name}:{subvol_name}{self.META_FILE_EXT}'
+        # in order to allow creation of this metadata file, 5 chars for ".meta"
+        # extension and 2 chars for "_" and ":" respectively. so that combina-
+        # -tion of group and subvolname should be shorter than 248 chars.
+        if len(metadata_filename) > FILE_NAME_MAX:
+            raise VolumeException(-errno.ENAMETOOLONG,
+                                 'use shorter group or subvol name, '
+                                 'combination of both should be less '
+                                 'than 249 characters')
+        return os.path.join(self.volume_prefix, metadata_filename)
 
     def _check_compat_version(self, compat_version):
         if self.version < compat_version:


### PR DESCRIPTION
When combination of subvolume group name and subvolume name is longer
than 248 characters, it leads to a failure because the metadata file is
a combination of both of these along with ":", "_" and ".meta".

Currently, when this comibnation longer than 248 characters, a bunch
stacktraces are printed along with multiple errors. This confuses the
user as well as looks bad.

Fixes: https://tracker.ceph.com/issues/69865

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>