### PR TITLE
doc: Clarify that there are no tertiary OSDs

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -436,7 +436,7 @@ the greater cluster provides several benefits:
    bad sectors on drives that are not detectable with light scrubs. See `Data
    Scrubbing`_ for details on configuring scrubbing.
 
-#. **Replication:** Data replication involves a collaboration between Ceph
+#. **Replication:** Data replication involves collaboration between Ceph
    Clients and Ceph OSD Daemons. Ceph OSD Daemons use the CRUSH algorithm to
    determine the storage location of object replicas. Ceph clients use the
    CRUSH algorithm to determine the storage location of an object, then the
@@ -445,11 +445,11 @@ the greater cluster provides several benefits:
 
    After identifying the target placement group, the client writes the object
    to the identified placement group's primary OSD. The primary OSD then
-   consults its own copy of the CRUSH map to identify secondary and tertiary
-   OSDS, replicates the object to the placement groups in those secondary and
-   tertiary OSDs, confirms that the object was stored successfully in the
-   secondary and tertiary OSDs, and reports to the client that the object
-   was stored successfully.
+   consults its own copy of the CRUSH map to identify secondary
+   OSDS, replicates the object to the placement groups in those secondary
+   OSDs, confirms that the object was stored successfully in the
+   secondary OSDs, and reports to the client that the object
+   was stored successfully.  We call these replication operations ``subops``.
 
 .. ditaa::
 
@@ -471,13 +471,13 @@ the greater cluster provides several benefits:
        |  +------+   +------+  |
        |  | Ack (4)  Ack (5)|  |
        v  *                 *  v
- +---------------+   +---------------+
- | Secondary OSD |   | Tertiary OSD  |
- |               |   |               |
- +---------------+   +---------------+
+ +---------------+   +----------------+
+ | Secondary OSD |   | Secondary OSD  |
+ |               |   |                |
+ +---------------+   +----------------+
 
-By performing this act of data replication, Ceph OSD Daemons relieve Ceph
-clients of the burden of replicating data.
+By performing this data replication, Ceph OSD Daemons relieve Ceph
+clients and their network interfaces of the burden of replicating data.
 
 Dynamic Cluster Management
 --------------------------

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -7,7 +7,7 @@ Pools are logical partitions that are used to store RADOS objects.
 
 Pools provide:
 
-- **Resilience**: It is possible to architect for the number of OSDs that may
+- **Resilience**: It is possible to plan for the number of OSDs that may
   fail in parallel without data being unavailable or lost. If your cluster
   uses replicated pools, the number of OSDs that can fail in parallel without
   data loss is one less than the number of replicas, and the number that can
@@ -245,7 +245,7 @@ pool by running the following command:
 Setting Pool Quotas
 ===================
 
-To set quotas for the maximum number of bytes and/or the maximum number of
+To set quotas for the maximum number of bytes or the maximum number of
 RADOS objects per pool, run a command of the following form:
 
 .. prompt:: bash $
@@ -258,7 +258,8 @@ For example:
 
    ceph osd pool set-quota data max_objects 10000
 
-To remove a quota, set its value to ``0``.
+To remove a quota, set its value to ``0``.  Note that you may set a quota only
+for bytes or only for RADOS objects, or you can set both.
 
 
 Deleting a Pool


### PR DESCRIPTION
doc: Clarify that there are no tertiary OSDs

The use of "tertiary" when discussing OSD replication implies that a secondary OSD chains subops to a tertiary OSD, or that the tertiary OSD subops are send from the primary only after the secondary commits.  Moreover that nomenclature is rooted in the concept of 3R and fails to accommodate EC.  Would we have quaternary OSDs?  I won't even speculate the adjectives for an 8+4 EC profile.

A prior PR adjusts RGW multisite replication documentation in the same fashion.

This PR also implements suggestions from Zac with respect to rados/operations/pools.rst as a followup to https://github.com/ceph/ceph/pull/61660

Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
