### PR TITLE
reef: qa/suites: add "mon down" log variations to ignorelist

### DIFF
--- a/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
@@ -1,3 +1,10 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - MON_DOWN
+      - mons down
+      - mon down
+      - out of quorum
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/upgrade/pacific-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/pacific-x/parallel/1-tasks.yaml
@@ -1,3 +1,10 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
 tasks:
 - install:
     branch: pacific

--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -19,3 +19,12 @@ overrides:
       - slow request
       - timeout on replica
       - late reservation from
+      - MON_DOWN
+      - OSDMAP_FLAGS
+      - OSD_DOWN
+      - PG_DEGRADED
+      - PG_AVAILABILITY
+      - POOL_APP_NOT_ENABLED
+      - mons down
+      - mon down
+      - out of quorum


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66476

---

backport of https://github.com/ceph/ceph/pull/56619
parent tracker: https://tracker.ceph.com/issues/64864

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh