### PR TITLE
reef: cephadm: fix apparmor profiles with spaces in the names

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -9838,8 +9838,9 @@ class HostFacts():
                     else:
                         summary = {}  # type: Dict[str, int]
                         for line in profiles.split('\n'):
-                            item, mode = line.split(' ')
-                            mode = mode.strip('()')
+                            mode = line.rsplit(' ', 1)[-1]
+                            assert mode[0] == '(' and mode[-1] == ')'
+                            mode = mode[1:-1]
                             if mode in summary:
                                 summary[mode] += 1
                             else:

--- a/src/cephadm/tests/test_enclosure.py
+++ b/src/cephadm/tests/test_enclosure.py
@@ -11,7 +11,8 @@ def enclosure(host_sysfs):
     e = _cephadm.Enclosure(
         enc_id='1',
         enc_path='/sys/class/scsi_generic/sg2/device/enclosure/0:0:1:0',
-        dev_path='/sys/class/scsi_generic/sg2')
+        dev_path='/sys/class/scsi_generic/sg2',
+    )
     yield e
 
 
@@ -19,7 +20,7 @@ class TestEnclosure:
 
     def test_enc_metadata(self, enclosure):
         """Check metadata for the enclosure e.g. vendor and model"""
-       
+
         assert enclosure.vendor == "EnclosuresInc"
         assert enclosure.components == '12'
         assert enclosure.model == "D12"
@@ -36,14 +37,19 @@ class TestEnclosure:
     def test_enc_slot_format(self, enclosure):
         """Check the attributes of a slot are as expected"""
 
-        assert all(k in ['fault', 'locate', 'serial', 'status'] 
-                   for k, _v in enclosure.slot_map['0'].items())
+        assert all(
+            k in ['fault', 'locate', 'serial', 'status']
+            for k, _v in enclosure.slot_map['0'].items()
+        )
 
     def test_enc_slot_status(self, enclosure):
         """Check the number of occupied slots is correct"""
 
-        occupied_slots = [slot_id for slot_id in enclosure.slot_map 
-                          if enclosure.slot_map[slot_id].get('status').upper() == 'OK']
+        occupied_slots = [
+            slot_id
+            for slot_id in enclosure.slot_map
+            if enclosure.slot_map[slot_id].get('status').upper() == 'OK'
+        ]
 
         assert len(occupied_slots) == 6
 
@@ -55,15 +61,18 @@ class TestEnclosure:
 
     def test_enc_device_serial(self, enclosure):
         """Check the device serial numbers are as expected"""
-        
-        assert all(fake_serial in enclosure.device_lookup.keys() 
-                   for fake_serial in [
-                       'fake000',
-                       'fake001',
-                       'fake002',
-                       'fake003',
-                       'fake004',
-                       'fake005'])
+
+        assert all(
+            fake_serial in enclosure.device_lookup.keys()
+            for fake_serial in [
+                'fake000',
+                'fake001',
+                'fake002',
+                'fake003',
+                'fake004',
+                'fake005',
+            ]
+        )
 
     def test_enc_slot_to_serial(self, enclosure):
         """Check serial number to slot matches across slot_map and device_lookup"""

--- a/src/cephadm/tests/test_enclosure.py
+++ b/src/cephadm/tests/test_enclosure.py
@@ -1,7 +1,7 @@
 import pytest
 
 from unittest import mock
-from tests.fixtures import host_sysfs, import_cephadm
+from tests.fixtures import host_sysfs, import_cephadm, cephadm_fs
 
 _cephadm = import_cephadm()
 
@@ -70,3 +70,38 @@ class TestEnclosure:
 
         for serial, slot in enclosure.device_lookup.items():
             assert enclosure.slot_map[slot].get('serial') == serial
+
+
+def test_host_facts_security(cephadm_fs):
+    cephadm_fs.create_file('/sys/kernel/security/lsm', contents='apparmor\n')
+    cephadm_fs.create_file('/etc/apparmor', contents='foo\n')
+    # List from https://tracker.ceph.com/issues/66389
+    profiles_lines = [
+        'foo (complain)',
+        '/usr/bin/man (enforce)',
+        '1password (unconfined)',
+        'Discord (unconfined)',
+        # These examples with spaces in the name fail currently
+        # 'MongoDB Compass (unconfined)',
+        # 'profile name with spaces (enforce)',
+    ]
+    cephadm_fs.create_file(
+        '/sys/kernel/security/apparmor/profiles',
+        contents='\n'.join(profiles_lines),
+    )
+
+    from cephadmlib.host_facts import HostFacts
+
+    class TestHostFacts(HostFacts):
+        def _populate_sysctl_options(self):
+            return {}
+
+    ctx = mock.MagicMock()
+    hfacts = TestHostFacts(ctx)
+    ksec = hfacts.kernel_security
+    assert ksec
+    assert ksec['type'] == 'AppArmor'
+    assert ksec['type'] == 'AppArmor'
+    assert ksec['complain'] == 0
+    assert ksec['enforce'] == 0
+    assert ksec['unconfined'] == 1

--- a/src/cephadm/tests/test_enclosure.py
+++ b/src/cephadm/tests/test_enclosure.py
@@ -81,9 +81,8 @@ def test_host_facts_security(cephadm_fs):
         '/usr/bin/man (enforce)',
         '1password (unconfined)',
         'Discord (unconfined)',
-        # These examples with spaces in the name fail currently
-        # 'MongoDB Compass (unconfined)',
-        # 'profile name with spaces (enforce)',
+        'MongoDB Compass (unconfined)',
+        'profile name with spaces (enforce)',
     ]
     cephadm_fs.create_file(
         '/sys/kernel/security/apparmor/profiles',
@@ -103,5 +102,5 @@ def test_host_facts_security(cephadm_fs):
     assert ksec['type'] == 'AppArmor'
     assert ksec['type'] == 'AppArmor'
     assert ksec['complain'] == 0
-    assert ksec['enforce'] == 0
-    assert ksec['unconfined'] == 1
+    assert ksec['enforce'] == 1
+    assert ksec['unconfined'] == 2

--- a/src/cephadm/tests/test_host_facts.py
+++ b/src/cephadm/tests/test_host_facts.py
@@ -98,9 +98,7 @@ def test_host_facts_security(cephadm_fs):
         contents='\n'.join(profiles_lines),
     )
 
-    from cephadmlib.host_facts import HostFacts
-
-    class TestHostFacts(HostFacts):
+    class TestHostFacts(_cephadm.HostFacts):
         def _populate_sysctl_options(self):
             return {}
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66529

---

backport of https://github.com/ceph/ceph/pull/57955
parent tracker: https://tracker.ceph.com/issues/66389

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh