### PR TITLE
reef: mgr/rgw: fix error handling in rgw zone create

### DIFF
--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -298,10 +298,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                              inbuf: Optional[str] = None) -> HandleCommandResult:
         """Bootstrap new rgw zone that syncs with zone on another cluster in the same realm"""
 
-        created_zones = self.rgw_zone_create(zone_name, realm_token, port, placement,
-                                             start_radosgw, zone_endpoints, inbuf)
-
-        return HandleCommandResult(retval=0, stdout=f"Zones {', '.join(created_zones)} created successfully")
+        try:
+            created_zones = self.rgw_zone_create(zone_name, realm_token, port, placement,
+                                                 start_radosgw, zone_endpoints, inbuf)
+            return HandleCommandResult(retval=0, stdout=f"Zones {', '.join(created_zones)} created successfully")
+        except RGWAMException as e:
+            return HandleCommandResult(retval=e.retcode, stderr=f'Failed to create zone: {str(e)}')
 
     def rgw_zone_create(self,
                         zone_name: Optional[str] = None,
@@ -310,13 +312,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                         placement: Optional[Union[str, Dict[str, Any]]] = None,
                         start_radosgw: Optional[bool] = True,
                         zone_endpoints: Optional[str] = None,
-                        inbuf: Optional[str] = None) -> Any:
+                        inbuf: Optional[str] = None) -> List[str]:
 
         if inbuf:
             try:
                 rgw_specs = self._parse_rgw_specs(inbuf)
             except RGWSpecParsingError as e:
-                return HandleCommandResult(retval=-errno.EINVAL, stderr=f'{e}')
+                raise RGWAMException(str(e))
         elif (zone_name and realm_token):
             token = RealmToken.from_base64_str(realm_token)
             if isinstance(placement, dict):
@@ -331,7 +333,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                  zone_endpoints=zone_endpoints)]
         else:
             err_msg = 'Invalid arguments: either pass a spec with -i or provide the zone_name and realm_token.'
-            return HandleCommandResult(retval=-errno.EINVAL, stdout='', stderr=err_msg)
+            raise RGWAMException(err_msg)
 
         try:
             created_zones = []
@@ -341,8 +343,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                     created_zones.append(rgw_spec.rgw_zone)
                     return created_zones
         except RGWAMException as e:
-            self.log.error('cmd run exception: (%d) %s' % (e.retcode, e.message))
-            return HandleCommandResult(retval=e.retcode, stdout=e.stdout, stderr=e.stderr)
+            err_msg = 'cmd run exception: (%d) %s' % (e.retcode, e.message)
+            self.log.error(err_msg)
+            raise e
         return created_zones
 
     @CLICommand('rgw realm reconcile', perm='rw')

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -776,7 +776,7 @@ class RGWAM:
 
         zonegroup = period.get_master_zonegroup()
         if not zonegroup:
-            raise RGWAMException('Cannot find master zonegroup of realm {realm_name}')
+            raise RGWAMException(f'Cannot find master zonegroup of realm {realm_name}')
 
         zone = self.create_zone(realm, zonegroup, rgw_spec.rgw_zone,
                                 False,  # secondary zone


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66647

---

backport of https://github.com/ceph/ceph/pull/58142
parent tracker: https://tracker.ceph.com/issues/66568

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh