### PR TITLE
reef: mgr/rgw: fix setting rgw realm token in secondary site rgw spec

### DIFF
--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -795,7 +795,7 @@ class RGWAM:
             realm_token_b = secondary_realm_token.to_json().encode('utf-8')
             realm_token_s = base64.b64encode(realm_token_b).decode('utf-8')
             rgw_spec.update_endpoints = True
-            rgw_spec.rgw_token = realm_token_s
+            rgw_spec.rgw_realm_token = realm_token_s
             rgw_spec.rgw_zonegroup = zonegroup.name  # master zonegroup is used
             self.env.mgr.apply_rgw(rgw_spec)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66891

---

backport of https://github.com/ceph/ceph/pull/58326
parent tracker: https://tracker.ceph.com/issues/66824

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh