### PR TITLE
qa/tasks: improve ignorelist for thrashing OSDs

### DIFF
--- a/qa/suites/upgrade/telemetry-upgrade/reef-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/reef-x/1-tasks.yaml
@@ -18,6 +18,7 @@ overrides:
       - do not have an application enabled
       - is down
       - TELEMETRY_CHANGED
+      - pg .*? is .*?degraded.*?, acting
 tasks:
 - install:
     branch: reef

--- a/qa/suites/upgrade/telemetry-upgrade/squid-x/1-tasks.yaml
+++ b/qa/suites/upgrade/telemetry-upgrade/squid-x/1-tasks.yaml
@@ -18,6 +18,7 @@ overrides:
       - do not have an application enabled
       - is down
       - TELEMETRY_CHANGED
+      - pg .*? is .*?degraded.*?, acting
 tasks:
 - install:
     branch: squid

--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -32,3 +32,6 @@ overrides:
       - nodeep-scrub
       - is down
       - osds down
+      - pg .*? is .*?degraded.*?, acting
+      - pg .*? is stuck inactive for .*?m, current state .*?degraded.*?, last acting
+      - pg degraded


### PR DESCRIPTION
In these commits, I added some pattern matching for warnings that show up in the cluster log detail that are related to degraded PGs. In these tests, we are intentionally marking down, killing, or restarting OSDs, which leads to these states showing up in the cluster log. So, the warnings are intended and can be ignored in the context of OSD thrashing and upgrades.

Fixes: https://tracker.ceph.com/issues/67881
Fixes: https://tracker.ceph.com/issues/67913





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
