### PR TITLE
cephadm: Ensure wildcard SAN is included in RGW self-signed certs

### DIFF
--- a/doc/cephadm/services/rgw.rst
+++ b/doc/cephadm/services/rgw.rst
@@ -173,6 +173,36 @@ Then apply this yaml document:
 Note the value of ``rgw_frontend_ssl_certificate`` is a literal string as
 indicated by a ``|`` character preserving newline characters.
 
+Setting up HTTPS with Wildcard SANs
+-----------------------------------
+
+To enable HTTPS for RGW services, apply a spec file following this scheme:
+
+.. code-block:: yaml
+
+  service_type: rgw
+  service_id: foo
+  placement:
+    label: rgw
+    count_per_host: 1
+  spec:
+    ssl: true
+    generate_cert: true  
+    rgw_frontend_port: 8080
+    wildcard_enabled: true  # Enables wildcard SANs in the certificate
+    zonegroup_hostnames:
+    - s3.cephlab.com
+
+Then apply this yaml document:
+
+.. prompt:: bash #
+
+  ceph orch apply -i myrgw.yaml
+
+The ``wildcard_enabled`` flag ensures that a wildcard SAN entry is included in the self-signed certificate,
+allowing access to buckets in virtual host mode. By default, this flag is disabled.
+example: wildcard SAN - (*.s3.cephlab.com)
+
 Disabling multisite sync traffic
 --------------------------------
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1234,6 +1234,7 @@ class RGWSpec(ServiceSpec):
                  rgw_bucket_counters_cache_size: Optional[int] = None,
                  generate_cert: bool = False,
                  disable_multisite_sync_traffic: Optional[bool] = None,
+                 wildcard_enabled: Optional[bool] = False,
                  ):
         assert service_type == 'rgw', service_type
 
@@ -1288,6 +1289,7 @@ class RGWSpec(ServiceSpec):
         self.generate_cert = generate_cert
         #: Used to make RGW not do multisite replication so it can dedicate to IO
         self.disable_multisite_sync_traffic = disable_multisite_sync_traffic
+        self.wildcard_enabled = wildcard_enabled
 
     def get_port_start(self) -> List[int]:
         return [self.get_port()]


### PR DESCRIPTION
cephadm: Ensure wildcard SAN is included in RGW self-signed certs

Fix:
- Updated `RgwService` in `cephadmservice.py` to append `*.` before each hostname in `zonegroup_hostnames` when generating certificates if wildcard_enabled flag is set to true.
- This ensures that both the entries including the wildcard entry (example: 's3.cephlab.com' and '*.s3.cephlab.com') are included in the SAN.
- After this fix, virtual host bucket access works without SSL errors.

Tracker: https://tracker.ceph.com/issues/69875

Logs:

```
[ceph: root@ceph-node-0 ~]# cat rgw_spec.yaml 
service_type: rgw 
service_id: foo 
placement: 
  label: rgw 
  count_per_host: 1 
spec: 
  ssl: true  # Required for SSL 
  generate_cert: true  
  rgw_frontend_port: 8080
  wildcard_enabled: true
  zonegroup_hostnames:
  - s3.cephlab.com

 
[ceph: root@ceph-node-0 ~]# ceph orch apply -i rgw.yaml 
Scheduled rgw.foo update...

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS   RUNNING  REFRESHED  AGE  PLACEMENT                   
crash                                  2/2  4m ago     68m  *                           
mgr                                    2/2  4m ago     68m  count:2                     
mon                                    2/5  4m ago     68m  count:5                     
osd.all-available-devices                2  4m ago     55m  *                           
rgw.foo                    ?:8080      1/1  4s ago     7s   count-per-host:1;label:rgw  

[ceph: root@ceph-node-0 ~]# ceph config dump | grep rgw
client.rgw.foo.ceph-node-0.tqpdxk                    basic     rgw_frontends                          beast ssl_port=8080 ssl_certificate=config://rgw/cert/rgw.foo.ceph-node-0.tqpdxk           * 

[ceph: root@ceph-node-0 ~]# ceph config-key get rgw/cert/rgw.foo.ceph-node-0.tqpdxk > cert.pem

[ceph: root@ceph-node-0 ~]# openssl x509 -text -noout -in cert.pem | grep "DNS:"
                DNS:ceph-node-0, IP Address:192.168.100.100, DNS:s3.cephlab.com, DNS:*.s3.cephlab.com
```
```

[ceph: root@ceph-node-0 ~]# curl -v --cacert cert.pem https://bucket1.s3.cephlab.com:8080
*   Trying 192.168.100.100:8080...
* Connected to bucket1.s3.cephlab.com (192.168.100.100) port 8080 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
*  CAfile: cert.pem
* TLSv1.0 (OUT), TLS header, Certificate Status (22):
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS header, Certificate Status (22):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS header, Finished (20):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.2 (OUT), TLS header, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS header, Unknown (23):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: CN=192.168.100.100
*  start date: Feb 28 06:35:38 2025 GMT
*  expire date: Mar  1 06:35:38 2035 GMT
*  subjectAltName: host "bucket1.s3.cephlab.com" matched cert's "*.s3.cephlab.com"
*  issuer: CN=cephadm-root
*  SSL certificate verify ok.
* TLSv1.2 (OUT), TLS header, Unknown (23):
> GET / HTTP/1.1
> Host: bucket1.s3.cephlab.com:8080
> User-Agent: curl/7.76.1
> Accept: */*
> 
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* TLSv1.2 (IN), TLS header, Unknown (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Transfer-Encoding: chunked
< x-amz-request-id: tx00000ab43fb37cb36c167-0067c15a10-34415-default
< Content-Type: application/xml
< Server: Ceph Object Gateway (squid)
< Date: Fri, 28 Feb 2025 06:39:12 GMT
< Connection: Keep-Alive
< 
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.2 (IN), TLS header, Unknown (23):
* TLSv1.2 (IN), TLS header, Unknown (23):
* Connection #0 to host bucket1.s3.cephlab.com left intact
<?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>anonymous</ID></Owner><Buckets></Buckets></ListAllMyBucketsResult>
```



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
