### PR TITLE
container: small container image improvements

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -51,6 +51,15 @@ OSD_FLAVOR=${OSD_FLAVOR}
 #   keeping run steps separate makes local rebuilds quick, but images are big without squash option
 #===================================================================================================
 
+# Disable documentation
+# (assumes only [main] section exists)
+RUN \
+    if grep -q 'tsflags' /etc/dnf/dnf.conf ; then \
+        sed -i 's/tsflags=.*/tsflags=nodocs/g' /etc/dnf/dnf.conf ; \
+    else \
+        echo "tsflags=nodocs" >> /etc/dnf/dnf.conf ; \
+    fi
+
 # Pre-reqs
 RUN dnf install -y --setopt=install_weak_deps=False epel-release jq
 
@@ -201,7 +210,7 @@ RUN set -ex && \
     rm -rf /var/lib/dnf/* && \
     rm -f /var/lib/rpm/__db* && \
     # remove unnecessary files with big impact
-    rm -rf /etc/selinux /usr/share/{doc,man,selinux} && \
+    rm -rf /etc/selinux /usr/share/selinux && \
     # don't keep compiled python binaries
     find / -xdev \( -name "*.pyc" -o -name "*.pyo" \) -delete && \
     rm -f /etc/yum.repos.d/{ceph,ganesha,tcmu-runner,ceph-iscsi}.repo

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -211,8 +211,6 @@ RUN set -ex && \
     rm -f /var/lib/rpm/__db* && \
     # remove unnecessary files with big impact
     rm -rf /etc/selinux /usr/share/selinux && \
-    # don't keep compiled python binaries
-    find / -xdev \( -name "*.pyc" -o -name "*.pyo" \) -delete && \
     rm -f /etc/yum.repos.d/{ceph,ganesha,tcmu-runner,ceph-iscsi}.repo
 
 # Verify that the packages installed haven't been accidentally cleaned, then


### PR DESCRIPTION
Two improvements to the container build process that I noticed:

Fixes: https://tracker.ceph.com/issues/69869
Fixes: https://tracker.ceph.com/issues/69868

Avoid installing and then deleting docs/manpages.
Stop deleting pyc files.

I discovered these issues by running `rpm -Va` inside the ceph container. While it's not 100% now, and probably will (should) never be... it generates a lot less noise now and we're buiding things in a more "standard" way.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
