### PR TITLE
Revert ".github/workflows: Do not exempt PRs with milestone"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,6 +47,9 @@ jobs:
           # Labels on PRs exempted from stale
           exempt-pr-labels: 'pinned,security'
           
+          # Exempt all PRs with milestones from stale (also exempts Issues)
+          exempt-all-pr-milestones: true
+          
           # Max number of operations per run
           operations-per-run: 100
 


### PR DESCRIPTION
This reverts commit 6054be59c56a13670abd7d00b828d43730c535c8.

follows discussion from https://github.com/ceph/ceph/pull/60736#issuecomment-2578815921 and consensus from the ceph steering committee

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
