### PR TITLE
libcephfs_proxy: add negotiation support to the CephFS proxy

### DIFF
--- a/doc/dev/libcephfs_proxy.rst
+++ b/doc/dev/libcephfs_proxy.rst
@@ -70,6 +70,30 @@ overhead for encoding and decoding, and would provide an easy way to support
 backward compatibility if the network protocol needs to be modified in the
 future.
 
+**Feature negotiation**
+
+During the initial connection through the UNIX socket, the client will
+initiate a negotiation of the features that it want to enable. Currently it
+supports a bitmap of features supported/required/desired, but it allows the
+structure containing the negotiated data to be extended by adding more fields
+without breaking backward compatibility.
+
+The structure itself contains the version and size of the structure, as well as
+the minimum required version supported, allowing the other peer to read the
+transmitted data even if it doesn't fully understand its contents, and adjust
+to the highest possible version known by both peers.
+
+The client will send the bitmap of supported features, the bitmap of features
+that must be available (otherwise the connection cannot proceed), and the
+bitmap of features the client would like to enable. When the server receives
+it, it will create a bitmap of the supported features on both sides, and verify
+that all required features by the server are supported by the client. It will
+also add its desired features to the features desired by the client. This data
+will be sent back to the client, who will do a final check and decide the
+final set of enabled features. Once this feature set is sent to the server,
+both peers can start using the enabled features.
+
+
 Design of the *libcephfs_proxy.so* library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -45,6 +45,9 @@ typedef struct _proxy_manager proxy_manager_t;
 struct _proxy_link;
 typedef struct _proxy_link proxy_link_t;
 
+struct _proxy_link_negotiate;
+typedef struct _proxy_link_negotiate proxy_link_negotiate_t;
+
 typedef int32_t (*proxy_output_write_t)(proxy_output_t *);
 typedef int32_t (*proxy_output_full_t)(proxy_output_t *);
 

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -9,7 +9,11 @@
 #include <stdbool.h>
 
 #define LIBCEPHFSD_MAJOR 0
+
+// Legacy version without negotiation support
 #define LIBCEPHFSD_MINOR 2
+// Current version with negotiation support
+#define LIBCEPHFSD_MINOR_NEG 3
 
 #define LIBCEPHFS_LIB_CLIENT 0xe3e5f0e8 // 'ceph' xor 0x80808080
 

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -25,6 +25,11 @@
 #define container_of(_ptr, _type, _field) \
 	((_type *)((uintptr_t)(_ptr) - offset_of(_type, _field)))
 
+enum {
+	/* Mask of all supported/known features. */
+	PROXY_FEAT_ALL = 0x00000000
+};
+
 struct _list;
 typedef struct _list list_t;
 

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -109,6 +109,10 @@ int32_t proxy_link_ctrl_send(int32_t sd, void *data, int32_t size, int32_t type,
 int32_t proxy_link_ctrl_recv(int32_t sd, void *data, int32_t size, int32_t type,
 			     void *ctrl, int32_t *ctrl_size);
 
+int32_t proxy_link_handshake_server(proxy_link_t *link, int32_t sd,
+				    proxy_link_negotiate_t *neg,
+				    proxy_link_negotiate_cbk_t cbk);
+
 int32_t proxy_link_handshake_client(proxy_link_t *link, int32_t sd,
 				    proxy_link_negotiate_t *neg,
 				    proxy_link_negotiate_cbk_t cbk);

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -72,6 +72,28 @@ typedef struct _proxy_link_ans {
 	 sizeof(proxy_link_negotiate_v##_ver##_t))
 #define NEG_VERSION_SIZE(_ver) NEG_VERSION_SIZE_1(_ver)
 
+#define proxy_link_negotiate_init_v0(_neg, _ver, _min) \
+	do { \
+		(_neg)->v0.size = NEG_VERSION_SIZE(_ver); \
+		(_neg)->v0.version = (_ver); \
+		(_neg)->v0.min_version = (_min); \
+		(_neg)->v0.flags = 0; \
+	} while (0)
+
+/* NEG_VERSION: Add new arguments and initialize the link->neg.vX with them. */
+static inline void proxy_link_negotiate_init(proxy_link_negotiate_t *neg,
+					     uint32_t min_version,
+					     uint32_t supported,
+					     uint32_t required,
+					     uint32_t enabled)
+{
+	proxy_link_negotiate_init_v0(neg, PROXY_LINK_NEGOTIATE_VERSION,
+				     min_version);
+	neg->v1.supported = supported;
+	neg->v1.required = required;
+	neg->v1.enabled = enabled;
+}
+
 static inline bool proxy_link_is_connected(proxy_link_t *link)
 {
 	return link->sd >= 0;

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -109,4 +109,8 @@ int32_t proxy_link_ctrl_send(int32_t sd, void *data, int32_t size, int32_t type,
 int32_t proxy_link_ctrl_recv(int32_t sd, void *data, int32_t size, int32_t type,
 			     void *ctrl, int32_t *ctrl_size);
 
+int32_t proxy_link_handshake_client(proxy_link_t *link, int32_t sd,
+				    proxy_link_negotiate_t *neg,
+				    proxy_link_negotiate_cbk_t cbk);
+
 #endif

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -40,12 +40,6 @@ void proxy_link_close(proxy_link_t *link);
 int32_t proxy_link_server(proxy_link_t *link, const char *path,
 			  proxy_link_start_t start, proxy_link_stop_t stop);
 
-int32_t proxy_link_read(proxy_link_t *link, int32_t sd, void *buffer,
-			int32_t size);
-
-int32_t proxy_link_write(proxy_link_t *link, int32_t sd, void *buffer,
-			 int32_t size);
-
 int32_t proxy_link_send(int32_t sd, struct iovec *iov, int32_t count);
 
 int32_t proxy_link_recv(int32_t sd, struct iovec *iov, int32_t count);

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -9,6 +9,46 @@
 
 #define PROXY_LINK_DISCONNECTED { NULL, -1 }
 
+/* To define newer versions of the negotiate structure, look for comments
+ * starting with "NEG_VERSION" and do the appropriate changes in each place. */
+
+/* NEG_VERSION: Update this value to the latest implemented version. */
+#define PROXY_LINK_NEGOTIATE_VERSION 1
+
+/* Version 0 structure will be used to handle legacy clients that don't support
+ * negotiation. */
+typedef struct _proxy_link_negotiate_v0 {
+	/* Size of the entire structure. Don't use sizeof() to compute it, use
+	 * NEG_VERSION_SIZE() to avoid alignement issues. */
+	uint16_t size;
+
+	/* Version of the negotiation structure. */
+	uint16_t version;
+
+	/* Minimum version that the peer needs to support to proceed. */
+	uint16_t min_version;
+
+	/* Reserved. Must be 0. */
+	uint16_t flags;
+} proxy_link_negotiate_v0_t;
+
+typedef struct _proxy_link_negotiate_v1 {
+	uint32_t supported;
+	uint32_t required;
+	uint32_t enabled;
+} proxy_link_negotiate_v1_t;
+
+/* NEG_VERSION: Add typedefs for new negotiate extensions above this comment. */
+
+struct _proxy_link_negotiate {
+	proxy_link_negotiate_v0_t v0;
+	proxy_link_negotiate_v1_t v1;
+
+	/* NEG_VERSION: Add newly defined typedefs above this comment. */
+};
+
+typedef int32_t (*proxy_link_negotiate_cbk_t)(proxy_link_negotiate_t *);
+
 struct _proxy_link {
 	proxy_link_stop_t stop;
 	int32_t sd;
@@ -26,6 +66,11 @@ typedef struct _proxy_link_ans {
 	int32_t result;
 	uint32_t data_len;
 } proxy_link_ans_t;
+
+#define NEG_VERSION_SIZE_1(_ver) \
+	(offset_of(proxy_link_negotiate_t, v##_ver) + \
+	 sizeof(proxy_link_negotiate_v##_ver##_t))
+#define NEG_VERSION_SIZE(_ver) NEG_VERSION_SIZE_1(_ver)
 
 static inline bool proxy_link_is_connected(proxy_link_t *link)
 {

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -58,4 +58,10 @@ int32_t proxy_link_request(int32_t sd, int32_t op, struct iovec *req_iov,
 			   int32_t req_count, struct iovec *ans_iov,
 			   int32_t ans_count);
 
+int32_t proxy_link_ctrl_send(int32_t sd, void *data, int32_t size, int32_t type,
+			     void *ctrl, int32_t ctrl_size);
+
+int32_t proxy_link_ctrl_recv(int32_t sd, void *data, int32_t size, int32_t type,
+			     void *ctrl, int32_t *ctrl_size);
+
 #endif

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -135,8 +135,6 @@ enum {
 
 /* Declaration of types used to transder requests and answers. */
 
-CEPH_TYPE(hello, FIELDS(uint32_t id;), FIELDS(int16_t major; int16_t minor;));
-
 CEPH_TYPE(ceph_version, REQ(),
 	  ANS(int32_t major; int32_t minor; int32_t patch; int16_t text;));
 


### PR DESCRIPTION
This PR adds a negotiation framework for the CephFS proxy that is backward compatible and allows extensions to be added in the future, also in a backward compatible way.

This will be used to add a feature that will allow the daemon to send notifications and callbacks back to the client in an asynchronous way.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
