### PR TITLE
rgw/notification/logging: add bucket as context param

### DIFF
--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -146,6 +146,7 @@
                 "Bucket":{
                     "shape":"BucketName",
                     "documentation":"<p>Name of the bucket to delete the notifications configuration from.</p>",
+                    "contextParam":{"name":"Bucket"},
                     "location":"uri",
                     "locationName":"Bucket"
                 },
@@ -164,6 +165,7 @@
                 "Bucket":{
                     "shape":"BucketName",
                     "documentation":"<p>Name of the bucket to flush its logging objects.</p>",
+                    "contextParam":{"name":"Bucket"},
                     "location":"uri",
                     "locationName":"Bucket"
                 }


### PR DESCRIPTION
when URI has the form: "/{Bucket}?<action>"
the "Bucket" parameter has to be added as context parameter for botocore based clients to send the operation as a bucket operation

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
