### PR TITLE
rgw: add dedicated config for max aio during bucket index cleanup

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -203,6 +203,14 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_clean_bucket_index_max_aio
+  type: uint
+  level: advanced
+  desc: Max number of concurrent RADOS requests when cleaning bucket shards.
+  default: 1
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_multi_obj_del_max_aio
   type: uint
   level: advanced

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5509,7 +5509,7 @@ int RGWRados::delete_bucket(RGWBucketInfo& bucket_info, RGWObjVersionTracker& ob
     maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
     (void) CLSRGWIssueBucketIndexClean(index_pool,
 				       bucket_objs,
-				       cct->_conf->rgw_bucket_index_max_aio)();
+				       cct->_conf->rgw_clean_bucket_index_max_aio)();
   }
 
   return 0;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -403,7 +403,7 @@ int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp, const RG
   maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   return CLSRGWIssueBucketIndexClean(index_pool,
 				     bucket_objs,
-				     cct->_conf->rgw_bucket_index_max_aio)();
+				     cct->_conf->rgw_clean_bucket_index_max_aio)();
 }
 
 int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,


### PR DESCRIPTION
When a bucket with many shards is resharded, especially with large omaps, the deletion of old index shards can put significant load on the index pool. The default value of rgw_bucket_index_max_aio (128) results in deleting 128 shards simultaneously, which can exacerbate the issue. Introducing a dedicated config to control the maximum number of deletions allows for better management of this load during cleanup.

Fixes: https://tracker.ceph.com/issues/69910