### PR TITLE
cephadm: ceph orch ls to Display SMB Service Ports

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3722,10 +3722,12 @@ class TestSMB:
             'name': 'smb.tango.briskly',
             'image': '',
             'deploy_arguments': [],
-            'params': {},
+            'params': {
+                "tcp_ports": [445, 9922]
+            },
             'meta': {
                 'service_name': 'smb',
-                'ports': [],
+                'ports': [445, 9922],
                 'ip': None,
                 'deployed_by': [],
                 'rank': None,
@@ -3785,10 +3787,12 @@ class TestSMB:
             'name': 'smb.tango.briskly',
             'image': '',
             'deploy_arguments': [],
-            'params': {},
+            'params': {
+                'tcp_ports': [445, 9922]
+            },
             'meta': {
                 'service_name': 'smb',
-                'ports': [],
+                'ports': [445, 9922],
                 'ip': None,
                 'deployed_by': [],
                 'rank': None,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -3161,6 +3161,9 @@ class SMBSpec(ServiceSpec):
         uri = 'rados://' + '/'.join(parts)
         return uri
 
+    def get_port_start(self) -> List[int]:
+        return [445, 9922]  # SMB service runs on port 445, and smbmetrics uses 9922
+
     def strict_cluster_ip_specs(self) -> List[Dict[str, Any]]:
         return [s.to_strict() for s in (self.cluster_public_addrs or [])]
 


### PR DESCRIPTION
cephadm: ceph orch ls to Display SMB Service Ports

The ceph orch ls command does not list the ports for SMB services, while ceph orch ps correctly displays them. This discrepancy occurs because ServiceDescription in describe_service() relies on spec.get_port_start(), but SMBSpec does not define this method. As a result, the ports field remains empty in ceph orch ls.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
