### PR TITLE
osd: Require explicit casting for shard_id_t

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -491,7 +491,7 @@ void ghobject_t::dump(Formatter *f) const
   if (generation != NO_GEN)
     f->dump_int("generation", generation);
   if (shard_id != shard_id_t::NO_SHARD)
-    f->dump_int("shard_id", shard_id);
+    f->dump_int("shard_id", int(shard_id));
   f->dump_int("max", (int)max);
 }
 
@@ -548,14 +548,16 @@ bool ghobject_t::parse(const string& s)
   // look for shard# prefix
   const char *start = s.c_str();
   const char *p;
-  int sh = shard_id_t::NO_SHARD;
+  shard_id_t sh = shard_id_t::NO_SHARD;
   for (p = start; *p && isxdigit(*p); ++p) ;
   if (!*p && *p != '#')
     return false;
   if (p > start) {
-    int r = sscanf(s.c_str(), "%x", &sh);
+    unsigned int sh_i;
+    int r = sscanf(s.c_str(), "%x", &sh_i);
     if (r < 1)
       return false;
+    sh = shard_id_t(sh_i);
     start = p + 1;
   } else {
     ++start;

--- a/src/common/scrub_types.cc
+++ b/src/common/scrub_types.cc
@@ -139,7 +139,8 @@ inconsistent_obj_wrapper::set_auth_missing(const hobject_t& hoid,
     else if (shard_map[pg_map.first].has_shallow_errors())
       ++shallow_errors;
     union_shards.errors |= shard_map[pg_map.first].errors;
-    shards.emplace(osd_shard_t{pg_map.first.osd, pg_map.first.shard}, shard_map[pg_map.first]);
+    shards.emplace(osd_shard_t{pg_map.first.osd,
+      static_cast<int8_t>(pg_map.first.shard)}, shard_map[pg_map.first]);
   }
 }
 

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -465,7 +465,7 @@ static ghobject_t test_ops_get_object_name(
 
   auto shard_id = cmd_getval_or<int64_t>(cmdmap,
 					 "shardid",
-					 shard_id_t::NO_SHARD);
+					 static_cast<int64_t>(shard_id_t::NO_SHARD));
 
   return ghobject_t{
     hobject_t{

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -430,7 +430,7 @@ class key_hobj_t {
    * common interfaces as a full_key_t
    */
   shard_t shard() const {
-    return ghobj.shard_id;
+    return static_cast<shard_t>(ghobj.shard_id);
   }
   pool_t pool() const {
     return ghobj.hobj.pool;

--- a/src/crimson/osd/scrub/scrub_validator.cc
+++ b/src/crimson/osd/scrub/scrub_validator.cc
@@ -306,7 +306,7 @@ object_evaluation_t evaluate_object(
 		  [](auto &cand) { return cand.has_errors(); })) {
     for (auto &eval : shards) {
       iow.shards.emplace(
-	librados::osd_shard_t{eval.source.osd, eval.source.shard},
+	librados::osd_shard_t{eval.source.osd, static_cast<int8_t>(eval.source.shard)},
 	eval.shard_info);
       iow.union_shards.errors |= eval.shard_info.errors;
     }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -519,9 +519,12 @@ struct shard_id_t {
   int8_t id;
 
   shard_id_t() : id(0) {}
-  constexpr explicit shard_id_t(int8_t _id) : id(_id) {}
+  explicit constexpr shard_id_t(int8_t _id) : id(_id) {}
 
-  constexpr operator int8_t() const { return id; }
+  explicit constexpr operator int8_t() const { return id; }
+  explicit constexpr operator int64_t() const { return id; }
+  explicit constexpr operator int() const { return id; }
+  explicit constexpr operator unsigned() const { return id; }
 
   const static shard_id_t NO_SHARD;
 
@@ -540,8 +543,26 @@ struct shard_id_t {
     ls.push_back(new shard_id_t(1));
     ls.push_back(new shard_id_t(2));
   }
-  bool operator==(const shard_id_t&) const = default;
-  auto operator<=>(const shard_id_t&) const = default;
+  shard_id_t& operator++() { ++id; return *this; }
+  friend constexpr std::strong_ordering operator<=>(const shard_id_t &lhs,
+                                                    const shard_id_t &rhs) {
+    return lhs.id <=> rhs.id;
+  }
+
+  friend constexpr std::strong_ordering operator<=>(int lhs,
+                                                    const shard_id_t &rhs) {
+    return lhs <=> rhs.id;
+  }
+  friend constexpr std::strong_ordering operator<=>(const shard_id_t &lhs,
+                                                    int rhs) {
+    return lhs.id <=> rhs;
+  }
+
+  shard_id_t& operator=(int other) { id = other; return *this; }
+  bool operator==(const shard_id_t &other) const { return id == other.id; }
+
+  shard_id_t operator+(int other) const { return shard_id_t(id + other); }
+  shard_id_t operator-(int other) const { return shard_id_t(id - other); }
 };
 WRITE_CLASS_ENCODER(shard_id_t)
 std::ostream &operator<<(std::ostream &lhs, const shard_id_t &rhs);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -374,13 +374,13 @@ void ECBackend::RecoveryBackend::handle_recovery_read_complete(
   for (set<shard_id_t>::iterator i = op.missing_on_shards.begin();
        i != op.missing_on_shards.end();
        ++i) {
-    target[*i] = &(op.returned_data[*i]);
+    target[static_cast<int>(*i)] = &(op.returned_data[static_cast<int>(*i)]);
   }
   map<int, bufferlist> from;
   for(map<pg_shard_t, bufferlist>::iterator i = to_read.get<2>().begin();
       i != to_read.get<2>().end();
       ++i) {
-    from[i->first.shard] = std::move(i->second);
+    from[static_cast<int>(i->first.shard)] = std::move(i->second);
   }
   dout(10) << __func__ << ": " << from << dendl;
   int r;
@@ -635,12 +635,12 @@ void ECBackend::RecoveryBackend::continue_recovery_op(
       for (set<pg_shard_t>::iterator mi = op.missing_on.begin();
 	   mi != op.missing_on.end();
 	   ++mi) {
-	ceph_assert(op.returned_data.count(mi->shard));
+	ceph_assert(op.returned_data.count(static_cast<int>(mi->shard)));
 	m->pushes[*mi].push_back(PushOp());
 	PushOp &pop = m->pushes[*mi].back();
 	pop.soid = op.hoid;
 	pop.version = op.v;
-	pop.data = op.returned_data[mi->shard];
+	pop.data = op.returned_data[static_cast<int>(mi->shard)];
 	dout(10) << __func__ << ": before_progress=" << op.recovery_progress
 		 << ", after_progress=" << after_progress
 		 << ", pop.data.length()=" << pop.data.length()
@@ -1124,11 +1124,11 @@ void ECBackend::handle_sub_read(
 	  dout(20) << __func__ << ": Checking hash of " << i->first << dendl;
 	  bufferhash h(-1);
 	  h << bl;
-	  if (h.digest() != hinfo->get_chunk_hash(shard)) {
+	  if (h.digest() != hinfo->get_chunk_hash(static_cast<int>(shard))) {
 	    get_parent()->clog_error() << "Bad hash for " << i->first << " digest 0x"
-				       << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(shard) << dec;
+				       << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(static_cast<int>(shard)) << dec;
 	    dout(5) << __func__ << ": Bad hash for " << i->first << " digest 0x"
-		    << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(shard) << dec << dendl;
+		    << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(static_cast<int>(shard)) << dec << dendl;
 	    r = -EIO;
 	    goto error;
 	  }
@@ -1305,7 +1305,7 @@ void ECBackend::handle_sub_read_reply(
           iter->second.returned.front().get<2>().begin();
         j != iter->second.returned.front().get<2>().end();
         ++j) {
-        have.insert(j->first.shard);
+        have.insert(static_cast<int>(j->first.shard));
         dout(20) << __func__ << " have shard=" << j->first.shard << dendl;
       }
       map<int, vector<pair<int, int>>> dummy_minimum;
@@ -1800,11 +1800,11 @@ int ECBackend::be_deep_scrub(
 	return 0;
       }
 
-      if (hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
+      if (hinfo->get_chunk_hash(static_cast<int>(get_parent()->whoami_shard().shard)) !=
 	  pos.data_hash.digest()) {
 	dout(0) << "_scan_list  " << poid << " got incorrect hash on read 0x"
 		<< std::hex << pos.data_hash.digest() << " !=  expected 0x"
-		<< hinfo->get_chunk_hash(get_parent()->whoami_shard().shard)
+		<< hinfo->get_chunk_hash(static_cast<int>(get_parent()->whoami_shard().shard))
 		<< std::dec << dendl;
 	o.ec_hash_mismatch = true;
 	return 0;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -366,7 +366,7 @@ public:
       for (std::set<pg_shard_t>::const_iterator i = _have.begin();
 	   i != _have.end();
 	   ++i) {
-	have.insert(i->shard);
+	have.insert(static_cast<int>(i->shard));
       }
       std::map<int, std::vector<std::pair<int, int>>> min;
       return ec_impl->minimum_to_decode(want, have, &min) == 0;

--- a/src/osd/ECBackendL.cc
+++ b/src/osd/ECBackendL.cc
@@ -376,13 +376,15 @@ void ECBackendL::RecoveryBackend::handle_recovery_read_complete(
   for (set<shard_id_t>::iterator i = op.missing_on_shards.begin();
        i != op.missing_on_shards.end();
        ++i) {
-    target[*i] = &(op.returned_data[*i]);
+    int s = static_cast<int>(*i);
+    target[s] = &(op.returned_data[s]);
   }
   map<int, bufferlist> from;
   for(map<pg_shard_t, bufferlist>::iterator i = to_read.get<2>().begin();
       i != to_read.get<2>().end();
       ++i) {
-    from[i->first.shard] = std::move(i->second);
+    int s = static_cast<int>(i->first.shard);
+    from[s] = std::move(i->second);
   }
   dout(10) << __func__ << ": " << from << dendl;
   int r;
@@ -637,12 +639,12 @@ void ECBackendL::RecoveryBackend::continue_recovery_op(
       for (set<pg_shard_t>::iterator mi = op.missing_on.begin();
 	   mi != op.missing_on.end();
 	   ++mi) {
-	ceph_assert(op.returned_data.count(mi->shard));
+	ceph_assert(op.returned_data.count(static_cast<int>(mi->shard)));
 	m->pushes[*mi].push_back(PushOp());
 	PushOp &pop = m->pushes[*mi].back();
 	pop.soid = op.hoid;
 	pop.version = op.v;
-	pop.data = op.returned_data[mi->shard];
+	pop.data = op.returned_data[static_cast<int>(mi->shard)];
 	dout(10) << __func__ << ": before_progress=" << op.recovery_progress
 		 << ", after_progress=" << after_progress
 		 << ", pop.data.length()=" << pop.data.length()
@@ -1126,11 +1128,12 @@ void ECBackendL::handle_sub_read(
 	  dout(20) << __func__ << ": Checking hash of " << i->first << dendl;
 	  bufferhash h(-1);
 	  h << bl;
-	  if (h.digest() != hinfo->get_chunk_hash(shard)) {
+          int s = static_cast<int>(shard);
+	  if (h.digest() != hinfo->get_chunk_hash(s)) {
 	    get_parent()->clog_error() << "Bad hash for " << i->first << " digest 0x"
-				       << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(shard) << dec;
+				       << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(s) << dec;
 	    dout(5) << __func__ << ": Bad hash for " << i->first << " digest 0x"
-		    << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(shard) << dec << dendl;
+		    << hex << h.digest() << " expected 0x" << hinfo->get_chunk_hash(s) << dec << dendl;
 	    r = -EIO;
 	    goto error;
 	  }
@@ -1307,7 +1310,7 @@ void ECBackendL::handle_sub_read_reply(
           iter->second.returned.front().get<2>().begin();
         j != iter->second.returned.front().get<2>().end();
         ++j) {
-        have.insert(j->first.shard);
+        have.insert(static_cast<int>(j->first.shard));
         dout(20) << __func__ << " have shard=" << j->first.shard << dendl;
       }
       map<int, vector<pair<int, int>>> dummy_minimum;
@@ -1802,11 +1805,11 @@ int ECBackendL::be_deep_scrub(
 	return 0;
       }
 
-      if (hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
-	  pos.data_hash.digest()) {
+      int s = static_cast<int>(get_parent()->whoami_shard().shard);
+      if (hinfo->get_chunk_hash(s) != pos.data_hash.digest()) {
 	dout(0) << "_scan_list  " << poid << " got incorrect hash on read 0x"
 		<< std::hex << pos.data_hash.digest() << " !=  expected 0x"
-		<< hinfo->get_chunk_hash(get_parent()->whoami_shard().shard)
+		<< hinfo->get_chunk_hash(s)
 		<< std::dec << dendl;
 	o.ec_hash_mismatch = true;
 	return 0;

--- a/src/osd/ECBackendL.h
+++ b/src/osd/ECBackendL.h
@@ -366,7 +366,7 @@ public:
       for (std::set<pg_shard_t>::const_iterator i = _have.begin();
 	   i != _have.end();
 	   ++i) {
-	have.insert(i->shard);
+	have.insert(static_cast<int>(i->shard));
       }
       std::map<int, std::vector<std::pair<int, int>>> min;
       return ec_impl->minimum_to_decode(want, have, &min) == 0;

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -229,8 +229,8 @@ void ECCommon::ReadPipeline::get_all_avail_shards(
       continue;
     }
     if (!missing.is_missing(hoid)) {
-      ceph_assert(!have.count(i->shard));
-      have.insert(i->shard);
+      ceph_assert(!have.count(static_cast<int>(i->shard)));
+      have.insert(static_cast<int>(i->shard));
       ceph_assert(!shards.count(i->shard));
       shards.insert(make_pair(i->shard, *i));
     }
@@ -243,7 +243,7 @@ void ECCommon::ReadPipeline::get_all_avail_shards(
 	 ++i) {
       if (error_shards.find(*i) != error_shards.end())
 	continue;
-      if (have.count(i->shard)) {
+      if (have.count(static_cast<int>(i->shard))) {
 	ceph_assert(shards.count(i->shard));
 	continue;
       }
@@ -253,7 +253,7 @@ void ECCommon::ReadPipeline::get_all_avail_shards(
       const pg_missing_t &missing = get_parent()->get_shard_missing(*i);
       if (hoid < info.last_backfill &&
 	  !missing.is_missing(hoid)) {
-	have.insert(i->shard);
+	have.insert(static_cast<int>(i->shard));
 	shards.insert(make_pair(i->shard, *i));
       }
     }
@@ -271,7 +271,7 @@ void ECCommon::ReadPipeline::get_all_avail_shards(
 	}
 	if (error_shards.find(*i) != error_shards.end())
 	  continue;
-	have.insert(i->shard);
+	have.insert(static_cast<int>(i->shard));
 	shards.insert(make_pair(i->shard, *i));
       }
     }
@@ -534,7 +534,7 @@ struct ClientReadCompleter : ECCommon::ReadCompleter {
 	     res.returned.front().get<2>().begin();
 	   j != res.returned.front().get<2>().end();
 	   ++j) {
-	to_decode[j->first.shard] = std::move(j->second);
+	to_decode[static_cast<int>(j->first.shard)] = std::move(j->second);
       }
       dout(20) << __func__ << " going to decode: "
                << " wanted_to_read=" << wanted_to_read
@@ -668,7 +668,7 @@ int ECCommon::ReadPipeline::send_all_remaining_reads(
   set<int> already_read;
   const set<pg_shard_t>& ots = rop.obj_to_source[hoid];
   for (set<pg_shard_t>::iterator i = ots.begin(); i != ots.end(); ++i)
-    already_read.insert(i->shard);
+    already_read.insert(static_cast<int>(i->shard));
   dout(10) << __func__ << " have/error shards=" << already_read << dendl;
   map<pg_shard_t, vector<pair<int, int>>> shards;
   int r = get_remaining_shards(hoid, already_read, rop.want_to_read[hoid],

--- a/src/osd/ECCommonL.cc
+++ b/src/osd/ECCommonL.cc
@@ -230,8 +230,8 @@ void ECCommonL::ReadPipeline::get_all_avail_shards(
       continue;
     }
     if (!missing.is_missing(hoid)) {
-      ceph_assert(!have.count(i->shard));
-      have.insert(i->shard);
+      ceph_assert(!have.count(static_cast<int>(i->shard)));
+      have.insert(static_cast<int>(i->shard));
       ceph_assert(!shards.count(i->shard));
       shards.insert(make_pair(i->shard, *i));
     }
@@ -244,7 +244,7 @@ void ECCommonL::ReadPipeline::get_all_avail_shards(
 	 ++i) {
       if (error_shards.find(*i) != error_shards.end())
 	continue;
-      if (have.count(i->shard)) {
+      if (have.count(static_cast<int>(i->shard))) {
 	ceph_assert(shards.count(i->shard));
 	continue;
       }
@@ -254,7 +254,7 @@ void ECCommonL::ReadPipeline::get_all_avail_shards(
       const pg_missing_t &missing = get_parent()->get_shard_missing(*i);
       if (hoid < info.last_backfill &&
 	  !missing.is_missing(hoid)) {
-	have.insert(i->shard);
+	have.insert(static_cast<int>(i->shard));
 	shards.insert(make_pair(i->shard, *i));
       }
     }
@@ -272,7 +272,7 @@ void ECCommonL::ReadPipeline::get_all_avail_shards(
 	}
 	if (error_shards.find(*i) != error_shards.end())
 	  continue;
-	have.insert(i->shard);
+	have.insert(static_cast<int>(i->shard));
 	shards.insert(make_pair(i->shard, *i));
       }
     }
@@ -535,7 +535,7 @@ struct ClientReadCompleter : ECCommonL::ReadCompleter {
 	     res.returned.front().get<2>().begin();
 	   j != res.returned.front().get<2>().end();
 	   ++j) {
-	to_decode[j->first.shard] = std::move(j->second);
+	to_decode[static_cast<int>(j->first.shard)] = std::move(j->second);
       }
       dout(20) << __func__ << " going to decode: "
                << " wanted_to_read=" << wanted_to_read
@@ -669,7 +669,7 @@ int ECCommonL::ReadPipeline::send_all_remaining_reads(
   set<int> already_read;
   const set<pg_shard_t>& ots = rop.obj_to_source[hoid];
   for (set<pg_shard_t>::iterator i = ots.begin(); i != ots.end(); ++i)
-    already_read.insert(i->shard);
+    already_read.insert(static_cast<int>(i->shard));
   dout(10) << __func__ << " have/error shards=" << already_read << dendl;
   map<pg_shard_t, vector<pair<int, int>>> shards;
   int r = get_remaining_shards(hoid, already_read, rop.want_to_read[hoid],

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -73,8 +73,8 @@ static void encode_and_write(
   }
 
   for (auto &&i : *transactions) {
-    ceph_assert(buffers.count(i.first));
-    bufferlist &enc_bl = buffers[i.first];
+    ceph_assert(buffers.count(static_cast<int>(i.first)));
+    bufferlist &enc_bl = buffers[static_cast<int>(i.first)];
     if (offset >= before_size) {
       i.second.set_alloc_hint(
 	coll_t(spg_t(pgid, i.first)),

--- a/src/osd/ECTransactionL.cc
+++ b/src/osd/ECTransactionL.cc
@@ -74,8 +74,8 @@ static void encode_and_write(
   }
 
   for (auto &&i : *transactions) {
-    ceph_assert(buffers.count(i.first));
-    bufferlist &enc_bl = buffers[i.first];
+    ceph_assert(buffers.count(static_cast<int>(i.first)));
+    bufferlist &enc_bl = buffers[static_cast<int>(i.first)];
     if (offset >= before_size) {
       i.second.set_alloc_hint(
 	coll_t(spg_t(pgid, i.first)),

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6567,10 +6567,12 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       return;
     }
 
-    int64_t shardid = cmd_getval_or<int64_t>(cmdmap, "shardid", shard_id_t::NO_SHARD);
+    int64_t shardid64 = cmd_getval_or<int64_t>(cmdmap, "shardid", static_cast<int64_t>(shard_id_t::NO_SHARD));
+    shard_id_t shardid = shard_id_t(static_cast<int8_t>(shardid64));
+
     hobject_t obj(object_t(objname), string(""), CEPH_NOSNAP, rawpg.ps(), pool, nspace);
-    ghobject_t gobj(obj, ghobject_t::NO_GEN, shard_id_t(uint8_t(shardid)));
-    spg_t pgid(curmap->raw_pg_to_pg(rawpg), shard_id_t(shardid));
+    ghobject_t gobj(obj, ghobject_t::NO_GEN, shardid);
+    spg_t pgid(curmap->raw_pg_to_pg(rawpg), shardid);
     if (curmap->pg_is_ec(rawpg)) {
         if ((command != "injectdataerr") &&
 	    (command != "injectmdataerr") &&

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2996,8 +2996,8 @@ int OSDMap::calc_pg_role(pg_shard_t who, const vector<int>& acting)
       }
     }
   } else {
-    if (who.shard < nrep && acting[who.shard] == who.osd) {
-      return who.shard;
+    if (who.shard < nrep && acting[static_cast<int>(who.shard)] == who.osd) {
+      return static_cast<int>(who.shard);
     }
   }
   return -1;

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -208,7 +208,8 @@ void PGBackend::rollback(
       PGBackend *pg) : hoid(hoid), pg(pg) {}
     void append(uint64_t old_size) override {
       ObjectStore::Transaction temp;
-      const uint64_t shard_size = pg->object_size_to_shard_size(old_size, pg->get_parent()->whoami_shard().shard);
+      int s = static_cast<int>(pg->get_parent()->whoami_shard().shard);
+      const uint64_t shard_size = pg->object_size_to_shard_size(old_size, s);
       pg->rollback_append(hoid, shard_size, &temp);
       temp.append(t);
       temp.swap(t);

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1628,7 +1628,7 @@ void PeeringState::calc_ec_acting(
       for (auto j = all_info_by_shard[shard_id_t(i)].begin();
 	   j != all_info_by_shard[shard_id_t(i)].end();
 	   ++j) {
-	ceph_assert(j->shard == i);
+	ceph_assert(static_cast<int>(j->shard) == i);
 	if (!all_info.find(*j)->second.is_incomplete() &&
 	    all_info.find(*j)->second.last_update >=
 	    auth_log_shard->second.log_tail) {
@@ -5998,7 +5998,7 @@ PeeringState::Active::Active(my_context ctx)
        p != ps->acting_recovery_backfill.end();
        ++p) {
     if (p->shard != ps->pg_whoami.shard) {
-      ps->blocked_by.insert(p->shard);
+      ps->blocked_by.insert(static_cast<int>(p->shard));
     }
   }
   pl->publish_stats_to_osd();
@@ -6174,7 +6174,7 @@ boost::statechart::result PeeringState::Active::react(const MInfoRec& infoevt)
       ps->peer_activated.insert(infoevt.from).second) {
     psdout(10) << " peer osd." << infoevt.from
 	       << " activated and committed" << dendl;
-    ps->blocked_by.erase(infoevt.from.shard);
+    ps->blocked_by.erase(static_cast<int>(infoevt.from.shard));
     pl->publish_stats_to_osd();
     if (ps->peer_activated.size() == ps->acting_recovery_backfill.size()) {
       all_activated_and_committed();

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2242,7 +2242,7 @@ public:
   }
   static bool has_shard(bool ec, const std::vector<int>& v, pg_shard_t osd) {
     if (ec) {
-      return v.size() > (unsigned)osd.shard && v[osd.shard] == osd.osd;
+      return v.size() > (unsigned)osd.shard && v[static_cast<int>(osd.shard)] == osd.osd;
     } else {
       return std::find(v.begin(), v.end(), osd.osd) != v.end();
     }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3735,8 +3735,8 @@ void pg_notify_t::decode(ceph::buffer::list::const_iterator &bl)
 
 void pg_notify_t::dump(Formatter *f) const
 {
-  f->dump_int("from", from);
-  f->dump_int("to", to);
+  f->dump_int("from", static_cast<int>(from));
+  f->dump_int("to", static_cast<int>(to));
   f->dump_unsigned("query_epoch", query_epoch);
   f->dump_unsigned("epoch_sent", epoch_sent);
   {
@@ -4476,8 +4476,8 @@ void pg_query_t::decode(ceph::buffer::list::const_iterator &bl) {
 
 void pg_query_t::dump(Formatter *f) const
 {
-  f->dump_int("from", from);
-  f->dump_int("to", to);
+  f->dump_int("from", static_cast<int>(from));
+  f->dump_int("to", static_cast<int>(to));
   f->dump_string("type", get_type_name());
   f->dump_stream("since") << since;
   f->dump_stream("epoch_sent") << epoch_sent;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -52,6 +52,7 @@
 #include "compressor/Compressor.h"
 #include "osd_perf_counters.h"
 #include "pg_features.h"
+#include "ECTypes.h"
 
 #define CEPH_OSD_ONDISK_MAGIC "ceph osd volume v026"
 
@@ -194,7 +195,7 @@ struct pg_shard_t {
   void dump(ceph::Formatter *f) const {
     f->dump_unsigned("osd", osd);
     if (shard != shard_id_t::NO_SHARD) {
-      f->dump_unsigned("shard", shard);
+      f->dump_unsigned("shard", static_cast<unsigned>(shard));
     }
   }
   static void generate_test_instances(std::list<pg_shard_t*>& o) {
@@ -608,7 +609,7 @@ struct spg_t {
   }
   void dump(ceph::Formatter *f) const {
     f->dump_stream("pgid") << pgid;
-    f->dump_unsigned("shard", shard);
+    f->dump_unsigned("shard", static_cast<unsigned>(shard));
   }
   static void generate_test_instances(std::list<spg_t*>& o) {
     o.push_back(new spg_t);
@@ -636,7 +637,9 @@ namespace std {
     size_t operator()( const spg_t& x ) const
       {
       static hash<uint32_t> H;
-      return H(hash<pg_t>()(x.pgid) ^ x.shard);
+      // Historically a "shard" was an int8_t, hence the unexpected cast in
+      // this XOR.
+      return H(hash<pg_t>()(x.pgid) ^ static_cast<int8_t>(x.shard));
     }
   };
 } // namespace std

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -132,7 +132,7 @@ struct formatter<spg_t> {
   template <typename FormatContext>
   auto format(const spg_t& spg, FormatContext& ctx) const
   {
-    if (shard_id_t::NO_SHARD == spg.shard.id) {
+    if (shard_id_t::NO_SHARD == spg.shard) {
       return fmt::format_to(ctx.out(), "{}", spg.pgid);
     } else {
       return fmt::format_to(ctx.out(), "{}s{}", spg.pgid, spg.shard.id);

--- a/src/test/crimson/test_crimson_scrub.cc
+++ b/src/test/crimson/test_crimson_scrub.cc
@@ -854,7 +854,7 @@ TEST_P(TestSingleError, SingleError) {
   bool found_selected_oi = false;
   for (const auto &shard : shards) {
     auto siter = obj_error.shards.find(
-      librados::osd_shard_t{shard.osd, shard.shard}
+      librados::osd_shard_t{shard.osd, static_cast<int8_t>(shard.shard)}
     );
     if (siter == obj_error.shards.end()) {
       EXPECT_NE(siter, obj_error.shards.end());

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1712,7 +1712,7 @@ static void dump_inconsistent(const inconsistent_obj_t& inc,
     f.dump_int("osd", osd_shard.osd);
     f.dump_bool("primary", shard_info.second.primary);
     auto shard = osd_shard.shard;
-    if (shard != shard_id_t::NO_SHARD)
+    if (shard != static_cast<int>(shard_id_t::NO_SHARD))
       f.dump_unsigned("shard", shard);
     dump_shard(shard_info.second, inc, f);
     f.close_section();


### PR DESCRIPTION
In new EC code, we want to be strict about usage of shard_id_t, to avoid confusion with raw_shard_id_t (to be added later), OSD ids, and other objects where ints are frequently used as IDs. 

This required adding quite a few explicit casts, which can potentially be removed the code owner thinks that these will provide some useful policing.

TO REVIEWER: Please only pay attention to the last commit. This is intentionally based on [another PR ](https://github.com/ceph/ceph/pull/61263), which I hope to push soon. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
