### PR TITLE
test: Add new sequences to the IO sequencer. 

### DIFF
--- a/src/common/io_exerciser/DataGenerator.h
+++ b/src/common/io_exerciser/DataGenerator.h
@@ -51,6 +51,8 @@ class DataGenerator {
   // Used for testing debug outputs from data generation
   virtual bufferlist generate_wrong_data(uint64_t offset, uint64_t length);
 
+  using SeedBytes = int;
+
  protected:
   const ObjectModel& m_model;
 

--- a/src/common/io_exerciser/EcIoSequence.cc
+++ b/src/common/io_exerciser/EcIoSequence.cc
@@ -33,6 +33,10 @@ std::unique_ptr<IoSequence> EcIoSequence::generate_sequence(
     case Sequence::SEQUENCE_SEQ8:
       [[fallthrough]];
     case Sequence::SEQUENCE_SEQ9:
+      [[fallthrough]];
+    case Sequence::SEQUENCE_SEQ11:
+      [[fallthrough]];
+    case Sequence::SEQUENCE_SEQ12:
       return std::make_unique<ReadInjectSequence>(obj_size_range, seed,
                                                   sequence, k, m);
     case Sequence::SEQUENCE_SEQ10:

--- a/src/common/io_exerciser/EcIoSequence.cc
+++ b/src/common/io_exerciser/EcIoSequence.cc
@@ -37,6 +37,8 @@ std::unique_ptr<IoSequence> EcIoSequence::generate_sequence(
     case Sequence::SEQUENCE_SEQ11:
       [[fallthrough]];
     case Sequence::SEQUENCE_SEQ12:
+      [[fallthrough]];
+    case Sequence::SEQUENCE_SEQ13:
       return std::make_unique<ReadInjectSequence>(obj_size_range, seed,
                                                   sequence, k, m);
     case Sequence::SEQUENCE_SEQ10:

--- a/src/common/io_exerciser/EcIoSequence.cc
+++ b/src/common/io_exerciser/EcIoSequence.cc
@@ -39,6 +39,8 @@ std::unique_ptr<IoSequence> EcIoSequence::generate_sequence(
     case Sequence::SEQUENCE_SEQ12:
       [[fallthrough]];
     case Sequence::SEQUENCE_SEQ13:
+      [[fallthrough]];
+    case Sequence::SEQUENCE_SEQ14:
       return std::make_unique<ReadInjectSequence>(obj_size_range, seed,
                                                   sequence, k, m);
     case Sequence::SEQUENCE_SEQ10:

--- a/src/common/io_exerciser/IoOp.cc
+++ b/src/common/io_exerciser/IoOp.cc
@@ -20,6 +20,7 @@ using SingleFailedWriteOp = ceph::io_exerciser::SingleFailedWriteOp;
 using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
 using SingleAppendOp = ceph::io_exerciser::SingleAppendOp;
+using TruncateOp = ceph::io_exerciser::TruncateOp;
 
 namespace {
 std::string value_to_string(uint64_t v) {
@@ -213,6 +214,17 @@ SingleAppendOp::SingleAppendOp(uint64_t length)
 
 std::unique_ptr<SingleAppendOp> SingleAppendOp::generate(uint64_t length) {
   return std::make_unique<SingleAppendOp>(length);
+}
+
+TruncateOp::TruncateOp(uint64_t size)
+    : TestOp<OpType::Truncate>(), size(size) {}
+
+std::unique_ptr<TruncateOp> TruncateOp::generate(uint64_t size) {
+  return std::make_unique<TruncateOp>(size);
+}
+
+std::string TruncateOp::to_string(uint64_t block_size) const {
+  return "Truncate (size=" + value_to_string(size * block_size) + ")";
 }
 
 SingleFailedWriteOp::SingleFailedWriteOp(uint64_t offset, uint64_t length)

--- a/src/common/io_exerciser/IoOp.cc
+++ b/src/common/io_exerciser/IoOp.cc
@@ -19,6 +19,7 @@ using TripleWriteOp = ceph::io_exerciser::TripleWriteOp;
 using SingleFailedWriteOp = ceph::io_exerciser::SingleFailedWriteOp;
 using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
+using SingleAppendOp = ceph::io_exerciser::SingleAppendOp;
 
 namespace {
 std::string value_to_string(uint64_t v) {
@@ -100,16 +101,21 @@ template <OpType opType, int numIOs>
 std::string ceph::io_exerciser::ReadWriteOp<opType, numIOs>::to_string(
     uint64_t block_size) const {
   std::string offset_length_desc;
+  std::string length_desc;
   if (numIOs > 0) {
     offset_length_desc += fmt::format(
         "offset1={}", value_to_string(this->offset[0] * block_size));
-    offset_length_desc += fmt::format(
-        ",length1={}", value_to_string(this->length[0] * block_size));
+    length_desc += fmt::format("length1={}",
+                               value_to_string(this->length[0] * block_size));
+    offset_length_desc += "," + length_desc;
     for (int i = 1; i < numIOs; i++) {
+      std::string length;
       offset_length_desc += fmt::format(
           ",offset{}={}", i + 1, value_to_string(this->offset[i] * block_size));
-      offset_length_desc += fmt::format(
-          ",length{}={}", i + 1, value_to_string(this->length[i] * block_size));
+      length += fmt::format(",length{}={}", i + 1,
+                            value_to_string(this->length[i] * block_size));
+      length_desc += length;
+      offset_length_desc += length;
     }
   }
   switch (opType) {
@@ -125,6 +131,8 @@ std::string ceph::io_exerciser::ReadWriteOp<opType, numIOs>::to_string(
       [[fallthrough]];
     case OpType::Write3:
       return fmt::format("Write{} ({})", numIOs, offset_length_desc);
+    case OpType::Append:
+      return fmt::format("Append{} ({})", numIOs, length_desc);
     case OpType::FailedWrite:
       [[fallthrough]];
     case OpType::FailedWrite2:
@@ -198,6 +206,13 @@ std::unique_ptr<TripleWriteOp> TripleWriteOp::generate(
     uint64_t offset3, uint64_t length3) {
   return std::make_unique<TripleWriteOp>(offset1, length1, offset2, length2,
                                          offset3, length3);
+}
+
+SingleAppendOp::SingleAppendOp(uint64_t length)
+    : ReadWriteOp<OpType::Append, 1>({0}, {length}) {}
+
+std::unique_ptr<SingleAppendOp> SingleAppendOp::generate(uint64_t length) {
+  return std::make_unique<SingleAppendOp>(length);
 }
 
 SingleFailedWriteOp::SingleFailedWriteOp(uint64_t offset, uint64_t length)

--- a/src/common/io_exerciser/IoOp.h
+++ b/src/common/io_exerciser/IoOp.h
@@ -131,6 +131,14 @@ class SingleAppendOp : public ReadWriteOp<OpType::Append, 1> {
   static std::unique_ptr<SingleAppendOp> generate(uint64_t length);
 };
 
+class TruncateOp : public TestOp<OpType::Truncate> {
+ public:
+  TruncateOp(uint64_t size);
+  static std::unique_ptr<TruncateOp> generate(uint64_t size);
+  std::string to_string(uint64_t block_size) const override;
+  uint64_t size;
+};
+
 class SingleFailedWriteOp : public ReadWriteOp<OpType::FailedWrite, 1> {
  public:
   SingleFailedWriteOp(uint64_t offset, uint64_t length);

--- a/src/common/io_exerciser/IoOp.h
+++ b/src/common/io_exerciser/IoOp.h
@@ -125,6 +125,12 @@ class TripleWriteOp : public ReadWriteOp<OpType::Write3, 3> {
       uint64_t offset3, uint64_t length3);
 };
 
+class SingleAppendOp : public ReadWriteOp<OpType::Append, 1> {
+ public:
+  SingleAppendOp(uint64_t length);
+  static std::unique_ptr<SingleAppendOp> generate(uint64_t length);
+};
+
 class SingleFailedWriteOp : public ReadWriteOp<OpType::FailedWrite, 1> {
  public:
   SingleFailedWriteOp(uint64_t offset, uint64_t length);

--- a/src/common/io_exerciser/IoSequence.h
+++ b/src/common/io_exerciser/IoSequence.h
@@ -42,6 +42,8 @@ enum class Sequence {
   SEQUENCE_SEQ8,
   SEQUENCE_SEQ9,
   SEQUENCE_SEQ10,
+  SEQUENCE_SEQ11,
+  SEQUENCE_SEQ12,
 
   SEQUENCE_END,
   SEQUENCE_BEGIN = SEQUENCE_SEQ0
@@ -227,6 +229,35 @@ class Seq9 : public IoSequence {
 
  public:
   Seq9(std::pair<int, int> obj_size_range, int seed);
+
+      Sequence get_id() const override;
+      std::string get_name() const override;
+      std::unique_ptr<IoOp> _next() override;
+    };
+
+class Seq11 : public IoSequence {
+ private:
+  uint64_t count;
+  bool doneread = true;
+  bool donebarrier = false;
+
+ public:
+  Seq11(std::pair<int, int> obj_size_range, int seed);
+
+  Sequence get_id() const override;
+  std::string get_name() const override;
+  std::unique_ptr<IoOp> _next() override;
+};
+
+class Seq12 : public IoSequence {
+ private:
+  uint64_t count;
+  uint64_t overlap;
+  bool doneread = true;
+  bool donebarrier = false;
+
+ public:
+  Seq12(std::pair<int, int> obj_size_range, int seed);
 
   Sequence get_id() const override;
   std::string get_name() const override;

--- a/src/common/io_exerciser/IoSequence.h
+++ b/src/common/io_exerciser/IoSequence.h
@@ -44,6 +44,7 @@ enum class Sequence {
   SEQUENCE_SEQ10,
   SEQUENCE_SEQ11,
   SEQUENCE_SEQ12,
+  SEQUENCE_SEQ13,
 
   SEQUENCE_END,
   SEQUENCE_BEGIN = SEQUENCE_SEQ0
@@ -258,6 +259,21 @@ class Seq12 : public IoSequence {
 
  public:
   Seq12(std::pair<int, int> obj_size_range, int seed);
+
+  Sequence get_id() const override;
+  std::string get_name() const override;
+  std::unique_ptr<IoOp> _next() override;
+};
+
+class Seq13 : public IoSequence {
+ private:
+  uint64_t count;
+  uint64_t gap;
+  bool doneread = true;
+  bool donebarrier = false;
+
+ public:
+  Seq13(std::pair<int, int> obj_size_range, int seed);
 
   Sequence get_id() const override;
   std::string get_name() const override;

--- a/src/common/io_exerciser/IoSequence.h
+++ b/src/common/io_exerciser/IoSequence.h
@@ -45,6 +45,7 @@ enum class Sequence {
   SEQUENCE_SEQ11,
   SEQUENCE_SEQ12,
   SEQUENCE_SEQ13,
+  SEQUENCE_SEQ14,
 
   SEQUENCE_END,
   SEQUENCE_BEGIN = SEQUENCE_SEQ0
@@ -275,6 +276,26 @@ class Seq13 : public IoSequence {
  public:
   Seq13(std::pair<int, int> obj_size_range, int seed);
 
+  Sequence get_id() const override;
+  std::string get_name() const override;
+  std::unique_ptr<IoOp> _next() override;
+};
+
+class Seq14 : public IoSequence {
+ private:
+  uint64_t offset;
+  uint64_t step;
+  uint64_t target_obj_size;
+  uint64_t current_size = 0;
+  std::default_random_engine startrng;
+  std::vector<uint64_t> starts;
+  size_t startidx;
+  bool doneread = false;
+
+ public:
+  Seq14(std::pair<int, int> obj_size_range, int seed);
+
+  void setup_starts();
   Sequence get_id() const override;
   std::string get_name() const override;
   std::unique_ptr<IoOp> _next() override;

--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -118,6 +118,13 @@ void ObjectModel::applyIoOp(IoOp& op) {
                     generate_random);
       break;
 
+    case OpType::Truncate:
+      ceph_assert(created);
+      ceph_assert(reads.empty());
+      ceph_assert(writes.empty());
+      contents.resize(static_cast<TruncateOp&>(op).size);
+      break;
+
     case OpType::Remove:
       ceph_assert(created);
       ceph_assert(reads.empty());

--- a/src/common/io_exerciser/ObjectModel.cc
+++ b/src/common/io_exerciser/ObjectModel.cc
@@ -45,7 +45,9 @@ std::string ObjectModel::to_string(int mask) const {
 bool ObjectModel::readyForIoOp(IoOp& op) { return true; }
 
 void ObjectModel::applyIoOp(IoOp& op) {
-  auto generate_random = [&rng = rng]() { return rng(); };
+  auto generate_random = [&rng = rng]() {
+    return rng(1, std::numeric_limits<int>::max());
+  };
 
   auto verify_and_record_read_op =
       [&contents = contents, &created = created, &num_io = num_io,

--- a/src/common/io_exerciser/OpType.h
+++ b/src/common/io_exerciser/OpType.h
@@ -23,6 +23,7 @@ enum class OpType {
   Write,                 // Write
   Write2,                // Two writes in a single op
   Write3,                // Three writes in a single op
+  Append,                // Append
   FailedWrite,           // A write which should fail
   FailedWrite2,          // Two writes in one op which should fail
   FailedWrite3,          // Three writes in one op which should fail
@@ -69,6 +70,8 @@ struct fmt::formatter<ceph::io_exerciser::OpType> {
         return fmt::format_to(ctx.out(), "Write2");
       case ceph::io_exerciser::OpType::Write3:
         return fmt::format_to(ctx.out(), "Write3");
+      case ceph::io_exerciser::OpType::Append:
+        return fmt::format_to(ctx.out(), "Append");
       case ceph::io_exerciser::OpType::FailedWrite:
         return fmt::format_to(ctx.out(), "FailedWrite");
       case ceph::io_exerciser::OpType::FailedWrite2:

--- a/src/common/io_exerciser/OpType.h
+++ b/src/common/io_exerciser/OpType.h
@@ -24,6 +24,7 @@ enum class OpType {
   Write2,                // Two writes in a single op
   Write3,                // Three writes in a single op
   Append,                // Append
+  Truncate,              // Truncate
   FailedWrite,           // A write which should fail
   FailedWrite2,          // Two writes in one op which should fail
   FailedWrite3,          // Three writes in one op which should fail
@@ -72,6 +73,8 @@ struct fmt::formatter<ceph::io_exerciser::OpType> {
         return fmt::format_to(ctx.out(), "Write3");
       case ceph::io_exerciser::OpType::Append:
         return fmt::format_to(ctx.out(), "Append");
+      case ceph::io_exerciser::OpType::Truncate:
+        return fmt::format_to(ctx.out(), "Truncate");
       case ceph::io_exerciser::OpType::FailedWrite:
         return fmt::format_to(ctx.out(), "FailedWrite");
       case ceph::io_exerciser::OpType::FailedWrite2:

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -146,6 +146,21 @@ void RadosIo::applyIoOp(IoOp& op) {
       break;
     }
 
+    case OpType::Truncate: {
+      start_io();
+      uint64_t opSize = static_cast<TruncateOp&>(op).size;
+      auto op_info = std::make_shared<AsyncOpInfo<0>>();
+      librados::ObjectWriteOperation wop;
+      wop.truncate(opSize * block_size);
+      auto truncate_cb = [this](boost::system::error_code ec, version_t ver) {
+        ceph_assert(ec == boost::system::errc::success);
+        finish_io();
+      };
+      librados::async_operate(asio.get_executor(), io, oid, std::move(wop), 0,
+                              nullptr, truncate_cb);
+      break;
+    }
+
     case OpType::Remove: {
       start_io();
       auto op_info = std::make_shared<AsyncOpInfo<0>>();

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -171,6 +171,8 @@ void RadosIo::applyIoOp(IoOp& op) {
       [[fallthrough]];
     case OpType::Write3:
       [[fallthrough]];
+    case OpType::Append:
+      [[fallthrough]];
     case OpType::FailedWrite:
       [[fallthrough]];
     case OpType::FailedWrite2:
@@ -295,6 +297,13 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
       start_io();
       TripleWriteOp& writeOp = static_cast<TripleWriteOp&>(op);
       applyWriteOp(writeOp);
+      break;
+    }
+
+    case OpType::Append: {
+      start_io();
+      SingleAppendOp& appendOp = static_cast<SingleAppendOp&>(op);
+      applyWriteOp(appendOp);
       break;
     }
 

--- a/src/test/osd/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence.cc
@@ -48,6 +48,7 @@ using TripleReadOp = ceph::io_exerciser::TripleReadOp;
 using SingleWriteOp = ceph::io_exerciser::SingleWriteOp;
 using DoubleWriteOp = ceph::io_exerciser::DoubleWriteOp;
 using TripleWriteOp = ceph::io_exerciser::TripleWriteOp;
+using SingleAppendOp = ceph::io_exerciser::SingleAppendOp;
 using SingleFailedWriteOp = ceph::io_exerciser::SingleFailedWriteOp;
 using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
@@ -667,9 +668,12 @@ void ceph::io_sequence::tester::TestRunner::clear_tokens() {
   tokens = split.end();
 }
 
-std::string ceph::io_sequence::tester::TestRunner::get_token() {
+std::string ceph::io_sequence::tester::TestRunner::get_token(bool allow_eof) {
   while (line.empty() || tokens == split.end()) {
     if (!std::getline(std::cin, line)) {
+      if (allow_eof) {
+        return "done";
+      }
       throw std::runtime_error("End of input");
     }
     split = ceph::split(line);
@@ -759,7 +763,7 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
   }
 
   while (!done) {
-    const std::string op = get_token();
+    const std::string op = get_token(true);
     if (op == "done" || op == "q" || op == "quit") {
       ioop = ceph::io_exerciser::DoneOp::generate();
     } else if (op == "create") {
@@ -804,6 +808,9 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
       uint64_t length3 = get_numeric_token();
       ioop = TripleWriteOp::generate(offset1, length1, offset2, length2,
                                      offset3, length3);
+    } else if (op == "append") {
+      uint64_t length = get_numeric_token();
+      ioop = SingleAppendOp::generate(length);
     } else if (op == "failedwrite") {
       uint64_t offset = get_numeric_token();
       uint64_t length = get_numeric_token();

--- a/src/test/osd/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence.cc
@@ -49,6 +49,7 @@ using SingleWriteOp = ceph::io_exerciser::SingleWriteOp;
 using DoubleWriteOp = ceph::io_exerciser::DoubleWriteOp;
 using TripleWriteOp = ceph::io_exerciser::TripleWriteOp;
 using SingleAppendOp = ceph::io_exerciser::SingleAppendOp;
+using TruncateOp = ceph::io_exerciser::TruncateOp;
 using SingleFailedWriteOp = ceph::io_exerciser::SingleFailedWriteOp;
 using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
@@ -811,6 +812,8 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
     } else if (op == "append") {
       uint64_t length = get_numeric_token();
       ioop = SingleAppendOp::generate(length);
+    } else if (op == "truncate") {
+      ioop = TruncateOp::generate(get_numeric_token());
     } else if (op == "failedwrite") {
       uint64_t offset = get_numeric_token();
       uint64_t length = get_numeric_token();

--- a/src/test/osd/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence.cc
@@ -677,6 +677,10 @@ std::string ceph::io_sequence::tester::TestRunner::get_token(bool allow_eof) {
       }
       throw std::runtime_error("End of input");
     }
+    if (line.starts_with('#')) {
+      dout(0) << line << dendl;
+      continue;
+    }
     split = ceph::split(line);
     tokens = split.begin();
   }
@@ -767,6 +771,10 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
     const std::string op = get_token(true);
     if (op == "done" || op == "q" || op == "quit") {
       ioop = ceph::io_exerciser::DoneOp::generate();
+    } else if (op == "sleep") {
+      uint64_t duration = get_numeric_token();
+      dout(0) << "Sleep " << duration << dendl;
+      sleep(duration);
     } else if (op == "create") {
       ioop = ceph::io_exerciser::CreateOp::generate(get_numeric_token());
     } else if (op == "remove" || op == "delete") {

--- a/src/test/osd/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence.h
@@ -322,7 +322,7 @@ class TestRunner {
   ceph::spliterator tokens;
 
   void clear_tokens();
-  std::string get_token();
+  std::string get_token(bool allow_eof = false);
   std::optional<std::string> get_optional_token();
   uint64_t get_numeric_token();
   std::optional<uint64_t> get_optional_numeric_token();


### PR DESCRIPTION
Reviewer NOTES:

 None of these sequences will run in teuthology YET, so there is a low risk to these changes either breaking production or infrastructure. 

This change adds some new sequences to test erasure coding:

1. Appends - specific and awkward appends to objects. Including writing off the end of object to make them large, overlapping, writes. 
2. Truncates - reduce the size of an object. Sequences associated with this which are awkward for EC pools. 
3. Write-object-filling-gap sequence (14) - this sequence creates an object with a hole in it, then fills the hole afterwards. 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
