### PR TITLE
squid: rgw: allow management of `accounts` user caps

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -382,7 +382,7 @@ form:
 
 .. prompt:: bash
 
-   --caps="[users|buckets|metadata|usage|zone|amz-cache|info|bilog|mdlog|datalog|user-policy|oidc-provider|roles|ratelimit|user-info-without-keys]=[\*|read|write|read, write]"
+   --caps="[users|buckets|metadata|usage|zone|amz-cache|info|bilog|mdlog|datalog|user-policy|oidc-provider|roles|ratelimit|user-info-without-keys|accounts]=[\*|read|write|read, write]"
 
 For example:
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2084,7 +2084,8 @@ bool RGWUserCaps::is_valid_cap_type(const string& tp)
                                     "amz-cache",
                                     "oidc-provider",
                                     "user-info-without-keys",
-				                            "ratelimit"};
+                                    "ratelimit",
+                                    "accounts"};
 
   for (unsigned int i = 0; i < sizeof(cap_type) / sizeof(char *); ++i) {
     if (tp.compare(cap_type[i]) == 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69933

---

backport of https://github.com/ceph/ceph/pull/61358
parent tracker: https://tracker.ceph.com/issues/69544

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh