### PR TITLE
mgr/dashboard: Ns create size fix

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
-from typing import Any, Dict, Optional
+from typing import Annotated, Any, Dict, Optional
 
 import cherrypy
+from ceph_argparse import CephSizeBytes
 from orchestrator import OrchestratorError
 
 from .. import mgr
@@ -365,8 +366,8 @@ else:
             rbd_image_name: str,
             rbd_pool: str = "rbd",
             create_image: Optional[bool] = True,
-            size: Optional[int] = 1024,
-            rbd_image_size: Optional[int] = None,
+            size: Optional[int] = None,
+            rbd_image_size: Optional[Annotated[int, CephSizeBytes()]] = None,
             trash_image: Optional[bool] = False,
             block_size: int = 512,
             load_balancing_group: Optional[int] = None,

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9032,7 +9032,6 @@ paths:
                   description: RBD pool name
                   type: string
                 size:
-                  default: 1024
                   description: RBD image size
                   type: integer
                 trash_image:

--- a/src/pybind/mgr/tests/test_ceph_argtypes.py
+++ b/src/pybind/mgr/tests/test_ceph_argtypes.py
@@ -1,0 +1,144 @@
+import enum
+import pytest
+from ceph_argparse import CephSizeBytes, CephArgtype
+
+class TestCephArgtypeArgdesc:
+
+    def test_to_argdesc_with_default(self):
+        attrs = {}
+        result = CephArgtype.to_argdesc(str, attrs, has_default=True)
+        assert result == "req=false,type=CephString"
+
+    def test_to_argdesc_without_default(self):
+        attrs = {}
+        result = CephArgtype.to_argdesc(str, attrs, has_default=False)
+        assert result == "type=CephString"
+
+    def test_to_argdesc_positional_false(self):
+        attrs = {}
+        result = CephArgtype.to_argdesc(str, attrs, positional=False)
+        assert result == "positional=false,type=CephString"
+
+    def test_to_argdesc_str(self):
+        attrs = {}
+        result = CephArgtype.to_argdesc(str, attrs)
+        assert result == "type=CephString"
+
+    def test_to_argdesc_int(self):
+        attrs = {}
+        result = CephArgtype.to_argdesc(int, attrs)
+        assert result == "type=CephInt"
+
+    def test_to_argdesc_float(self):
+        attrs = {}
+        result = CephArgtype.to_argdesc(float, attrs)
+        assert result == "type=CephFloat"
+
+    def test_to_argdesc_bool(self):
+        attrs = {}
+        result = CephArgtype.to_argdesc(bool, attrs)
+        assert result == "type=CephBool"
+
+    def test_to_argdesc_invalid_type(self):
+        attrs = {}
+        # Simulate an invalid type that isn't in CEPH_ARG_TYPES
+        with pytest.raises(ValueError):
+            CephArgtype.to_argdesc(object, attrs)
+
+    def test_to_argdesc_with_enum(self):
+        import enum
+        class MyEnum(enum.Enum):
+            A = "one"
+            B = "two"
+
+        attrs = {}
+        result = CephArgtype.to_argdesc(MyEnum, attrs)
+        assert result == "strings=one|two,type=CephChoices"
+
+        
+class TestCephArgtypeCastTo:
+    def test_cast_to_with_str(self):
+        result = CephArgtype.cast_to(str, 123)
+        assert result == "123"
+
+    def test_cast_to_with_int(self):
+        result = CephArgtype.cast_to(int, "123")
+        assert result == 123
+
+    def test_cast_to_with_float(self):
+        result = CephArgtype.cast_to(float, "123.45")
+        assert result == 123.45
+
+    def test_cast_to_with_bool(self):
+        result = CephArgtype.cast_to(bool, "True")
+        assert result is True
+
+    def test_cast_to_with_enum(self):
+        class MyEnum(enum.Enum):
+            A = "one"
+            B = "two"
+
+        result = CephArgtype.cast_to(MyEnum, "one")
+        assert result == MyEnum.A
+
+    def test_cast_to_with_unknown_type(self):
+        class UnknownType:
+            pass
+        
+        with pytest.raises(ValueError):
+            CephArgtype.cast_to(UnknownType, "value")
+
+    def test_cast_to_invalid_value_for_type(self):
+        with pytest.raises(ValueError):
+            CephArgtype.cast_to(int, "invalid_integer")
+
+
+class TestConvertToBytes:
+    def test_with_kb(self):
+        assert CephSizeBytes._convert_to_bytes(f"100KB") == 102400
+        assert CephSizeBytes._convert_to_bytes(f"100K") == 102400
+
+    def test_with_mb(self):
+        assert CephSizeBytes._convert_to_bytes(f"2MB") == 2 * 1024 ** 2
+        assert CephSizeBytes._convert_to_bytes(f"2M") == 2 * 1024 ** 2
+
+    def test_with_gb(self):
+        assert CephSizeBytes._convert_to_bytes(f"1GB") == 1024 ** 3
+        assert CephSizeBytes._convert_to_bytes(f"1G") == 1024 ** 3
+
+    def test_with_tb(self):
+        assert CephSizeBytes._convert_to_bytes(f"1TB") == 1024 ** 4
+        assert CephSizeBytes._convert_to_bytes(f"1T") == 1024 ** 4
+
+    def test_with_pb(self):
+        assert CephSizeBytes._convert_to_bytes(f"1PB") == 1024 ** 5
+        assert CephSizeBytes._convert_to_bytes(f"1P") == 1024 ** 5
+
+    def test_with_integer(self):
+        assert CephSizeBytes._convert_to_bytes(50, default_unit="B") == 50
+
+    def test_invalid_unit(self):
+        with pytest.raises(ValueError):
+            CephSizeBytes._convert_to_bytes("50XYZ")
+
+    def test_b(self):
+        assert CephSizeBytes._convert_to_bytes(f"500B") == 500
+
+    def test_with_large_number(self):
+        assert CephSizeBytes._convert_to_bytes(f"1000GB") == 1000 * 1024 ** 3
+
+    def test_no_number(self):
+        with pytest.raises(ValueError):
+            CephSizeBytes._convert_to_bytes("GB")
+
+    def test_no_unit_with_default_unit_gb(self):
+        assert CephSizeBytes._convert_to_bytes("500", default_unit="GB") == 500 * 1024 ** 3
+
+    def test_no_unit_with_no_default_unit_raises(self):
+        with pytest.raises(ValueError):
+            CephSizeBytes._convert_to_bytes("500")
+
+    def test_unit_in_input_overrides_default(self):
+        assert CephSizeBytes._convert_to_bytes("50", default_unit="KB") == 50 * 1024
+        assert CephSizeBytes._convert_to_bytes("50KB", default_unit="KB") == 50 * 1024
+        assert CephSizeBytes._convert_to_bytes("50MB", default_unit="KB") == 50 * 1024 ** 2

--- a/src/pybind/mgr/tests/test_cli_command.py
+++ b/src/pybind/mgr/tests/test_cli_command.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+import json
+import pytest
+from typing import Annotated
+
+from mgr_module import CLICommand
+from ceph_argparse import CephSizeBytes
+
+@pytest.fixture(scope="class", name="command_with_size_annotation_name")
+def fixture_command_with_size_annotation_name():
+    return "test annotated size command"
+
+
+@pytest.fixture(scope="class", name="command_with_size_annotation")
+def fixture_command_with_size_annotation(command_with_size_annotation_name):
+    @CLICommand(command_with_size_annotation_name)
+    def func(_, param: Annotated[int, CephSizeBytes()]): # noqa # pylint: disable=unused-variable
+        return {'a': '1', 'param': param}
+    yield func
+    del CLICommand.COMMANDS[command_with_size_annotation_name]
+    assert command_with_size_annotation_name not in CLICommand.COMMANDS
+
+
+class TestConvertAnnotatedType:
+    def test_command_convert_annotated_parameter(self, command_with_size_annotation, command_with_size_annotation_name):
+        result = CLICommand.COMMANDS[command_with_size_annotation_name].call(MagicMock(), {"param": f"{5 * 1024 ** 2}"})
+        assert result['param'] == 5 * 1024 ** 2
+
+        result = CLICommand.COMMANDS[command_with_size_annotation_name].call(MagicMock(), {"param": f"{5 * 1024}KB"})
+        assert result['param'] == 5 * 1024 ** 2
+
+        result = CLICommand.COMMANDS[command_with_size_annotation_name].call(MagicMock(), {"param": f"5MB"})
+        assert result['param'] == 5 * 1024 ** 2


### PR DESCRIPTION
it seems like the default value for size is 1024, which raises must be aligned to MiBs error when the route is being triggered without size value (I mean when using the default value), when I pass size=1048576 (1024*1024= 1MB) It works.
To complicate it a bit, the CLI today doesn't expects integer value but a string that might be of the following forms: "1048576", "1MB", "100GB", etc...
This PR attempts to  solve this issue in way that will satisfy the API and the CLI together.
it seems like CLICommand decorator doesn't support Union[str,int] as a param (it makes sense), so I can't really give the parameter a type of both str and int, I go for now with str (since I must allow "10MB"), I guess it means that we will need to adapt current API clients. Another option is to introduce a new parameter in addition to the existing `size` param, and start using it while deprecating the old one. Let me know what you think is better :) 
I also removed the default value as I believe it is not really make sense (correct me if I am wrong here), when someone is creating a namespace the size is not a thing to forget about.
It is not yet tested so I open it in a draft PR to get your feedback until I find time to test it properly :) 

fixes: https://tracker.ceph.com/issues/62705
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
