### PR TITLE
qa/suite/nvmeof: Add asserts to scalability_test and extra logs in fio_test

### DIFF
--- a/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
@@ -31,11 +31,12 @@ tasks:
     no_coverage_and_limits: true
     timeout: 30m
     clients:
+      client.0:
+        - nvmeof/fio_test.sh
       client.3:
         - nvmeof/scalability_test.sh nvmeof.a,nvmeof.b
         - nvmeof/scalability_test.sh nvmeof.b,nvmeof.c,nvmeof.d
         - nvmeof/scalability_test.sh nvmeof.b,nvmeof.c
     env:
       SCALING_DELAYS: '300'
-      RBD_POOL: mypool
-      NVMEOF_GROUP: mygroup0
+      RUNTIME: '1200'

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
@@ -36,6 +36,6 @@ tasks:
         - nvmeof/scalability_test.sh nvmeof.b,nvmeof.c,nvmeof.d
         - nvmeof/scalability_test.sh nvmeof.b,nvmeof.c
     env:
-      SCALING_DELAYS: '120'
+      SCALING_DELAYS: '300'
       RBD_POOL: mypool
       NVMEOF_GROUP: mygroup0

--- a/qa/suites/nvmeof/thrash/workloads/fio.yaml
+++ b/qa/suites/nvmeof/thrash/workloads/fio.yaml
@@ -7,5 +7,6 @@ tasks:
         - nvmeof/fio_test.sh --random_devices 200
     env:
       RBD_POOL: mypool
+      NVMEOF_GROUP: mygroup0
       IOSTAT_INTERVAL: '10'
       RUNTIME: '1800'

--- a/qa/workunits/nvmeof/fio_test.sh
+++ b/qa/workunits/nvmeof/fio_test.sh
@@ -72,11 +72,19 @@ status_log() {
     POOL="${RBD_POOL:-mypool}"
     GROUP="${NVMEOF_GROUP:-mygroup0}"
     ceph -s
-    ceph host ls
+    ceph orch host ls
     ceph orch ls 
     ceph orch ps
     ceph health detail
     ceph nvme-gw show $POOL $GROUP
+    sudo nvme list
+    sudo nvme list | wc -l
+    for device in $selected_drives; do
+        echo "Processing device: $device"
+        sudo nvme list-subsys /dev/$device
+        sudo nvme id-ns /dev/$device
+    done
+    
 }
 
 

--- a/qa/workunits/nvmeof/fio_test.sh
+++ b/qa/workunits/nvmeof/fio_test.sh
@@ -68,6 +68,18 @@ verify_fatal=1
 direct=1
 EOF
 
+status_log() {
+    POOL="${RBD_POOL:-mypool}"
+    GROUP="${NVMEOF_GROUP:-mygroup0}"
+    ceph -s
+    ceph host ls
+    ceph orch ls 
+    ceph orch ps
+    ceph health detail
+    ceph nvme-gw show $POOL $GROUP
+}
+
+
 echo "[nvmeof.fio] starting fio test..."
 
 if [ -n "$IOSTAT_INTERVAL" ]; then
@@ -79,6 +91,13 @@ if [ "$rbd_iostat" = true  ]; then
     timeout 20 rbd perf image iostat $RBD_POOL --iterations $iterations &
 fi
 fio --showcmd $fio_file
-sudo fio $fio_file 
+
+set +e 
+sudo fio $fio_file
+if [ $? -ne 0 ]; then
+    status_log
+    exit 1
+fi
+
 
 echo "[nvmeof.fio] fio test successful!"


### PR DESCRIPTION
Results: 
https://pulpito.ceph.com/vallariag-2025-02-13_09:19:48-nvmeof-main-distro-default-smithi/ - the errors are unrelated to the PR. 
scalability test: https://pulpito.ceph.com/vallariag-2025-02-13_07:36:22-nvmeof-main-distro-default-smithi/

TODO: also print more details from host if fio fails:
- "nvme list-subsys /dev/nvme2n2" 
- nvme list from the initiator
- nvme list | wc -l
- `nvme id-ns /dev/nvme1n2` - this will help us map these devices to the nvmeof namespaces created.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
