### PR TITLE
Add filtering capabilities to exporter's metrics endpoint

### DIFF
--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -476,15 +476,14 @@ std::string MetricsBuilder::dump() {
 std::string MetricsBuilder::filtered_dump(std::map<std::string, std::string> filters) {
   out.clear();
 
-  auto only_filters = filters["only_perf_counter_prefix"];
-  auto exclude_filters = filters["exclude_perf_counter_prefix"];
+  std::string only_filters = filters[OnlyFilterPrefix];
+  std::string exclude_filters = filters[ExcludeFilterPrefix];
 
   if (!only_filters.empty()) {
-    std::vector<std::string> only_filters_regexes = split_regexes(only_filters);
+    std::vector<std::string> only_filters_list = split_string_on_delimeter(only_filters, ',');
     for (std::map<std::string, Metric>::iterator it = metrics.begin(); it != metrics.end(); ++it) {
-      for (const auto& reg : only_filters_regexes) {
-        std::regex pattern(reg);
-        if (std::regex_search(it->first, pattern)) {
+      for (const auto& pattern : only_filters_list) {
+        if (it->first.find(pattern) == 0) { 
           out += it->second.dump() + "\n";
           break;
         }
@@ -493,14 +492,13 @@ std::string MetricsBuilder::filtered_dump(std::map<std::string, std::string> fil
   }
 
   if (!exclude_filters.empty()) {
-    std::vector<std::string> exclude_filters_regexes = split_regexes(exclude_filters);
+    std::vector<std::string> exclude_filters_list = split_string_on_delimeter(exclude_filters, ',');
     for (std::map<std::string, Metric>::iterator it = metrics.begin(); it != metrics.end(); ++it) {
       auto is_exclude_match = false;
-      for (const auto& reg : exclude_filters_regexes) {
-        std::regex pattern(reg);
-        auto is_regex_match = std::regex_search(it->first, pattern);
-        is_exclude_match = is_exclude_match || is_regex_match;
-        if (is_regex_match) {
+      for (const auto& pattern : exclude_filters_list) {
+        auto is_pattern_match = it->first.find(pattern) == 0;
+        is_exclude_match = is_exclude_match || is_pattern_match;
+        if (is_pattern_match) {
           break;
         }
       }

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -26,6 +26,9 @@ struct pstat {
   int resident_size;
 };
 
+const std::string ExcludeFilterPrefix = "exclude_perf_counter_prefix";
+const std::string OnlyFilterPrefix = "only_perf_counter_prefix";
+
 class MetricsBuilder;
 class OrderedMetricsBuilder;
 class UnorderedMetricsBuilder;

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -36,7 +36,7 @@ typedef std::map<std::string, std::string> labels_t;
 class DaemonMetricCollector {
 public:
   void main();
-  std::string get_metrics();
+  std::string get_metrics(std::map<std::string, std::string> filters);
   labels_t get_extra_labels(std::string daemon_name);
   void dump_asok_metrics(bool sort_metrics, int64_t counter_prio,
                          bool sockClientsPing, std::string &dump_response,
@@ -90,22 +90,22 @@ public:
 class MetricsBuilder {
 public:
   virtual ~MetricsBuilder() = default;
-  virtual std::string dump() = 0;
+  std::string dump();
   virtual void add(std::string value, std::string name, std::string description,
                    std::string mtype, labels_t labels) = 0;
+  std::string filtered_dump(std::map<std::string, std::string> filters);
 
 protected:
   std::string out;
+  std::map<std::string, Metric> metrics;
 };
 
 class OrderedMetricsBuilder : public MetricsBuilder {
-private:
-  std::map<std::string, Metric> metrics;
-
 public:
   std::string dump();
   void add(std::string value, std::string name, std::string description,
            std::string mtype, labels_t labels);
+  void filtered_dump(std::map<std::string, std::string> filters);
 };
 
 class UnorderedMetricsBuilder : public MetricsBuilder {
@@ -113,6 +113,7 @@ public:
   std::string dump();
   void add(std::string value, std::string name, std::string description,
            std::string mtype, labels_t labels);
+  void filtered_dump(std::map<std::string, std::string> filters);
 };
 
 DaemonMetricCollector &collector_instance();

--- a/src/exporter/util.cc
+++ b/src/exporter/util.cc
@@ -61,17 +61,15 @@ void promethize(std::string &name) {
   name = "ceph_" + name;
 }
 
-std::vector<std::string> split_regexes(std::string regexes) {
-  std::regex delimiter("\\|\\|");  // Escape the "|" in regex
+std::vector<std::string> split_string_on_delimeter(std::string s, char delimiter) {
+  std::vector<std::string> tokens;
+  size_t start = 0, end;
 
-  std::sregex_token_iterator iter(regexes.begin(), regexes.end(), delimiter, -1);
-  std::sregex_token_iterator end;
-    
-  std::vector<std::string> regex_list;
-  while (iter != end) {
-    regex_list.push_back(*iter);
-    ++iter;
+  while ((end = s.find(delimiter, start)) != std::string::npos) {
+      tokens.push_back(s.substr(start, end - start));
+      start = end + 1;
   }
+  tokens.push_back(s.substr(start));  // Last token
 
-  return regex_list;
+  return tokens;
 }

--- a/src/exporter/util.cc
+++ b/src/exporter/util.cc
@@ -7,7 +7,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-
+#include <regex>
 #include "common/debug.h"
 
 #define dout_context g_ceph_context
@@ -59,4 +59,19 @@ void promethize(std::string &name) {
   boost::replace_all(name, "+", "_plus");
 
   name = "ceph_" + name;
+}
+
+std::vector<std::string> split_regexes(std::string regexes) {
+  std::regex delimiter("\\|\\|");  // Escape the "|" in regex
+
+  std::sregex_token_iterator iter(regexes.begin(), regexes.end(), delimiter, -1);
+  std::sregex_token_iterator end;
+    
+  std::vector<std::string> regex_list;
+  while (iter != end) {
+    regex_list.push_back(*iter);
+    ++iter;
+  }
+
+  return regex_list;
 }

--- a/src/exporter/util.h
+++ b/src/exporter/util.h
@@ -22,4 +22,4 @@ std::string read_file_to_string(std::string path);
 
 void promethize(std::string &name);
 
-std::vector<std::string> split_regexes(std::string regexes);
+std::vector<std::string> split_string_on_delimeter(std::string s, char delimiter);

--- a/src/exporter/util.h
+++ b/src/exporter/util.h
@@ -1,6 +1,7 @@
 #include "common/hostname.h"
 #include <chrono>
 #include <string_view>
+#include <vector>
 
 class BlockTimer {
  public:
@@ -20,3 +21,5 @@ class BlockTimer {
 std::string read_file_to_string(std::string path);
 
 void promethize(std::string &name);
+
+std::vector<std::string> split_regexes(std::string regexes);

--- a/src/exporter/web_server.cc
+++ b/src/exporter/web_server.cc
@@ -105,8 +105,8 @@ protected:
       response_.set(http::field::content_type, "text/plain; charset=utf-8");
 
       auto filters = parse_query_string(extract_query_string(request_.target()));
-      auto is_only = (filters.find("exclude_perf_counter_prefix") != filters.end());
-      auto is_exclude = (filters.find("only_perf_counter_prefix") != filters.end());
+      auto is_only = (filters.find(OnlyFilterPrefix) != filters.end());
+      auto is_exclude = (filters.find(ExcludeFilterPrefix) != filters.end());
       if (is_only && is_exclude) {
         response_.body() = "Please pass either exclude_perf_counter_prefix or only_perf_counter_prefix and not both";
       } else {


### PR DESCRIPTION
[ceph-exporter]This is required to allow different scrape intervals for different metrics.
This PR introduces 2 query parameters:
1. only_perf_counter_prefix: which will only return metrics that match the passed `||` separated regexes.
2. exclude_perf_counter_prefix: which returns all metrics that don't match the passed `||` separated regexes.
This is the beginning of PRs for facilitating different scrape jobs with different scrape intervals
for slow and fast RGW counters

This can be tested as:
1. Build and start vstart cluster
2. Build Ceph-exporter as `ninja ceph-exporter`
3. Start Ceph-exporter using `bin/ceph-exporter -c /home/anmolb/code/ceph/build/ceph.conf --sock-dir /home/anmolb/code/ceph/build/asok --addrs 127.0.0.1`
4. Test endpoints similar to:

- http://127.0.0.1:9926/metrics?exclude_perf_counter_prefix=ceph_blk_kernel,ceph_bluestore_pricache,ceph_AsyncMessenger
- http://127.0.0.1:9926/metrics?only_perf_counter_prefix=ceph_bluestore_pricache,ceph_AsyncMessenger
- http://127.0.0.1:9926/metrics?only_perf_counter_prefix=ceph_bluestore_pricache,ceph_AsyncMessenger&&exclude_perf_counter_prefix=ceph
- http://127.0.0.1:9926/metrics