### PR TITLE
crush: include cleanup

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -1,18 +1,20 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <vector>
-#include <boost/algorithm/string/trim.hpp>
-
 #include "CrushLocation.h"
 #include "CrushWrapper.h"
 #include "common/ceph_context.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/errno.h"
+#include "common/SubProcess.h"
 #include "include/common_fwd.h"
 #include "include/compat.h"
 #include "include/str_list.h"
+
+#include <boost/algorithm/string/trim.hpp>
+
+#include <vector>
 
 namespace ceph::crush {
 

--- a/src/crush/CrushLocation.h
+++ b/src/crush/CrushLocation.h
@@ -7,6 +7,8 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+
+#include <fmt/core.h> // for FMT_VERSION
 #if FMT_VERSION >= 90000
 #include <fmt/ostream.h>
 #endif

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 
 #include <boost/lexical_cast.hpp>

--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -18,7 +18,12 @@
 #define CRUSH_TREE_DUMPER_H
 
 #include "CrushWrapper.h"
+#include "common/Formatter.h"
 #include "include/stringify.h"
+
+#include <list>
+#include <map>
+#include <string>
 
 /**
  * CrushTreeDumper:

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1,15 +1,16 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "CrushWrapper.h"
+#include "CrushTreeDumper.h"
+
 #include "osd/osd_types.h"
+#include "common/ceph_context.h"
 #include "common/debug.h"
 #include "common/Formatter.h"
 #include "common/errno.h"
 #include "common/TextTable.h"
 #include "include/stringify.h"
-
-#include "CrushWrapper.h"
-#include "CrushTreeDumper.h"
 
 #define dout_subsys ceph_subsys_crush
 

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include <iosfwd>
 


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
