### PR TITLE
rgw: check for duplicate rule priorities in replication configuration

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1419,7 +1419,13 @@ struct ReplicationConfiguration {
     disabled_group.id = disabled_group_id;
     disabled_group.status = rgw_sync_policy_group::Status::ALLOWED; /* not enabled, not forbidden */
 
+    std::unordered_set<int32_t> priorities; // used to check for duplicates
     for (auto& rule : rules) {
+      if (!priorities.insert(rule.priority).second) {
+        s->err.message = fmt::format("Found duplicate priority {}.", rule.priority);
+        return -EINVAL;
+      }
+
       rgw_sync_bucket_pipes pipe;
       bool enabled;
       int r = rule.to_sync_policy_pipe(s, driver, &pipe, &enabled);


### PR DESCRIPTION
When multiple replication rules target the same bucket, the rule with the highest priority should be applied. While this logic is already in place, the configuration does not enforce priority settings, which could lead to confusion. This behavior aligns with AWS's implementation for multiple destination buckets as outlined https://aws.amazon.com/blogs/aws/new-amazon-s3-replication-adds-support-for-multiple-destination-buckets/

Fixes: https://tracker.ceph.com/issues/69946