### PR TITLE
exporter: add rgw_instance label to radosgw metrics

### DIFF
--- a/doc/monitoring/index.rst
+++ b/doc/monitoring/index.rst
@@ -266,13 +266,14 @@ Object metrics
 These metrics have the following labels:
 ``instance``: the ip address of the ceph exporter daemon providing the metric
 ``instance_id``: identifier of the rgw daemon
+``rgw_instance``: full identifier of the rgw daemon
 ``job``: prometheus scrape job
 
 Example:
 
 .. code-block:: bash
 
-  ceph_rgw_req{instance="192.168.122.7:9283", instance_id="154247", job="ceph"} = 12345
+  ceph_rgw_req{instance="192.168.122.7:9283", instance_id="154247", rgw_instance="154247.a", job="ceph"} = 12345
 
 
 Generic metrics

--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -369,6 +369,16 @@ labels_t DaemonMetricCollector::get_extra_labels(std::string daemon_name) {
     }
     if (elems.size() >= 4) {
       labels["instance_id"] = quote(elems[3]);
+
+      // fetch rgw_instance for e.g. "ceph-node-00.hrgsea" from daemon_name=rgw.foo.ceph-node-00.hrgsea.2.94739968030880
+      std::string rgw_instance;
+      for (size_t i = 2; i < elems.size() - 2; ++i) {
+        if (!rgw_instance.empty()) {
+          rgw_instance += ".";
+        }
+        rgw_instance += elems[i];
+      }
+      labels["rgw_instance"] = quote(rgw_instance);
     } else {
       return labels_t();
     }


### PR DESCRIPTION

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

Fixes https://tracker.ceph.com/issues/69947

In case, when a node contains multiple radosgw instances (see https://rook.io/docs/rook/v1.16/Storage-Configuration/Object-Storage-RGW/object-storage/#object-multi-instance) pointing to the same storage, rgw metrics contain duplicates (see https://github.com/rook/rook/issues/15390). This patch adds an extra `rgw_instance` label, which contains the full rgw ID, provided by the `radosgw --id` argument.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
