### PR TITLE
reef: osd/scrub: lock the PG before handling timeout events

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -543,15 +543,14 @@ options:
   - osd_scrub_reservation_timeout
   with_legacy: false
 # when a replica does not respond to scrub resource request
-# Note: disable by using a very large value
+# Note: disable by setting to 0
 - name: osd_scrub_reservation_timeout
   type: millisecs
   level: advanced
-  desc: Duration before aborting the scrub session
+  desc: Duration before issuing a warning
   long_desc: Waiting too long for some replicas to respond to
     scrub reservation requests.
   default: 5000
-  min: 2000
   see_also:
   - osd_scrub_slow_reservation_response
   with_legacy: false

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -134,8 +134,8 @@ class ReplicaReservations {
     ~no_reply_t();
     OSDService* m_osds;
     const ConfigProxy& m_conf;
-    ReplicaReservations& m_parent;
     std::string m_log_prfx;
+    PGRef m_pg;         ///< keep the PG alive for the duration of the timer
     Context* m_abort_callback{nullptr};
   };
 
@@ -600,6 +600,8 @@ class PgScrubber : public ScrubPgIF,
   {
     return m_pg->snap_mapper;
   }
+
+  PGRef get_pgref() final { return m_pg; }
 
   void log_cluster_warning(const std::string& warning) const final;
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -50,15 +50,12 @@ struct preemption_t {
 struct blocked_range_t {
   blocked_range_t(OSDService* osds,
 		  ceph::timespan waittime,
-		  ScrubMachineListener& scrubber,
-		  spg_t pg_id);
+		  ScrubMachineListener& scrubber);
   ~blocked_range_t();
 
   OSDService* m_osds;
   ScrubMachineListener& m_scrubber;
 
-  /// used to identify ourselves to the PG, when no longer blocked
-  spg_t m_pgid;
   Context* m_callbk;
 
   // once timed-out, we flag the OSD's scrub-queue as having
@@ -220,4 +217,8 @@ struct ScrubMachineListener {
 
   /// sending cluster-log warnings
   virtual void log_cluster_warning(const std::string& msg) const = 0;
+
+  /// get a counting-ref to the PG itself.
+  /// (used mainly when a sub-object of the Scrubber creates callbacks)
+  virtual PGRef get_pgref() = 0;
 };


### PR DESCRIPTION
This is a partial fix. A full fix was implemented in Squid, as https://github.com/ceph/ceph/pull/50199.
That PR is large, this the partial alternative here (instead of backporting the full fix).

Fixes: https://tracker.ceph.com/issues/66988


