### PR TITLE
os/bluestore : Fill onode test instances with sample data

### DIFF
--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1419,8 +1419,52 @@ void bluestore_onode_t::dump(Formatter *f) const
 
 void bluestore_onode_t::generate_test_instances(list<bluestore_onode_t*>& o)
 {
-  o.push_back(new bluestore_onode_t());
-  // FIXME
+
+  auto* onode1 = new bluestore_onode_t();
+  onode1->nid = 0xDEADBEEF;
+  onode1->size = 99999;
+  onode1->expected_object_size = 123456;
+  onode1->expected_write_size = 7890;
+  onode1->set_flag(FLAG_OMAP | FLAG_PERPOOL_OMAP | FLAG_PERPG_OMAP);
+
+  ceph::buffer::ptr buf1 = ceph::buffer::create(50);
+  memset(buf1.c_str(), 0x42, 50);
+  onode1->attrs["chaos_attr1"] = buf1;
+
+  onode1->extent_map_shards.push_back({.offset = 555, .bytes = 777});
+
+  o.push_back(onode1);
+
+  auto* onode2 = new bluestore_onode_t();
+  onode2->nid = 0xBAADF00D;
+  onode2->size = 54321;
+  onode2->expected_object_size = 654321;
+  onode2->expected_write_size = 4321;
+  onode2->set_flag(FLAG_OMAP | FLAG_PGMETA_OMAP);
+
+  ceph::buffer::ptr buf2 = ceph::buffer::create(30);
+  memset(buf2.c_str(), 0xAB, 30);
+  onode2->attrs["glitch_attr"] = buf2;
+
+  onode2->extent_map_shards.push_back({.offset = 333, .bytes = 444});
+
+  o.push_back(onode2);
+
+  auto* onode3 = new bluestore_onode_t();
+  onode3->nid = 0xFEEDFACE;
+  onode3->size = 0;
+  onode3->expected_object_size = 1;
+  onode3->expected_write_size = 1;
+  onode3->set_flag(FLAG_OMAP | FLAG_PERPOOL_OMAP);
+
+  ceph::buffer::ptr buf3 = ceph::buffer::create(100);
+  memset(buf3.c_str(), 0xFF, 100);
+  onode3->attrs["maxed_out"] = buf3;
+
+  onode3->extent_map_shards.push_back({.offset = 999, .bytes = 2048});
+
+  o.push_back(onode3);
+
 }
 
 // bluestore_deferred_op_t


### PR DESCRIPTION
Fill onode test instances with sample data


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
