### PR TITLE
qa/standalone: do not use /etc/fstab as an always-there bytes source

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -2326,6 +2326,37 @@ function test_get_op_scheduler() {
     teardown $dir || return 1
 }
 
+########################################################################
+##
+# Create a temporary file with random data and return its name. The file
+# should be removed by the caller.
+#
+# Example:
+#   testdata=$(file_with_random_data 1024)
+#
+# @param the size of the file created in bytes. As in most use cases
+#     the size is meaningless, a default (512) is used if not specified
+# @return the name of the file created
+#
+function file_with_random_data() {
+  local size_bytes=${1:-512}
+  local file=$(mktemp)
+  dd if=/dev/urandom of=$file bs=$size_bytes count=1
+  printf '%s' "$file"
+}
+
+function test_file_with_random_data() {
+    local dir=$1
+
+    setup $dir || return 1
+    local file=$(file_with_random_data 4000)
+    test -f $file || return 1
+    test $(stat -c %s $file) = 4000 || return 1
+    rm $file
+    teardown $dir || return 1
+}
+
+
 #######################################################################
 
 ##

--- a/qa/standalone/osd/divergent-priors.sh
+++ b/qa/standalone/osd/divergent-priors.sh
@@ -56,10 +56,7 @@ function run() {
 function TEST_divergent() {
     local dir=$1
 
-    # something that is always there
-    local dummyfile='/etc/fstab'
-    local dummyfile2='/etc/resolv.conf'
-
+    local dummyfile=$(file_with_random_data)
     local num_osds=3
     local osds="$(seq 0 $(expr $num_osds - 1))"
     run_mon $dir a || return 1
@@ -96,7 +93,7 @@ function TEST_divergent() {
     # write a bunch of objects
     for i in $(seq 1 $testobjects)
     do
-      rados -p $poolname put existing_$i $dummyfile
+      rados -p $poolname put existing_$i $dummyfile || return 1
     done
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
@@ -153,7 +150,8 @@ function TEST_divergent() {
     objname="existing_$(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE)"
     echo "writing non-divergent object $objname"
     ceph pg dump pgs
-    rados -p $poolname put $objname $dummyfile2
+    # a second object (using a different size, for good measure)
+    dd if=/dev/urandom bs=1000 count=1 | rados -p "$poolname" put "$objname" - || return 1
 
     # ensure no recovery of up osds first
     echo 'delay recovery'
@@ -220,6 +218,7 @@ function TEST_divergent() {
     fi
     echo "success"
 
+    rm -f $dummyfile
     delete_pool $poolname
     kill_daemons $dir || return 1
 }
@@ -227,9 +226,9 @@ function TEST_divergent() {
 function TEST_divergent_ec() {
     local dir=$1
 
-    # something that is always there
-    local dummyfile='/etc/fstab'
-    local dummyfile2='/etc/resolv.conf'
+    local dummyfile=$(file_with_random_data)
+    # a second object, different in size and contents
+    local dummyfile2=$(file_with_random_data 1000)
 
     local num_osds=3
     local osds="$(seq 0 $(expr $num_osds - 1))"
@@ -265,7 +264,7 @@ function TEST_divergent_ec() {
     # write a bunch of objects
     for i in $(seq 1 $testobjects)
     do
-      rados -p $poolname put existing_$i $dummyfile
+      rados -p $poolname put existing_$i $dummyfile || return 1
     done
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
@@ -322,7 +321,8 @@ function TEST_divergent_ec() {
     objname="existing_$(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE)"
     echo "writing non-divergent object $objname"
     ceph pg dump pgs
-    rados -p $poolname put $objname $dummyfile2
+    rados -p $poolname put $objname $dummyfile2 || return 1
+    rm -f $dummyfile2
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
 
@@ -366,6 +366,7 @@ function TEST_divergent_ec() {
     echo 'wait for peering'
     ceph pg dump pgs
     rados -p $poolname put foo $dummyfile
+    rm -f $dummyfile
 
     echo "killing divergent $divergent"
     ceph pg dump pgs
@@ -420,9 +421,9 @@ function TEST_divergent_ec() {
 function TEST_divergent_2() {
     local dir=$1
 
-    # something that is always there
-    local dummyfile='/etc/fstab'
-    local dummyfile2='/etc/resolv.conf'
+    local dummyfile=$(file_with_random_data)
+    # a second object, different in size and contents
+    local dummyfile2=$(file_with_random_data 1000)
 
     local num_osds=3
     local osds="$(seq 0 $(expr $num_osds - 1))"
@@ -460,7 +461,7 @@ function TEST_divergent_2() {
     # write a bunch of objects
     for i in $(seq 1 $testobjects)
     do
-      rados -p $poolname put existing_$i $dummyfile
+      rados -p $poolname put existing_$i $dummyfile || return 1
     done
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
@@ -528,7 +529,8 @@ function TEST_divergent_2() {
     objname="existing_$(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE)"
     echo "writing non-divergent object $objname"
     ceph pg dump pgs
-    rados -p $poolname put $objname $dummyfile2
+    rados -p $poolname put $objname $dummyfile2 || return 1
+    rm -f $dummyfile2
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
 
@@ -560,7 +562,8 @@ function TEST_divergent_2() {
     ceph pg dump pgs
     echo 'wait for peering'
     ceph pg dump pgs
-    rados -p $poolname put foo $dummyfile
+    rados -p $poolname put foo $dummyfile || return 1
+    rm -f $dummyfile
 
     # At this point the divergent_priors should have been detected
 
@@ -617,7 +620,6 @@ function TEST_divergent_2() {
     echo "success"
 
     rm $dir/$expfile
-
     delete_pool $poolname
     kill_daemons $dir || return 1
 }
@@ -627,9 +629,9 @@ function TEST_divergent_2() {
 function TEST_divergent_3() {
     local dir=$1
 
-    # something that is always there
-    local dummyfile='/etc/fstab'
-    local dummyfile2='/etc/resolv.conf'
+    local dummyfile=$(file_with_random_data)
+    # a second file (using a different size, for good measure)
+    local dummyfile2=$(file_with_random_data 1000)
 
     local num_osds=3
     local osds="$(seq 0 $(expr $num_osds - 1))"
@@ -685,7 +687,7 @@ function TEST_divergent_3() {
     # write a bunch of objects
     for i in $(seq 1 $testobjects)
     do
-      rados -p $poolname put existing_$i $dummyfile
+      rados -p $poolname put existing_$i $dummyfile || return 1
     done
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
@@ -753,7 +755,7 @@ function TEST_divergent_3() {
     objname="existing_$(expr $DIVERGENT_WRITE + $DIVERGENT_REMOVE)"
     echo "writing non-divergent object $objname"
     ceph pg dump pgs
-    rados -p $poolname put $objname $dummyfile2
+    rados -p $poolname put $objname $dummyfile2 || return 1
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
 
@@ -786,6 +788,8 @@ function TEST_divergent_3() {
     echo 'wait for peering'
     ceph pg dump pgs
     rados -p $poolname put foo $dummyfile
+    rm -f $dummyfile
+    rm -f $dummyfile2
 
     # At this point the divergent_priors should have been detected
 
@@ -842,7 +846,6 @@ function TEST_divergent_3() {
     echo "success"
 
     rm $dir/$expfile
-
     delete_pool $poolname
     kill_daemons $dir || return 1
 }

--- a/qa/standalone/osd/repeer-on-acting-back.sh
+++ b/qa/standalone/osd/repeer-on-acting-back.sh
@@ -46,7 +46,6 @@ function run() {
 
 function TEST_repeer_on_down_acting_member_coming_back() {
     local dir=$1
-    local dummyfile='/etc/fstab'
 
     local num_osds=6
     local osds="$(seq 0 $(expr $num_osds - 1))"
@@ -72,11 +71,13 @@ function TEST_repeer_on_down_acting_member_coming_back() {
     wait_for_clean || return 1
 
     echo "writing initial objects"
+    local dummyfile=$(file_with_random_data)
     # write a bunch of objects
     for i in $(seq 1 $testobjects)
     do
-      rados -p $poolname put existing_$i $dummyfile
+      rados -p $poolname put existing_$i $dummyfile || return 1
     done
+    rm -f $dummyfile
 
     WAIT_FOR_CLEAN_TIMEOUT=20 wait_for_clean
 


### PR DESCRIPTION
Multiple tests use /etc/fstab whenever a small data file is required as input. After all, as some comments say:
    # something that is always there

Alas - it's not always there. Not in containers.

Replacing with a newly-created temporary file filled with random bytes.

