### PR TITLE
qa/suites/rados/basic: ignore POOL_APP_NOT_ENABLED detail in cluster log

### DIFF
--- a/qa/suites/rados/basic/tasks/libcephsqlite.yaml
+++ b/qa/suites/rados/basic/tasks/libcephsqlite.yaml
@@ -8,6 +8,8 @@ overrides:
     log-ignorelist:
     - POOL_APP_NOT_ENABLED
     - do not have an application enabled
+    - application not enabled
+    - or freeform for custom applications
 tasks:
 - exec:
    client.0:

--- a/qa/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -12,6 +12,10 @@ overrides:
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
     - CEPHADM_STRAY_DAEMON
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
     conf:
       client:
         debug ms: 1

--- a/qa/suites/rados/basic/tasks/rados_cls_all.yaml
+++ b/qa/suites/rados/basic/tasks/rados_cls_all.yaml
@@ -3,6 +3,10 @@ overrides:
     log-ignorelist:
     - \(PG_AVAILABILITY\)
     - \(POOL_APP_NOT_ENABLED\)
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
     conf:
       osd:
         osd_class_load_list: "*"

--- a/qa/suites/rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/rados/basic/tasks/rados_python.yaml
@@ -8,6 +8,10 @@ overrides:
     - \(OSD_
     - \(OBJECT_
     - \(POOL_APP_NOT_ENABLED\)
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
   install:
     ceph:
       extra_system_packages:

--- a/qa/suites/rados/basic/tasks/rados_stress_watch.yaml
+++ b/qa/suites/rados/basic/tasks/rados_stress_watch.yaml
@@ -5,6 +5,10 @@ overrides:
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(TOO_FEW_PGS\)
       - \(POOL_APP_NOT_ENABLED\)
+      - do not have an application enabled
+      - POOL_APP_NOT_ENABLED
+      - application not enabled
+      - or freeform for custom applications
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/basic/tasks/rados_striper.yaml
+++ b/qa/suites/rados/basic/tasks/rados_striper.yaml
@@ -2,6 +2,10 @@ overrides:
   ceph:
     log-ignorelist:
     - \(POOL_APP_NOT_ENABLED\)
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
 tasks:
 - exec:
    client.0:

--- a/qa/suites/rados/basic/tasks/rados_workunit_loadgen_big.yaml
+++ b/qa/suites/rados/basic/tasks/rados_workunit_loadgen_big.yaml
@@ -4,6 +4,10 @@ overrides:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mix.yaml
+++ b/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mix.yaml
@@ -4,6 +4,10 @@ overrides:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mostlyread.yaml
+++ b/qa/suites/rados/basic/tasks/rados_workunit_loadgen_mostlyread.yaml
@@ -4,6 +4,10 @@ overrides:
     - but it is still running
     - overall HEALTH_
     - \(POOL_APP_NOT_ENABLED\)
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/basic/tasks/readwrite.yaml
+++ b/qa/suites/rados/basic/tasks/readwrite.yaml
@@ -8,6 +8,10 @@ overrides:
         osd_discard_disconnected_ops: false
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+      - do not have an application enabled
+      - POOL_APP_NOT_ENABLED
+      - application not enabled
+      - or freeform for custom applications
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/suites/rados/basic/tasks/repair_test.yaml
+++ b/qa/suites/rados/basic/tasks/repair_test.yaml
@@ -23,6 +23,10 @@ overrides:
       - \(OSD_
       - \(PG_
       - \(POOL_APP_NOT_ENABLED\)
+      - do not have an application enabled
+      - POOL_APP_NOT_ENABLED
+      - application not enabled
+      - or freeform for custom applications
     conf:
       osd:
         filestore debug inject read err: true

--- a/qa/suites/rados/basic/tasks/scrub_test.yaml
+++ b/qa/suites/rados/basic/tasks/scrub_test.yaml
@@ -23,6 +23,10 @@ overrides:
     - \(OSD_SCRUB_ERRORS\)
     - \(TOO_FEW_PGS\)
     - \(POOL_APP_NOT_ENABLED\)
+    - do not have an application enabled
+    - POOL_APP_NOT_ENABLED
+    - application not enabled
+    - or freeform for custom applications
     conf:
       osd:
         osd deep scrub update digest min age: 0


### PR DESCRIPTION
We already ignore POOL_APP_NOT_ENABLED, but the detail in the cluster health still gets picked up by the badness check, so we have to ignore that too.

Fixes: https://tracker.ceph.com/issues/62776





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
