### PR TITLE
reef: doc/dev/release-process.rst: release builds cannot build containers

### DIFF
--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -120,14 +120,14 @@ Packages take hours to build. Use those hours to create the Release Notes and An
 
 See `the Ceph Tracker wiki page that explains how to write the release notes <https://tracker.ceph.com/projects/ceph-releases/wiki/HOWTO_write_the_release_notes>`_. 
 
+.. _Signing and Publishing the Build:
+
 4. Signing and Publishing the Build
 ===================================
 
 #. Obtain the sha1 of the version commit from the `build job <https://jenkins.ceph.com/view/all/job/ceph>`_ or the ``sha1`` file created by the `ceph-setup <https://jenkins.ceph.com/job/ceph-setup/>`_ job.
 
-#. Download the packages from chacra.ceph.com to the signing virtual machine. These packages get downloaded to ``/opt/repos`` where the `Sepia Lab Long Running (Ceph) Cluster <https://wiki.sepia.ceph.com/doku.php?id=services:longrunningcluster>`_ is mounted.  Note: this step will also run a command to transfer the
-source tarballs from chacra.ceph.com to download.ceph.com directly, by
-ssh'ing to download.ceph.com and running /home/signer/bin/get-tarballs.sh.
+#. Download the packages from chacra.ceph.com to the signing virtual machine. These packages get downloaded to ``/opt/repos`` where the `Sepia Lab Long Running (Ceph) Cluster <https://wiki.sepia.ceph.com/doku.php?id=services:longrunningcluster>`_ is mounted.  Note: this step will also run a command to transfer the source tarballs from chacra.ceph.com to download.ceph.com directly, by ssh'ing to download.ceph.com and running /home/signer/bin/get-tarballs.sh.
 
    .. prompt:: bash $
 
@@ -195,7 +195,7 @@ ssh'ing to download.ceph.com and running /home/signer/bin/get-tarballs.sh.
    
       etc...
 
-5. Publish the packages to download.ceph.com:
+#. Publish the packages to download.ceph.com:
 
    .. prompt:: bash $
 
@@ -212,51 +212,91 @@ mv the directories and the tarballs from the prerelease home
 5. Build Containers
 ===================
 
-Architecture-specific containers are built during the ceph build and
-pushed to quay.ceph.io/ceph/prerelease-{amd64,arm64}, containing the
-packages built in that ceph build.  The prerelease 'fat' container,
-or manifest-list container, that refers to both arch-specific containers,
-is built by hand using the command "make-manifest-list.py" in
-ceph.git:src/container/make-manifest-list.py.  Note that you must
-be logged into the appropriate container repos for any of these
-manipulations: quay.ceph.io for fetching prerelease arch-specific
-containers and pushing the prerelease manifest-list container, and
-quay.io for promoting the prerelease containers to released containers.
+Unlike CI builds, which have access to packages in the correct form for
+the container, release builds do not, because the build does not 
+sign the packages.  Thus, release builds do not build the containers.
+This must be done after :ref:`Signing and Publishing the Build`.
+
+Architecture-specific containers are built first, and pushed to
+quay.ceph.io/ceph/prerelease-{amd64,arm64}.  Note: this must be done on
+both architectures.
+
+#. Use a host with a relatively-recent version of podman and skopeo available.
+   CentOS/RHEL/Fedora usually have later versions than Ubuntu, but Ubuntu 22.04
+   or later are probably ok.
+
+#. Copy and run this shell wrapper for building a container (in container/ is
+   assumed below, to invoke ``./build.sh``), replacing the values in ``<>`` as
+   appropriate:
+
+     .. code-block:: bash
+
+        #!/bin/bash
+        set -xa
+
+        CI_CONTAINER=false
+        VERSION=19.2.1
+        FLAVOR=default
+        BRANCH=squid
+        ARCH=x86_64
+        CEPH_SHA1=58a7fab8be0a062d730ad7da874972fd3fba59fb
+        CONTAINER_REPO_HOSTNAME=quay.ceph.io
+        CONTAINER_REPO_ORGANIZATION=ceph
+        CONTAINER_REPO_USERNAME=<quay.ceph.io username>
+        CONTAINER_REPO_PASSWORD=<password for above>
+        PRERELEASE_USERNAME=<download.ceph.com prerelease username>
+        PRERELEASE_PASSWORD=<password for above>
+        unset NO_PUSH
+        ./build.sh  | tee build.sh.log
+
+#. Verify that the container images exist on
+   ``quay.ceph.io/ceph/prerelease-amd64`` and
+   ``quay.ceph.io/ceph/prerelease-arm64``.
+
+#. The prerelease manifest-list container, which refers to both arch-specific
+   containers, is built by using the command ``make-manifest-list.py`` in
+   ``ceph.git:src/container/make-manifest-list.py``. Note that you must be
+   logged into the appropriate container repos for any of these manipulations:
+   ``quay.ceph.io`` for fetching prerelease arch-specific containers and
+   pushing the prerelease manifest-list container, and ``quay.io`` for
+   promoting the prerelease containers to released containers.
 
     .. prompt:: bash
 
-       cd <ceph-checkout>/src/container
+       cd <ceph-checkout>/container
        ./make-manifest-list.py
 
-Reasonable defaults are set for all inputs, but environment variables
-can be used to override:
+   Reasonable defaults are set for all inputs, but environment variables can be
+   used to override the following:
 
-    * ARCH_SPECIFIC_HOST (default 'quay.ceph.io'): host of prerelease repos
-    * AMD64_REPO (default 'ceph/prerelease-amd64') prerelease amd64 repo
-    * ARM64_REPO (default 'ceph/prerelease-arm64') prerelease arm64 repo
+    * ``ARCH_SPECIFIC_HOST`` (default 'quay.ceph.io'): host of prerelease repos
+    * ``AMD64_REPO`` (default 'ceph/prerelease-amd64') prerelease amd64 repo
+    * ``ARM64_REPO`` (default 'ceph/prerelease-arm64') prerelease arm64 repo
 
-(prerelease arch-specific containers will be copied from here)
+   (prerelease arch-specific containers will be copied from here)
 
-    * MANIFEST_HOST (default 'quay.ceph.io') prerelease manifest-list host
-    * MANIFEST_REPO (default 'ceph/prerelease') prerelease manifest-list repo
+    * ``MANIFEST_HOST`` (default 'quay.ceph.io') prerelease manifest-list host
+    * ``MANIFEST_REPO`` (default 'ceph/prerelease') prerelease manifest-list
+      repo
 
-(prerelease manifest-list containers will be placed here)
+   (prerelease manifest-list containers will be placed here)
 
-Finally, when all appropriate testing/ verification is done on the
-container images, you can use make-manifest-list.py to promote them to
-their final release location on quay.io/ceph/ceph:
+#. Finally, when all appropriate testing and verification is done on the
+   container images, you can use ``make-manifest-list.py`` to promote them to
+   their final release location on ``quay.io/ceph/ceph`` (again, be sure you're
+   logged into ``quay.io/ceph`` with appropriate permissions):
 
     .. prompt:: bash
 
        cd <ceph-checkout>/src/container
        ./make-manifest-list.py --promote
 
-Two more environment variables can override the default destination for
-promotion (the source of the prerelease container to be promoted is
-as above, in MANIFEST_HOST/REPO):
+   Two more environment variables can override the default destination for
+   promotion (the source of the prerelease container to be promoted is as
+   above, in ``MANIFEST_HOST/REPO``):
 
-    * RELEASE_MANIFEST_HOST (default 'quay.io') release host
-    * RELEASE_MANIFEST_REPO (default 'ceph/ceph') release repo
+    * ``RELEASE_MANIFEST_HOST`` (default 'quay.io') release host
+    * ``RELEASE_MANIFEST_REPO`` (default 'ceph/ceph') release repo
 
 6. Announce the Release
 =======================


### PR DESCRIPTION
Document that container images are not built by the ceph-build job, but must be done manually after the package signing and upload to download.ceph.com.

Signed-off-by: Dan Mick <dan.mick@redhat.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 8abba8b150346ffc6486efb3520c6445c56560a3)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

