### PR TITLE
rgw/sts: replacing load_stats with list_buckets

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -672,16 +672,18 @@ auto rgw::auth::WebIdentityApplier::load_acct_info(const DoutPrefixProvider* dpp
   }
 
   //Check if user_id.buckets already exists, may have been from the time, when shadow users didnt exist
-  RGWStorageStats stats;
-  ceph::real_time last_synced;
-  ceph::real_time last_updated;
-  int ret = driver->load_stats(dpp, null_yield, federated_user, stats,
-                               last_synced, last_updated);
-  if (ret < 0 && ret != -ENOENT) {
-    ldpp_dout(dpp, 0) << "ERROR: reading stats for the user returned error " << ret << dendl;
+  federated_user.ns = "";
+  constexpr bool need_stats = false;
+  const std::string marker; // empty
+  constexpr uint32_t max_items = 1;
+  rgw::sal::BucketList buckets;
+  auto ret = driver->list_buckets(dpp, federated_user, federated_user.tenant, marker, marker,
+                             max_items, need_stats, buckets, null_yield);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: list buckets for the user returned error " << ret << dendl;
     return user;
   }
-  if (ret == -ENOENT) { /* in case of ENOENT, which means user doesnt have buckets */
+  if (buckets.buckets.empty()) { /* no buckets */
     //In this case user will be created in oidc namespace
     ldpp_dout(dpp, 5) << "NOTICE: incoming user has no buckets " << federated_user << dendl;
     federated_user.ns = "oidc";


### PR DESCRIPTION
to correctly create a federated user in oidc namespace.

The idea was to check if the federated user had any buckets associated with it from the time when the logic for creating a shadow user was not in place, and this was done by calling read_stats which returned -ENOENT when the user did not exist, which was erroneously interpreted as buckets not existing for the user - but this logic correctly led to creation of user in oidc namespace. Later read_stats() was replaced by load_stats() and load_stats() does not return -ENOENT when a user does not exist, hence according to the code, the federated user was not getting created in 'oidc' namespace. Hence replaced load_stats() with list_buckets() and corrected the code to create a user in oidc namespace if the user did not own any bucket.

Fixes: https://tracker.ceph.com/issues/69924





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
