### PR TITLE
mgr/nfs: NFS cluster and export commands to enable and disable ops control

### DIFF
--- a/src/cephadm/cephadmlib/container_engines.py
+++ b/src/cephadm/cephadmlib/container_engines.py
@@ -14,7 +14,7 @@ from .constants import (
     MIN_PODMAN_VERSION,
     PIDS_LIMIT_UNLIMITED_PODMAN_VERSION,
 )
-from .data_utils import with_units_to_int
+from ceph.utils import with_units_to_int
 from .exceptions import Error
 
 

--- a/src/cephadm/cephadmlib/data_utils.py
+++ b/src/cephadm/cephadmlib/data_utils.py
@@ -56,51 +56,6 @@ def dict_get_join(d: Dict[str, Any], key: str) -> Any:
     return value
 
 
-def bytes_to_human(num, mode='decimal'):
-    # type: (float, str) -> str
-    """Convert a bytes value into it's human-readable form.
-
-    :param num: number, in bytes, to convert
-    :param mode: Either decimal (default) or binary to determine divisor
-    :returns: string representing the bytes value in a more readable format
-    """
-    unit_list = ['', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
-    divisor = 1000.0
-    yotta = 'YB'
-
-    if mode == 'binary':
-        unit_list = ['', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
-        divisor = 1024.0
-        yotta = 'YiB'
-
-    for unit in unit_list:
-        if abs(num) < divisor:
-            return '%3.1f%s' % (num, unit)
-        num /= divisor
-    return '%.1f%s' % (num, yotta)
-
-
-def with_units_to_int(v: str) -> int:
-    if v.endswith('iB'):
-        v = v[:-2]
-    elif v.endswith('B'):
-        v = v[:-1]
-    mult = 1
-    if v[-1].upper() == 'K':
-        mult = 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'M':
-        mult = 1024 * 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'G':
-        mult = 1024 * 1024 * 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'T':
-        mult = 1024 * 1024 * 1024 * 1024
-        v = v[:-1]
-    return int(float(v) * mult)
-
-
 def read_config(fn):
     # type: (Optional[str]) -> ConfigParser
     cp = ConfigParser()

--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -16,7 +16,7 @@ from typing import Any, cast, Dict, List, Optional, Set, Union
 
 from cephadmlib.call_wrappers import call, call_throws, CallVerbosity
 from cephadmlib.context import CephadmContext
-from cephadmlib.data_utils import bytes_to_human
+from ceph.utils import bytes_to_human
 from cephadmlib.exe_utils import find_executable
 from cephadmlib.file_utils import read_file
 from cephadmlib.net_utils import get_fqdn, get_ipv4_address, get_ipv6_address

--- a/src/cephadm/tests/test_agent.py
+++ b/src/cephadm/tests/test_agent.py
@@ -254,8 +254,8 @@ def test_agent_daemon_ls_subset(cephadm_fs, funkypatch):
         assert daemons['mgr.host1.pntmho']['container_id'] == mgr_cid
         assert daemons['crash.host1']['container_id'] == crash_cid
 
-        assert daemons['mgr.host1.pntmho']['memory_usage'] == 478570086  # 456.4 MB
-        assert daemons['crash.host1']['memory_usage'] == 7426015  # 7.082 MB
+        assert daemons['mgr.host1.pntmho']['memory_usage'] == 456400000  # 456.4 MB
+        assert daemons['crash.host1']['memory_usage'] == 7082000  # 7.082 MB
 
 
 @mock.patch("cephadm.list_daemons")

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -936,6 +936,9 @@ class CephadmServe:
 
         hosts_altered: Set[str] = set()
 
+        if service_type == 'nfs' and self.mgr.spec_store.needs_configuration(spec.service_name()):
+            svc.pre_daemon_service_config(spec)
+
         try:
             # assign names
             for i in range(len(slots_to_add)):

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -891,6 +891,9 @@ class CephadmService(metaclass=ABCMeta):
     def get_blocking_daemon_hosts(self, service_name: str) -> List[HostSpec]:
         return []
 
+    def pre_daemon_service_config(self, spec: ServiceSpec) -> None:
+        return
+
     def has_placement_changed(self, deps: List[str], spec: ServiceSpec) -> bool:
         return False
 

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -171,9 +171,6 @@ class NFSService(CephService):
         )
         self.run_grace_tool(spec, 'add', nodeid)
 
-        # create the rados config object
-        self.create_rados_config_obj(spec)
-
         port = daemon_spec.ports[0] if daemon_spec.ports else 2049
         monitoring_ip, monitoring_port = self.get_monitoring_details(daemon_spec.service_name, host, daemon_spec)
 
@@ -308,9 +305,15 @@ class NFSService(CephService):
 
         return get_cephadm_config(), self.get_dependencies(self.mgr, spec)
 
+    def pre_daemon_service_config(self, spec: ServiceSpec) -> None:
+        nfs_spec = cast(NFSServiceSpec, spec)
+        self.config(nfs_spec)
+        self.create_rados_config_obj(nfs_spec)
+
     def create_rados_config_obj(self,
                                 spec: NFSServiceSpec,
                                 clobber: bool = False) -> None:
+        config_file_data = None
         objname = spec.rados_config_name()
         cmd = [
             'rados',
@@ -325,6 +328,7 @@ class NFSService(CephService):
             timeout=10)
         if not result.returncode and not clobber:
             logger.info('Rados config object exists: %s' % objname)
+            config_file_data = result.stdout
         else:
             logger.info('Creating rados config object: %s' % objname)
             result = subprocess.run(
@@ -336,6 +340,20 @@ class NFSService(CephService):
                     f'Unable to create rados config object {objname}: {result.stderr.decode("utf-8")}'
                 )
                 raise RuntimeError(result.stderr.decode("utf-8"))
+        if spec.cluster_qos_config:
+            # set cluster level qos config
+            from nfs.cluster import config_cluster_qos_from_dict
+            assert spec.service_id
+            update_obj = False
+            if config_file_data and 'qosconf-nfs' in config_file_data.decode('utf-8'):
+                update_obj = True
+
+            config_cluster_qos_from_dict(
+                mgr=self.mgr,
+                cluster_id=spec.service_id,
+                qos_dict=spec.cluster_qos_config,
+                update_existing_obj=update_obj
+            )
 
     def create_keyring(self, daemon_spec: CephadmDaemonDeploySpec) -> str:
         daemon_id = daemon_spec.daemon_id

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -231,8 +231,8 @@ class NFSService(CephService):
 
         # generate the ganesha config
         rdma_port = None
-        if spec.enable_rdma and daemon_spec.ports and len(daemon_spec.ports) > 2:
-            rdma_port = daemon_spec.ports[2]
+        if spec.enable_rdma and daemon_spec.ports and len(daemon_spec.ports) > 3:
+            rdma_port = daemon_spec.ports[3]
         elif spec.enable_rdma:
             rdma_port = spec.rdma_port
 

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -223,6 +223,12 @@ class NFSService(CephService):
             host_ip = self.mgr.inventory.get_addr(host.hostname)
             ceph_nodes.append(host_ip)
 
+        cluster_qos_port = None
+        if daemon_spec.ports and len(daemon_spec.ports) > 2:
+            cluster_qos_port = daemon_spec.ports[2]
+        elif spec.cluster_qos_port:
+            cluster_qos_port = spec.cluster_qos_port
+
         # generate the ganesha config
         rdma_port = None
         if spec.enable_rdma and daemon_spec.ports and len(daemon_spec.ports) > 2:
@@ -242,7 +248,7 @@ class NFSService(CephService):
                 "port": port,
                 "monitoring_addr": monitoring_ip,
                 "monitoring_port": monitoring_port,
-                "cqos_port": spec.cluster_qos_port,
+                "cqos_port": cluster_qos_port,
                 "bind_addr": bind_addr,
                 "haproxy_hosts": [],
                 "nfs_idmap_conf": nfs_idmap_conf,

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -18,6 +18,7 @@ from .service_registry import register_cephadm_service
 from orchestrator import DaemonDescription, OrchestratorError
 from cephadm import utils
 from cephadm.services.cephadmservice import AuthEntity, CephadmDaemonDeploySpec, CephService
+from cephadm.schedule import get_placement_hosts
 if TYPE_CHECKING:
     from ..module import CephadmOrchestrator
 
@@ -216,6 +217,12 @@ class NFSService(CephService):
         if monitoring_ip:
             daemon_spec.port_ips.update({str(monitoring_port): monitoring_ip})
 
+        ceph_nodes = []
+        hosts = get_placement_hosts(spec, self.mgr.cache.get_schedulable_hosts(), self.mgr.cache.get_draining_hosts())
+        for host in hosts:
+            host_ip = self.mgr.inventory.get_addr(host.hostname)
+            ceph_nodes.append(host_ip)
+
         # generate the ganesha config
         rdma_port = None
         if spec.enable_rdma and daemon_spec.ports and len(daemon_spec.ports) > 2:
@@ -235,6 +242,7 @@ class NFSService(CephService):
                 "port": port,
                 "monitoring_addr": monitoring_ip,
                 "monitoring_port": monitoring_port,
+                "cqos_port": spec.cluster_qos_port,
                 "bind_addr": bind_addr,
                 "haproxy_hosts": [],
                 "nfs_idmap_conf": nfs_idmap_conf,
@@ -247,6 +255,7 @@ class NFSService(CephService):
                 "tls_min_version": spec.tls_min_version,
                 "tls_ktls": spec.tls_ktls,
                 "tls_debug": spec.tls_debug,
+                "ceph_nodes": ceph_nodes
             }
             if spec.enable_haproxy_protocol:
                 context["haproxy_hosts"] = self._haproxy_hosts()

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -24,6 +24,9 @@ NFS_CORE_PARAM {
 {% if enable_rdma and rdma_port %}
         NFS_RDMA_Port = {{ rdma_port }};
 {% endif %}
+{% if cqos_port %}
+        Cqos_Port = {{ cqos_port }};
+{% endif %}
 }
 
 NFSv4 {
@@ -41,6 +44,10 @@ RADOS_KV {
         nodeid = {{ nodeid }};
         pool = "{{ pool }}";
         namespace = "{{ namespace }}";
+}
+
+CEPH_NODES_LIST {
+        Ceph_Nodes = {{ ceph_nodes|join(", ") }};
 }
 
 RADOS_URLS {

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -1067,7 +1067,7 @@ class TestIngressService:
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 
         def fake_resolve_ip(hostname: str) -> str:
-            if hostname in ('host1', "192.168.122.111"):
+            if hostname in ('host1', '192.168.122.111'):
                 return '192.168.122.111'
             elif hostname in ('host2', '192.168.122.222'):
                 return '192.168.122.222'
@@ -1191,6 +1191,10 @@ class TestIngressService:
             '        nodeid = 0;\n'
             '        pool = ".nfs";\n'
             '        namespace = "foo";\n'
+            '}\n'
+            '\n'
+            'CEPH_NODES_LIST {\n'
+            '        Ceph_Nodes = 192.168.122.111, 192.168.122.222;\n'
             '}\n'
             '\n'
             'RADOS_URLS {\n'

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -598,8 +598,8 @@ def test_nfs_colocation_ports_validation():
         port=2049,
         monitoring_port=9587,
         colocation_ports=[
-            {'data_port': 3049, 'monitoring_port': 9588},
-            {'data_port': 4049, 'monitoring_port': 9589}
+            {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312},
+            {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313}
         ]
     )
     spec.validate()  # Should not raise
@@ -611,7 +611,7 @@ def test_nfs_colocation_ports_validation():
             placement=PlacementSpec(count=4),
             port=2049,
             monitoring_port=9587,
-            colocation_ports=[{'data_port': 3049, 'monitoring_port': 9588}]
+            colocation_ports=[{'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312}]
         )
         spec.validate()
     assert "colocation_ports requires 3 entries for count=4 (got 1)" in str(e.value)
@@ -625,7 +625,7 @@ def test_nfs_colocation_ports_validation():
             monitoring_port=9587,
             colocation_ports=[
                 {'data_port': 3049},  # Missing monitoring_port
-                {'data_port': 4049, 'monitoring_port': 9589}
+                {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31312}
             ]
         )
         spec.validate()
@@ -643,8 +643,8 @@ def test_nfs_colocation_ports_validation_with_rdma():
         enable_rdma=True,
         rdma_port=20049,
         colocation_ports=[
-            {'data_port': 3049, 'monitoring_port': 9588, 'rdma_port': 20050},
-            {'data_port': 4049, 'monitoring_port': 9589, 'rdma_port': 20051},
+            {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312, 'rdma_port': 20050},
+            {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313, 'rdma_port': 20051},
         ]
     )
     spec.validate()
@@ -658,8 +658,8 @@ def test_nfs_colocation_ports_validation_with_rdma():
             monitoring_port=9587,
             enable_rdma=True,
             colocation_ports=[
-                {'data_port': 3049, 'monitoring_port': 9588},  # missing rdma_port
-                {'data_port': 4049, 'monitoring_port': 9589, 'rdma_port': 20051},
+                {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31312},  # missing rdma_port
+                {'data_port': 4049, 'monitoring_port': 9589, 'cluster_qos_port': 31313, 'rdma_port': 20051},
             ]
         )
         spec.validate()

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -675,8 +675,8 @@ class NodeAssignmentTest(NamedTuple):
             [],
             {},
             {0: {0: None}, 1: {0: None}, 2: {0: None}},
-            ['nfs:host3(rank=0.0 *:2049,9587)', 'nfs:host2(rank=1.0 *:2049,9587)', 'nfs:host1(rank=2.0 *:2049,9587)'],
-            ['nfs:host3(rank=0.0 *:2049,9587)', 'nfs:host2(rank=1.0 *:2049,9587)', 'nfs:host1(rank=2.0 *:2049,9587)'],
+            ['nfs:host3(rank=0.0 *:2049,9587,31311)', 'nfs:host2(rank=1.0 *:2049,9587,31311)', 'nfs:host1(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host3(rank=0.0 *:2049,9587,31311)', 'nfs:host2(rank=1.0 *:2049,9587,31311)', 'nfs:host1(rank=2.0 *:2049,9587,31311)'],
             []
         ),
         # 21: ranked, exist
@@ -689,8 +689,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {1: '0.1'}},
             {0: {1: '0.1'}, 1: {0: None}, 2: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host3(rank=1.0 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
-            ['nfs:host3(rank=1.0 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
+            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host3(rank=1.0 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host3(rank=1.0 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
             []
         ),
         # ranked, exist, different ranks
@@ -704,8 +704,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {1: '0.1'}, 1: {1: '1.1'}},
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host2(rank=1.1 *:2049,9587)', 'nfs:host3(rank=2.0 *:2049,9587)'],
-            ['nfs:host3(rank=2.0 *:2049,9587)'],
+            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host2(rank=1.1 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host3(rank=2.0 *:2049,9587,31311)'],
             []
         ),
         # ranked, exist, different ranks (2)
@@ -719,8 +719,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {1: '0.1'}, 1: {1: '1.1'}},
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host3(rank=1.1 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
-            ['nfs:host2(rank=2.0 *:2049,9587)'],
+            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host3(rank=1.1 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host2(rank=2.0 *:2049,9587,31311)'],
             []
         ),
         # ranked, exist, extra ranks
@@ -735,8 +735,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {5: '0.5'}, 1: {5: '1.5'}},
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {0: None}},
-            ['nfs:host1(rank=0.5 *:2049,9587)', 'nfs:host2(rank=1.5 *:2049,9587)', 'nfs:host3(rank=2.0 *:2049,9587)'],
-            ['nfs:host3(rank=2.0 *:2049,9587)'],
+            ['nfs:host1(rank=0.5 *:2049,9587,31311)', 'nfs:host2(rank=1.5 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host3(rank=2.0 *:2049,9587,31311)'],
             ['nfs.4.5']
         ),
         # 25: ranked, exist, extra ranks (scale down: kill off high rank)
@@ -751,7 +751,7 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
-            ['nfs:host1(rank=0.5 *:2049,9587)', 'nfs:host2(rank=1.5 *:2049,9587)'],
+            ['nfs:host1(rank=0.5 *:2049,9587,31311)', 'nfs:host2(rank=1.5 *:2049,9587,31311)'],
             [],
             ['nfs.2.5']
         ),
@@ -767,8 +767,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
             {0: {5: '0.5'}, 1: {5: '1.5', 6: None}, 2: {5: '2.5'}},
-            ['nfs:host1(rank=0.5 *:2049,9587)', 'nfs:host3(rank=1.6 *:2049,9587)'],
-            ['nfs:host3(rank=1.6 *:2049,9587)'],
+            ['nfs:host1(rank=0.5 *:2049,9587,31311)', 'nfs:host3(rank=1.6 *:2049,9587,31311)'],
+            ['nfs:host3(rank=1.6 *:2049,9587,31311)'],
             ['nfs.2.5', 'nfs.1.5']
         ),
         # ranked, exist, duplicate rank
@@ -783,8 +783,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {0: '0.0'}, 1: {2: '1.2'}},
             {0: {0: '0.0'}, 1: {2: '1.2'}, 2: {0: None}},
-            ['nfs:host1(rank=0.0 *:2049,9587)', 'nfs:host3(rank=1.2 *:2049,9587)', 'nfs:host2(rank=2.0 *:2049,9587)'],
-            ['nfs:host2(rank=2.0 *:2049,9587)'],
+            ['nfs:host1(rank=0.0 *:2049,9587,31311)', 'nfs:host3(rank=1.2 *:2049,9587,31311)', 'nfs:host2(rank=2.0 *:2049,9587,31311)'],
+            ['nfs:host2(rank=2.0 *:2049,9587,31311)'],
             ['nfs.1.1']
         ),
         # 28: ranked, all gens stale (failure during update cycle)
@@ -798,8 +798,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {2: '0.2'}, 1: {2: '1.2', 3: '1.3'}},
             {0: {2: '0.2'}, 1: {2: '1.2', 3: '1.3', 4: None}},
-            ['nfs:host1(rank=0.2 *:2049,9587)', 'nfs:host3(rank=1.4 *:2049,9587)'],
-            ['nfs:host3(rank=1.4 *:2049,9587)'],
+            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host3(rank=1.4 *:2049,9587,31311)'],
+            ['nfs:host3(rank=1.4 *:2049,9587,31311)'],
             ['nfs.1.2']
         ),
         # ranked, not enough hosts (with colocation, 4th daemon can be placed)
@@ -813,8 +813,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {2: '0.2'}, 1: {2: '1.2'}},
             {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host1(rank=0.2 *:2049,9587)', 'nfs:host2(rank=1.2 *:2049,9587)', 'nfs:host3(rank=2.0 *:2049,9587)', 'nfs:host3(rank=3.0 *:2050,9588)'],
-            ['nfs:host3(rank=2.0 *:2049,9587)', 'nfs:host3(rank=3.0 *:2050,9588)'],
+            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host2(rank=1.2 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31311)'],
+            ['nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31311)'],
             []
         ),
         # ranked, scale down
@@ -829,8 +829,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {2: '2.2'}},
             {0: {2: '0.2', 3: None}, 1: {2: '1.2'}, 2: {2: '2.2'}},
-            ['nfs:host2(rank=0.3 *:2049,9587)'],
-            ['nfs:host2(rank=0.3 *:2049,9587)'],
+            ['nfs:host2(rank=0.3 *:2049,9587,31311)'],
+            ['nfs:host2(rank=0.3 *:2049,9587,31311)'],
             ['nfs.0.2', 'nfs.1.2', 'nfs.2.2']
         ),
         # NFS colocation - count > hosts, ports should increment

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -813,8 +813,8 @@ class NodeAssignmentTest(NamedTuple):
             ],
             {0: {2: '0.2'}, 1: {2: '1.2'}},
             {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host2(rank=1.2 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31311)'],
-            ['nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31311)'],
+            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host2(rank=1.2 *:2049,9587,31311)', 'nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31312)'],
+            ['nfs:host3(rank=2.0 *:2049,9587,31311)', 'nfs:host3(rank=3.0 *:2050,9588,31312)'],
             []
         ),
         # ranked, scale down
@@ -841,10 +841,10 @@ class NodeAssignmentTest(NamedTuple):
             [],
             {},
             {0: {0: None}, 1: {0: None}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
-             'nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
-            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
-             'nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
+            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
+             'nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
+            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
+             'nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
             []
         ),
         # NFS colocation with existing daemons
@@ -853,14 +853,14 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=4),
             'host1 host2'.split(),
             [
-                DaemonDescription('nfs', '0.1', 'host1', rank=0, rank_generation=1, ports=[2049, 9587]),
-                DaemonDescription('nfs', '1.1', 'host2', rank=1, rank_generation=1, ports=[2049, 9587]),
+                DaemonDescription('nfs', '0.1', 'host1', rank=0, rank_generation=1, ports=[2049, 9587, 31311]),
+                DaemonDescription('nfs', '1.1', 'host2', rank=1, rank_generation=1, ports=[2049, 9587, 31311]),
             ],
             {0: {1: '0.1'}, 1: {1: '1.1'}},
             {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host1(rank=0.1 *:2049,9587)', 'nfs:host2(rank=1.1 *:2049,9587)',
-             'nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
-            ['nfs:host2(rank=2.0 *:2050,9588)', 'nfs:host1(rank=3.0 *:2050,9588)'],
+            ['nfs:host1(rank=0.1 *:2049,9587,31311)', 'nfs:host2(rank=1.1 *:2049,9587,31311)',
+             'nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
+            ['nfs:host2(rank=2.0 *:2050,9588,31312)', 'nfs:host1(rank=3.0 *:2050,9588,31312)'],
             []
         ),
         # NFS colocation with custom ports
@@ -871,10 +871,10 @@ class NodeAssignmentTest(NamedTuple):
             [],
             {},
             {0: {0: None}, 1: {0: None}, 2: {0: None}, 3: {0: None}},
-            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
-             'nfs:host2(rank=2.0 *:3049,9588)', 'nfs:host1(rank=3.0 *:3049,9588)'],
-            ['nfs:host2(rank=0.0 *:2049,9587)', 'nfs:host1(rank=1.0 *:2049,9587)',
-             'nfs:host2(rank=2.0 *:3049,9588)', 'nfs:host1(rank=3.0 *:3049,9588)'],
+            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
+             'nfs:host2(rank=2.0 *:3049,9588,31315)', 'nfs:host1(rank=3.0 *:3049,9588,31315)'],
+            ['nfs:host2(rank=0.0 *:2049,9587,31311)', 'nfs:host1(rank=1.0 *:2049,9587,31311)',
+             'nfs:host2(rank=2.0 *:3049,9588,31315)', 'nfs:host1(rank=3.0 *:3049,9588,31315)'],
             []
         ),
     ])
@@ -895,7 +895,7 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
         # Check if this is the custom ports test by looking at expected ports
         if expected and any('3049' in str(e) for e in expected):
             # Custom colocation ports test case
-            # First daemon uses base ports (port, monitoring_port)
+            # First daemon uses base ports (port, monitoring_port, cluster_qos_port)
             # colocation_ports defines ADDITIONAL daemons only
             spec = NFSServiceSpec(service_type=service_type,
                                   service_id=service_id,
@@ -903,10 +903,10 @@ def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post
                                   port=2049,
                                   monitoring_port=9587,
                                   colocation_ports=[
-                                      {'data_port': 3049, 'monitoring_port': 9588},
-                                      {'data_port': 3050, 'monitoring_port': 9589},
-                                      {'data_port': 3051, 'monitoring_port': 9590},
-                                      {'data_port': 3052, 'monitoring_port': 9591}
+                                      {'data_port': 3049, 'monitoring_port': 9588, 'cluster_qos_port': 31315},
+                                      {'data_port': 3050, 'monitoring_port': 9589, 'cluster_qos_port': 31316},
+                                      {'data_port': 3051, 'monitoring_port': 9590, 'cluster_qos_port': 31317},
+                                      {'data_port': 3052, 'monitoring_port': 9591, 'cluster_qos_port': 31318}
                                   ])
         else:
             spec = ServiceSpec(service_type=service_type,
@@ -1978,7 +1978,7 @@ def test_blocking_daemon_host(
             ],
             [],
             None,
-            ['nfs:host1(*:2049,9587)'],
+            ['nfs:host1(*:2049,9587,31311)'],
             [],
             ['nfs.nfs2']  # to_remove
         ),
@@ -2022,7 +2022,7 @@ def test_blocking_daemon_host(
                 DaemonDescription('keepalived', 'ingress4', 'host4'),
             ],
             None,
-            ['nfs:host3(*:2049,9587)', 'nfs:host4(*:2049,9587)'],
+            ['nfs:host3(*:2049,9587,31311)', 'nfs:host4(*:2049,9587,31311)'],
             [],
             ['nfs.nfs1', 'nfs.nfs2']  # to_remove
         ),
@@ -2042,7 +2042,7 @@ def test_blocking_daemon_host(
                 DaemonDescription('keepalived', 'ingress3', 'host3'),
             ],
             {0: {1: '0.1', 2: '0.2'}, 1: {1: '1.1'}},
-            ['nfs:host1(rank=0.2 *:2049,9587)', 'nfs:host3(rank=1.1 *:2049,9587)'],
+            ['nfs:host1(rank=0.2 *:2049,9587,31311)', 'nfs:host3(rank=1.1 *:2049,9587,31311)'],
             [],
             ['nfs.0.1']
         ),

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -18,8 +18,15 @@ from .utils import (
     available_clusters,
     conf_obj_name,
     restart_nfs_service,
-    user_conf_obj_name)
-from .export import NFSRados
+    user_conf_obj_name,
+    USER_CONF_PREFIX,
+    qos_conf_obj_name)
+from .rados_utils import NFSRados
+from .ganesha_conf import format_block, GaneshaConfParser
+from .qos_conf import (
+    QOS,
+    QOSType,
+    QOSBandwidthControl)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -324,7 +331,7 @@ class NFSCluster:
         try:
             if cluster_id in available_clusters(self.mgr):
                 rados_obj = self._rados(cluster_id)
-                if rados_obj.check_user_config():
+                if rados_obj.check_config(USER_CONF_PREFIX):
                     raise NonFatalError("NFS-Ganesha User Config already exists")
                 rados_obj.write_obj(nfs_config, user_conf_obj_name(cluster_id),
                                     conf_obj_name(cluster_id))
@@ -342,7 +349,7 @@ class NFSCluster:
         try:
             if cluster_id in available_clusters(self.mgr):
                 rados_obj = self._rados(cluster_id)
-                if not rados_obj.check_user_config():
+                if not rados_obj.check_config(USER_CONF_PREFIX):
                     raise NonFatalError("NFS-Ganesha User Config does not exist")
                 rados_obj.remove_obj(user_conf_obj_name(cluster_id),
                                      conf_obj_name(cluster_id))
@@ -358,3 +365,100 @@ class NFSCluster:
     def _rados(self, cluster_id: str) -> NFSRados:
         """Return a new NFSRados object for the given cluster id."""
         return NFSRados(self.mgr.rados, cluster_id)
+
+    def get_cluster_qos_config(self, cluster_id: str) -> Optional[QOS]:
+        """Return QOS object for the given cluster id."""
+        rados_obj = self._rados(cluster_id)
+        conf = rados_obj.read_obj(qos_conf_obj_name(cluster_id))
+        if conf:
+            qos_block = GaneshaConfParser(conf).parse()
+            qos_obj = QOS.from_qos_block(qos_block[0], True)
+            return qos_obj
+        return None
+
+    def update_cluster_qos_bw(self,
+                              cluster_id: str,
+                              enable_qos: bool,
+                              bw_obj: QOSBandwidthControl,
+                              qos_type: Optional[QOSType] = None) -> None:
+        """Update cluster QOS config"""
+        qos_obj_exists = False
+        qos_obj = self.get_cluster_qos_config(cluster_id)
+        if not qos_obj:
+            log.debug(f"Creating new QOS block for cluster {cluster_id}")
+            qos_obj = QOS(True, enable_qos, qos_type, bw_obj)
+        else:
+            log.debug(f"Updating existing QOS block for cluster {cluster_id}")
+            qos_obj_exists = True
+            qos_obj.enable_qos = enable_qos
+            qos_obj.qos_type = qos_type
+            qos_obj.bw_obj = bw_obj
+
+        qos_config = format_block(qos_obj.to_qos_block())
+        rados_obj = self._rados(cluster_id)
+        if not qos_obj_exists:
+            rados_obj.write_obj(qos_config, qos_conf_obj_name(cluster_id),
+                                conf_obj_name(cluster_id))
+        else:
+            rados_obj.update_obj(qos_config, qos_conf_obj_name(cluster_id),
+                                 conf_obj_name(cluster_id), should_notify=False)
+        log.debug(f"Successfully saved {cluster_id}s QOS bandwidth control config: \n {qos_config}")
+
+    def enable_cluster_qos_bw(self,
+                              cluster_id: str,
+                              qos_type: QOSType,
+                              bw_obj: QOSBandwidthControl
+                              ) -> None:
+        """
+        There are 2 cases to consider:
+        1. If combined bandwith control is disabled
+            a. If qos_type is pershare, then export_writebw and export_readbw parameters are compulsory
+            b. If qos_type is perclient, then client_writebw and client_readbw parameters are compulsory
+            c. If qos_type is pershare_perclient then export_writebw, export_readbw, client_writebw and
+               client_readbw are compulsory parameters
+        2. If combined bandwidth control is enabled
+            a. If qos_type is pershare, then export_rw_bw parameter is compulsory
+            b. If qos_type is perclient, then client_rw_bw parameter is compulsory
+            c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory
+        """
+        try:
+            bw_obj.qos_bandwidth_checks(qos_type)
+            if cluster_id in available_clusters(self.mgr):
+                self.update_cluster_qos_bw(cluster_id, True, bw_obj, qos_type)
+                restart_nfs_service(self.mgr, cluster_id)
+                log.info(f"QOS bandwidth control has been successfully enabled for cluster {cluster_id}. "
+                         "If the qos_type is changed during this process, ensure that the bandwidth "
+                         "values for all exports are updated accordingly.")
+                return
+            raise ClusterNotFound()
+        except NotImplementedError:
+            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added Successfully for {cluster_id}")
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def get_cluster_qos(self, cluster_id: str) -> Dict[str, Any]:
+        try:
+            if cluster_id in available_clusters(self.mgr):
+                qos_obj = self.get_cluster_qos_config(cluster_id)
+                return qos_obj.to_dict() if qos_obj else {}
+            raise ClusterNotFound()
+        except Exception as e:
+            log.exception(f"Fetching NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def disable_cluster_qos_bw(self, cluster_id: str) -> None:
+        try:
+            if cluster_id in available_clusters(self.mgr):
+                self.update_cluster_qos_bw(cluster_id, False, QOSBandwidthControl())
+                restart_nfs_service(self.mgr, cluster_id)
+                log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
+                         f"cluster {cluster_id}. As a result, export-level bandwidth control will "
+                         "no longer have any effect, even if it's enabled.")
+                return
+            raise ClusterNotFound()
+        except NotImplementedError:
+            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added successfully for {cluster_id}")
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -487,11 +487,11 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def get_cluster_qos(self, cluster_id: str) -> Dict[str, Any]:
+    def get_cluster_qos(self, cluster_id: str, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         try:
             if cluster_id in available_clusters(self.mgr):
                 qos_obj = self.get_cluster_qos_config(cluster_id)
-                return qos_obj.to_dict() if qos_obj else {}
+                return qos_obj.to_dict(ret_bw_in_bytes) if qos_obj else {}
             raise ClusterNotFound()
         except Exception as e:
             log.exception(f"Fetching NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -26,7 +26,8 @@ from .ganesha_conf import format_block, GaneshaConfParser
 from .qos_conf import (
     QOS,
     QOSType,
-    QOSBandwidthControl)
+    QOSBandwidthControl,
+    QOSOpsControl)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -376,23 +377,27 @@ class NFSCluster:
             return qos_obj
         return None
 
-    def update_cluster_qos_bw(self,
-                              cluster_id: str,
-                              enable_qos: bool,
-                              bw_obj: QOSBandwidthControl,
-                              qos_type: Optional[QOSType] = None) -> None:
+    def update_cluster_qos_obj(self,
+                               cluster_id: str,
+                               qos_obj: Optional[QOS],
+                               enable_qos: bool,
+                               qos_type: Optional[QOSType] = None,
+                               bw_obj: Optional[QOSBandwidthControl] = None,
+                               ops_obj: Optional[QOSOpsControl] = None) -> None:
         """Update cluster QOS config"""
         qos_obj_exists = False
-        qos_obj = self.get_cluster_qos_config(cluster_id)
         if not qos_obj:
             log.debug(f"Creating new QOS block for cluster {cluster_id}")
-            qos_obj = QOS(True, enable_qos, qos_type, bw_obj)
+            qos_obj = QOS(True, enable_qos, qos_type, bw_obj, ops_obj)
         else:
             log.debug(f"Updating existing QOS block for cluster {cluster_id}")
             qos_obj_exists = True
             qos_obj.enable_qos = enable_qos
             qos_obj.qos_type = qos_type
-            qos_obj.bw_obj = bw_obj
+            if bw_obj:
+                qos_obj.bw_obj = bw_obj
+            if ops_obj:
+                qos_obj.ops_obj = ops_obj
 
         qos_config = format_block(qos_obj.to_qos_block())
         rados_obj = self._rados(cluster_id)
@@ -403,6 +408,53 @@ class NFSCluster:
             rados_obj.update_obj(qos_config, qos_conf_obj_name(cluster_id),
                                  conf_obj_name(cluster_id), should_notify=False)
         log.debug(f"Successfully saved {cluster_id}s QOS bandwidth control config: \n {qos_config}")
+
+    def update_cluster_qos(self,
+                           cluster_id: str,
+                           qos_obj: Optional[QOS],
+                           enable_qos: bool,
+                           qos_type: Optional[QOSType] = None,
+                           bw_obj: Optional[QOSBandwidthControl] = None,
+                           ops_obj: Optional[QOSOpsControl] = None) -> None:
+        try:
+            if cluster_id in available_clusters(self.mgr):
+                self.update_cluster_qos_obj(cluster_id, qos_obj, enable_qos, qos_type, bw_obj, ops_obj)
+                restart_nfs_service(self.mgr, cluster_id)
+                return
+            raise ClusterNotFound()
+        except NotImplementedError:
+            raise ManualRestartRequired(f"NFS-Ganesha QOS config added successfully for {cluster_id}")
+
+    def validate_qos_type(self,
+                          qos_obj: QOS,
+                          qos_type: QOSType,
+                          bw_obj: Optional[QOSBandwidthControl] = None,
+                          ops_obj: Optional[QOSOpsControl] = None) -> None:
+        if not qos_obj or not (bw_obj or ops_obj):
+            return
+        # if qos is not enabled then we can set new directly
+        if not (qos_obj.enable_qos and qos_obj.qos_type):
+            return
+
+        other_qos_obj: Any = None
+        if bw_obj:
+            other_qos_obj = qos_obj.ops_obj
+            is_other_enable = qos_obj.ops_obj.enable_iops_ctrl if qos_obj.ops_obj else False
+            is_this_enable = qos_obj.bw_obj.enable_bw_ctrl if qos_obj.bw_obj else False
+            ctrl_type = "IOPS"
+        else:
+            other_qos_obj = qos_obj.bw_obj
+            is_other_enable = qos_obj.bw_obj.enable_bw_ctrl if qos_obj.bw_obj else False
+            is_this_enable = qos_obj.ops_obj.enable_iops_ctrl if qos_obj.ops_obj else False
+            ctrl_type = "Bandwidth"
+
+        if other_qos_obj and is_other_enable:
+            # if earlier only other qos control is enabled
+            if not is_this_enable and qos_obj.qos_type != qos_type:
+                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} qos type, please update that qos type for {ctrl_type} first.")
+            # if both qos control are enabled, the user will need to disable one first to change qos type
+            elif is_this_enable and qos_obj.qos_type != qos_type:
+                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} qos type, please disable {ctrl_type} control to update qos type and then enable {ctrl_type} control again with new qos type")
 
     def enable_cluster_qos_bw(self,
                               cluster_id: str,
@@ -422,17 +474,15 @@ class NFSCluster:
             c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory
         """
         try:
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            if qos_obj:
+                self.validate_qos_type(qos_obj, qos_type, bw_obj=bw_obj)
             bw_obj.qos_bandwidth_checks(qos_type)
-            if cluster_id in available_clusters(self.mgr):
-                self.update_cluster_qos_bw(cluster_id, True, bw_obj, qos_type)
-                restart_nfs_service(self.mgr, cluster_id)
-                log.info(f"QOS bandwidth control has been successfully enabled for cluster {cluster_id}. "
-                         "If the qos_type is changed during this process, ensure that the bandwidth "
-                         "values for all exports are updated accordingly.")
-                return
-            raise ClusterNotFound()
-        except NotImplementedError:
-            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added Successfully for {cluster_id}")
+            self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, bw_obj=bw_obj)
+            log.info(f"QOS bandwidth control has been successfully enabled for cluster {cluster_id}. "
+                     "If the qos_type is changed during this process, ensure that the bandwidth "
+                     "values for all exports are updated accordingly.")
+            return
         except Exception as e:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
@@ -449,16 +499,51 @@ class NFSCluster:
 
     def disable_cluster_qos_bw(self, cluster_id: str) -> None:
         try:
-            if cluster_id in available_clusters(self.mgr):
-                self.update_cluster_qos_bw(cluster_id, False, QOSBandwidthControl())
-                restart_nfs_service(self.mgr, cluster_id)
-                log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
-                         f"cluster {cluster_id}. As a result, export-level bandwidth control will "
-                         "no longer have any effect, even if it's enabled.")
-                return
-            raise ClusterNotFound()
-        except NotImplementedError:
-            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added successfully for {cluster_id}")
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            status = False
+            qos_type = None
+            if qos_obj:
+                status = qos_obj.get_enable_qos_val(disable_bw=True)
+                if status:
+                    qos_type = qos_obj.qos_type
+            self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, bw_obj=QOSBandwidthControl())
+            log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
+                     f"cluster {cluster_id}. As a result, export-level bandwidth control will "
+                     "no longer have any effect, even if it's enabled.")
+            return
         except Exception as e:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl) -> None:
+        try:
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            if qos_obj:
+                self.validate_qos_type(qos_obj, qos_type, ops_obj=ops_obj)
+            ops_obj.qos_ops_checks(qos_type)
+            self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, ops_obj=ops_obj)
+            log.info(f"QOS IOPS control has been successfully enabled for cluster {cluster_id}. "
+                     "If the qos_type is changed during this process, ensure that ops count "
+                     "values for all exports are updated accordingly.")
+            return
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS IOPS control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def disable_cluster_qos_ops(self, cluster_id: str) -> None:
+        try:
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            status = False
+            qos_type = None
+            if qos_obj:
+                status = qos_obj.get_enable_qos_val(disable_ops=True)
+                if status:
+                    qos_type = qos_obj.qos_type
+            self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, ops_obj=QOSOpsControl())
+            log.info("Cluster-level QoS IOPS control has been successfully disabled for "
+                     f"cluster {cluster_id}. As a result, export-level ops control will "
+                     "no longer have any effect, even if it's enabled.")
+            return
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS IOPS control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -387,10 +387,10 @@ class NFSCluster:
         """Update cluster QOS config"""
         qos_obj_exists = False
         if not qos_obj:
-            log.debug(f"Creating new QOS block for cluster {cluster_id}")
+            log.debug(f"Creating new QoS block for cluster {cluster_id}")
             qos_obj = QOS(True, enable_qos, qos_type, bw_obj, ops_obj)
         else:
-            log.debug(f"Updating existing QOS block for cluster {cluster_id}")
+            log.debug(f"Updating existing QoS block for cluster {cluster_id}")
             qos_obj_exists = True
             qos_obj.enable_qos = enable_qos
             qos_obj.qos_type = qos_type
@@ -423,7 +423,7 @@ class NFSCluster:
                 return
             raise ClusterNotFound()
         except NotImplementedError:
-            raise ManualRestartRequired(f"NFS-Ganesha QOS config added successfully for {cluster_id}")
+            raise ManualRestartRequired(f"NFS-Ganesha QoS config added successfully for {cluster_id}")
 
     def validate_qos_type(self,
                           qos_obj: QOS,
@@ -451,10 +451,10 @@ class NFSCluster:
         if other_qos_obj and is_other_enable:
             # if earlier only other qos control is enabled
             if not is_this_enable and qos_obj.qos_type != qos_type:
-                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} qos type, please update that qos type for {ctrl_type} first.")
+                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} QoS type, please update that QoS type for {ctrl_type} first.")
             # if both qos control are enabled, the user will need to disable one first to change qos type
             elif is_this_enable and qos_obj.qos_type != qos_type:
-                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} qos type, please disable {ctrl_type} control to update qos type and then enable {ctrl_type} control again with new qos type")
+                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} QoS type, please disable {ctrl_type} control to update QoS type and then enable {ctrl_type} control again with new QoS type")
 
     def enable_cluster_qos_bw(self,
                               cluster_id: str,
@@ -479,12 +479,12 @@ class NFSCluster:
                 self.validate_qos_type(qos_obj, qos_type, bw_obj=bw_obj)
             bw_obj.qos_bandwidth_checks(qos_type)
             self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, bw_obj=bw_obj)
-            log.info(f"QOS bandwidth control has been successfully enabled for cluster {cluster_id}. "
+            log.info(f"QoS bandwidth control has been successfully enabled for cluster {cluster_id}. "
                      "If the qos_type is changed during this process, ensure that the bandwidth "
                      "values for all exports are updated accordingly.")
             return
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QoS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def get_cluster_qos(self, cluster_id: str, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
@@ -494,7 +494,7 @@ class NFSCluster:
                 return qos_obj.to_dict(ret_bw_in_bytes) if qos_obj else {}
             raise ClusterNotFound()
         except Exception as e:
-            log.exception(f"Fetching NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            log.exception(f"Fetching NFS-Ganesha QoS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def disable_cluster_qos_bw(self, cluster_id: str) -> None:
@@ -509,10 +509,10 @@ class NFSCluster:
             self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, bw_obj=QOSBandwidthControl())
             log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
                      f"cluster {cluster_id}. As a result, export-level bandwidth control will "
-                     "no longer have any effect, even if it's enabled.")
+                     "no longer have any effect, even if enabled.")
             return
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QoS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl) -> None:
@@ -542,8 +542,8 @@ class NFSCluster:
             self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, ops_obj=QOSOpsControl())
             log.info("Cluster-level QoS IOPS control has been successfully disabled for "
                      f"cluster {cluster_id}. As a result, export-level ops control will "
-                     "no longer have any effect, even if it's enabled.")
+                     "no longer have any effect, even if enabled.")
             return
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS IOPS control config failed for {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QoS IOPS control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -27,7 +27,8 @@ from .qos_conf import (
     QOS,
     QOSType,
     QOSBandwidthControl,
-    QOSOpsControl)
+    QOSOpsControl,
+    QOSParams)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -62,6 +63,87 @@ def create_ganesha_pool(mgr: 'MgrModule') -> None:
         log.debug("Successfully created nfs-ganesha pool %s", POOL_NAME)
 
 
+def config_cluster_qos_from_dict(
+    mgr: 'MgrModule',
+    cluster_id: str,
+    qos_dict: Dict[str, Union[str, bool, int]],
+    update_existing_obj: bool = False,
+) -> None:
+    qos_type = qos_dict.get(QOSParams.qos_type.value)
+    if not qos_type:
+        raise NFSInvalidOperation('qos_type is not specified in qos dict')
+    qos_type = QOSType[str(qos_type)]
+    enable_bw_ctrl = qos_dict.get(QOSParams.enable_bw_ctrl.value)
+    combined_bw_ctrl = qos_dict.get(QOSParams.combined_bw_ctrl.value)
+    enable_iops_ctrl = qos_dict.get(QOSParams.enable_iops_ctrl.value)
+    bw_obj = ops_obj = None
+    if enable_bw_ctrl:
+        bw_obj = QOSBandwidthControl(
+            bool(enable_bw_ctrl),
+            bool(combined_bw_ctrl),
+            export_writebw=str(qos_dict.get(QOSParams.export_writebw.value, "0")),
+            export_readbw=str(qos_dict.get(QOSParams.export_readbw.value, "0")),
+            client_writebw=str(qos_dict.get(QOSParams.client_writebw.value, "0")),
+            client_readbw=str(qos_dict.get(QOSParams.client_readbw.value, "0")),
+            export_rw_bw=str(qos_dict.get(QOSParams.export_rw_bw.value, "0")),
+            client_rw_bw=str(qos_dict.get(QOSParams.client_rw_bw.value, "0")),
+        )
+        bw_obj.qos_bandwidth_checks(qos_type)
+    if enable_iops_ctrl:
+        ops_obj = QOSOpsControl(
+            bool(enable_iops_ctrl),
+            max_export_iops=int(qos_dict.get(QOSParams.max_export_iops.value, 0)),
+            max_client_iops=int(qos_dict.get(QOSParams.max_client_iops.value, 0)),
+        )
+        ops_obj.qos_ops_checks(qos_type)
+
+    write_cluster_qos_obj(
+        mgr=mgr,
+        cluster_id=cluster_id,
+        qos_obj=None,
+        enable_qos=True,
+        qos_type=qos_type,
+        bw_obj=bw_obj,
+        ops_obj=ops_obj,
+        update_existing_obj=update_existing_obj
+    )
+
+
+def write_cluster_qos_obj(
+    mgr: 'MgrModule',
+    cluster_id: str,
+    qos_obj: Optional[QOS],
+    enable_qos: bool,
+    qos_type: Optional[QOSType] = None,
+    bw_obj: Optional[QOSBandwidthControl] = None,
+    ops_obj: Optional[QOSOpsControl] = None,
+    update_existing_obj: bool = False
+) -> None:
+    qos_obj_exists = False
+    if not qos_obj:
+        log.debug(f"Creating new QoS block for cluster {cluster_id}")
+        qos_obj = QOS(True, enable_qos, qos_type, bw_obj, ops_obj)
+    else:
+        log.debug(f"Updating existing QoS block for cluster {cluster_id}")
+        qos_obj_exists = True
+        qos_obj.enable_qos = enable_qos
+        qos_obj.qos_type = qos_type
+        if bw_obj:
+            qos_obj.bw_obj = bw_obj
+        if ops_obj:
+            qos_obj.ops_obj = ops_obj
+
+    qos_config = format_block(qos_obj.to_qos_block())
+    rados_obj = NFSRados(mgr.rados, cluster_id)
+    if not qos_obj_exists and not update_existing_obj:
+        rados_obj.write_obj(qos_config, qos_conf_obj_name(cluster_id),
+                            conf_obj_name(cluster_id))
+    else:
+        rados_obj.update_obj(qos_config, qos_conf_obj_name(cluster_id),
+                             conf_obj_name(cluster_id), should_notify=False)
+    log.debug(f"Successfully saved {cluster_id}s QOS bandwidth control config: \n {qos_config}")
+
+
 class NFSCluster:
     def __init__(self, mgr: 'Module') -> None:
         self.mgr = mgr
@@ -73,6 +155,7 @@ class NFSCluster:
             virtual_ip: Optional[str] = None,
             ingress_mode: Optional[IngressType] = None,
             port: Optional[int] = None,
+            cluster_qos_config: Optional[Dict[str, Union[str, bool, int]]] = None,
             ssl: bool = False,
             ssl_cert: Optional[str] = None,
             ssl_key: Optional[str] = None,
@@ -117,6 +200,7 @@ class NFSCluster:
                                   port=ganesha_port,
                                   virtual_ip=virtual_ip_for_ganesha,
                                   enable_haproxy_protocol=enable_haproxy_protocol,
+                                  cluster_qos_config=cluster_qos_config,
                                   ssl=ssl,
                                   ssl_cert=ssl_cert,
                                   ssl_key=ssl_key,
@@ -145,6 +229,7 @@ class NFSCluster:
             spec = NFSServiceSpec(service_type='nfs', service_id=cluster_id,
                                   placement=PlacementSpec.from_string(placement),
                                   port=port,
+                                  cluster_qos_config=cluster_qos_config,
                                   ssl=ssl,
                                   ssl_cert=ssl_cert,
                                   ssl_key=ssl_key,
@@ -178,6 +263,7 @@ class NFSCluster:
             ingress: Optional[bool] = None,
             ingress_mode: Optional[IngressType] = None,
             port: Optional[int] = None,
+            cluster_qos_config: Optional[Dict[str, Union[str, bool, int]]] = None,
             ssl: bool = False,
             ssl_cert: Optional[str] = None,
             ssl_key: Optional[str] = None,
@@ -211,9 +297,24 @@ class NFSCluster:
             self.create_empty_rados_obj(cluster_id)
 
             if cluster_id not in available_clusters(self.mgr):
-                self._call_orch_apply_nfs(cluster_id, placement, virtual_ip, ingress_mode, port,
-                                          ssl, ssl_cert, ssl_key, ssl_ca_cert, tls_ktls, tls_debug,
-                                          tls_min_version, tls_ciphers, enable_rdma, rdma_port)
+                self._call_orch_apply_nfs(
+                    cluster_id,
+                    placement,
+                    virtual_ip,
+                    ingress_mode,
+                    port,
+                    cluster_qos_config=cluster_qos_config,
+                    ssl=ssl,
+                    ssl_cert=ssl_cert,
+                    ssl_key=ssl_key,
+                    ssl_ca_cert=ssl_ca_cert,
+                    tls_ktls=tls_ktls,
+                    tls_debug=tls_debug,
+                    tls_min_version=tls_min_version,
+                    tls_ciphers=tls_ciphers,
+                    enable_rdma=enable_rdma,
+                    rdma_port=rdma_port
+                )
                 return
             raise NonFatalError(f"{cluster_id} cluster already exists")
         except Exception as e:
@@ -385,29 +486,15 @@ class NFSCluster:
                                bw_obj: Optional[QOSBandwidthControl] = None,
                                ops_obj: Optional[QOSOpsControl] = None) -> None:
         """Update cluster QOS config"""
-        qos_obj_exists = False
-        if not qos_obj:
-            log.debug(f"Creating new QoS block for cluster {cluster_id}")
-            qos_obj = QOS(True, enable_qos, qos_type, bw_obj, ops_obj)
-        else:
-            log.debug(f"Updating existing QoS block for cluster {cluster_id}")
-            qos_obj_exists = True
-            qos_obj.enable_qos = enable_qos
-            qos_obj.qos_type = qos_type
-            if bw_obj:
-                qos_obj.bw_obj = bw_obj
-            if ops_obj:
-                qos_obj.ops_obj = ops_obj
-
-        qos_config = format_block(qos_obj.to_qos_block())
-        rados_obj = self._rados(cluster_id)
-        if not qos_obj_exists:
-            rados_obj.write_obj(qos_config, qos_conf_obj_name(cluster_id),
-                                conf_obj_name(cluster_id))
-        else:
-            rados_obj.update_obj(qos_config, qos_conf_obj_name(cluster_id),
-                                 conf_obj_name(cluster_id), should_notify=False)
-        log.debug(f"Successfully saved {cluster_id}s QOS bandwidth control config: \n {qos_config}")
+        write_cluster_qos_obj(
+            mgr=self.mgr,
+            cluster_id=cluster_id,
+            qos_obj=qos_obj,
+            enable_qos=enable_qos,
+            qos_type=qos_type,
+            bw_obj=bw_obj,
+            ops_obj=ops_obj
+        )
 
     def update_cluster_qos(self,
                            cluster_id: str,

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -3,6 +3,7 @@ import logging
 import re
 import socket
 from typing import cast, Dict, List, Any, Union, Optional, TYPE_CHECKING
+from enum import Enum
 
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
@@ -28,7 +29,8 @@ from .qos_conf import (
     QOSType,
     QOSBandwidthControl,
     QOSOpsControl,
-    QOSParams)
+    QOSParams,
+    validate_clust_qos_msg_interval)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -36,6 +38,11 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+class ClusterQosAction(Enum):
+    enable = 'enable'
+    disable = 'disable'
 
 
 def resolve_ip(hostname: str) -> str:
@@ -73,6 +80,9 @@ def config_cluster_qos_from_dict(
     if not qos_type:
         raise NFSInvalidOperation('qos_type is not specified in qos dict')
     qos_type = QOSType[str(qos_type)]
+    enable_cluster_qos = qos_dict.get(QOSParams.enable_cluster_qos.value, True)
+    clust_qos_msg_interval = int(qos_dict.get(QOSParams.clust_qos_msg_interval.value, 0))
+    assert isinstance(enable_cluster_qos, (bool, type(None)))
     enable_bw_ctrl = qos_dict.get(QOSParams.enable_bw_ctrl.value)
     combined_bw_ctrl = qos_dict.get(QOSParams.combined_bw_ctrl.value)
     enable_iops_ctrl = qos_dict.get(QOSParams.enable_iops_ctrl.value)
@@ -102,6 +112,8 @@ def config_cluster_qos_from_dict(
         cluster_id=cluster_id,
         qos_obj=None,
         enable_qos=True,
+        enable_cluster_qos=enable_cluster_qos,
+        clust_qos_msg_interval=clust_qos_msg_interval,
         qos_type=qos_type,
         bw_obj=bw_obj,
         ops_obj=ops_obj,
@@ -114,6 +126,8 @@ def write_cluster_qos_obj(
     cluster_id: str,
     qos_obj: Optional[QOS],
     enable_qos: bool,
+    enable_cluster_qos: Optional[bool] = None,
+    clust_qos_msg_interval: int = 0,
     qos_type: Optional[QOSType] = None,
     bw_obj: Optional[QOSBandwidthControl] = None,
     ops_obj: Optional[QOSOpsControl] = None,
@@ -122,11 +136,13 @@ def write_cluster_qos_obj(
     qos_obj_exists = False
     if not qos_obj:
         log.debug(f"Creating new QoS block for cluster {cluster_id}")
-        qos_obj = QOS(True, enable_qos, qos_type, bw_obj, ops_obj)
+        qos_obj = QOS(True, enable_qos, enable_cluster_qos, clust_qos_msg_interval, qos_type, bw_obj, ops_obj)
     else:
         log.debug(f"Updating existing QoS block for cluster {cluster_id}")
         qos_obj_exists = True
         qos_obj.enable_qos = enable_qos
+        qos_obj.enable_cluster_qos = enable_cluster_qos
+        qos_obj.clust_qos_msg_interval = validate_clust_qos_msg_interval(clust_qos_msg_interval)
         qos_obj.qos_type = qos_type
         if bw_obj:
             qos_obj.bw_obj = bw_obj
@@ -482,6 +498,8 @@ class NFSCluster:
                                cluster_id: str,
                                qos_obj: Optional[QOS],
                                enable_qos: bool,
+                               enable_cluster_qos: Optional[bool] = None,
+                               clust_qos_msg_interval: int = 0,
                                qos_type: Optional[QOSType] = None,
                                bw_obj: Optional[QOSBandwidthControl] = None,
                                ops_obj: Optional[QOSOpsControl] = None) -> None:
@@ -491,6 +509,8 @@ class NFSCluster:
             cluster_id=cluster_id,
             qos_obj=qos_obj,
             enable_qos=enable_qos,
+            enable_cluster_qos=enable_cluster_qos,
+            clust_qos_msg_interval=clust_qos_msg_interval,
             qos_type=qos_type,
             bw_obj=bw_obj,
             ops_obj=ops_obj
@@ -500,12 +520,15 @@ class NFSCluster:
                            cluster_id: str,
                            qos_obj: Optional[QOS],
                            enable_qos: bool,
+                           enable_cluster_qos: Optional[bool] = None,
+                           clust_qos_msg_interval: int = 0,
                            qos_type: Optional[QOSType] = None,
                            bw_obj: Optional[QOSBandwidthControl] = None,
                            ops_obj: Optional[QOSOpsControl] = None) -> None:
         try:
             if cluster_id in available_clusters(self.mgr):
-                self.update_cluster_qos_obj(cluster_id, qos_obj, enable_qos, qos_type, bw_obj, ops_obj)
+                self.update_cluster_qos_obj(cluster_id, qos_obj, enable_qos, enable_cluster_qos,
+                                            clust_qos_msg_interval, qos_type, bw_obj, ops_obj)
                 restart_nfs_service(self.mgr, cluster_id)
                 return
             raise ClusterNotFound()
@@ -565,7 +588,14 @@ class NFSCluster:
             if qos_obj:
                 self.validate_qos_type(qos_obj, qos_type, bw_obj=bw_obj)
             bw_obj.qos_bandwidth_checks(qos_type)
-            self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, bw_obj=bw_obj)
+            self.update_cluster_qos(
+                cluster_id,
+                qos_obj,
+                True,
+                enable_cluster_qos=True,
+                qos_type=qos_type,
+                bw_obj=bw_obj
+            )
             log.info(f"QoS bandwidth control has been successfully enabled for cluster {cluster_id}. "
                      "If the qos_type is changed during this process, ensure that the bandwidth "
                      "values for all exports are updated accordingly.")
@@ -589,11 +619,17 @@ class NFSCluster:
             qos_obj = self.get_cluster_qos_config(cluster_id)
             status = False
             qos_type = None
+            enable_cluster_qos = None
+            clust_qos_msg_interval = 0
             if qos_obj:
                 status = qos_obj.get_enable_qos_val(disable_bw=True)
                 if status:
                     qos_type = qos_obj.qos_type
-            self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, bw_obj=QOSBandwidthControl())
+                    enable_cluster_qos = qos_obj.enable_cluster_qos
+                    if qos_obj.clust_qos_msg_interval:
+                        clust_qos_msg_interval = qos_obj.clust_qos_msg_interval
+            self.update_cluster_qos(cluster_id, qos_obj, status, enable_cluster_qos,
+                                    clust_qos_msg_interval, qos_type=qos_type, bw_obj=QOSBandwidthControl())
             log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
                      f"cluster {cluster_id}. As a result, export-level bandwidth control will "
                      "no longer have any effect, even if enabled.")
@@ -608,7 +644,14 @@ class NFSCluster:
             if qos_obj:
                 self.validate_qos_type(qos_obj, qos_type, ops_obj=ops_obj)
             ops_obj.qos_ops_checks(qos_type)
-            self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, ops_obj=ops_obj)
+            self.update_cluster_qos(
+                cluster_id,
+                qos_obj,
+                True,
+                enable_cluster_qos=True,
+                qos_type=qos_type,
+                ops_obj=ops_obj
+            )
             log.info(f"QOS IOPS control has been successfully enabled for cluster {cluster_id}. "
                      "If the qos_type is changed during this process, ensure that ops count "
                      "values for all exports are updated accordingly.")
@@ -622,15 +665,58 @@ class NFSCluster:
             qos_obj = self.get_cluster_qos_config(cluster_id)
             status = False
             qos_type = None
+            enable_cluster_qos = None
+            clust_qos_msg_interval = 0
             if qos_obj:
                 status = qos_obj.get_enable_qos_val(disable_ops=True)
                 if status:
                     qos_type = qos_obj.qos_type
-            self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, ops_obj=QOSOpsControl())
+                    enable_cluster_qos = qos_obj.enable_cluster_qos
+                    if qos_obj.clust_qos_msg_interval:
+                        clust_qos_msg_interval = qos_obj.clust_qos_msg_interval
+            self.update_cluster_qos(cluster_id, qos_obj, status, enable_cluster_qos,
+                                    clust_qos_msg_interval, qos_type=qos_type, ops_obj=QOSOpsControl())
             log.info("Cluster-level QoS IOPS control has been successfully disabled for "
                      f"cluster {cluster_id}. As a result, export-level ops control will "
                      "no longer have any effect, even if enabled.")
             return
         except Exception as e:
             log.exception(f"Setting NFS-Ganesha QoS IOPS control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def global_cluster_qos_action(
+        self,
+        cluster_id: str,
+        action: str,
+        msg_interval: int = 0
+    ) -> None:
+        try:
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            if not qos_obj:
+                err_msg = f'No existing QoS configuration found for cluster {cluster_id}. Can not {action} cluster-qos'
+                log.error(err_msg)
+                raise Exception(err_msg)
+
+            clust_qos_msg_interval = 0
+            if action == 'enable':
+                if (qos_obj.enable_cluster_qos or qos_obj.enable_cluster_qos is None) and not msg_interval:
+                    log.info('Cluster QoS is already enabled')
+                    return
+
+                enable_cluster_qos = True
+                clust_qos_msg_interval = msg_interval
+            else:  # disable
+                enable_cluster_qos = False
+            self.update_cluster_qos(
+                cluster_id=cluster_id,
+                qos_obj=qos_obj,
+                enable_qos=qos_obj.enable_qos,
+                enable_cluster_qos=enable_cluster_qos,
+                clust_qos_msg_interval=clust_qos_msg_interval,
+                qos_type=qos_obj.qos_type
+            )
+            action_past = "enabled" if action == "enable" else "disabled"
+            log.info(f"Cluster-level QoS has been successfully {action_past} for cluster {cluster_id}")
+        except Exception as e:
+            log.exception(f"Failed to {action} cluster-level QoS for cluster {cluster_id}")
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -3,7 +3,6 @@ import logging
 import re
 import socket
 from typing import cast, Dict, List, Any, Union, Optional, TYPE_CHECKING
-from enum import Enum
 
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
@@ -38,11 +37,6 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
-
-
-class ClusterQosAction(Enum):
-    enable = 'enable'
-    disable = 'disable'
 
 
 def resolve_ip(hostname: str) -> str:
@@ -80,9 +74,7 @@ def config_cluster_qos_from_dict(
     if not qos_type:
         raise NFSInvalidOperation('qos_type is not specified in qos dict')
     qos_type = QOSType[str(qos_type)]
-    enable_cluster_qos = qos_dict.get(QOSParams.enable_cluster_qos.value, True)
     clust_qos_msg_interval = int(qos_dict.get(QOSParams.clust_qos_msg_interval.value, 0))
-    assert isinstance(enable_cluster_qos, (bool, type(None)))
     enable_bw_ctrl = qos_dict.get(QOSParams.enable_bw_ctrl.value)
     combined_bw_ctrl = qos_dict.get(QOSParams.combined_bw_ctrl.value)
     enable_iops_ctrl = qos_dict.get(QOSParams.enable_iops_ctrl.value)
@@ -112,7 +104,6 @@ def config_cluster_qos_from_dict(
         cluster_id=cluster_id,
         qos_obj=None,
         enable_qos=True,
-        enable_cluster_qos=enable_cluster_qos,
         clust_qos_msg_interval=clust_qos_msg_interval,
         qos_type=qos_type,
         bw_obj=bw_obj,
@@ -126,7 +117,6 @@ def write_cluster_qos_obj(
     cluster_id: str,
     qos_obj: Optional[QOS],
     enable_qos: bool,
-    enable_cluster_qos: Optional[bool] = None,
     clust_qos_msg_interval: int = 0,
     qos_type: Optional[QOSType] = None,
     bw_obj: Optional[QOSBandwidthControl] = None,
@@ -136,12 +126,11 @@ def write_cluster_qos_obj(
     qos_obj_exists = False
     if not qos_obj:
         log.debug(f"Creating new QoS block for cluster {cluster_id}")
-        qos_obj = QOS(True, enable_qos, enable_cluster_qos, clust_qos_msg_interval, qos_type, bw_obj, ops_obj)
+        qos_obj = QOS(True, enable_qos, clust_qos_msg_interval, qos_type, bw_obj, ops_obj)
     else:
         log.debug(f"Updating existing QoS block for cluster {cluster_id}")
         qos_obj_exists = True
         qos_obj.enable_qos = enable_qos
-        qos_obj.enable_cluster_qos = enable_cluster_qos
         qos_obj.clust_qos_msg_interval = validate_clust_qos_msg_interval(clust_qos_msg_interval)
         qos_obj.qos_type = qos_type
         if bw_obj:
@@ -498,7 +487,6 @@ class NFSCluster:
                                cluster_id: str,
                                qos_obj: Optional[QOS],
                                enable_qos: bool,
-                               enable_cluster_qos: Optional[bool] = None,
                                clust_qos_msg_interval: int = 0,
                                qos_type: Optional[QOSType] = None,
                                bw_obj: Optional[QOSBandwidthControl] = None,
@@ -509,7 +497,6 @@ class NFSCluster:
             cluster_id=cluster_id,
             qos_obj=qos_obj,
             enable_qos=enable_qos,
-            enable_cluster_qos=enable_cluster_qos,
             clust_qos_msg_interval=clust_qos_msg_interval,
             qos_type=qos_type,
             bw_obj=bw_obj,
@@ -520,14 +507,13 @@ class NFSCluster:
                            cluster_id: str,
                            qos_obj: Optional[QOS],
                            enable_qos: bool,
-                           enable_cluster_qos: Optional[bool] = None,
                            clust_qos_msg_interval: int = 0,
                            qos_type: Optional[QOSType] = None,
                            bw_obj: Optional[QOSBandwidthControl] = None,
                            ops_obj: Optional[QOSOpsControl] = None) -> None:
         try:
             if cluster_id in available_clusters(self.mgr):
-                self.update_cluster_qos_obj(cluster_id, qos_obj, enable_qos, enable_cluster_qos,
+                self.update_cluster_qos_obj(cluster_id, qos_obj, enable_qos,
                                             clust_qos_msg_interval, qos_type, bw_obj, ops_obj)
                 restart_nfs_service(self.mgr, cluster_id)
                 return
@@ -592,7 +578,6 @@ class NFSCluster:
                 cluster_id,
                 qos_obj,
                 True,
-                enable_cluster_qos=True,
                 qos_type=qos_type,
                 bw_obj=bw_obj
             )
@@ -619,16 +604,14 @@ class NFSCluster:
             qos_obj = self.get_cluster_qos_config(cluster_id)
             status = False
             qos_type = None
-            enable_cluster_qos = None
             clust_qos_msg_interval = 0
             if qos_obj:
                 status = qos_obj.get_enable_qos_val(disable_bw=True)
                 if status:
                     qos_type = qos_obj.qos_type
-                    enable_cluster_qos = qos_obj.enable_cluster_qos
                     if qos_obj.clust_qos_msg_interval:
                         clust_qos_msg_interval = qos_obj.clust_qos_msg_interval
-            self.update_cluster_qos(cluster_id, qos_obj, status, enable_cluster_qos,
+            self.update_cluster_qos(cluster_id, qos_obj, status,
                                     clust_qos_msg_interval, qos_type=qos_type, bw_obj=QOSBandwidthControl())
             log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
                      f"cluster {cluster_id}. As a result, export-level bandwidth control will "
@@ -648,7 +631,6 @@ class NFSCluster:
                 cluster_id,
                 qos_obj,
                 True,
-                enable_cluster_qos=True,
                 qos_type=qos_type,
                 ops_obj=ops_obj
             )
@@ -665,16 +647,14 @@ class NFSCluster:
             qos_obj = self.get_cluster_qos_config(cluster_id)
             status = False
             qos_type = None
-            enable_cluster_qos = None
             clust_qos_msg_interval = 0
             if qos_obj:
                 status = qos_obj.get_enable_qos_val(disable_ops=True)
                 if status:
                     qos_type = qos_obj.qos_type
-                    enable_cluster_qos = qos_obj.enable_cluster_qos
                     if qos_obj.clust_qos_msg_interval:
                         clust_qos_msg_interval = qos_obj.clust_qos_msg_interval
-            self.update_cluster_qos(cluster_id, qos_obj, status, enable_cluster_qos,
+            self.update_cluster_qos(cluster_id, qos_obj, status,
                                     clust_qos_msg_interval, qos_type=qos_type, ops_obj=QOSOpsControl())
             log.info("Cluster-level QoS IOPS control has been successfully disabled for "
                      f"cluster {cluster_id}. As a result, export-level ops control will "
@@ -684,39 +664,26 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QoS IOPS control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def global_cluster_qos_action(
+    def cluster_qos_set_config(
         self,
         cluster_id: str,
-        action: str,
         msg_interval: int = 0
     ) -> None:
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
             if not qos_obj:
-                err_msg = f'No existing QoS configuration found for cluster {cluster_id}. Can not {action} cluster-qos'
+                err_msg = f'No existing QoS configuration found for cluster {cluster_id}.'
                 log.error(err_msg)
                 raise Exception(err_msg)
 
-            clust_qos_msg_interval = 0
-            if action == 'enable':
-                if (qos_obj.enable_cluster_qos or qos_obj.enable_cluster_qos is None) and not msg_interval:
-                    log.info('Cluster QoS is already enabled')
-                    return
-
-                enable_cluster_qos = True
-                clust_qos_msg_interval = msg_interval
-            else:  # disable
-                enable_cluster_qos = False
             self.update_cluster_qos(
                 cluster_id=cluster_id,
                 qos_obj=qos_obj,
                 enable_qos=qos_obj.enable_qos,
-                enable_cluster_qos=enable_cluster_qos,
-                clust_qos_msg_interval=clust_qos_msg_interval,
+                clust_qos_msg_interval=msg_interval,
                 qos_type=qos_obj.qos_type
             )
-            action_past = "enabled" if action == "enable" else "disabled"
-            log.info(f"Cluster-level QoS has been successfully {action_past} for cluster {cluster_id}")
+            log.info("Cluster-level QoS config updated successfully for cluster %s", cluster_id)
         except Exception as e:
-            log.exception(f"Failed to {action} cluster-level QoS for cluster {cluster_id}")
+            log.exception("Failed to update cluster-level QoS config for cluster %s", cluster_id)
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -937,10 +937,10 @@ class ExportMgr:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def get_export_qos(self, cluster_id: str, pseudo_path: str) -> Dict[str, int]:
+    def get_export_qos(self, cluster_id: str, pseudo_path: str, ret_bw_in_bytes: bool = False) -> Dict[str, int]:
         try:
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
-            return export_obj.qos_block.to_dict() if export_obj.qos_block else {}
+            return export_obj.qos_block.to_dict(ret_bw_in_bytes) if export_obj.qos_block else {}
         except Exception as e:
             log.exception(f"Failed to get QOS configuration for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -864,7 +864,11 @@ class ExportMgr:
 
         # check QOS
         if new_export_dict.get('qos_block'):
-            export_dict_qos_bw_ops_checks(cluster_id, self.mgr, dict(new_export_dict.get('qos_block', {})))
+            old_qos = {}
+            if old_export.qos_block:
+                old_qos = old_export.qos_block.to_dict()
+            export_dict_qos_bw_ops_checks(cluster_id, self.mgr, dict(new_export_dict.get('qos_block', {})),
+                                          old_qos)
 
         self.exports[cluster_id].remove(old_export)
 

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -898,13 +898,13 @@ class ExportMgr:
                           enable_qos: bool,
                           bw_obj: Optional[QOSBandwidthControl] = None,
                           ops_obj: Optional[QOSOpsControl] = None) -> None:
-        """Update Export QOS block"""
+        """Update Export QoS block"""
         # if qos_block does not exists in export create one else update existing block
         if not export_obj.qos_block:
-            log.debug(f"Creating new QOS block for export {pseudo_path} of cluster {cluster_id}")
+            log.debug(f"Creating new QoS block for export {pseudo_path} of cluster {cluster_id}")
             export_obj.qos_block = QOS(enable_qos=enable_qos, bw_obj=bw_obj, ops_obj=ops_obj)
         else:
-            log.debug(f"Updating existing QOS block of export {pseudo_path} of cluster {cluster_id}")
+            log.debug(f"Updating existing QoS block of export {pseudo_path} of cluster {cluster_id}")
             export_obj.qos_block.enable_qos = enable_qos
             if bw_obj:
                 export_obj.qos_block.bw_obj = bw_obj
@@ -913,7 +913,7 @@ class ExportMgr:
 
         self.exports[cluster_id].remove(export_obj)
         self._update_export(cluster_id, export_obj, False)
-        log.debug(f"Successfully updated QOS control config for export {pseudo_path} of cluster {cluster_id}")
+        log.debug(f"Successfully updated QoS control config for export {pseudo_path} of cluster {cluster_id}")
 
     def get_export_obj(self, cluster_id: str, pseudo_path: str) -> Export:
         self._validate_cluster_id(cluster_id)
@@ -943,9 +943,9 @@ class ExportMgr:
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
             export_qos_bw_checks(cluster_id, self.mgr, bw_obj=bw_obj)
             self.update_export_qos(cluster_id, pseudo_path, export_obj, True, bw_obj=bw_obj)
-            log.debug(f"Successfully enabled QOS bandwidth control for export {pseudo_path} of cluster {cluster_id}")
+            log.debug(f"Successfully enabled QoS bandwidth control for export {pseudo_path} of cluster {cluster_id}")
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS bandwidth control failed for {pseudo_path} of {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QoS bandwidth control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def get_export_qos(self, cluster_id: str, pseudo_path: str, ret_bw_in_bytes: bool = False) -> Dict[str, int]:
@@ -966,7 +966,7 @@ class ExportMgr:
                 return qos_block
             return {}
         except Exception as e:
-            log.exception(f"Failed to get QOS configuration for {pseudo_path} of {cluster_id}")
+            log.exception(f"Failed to get QoS configuration for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def disable_export_qos_bw(self, cluster_id: str, pseudo_path: str) -> None:
@@ -975,9 +975,9 @@ class ExportMgr:
             if export_obj.qos_block:
                 status = export_obj.qos_block.get_enable_qos_val(disable_bw=True)
             self.update_export_qos(cluster_id, pseudo_path, export_obj, status, bw_obj=QOSBandwidthControl())
-            log.debug(f"Successfully disabled QOS bandwidth control for export {pseudo_path} of cluster {cluster_id}")
+            log.debug(f"Successfully disabled QoS bandwidth control for export {pseudo_path} of cluster {cluster_id}")
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS bandwidth control failed for {pseudo_path} of {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QoS bandwidth control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def enable_export_qos_ops(self, cluster_id: str, pseudo_path: str, ops_obj: QOSOpsControl) -> None:
@@ -985,9 +985,9 @@ class ExportMgr:
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
             export_qos_ops_checks(cluster_id, self.mgr, ops_obj=ops_obj)
             self.update_export_qos(cluster_id, pseudo_path, export_obj, True, ops_obj=ops_obj)
-            log.debug(f"Successfully enabled QOS IOPS control for export {pseudo_path} of cluster {cluster_id}")
+            log.debug(f"Successfully enabled QoS IOPS control for export {pseudo_path} of cluster {cluster_id}")
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS IOPS control failed for {pseudo_path} of {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QoS IOPS control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def disable_export_qos_ops(self, cluster_id: str, pseudo_path: str) -> None:
@@ -998,9 +998,9 @@ class ExportMgr:
             if export_obj.qos_block:
                 status = export_obj.qos_block.get_enable_qos_val(disable_ops=True)
             self.update_export_qos(cluster_id, pseudo_path, export_obj, status, ops_obj=QOSOpsControl())
-            log.debug(f"Successfully updated QOS IOPS control for export {pseudo_path} of cluster {cluster_id}")
+            log.debug(f"Successfully updated QoS IOPS control for export {pseudo_path} of cluster {cluster_id}")
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS IOPS control failed for {pseudo_path} of {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QoS IOPS control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
 

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -28,8 +28,8 @@ from .ganesha_conf import (
     GaneshaConfParser,
     RGWFSAL,
     format_block)
-from .qos_conf import QOS, QOSBandwidthControl
-from .export_utils import export_qos_bw_checks, export_dict_qos_checks
+from .qos_conf import QOS, QOSBandwidthControl, QOSOpsControl
+from .export_utils import export_qos_bw_checks, export_dict_qos_bw_ops_checks, export_qos_ops_checks
 from .exception import NFSException, NFSInvalidOperation, FSNotFound, NFSObjectNotFound
 from .utils import (
     EXPORT_PREFIX,
@@ -860,7 +860,7 @@ class ExportMgr:
 
         # check QOS
         if new_export_dict.get('qos_block'):
-            export_dict_qos_checks(cluster_id, self.mgr, dict(new_export_dict.get('qos_block', {})))
+            export_dict_qos_bw_ops_checks(cluster_id, self.mgr, dict(new_export_dict.get('qos_block', {})))
 
         self.exports[cluster_id].remove(old_export)
 
@@ -880,27 +880,36 @@ class ExportMgr:
                 exports_count += 1
         return exports_count
 
-    def update_export_qos_bw(self,
-                             cluster_id: str,
-                             pseudo_path: str,
-                             enable_qos: bool,
-                             bw_obj: QOSBandwidthControl) -> None:
+    def update_export_qos(self,
+                          cluster_id: str,
+                          pseudo_path: str,
+                          export_obj: Export,
+                          enable_qos: bool,
+                          bw_obj: Optional[QOSBandwidthControl] = None,
+                          ops_obj: Optional[QOSOpsControl] = None) -> None:
         """Update Export QOS block"""
+        # if qos_block does not exists in export create one else update existing block
+        if not export_obj.qos_block:
+            log.debug(f"Creating new QOS block for export {pseudo_path} of cluster {cluster_id}")
+            export_obj.qos_block = QOS(enable_qos=enable_qos, bw_obj=bw_obj, ops_obj=ops_obj)
+        else:
+            log.debug(f"Updating existing QOS block of export {pseudo_path} of cluster {cluster_id}")
+            export_obj.qos_block.enable_qos = enable_qos
+            if bw_obj:
+                export_obj.qos_block.bw_obj = bw_obj
+            if ops_obj:
+                export_obj.qos_block.ops_obj = ops_obj
+
+        self.exports[cluster_id].remove(export_obj)
+        self._update_export(cluster_id, export_obj, False)
+        log.debug(f"Successfully updated QOS control config for export {pseudo_path} of cluster {cluster_id}")
+
+    def get_export_obj(self, cluster_id: str, pseudo_path: str) -> Export:
+        self._validate_cluster_id(cluster_id)
         export = self._fetch_export(cluster_id, pseudo_path)
         if not export:
             raise NFSObjectNotFound(f"Export {pseudo_path} not found in NFS cluster {cluster_id}")
-        # if qos_block does not exists in export create one else update existing block
-        if not export.qos_block:
-            log.debug(f"Creating new QOS block for export {pseudo_path} of cluster {cluster_id}")
-            export.qos_block = QOS(enable_qos=enable_qos, bw_obj=bw_obj)
-        else:
-            log.debug(f"Updating existing QOS block of export {pseudo_path} of cluster {cluster_id}")
-            export.qos_block.enable_qos = enable_qos
-            export.qos_block.bw_obj = bw_obj
-
-        self.exports[cluster_id].remove(export)
-        self._update_export(cluster_id, export, False)
-        log.debug(f"Successfully updated QOS bandwidth control config for export {pseudo_path} of cluster {cluster_id}")
+        return export
 
     def enable_export_qos_bw(self,
                              cluster_id: str,
@@ -920,32 +929,54 @@ class ExportMgr:
             c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory
         """
         try:
-            self._validate_cluster_id(cluster_id)
-            assert pseudo_path
+            export_obj = self.get_export_obj(cluster_id, pseudo_path)
             export_qos_bw_checks(cluster_id, self.mgr, bw_obj=bw_obj)
-            self.update_export_qos_bw(cluster_id, pseudo_path, True, bw_obj)
+            self.update_export_qos(cluster_id, pseudo_path, export_obj, True, bw_obj=bw_obj)
+            log.debug(f"Successfully enabled QOS bandwidth control for export {pseudo_path} of cluster {cluster_id}")
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {pseudo_path} of {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def get_export_qos(self, cluster_id: str, pseudo_path: str) -> Dict[str, int]:
         try:
-            self._validate_cluster_id(cluster_id)
-            export = self._fetch_export(cluster_id, pseudo_path)
-            if not export:
-                raise NFSObjectNotFound(f"Export {pseudo_path} not found in NFS cluster {cluster_id}")
-            return export.qos_block.to_dict() if export.qos_block else {}
+            export_obj = self.get_export_obj(cluster_id, pseudo_path)
+            return export_obj.qos_block.to_dict() if export_obj.qos_block else {}
         except Exception as e:
             log.exception(f"Failed to get QOS configuration for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
     def disable_export_qos_bw(self, cluster_id: str, pseudo_path: str) -> None:
         try:
-            self._validate_cluster_id(cluster_id)
-            assert pseudo_path
-            self.update_export_qos_bw(cluster_id, pseudo_path, False, QOSBandwidthControl())
+            export_obj = self.get_export_obj(cluster_id, pseudo_path)
+            if export_obj.qos_block:
+                status = export_obj.qos_block.get_enable_qos_val(disable_bw=True)
+            self.update_export_qos(cluster_id, pseudo_path, export_obj, status, bw_obj=QOSBandwidthControl())
+            log.debug(f"Successfully disabled QOS bandwidth control for export {pseudo_path} of cluster {cluster_id}")
         except Exception as e:
-            log.exception(f"Setting NFS-Ganesha QOS bandwidth control Config failed for {pseudo_path} of {cluster_id}")
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control failed for {pseudo_path} of {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def enable_export_qos_ops(self, cluster_id: str, pseudo_path: str, ops_obj: QOSOpsControl) -> None:
+        try:
+            export_obj = self.get_export_obj(cluster_id, pseudo_path)
+            export_qos_ops_checks(cluster_id, self.mgr, ops_obj=ops_obj)
+            self.update_export_qos(cluster_id, pseudo_path, export_obj, True, ops_obj=ops_obj)
+            log.debug(f"Successfully enabled QOS IOPS control for export {pseudo_path} of cluster {cluster_id}")
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS IOPS control failed for {pseudo_path} of {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def disable_export_qos_ops(self, cluster_id: str, pseudo_path: str) -> None:
+        try:
+            export_obj = self.get_export_obj(cluster_id, pseudo_path)
+            if not export_obj:
+                raise NFSObjectNotFound(f"Export {pseudo_path} not found in NFS cluster {cluster_id}")
+            if export_obj.qos_block:
+                status = export_obj.qos_block.get_enable_qos_val(disable_ops=True)
+            self.update_export_qos(cluster_id, pseudo_path, export_obj, status, ops_obj=QOSOpsControl())
+            log.debug(f"Successfully updated QOS IOPS control for export {pseudo_path} of cluster {cluster_id}")
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS IOPS control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
 

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -17,7 +17,7 @@ from ceph.fs.earmarking import EarmarkTopScope
 import cephfs
 
 from mgr_util import CephFSEarmarkResolver
-from rados import TimedOut, ObjectNotFound, Rados
+from rados import TimedOut, ObjectNotFound
 
 from object_format import ErrorResponse
 from mgr_module import NFS_POOL_NAME as POOL_NAME, NFS_GANESHA_SUPPORTED_FSALS
@@ -27,13 +27,13 @@ from .ganesha_conf import (
     Export,
     GaneshaConfParser,
     RGWFSAL,
-    RawBlock,
     format_block)
+from .qos_conf import QOS, QOSBandwidthControl
+from .export_utils import export_qos_bw_checks, export_dict_qos_checks
 from .exception import NFSException, NFSInvalidOperation, FSNotFound, NFSObjectNotFound
 from .utils import (
     EXPORT_PREFIX,
     NonFatalError,
-    USER_CONF_PREFIX,
     export_obj_name,
     conf_obj_name,
     available_clusters,
@@ -41,6 +41,7 @@ from .utils import (
     get_nfs_spec_for_cluster,
     restart_nfs_service,
     cephfs_path_is_dir)
+from .rados_utils import NFSRados
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -88,79 +89,6 @@ def _validate_cmount_path(cmount_path: str, path: str) -> None:
             f"Please ensure that the cmount_path includes the specified path '{path}'. "
             "It is allowed to be any complete path hierarchy between / and the EXPORT {path}."
         )
-
-
-class NFSRados:
-    def __init__(self, rados: 'Rados', namespace: str) -> None:
-        self.rados = rados
-        self.pool = POOL_NAME
-        self.namespace = namespace
-
-    def _make_rados_url(self, obj: str) -> str:
-        return "rados://{}/{}/{}".format(self.pool, self.namespace, obj)
-
-    def _create_url_block(self, obj_name: str) -> RawBlock:
-        return RawBlock('%url', values={'value': self._make_rados_url(obj_name)})
-
-    def write_obj(self, conf_block: str, obj: str, config_obj: str = '') -> None:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            ioctx.write_full(obj, conf_block.encode('utf-8'))
-            if not config_obj:
-                # Return after creating empty common config object
-                return
-            log.debug("write configuration into rados object %s/%s/%s",
-                      self.pool, self.namespace, obj)
-
-            # Add created obj url to common config obj
-            ioctx.append(config_obj, format_block(
-                         self._create_url_block(obj)).encode('utf-8'))
-            _check_rados_notify(ioctx, config_obj)
-            log.debug("Added %s url to %s", obj, config_obj)
-
-    def read_obj(self, obj: str) -> Optional[str]:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            try:
-                return ioctx.read(obj, 1048576).decode()
-            except ObjectNotFound:
-                return None
-
-    def update_obj(self, conf_block: str, obj: str, config_obj: str,
-                   should_notify: Optional[bool] = True) -> None:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            ioctx.write_full(obj, conf_block.encode('utf-8'))
-            log.debug("write configuration into rados object %s/%s/%s",
-                      self.pool, self.namespace, obj)
-            if should_notify:
-                _check_rados_notify(ioctx, config_obj)
-            log.debug("Update export %s in %s", obj, config_obj)
-
-    def remove_obj(self, obj: str, config_obj: str) -> None:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            export_urls = ioctx.read(config_obj)
-            url = '%url "{}"\n\n'.format(self._make_rados_url(obj))
-            export_urls = export_urls.replace(url.encode('utf-8'), b'')
-            ioctx.remove_object(obj)
-            ioctx.write_full(config_obj, export_urls)
-            _check_rados_notify(ioctx, config_obj)
-            log.debug("Object deleted: %s", url)
-
-    def remove_all_obj(self) -> None:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            for obj in ioctx.list_objects():
-                obj.remove()
-
-    def check_user_config(self) -> bool:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            for obj in ioctx.list_objects():
-                if obj.key.startswith(USER_CONF_PREFIX):
-                    return True
-        return False
 
 
 class AppliedExportResults:
@@ -930,6 +858,10 @@ class ExportMgr:
             elif old_rgw_fsal.secret_access_key != new_rgw_fsal.secret_access_key:
                 raise NFSInvalidOperation('secret_access_key change is not allowed')
 
+        # check QOS
+        if new_export_dict.get('qos_block'):
+            export_dict_qos_checks(cluster_id, self.mgr, dict(new_export_dict.get('qos_block', {})))
+
         self.exports[cluster_id].remove(old_export)
 
         self._update_export(cluster_id, new_export, need_nfs_service_restart)
@@ -947,6 +879,74 @@ class ExportMgr:
             if export['fsal']['name'] == 'CEPH' and export['fsal']['cmount_path'] == cmount_path and export['fsal']['fs_name'] == fs_name:
                 exports_count += 1
         return exports_count
+
+    def update_export_qos_bw(self,
+                             cluster_id: str,
+                             pseudo_path: str,
+                             enable_qos: bool,
+                             bw_obj: QOSBandwidthControl) -> None:
+        """Update Export QOS block"""
+        export = self._fetch_export(cluster_id, pseudo_path)
+        if not export:
+            raise NFSObjectNotFound(f"Export {pseudo_path} not found in NFS cluster {cluster_id}")
+        # if qos_block does not exists in export create one else update existing block
+        if not export.qos_block:
+            log.debug(f"Creating new QOS block for export {pseudo_path} of cluster {cluster_id}")
+            export.qos_block = QOS(enable_qos=enable_qos, bw_obj=bw_obj)
+        else:
+            log.debug(f"Updating existing QOS block of export {pseudo_path} of cluster {cluster_id}")
+            export.qos_block.enable_qos = enable_qos
+            export.qos_block.bw_obj = bw_obj
+
+        self.exports[cluster_id].remove(export)
+        self._update_export(cluster_id, export, False)
+        log.debug(f"Successfully updated QOS bandwidth control config for export {pseudo_path} of cluster {cluster_id}")
+
+    def enable_export_qos_bw(self,
+                             cluster_id: str,
+                             pseudo_path: str,
+                             bw_obj: QOSBandwidthControl
+                             ) -> None:
+        """
+        There are 2 cases to consider, based on QOS type set on cluster level
+        1. If combined bandwith control is disabled
+            a. If qos_type is pershare, then export_writebw and export_readbw parameters are compulsory
+            b. If qos_type is perclient, then can't enable export level qos
+            c. If qos_type is pershare_perclient then export_writebw, export_readbw, client_writebw and
+               client_readbw are compulsory parameters
+        2. If combined bandwidth control is enabled
+            a. If qos_type is pershare, then export_rw_bw parameter is compulsory
+            b. If qos_type is perclient, then can't enable export level qos
+            c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory
+        """
+        try:
+            self._validate_cluster_id(cluster_id)
+            assert pseudo_path
+            export_qos_bw_checks(cluster_id, self.mgr, bw_obj=bw_obj)
+            self.update_export_qos_bw(cluster_id, pseudo_path, True, bw_obj)
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {pseudo_path} of {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def get_export_qos(self, cluster_id: str, pseudo_path: str) -> Dict[str, int]:
+        try:
+            self._validate_cluster_id(cluster_id)
+            export = self._fetch_export(cluster_id, pseudo_path)
+            if not export:
+                raise NFSObjectNotFound(f"Export {pseudo_path} not found in NFS cluster {cluster_id}")
+            return export.qos_block.to_dict() if export.qos_block else {}
+        except Exception as e:
+            log.exception(f"Failed to get QOS configuration for {pseudo_path} of {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def disable_export_qos_bw(self, cluster_id: str, pseudo_path: str) -> None:
+        try:
+            self._validate_cluster_id(cluster_id)
+            assert pseudo_path
+            self.update_export_qos_bw(cluster_id, pseudo_path, False, QOSBandwidthControl())
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS bandwidth control Config failed for {pseudo_path} of {cluster_id}")
+            raise ErrorResponse.wrap(e)
 
 
 def get_user_id(cluster_id: str, fs_name: str, cmount_path: str) -> str:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -28,8 +28,12 @@ from .ganesha_conf import (
     GaneshaConfParser,
     RGWFSAL,
     format_block)
-from .qos_conf import QOS, QOSBandwidthControl, QOSOpsControl
-from .export_utils import export_qos_bw_checks, export_dict_qos_bw_ops_checks, export_qos_ops_checks
+from .qos_conf import QOS, QOSBandwidthControl, QOSOpsControl, QOSParams
+from .export_utils import (
+    export_qos_bw_checks,
+    export_dict_qos_bw_ops_checks,
+    export_qos_ops_checks,
+    get_cluster_qos_config)
 from .exception import NFSException, NFSInvalidOperation, FSNotFound, NFSObjectNotFound
 from .utils import (
     EXPORT_PREFIX,
@@ -939,8 +943,21 @@ class ExportMgr:
 
     def get_export_qos(self, cluster_id: str, pseudo_path: str, ret_bw_in_bytes: bool = False) -> Dict[str, int]:
         try:
+            clust_qos_obj = get_cluster_qos_config(cluster_id, self.mgr)
+            clust_qos_conf = {}
+            if clust_qos_obj:
+                clust_qos_conf[f'cluster_{QOSParams.enable_qos.value}'] = clust_qos_obj.enable_qos
+                if clust_qos_obj.bw_obj:
+                    clust_qos_conf[f'cluster_{QOSParams.enable_bw_ctrl.value}'] = clust_qos_obj.bw_obj.enable_bw_ctrl
+                if clust_qos_obj.ops_obj:
+                    clust_qos_conf[f'cluster_{QOSParams.enable_iops_ctrl.value}'] = clust_qos_obj.ops_obj.enable_iops_ctrl
+
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
-            return export_obj.qos_block.to_dict(ret_bw_in_bytes) if export_obj.qos_block else {}
+            if export_obj.qos_block:
+                qos_block = export_obj.qos_block.to_dict(ret_bw_in_bytes)
+                qos_block.update(clust_qos_conf)
+                return qos_block
+            return {}
         except Exception as e:
             log.exception(f"Failed to get QOS configuration for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -953,11 +953,11 @@ class ExportMgr:
             clust_qos_obj = get_cluster_qos_config(cluster_id, self.mgr)
             clust_qos_conf = {}
             if clust_qos_obj:
-                clust_qos_conf[f'cluster_{QOSParams.enable_qos.value}'] = clust_qos_obj.enable_qos
+                clust_qos_conf[f'global_{QOSParams.enable_qos.value}'] = clust_qos_obj.enable_qos
                 if clust_qos_obj.bw_obj:
-                    clust_qos_conf[f'cluster_{QOSParams.enable_bw_ctrl.value}'] = clust_qos_obj.bw_obj.enable_bw_ctrl
+                    clust_qos_conf[f'global_{QOSParams.enable_bw_ctrl.value}'] = clust_qos_obj.bw_obj.enable_bw_ctrl
                 if clust_qos_obj.ops_obj:
-                    clust_qos_conf[f'cluster_{QOSParams.enable_iops_ctrl.value}'] = clust_qos_obj.ops_obj.enable_iops_ctrl
+                    clust_qos_conf[f'global_{QOSParams.enable_iops_ctrl.value}'] = clust_qos_obj.ops_obj.enable_iops_ctrl
 
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
             if export_obj.qos_block:

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -160,6 +160,7 @@ class ExportMgr:
         self.mgr = mgr
         self.rados_pool = POOL_NAME
         self._exports: Optional[Dict[str, List[Export]]] = export_ls
+        self.skip_notify_nfs_server = False
 
     @property
     def exports(self) -> Dict[str, List[Export]]:
@@ -280,7 +281,8 @@ class ExportMgr:
         self._rados(cluster_id).write_obj(
             format_block(export.to_export_block()),
             export_obj_name(export.export_id),
-            conf_obj_name(export.cluster_id)
+            conf_obj_name(export.cluster_id),
+            (not self.skip_notify_nfs_server)
         )
 
     def _delete_export(
@@ -305,7 +307,8 @@ class ExportMgr:
                         self._delete_export_user(export)
                 if pseudo_path:
                     self._rados(cluster_id).remove_obj(
-                        export_obj_name(export.export_id), conf_obj_name(cluster_id))
+                        export_obj_name(export.export_id), conf_obj_name(cluster_id),
+                        (not self.skip_notify_nfs_server))
                 self.exports[cluster_id].remove(export)
                 if export.fsal.name == NFS_GANESHA_SUPPORTED_FSALS[1]:
                     self._delete_export_user(export)
@@ -339,7 +342,7 @@ class ExportMgr:
         self._rados(cluster_id).update_obj(
             format_block(export.to_export_block()),
             export_obj_name(export.export_id), conf_obj_name(export.cluster_id),
-            should_notify=not need_nfs_service_restart)
+            should_notify=(not need_nfs_service_restart and not self.skip_notify_nfs_server))
         if need_nfs_service_restart:
             restart_nfs_service(self.mgr, export.cluster_id)
 

--- a/src/pybind/mgr/nfs/export_utils.py
+++ b/src/pybind/mgr/nfs/export_utils.py
@@ -68,7 +68,7 @@ def export_dict_qos_bw_ops_checks(cluster_id: str,
     """Validate the qos block of dict passed to apply_export method"""
     qos_enable = qos_dict.get('enable_qos')
     if qos_enable is None:
-        raise Exception('The QOS block requires at least the enable_qos parameter')
+        raise Exception('The QoS block requires at least the enable_qos parameter')
     if not isinstance(qos_enable, bool):
         raise Exception('Invalid value for the enable_qos parameter')
     # if cluster level bandwidth or ops control is disabled or qos type changed to PerClient

--- a/src/pybind/mgr/nfs/export_utils.py
+++ b/src/pybind/mgr/nfs/export_utils.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+from .cluster import NFSCluster
+from .qos_conf import QOSType, QOSParams, QOSBandwidthControl
+
+
+def export_dict_bw_checks(cluster_id: str,
+                          mgr_obj: Any,
+                          qos_enable: bool,
+                          qos_dict: dict) -> None:
+    enable_bw_ctrl = qos_dict.get('enable_bw_control')
+    combined_bw_ctrl = qos_dict.get('combined_rw_bw_control')
+    bandwith_param_exists = any(key.endswith('bw') for key in qos_dict)
+    if enable_bw_ctrl is None:
+        if combined_bw_ctrl and bandwith_param_exists:
+            raise Exception('Bandwidth control is not enabled but associated parameters exists')
+        return
+    if combined_bw_ctrl is None:
+        combined_bw_ctrl = False
+    if not qos_enable and enable_bw_ctrl:
+        raise Exception('To enable bandwidth control, qos_enable should be true.')
+    if not (isinstance(enable_bw_ctrl, bool) and isinstance(combined_bw_ctrl, bool)):
+        raise Exception('Invalid values for the enable_bw_ctrl and combined_bw_ctrl parameters.')
+    # if qos is disabled, then bandwidths should not be set and no need to bandwidth checks
+    if not enable_bw_ctrl:
+        if bandwith_param_exists:
+            raise Exception('Bandwidths should not be passed when enable_bw_control is false.')
+        return
+    if enable_bw_ctrl and not bandwith_param_exists:
+        raise Exception('Bandwidths should be set when enable_bw_control is true.')
+    bw_obj = QOSBandwidthControl(enable_bw_ctrl,
+                                 combined_bw_ctrl,
+                                 export_writebw=qos_dict.get(QOSParams.export_writebw.value, '0'),
+                                 export_readbw=qos_dict.get(QOSParams.export_readbw.value, '0'),
+                                 client_writebw=qos_dict.get(QOSParams.client_writebw.value, '0'),
+                                 client_readbw=qos_dict.get(QOSParams.client_readbw.value, '0'),
+                                 export_rw_bw=qos_dict.get(QOSParams.export_rw_bw.value, '0'),
+                                 client_rw_bw=qos_dict.get(QOSParams.client_rw_bw.value, '0'))
+    export_qos_bw_checks(cluster_id, mgr_obj, bw_obj)
+
+
+def export_dict_qos_checks(cluster_id: str,
+                           mgr_obj: Any,
+                           qos_dict: dict) -> None:
+    """Validate the qos block of dict passed to apply_export method"""
+    qos_enable = qos_dict.get('enable_qos')
+    if qos_enable is None:
+        raise Exception('The QOS block requires at least the enable_qos parameter')
+    if not isinstance(qos_enable, bool):
+        raise Exception('Invalid value for the enable_qos parameter')
+    export_dict_bw_checks(cluster_id, mgr_obj, qos_enable, qos_dict)
+
+
+def export_qos_bw_checks(cluster_id: str,
+                         mgr_obj: Any,
+                         bw_obj: QOSBandwidthControl,
+                         nfs_clust_obj: Any = None) -> None:
+    """check cluster level qos is enabled to enable export level qos and validate bandwidths"""
+    if not nfs_clust_obj:
+        nfs_clust_obj = NFSCluster(mgr_obj)
+    clust_qos_obj = nfs_clust_obj.get_cluster_qos_config(cluster_id)
+    if not clust_qos_obj or (clust_qos_obj and not (clust_qos_obj.enable_qos)):
+        raise Exception('To configure bandwidth control for export, you must first enable bandwidth control at the cluster level.')
+    if clust_qos_obj.qos_type:
+        if clust_qos_obj.qos_type == QOSType.PerClient:
+            raise Exception('Export-level QoS bandwidth control cannot be enabled if the QoS type at the cluster level is set to PerClient.')
+        bw_obj.qos_bandwidth_checks(clust_qos_obj.qos_type)

--- a/src/pybind/mgr/nfs/export_utils.py
+++ b/src/pybind/mgr/nfs/export_utils.py
@@ -1,7 +1,7 @@
-from typing import Any
+from typing import Any, Optional
 
 from .cluster import NFSCluster
-from .qos_conf import QOSType, QOSParams, QOSBandwidthControl, QOSOpsControl
+from .qos_conf import QOSType, QOSParams, QOSBandwidthControl, QOSOpsControl, QOS
 
 
 def export_dict_bw_checks(cluster_id: str,
@@ -109,3 +109,8 @@ def export_qos_ops_checks(cluster_id: str,
         if clust_qos_obj.qos_type == QOSType.PerClient:
             raise Exception(f'Export-level QoS IOPS control cannot be enabled if the QoS type at the cluster {cluster_id} level is set to PerClient.')
         ops_obj.qos_ops_checks(clust_qos_obj.qos_type)
+
+
+def get_cluster_qos_config(cluster_id: str, mgr_obj: Any) -> Optional[QOS]:
+    nfs_clust_obj = NFSCluster(mgr_obj)
+    return nfs_clust_obj.get_cluster_qos_config(cluster_id)

--- a/src/pybind/mgr/nfs/export_utils.py
+++ b/src/pybind/mgr/nfs/export_utils.py
@@ -4,73 +4,88 @@ from .cluster import NFSCluster
 from .qos_conf import QOSType, QOSParams, QOSBandwidthControl, QOSOpsControl, QOS
 
 
-def export_dict_bw_checks(cluster_id: str,
-                          mgr_obj: Any,
-                          qos_enable: bool,
-                          qos_dict: dict) -> None:
-    enable_bw_ctrl = qos_dict.get('enable_bw_control')
-    combined_bw_ctrl = qos_dict.get('combined_rw_bw_control')
-    bandwith_param_exists = any(key.endswith('bw') for key in qos_dict)
+def export_dict_bw_checks(
+    cluster_id: str, mgr_obj: Any, qos_enable: bool, qos_dict: dict
+) -> None:
+    enable_bw_ctrl = qos_dict.get("enable_bw_control")
+    combined_bw_ctrl = qos_dict.get("combined_rw_bw_control")
+    bandwith_param_exists = any(key.endswith("bw") for key in qos_dict)
     if enable_bw_ctrl is None:
         if combined_bw_ctrl and bandwith_param_exists:
-            raise Exception('Bandwidth control is not enabled but associated parameters exists')
+            raise Exception(
+                "Bandwidth control is not enabled but associated parameters exists"
+            )
         return
     if combined_bw_ctrl is None:
         combined_bw_ctrl = False
     if not qos_enable and enable_bw_ctrl:
-        raise Exception('To enable bandwidth control, qos_enable and enable_bw_control should be true.')
+        raise Exception(
+            "To enable bandwidth control, qos_enable and enable_bw_control should be true."
+        )
     if not (isinstance(enable_bw_ctrl, bool) and isinstance(combined_bw_ctrl, bool)):
-        raise Exception('Invalid values for the enable_bw_ctrl and combined_bw_ctrl parameters.')
+        raise Exception(
+            "Invalid values for the enable_bw_ctrl and combined_bw_ctrl parameters."
+        )
     # if qos bandwidth control is disabled, then bandwidths should not be set and no need to bandwidth checks
     if not enable_bw_ctrl:
         if bandwith_param_exists:
-            raise Exception('Bandwidths should not be passed when enable_bw_control is false.')
+            raise Exception(
+                "Bandwidths should not be passed when enable_bw_control is false."
+            )
         return
     if enable_bw_ctrl and not bandwith_param_exists:
-        raise Exception('Bandwidths should be set when enable_bw_control is true.')
-    bw_obj = QOSBandwidthControl(enable_bw_ctrl,
-                                 combined_bw_ctrl,
-                                 export_writebw=qos_dict.get(QOSParams.export_writebw.value, '0'),
-                                 export_readbw=qos_dict.get(QOSParams.export_readbw.value, '0'),
-                                 client_writebw=qos_dict.get(QOSParams.client_writebw.value, '0'),
-                                 client_readbw=qos_dict.get(QOSParams.client_readbw.value, '0'),
-                                 export_rw_bw=qos_dict.get(QOSParams.export_rw_bw.value, '0'),
-                                 client_rw_bw=qos_dict.get(QOSParams.client_rw_bw.value, '0'))
+        raise Exception("Bandwidths should be set when enable_bw_control is true.")
+    bw_obj = QOSBandwidthControl(
+        enable_bw_ctrl,
+        combined_bw_ctrl,
+        export_writebw=qos_dict.get(QOSParams.export_writebw.value, "0"),
+        export_readbw=qos_dict.get(QOSParams.export_readbw.value, "0"),
+        client_writebw=qos_dict.get(QOSParams.client_writebw.value, "0"),
+        client_readbw=qos_dict.get(QOSParams.client_readbw.value, "0"),
+        export_rw_bw=qos_dict.get(QOSParams.export_rw_bw.value, "0"),
+        client_rw_bw=qos_dict.get(QOSParams.client_rw_bw.value, "0"),
+    )
     export_qos_bw_checks(cluster_id, mgr_obj, bw_obj)
 
 
-def export_dict_ops_checks(cluster_id: str,
-                           mgr_obj: Any,
-                           qos_enable: bool,
-                           qos_dict: dict) -> None:
+def export_dict_ops_checks(
+    cluster_id: str, mgr_obj: Any, qos_enable: bool, qos_dict: dict
+) -> None:
     enable_iops_ctrl = qos_dict.get(QOSParams.enable_iops_ctrl.value)
     if enable_iops_ctrl is None:
         return
     if not isinstance(enable_iops_ctrl, bool):
-        raise Exception(f'Invalid values for the {QOSParams.enable_iops_ctrl.value} parameter')
-    ops_param_exists = any(key.endswith('iops') for key in qos_dict)
+        raise Exception(
+            f"Invalid values for the {QOSParams.enable_iops_ctrl.value} parameter"
+        )
+    ops_param_exists = any(key.endswith("iops") for key in qos_dict)
     if not enable_iops_ctrl:
         if ops_param_exists:
-            raise Exception(f'IOPS count parameters should not be passed when {QOSParams.enable_iops_ctrl.value} is false.')
+            raise Exception(
+                f"IOPS count parameters should not be passed when {QOSParams.enable_iops_ctrl.value} is false."
+            )
         return
     if enable_iops_ctrl and not ops_param_exists:
-        raise Exception(f'IOPS count parameters should be set when {QOSParams.enable_iops_ctrl.value} is true.')
-    ops_obj = QOSOpsControl(enable_iops_ctrl,
-                            max_export_iops=qos_dict.get(QOSParams.max_export_iops.value, 0),
-                            max_client_iops=qos_dict.get(QOSParams.max_client_iops.value, 0))
+        raise Exception(
+            f"IOPS count parameters should be set when {QOSParams.enable_iops_ctrl.value} is true."
+        )
+    ops_obj = QOSOpsControl(
+        enable_iops_ctrl,
+        max_export_iops=qos_dict.get(QOSParams.max_export_iops.value, 0),
+        max_client_iops=qos_dict.get(QOSParams.max_client_iops.value, 0),
+    )
     export_qos_ops_checks(cluster_id, mgr_obj, ops_obj)
 
 
-def export_dict_qos_bw_ops_checks(cluster_id: str,
-                                  mgr_obj: Any,
-                                  qos_dict: dict,
-                                  old_qos_block: dict = {}) -> None:
+def export_dict_qos_bw_ops_checks(
+    cluster_id: str, mgr_obj: Any, qos_dict: dict, old_qos_block: dict = {}
+) -> None:
     """Validate the qos block of dict passed to apply_export method"""
-    qos_enable = qos_dict.get('enable_qos')
+    qos_enable = qos_dict.get("enable_qos")
     if qos_enable is None:
-        raise Exception('The QoS block requires at least the enable_qos parameter')
+        raise Exception("The QoS block requires at least the enable_qos parameter")
     if not isinstance(qos_enable, bool):
-        raise Exception('Invalid value for the enable_qos parameter')
+        raise Exception("Invalid value for the enable_qos parameter")
     # if cluster level bandwidth or ops control is disabled or qos type changed to PerClient
     # but old qos block still has those values we should accept it in apply command
     validate_bw = True
@@ -80,16 +95,33 @@ def export_dict_qos_bw_ops_checks(cluster_id: str,
         if not clust_qos_obj.enable_qos or clust_qos_obj.qos_type == QOSType.PerClient:
             if old_qos_block == qos_dict:
                 return
-        if clust_qos_obj.enable_qos and clust_qos_obj.bw_obj and not clust_qos_obj.bw_obj.enable_bw_ctrl:
-            keys = [QOSParams.export_writebw.value, QOSParams.export_readbw.value,
-                    QOSParams.client_writebw.value, QOSParams.client_readbw.value,
-                    QOSParams.export_rw_bw.value, QOSParams.client_rw_bw.value,
-                    QOSParams.enable_bw_ctrl.value, QOSParams.combined_bw_ctrl.value]
+        if (
+            clust_qos_obj.enable_qos
+            and clust_qos_obj.bw_obj
+            and not clust_qos_obj.bw_obj.enable_bw_ctrl
+        ):
+            keys = [
+                QOSParams.export_writebw.value,
+                QOSParams.export_readbw.value,
+                QOSParams.client_writebw.value,
+                QOSParams.client_readbw.value,
+                QOSParams.export_rw_bw.value,
+                QOSParams.client_rw_bw.value,
+                QOSParams.enable_bw_ctrl.value,
+                QOSParams.combined_bw_ctrl.value,
+            ]
             if all(old_qos_block.get(key) == qos_dict.get(key) for key in keys):
                 validate_bw = False
-        if clust_qos_obj.enable_qos and clust_qos_obj.ops_obj and not clust_qos_obj.ops_obj.enable_iops_ctrl:
-            keys = [QOSParams.max_export_iops.value, QOSParams.max_client_iops.value,
-                    QOSParams.enable_iops_ctrl.value]
+        if (
+            clust_qos_obj.enable_qos
+            and clust_qos_obj.ops_obj
+            and not clust_qos_obj.ops_obj.enable_iops_ctrl
+        ):
+            keys = [
+                QOSParams.max_export_iops.value,
+                QOSParams.max_client_iops.value,
+                QOSParams.enable_iops_ctrl.value,
+            ]
             if all(old_qos_block.get(key) == qos_dict.get(key) for key in keys):
                 validate_ops = False
     if validate_bw:
@@ -98,40 +130,59 @@ def export_dict_qos_bw_ops_checks(cluster_id: str,
         export_dict_ops_checks(cluster_id, mgr_obj, qos_enable, qos_dict)
 
 
-def export_qos_bw_checks(cluster_id: str,
-                         mgr_obj: Any,
-                         bw_obj: QOSBandwidthControl,
-                         nfs_clust_obj: Any = None) -> None:
+def export_qos_bw_checks(
+    cluster_id: str,
+    mgr_obj: Any,
+    bw_obj: QOSBandwidthControl,
+    nfs_clust_obj: Any = None,
+) -> None:
     """check cluster level qos bandwidth control is enabled to enable export level qos
     bandwidth control and validate bandwidths"""
     if not nfs_clust_obj:
         nfs_clust_obj = NFSCluster(mgr_obj)
     clust_qos_obj = nfs_clust_obj.get_cluster_qos_config(cluster_id)
-    if not clust_qos_obj or (clust_qos_obj and not (clust_qos_obj.enable_qos
-                                                    and clust_qos_obj.bw_obj
-                                                    and clust_qos_obj.bw_obj.enable_bw_ctrl)):
-        raise Exception(f'To configure bandwidth control for export, you must first enable bandwidth control at the cluster level for {cluster_id}.')
+    if not clust_qos_obj or (
+        clust_qos_obj
+        and not (
+            clust_qos_obj.enable_qos
+            and clust_qos_obj.bw_obj
+            and clust_qos_obj.bw_obj.enable_bw_ctrl
+        )
+    ):
+        raise Exception(
+            f"To configure bandwidth control for export, you must first enable bandwidth control at the cluster level for {cluster_id}."
+        )
     if clust_qos_obj.qos_type:
         if clust_qos_obj.qos_type == QOSType.PerClient:
-            raise Exception(f'Export-level QoS bandwidth control cannot be enabled if the QoS type at the cluster {cluster_id} level is set to PerClient.')
+            raise Exception(
+                f"Export-level QoS bandwidth control cannot be enabled if the QoS type at the cluster {cluster_id} level is set to PerClient."
+            )
         bw_obj.qos_bandwidth_checks(clust_qos_obj.qos_type)
 
 
-def export_qos_ops_checks(cluster_id: str,
-                          mgr_obj: Any,
-                          ops_obj: QOSOpsControl,
-                          nfs_clust_obj: Any = None) -> None:
+def export_qos_ops_checks(
+    cluster_id: str, mgr_obj: Any, ops_obj: QOSOpsControl, nfs_clust_obj: Any = None
+) -> None:
     """check cluster level qos IOPS is enabled to enable export level qos IOPS and validate IOPS count"""
     if not nfs_clust_obj:
         nfs_clust_obj = NFSCluster(mgr_obj)
     clust_qos_obj = nfs_clust_obj.get_cluster_qos_config(cluster_id)
-    if not clust_qos_obj or (clust_qos_obj and not (clust_qos_obj.enable_qos
-                                                    and clust_qos_obj.ops_obj
-                                                    and clust_qos_obj.ops_obj.enable_iops_ctrl)):
-        raise Exception(f'To configure IOPS control for export, you must first enable IOPS control at the cluster level {cluster_id}.')
+    if not clust_qos_obj or (
+        clust_qos_obj
+        and not (
+            clust_qos_obj.enable_qos
+            and clust_qos_obj.ops_obj
+            and clust_qos_obj.ops_obj.enable_iops_ctrl
+        )
+    ):
+        raise Exception(
+            f"To configure IOPS control for export, you must first enable IOPS control at the cluster level {cluster_id}."
+        )
     if clust_qos_obj.qos_type:
         if clust_qos_obj.qos_type == QOSType.PerClient:
-            raise Exception(f'Export-level QoS IOPS control cannot be enabled if the QoS type at the cluster {cluster_id} level is set to PerClient.')
+            raise Exception(
+                f"Export-level QoS IOPS control cannot be enabled if the QoS type at the cluster {cluster_id} level is set to PerClient."
+            )
         ops_obj.qos_ops_checks(clust_qos_obj.qos_type)
 
 

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -5,7 +5,8 @@ from mgr_module import NFS_GANESHA_SUPPORTED_FSALS
 
 from .exception import NFSInvalidOperation, FSNotFound
 from .utils import check_fs
-from .qos_conf import QOS, RawBlock
+from .qos_conf import QOS
+from .ganesha_raw_conf import RawBlock
 
 if TYPE_CHECKING:
     from nfs.module import Module

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -5,6 +5,7 @@ from mgr_module import NFS_GANESHA_SUPPORTED_FSALS
 
 from .exception import NFSInvalidOperation, FSNotFound
 from .utils import check_fs
+from .qos_conf import QOS, RawBlock
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -58,27 +59,6 @@ def _validate_xprtsec_type(xprtsec: str) -> None:
     if not isinstance(xprtsec, str) or xprtsec not in valid_xprtsec_types:
         raise NFSInvalidOperation(
             f"XprtSec {xprtsec} invalid, valid types are {valid_xprtsec_types}")
-
-
-class RawBlock():
-    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
-        if not values:  # workaround mutable default argument
-            values = {}
-        if not blocks:  # workaround mutable default argument
-            blocks = []
-        self.block_name = block_name
-        self.blocks = blocks
-        self.values = values
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, RawBlock):
-            return False
-        return self.block_name == other.block_name and \
-            self.blocks == other.blocks and \
-            self.values == other.values
-
-    def __repr__(self) -> str:
-        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'
 
 
 class GaneshaConfParser:
@@ -383,7 +363,8 @@ class Export:
             fsal: FSAL,
             clients: Optional[List[Client]] = None,
             sectype: Optional[List[str]] = None,
-            xprtsec: Optional[str] = None) -> None:
+            xprtsec: Optional[str] = None,
+            qos_block: Optional[QOS] = None) -> None:
         self.export_id = export_id
         self.path = path
         self.fsal = fsal
@@ -398,6 +379,7 @@ class Export:
         self.clients: List[Client] = clients or []
         self.sectype = sectype
         self.xprtsec = xprtsec
+        self.qos_block = qos_block
 
     @classmethod
     def from_export_block(cls, export_block: RawBlock, cluster_id: str) -> 'Export':
@@ -406,6 +388,10 @@ class Export:
 
         client_blocks = [b for b in export_block.blocks
                          if b.block_name == "CLIENT"]
+
+        qos_block = [b for b in export_block.blocks
+                     if b.block_name == "qos_block"]
+        qos_block = QOS.from_qos_block(qos_block[0]) if qos_block else None
 
         protocols = export_block.values.get('protocols')
         if not isinstance(protocols, list):
@@ -443,7 +429,9 @@ class Export:
                    [Client.from_client_block(client)
                     for client in client_blocks],
                    sectype=sectype,
-                   xprtsec=xprtsec)
+                   xprtsec=xprtsec,
+                   qos_block=qos_block
+                   )
 
     def to_export_block(self) -> RawBlock:
         values = {
@@ -468,10 +456,16 @@ class Export:
             client.to_client_block()
             for client in self.clients
         ]
+        if self.qos_block:
+            result.blocks.append(self.qos_block.to_qos_block())
         return result
 
     @classmethod
     def from_dict(cls, export_id: int, ex_dict: Dict[str, Any]) -> 'Export':
+        if ex_dict.get('qos_block'):
+            qos_block = QOS.from_dict(ex_dict.get('qos_block', {}))
+        else:
+            qos_block = None
         return cls(export_id,
                    ex_dict.get('path', '/'),
                    ex_dict['cluster_id'],
@@ -484,7 +478,9 @@ class Export:
                    FSAL.from_dict(ex_dict.get('fsal', {})),
                    [Client.from_dict(client) for client in ex_dict.get('clients', [])],
                    sectype=ex_dict.get("sectype"),
-                   xprtsec=ex_dict.get('XprtSec'))
+                   xprtsec=ex_dict.get('XprtSec'),
+                   qos_block=qos_block
+                   )
 
     def to_dict(self) -> Dict[str, Any]:
         values = {
@@ -504,6 +500,8 @@ class Export:
             values['sectype'] = self.sectype
         if self.xprtsec:
             values['XprtSec'] = self.xprtsec
+        if self.qos_block:
+            values['qos_block'] = self.qos_block.to_dict()
         return values
 
     def validate(self, mgr: 'Module') -> None:

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -391,7 +391,7 @@ class Export:
                          if b.block_name == "CLIENT"]
 
         qos_block = [b for b in export_block.blocks
-                     if b.block_name == "qos_block"]
+                     if b.block_name == "QOS_BLOCK"]
         qos_block = QOS.from_qos_block(qos_block[0]) if qos_block else None
 
         protocols = export_block.values.get('protocols')

--- a/src/pybind/mgr/nfs/ganesha_raw_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_raw_conf.py
@@ -1,0 +1,22 @@
+from typing import List, Dict, Any
+
+
+class RawBlock():
+    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
+        if not values:  # workaround mutable default argument
+            values = {}
+        if not blocks:  # workaround mutable default argument
+            blocks = []
+        self.block_name = block_name
+        self.blocks = blocks
+        self.values = values
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, RawBlock):
+            return False
+        return self.block_name == other.block_name and \
+            self.blocks == other.blocks and \
+            self.values == other.values
+
+    def __repr__(self) -> str:
+        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -14,7 +14,7 @@ from mgr_util import CephFSEarmarkResolver
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
 from .utils import available_clusters
-from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType
+from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 
 log = logging.getLogger(__name__)
 
@@ -258,7 +258,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                   max_export_combined_bw: str = '0',
                                   max_client_combined_bw: str = '0'
                                   ) -> None:
-        """enable QOS config for NFS export and set different bandwidth"""
+        """enable QOS bandwidth control for NFS export and set different bandwidth"""
         try:
             bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
                                          combined_bw_ctrl=combined_rw_bw_ctrl,
@@ -283,7 +283,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @CLICommand('nfs export qos disable bandwidth_control', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_export_qos_bw_disable(self, cluster_id: str, pseudo_path: str) -> None:
-        """Disable NFS export QOS config"""
+        """Disable NFS export QOS bandwidth control"""
         return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
 
     @CLICommand('nfs cluster qos enable bandwidth_control', perm='rw')
@@ -298,7 +298,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                    max_client_read_bw: str = '0',
                                    max_export_combined_bw: str = '0',
                                    max_client_combined_bw: str = '0') -> None:
-        """Enable QOS ratelimiting for NFS cluster and set default export and client max bandwidth"""
+        """Enable QOS bandwidth control for NFS cluster and set default export and client max bandwidth"""
         try:
             bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
                                          combined_bw_ctrl=combined_rw_bw_ctrl,
@@ -317,7 +317,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @CLICommand('nfs cluster qos disable bandwidth_control', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_cluster_qos_bw_disable(self, cluster_id: str) -> None:
-        """Disable QOS for NFS cluster"""
+        """Disable QOS bandwidth control for NFS cluster"""
         return self.nfs.disable_cluster_qos_bw(cluster_id)
 
     @CLICommand('nfs cluster qos get', perm='r')
@@ -325,3 +325,53 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_cluster_qos_get(self, cluster_id: str) -> Dict[str, Any]:
         """Get QOS configuration of NFS cluster"""
         return self.nfs.get_cluster_qos(cluster_id)
+
+    @CLICommand('nfs export qos enable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_ops_enable(self,
+                                   cluster_id: str,
+                                   pseudo_path: str,
+                                   max_export_iops: int = 0,
+                                   max_client_iops: int = 0,
+                                   ) -> None:
+        """enable QOS IOPS control for NFS export"""
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=max_export_iops,
+                                    max_client_iops=max_client_iops)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_ops(cluster_id=cluster_id,
+                                                     pseudo_path=pseudo_path,
+                                                     ops_obj=ops_obj)
+
+    @CLICommand('nfs export qos disable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_ops_disable(self, cluster_id: str, pseudo_path: str) -> None:
+        """Disable NFS export QOS IOPS control"""
+        return self.export_mgr.disable_export_qos_ops(cluster_id, pseudo_path)
+
+    @CLICommand('nfs cluster qos enable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_ops_enable(self,
+                                    cluster_id: str,
+                                    qos_type: UserQoSType,
+                                    max_export_iops: int = 0,
+                                    max_client_iops: int = 0,
+                                    ) -> None:
+        """enable QOS IOPS control for NFS cluster"""
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=max_export_iops,
+                                    max_client_iops=max_client_iops)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_ops(cluster_id=cluster_id,
+                                               qos_type=QOSType[qos_type.value],
+                                               ops_obj=ops_obj)
+
+    @CLICommand('nfs cluster qos disable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_ops_disable(self, cluster_id: str) -> None:
+        """Disable NFS cluster QOS IOPS control"""
+        return self.nfs.disable_cluster_qos_ops(cluster_id)

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -164,10 +164,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                 rdma_port: Optional[int] = None,
                                 inbuf: Optional[str] = None) -> None:
         """Create an NFS Cluster"""
+        cluster_qos_config = None
         ssl_cert = ssl_key = ssl_ca_cert = tls_min_version = tls_ciphers = None
         ssl = tls_ktls = tls_debug = False
         if inbuf:
             config = yaml.safe_load(inbuf)
+            cluster_qos_config = config.get('cluster_qos_config')
             ssl = config.get('ssl')
             ssl_cert = config.get('ssl_cert')
             ssl_key = config.get('ssl_key')
@@ -180,6 +182,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.nfs.create_nfs_cluster(cluster_id=cluster_id, placement=placement,
                                            virtual_ip=virtual_ip, ingress=ingress,
                                            ingress_mode=ingress_mode, port=port,
+                                           cluster_qos_config=cluster_qos_config,
                                            ssl=ssl,
                                            ssl_cert=ssl_cert,
                                            ssl_key=ssl_key,

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -14,6 +14,7 @@ from mgr_util import CephFSEarmarkResolver
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
 from .utils import available_clusters
+from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType
 
 log = logging.getLogger(__name__)
 
@@ -243,3 +244,84 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def fetch_nfs_cluster_obj(self) -> NFSCluster:
         return self.nfs
+
+    @CLICommand('nfs export qos enable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_bw_enable(self,
+                                  cluster_id: str,
+                                  pseudo_path: str,
+                                  combined_rw_bw_ctrl: bool = False,
+                                  max_export_write_bw: str = '0',
+                                  max_export_read_bw: str = '0',
+                                  max_client_write_bw: str = '0',
+                                  max_client_read_bw: str = '0',
+                                  max_export_combined_bw: str = '0',
+                                  max_client_combined_bw: str = '0'
+                                  ) -> None:
+        """enable QOS config for NFS export and set different bandwidth"""
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_rw_bw_ctrl,
+                                         export_writebw=max_export_write_bw,
+                                         export_readbw=max_export_read_bw,
+                                         client_writebw=max_client_write_bw,
+                                         client_readbw=max_client_read_bw,
+                                         export_rw_bw=max_export_combined_bw,
+                                         client_rw_bw=max_client_combined_bw)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_bw(cluster_id=cluster_id,
+                                                    pseudo_path=pseudo_path,
+                                                    bw_obj=bw_obj)
+
+    @CLICommand('nfs export qos get', perm='r')
+    @object_format.Responder()
+    def _cmd_export_qos_get(self, cluster_id: str, pseudo_path: str) -> Dict[str, int]:
+        """Get NFS export QOS config"""
+        return self.export_mgr.get_export_qos(cluster_id, pseudo_path)
+
+    @CLICommand('nfs export qos disable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_bw_disable(self, cluster_id: str, pseudo_path: str) -> None:
+        """Disable NFS export QOS config"""
+        return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
+
+    @CLICommand('nfs cluster qos enable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_bw_enable(self,
+                                   cluster_id: str,
+                                   qos_type: UserQoSType,
+                                   combined_rw_bw_ctrl: bool = False,
+                                   max_export_write_bw: str = '0',
+                                   max_export_read_bw: str = '0',
+                                   max_client_write_bw: str = '0',
+                                   max_client_read_bw: str = '0',
+                                   max_export_combined_bw: str = '0',
+                                   max_client_combined_bw: str = '0') -> None:
+        """Enable QOS ratelimiting for NFS cluster and set default export and client max bandwidth"""
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_rw_bw_ctrl,
+                                         export_writebw=max_export_write_bw,
+                                         export_readbw=max_export_read_bw,
+                                         client_writebw=max_client_write_bw,
+                                         client_readbw=max_client_read_bw,
+                                         export_rw_bw=max_export_combined_bw,
+                                         client_rw_bw=max_client_combined_bw)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_bw(cluster_id=cluster_id,
+                                              qos_type=QOSType[qos_type.value],
+                                              bw_obj=bw_obj)
+
+    @CLICommand('nfs cluster qos disable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_bw_disable(self, cluster_id: str) -> None:
+        """Disable QOS for NFS cluster"""
+        return self.nfs.disable_cluster_qos_bw(cluster_id)
+
+    @CLICommand('nfs cluster qos get', perm='r')
+    @object_format.Responder()
+    def _cmd_cluster_qos_get(self, cluster_id: str) -> Dict[str, Any]:
+        """Get QOS configuration of NFS cluster"""
+        return self.nfs.get_cluster_qos(cluster_id)

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -12,7 +12,7 @@ from orchestrator.module import IngressType
 from mgr_util import CephFSEarmarkResolver
 
 from .export import ExportMgr, AppliedExportResults
-from .cluster import NFSCluster, ClusterQosAction
+from .cluster import NFSCluster
 from .utils import available_clusters
 from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 
@@ -345,15 +345,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """Disable QOS bandwidth control for NFS cluster"""
         return self.nfs.disable_cluster_qos_bw(cluster_id)
 
-    @CLICommand('nfs cluster cluster_qos', perm='rw')
+    @CLICommand('nfs cluster qos set', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_nfs_cluster_global_qos(self,
                                     cluster_id: str,
-                                    action: ClusterQosAction,
-                                    msg_interval: int = 0) -> None:
-        """Enable or disable cluster-wide QoS. If disabled, QoS remains enabled,
-        but the configured values apply on a per-host basis"""
-        return self.nfs.global_cluster_qos_action(cluster_id, action.name, msg_interval)
+                                    msg_interval: int) -> None:
+        """Set the message interval for cluster QoS synchronization among hosts."""
+        return self.nfs.cluster_qos_set_config(cluster_id, msg_interval)
 
     @CLICommand('nfs cluster qos get', perm='r')
     @object_format.Responder()

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -12,7 +12,7 @@ from orchestrator.module import IngressType
 from mgr_util import CephFSEarmarkResolver
 
 from .export import ExportMgr, AppliedExportResults
-from .cluster import NFSCluster
+from .cluster import NFSCluster, ClusterQosAction
 from .utils import available_clusters
 from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 
@@ -344,6 +344,16 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_cluster_qos_bw_disable(self, cluster_id: str) -> None:
         """Disable QOS bandwidth control for NFS cluster"""
         return self.nfs.disable_cluster_qos_bw(cluster_id)
+
+    @CLICommand('nfs cluster cluster_qos', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_nfs_cluster_global_qos(self,
+                                    cluster_id: str,
+                                    action: ClusterQosAction,
+                                    msg_interval: int = 0) -> None:
+        """Enable or disable cluster-wide QoS. If disabled, QoS remains enabled,
+        but the configured values apply on a per-host basis"""
+        return self.nfs.global_cluster_qos_action(cluster_id, action.name, msg_interval)
 
     @CLICommand('nfs cluster qos get', perm='r')
     @object_format.Responder()

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -46,9 +46,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             sectype: Optional[List[str]] = None,
             xprtsec: Optional[str] = None,
             cmount_path: Optional[str] = "/",
-            transports: Optional[List[str]] = None
+            transports: Optional[List[str]] = None,
+            skip_notify_nfs_server: bool = False
     ) -> Dict[str, Any]:
         """Create a CephFS export"""
+        self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
         earmark_resolver = CephFSEarmarkResolver(self)
         return self.export_mgr.create_export(
             fsal_type='cephfs',
@@ -79,9 +81,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             squash: str = 'none',
             sectype: Optional[List[str]] = None,
             xprtsec: Optional[str] = None,
-            transports: Optional[List[str]] = None
+            transports: Optional[List[str]] = None,
+            skip_notify_nfs_server: bool = False
     ) -> Dict[str, Any]:
         """Create an RGW export"""
+        self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
         return self.export_mgr.create_export(
             fsal_type='rgw',
             bucket=bucket,
@@ -98,14 +102,22 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @NFSCLICommand('nfs export rm', perm='rw')
     @object_format.EmptyResponder()
-    def _cmd_nfs_export_rm(self, cluster_id: str, pseudo_path: str) -> None:
+    def _cmd_nfs_export_rm(self,
+                           cluster_id: str,
+                           pseudo_path: str,
+                           skip_notify_nfs_server: bool = False) -> None:
         """Remove a cephfs export"""
+        self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
         return self.export_mgr.delete_export(cluster_id=cluster_id, pseudo_path=pseudo_path)
 
     @NFSCLICommand('nfs export delete', perm='rw')
     @object_format.EmptyResponder()
-    def _cmd_nfs_export_delete(self, cluster_id: str, pseudo_path: str) -> None:
+    def _cmd_nfs_export_delete(self,
+                               cluster_id: str,
+                               pseudo_path: str,
+                               skip_notify_nfs_server: bool = False) -> None:
         """Delete a cephfs export (DEPRECATED)"""
+        self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
         return self.export_mgr.delete_export(cluster_id=cluster_id, pseudo_path=pseudo_path)
 
     @NFSCLICommand('nfs export ls', perm='r')
@@ -129,9 +141,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @NFSCLICommand('nfs export apply', perm='rw')
     @CLICheckNonemptyFileInput(desc='Export JSON or Ganesha EXPORT specification')
     @object_format.Responder()
-    def _cmd_nfs_export_apply(self, cluster_id: str, inbuf: str) -> AppliedExportResults:
+    def _cmd_nfs_export_apply(self,
+                              cluster_id: str,
+                              inbuf: str,
+                              skip_notify_nfs_server: bool = False) -> AppliedExportResults:
         earmark_resolver = CephFSEarmarkResolver(self)
         """Create or update an export by `-i <json_or_ganesha_export_file>`"""
+        self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
         return self.export_mgr.apply_export(cluster_id, export_config=inbuf,
                                             earmark_resolver=earmark_resolver)
 
@@ -256,10 +272,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                   max_client_write_bw: str = '0',
                                   max_client_read_bw: str = '0',
                                   max_export_combined_bw: str = '0',
-                                  max_client_combined_bw: str = '0'
+                                  max_client_combined_bw: str = '0',
+                                  skip_notify_nfs_server: bool = False
                                   ) -> None:
         """enable QOS bandwidth control for NFS export and set different bandwidth"""
         try:
+            self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
             bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
                                          combined_bw_ctrl=combined_rw_bw_ctrl,
                                          export_writebw=max_export_write_bw,
@@ -282,8 +300,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @CLICommand('nfs export qos disable bandwidth_control', perm='rw')
     @object_format.EmptyResponder()
-    def _cmd_export_qos_bw_disable(self, cluster_id: str, pseudo_path: str) -> None:
+    def _cmd_export_qos_bw_disable(self,
+                                   cluster_id: str,
+                                   pseudo_path: str,
+                                   skip_notify_nfs_server: bool = False) -> None:
         """Disable NFS export QOS bandwidth control"""
+        self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
         return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
 
     @CLICommand('nfs cluster qos enable bandwidth_control', perm='rw')
@@ -333,9 +355,11 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                    pseudo_path: str,
                                    max_export_iops: int = 0,
                                    max_client_iops: int = 0,
+                                   skip_notify_nfs_server: bool = False
                                    ) -> None:
         """enable QOS IOPS control for NFS export"""
         try:
+            self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
             ops_obj = QOSOpsControl(enable_iops_ctrl=True,
                                     max_export_iops=max_export_iops,
                                     max_client_iops=max_client_iops)
@@ -347,8 +371,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @CLICommand('nfs export qos disable ops_control', perm='rw')
     @object_format.EmptyResponder()
-    def _cmd_export_qos_ops_disable(self, cluster_id: str, pseudo_path: str) -> None:
+    def _cmd_export_qos_ops_disable(self,
+                                    cluster_id: str,
+                                    pseudo_path: str,
+                                    skip_notify_nfs_server: bool = False) -> None:
         """Disable NFS export QOS IOPS control"""
+        self.export_mgr.skip_notify_nfs_server = skip_notify_nfs_server
         return self.export_mgr.disable_export_qos_ops(cluster_id, pseudo_path)
 
     @CLICommand('nfs cluster qos enable ops_control', perm='rw')

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -1,0 +1,247 @@
+from typing import List, Dict, Any, Optional
+from enum import Enum
+
+from ceph.utils import bytes_to_human, with_units_to_int
+
+
+class RawBlock():
+    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
+        if not values:  # workaround mutable default argument
+            values = {}
+        if not blocks:  # workaround mutable default argument
+            blocks = []
+        self.block_name = block_name
+        self.blocks = blocks
+        self.values = values
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, RawBlock):
+            return False
+        return self.block_name == other.block_name and \
+            self.blocks == other.blocks and \
+            self.values == other.values
+
+    def __repr__(self) -> str:
+        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'
+
+
+class QOSParams(Enum):
+    clust_block = "QOS_DEFAULT_CONFIG"
+    export_block = "QOS_BLOCK"
+    enable_qos = "enable_qos"
+    enable_bw_ctrl = "enable_bw_control"
+    combined_bw_ctrl = "combined_rw_bw_control"
+    qos_type = "qos_type"
+    export_writebw = "max_export_write_bw"
+    export_readbw = "max_export_read_bw"
+    client_writebw = "max_client_write_bw"
+    client_readbw = "max_client_read_bw"
+    export_rw_bw = "max_export_combined_bw"
+    client_rw_bw = "max_client_combined_bw"
+
+
+class UserQoSType(Enum):
+    per_share = 'PerShare'
+    per_client = 'PerClient'
+    per_share_per_client = 'PerShare_PerClient'
+
+
+class QOSType(Enum):
+    PerShare = 1
+    PerClient = 2
+    PerShare_PerClient = 3
+
+
+def _validate_qos_bw(bandwidth: str) -> int:
+    min_bw = 1000000  # 1MB
+    max_bw = 2000000000  # 2GB
+    bw_bytes = with_units_to_int(bandwidth)
+    if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
+        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (2GB) bytes")
+    return bw_bytes
+
+
+QOS_REQ_PARAMS = {
+    'combined_bw_disabled': {
+        'PerShare': ['max_export_write_bw', 'max_export_read_bw'],
+        'PerClient': ['max_client_write_bw', 'max_client_read_bw'],
+        'PerShare_PerClient': ['max_export_write_bw', 'max_export_read_bw', 'max_client_write_bw', 'max_client_read_bw']
+    },
+    'combined_bw_enabled': {
+        'PerShare': ['max_export_combined_bw'],
+        'PerClient': ['max_client_combined_bw'],
+        'PerShare_PerClient': ['max_export_combined_bw', 'max_client_combined_bw'],
+    }
+}
+
+
+class QOSBandwidthControl(object):
+    def __init__(self,
+                 enable_bw_ctrl: bool = False,
+                 combined_bw_ctrl: bool = False,
+                 export_writebw: str = '0',
+                 export_readbw: str = '0',
+                 client_writebw: str = '0',
+                 client_readbw: str = '0',
+                 export_rw_bw: str = '0',
+                 client_rw_bw: str = '0'
+                 ) -> None:
+        self.enable_bw_ctrl = enable_bw_ctrl
+        self.combined_bw_ctrl = combined_bw_ctrl
+        try:
+            self.export_writebw: int = _validate_qos_bw(export_writebw)
+            self.export_readbw: int = _validate_qos_bw(export_readbw)
+            self.client_writebw: int = _validate_qos_bw(client_writebw)
+            self.client_readbw: int = _validate_qos_bw(client_readbw)
+            self.export_rw_bw: int = _validate_qos_bw(export_rw_bw)
+            self.client_rw_bw: int = _validate_qos_bw(client_rw_bw)
+        except Exception as e:
+            raise Exception(f"Invalid bandwidth value. {e}")
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSBandwidthControl':
+        # json has bandwidths in human readable format(str)
+        bw_kwargs = {
+            'enable_bw_ctrl': qos_dict.get(QOSParams.enable_bw_ctrl.value, False),
+            'combined_bw_ctrl': qos_dict.get(QOSParams.combined_bw_ctrl.value, False),
+            'export_writebw': qos_dict.get(QOSParams.export_writebw.value, '0'),
+            'export_readbw': qos_dict.get(QOSParams.export_readbw.value, '0'),
+            'client_writebw': qos_dict.get(QOSParams.client_writebw.value, '0'),
+            'client_readbw': qos_dict.get(QOSParams.client_readbw.value, '0'),
+            'export_rw_bw': qos_dict.get(QOSParams.export_rw_bw.value, '0'),
+            'client_rw_bw': qos_dict.get(QOSParams.client_rw_bw.value, '0')
+        }
+        return cls(**bw_kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock) -> 'QOSBandwidthControl':
+        # block has bandwidths in bytes(int)
+        bw_kwargs = {
+            'enable_bw_ctrl': qos_block.values.get(QOSParams.enable_bw_ctrl.value, False),
+            'combined_bw_ctrl': qos_block.values.get(QOSParams.combined_bw_ctrl.value, False),
+            'export_writebw': str(qos_block.values.get(QOSParams.export_writebw.value, 0)),
+            'export_readbw': str(qos_block.values.get(QOSParams.export_readbw.value, 0)),
+            'client_writebw': str(qos_block.values.get(QOSParams.client_writebw.value, 0)),
+            'client_readbw': str(qos_block.values.get(QOSParams.client_readbw.value, 0)),
+            'export_rw_bw': str(qos_block.values.get(QOSParams.export_rw_bw.value, 0)),
+            'client_rw_bw': str(qos_block.values.get(QOSParams.client_rw_bw.value, 0))
+        }
+        return cls(**bw_kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        result = RawBlock('qos_bandwidths_control')
+        result.values[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
+        result.values[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
+        if self.export_writebw:
+            result.values[QOSParams.export_writebw.value] = self.export_writebw
+        if self.export_readbw:
+            result.values[QOSParams.export_readbw.value] = self.export_readbw
+        if self.client_writebw:
+            result.values[QOSParams.client_writebw.value] = self.client_writebw
+        if self.client_readbw:
+            result.values[QOSParams.client_readbw.value] = self.client_readbw
+        if self.export_rw_bw:
+            result.values[QOSParams.export_rw_bw.value] = self.export_rw_bw
+        if self.client_rw_bw:
+            result.values[QOSParams.client_rw_bw.value] = self.client_rw_bw
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: dict[str, Any] = {}
+        r[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
+        r[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
+        if self.export_writebw:
+            r[QOSParams.export_writebw.value] = bytes_to_human(self.export_writebw)
+        if self.export_readbw:
+            r[QOSParams.export_readbw.value] = bytes_to_human(self.export_readbw)
+        if self.client_writebw:
+            r[QOSParams.client_writebw.value] = bytes_to_human(self.client_writebw)
+        if self.client_readbw:
+            r[QOSParams.client_readbw.value] = bytes_to_human(self.client_readbw)
+        if self.export_rw_bw:
+            r[QOSParams.export_rw_bw.value] = bytes_to_human(self.export_rw_bw)
+        if self.client_rw_bw:
+            r[QOSParams.client_rw_bw.value] = bytes_to_human(self.client_rw_bw)
+        return r
+
+    def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
+        """Checks for enabling qos"""
+        params = {}
+        d = vars(self)
+        for key in d:
+            if key.endswith('bw'):
+                params[QOSParams[key].value] = d[key]
+        if not self.combined_bw_ctrl:
+            req_params = QOS_REQ_PARAMS['combined_bw_disabled'][qos_type.name]
+        else:
+            req_params = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+        allowed_params = []
+        not_allowed_params = []
+        for key in params:
+            if key in req_params and params[key] == 0:
+                allowed_params.append(key)
+            elif key not in req_params and params[key] != 0:
+                not_allowed_params.append(key)
+        if allowed_params or not_allowed_params:
+            raise Exception(f"When combined_rw_bw is {'enabled' if self.combined_bw_ctrl else 'disabled'} "
+                            f"and qos_type is {qos_type.name}, "
+                            f"{'attributes ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                            f"{'attributes ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+
+
+class QOS(object):
+    def __init__(self,
+                 cluster_op: bool = False,
+                 enable_qos: bool = False,
+                 qos_type: Optional[QOSType] = None,
+                 bw_obj: Optional[QOSBandwidthControl] = None
+                 ) -> None:
+        self.cluster_op = cluster_op
+        self.enable_qos = enable_qos
+        self.qos_type = qos_type
+        self.bw_obj = bw_obj
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any], cluster_op: bool = False) -> 'QOS':
+        kwargs: dict[str, Any] = {}
+        # qos dict will have qos type as enum name
+        if cluster_op:
+            qos_type = qos_dict.get(QOSParams.qos_type.value)
+            if qos_type:
+                kwargs['qos_type'] = QOSType[qos_type]
+        kwargs['enable_qos'] = qos_dict.get(QOSParams.enable_qos.value)
+        kwargs['bw_obj'] = QOSBandwidthControl.from_dict(qos_dict)
+        return cls(cluster_op, **kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock, cluster_op: bool = False) -> 'QOS':
+        kwargs: dict[str, Any] = {}
+        # qos block will have qos type as enum value
+        if cluster_op:
+            qos_type = qos_block.values.get(QOSParams.qos_type.value)
+            if qos_type:
+                kwargs['qos_type'] = QOSType(qos_type)
+        kwargs['enable_qos'] = qos_block.values.get(QOSParams.enable_qos.value)
+        kwargs['bw_obj'] = QOSBandwidthControl.from_qos_block(qos_block)
+        return cls(cluster_op, **kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        if self.cluster_op:
+            result = RawBlock(QOSParams.clust_block.value)
+        else:
+            result = RawBlock(QOSParams.export_block.value)
+        result.values[QOSParams.enable_qos.value] = self.enable_qos
+        if self.cluster_op and self.qos_type:
+            result.values[QOSParams.qos_type.value] = self.qos_type.value
+        if self.bw_obj and (res := self.bw_obj.to_qos_block()):
+            result.values.update(res.values)
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: Dict[str, Any] = {}
+        r[QOSParams.enable_qos.value] = self.enable_qos
+        if self.cluster_op and self.qos_type:
+            r[QOSParams.qos_type.value] = self.qos_type.name
+        if self.bw_obj and (res := self.bw_obj.to_dict()):
+            r.update(res)
+        return r

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -169,7 +169,7 @@ class QOSBandwidthControl(object):
 
     @staticmethod
     def bw_for_to_dict(bandwidth: int, ret_bw_in_bytes: bool = False) -> str:
-        return bytes_to_human(bandwidth) if not ret_bw_in_bytes else str(bandwidth)
+        return bytes_to_human(bandwidth, mode='binary') if not ret_bw_in_bytes else str(bandwidth)
 
     def to_dict(self, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         r: dict[str, Any] = {}

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -38,22 +38,22 @@ class QOSType(Enum):
 
 
 def _validate_qos_bw(bandwidth: str) -> int:
-    min_bw = 1000000  # 1MB
-    max_bw = 4000000000  # 4GB
+    min_bw = 1024 * 1024  # 1MiB
+    max_bw = 100 * 1024 * 1024 * 1024  # 100GiB
     bw_bytes = with_units_to_int(bandwidth)
     if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
         raise Exception(
-            f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (4GB) bytes per second."
+            f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MiB) and {max_bw} (100GiB) bytes per second."
         )
     return bw_bytes
 
 
 def _validate_qos_ops(count: int) -> int:
     min_cnt = 10
-    max_cnt = 16384
+    max_cnt = 409600
     if count != 0 and (count < min_cnt or count > max_cnt):
         raise Exception(
-            f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} bytes per second."
+            f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} count per second."
         )
     return count
 

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -29,15 +29,20 @@ class QOSParams(Enum):
     clust_block = "QOS_DEFAULT_CONFIG"
     export_block = "QOS_BLOCK"
     enable_qos = "enable_qos"
+    qos_type = "qos_type"
+    # bandwidth control
     enable_bw_ctrl = "enable_bw_control"
     combined_bw_ctrl = "combined_rw_bw_control"
-    qos_type = "qos_type"
     export_writebw = "max_export_write_bw"
     export_readbw = "max_export_read_bw"
     client_writebw = "max_client_write_bw"
     client_readbw = "max_client_read_bw"
     export_rw_bw = "max_export_combined_bw"
     client_rw_bw = "max_client_combined_bw"
+    # ops control
+    enable_iops_ctrl = "enable_iops_control"
+    max_export_iops = "max_export_iops"
+    max_client_iops = "max_client_iops"
 
 
 class UserQoSType(Enum):
@@ -61,7 +66,15 @@ def _validate_qos_bw(bandwidth: str) -> int:
     return bw_bytes
 
 
-QOS_REQ_PARAMS = {
+def _validate_qos_ops(count: int) -> int:
+    min_cnt = 1000  # 1K
+    max_cnt = 500000  # 5L
+    if count != 0 and (count < min_cnt or count > max_cnt):
+        raise Exception(f"Provided IOS count value is not in range, Please enter a value between {min_cnt} (1K) and {max_cnt} (5L) bytes")
+    return count
+
+
+QOS_REQ_BW_PARAMS = {
     'combined_bw_disabled': {
         'PerShare': ['max_export_write_bw', 'max_export_read_bw'],
         'PerClient': ['max_client_write_bw', 'max_client_read_bw'],
@@ -72,6 +85,12 @@ QOS_REQ_PARAMS = {
         'PerClient': ['max_client_combined_bw'],
         'PerShare_PerClient': ['max_export_combined_bw', 'max_client_combined_bw'],
     }
+}
+
+QOS_REQ_OPS_PARAMS = {
+    'PerShare': ['max_export_iops'],
+    'PerClient': ['max_client_iops'],
+    'PerShare_PerClient': ['max_export_iops', 'max_client_iops']
 }
 
 
@@ -100,7 +119,7 @@ class QOSBandwidthControl(object):
 
     @classmethod
     def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSBandwidthControl':
-        # json has bandwidths in human readable format(str)
+        # qos dict has bandwidths in human readable format(str)
         bw_kwargs = {
             'enable_bw_ctrl': qos_dict.get(QOSParams.enable_bw_ctrl.value, False),
             'combined_bw_ctrl': qos_dict.get(QOSParams.combined_bw_ctrl.value, False),
@@ -115,7 +134,7 @@ class QOSBandwidthControl(object):
 
     @classmethod
     def from_qos_block(cls, qos_block: RawBlock) -> 'QOSBandwidthControl':
-        # block has bandwidths in bytes(int)
+        # qos block has bandwidths in bytes(int)
         bw_kwargs = {
             'enable_bw_ctrl': qos_block.values.get(QOSParams.enable_bw_ctrl.value, False),
             'combined_bw_ctrl': qos_block.values.get(QOSParams.combined_bw_ctrl.value, False),
@@ -165,16 +184,16 @@ class QOSBandwidthControl(object):
         return r
 
     def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
-        """Checks for enabling qos"""
+        """Checks for enabling qos bandwidth control"""
         params = {}
         d = vars(self)
         for key in d:
             if key.endswith('bw'):
                 params[QOSParams[key].value] = d[key]
         if not self.combined_bw_ctrl:
-            req_params = QOS_REQ_PARAMS['combined_bw_disabled'][qos_type.name]
+            req_params = QOS_REQ_BW_PARAMS['combined_bw_disabled'][qos_type.name]
         else:
-            req_params = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+            req_params = QOS_REQ_BW_PARAMS['combined_bw_enabled'][qos_type.name]
         allowed_params = []
         not_allowed_params = []
         for key in params:
@@ -185,8 +204,73 @@ class QOSBandwidthControl(object):
         if allowed_params or not_allowed_params:
             raise Exception(f"When combined_rw_bw is {'enabled' if self.combined_bw_ctrl else 'disabled'} "
                             f"and qos_type is {qos_type.name}, "
-                            f"{'attributes ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
-                            f"{'attributes ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+                            f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                            f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+
+
+class QOSOpsControl(object):
+    def __init__(self,
+                 enable_iops_ctrl: bool = False,
+                 max_export_iops: int = 0,
+                 max_client_iops: int = 0
+                 ) -> None:
+        self.enable_iops_ctrl = enable_iops_ctrl
+        self.max_export_iops = _validate_qos_ops(max_export_iops)
+        self.max_client_iops = _validate_qos_ops(max_client_iops)
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSOpsControl':
+        kwargs: dict[str, Any] = {}
+        kwargs['enable_iops_ctrl'] = qos_dict.get(QOSParams.enable_iops_ctrl.value, False)
+        kwargs['max_export_iops'] = qos_dict.get(QOSParams.max_export_iops.value, 0)
+        kwargs['max_client_iops'] = qos_dict.get(QOSParams.max_client_iops.value, 0)
+        return cls(**kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock) -> 'QOSOpsControl':
+        kwargs: dict[str, Any] = {}
+        kwargs['enable_iops_ctrl'] = qos_block.values.get(QOSParams.enable_iops_ctrl.value, False)
+        kwargs['max_export_iops'] = qos_block.values.get(QOSParams.max_export_iops.value, 0)
+        kwargs['max_client_iops'] = qos_block.values.get(QOSParams.max_client_iops.value, 0)
+        return cls(**kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        result = RawBlock('qos_ops_control')
+        result.values[QOSParams.enable_iops_ctrl.value] = self.enable_iops_ctrl
+        if self.max_export_iops:
+            result.values[QOSParams.max_export_iops.value] = self.max_export_iops
+        if self.max_client_iops:
+            result.values[QOSParams.max_client_iops.value] = self.max_client_iops
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: dict[str, Any] = {}
+        r[QOSParams.enable_iops_ctrl.value] = self.enable_iops_ctrl
+        if self.max_export_iops:
+            r[QOSParams.max_export_iops.value] = self.max_export_iops
+        if self.max_client_iops:
+            r[QOSParams.max_client_iops.value] = self.max_client_iops
+        return r
+
+    def qos_ops_checks(self, qos_type: QOSType) -> None:
+        """Checks for enabling qos IOPS control"""
+        params = {}
+        d = vars(self)
+        for key in d:
+            if key.endswith('iops'):
+                params[QOSParams[key].value] = d[key]
+        req_params = QOS_REQ_OPS_PARAMS[qos_type.name]
+        allowed_params = []
+        not_allowed_params = []
+        for key in params:
+            if key in req_params and params[key] == 0:
+                allowed_params.append(key)
+            elif key not in req_params and params[key] != 0:
+                not_allowed_params.append(key)
+        if allowed_params or not_allowed_params:
+            raise Exception(f"When qos_type is {qos_type.name}, "
+                            f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                            f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
 
 
 class QOS(object):
@@ -194,12 +278,14 @@ class QOS(object):
                  cluster_op: bool = False,
                  enable_qos: bool = False,
                  qos_type: Optional[QOSType] = None,
-                 bw_obj: Optional[QOSBandwidthControl] = None
+                 bw_obj: Optional[QOSBandwidthControl] = None,
+                 ops_obj: Optional[QOSOpsControl] = None
                  ) -> None:
         self.cluster_op = cluster_op
         self.enable_qos = enable_qos
         self.qos_type = qos_type
         self.bw_obj = bw_obj
+        self.ops_obj = ops_obj
 
     @classmethod
     def from_dict(cls, qos_dict: Dict[str, Any], cluster_op: bool = False) -> 'QOS':
@@ -211,6 +297,7 @@ class QOS(object):
                 kwargs['qos_type'] = QOSType[qos_type]
         kwargs['enable_qos'] = qos_dict.get(QOSParams.enable_qos.value)
         kwargs['bw_obj'] = QOSBandwidthControl.from_dict(qos_dict)
+        kwargs['ops_obj'] = QOSOpsControl.from_dict(qos_dict)
         return cls(cluster_op, **kwargs)
 
     @classmethod
@@ -223,6 +310,7 @@ class QOS(object):
                 kwargs['qos_type'] = QOSType(qos_type)
         kwargs['enable_qos'] = qos_block.values.get(QOSParams.enable_qos.value)
         kwargs['bw_obj'] = QOSBandwidthControl.from_qos_block(qos_block)
+        kwargs['ops_obj'] = QOSOpsControl.from_qos_block(qos_block)
         return cls(cluster_op, **kwargs)
 
     def to_qos_block(self) -> RawBlock:
@@ -235,6 +323,8 @@ class QOS(object):
             result.values[QOSParams.qos_type.value] = self.qos_type.value
         if self.bw_obj and (res := self.bw_obj.to_qos_block()):
             result.values.update(res.values)
+        if self.ops_obj and (res := self.ops_obj.to_qos_block()):
+            result.values.update(res.values)
         return result
 
     def to_dict(self) -> Dict[str, Any]:
@@ -244,4 +334,17 @@ class QOS(object):
             r[QOSParams.qos_type.value] = self.qos_type.name
         if self.bw_obj and (res := self.bw_obj.to_dict()):
             r.update(res)
+        if self.ops_obj and (res := self.ops_obj.to_dict()):
+            r.update(res)
         return r
+
+    def get_enable_qos_val(self, disable_bw: bool = False, disable_ops: bool = False) -> bool:
+        if not (self.enable_qos) or not (disable_bw or disable_ops):
+            return False
+        # check if ops control is enabled
+        if disable_bw and self.ops_obj and self.ops_obj.enable_iops_ctrl:
+            return True
+        # check if bandwidth control is enabled
+        if disable_ops and self.bw_obj and self.bw_obj.enable_bw_ctrl:
+            return True
+        return False

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -59,18 +59,18 @@ class QOSType(Enum):
 
 def _validate_qos_bw(bandwidth: str) -> int:
     min_bw = 1000000  # 1MB
-    max_bw = 2000000000  # 2GB
+    max_bw = 4000000000  # 4GB
     bw_bytes = with_units_to_int(bandwidth)
     if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
-        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (2GB) bytes")
+        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (4GB) bytes per second.")
     return bw_bytes
 
 
 def _validate_qos_ops(count: int) -> int:
-    min_cnt = 1000  # 1K
-    max_cnt = 500000  # 5L
+    min_cnt = 10
+    max_cnt = 16384
     if count != 0 and (count < min_cnt or count > max_cnt):
-        raise Exception(f"Provided IOS count value is not in range, Please enter a value between {min_cnt} (1K) and {max_cnt} (5L) bytes")
+        raise Exception(f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} bytes per second.")
     return count
 
 

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -1,28 +1,8 @@
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 from enum import Enum
 
 from ceph.utils import bytes_to_human, with_units_to_int
-
-
-class RawBlock():
-    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
-        if not values:  # workaround mutable default argument
-            values = {}
-        if not blocks:  # workaround mutable default argument
-            blocks = []
-        self.block_name = block_name
-        self.blocks = blocks
-        self.values = values
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, RawBlock):
-            return False
-        return self.block_name == other.block_name and \
-            self.blocks == other.blocks and \
-            self.values == other.values
-
-    def __repr__(self) -> str:
-        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'
+from .ganesha_raw_conf import RawBlock
 
 
 class QOSParams(Enum):
@@ -46,9 +26,9 @@ class QOSParams(Enum):
 
 
 class UserQoSType(Enum):
-    per_share = 'PerShare'
-    per_client = 'PerClient'
-    per_share_per_client = 'PerShare_PerClient'
+    per_share = "PerShare"
+    per_client = "PerClient"
+    per_share_per_client = "PerShare_PerClient"
 
 
 class QOSType(Enum):
@@ -62,7 +42,9 @@ def _validate_qos_bw(bandwidth: str) -> int:
     max_bw = 4000000000  # 4GB
     bw_bytes = with_units_to_int(bandwidth)
     if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
-        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (4GB) bytes per second.")
+        raise Exception(
+            f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (4GB) bytes per second."
+        )
     return bw_bytes
 
 
@@ -70,41 +52,49 @@ def _validate_qos_ops(count: int) -> int:
     min_cnt = 10
     max_cnt = 16384
     if count != 0 and (count < min_cnt or count > max_cnt):
-        raise Exception(f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} bytes per second.")
+        raise Exception(
+            f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} bytes per second."
+        )
     return count
 
 
 QOS_REQ_BW_PARAMS = {
-    'combined_bw_disabled': {
-        'PerShare': ['max_export_write_bw', 'max_export_read_bw'],
-        'PerClient': ['max_client_write_bw', 'max_client_read_bw'],
-        'PerShare_PerClient': ['max_export_write_bw', 'max_export_read_bw', 'max_client_write_bw', 'max_client_read_bw']
+    "combined_bw_disabled": {
+        "PerShare": ["max_export_write_bw", "max_export_read_bw"],
+        "PerClient": ["max_client_write_bw", "max_client_read_bw"],
+        "PerShare_PerClient": [
+            "max_export_write_bw",
+            "max_export_read_bw",
+            "max_client_write_bw",
+            "max_client_read_bw",
+        ],
     },
-    'combined_bw_enabled': {
-        'PerShare': ['max_export_combined_bw'],
-        'PerClient': ['max_client_combined_bw'],
-        'PerShare_PerClient': ['max_export_combined_bw', 'max_client_combined_bw'],
-    }
+    "combined_bw_enabled": {
+        "PerShare": ["max_export_combined_bw"],
+        "PerClient": ["max_client_combined_bw"],
+        "PerShare_PerClient": ["max_export_combined_bw", "max_client_combined_bw"],
+    },
 }
 
 QOS_REQ_OPS_PARAMS = {
-    'PerShare': ['max_export_iops'],
-    'PerClient': ['max_client_iops'],
-    'PerShare_PerClient': ['max_export_iops', 'max_client_iops']
+    "PerShare": ["max_export_iops"],
+    "PerClient": ["max_client_iops"],
+    "PerShare_PerClient": ["max_export_iops", "max_client_iops"],
 }
 
 
 class QOSBandwidthControl(object):
-    def __init__(self,
-                 enable_bw_ctrl: bool = False,
-                 combined_bw_ctrl: bool = False,
-                 export_writebw: str = '0',
-                 export_readbw: str = '0',
-                 client_writebw: str = '0',
-                 client_readbw: str = '0',
-                 export_rw_bw: str = '0',
-                 client_rw_bw: str = '0'
-                 ) -> None:
+    def __init__(
+        self,
+        enable_bw_ctrl: bool = False,
+        combined_bw_ctrl: bool = False,
+        export_writebw: str = "0",
+        export_readbw: str = "0",
+        client_writebw: str = "0",
+        client_readbw: str = "0",
+        export_rw_bw: str = "0",
+        client_rw_bw: str = "0",
+    ) -> None:
         self.enable_bw_ctrl = enable_bw_ctrl
         self.combined_bw_ctrl = combined_bw_ctrl
         try:
@@ -118,37 +108,49 @@ class QOSBandwidthControl(object):
             raise Exception(f"Invalid bandwidth value. {e}")
 
     @classmethod
-    def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSBandwidthControl':
+    def from_dict(cls, qos_dict: Dict[str, Any]) -> "QOSBandwidthControl":
         # qos dict has bandwidths in human readable format(str)
         bw_kwargs = {
-            'enable_bw_ctrl': qos_dict.get(QOSParams.enable_bw_ctrl.value, False),
-            'combined_bw_ctrl': qos_dict.get(QOSParams.combined_bw_ctrl.value, False),
-            'export_writebw': qos_dict.get(QOSParams.export_writebw.value, '0'),
-            'export_readbw': qos_dict.get(QOSParams.export_readbw.value, '0'),
-            'client_writebw': qos_dict.get(QOSParams.client_writebw.value, '0'),
-            'client_readbw': qos_dict.get(QOSParams.client_readbw.value, '0'),
-            'export_rw_bw': qos_dict.get(QOSParams.export_rw_bw.value, '0'),
-            'client_rw_bw': qos_dict.get(QOSParams.client_rw_bw.value, '0')
+            "enable_bw_ctrl": qos_dict.get(QOSParams.enable_bw_ctrl.value, False),
+            "combined_bw_ctrl": qos_dict.get(QOSParams.combined_bw_ctrl.value, False),
+            "export_writebw": qos_dict.get(QOSParams.export_writebw.value, "0"),
+            "export_readbw": qos_dict.get(QOSParams.export_readbw.value, "0"),
+            "client_writebw": qos_dict.get(QOSParams.client_writebw.value, "0"),
+            "client_readbw": qos_dict.get(QOSParams.client_readbw.value, "0"),
+            "export_rw_bw": qos_dict.get(QOSParams.export_rw_bw.value, "0"),
+            "client_rw_bw": qos_dict.get(QOSParams.client_rw_bw.value, "0"),
         }
         return cls(**bw_kwargs)
 
     @classmethod
-    def from_qos_block(cls, qos_block: RawBlock) -> 'QOSBandwidthControl':
+    def from_qos_block(cls, qos_block: RawBlock) -> "QOSBandwidthControl":
         # qos block has bandwidths in bytes(int)
         bw_kwargs = {
-            'enable_bw_ctrl': qos_block.values.get(QOSParams.enable_bw_ctrl.value, False),
-            'combined_bw_ctrl': qos_block.values.get(QOSParams.combined_bw_ctrl.value, False),
-            'export_writebw': str(qos_block.values.get(QOSParams.export_writebw.value, 0)),
-            'export_readbw': str(qos_block.values.get(QOSParams.export_readbw.value, 0)),
-            'client_writebw': str(qos_block.values.get(QOSParams.client_writebw.value, 0)),
-            'client_readbw': str(qos_block.values.get(QOSParams.client_readbw.value, 0)),
-            'export_rw_bw': str(qos_block.values.get(QOSParams.export_rw_bw.value, 0)),
-            'client_rw_bw': str(qos_block.values.get(QOSParams.client_rw_bw.value, 0))
+            "enable_bw_ctrl": qos_block.values.get(
+                QOSParams.enable_bw_ctrl.value, False
+            ),
+            "combined_bw_ctrl": qos_block.values.get(
+                QOSParams.combined_bw_ctrl.value, False
+            ),
+            "export_writebw": str(
+                qos_block.values.get(QOSParams.export_writebw.value, 0)
+            ),
+            "export_readbw": str(
+                qos_block.values.get(QOSParams.export_readbw.value, 0)
+            ),
+            "client_writebw": str(
+                qos_block.values.get(QOSParams.client_writebw.value, 0)
+            ),
+            "client_readbw": str(
+                qos_block.values.get(QOSParams.client_readbw.value, 0)
+            ),
+            "export_rw_bw": str(qos_block.values.get(QOSParams.export_rw_bw.value, 0)),
+            "client_rw_bw": str(qos_block.values.get(QOSParams.client_rw_bw.value, 0)),
         }
         return cls(**bw_kwargs)
 
     def to_qos_block(self) -> RawBlock:
-        result = RawBlock('qos_bandwidths_control')
+        result = RawBlock("qos_bandwidths_control")
         result.values[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
         result.values[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
         if self.export_writebw:
@@ -174,17 +176,29 @@ class QOSBandwidthControl(object):
         r[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
         r[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
         if self.export_writebw:
-            r[QOSParams.export_writebw.value] = self.bw_for_to_dict(self.export_writebw, ret_bw_in_bytes)
+            r[QOSParams.export_writebw.value] = self.bw_for_to_dict(
+                self.export_writebw, ret_bw_in_bytes
+            )
         if self.export_readbw:
-            r[QOSParams.export_readbw.value] = self.bw_for_to_dict(self.export_readbw, ret_bw_in_bytes)
+            r[QOSParams.export_readbw.value] = self.bw_for_to_dict(
+                self.export_readbw, ret_bw_in_bytes
+            )
         if self.client_writebw:
-            r[QOSParams.client_writebw.value] = self.bw_for_to_dict(self.client_writebw, ret_bw_in_bytes)
+            r[QOSParams.client_writebw.value] = self.bw_for_to_dict(
+                self.client_writebw, ret_bw_in_bytes
+            )
         if self.client_readbw:
-            r[QOSParams.client_readbw.value] = self.bw_for_to_dict(self.client_readbw, ret_bw_in_bytes)
+            r[QOSParams.client_readbw.value] = self.bw_for_to_dict(
+                self.client_readbw, ret_bw_in_bytes
+            )
         if self.export_rw_bw:
-            r[QOSParams.export_rw_bw.value] = self.bw_for_to_dict(self.export_rw_bw, ret_bw_in_bytes)
+            r[QOSParams.export_rw_bw.value] = self.bw_for_to_dict(
+                self.export_rw_bw, ret_bw_in_bytes
+            )
         if self.client_rw_bw:
-            r[QOSParams.client_rw_bw.value] = self.bw_for_to_dict(self.client_rw_bw, ret_bw_in_bytes)
+            r[QOSParams.client_rw_bw.value] = self.bw_for_to_dict(
+                self.client_rw_bw, ret_bw_in_bytes
+            )
         return r
 
     def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
@@ -192,12 +206,12 @@ class QOSBandwidthControl(object):
         params = {}
         d = vars(self)
         for key in d:
-            if key.endswith('bw'):
+            if key.endswith("bw"):
                 params[QOSParams[key].value] = d[key]
         if not self.combined_bw_ctrl:
-            req_params = QOS_REQ_BW_PARAMS['combined_bw_disabled'][qos_type.name]
+            req_params = QOS_REQ_BW_PARAMS["combined_bw_disabled"][qos_type.name]
         else:
-            req_params = QOS_REQ_BW_PARAMS['combined_bw_enabled'][qos_type.name]
+            req_params = QOS_REQ_BW_PARAMS["combined_bw_enabled"][qos_type.name]
         allowed_params = []
         not_allowed_params = []
         for key in params:
@@ -206,40 +220,51 @@ class QOSBandwidthControl(object):
             elif key not in req_params and params[key] != 0:
                 not_allowed_params.append(key)
         if allowed_params or not_allowed_params:
-            raise Exception(f"When combined_rw_bw is {'enabled' if self.combined_bw_ctrl else 'disabled'} "
-                            f"and qos_type is {qos_type.name}, "
-                            f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
-                            f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+            raise Exception(
+                f"When combined_rw_bw is {'enabled' if self.combined_bw_ctrl else 'disabled'} "
+                f"and qos_type is {qos_type.name}, "
+                f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}."
+            )
 
 
 class QOSOpsControl(object):
-    def __init__(self,
-                 enable_iops_ctrl: bool = False,
-                 max_export_iops: int = 0,
-                 max_client_iops: int = 0
-                 ) -> None:
+    def __init__(
+        self,
+        enable_iops_ctrl: bool = False,
+        max_export_iops: int = 0,
+        max_client_iops: int = 0,
+    ) -> None:
         self.enable_iops_ctrl = enable_iops_ctrl
         self.max_export_iops = _validate_qos_ops(max_export_iops)
         self.max_client_iops = _validate_qos_ops(max_client_iops)
 
     @classmethod
-    def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSOpsControl':
+    def from_dict(cls, qos_dict: Dict[str, Any]) -> "QOSOpsControl":
         kwargs: dict[str, Any] = {}
-        kwargs['enable_iops_ctrl'] = qos_dict.get(QOSParams.enable_iops_ctrl.value, False)
-        kwargs['max_export_iops'] = qos_dict.get(QOSParams.max_export_iops.value, 0)
-        kwargs['max_client_iops'] = qos_dict.get(QOSParams.max_client_iops.value, 0)
+        kwargs["enable_iops_ctrl"] = qos_dict.get(
+            QOSParams.enable_iops_ctrl.value, False
+        )
+        kwargs["max_export_iops"] = qos_dict.get(QOSParams.max_export_iops.value, 0)
+        kwargs["max_client_iops"] = qos_dict.get(QOSParams.max_client_iops.value, 0)
         return cls(**kwargs)
 
     @classmethod
-    def from_qos_block(cls, qos_block: RawBlock) -> 'QOSOpsControl':
+    def from_qos_block(cls, qos_block: RawBlock) -> "QOSOpsControl":
         kwargs: dict[str, Any] = {}
-        kwargs['enable_iops_ctrl'] = qos_block.values.get(QOSParams.enable_iops_ctrl.value, False)
-        kwargs['max_export_iops'] = qos_block.values.get(QOSParams.max_export_iops.value, 0)
-        kwargs['max_client_iops'] = qos_block.values.get(QOSParams.max_client_iops.value, 0)
+        kwargs["enable_iops_ctrl"] = qos_block.values.get(
+            QOSParams.enable_iops_ctrl.value, False
+        )
+        kwargs["max_export_iops"] = qos_block.values.get(
+            QOSParams.max_export_iops.value, 0
+        )
+        kwargs["max_client_iops"] = qos_block.values.get(
+            QOSParams.max_client_iops.value, 0
+        )
         return cls(**kwargs)
 
     def to_qos_block(self) -> RawBlock:
-        result = RawBlock('qos_ops_control')
+        result = RawBlock("qos_ops_control")
         result.values[QOSParams.enable_iops_ctrl.value] = self.enable_iops_ctrl
         if self.max_export_iops:
             result.values[QOSParams.max_export_iops.value] = self.max_export_iops
@@ -261,7 +286,7 @@ class QOSOpsControl(object):
         params = {}
         d = vars(self)
         for key in d:
-            if key.endswith('iops'):
+            if key.endswith("iops"):
                 params[QOSParams[key].value] = d[key]
         req_params = QOS_REQ_OPS_PARAMS[qos_type.name]
         allowed_params = []
@@ -272,19 +297,22 @@ class QOSOpsControl(object):
             elif key not in req_params and params[key] != 0:
                 not_allowed_params.append(key)
         if allowed_params or not_allowed_params:
-            raise Exception(f"When qos_type is {qos_type.name}, "
-                            f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
-                            f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+            raise Exception(
+                f"When qos_type is {qos_type.name}, "
+                f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}."
+            )
 
 
 class QOS(object):
-    def __init__(self,
-                 cluster_op: bool = False,
-                 enable_qos: bool = False,
-                 qos_type: Optional[QOSType] = None,
-                 bw_obj: Optional[QOSBandwidthControl] = None,
-                 ops_obj: Optional[QOSOpsControl] = None
-                 ) -> None:
+    def __init__(
+        self,
+        cluster_op: bool = False,
+        enable_qos: bool = False,
+        qos_type: Optional[QOSType] = None,
+        bw_obj: Optional[QOSBandwidthControl] = None,
+        ops_obj: Optional[QOSOpsControl] = None,
+    ) -> None:
         self.cluster_op = cluster_op
         self.enable_qos = enable_qos
         self.qos_type = qos_type
@@ -292,29 +320,29 @@ class QOS(object):
         self.ops_obj = ops_obj
 
     @classmethod
-    def from_dict(cls, qos_dict: Dict[str, Any], cluster_op: bool = False) -> 'QOS':
+    def from_dict(cls, qos_dict: Dict[str, Any], cluster_op: bool = False) -> "QOS":
         kwargs: dict[str, Any] = {}
         # qos dict will have qos type as enum name
         if cluster_op:
             qos_type = qos_dict.get(QOSParams.qos_type.value)
             if qos_type:
-                kwargs['qos_type'] = QOSType[qos_type]
-        kwargs['enable_qos'] = qos_dict.get(QOSParams.enable_qos.value)
-        kwargs['bw_obj'] = QOSBandwidthControl.from_dict(qos_dict)
-        kwargs['ops_obj'] = QOSOpsControl.from_dict(qos_dict)
+                kwargs["qos_type"] = QOSType[qos_type]
+        kwargs["enable_qos"] = qos_dict.get(QOSParams.enable_qos.value)
+        kwargs["bw_obj"] = QOSBandwidthControl.from_dict(qos_dict)
+        kwargs["ops_obj"] = QOSOpsControl.from_dict(qos_dict)
         return cls(cluster_op, **kwargs)
 
     @classmethod
-    def from_qos_block(cls, qos_block: RawBlock, cluster_op: bool = False) -> 'QOS':
+    def from_qos_block(cls, qos_block: RawBlock, cluster_op: bool = False) -> "QOS":
         kwargs: dict[str, Any] = {}
         # qos block will have qos type as enum value
         if cluster_op:
             qos_type = qos_block.values.get(QOSParams.qos_type.value)
             if qos_type:
-                kwargs['qos_type'] = QOSType(qos_type)
-        kwargs['enable_qos'] = qos_block.values.get(QOSParams.enable_qos.value)
-        kwargs['bw_obj'] = QOSBandwidthControl.from_qos_block(qos_block)
-        kwargs['ops_obj'] = QOSOpsControl.from_qos_block(qos_block)
+                kwargs["qos_type"] = QOSType(qos_type)
+        kwargs["enable_qos"] = qos_block.values.get(QOSParams.enable_qos.value)
+        kwargs["bw_obj"] = QOSBandwidthControl.from_qos_block(qos_block)
+        kwargs["ops_obj"] = QOSOpsControl.from_qos_block(qos_block)
         return cls(cluster_op, **kwargs)
 
     def to_qos_block(self) -> RawBlock:
@@ -342,7 +370,9 @@ class QOS(object):
             r.update(res)
         return r
 
-    def get_enable_qos_val(self, disable_bw: bool = False, disable_ops: bool = False) -> bool:
+    def get_enable_qos_val(
+        self, disable_bw: bool = False, disable_ops: bool = False
+    ) -> bool:
         if not (self.enable_qos) or not (disable_bw or disable_ops):
             return False
         # check if ops control is enabled

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -165,22 +165,26 @@ class QOSBandwidthControl(object):
             result.values[QOSParams.client_rw_bw.value] = self.client_rw_bw
         return result
 
-    def to_dict(self) -> Dict[str, Any]:
+    @staticmethod
+    def bw_for_to_dict(bandwidth: int, ret_bw_in_bytes: bool = False) -> str:
+        return bytes_to_human(bandwidth) if not ret_bw_in_bytes else str(bandwidth)
+
+    def to_dict(self, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         r: dict[str, Any] = {}
         r[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
         r[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
         if self.export_writebw:
-            r[QOSParams.export_writebw.value] = bytes_to_human(self.export_writebw)
+            r[QOSParams.export_writebw.value] = self.bw_for_to_dict(self.export_writebw, ret_bw_in_bytes)
         if self.export_readbw:
-            r[QOSParams.export_readbw.value] = bytes_to_human(self.export_readbw)
+            r[QOSParams.export_readbw.value] = self.bw_for_to_dict(self.export_readbw, ret_bw_in_bytes)
         if self.client_writebw:
-            r[QOSParams.client_writebw.value] = bytes_to_human(self.client_writebw)
+            r[QOSParams.client_writebw.value] = self.bw_for_to_dict(self.client_writebw, ret_bw_in_bytes)
         if self.client_readbw:
-            r[QOSParams.client_readbw.value] = bytes_to_human(self.client_readbw)
+            r[QOSParams.client_readbw.value] = self.bw_for_to_dict(self.client_readbw, ret_bw_in_bytes)
         if self.export_rw_bw:
-            r[QOSParams.export_rw_bw.value] = bytes_to_human(self.export_rw_bw)
+            r[QOSParams.export_rw_bw.value] = self.bw_for_to_dict(self.export_rw_bw, ret_bw_in_bytes)
         if self.client_rw_bw:
-            r[QOSParams.client_rw_bw.value] = bytes_to_human(self.client_rw_bw)
+            r[QOSParams.client_rw_bw.value] = self.bw_for_to_dict(self.client_rw_bw, ret_bw_in_bytes)
         return r
 
     def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
@@ -327,12 +331,12 @@ class QOS(object):
             result.values.update(res.values)
         return result
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         r: Dict[str, Any] = {}
         r[QOSParams.enable_qos.value] = self.enable_qos
         if self.cluster_op and self.qos_type:
             r[QOSParams.qos_type.value] = self.qos_type.name
-        if self.bw_obj and (res := self.bw_obj.to_dict()):
+        if self.bw_obj and (res := self.bw_obj.to_dict(ret_bw_in_bytes)):
             r.update(res)
         if self.ops_obj and (res := self.ops_obj.to_dict()):
             r.update(res)

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -38,19 +38,19 @@ class QOSType(Enum):
 
 
 def _validate_qos_bw(bandwidth: str) -> int:
-    min_bw = 1024 * 1024  # 1MiB
+    min_bw = 128 * 1024  # 128KiB
     max_bw = 100 * 1024 * 1024 * 1024  # 100GiB
     bw_bytes = with_units_to_int(bandwidth)
     if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
         raise Exception(
-            f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MiB) and {max_bw} (100GiB) bytes per second."
+            f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (128KiB) and {max_bw} (100GiB) bytes per second."
         )
     return bw_bytes
 
 
 def _validate_qos_ops(count: int) -> int:
     min_cnt = 10
-    max_cnt = 409600
+    max_cnt = 1638400
     if count != 0 and (count < min_cnt or count > max_cnt):
         raise Exception(
             f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} count per second."

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -9,6 +9,8 @@ class QOSParams(Enum):
     clust_block = "QOS_DEFAULT_CONFIG"
     export_block = "QOS_BLOCK"
     enable_qos = "enable_qos"
+    enable_cluster_qos = "enable_cluster_qos"
+    clust_qos_msg_interval = "cqos_msg_interval"
     qos_type = "qos_type"
     # bandwidth control
     enable_bw_ctrl = "enable_bw_control"
@@ -56,6 +58,21 @@ def _validate_qos_ops(count: int) -> int:
             f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} count per second."
         )
     return count
+
+
+def validate_clust_qos_msg_interval(msg_interval: int = 0) -> int:
+    min_interval = 100  # ms
+    max_interval = 300  # ms
+
+    if not msg_interval:
+        # msg_interval of 0 is treated as unset
+        return 0
+    if msg_interval < min_interval or msg_interval > max_interval:
+        raise Exception(
+            f'Provided message interval {msg_interval} is not in range, Please '
+            f'enter a value between {min_interval}ms and {max_interval}ms.'
+        )
+    return msg_interval
 
 
 QOS_REQ_BW_PARAMS = {
@@ -309,12 +326,16 @@ class QOS(object):
         self,
         cluster_op: bool = False,
         enable_qos: bool = False,
+        enable_cluster_qos: Optional[bool] = None,
+        clust_qos_msg_interval: int = 0,
         qos_type: Optional[QOSType] = None,
         bw_obj: Optional[QOSBandwidthControl] = None,
         ops_obj: Optional[QOSOpsControl] = None,
     ) -> None:
         self.cluster_op = cluster_op
         self.enable_qos = enable_qos
+        self.enable_cluster_qos = enable_cluster_qos
+        self.clust_qos_msg_interval: int = validate_clust_qos_msg_interval(clust_qos_msg_interval)
         self.qos_type = qos_type
         self.bw_obj = bw_obj
         self.ops_obj = ops_obj
@@ -327,6 +348,8 @@ class QOS(object):
             qos_type = qos_dict.get(QOSParams.qos_type.value)
             if qos_type:
                 kwargs["qos_type"] = QOSType[qos_type]
+            kwargs["enable_cluster_qos"] = qos_dict.get(QOSParams.enable_cluster_qos.value)
+            kwargs['clust_qos_msg_interval'] = qos_dict.get(QOSParams.clust_qos_msg_interval.value)
         kwargs["enable_qos"] = qos_dict.get(QOSParams.enable_qos.value)
         kwargs["bw_obj"] = QOSBandwidthControl.from_dict(qos_dict)
         kwargs["ops_obj"] = QOSOpsControl.from_dict(qos_dict)
@@ -340,6 +363,8 @@ class QOS(object):
             qos_type = qos_block.values.get(QOSParams.qos_type.value)
             if qos_type:
                 kwargs["qos_type"] = QOSType(qos_type)
+            kwargs["enable_cluster_qos"] = qos_block.values.get(QOSParams.enable_cluster_qos.value)
+            kwargs['clust_qos_msg_interval'] = qos_block.values.get(QOSParams.clust_qos_msg_interval.value)
         kwargs["enable_qos"] = qos_block.values.get(QOSParams.enable_qos.value)
         kwargs["bw_obj"] = QOSBandwidthControl.from_qos_block(qos_block)
         kwargs["ops_obj"] = QOSOpsControl.from_qos_block(qos_block)
@@ -351,8 +376,13 @@ class QOS(object):
         else:
             result = RawBlock(QOSParams.export_block.value)
         result.values[QOSParams.enable_qos.value] = self.enable_qos
-        if self.cluster_op and self.qos_type:
-            result.values[QOSParams.qos_type.value] = self.qos_type.value
+        if self.cluster_op:
+            if self.qos_type:
+                result.values[QOSParams.qos_type.value] = self.qos_type.value
+            if self.enable_cluster_qos is not None:
+                result.values[QOSParams.enable_cluster_qos.value] = self.enable_cluster_qos
+            if self.clust_qos_msg_interval:
+                result.values[QOSParams.clust_qos_msg_interval.value] = self.clust_qos_msg_interval
         if self.bw_obj and (res := self.bw_obj.to_qos_block()):
             result.values.update(res.values)
         if self.ops_obj and (res := self.ops_obj.to_qos_block()):
@@ -362,8 +392,13 @@ class QOS(object):
     def to_dict(self, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         r: Dict[str, Any] = {}
         r[QOSParams.enable_qos.value] = self.enable_qos
-        if self.cluster_op and self.qos_type:
-            r[QOSParams.qos_type.value] = self.qos_type.name
+        if self.cluster_op:
+            if self.qos_type:
+                r[QOSParams.qos_type.value] = self.qos_type.name
+            if self.enable_cluster_qos is not None:
+                r[QOSParams.enable_cluster_qos.value] = self.enable_cluster_qos
+            if self.clust_qos_msg_interval:
+                r[QOSParams.clust_qos_msg_interval.value] = self.clust_qos_msg_interval
         if self.bw_obj and (res := self.bw_obj.to_dict(ret_bw_in_bytes)):
             r.update(res)
         if self.ops_obj and (res := self.ops_obj.to_dict()):

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -9,7 +9,6 @@ class QOSParams(Enum):
     clust_block = "QOS_DEFAULT_CONFIG"
     export_block = "QOS_BLOCK"
     enable_qos = "enable_qos"
-    enable_cluster_qos = "enable_cluster_qos"
     clust_qos_msg_interval = "cqos_msg_interval"
     qos_type = "qos_type"
     # bandwidth control
@@ -326,7 +325,6 @@ class QOS(object):
         self,
         cluster_op: bool = False,
         enable_qos: bool = False,
-        enable_cluster_qos: Optional[bool] = None,
         clust_qos_msg_interval: int = 0,
         qos_type: Optional[QOSType] = None,
         bw_obj: Optional[QOSBandwidthControl] = None,
@@ -334,7 +332,6 @@ class QOS(object):
     ) -> None:
         self.cluster_op = cluster_op
         self.enable_qos = enable_qos
-        self.enable_cluster_qos = enable_cluster_qos
         self.clust_qos_msg_interval: int = validate_clust_qos_msg_interval(clust_qos_msg_interval)
         self.qos_type = qos_type
         self.bw_obj = bw_obj
@@ -348,7 +345,6 @@ class QOS(object):
             qos_type = qos_dict.get(QOSParams.qos_type.value)
             if qos_type:
                 kwargs["qos_type"] = QOSType[qos_type]
-            kwargs["enable_cluster_qos"] = qos_dict.get(QOSParams.enable_cluster_qos.value)
             kwargs['clust_qos_msg_interval'] = qos_dict.get(QOSParams.clust_qos_msg_interval.value)
         kwargs["enable_qos"] = qos_dict.get(QOSParams.enable_qos.value)
         kwargs["bw_obj"] = QOSBandwidthControl.from_dict(qos_dict)
@@ -363,7 +359,6 @@ class QOS(object):
             qos_type = qos_block.values.get(QOSParams.qos_type.value)
             if qos_type:
                 kwargs["qos_type"] = QOSType(qos_type)
-            kwargs["enable_cluster_qos"] = qos_block.values.get(QOSParams.enable_cluster_qos.value)
             kwargs['clust_qos_msg_interval'] = qos_block.values.get(QOSParams.clust_qos_msg_interval.value)
         kwargs["enable_qos"] = qos_block.values.get(QOSParams.enable_qos.value)
         kwargs["bw_obj"] = QOSBandwidthControl.from_qos_block(qos_block)
@@ -379,8 +374,6 @@ class QOS(object):
         if self.cluster_op:
             if self.qos_type:
                 result.values[QOSParams.qos_type.value] = self.qos_type.value
-            if self.enable_cluster_qos is not None:
-                result.values[QOSParams.enable_cluster_qos.value] = self.enable_cluster_qos
             if self.clust_qos_msg_interval:
                 result.values[QOSParams.clust_qos_msg_interval.value] = self.clust_qos_msg_interval
         if self.bw_obj and (res := self.bw_obj.to_qos_block()):
@@ -395,8 +388,6 @@ class QOS(object):
         if self.cluster_op:
             if self.qos_type:
                 r[QOSParams.qos_type.value] = self.qos_type.name
-            if self.enable_cluster_qos is not None:
-                r[QOSParams.enable_cluster_qos.value] = self.enable_cluster_qos
             if self.clust_qos_msg_interval:
                 r[QOSParams.clust_qos_msg_interval.value] = self.clust_qos_msg_interval
         if self.bw_obj and (res := self.bw_obj.to_dict(ret_bw_in_bytes)):

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -34,9 +34,9 @@ class UserQoSType(Enum):
 
 
 class QOSType(Enum):
-    PerShare = 1
-    PerClient = 2
-    PerShare_PerClient = 3
+    PerShare = "Per_Export"
+    PerClient = "Per_Client"
+    PerShare_PerClient = "Per_Export_Per_Client"
 
 
 def _validate_qos_bw(bandwidth: str) -> int:

--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -3,8 +3,9 @@ from typing import Optional, Any
 
 from rados import TimedOut, ObjectNotFound, Rados
 from mgr_module import NFS_POOL_NAME as POOL_NAME
-from .ganesha_conf import RawBlock, format_block
+from .ganesha_conf import format_block
 from .utils import USER_CONF_PREFIX
+from .ganesha_raw_conf import RawBlock
 
 log = logging.getLogger(__name__)
 

--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Optional, Any
+
+from rados import TimedOut, ObjectNotFound, Rados
+from mgr_module import NFS_POOL_NAME as POOL_NAME
+from .ganesha_conf import RawBlock, format_block
+from .utils import USER_CONF_PREFIX
+
+log = logging.getLogger(__name__)
+
+
+def _check_rados_notify(ioctx: Any, obj: str) -> None:
+    try:
+        ioctx.notify(obj)
+    except TimedOut:
+        log.exception("Ganesha timed out")
+
+
+class NFSRados:
+    def __init__(self, rados: 'Rados', namespace: str) -> None:
+        self.rados = rados
+        self.pool = POOL_NAME
+        self.namespace = namespace
+
+    def _make_rados_url(self, obj: str) -> str:
+        return "rados://{}/{}/{}".format(self.pool, self.namespace, obj)
+
+    def _create_url_block(self, obj_name: str) -> RawBlock:
+        return RawBlock('%url', values={'value': self._make_rados_url(obj_name)})
+
+    def write_obj(self, conf_block: str, obj: str, config_obj: str = '') -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            ioctx.write_full(obj, conf_block.encode('utf-8'))
+            if not config_obj:
+                # Return after creating empty common config object
+                return
+            log.debug("write configuration into rados object %s/%s/%s",
+                      self.pool, self.namespace, obj)
+
+            # Add created obj url to common config obj
+            ioctx.append(config_obj, format_block(
+                         self._create_url_block(obj)).encode('utf-8'))
+            _check_rados_notify(ioctx, config_obj)
+            log.debug("Added %s url to %s", obj, config_obj)
+
+    def read_obj(self, obj: str) -> Optional[str]:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            try:
+                return ioctx.read(obj, 1048576).decode()
+            except ObjectNotFound:
+                return None
+
+    def update_obj(self, conf_block: str, obj: str, config_obj: str,
+                   should_notify: Optional[bool] = True) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            ioctx.write_full(obj, conf_block.encode('utf-8'))
+            log.debug("write configuration into rados object %s/%s/%s",
+                      self.pool, self.namespace, obj)
+            if should_notify:
+                _check_rados_notify(ioctx, config_obj)
+            log.debug("Update export %s in %s", obj, config_obj)
+
+    def remove_obj(self, obj: str, config_obj: str) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            export_urls = ioctx.read(config_obj)
+            url = '%url "{}"\n\n'.format(self._make_rados_url(obj))
+            export_urls = export_urls.replace(url.encode('utf-8'), b'')
+            ioctx.remove_object(obj)
+            ioctx.write_full(config_obj, export_urls)
+            _check_rados_notify(ioctx, config_obj)
+            log.debug("Object deleted: %s", url)
+
+    def remove_all_obj(self) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            for obj in ioctx.list_objects():
+                obj.remove()
+
+    def check_config(self, config: str = USER_CONF_PREFIX) -> bool:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            for obj in ioctx.list_objects():
+                if obj.key.startswith(config):
+                    return True
+        return False

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -186,6 +186,18 @@ QOS_BLOCK {
         "enable_iops_control": False
     }
 
+    qos_cluster_dict_bw_in_bytes = {
+        "enable_bw_control": True,
+        "enable_qos": True,
+        "combined_rw_bw_control": False,
+        "max_client_read_bw": "4000000",
+        "max_client_write_bw": "3000000",
+        "max_export_read_bw": "2000000",
+        "max_export_write_bw": "1000000",
+        "qos_type": "PerShare_PerClient",
+        "enable_iops_control": False
+    }
+
     qos_export_dict = {
         "enable_bw_control": True,
         "enable_qos": True,
@@ -194,6 +206,16 @@ QOS_BLOCK {
         "max_client_write_bw": "3.0MB",
         "max_export_read_bw": "2.0MB",
         "max_export_write_bw": "1.0MB",
+        "enable_iops_control": False
+    }
+    qos_export_dict_bw_in_bytes = {
+        "enable_bw_control": True,
+        "enable_qos": True,
+        "combined_rw_bw_control": False,
+        "max_client_read_bw": "4000000",
+        "max_client_write_bw": "3000000",
+        "max_export_read_bw": "2000000",
+        "max_export_write_bw": "1000000",
         "enable_iops_control": False
     }
 
@@ -1452,16 +1474,17 @@ EXPORT {
         assert qos.bw_obj.client_writebw == 3000000
         assert qos.bw_obj.client_readbw == 4000000
 
-    @pytest.mark.parametrize("qos_block, qos_dict", [
-        (qos_cluster_block, qos_cluster_dict),
-        (qos_export_block, qos_export_dict)
+    @pytest.mark.parametrize("qos_block, qos_dict, qos_dict_bw_in_bytes", [
+        (qos_cluster_block, qos_cluster_dict, qos_cluster_dict_bw_in_bytes),
+        (qos_export_block, qos_export_dict, qos_export_dict_bw_in_bytes)
         ])
-    def test_qos_from_block(self, qos_block, qos_dict):
+    def test_qos_from_block(self, qos_block, qos_dict, qos_dict_bw_in_bytes):
         blocks = GaneshaConfParser(qos_block).parse()
         assert isinstance(blocks, list)
         assert len(blocks) == 1
         qos = QOS.from_qos_block(blocks[0], True)
         assert qos.to_dict() == qos_dict
+        assert qos.to_dict(ret_bw_in_bytes=True) == qos_dict_bw_in_bytes
 
     def _do_test_cluster_qos_bw(self, qos_type, combined_bw_ctrl, params, positive_tc):
         nfs_mod = Module('nfs', '', '')

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -15,7 +15,15 @@ from ceph.utils import with_units_to_int, bytes_to_human
 from nfs import Module
 from nfs.export import ExportMgr, normalize_path
 from nfs.ganesha_conf import GaneshaConfParser, Export
-from nfs.qos_conf import RawBlock, QOS, QOSType, QOSParams, QOS_REQ_PARAMS, QOSBandwidthControl
+from nfs.qos_conf import (
+    RawBlock,
+    QOS,
+    QOSType,
+    QOSParams,
+    QOS_REQ_BW_PARAMS,
+    QOSBandwidthControl,
+    QOSOpsControl,
+    QOS_REQ_OPS_PARAMS)
 from nfs.cluster import NFSCluster
 from orchestrator import ServiceDescription, DaemonDescription, OrchResult
 
@@ -174,7 +182,8 @@ QOS_BLOCK {
         "max_client_write_bw": "3.0MB",
         "max_export_read_bw": "2.0MB",
         "max_export_write_bw": "1.0MB",
-        "qos_type": "PerShare_PerClient"
+        "qos_type": "PerShare_PerClient",
+        "enable_iops_control": False
     }
 
     qos_export_dict = {
@@ -184,7 +193,8 @@ QOS_BLOCK {
         "max_client_read_bw": "4.0MB",
         "max_client_write_bw": "3.0MB",
         "max_export_read_bw": "2.0MB",
-        "max_export_write_bw": "1.0MB"
+        "max_export_write_bw": "1.0MB",
+        "enable_iops_control": False
     }
 
     class RObject(object):
@@ -1453,7 +1463,7 @@ EXPORT {
         qos = QOS.from_qos_block(blocks[0], True)
         assert qos.to_dict() == qos_dict
 
-    def _do_test_cluster_qos(self, qos_type, combined_bw_ctrl, params, positive_tc):
+    def _do_test_cluster_qos_bw(self, qos_type, combined_bw_ctrl, params, positive_tc):
         nfs_mod = Module('nfs', '', '')
         cluster = NFSCluster(nfs_mod)
         try:
@@ -1462,14 +1472,16 @@ EXPORT {
         except Exception:
             if not positive_tc:
                 return
+        if not positive_tc:
+            raise Exception("This TC was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name}
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False}
         for key in params:
             expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(params[key]))
         assert out == expected_out
         cluster.disable_cluster_qos_bw(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
-        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False}
+        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
 
     @pytest.mark.parametrize("qos_type, combined_bw_ctrl, params, positive_tc", [
         (QOSType['PerShare'], False, {'export_writebw': '100MB', 'export_readbw': '200MB'}, True),
@@ -1490,10 +1502,10 @@ EXPORT {
         (QOSType['PerClient'], True, {'client_rw_bw': '200MB', 'export_rw_bw': '100MB'}, False),
         (QOSType['PerShare_PerClient'], True, {'export_rw_bw': '100MB'}, False)
         ])
-    def test_cluster_qos(self, qos_type, combined_bw_ctrl, params, positive_tc):
-        self._do_mock_test(self._do_test_cluster_qos, qos_type, combined_bw_ctrl, params, positive_tc)
+    def test_cluster_qos_bw(self, qos_type, combined_bw_ctrl, params, positive_tc):
+        self._do_mock_test(self._do_test_cluster_qos_bw, qos_type, combined_bw_ctrl, params, positive_tc)
 
-    def _do_test_export_qos(self, qos_type, clust_combined_bw_ctrl, clust_params, export_combined_bw_ctrl, export_params):
+    def _do_test_export_qos_bw(self, qos_type, clust_combined_bw_ctrl, clust_params, export_combined_bw_ctrl, export_params):
         nfs_mod = Module('nfs', '', '')
         cluster = NFSCluster(nfs_mod)
         export_mgr = ExportMgr(nfs_mod)
@@ -1502,7 +1514,7 @@ EXPORT {
             bw_obj = QOSBandwidthControl(True, export_combined_bw_ctrl, **export_params)
             export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
         except Exception as e:
-            assert str(e) == 'To configure bandwidth control for export, you must first enable bandwidth control at the cluster level.'
+            assert str(e) == 'To configure bandwidth control for export, you must first enable bandwidth control at the cluster level for foo.'
         bw_obj = QOSBandwidthControl(True, clust_combined_bw_ctrl, **clust_params)
         cluster.enable_cluster_qos_bw(self.cluster_id, qos_type, bw_obj)
 
@@ -1512,9 +1524,9 @@ EXPORT {
             export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
         except Exception:
             if export_combined_bw_ctrl:
-                req = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+                req = QOS_REQ_BW_PARAMS['combined_bw_enabled'][qos_type.name]
             else:
-                req = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+                req = QOS_REQ_BW_PARAMS['combined_bw_disabled'][qos_type.name]
             if sorted(export_params.keys()) != sorted(req):
                 return
             if qos_type.name == 'PerClient':
@@ -1545,10 +1557,215 @@ EXPORT {
         (True, {'client_rw_bw': '200MB'}),
         (True, {'export_rw_bw': '100MB', 'client_rw_bw': '200MB'})
         ])
-    def test_export_qos(self, qos_type, clust_combined_bw_ctrl, clust_params,
+    def test_export_qos_bw(self, qos_type, clust_combined_bw_ctrl, clust_params,
                         export_combined_bw_ctrl, export_params):
-        self._do_mock_test(self._do_test_export_qos, qos_type, clust_combined_bw_ctrl,
+        self._do_mock_test(self._do_test_export_qos_bw, qos_type, clust_combined_bw_ctrl,
                            clust_params, export_combined_bw_ctrl, export_params)
+
+    def _do_test_cluster_qos_ops(self, qos_type, params, positive_tc):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+        try:
+            ops_obj = QOSOpsControl(True, **params)
+            cluster.enable_cluster_qos_ops(self.cluster_id, qos_type, ops_obj)
+        except Exception:
+            if not positive_tc:
+                return
+        if not positive_tc:
+            raise Exception("This TC was supposed to fail")
+        out = cluster.get_cluster_qos(self.cluster_id)
+        expected_out = {"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": qos_type.name, "enable_iops_control": True}
+        for key in params:
+            expected_out[QOSParams[key].value] = params[key]
+        assert out == expected_out
+        cluster.disable_cluster_qos_ops(self.cluster_id)
+        out = cluster.get_cluster_qos(self.cluster_id)
+        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
+
+    @pytest.mark.parametrize("qos_type, params, positive_tc", [
+        (QOSType['PerShare'], {'max_export_iops': 10000}, True),
+        (QOSType['PerClient'], {'max_client_iops': 20000}, True),
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000}, True),
+        # negative testing
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 1000}, False),
+        (QOSType['PerShare'], {'max_client_iops': 10000}, False),
+        (QOSType['PerShare'], {}, False),
+        (QOSType['PerClient'], {'max_export_iops': 2000, 'max_client_iops': 1000}, False),
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 10}, False)
+        ])
+    def test_cluster_qos_ops(self, qos_type, params, positive_tc):
+        self._do_mock_test(self._do_test_cluster_qos_ops, qos_type, params, positive_tc)
+
+    def _do_test_export_qos_ops(self, qos_type, clust_params, export_params):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+        export_mgr = ExportMgr(nfs_mod)
+        # try enabling export level qos before enabling cluster level qos
+        try:
+            ops_obj = QOSOpsControl(True, **export_params)
+            export_mgr.enable_export_qos_ops(self.cluster_id, '/cephfs_a/', ops_obj)
+        except Exception as e:
+            assert str(e) == 'To configure IOPS control for export, you must first enable IOPS control at the cluster level foo.'
+        ops_obj = QOSOpsControl(True, **clust_params)
+        cluster.enable_cluster_qos_ops(self.cluster_id, qos_type, ops_obj)
+
+        # set export qos
+        try:
+            ops_obj = QOSOpsControl(True, **export_params)
+            export_mgr.enable_export_qos_ops(self.cluster_id, '/cephfs_a/', ops_obj)
+        except Exception:
+            req = QOS_REQ_OPS_PARAMS[qos_type.name]
+            if sorted(export_params.keys()) != sorted(req):
+                return
+            if qos_type.name == 'PerClient':
+                return
+        out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
+        expected_out = {"enable_iops_control": True, "enable_qos": True}
+        for key in export_params:
+            expected_out[QOSParams[key].value] = export_params[key]
+        assert out == expected_out
+        export_mgr.disable_export_qos_ops(self.cluster_id, '/cephfs_a/')
+        out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
+        assert out == {"enable_iops_control": False, "enable_qos": False}
+
+    @pytest.mark.parametrize("qos_type, clust_params", [
+        (QOSType['PerShare'], {'max_export_iops': 10000}),
+        (QOSType['PerClient'], {'max_client_iops': 20000}),
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000})
+        ])
+    @pytest.mark.parametrize("export_params", [
+        ({'max_export_iops': 10000}),
+        ({'max_client_iops': 20000}),
+        ({'max_export_iops': 3000, 'max_client_iops': 40000})
+        ])
+    def test_export_qos_ops(self, qos_type, clust_params, export_params):
+        self._do_mock_test(self._do_test_export_qos_ops, qos_type, clust_params, export_params)
+
+    def _do_test_cluster_qos_bw_ops(self, bw_qos_type, bw_params, ops_qos_type, ops_params, positive_tc):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+        try:
+            bw_obj = QOSBandwidthControl(True, combined_bw_ctrl=False, **bw_params)
+            cluster.enable_cluster_qos_bw(self.cluster_id, bw_qos_type, bw_obj)
+            ops_obj = QOSOpsControl(True, **ops_params)
+            cluster.enable_cluster_qos_ops(self.cluster_id, ops_qos_type, ops_obj)
+        except Exception:
+            if not positive_tc:
+                return
+        if not positive_tc:
+            raise Exception("This TC passed but it was supposed to fail")
+        out = cluster.get_cluster_qos(self.cluster_id)
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": ops_qos_type.name, "enable_iops_control": True}
+        bw_out = {}
+        ops_out = {}
+        for key in bw_params:
+            bw_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(bw_params[key]))
+        for key in ops_params:
+            ops_out[QOSParams[key].value] = ops_params[key]
+        expected_out.update(bw_out)
+        expected_out.update(ops_out)
+        assert out == expected_out
+        # disable bandwidth control
+        cluster.disable_cluster_qos_bw(self.cluster_id)
+        out = cluster.get_cluster_qos(self.cluster_id)
+        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True, "qos_type": ops_qos_type.name})
+        assert out == ops_out
+        # disable ops control
+        cluster.disable_cluster_qos_ops(self.cluster_id)
+        out = cluster.get_cluster_qos(self.cluster_id)
+        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
+
+    @pytest.mark.parametrize("bw_qos_type, bw_params, ops_qos_type, ops_params, positive_tc", [
+        # positive TCs
+        (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, 
+         QOSType['PerShare'], {'max_export_iops': 10000}, True),
+        (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'},
+         QOSType['PerClient'], {'max_client_iops': 20000}, True),
+        (QOSType['PerShare_PerClient'],
+         {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'},
+         QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000}, True),
+        # negative TCs
+        (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, QOSType['PerClient'], {}, False),
+        (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, QOSType['PerShare'], {}, False),
+        (QOSType['PerShare_PerClient'], {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, QOSType['PerClient'], {'max_client_iops': 20000}, False),
+        ])
+    def test_cluster_qos_bw_ops(self, bw_qos_type, bw_params, ops_qos_type, ops_params, positive_tc):
+        self._do_mock_test(self._do_test_cluster_qos_bw_ops, bw_qos_type, bw_params, ops_qos_type, ops_params, positive_tc)
+
+    def _do_test_export_qos_bw_ops(self, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+        export_mgr = ExportMgr(nfs_mod)
+        # enable cluster level bandwidth conrtol and try to enable ops control for export
+        bw_obj = QOSBandwidthControl(True, combined_bw_ctrl=False, **clust_bw_params)
+        cluster.enable_cluster_qos_bw(self.cluster_id, qos_type, bw_obj)
+        try:
+            ops_obj = QOSOpsControl(True, **export_ops_params)
+            export_mgr.enable_export_qos_ops(self.cluster_id, '/cephfs_a/', ops_obj)
+        except Exception:
+            pass
+        cluster.disable_cluster_qos_bw(self.cluster_id)
+        # enable ops control for cluster and try to enable bw control for export
+        ops_obj = QOSOpsControl(True, **clust_ops_params)
+        cluster.enable_cluster_qos_ops(self.cluster_id, qos_type, ops_obj)
+        try:
+            bw_obj = QOSBandwidthControl(True, combined_bw_ctrl=False, **export_bw_params)
+            export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
+        except Exception:
+            pass
+        # enbale both and verify export get
+        bw_obj = QOSBandwidthControl(True, combined_bw_ctrl=False, **clust_bw_params)
+        cluster.enable_cluster_qos_bw(self.cluster_id, qos_type, bw_obj)
+        try:
+            bw_obj = QOSBandwidthControl(True, combined_bw_ctrl=False, **export_bw_params)
+            export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
+            ops_obj = QOSOpsControl(True, **export_ops_params)
+            export_mgr.enable_export_qos_ops(self.cluster_id, '/cephfs_a/', ops_obj)
+        except Exception:
+            req = QOS_REQ_BW_PARAMS['combined_bw_disabled'][qos_type.name]
+            if sorted(export_bw_params.keys()) != sorted(req):
+                return
+            if qos_type.name == 'PerClient':
+                return
+            req = QOS_REQ_OPS_PARAMS[qos_type.name]
+            if sorted(export_ops_params.keys()) != sorted(req):
+                return
+        out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True}
+        bw_out = {}
+        ops_out = {}
+        for key in export_bw_params:
+            bw_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(export_bw_params[key]))
+        for key in export_ops_params:
+            ops_out[QOSParams[key].value] = export_ops_params[key]
+        expected_out.update(bw_out)
+        expected_out.update(ops_out)
+        assert out == expected_out
+        # disable bandwidth control of export
+        export_mgr.disable_export_qos_bw(self.cluster_id, '/cephfs_a/')
+        out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
+        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True})
+        assert out == ops_out
+        # disable ops control of export
+        export_mgr.disable_export_qos_ops(self.cluster_id, '/cephfs_a/')
+        out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
+        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
+
+    @pytest.mark.parametrize("qos_type, clust_bw_params, clust_ops_params", [
+        # positive TCs
+        (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, {'max_export_iops': 10000}),
+        (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 20000}),
+        (QOSType['PerShare_PerClient'],
+         {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 40000})
+    ])
+    @pytest.mark.parametrize("export_bw_params, export_ops_params", [
+        ({'export_writebw': '100MB', 'export_readbw': '200MB'}, {'max_export_iops': 10000}),
+        ({'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 20000}),
+        ({'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 40000})
+        ])
+    def test_export_qos_bw_ops(self, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params):
+        self._do_mock_test(self._do_test_export_qos_bw_ops, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params)
+
 
 @pytest.mark.parametrize(
     "path,expected",

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -150,7 +150,7 @@ QOS {
     enable_cluster_qos = true;
     enable_bw_control = true;
     combined_rw_bw_control = false;
-    qos_type = 3;
+    qos_type = "Per_Export_Per_Client";
     max_export_write_bw = 2000000;
     max_export_read_bw = 2000000;
     max_client_write_bw = 3000000;

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -150,7 +150,7 @@ QOS {
     enable_bw_control = true;
     combined_rw_bw_control = false;
     qos_type = 3;
-    max_export_write_bw = 1000000;
+    max_export_write_bw = 2000000;
     max_export_read_bw = 2000000;
     max_client_write_bw = 3000000;
     max_client_read_bw = 4000000;
@@ -164,7 +164,7 @@ QOS_BLOCK {
     enable_qos = true;
     enable_bw_control = true;
     combined_rw_bw_control = false;
-    max_export_write_bw = 1000000;
+    max_export_write_bw = 2000000;
     max_export_read_bw = 2000000;
     max_client_write_bw = 3000000;
     max_client_read_bw = 4000000;
@@ -181,7 +181,7 @@ QOS_BLOCK {
         "max_client_read_bw": "4.0MB",
         "max_client_write_bw": "3.0MB",
         "max_export_read_bw": "2.0MB",
-        "max_export_write_bw": "1.0MB",
+        "max_export_write_bw": "2.0MB",
         "qos_type": "PerShare_PerClient",
         "enable_iops_control": False
     }
@@ -193,7 +193,7 @@ QOS_BLOCK {
         "max_client_read_bw": "4000000",
         "max_client_write_bw": "3000000",
         "max_export_read_bw": "2000000",
-        "max_export_write_bw": "1000000",
+        "max_export_write_bw": "2000000",
         "qos_type": "PerShare_PerClient",
         "enable_iops_control": False
     }
@@ -205,7 +205,7 @@ QOS_BLOCK {
         "max_client_read_bw": "4.0MB",
         "max_client_write_bw": "3.0MB",
         "max_export_read_bw": "2.0MB",
-        "max_export_write_bw": "1.0MB",
+        "max_export_write_bw": "2.0MB",
         "enable_iops_control": False
     }
     qos_export_dict_bw_in_bytes = {
@@ -215,7 +215,7 @@ QOS_BLOCK {
         "max_client_read_bw": "4000000",
         "max_client_write_bw": "3000000",
         "max_export_read_bw": "2000000",
-        "max_export_write_bw": "1000000",
+        "max_export_write_bw": "2000000",
         "enable_iops_control": False
     }
 
@@ -1460,7 +1460,7 @@ EXPORT {
         assert qos.enable_qos == True
         assert qos.bw_obj.enable_bw_ctrl == True
         assert isinstance(qos.qos_type, QOSType)
-        assert qos.bw_obj.export_writebw == 1000000
+        assert qos.bw_obj.export_writebw == 2000000
         assert qos.bw_obj.export_readbw == 2000000
         assert qos.bw_obj.client_writebw == 3000000
         assert qos.bw_obj.client_readbw == 4000000
@@ -1469,7 +1469,7 @@ EXPORT {
         assert qos.enable_qos == True
         assert qos.bw_obj.enable_bw_ctrl == True
         assert qos.qos_type is None
-        assert qos.bw_obj.export_writebw == 1000000
+        assert qos.bw_obj.export_writebw == 2000000
         assert qos.bw_obj.export_readbw == 2000000
         assert qos.bw_obj.client_writebw == 3000000
         assert qos.bw_obj.client_readbw == 4000000

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -178,10 +178,10 @@ QOS_BLOCK {
         "enable_bw_control": True,
         "enable_qos": True,
         "combined_rw_bw_control": False,
-        "max_client_read_bw": "4.0MB",
-        "max_client_write_bw": "3.0MB",
-        "max_export_read_bw": "2.0MB",
-        "max_export_write_bw": "2.0MB",
+        "max_client_read_bw": bytes_to_human(4000000, mode='binary'),
+        "max_client_write_bw": bytes_to_human(3000000, mode='binary'),
+        "max_export_read_bw": bytes_to_human(2000000, mode='binary'),
+        "max_export_write_bw": bytes_to_human(2000000, mode='binary'),
         "qos_type": "PerShare_PerClient",
         "enable_iops_control": False
     }
@@ -202,10 +202,10 @@ QOS_BLOCK {
         "enable_bw_control": True,
         "enable_qos": True,
         "combined_rw_bw_control": False,
-        "max_client_read_bw": "4.0MB",
-        "max_client_write_bw": "3.0MB",
-        "max_export_read_bw": "2.0MB",
-        "max_export_write_bw": "2.0MB",
+        "max_client_read_bw": bytes_to_human(4000000, mode='binary'),
+        "max_client_write_bw": bytes_to_human(3000000, mode='binary'),
+        "max_export_read_bw": bytes_to_human(2000000, mode='binary'),
+        "max_export_write_bw": bytes_to_human(2000000, mode='binary'),
         "enable_iops_control": False
     }
     qos_export_dict_bw_in_bytes = {
@@ -1457,22 +1457,10 @@ EXPORT {
 
     def test_qos_from_dict(self):
         qos = QOS.from_dict(self.qos_cluster_dict, True)
-        assert qos.enable_qos == True
-        assert qos.bw_obj.enable_bw_ctrl == True
-        assert isinstance(qos.qos_type, QOSType)
-        assert qos.bw_obj.export_writebw == 2000000
-        assert qos.bw_obj.export_readbw == 2000000
-        assert qos.bw_obj.client_writebw == 3000000
-        assert qos.bw_obj.client_readbw == 4000000
+        assert qos.to_dict() == self.qos_cluster_dict
 
         qos = QOS.from_dict(self.qos_export_dict)
-        assert qos.enable_qos == True
-        assert qos.bw_obj.enable_bw_ctrl == True
-        assert qos.qos_type is None
-        assert qos.bw_obj.export_writebw == 2000000
-        assert qos.bw_obj.export_readbw == 2000000
-        assert qos.bw_obj.client_writebw == 3000000
-        assert qos.bw_obj.client_readbw == 4000000
+        assert qos.to_dict() == self.qos_export_dict
 
     @pytest.mark.parametrize("qos_block, qos_dict, qos_dict_bw_in_bytes", [
         (qos_cluster_block, qos_cluster_dict, qos_cluster_dict_bw_in_bytes),
@@ -1500,7 +1488,7 @@ EXPORT {
         out = cluster.get_cluster_qos(self.cluster_id)
         expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False}
         for key in params:
-            expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(params[key]))
+            expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(params[key]), mode='binary')
         assert out == expected_out
         cluster.disable_cluster_qos_bw(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
@@ -1557,7 +1545,7 @@ EXPORT {
         out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
         expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": export_combined_bw_ctrl}
         for key in export_params:
-            expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(export_params[key]))
+            expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(export_params[key]), mode='binary')
         expected_out.update(clust_qos_conf)
         assert out == expected_out
         export_mgr.disable_export_qos_bw(self.cluster_id, '/cephfs_a/')
@@ -1686,7 +1674,7 @@ EXPORT {
         bw_out = {}
         ops_out = {}
         for key in bw_params:
-            bw_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(bw_params[key]))
+            bw_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(bw_params[key]), mode='binary')
         for key in ops_params:
             ops_out[QOSParams[key].value] = ops_params[key]
         expected_out.update(bw_out)
@@ -1763,7 +1751,7 @@ EXPORT {
         bw_out = {}
         ops_out = {}
         for key in export_bw_params:
-            bw_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(export_bw_params[key]))
+            bw_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(export_bw_params[key]), mode='binary')
         for key in export_ops_params:
             ops_out[QOSParams[key].value] = export_ops_params[key]
         expected_out.update(bw_out)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -147,7 +147,6 @@ EXPORT {
     qos_cluster_block = """
 QOS {
     enable_qos = true;
-    enable_cluster_qos = true;
     enable_bw_control = true;
     combined_rw_bw_control = false;
     qos_type = "Per_Export_Per_Client";
@@ -178,7 +177,6 @@ QOS_BLOCK {
     qos_cluster_dict = {
         "enable_bw_control": True,
         "enable_qos": True,
-        "enable_cluster_qos": True,
         "combined_rw_bw_control": False,
         "max_client_read_bw": bytes_to_human(4000000, mode='binary'),
         "max_client_write_bw": bytes_to_human(3000000, mode='binary'),
@@ -191,7 +189,6 @@ QOS_BLOCK {
     qos_cluster_dict_bw_in_bytes = {
         "enable_bw_control": True,
         "enable_qos": True,
-        "enable_cluster_qos": True,
         "combined_rw_bw_control": False,
         "max_client_read_bw": "4000000",
         "max_client_write_bw": "3000000",
@@ -1488,16 +1485,12 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False, "enable_cluster_qos": True}
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False}
         for key in params:
             expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(params[key]), mode='binary')
         assert out == expected_out
-        cluster.global_cluster_qos_action(self.cluster_id, 'enable', 200)
-        expected_out.update({'enable_cluster_qos': True, 'cqos_msg_interval': 200})
-        assert cluster.get_cluster_qos(self.cluster_id) == expected_out
-        cluster.global_cluster_qos_action(self.cluster_id, 'disable')
-        expected_out.update({'enable_cluster_qos': False})
-        del expected_out['cqos_msg_interval']
+        cluster.cluster_qos_set_config(self.cluster_id, 200)
+        expected_out.update({'cqos_msg_interval': 200})
         assert cluster.get_cluster_qos(self.cluster_id) == expected_out
         cluster.disable_cluster_qos_bw(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
@@ -1537,7 +1530,7 @@ EXPORT {
             assert str(e) == 'To configure bandwidth control for export, you must first enable bandwidth control at the cluster level for foo.'
         bw_obj = QOSBandwidthControl(True, clust_combined_bw_ctrl, **clust_params)
         cluster.enable_cluster_qos_bw(self.cluster_id, qos_type, bw_obj)
-        clust_qos_conf = {'cluster_enable_qos': True, 'cluster_enable_bw_control': True, 'cluster_enable_iops_control': False}
+        clust_qos_conf = {'global_enable_qos': True, 'global_enable_bw_control': True, 'global_enable_iops_control': False}
         # set export qos
         try:
             bw_obj = QOSBandwidthControl(True, export_combined_bw_ctrl, **export_params)
@@ -1596,16 +1589,13 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": qos_type.name, "enable_iops_control": True, "enable_cluster_qos": True}
+        expected_out = {"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": qos_type.name, "enable_iops_control": True}
         for key in params:
             expected_out[QOSParams[key].value] = params[key]
         assert out == expected_out
-        cluster.global_cluster_qos_action(self.cluster_id, 'enable', 200)
-        expected_out.update({'enable_cluster_qos': True, 'cqos_msg_interval': 200})
+        cluster.cluster_qos_set_config(self.cluster_id, 200)
+        expected_out.update({'cqos_msg_interval': 200})
         assert cluster.get_cluster_qos(self.cluster_id) == expected_out
-        cluster.global_cluster_qos_action(self.cluster_id, 'disable')
-        expected_out.update({'enable_cluster_qos': False})
-        del expected_out['cqos_msg_interval']
         cluster.disable_cluster_qos_ops(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
         assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
@@ -1636,7 +1626,7 @@ EXPORT {
             assert str(e) == 'To configure IOPS control for export, you must first enable IOPS control at the cluster level foo.'
         ops_obj = QOSOpsControl(True, **clust_params)
         cluster.enable_cluster_qos_ops(self.cluster_id, qos_type, ops_obj)
-        clust_qos_conf = {'cluster_enable_qos': True, 'cluster_enable_bw_control': False, 'cluster_enable_iops_control': True}
+        clust_qos_conf = {'global_enable_qos': True, 'global_enable_bw_control': False, 'global_enable_iops_control': True}
         # set export qos
         try:
             ops_obj = QOSOpsControl(True, **export_params)
@@ -1685,7 +1675,7 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC passed but it was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": ops_qos_type.name, "enable_iops_control": True, "enable_cluster_qos":True}
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": ops_qos_type.name, "enable_iops_control": True}
         bw_out = {}
         ops_out = {}
         for key in bw_params:
@@ -1698,7 +1688,7 @@ EXPORT {
         # disable bandwidth control
         cluster.disable_cluster_qos_bw(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
-        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True, "qos_type": ops_qos_type.name, "enable_cluster_qos": True})
+        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True, "qos_type": ops_qos_type.name})
         assert out == ops_out
         # disable ops control
         cluster.disable_cluster_qos_ops(self.cluster_id)
@@ -1751,7 +1741,7 @@ EXPORT {
             export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
             ops_obj = QOSOpsControl(True, **export_ops_params)
             export_mgr.enable_export_qos_ops(self.cluster_id, '/cephfs_a/', ops_obj)
-            clust_qos_conf = {'cluster_enable_qos': True, 'cluster_enable_bw_control': True, 'cluster_enable_iops_control': True}
+            clust_qos_conf = {'global_enable_qos': True, 'global_enable_bw_control': True, 'global_enable_iops_control': True}
         except Exception:
             req = QOS_REQ_BW_PARAMS['combined_bw_disabled'][qos_type.name]
             if sorted(export_bw_params.keys()) != sorted(req):

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1584,14 +1584,14 @@ EXPORT {
 
     @pytest.mark.parametrize("qos_type, params, positive_tc", [
         (QOSType['PerShare'], {'max_export_iops': 10000}, True),
-        (QOSType['PerClient'], {'max_client_iops': 20000}, True),
-        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000}, True),
+        (QOSType['PerClient'], {'max_client_iops': 15000}, True),
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 14000}, True),
         # negative testing
         (QOSType['PerShare_PerClient'], {'max_export_iops': 1000}, False),
         (QOSType['PerShare'], {'max_client_iops': 10000}, False),
         (QOSType['PerShare'], {}, False),
         (QOSType['PerClient'], {'max_export_iops': 2000, 'max_client_iops': 1000}, False),
-        (QOSType['PerShare_PerClient'], {'max_export_iops': 10}, False)
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 9}, False)
         ])
     def test_cluster_qos_ops(self, qos_type, params, positive_tc):
         self._do_mock_test(self._do_test_cluster_qos_ops, qos_type, params, positive_tc)
@@ -1630,13 +1630,13 @@ EXPORT {
 
     @pytest.mark.parametrize("qos_type, clust_params", [
         (QOSType['PerShare'], {'max_export_iops': 10000}),
-        (QOSType['PerClient'], {'max_client_iops': 20000}),
-        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000})
+        (QOSType['PerClient'], {'max_client_iops': 2000}),
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 4000})
         ])
     @pytest.mark.parametrize("export_params", [
         ({'max_export_iops': 10000}),
-        ({'max_client_iops': 20000}),
-        ({'max_export_iops': 3000, 'max_client_iops': 40000})
+        ({'max_client_iops': 2000}),
+        ({'max_export_iops': 3000, 'max_client_iops': 4000})
         ])
     def test_export_qos_ops(self, qos_type, clust_params, export_params):
         self._do_mock_test(self._do_test_export_qos_ops, qos_type, clust_params, export_params)
@@ -1680,10 +1680,10 @@ EXPORT {
         (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, 
          QOSType['PerShare'], {'max_export_iops': 10000}, True),
         (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'},
-         QOSType['PerClient'], {'max_client_iops': 20000}, True),
+         QOSType['PerClient'], {'max_client_iops': 2000}, True),
         (QOSType['PerShare_PerClient'],
          {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'},
-         QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000}, True),
+         QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 4000}, True),
         # negative TCs
         (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, QOSType['PerClient'], {}, False),
         (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, QOSType['PerShare'], {}, False),
@@ -1754,14 +1754,14 @@ EXPORT {
     @pytest.mark.parametrize("qos_type, clust_bw_params, clust_ops_params", [
         # positive TCs
         (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, {'max_export_iops': 10000}),
-        (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 20000}),
+        (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 2000}),
         (QOSType['PerShare_PerClient'],
-         {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 40000})
+         {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 4000})
     ])
     @pytest.mark.parametrize("export_bw_params, export_ops_params", [
         ({'export_writebw': '100MB', 'export_readbw': '200MB'}, {'max_export_iops': 10000}),
-        ({'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 20000}),
-        ({'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 40000})
+        ({'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 12000}),
+        ({'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 4000})
         ])
     def test_export_qos_bw_ops(self, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params):
         self._do_mock_test(self._do_test_export_qos_bw_ops, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1540,7 +1540,7 @@ EXPORT {
             assert str(e) == 'To configure bandwidth control for export, you must first enable bandwidth control at the cluster level for foo.'
         bw_obj = QOSBandwidthControl(True, clust_combined_bw_ctrl, **clust_params)
         cluster.enable_cluster_qos_bw(self.cluster_id, qos_type, bw_obj)
-
+        clust_qos_conf = {'cluster_enable_qos': True, 'cluster_enable_bw_control': True, 'cluster_enable_iops_control': False}
         # set export qos
         try:
             bw_obj = QOSBandwidthControl(True, export_combined_bw_ctrl, **export_params)
@@ -1558,10 +1558,12 @@ EXPORT {
         expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": export_combined_bw_ctrl}
         for key in export_params:
             expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(export_params[key]))
+        expected_out.update(clust_qos_conf)
         assert out == expected_out
         export_mgr.disable_export_qos_bw(self.cluster_id, '/cephfs_a/')
         out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
-        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False}
+        clust_qos_conf.update({"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False})
+        assert out == clust_qos_conf
 
 
     @pytest.mark.parametrize("qos_type, clust_combined_bw_ctrl, clust_params", [
@@ -1631,7 +1633,7 @@ EXPORT {
             assert str(e) == 'To configure IOPS control for export, you must first enable IOPS control at the cluster level foo.'
         ops_obj = QOSOpsControl(True, **clust_params)
         cluster.enable_cluster_qos_ops(self.cluster_id, qos_type, ops_obj)
-
+        clust_qos_conf = {'cluster_enable_qos': True, 'cluster_enable_bw_control': False, 'cluster_enable_iops_control': True}
         # set export qos
         try:
             ops_obj = QOSOpsControl(True, **export_params)
@@ -1646,10 +1648,12 @@ EXPORT {
         expected_out = {"enable_iops_control": True, "enable_qos": True}
         for key in export_params:
             expected_out[QOSParams[key].value] = export_params[key]
+        expected_out.update(clust_qos_conf)
         assert out == expected_out
         export_mgr.disable_export_qos_ops(self.cluster_id, '/cephfs_a/')
         out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
-        assert out == {"enable_iops_control": False, "enable_qos": False}
+        clust_qos_conf.update({"enable_iops_control": False, "enable_qos": False})
+        assert out == clust_qos_conf
 
     @pytest.mark.parametrize("qos_type, clust_params", [
         (QOSType['PerShare'], {'max_export_iops': 10000}),
@@ -1744,6 +1748,7 @@ EXPORT {
             export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
             ops_obj = QOSOpsControl(True, **export_ops_params)
             export_mgr.enable_export_qos_ops(self.cluster_id, '/cephfs_a/', ops_obj)
+            clust_qos_conf = {'cluster_enable_qos': True, 'cluster_enable_bw_control': True, 'cluster_enable_iops_control': True}
         except Exception:
             req = QOS_REQ_BW_PARAMS['combined_bw_disabled'][qos_type.name]
             if sorted(export_bw_params.keys()) != sorted(req):
@@ -1763,16 +1768,19 @@ EXPORT {
             ops_out[QOSParams[key].value] = export_ops_params[key]
         expected_out.update(bw_out)
         expected_out.update(ops_out)
+        expected_out.update(clust_qos_conf)
         assert out == expected_out
         # disable bandwidth control of export
         export_mgr.disable_export_qos_bw(self.cluster_id, '/cephfs_a/')
         out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
         ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True})
+        ops_out.update(clust_qos_conf)
         assert out == ops_out
         # disable ops control of export
         export_mgr.disable_export_qos_ops(self.cluster_id, '/cephfs_a/')
         out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
-        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
+        clust_qos_conf.update({"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False})
+        assert out == clust_qos_conf
 
     @pytest.mark.parametrize("qos_type, clust_bw_params, clust_ops_params", [
         # positive TCs

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -11,9 +11,11 @@ from mgr_module import MgrModule, NFS_POOL_NAME
 from rados import ObjectNotFound
 
 from ceph.deployment.service_spec import NFSServiceSpec
+from ceph.utils import with_units_to_int, bytes_to_human
 from nfs import Module
 from nfs.export import ExportMgr, normalize_path
-from nfs.ganesha_conf import GaneshaConfParser, Export, RawBlock
+from nfs.ganesha_conf import GaneshaConfParser, Export
+from nfs.qos_conf import RawBlock, QOS, QOSType, QOSParams, QOS_REQ_PARAMS, QOSBandwidthControl
 from nfs.cluster import NFSCluster
 from orchestrator import ServiceDescription, DaemonDescription, OrchResult
 
@@ -133,6 +135,57 @@ EXPORT {
 %url "rados://{NFS_POOL_NAME}/{cluster_id}/export-1"
 
 %url "rados://{NFS_POOL_NAME}/{cluster_id}/export-2"'''
+
+    qos_cluster_block = """
+QOS {
+    enable_qos = true;
+    enable_bw_control = true;
+    combined_rw_bw_control = false;
+    qos_type = 3;
+    max_export_write_bw = 1000000;
+    max_export_read_bw = 2000000;
+    max_client_write_bw = 3000000;
+    max_client_read_bw = 4000000;
+    max_export_combined_bw = 0;
+    max_client_combined_bw = 0;
+}
+"""
+
+    qos_export_block = """
+QOS_BLOCK {
+    enable_qos = true;
+    enable_bw_control = true;
+    combined_rw_bw_control = false;
+    max_export_write_bw = 1000000;
+    max_export_read_bw = 2000000;
+    max_client_write_bw = 3000000;
+    max_client_read_bw = 4000000;
+    max_export_combined_bw = 0;
+    max_client_combined_bw = 0;
+
+}
+"""
+
+    qos_cluster_dict = {
+        "enable_bw_control": True,
+        "enable_qos": True,
+        "combined_rw_bw_control": False,
+        "max_client_read_bw": "4.0MB",
+        "max_client_write_bw": "3.0MB",
+        "max_export_read_bw": "2.0MB",
+        "max_export_write_bw": "1.0MB",
+        "qos_type": "PerShare_PerClient"
+    }
+
+    qos_export_dict = {
+        "enable_bw_control": True,
+        "enable_qos": True,
+        "combined_rw_bw_control": False,
+        "max_client_read_bw": "4.0MB",
+        "max_client_write_bw": "3.0MB",
+        "max_export_read_bw": "2.0MB",
+        "max_export_write_bw": "1.0MB"
+    }
 
     class RObject(object):
         def __init__(self, key: str, raw: str) -> None:
@@ -712,7 +765,11 @@ NFS_CORE_PARAM {
         assert export.clients[0].access_type is None
         assert export.cluster_id == self.cluster_id
 
-        # again, but without export_id
+        # again, but without export_id and qos_block
+        cluster = NFSCluster(nfs_mod)
+        bw_obj = QOSBandwidthControl(True, export_writebw='100MB', export_readbw='200MB')
+        cluster.enable_cluster_qos_bw(self.cluster_id, QOSType['PerShare'], bw_obj)
+
         r = conf.apply_export(self.cluster_id, json.dumps({
             'path': 'newestbucket',
             'pseudo': '/rgw/bucket',
@@ -732,6 +789,13 @@ NFS_CORE_PARAM {
                 'user_id': 'nfs.foo.newestbucket',
                 'access_key_id': 'the_access_key',
                 'secret_access_key': 'the_secret_key',
+            },
+            'qos_block': {
+               'combined_rw_bw_control': False,
+               'enable_bw_control': True,
+               'enable_qos': True,
+               'max_export_read_bw': '3000000',
+               'max_export_write_bw': '2000000'
             }
         }))
         assert len(r.changes) == 1
@@ -751,6 +815,11 @@ NFS_CORE_PARAM {
         assert export.clients[0].squash is None
         assert export.clients[0].access_type is None
         assert export.cluster_id == self.cluster_id
+        assert export.qos_block.enable_qos == True
+        assert export.qos_block.bw_obj.enable_bw_ctrl == True
+        assert export.qos_block.bw_obj.combined_bw_ctrl == False
+        assert export.qos_block.bw_obj.export_writebw == 2000000
+        assert export.qos_block.bw_obj.export_readbw == 3000000
 
     def test_update_export_sectype(self):
         self._do_mock_test(self._test_update_export_sectype)
@@ -1354,6 +1423,132 @@ EXPORT {
     def test_cluster_config(self):
         self._do_mock_test(self._do_test_cluster_config)
 
+    def test_qos_from_dict(self):
+        qos = QOS.from_dict(self.qos_cluster_dict, True)
+        assert qos.enable_qos == True
+        assert qos.bw_obj.enable_bw_ctrl == True
+        assert isinstance(qos.qos_type, QOSType)
+        assert qos.bw_obj.export_writebw == 1000000
+        assert qos.bw_obj.export_readbw == 2000000
+        assert qos.bw_obj.client_writebw == 3000000
+        assert qos.bw_obj.client_readbw == 4000000
+
+        qos = QOS.from_dict(self.qos_export_dict)
+        assert qos.enable_qos == True
+        assert qos.bw_obj.enable_bw_ctrl == True
+        assert qos.qos_type is None
+        assert qos.bw_obj.export_writebw == 1000000
+        assert qos.bw_obj.export_readbw == 2000000
+        assert qos.bw_obj.client_writebw == 3000000
+        assert qos.bw_obj.client_readbw == 4000000
+
+    @pytest.mark.parametrize("qos_block, qos_dict", [
+        (qos_cluster_block, qos_cluster_dict),
+        (qos_export_block, qos_export_dict)
+        ])
+    def test_qos_from_block(self, qos_block, qos_dict):
+        blocks = GaneshaConfParser(qos_block).parse()
+        assert isinstance(blocks, list)
+        assert len(blocks) == 1
+        qos = QOS.from_qos_block(blocks[0], True)
+        assert qos.to_dict() == qos_dict
+
+    def _do_test_cluster_qos(self, qos_type, combined_bw_ctrl, params, positive_tc):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+        try:
+            bw_obj = QOSBandwidthControl(True, combined_bw_ctrl, **params)
+            cluster.enable_cluster_qos_bw(self.cluster_id, qos_type, bw_obj)
+        except Exception:
+            if not positive_tc:
+                return
+        out = cluster.get_cluster_qos(self.cluster_id)
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name}
+        for key in params:
+            expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(params[key]))
+        assert out == expected_out
+        cluster.disable_cluster_qos_bw(self.cluster_id)
+        out = cluster.get_cluster_qos(self.cluster_id)
+        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False}
+
+    @pytest.mark.parametrize("qos_type, combined_bw_ctrl, params, positive_tc", [
+        (QOSType['PerShare'], False, {'export_writebw': '100MB', 'export_readbw': '200MB'}, True),
+        (QOSType['PerClient'], False, {'client_writebw': '300MB', 'client_readbw': '400MB'}, True),
+        (QOSType['PerShare_PerClient'], False, {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, True),
+        (QOSType['PerShare'], True, {'export_rw_bw': '100MB'}, True),
+        (QOSType['PerClient'], True, {'client_rw_bw': '200MB'}, True),
+        (QOSType['PerShare_PerClient'], True, {'export_rw_bw': '100MB', 'client_rw_bw': '200MB'}, True),
+        # negative testing
+        (QOSType['PerShare'], False, {'export_writebw': '100MB', 'client_readbw': '200MB'}, False),
+        (QOSType['PerShare'], False, {'export_writebw': '100MB'}, False),
+        (QOSType['PerClient'], False, {'client_writebw': '300MB'}, False),
+        (QOSType['PerClient'], False, {'client_writebw': '300MB', 'export_readbw': '400MB'}, False),
+        (QOSType['PerShare_PerClient'], False, {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB'}, False),
+        (QOSType['PerShare_PerClient'], False, {'export_writebw': '100MB'}, False),
+        (QOSType['PerShare'], True, {'client_rw_bw': '100MB'}, False),
+        (QOSType['PerShare'], True, {}, False),
+        (QOSType['PerClient'], True, {'client_rw_bw': '200MB', 'export_rw_bw': '100MB'}, False),
+        (QOSType['PerShare_PerClient'], True, {'export_rw_bw': '100MB'}, False)
+        ])
+    def test_cluster_qos(self, qos_type, combined_bw_ctrl, params, positive_tc):
+        self._do_mock_test(self._do_test_cluster_qos, qos_type, combined_bw_ctrl, params, positive_tc)
+
+    def _do_test_export_qos(self, qos_type, clust_combined_bw_ctrl, clust_params, export_combined_bw_ctrl, export_params):
+        nfs_mod = Module('nfs', '', '')
+        cluster = NFSCluster(nfs_mod)
+        export_mgr = ExportMgr(nfs_mod)
+        # try enabling export level qos before enabling cluster level qos
+        try:
+            bw_obj = QOSBandwidthControl(True, export_combined_bw_ctrl, **export_params)
+            export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
+        except Exception as e:
+            assert str(e) == 'To configure bandwidth control for export, you must first enable bandwidth control at the cluster level.'
+        bw_obj = QOSBandwidthControl(True, clust_combined_bw_ctrl, **clust_params)
+        cluster.enable_cluster_qos_bw(self.cluster_id, qos_type, bw_obj)
+
+        # set export qos
+        try:
+            bw_obj = QOSBandwidthControl(True, export_combined_bw_ctrl, **export_params)
+            export_mgr.enable_export_qos_bw(self.cluster_id, '/cephfs_a/', bw_obj)
+        except Exception:
+            if export_combined_bw_ctrl:
+                req = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+            else:
+                req = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+            if sorted(export_params.keys()) != sorted(req):
+                return
+            if qos_type.name == 'PerClient':
+                return
+        out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": export_combined_bw_ctrl}
+        for key in export_params:
+            expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(export_params[key]))
+        assert out == expected_out
+        export_mgr.disable_export_qos_bw(self.cluster_id, '/cephfs_a/')
+        out = export_mgr.get_export_qos(self.cluster_id, '/cephfs_a/')
+        assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False}
+
+
+    @pytest.mark.parametrize("qos_type, clust_combined_bw_ctrl, clust_params", [
+        (QOSType['PerShare'], False, {'export_writebw': '100MB', 'export_readbw': '200MB'}),
+        (QOSType['PerClient'], False, {'client_writebw': '300MB', 'client_readbw': '400MB'}),
+        (QOSType['PerShare_PerClient'], False, {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}),
+        (QOSType['PerShare'], True, {'export_rw_bw': '100MB'}),
+        (QOSType['PerClient'], True, {'client_rw_bw': '200MB'}),
+        (QOSType['PerShare_PerClient'], True, {'export_rw_bw': '100MB', 'client_rw_bw': '200MB'})
+        ])
+    @pytest.mark.parametrize("export_combined_bw_ctrl, export_params", [
+        (False, {'export_writebw': '100MB', 'export_readbw': '200MB'}),
+        (False, {'client_writebw': '300MB', 'client_readbw': '400MB'}),
+        (False, {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}),
+        (True, {'export_rw_bw': '100MB'}),
+        (True, {'client_rw_bw': '200MB'}),
+        (True, {'export_rw_bw': '100MB', 'client_rw_bw': '200MB'})
+        ])
+    def test_export_qos(self, qos_type, clust_combined_bw_ctrl, clust_params,
+                        export_combined_bw_ctrl, export_params):
+        self._do_mock_test(self._do_test_export_qos, qos_type, clust_combined_bw_ctrl,
+                           clust_params, export_combined_bw_ctrl, export_params)
 
 @pytest.mark.parametrize(
     "path,expected",

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -147,6 +147,7 @@ EXPORT {
     qos_cluster_block = """
 QOS {
     enable_qos = true;
+    enable_cluster_qos = true;
     enable_bw_control = true;
     combined_rw_bw_control = false;
     qos_type = 3;
@@ -177,6 +178,7 @@ QOS_BLOCK {
     qos_cluster_dict = {
         "enable_bw_control": True,
         "enable_qos": True,
+        "enable_cluster_qos": True,
         "combined_rw_bw_control": False,
         "max_client_read_bw": bytes_to_human(4000000, mode='binary'),
         "max_client_write_bw": bytes_to_human(3000000, mode='binary'),
@@ -189,6 +191,7 @@ QOS_BLOCK {
     qos_cluster_dict_bw_in_bytes = {
         "enable_bw_control": True,
         "enable_qos": True,
+        "enable_cluster_qos": True,
         "combined_rw_bw_control": False,
         "max_client_read_bw": "4000000",
         "max_client_write_bw": "3000000",
@@ -1462,15 +1465,14 @@ EXPORT {
         qos = QOS.from_dict(self.qos_export_dict)
         assert qos.to_dict() == self.qos_export_dict
 
-    @pytest.mark.parametrize("qos_block, qos_dict, qos_dict_bw_in_bytes", [
-        (qos_cluster_block, qos_cluster_dict, qos_cluster_dict_bw_in_bytes),
-        (qos_export_block, qos_export_dict, qos_export_dict_bw_in_bytes)
+    @pytest.mark.parametrize("qos_block, qos_dict, qos_dict_bw_in_bytes, clust_op", [
+        (qos_cluster_block, qos_cluster_dict, qos_cluster_dict_bw_in_bytes, True),
+        (qos_export_block, qos_export_dict, qos_export_dict_bw_in_bytes, False)
         ])
-    def test_qos_from_block(self, qos_block, qos_dict, qos_dict_bw_in_bytes):
+    def test_qos_from_block(self, qos_block, qos_dict, qos_dict_bw_in_bytes, clust_op):
         blocks = GaneshaConfParser(qos_block).parse()
         assert isinstance(blocks, list)
-        assert len(blocks) == 1
-        qos = QOS.from_qos_block(blocks[0], True)
+        qos = QOS.from_qos_block(blocks[0], clust_op)
         assert qos.to_dict() == qos_dict
         assert qos.to_dict(ret_bw_in_bytes=True) == qos_dict_bw_in_bytes
 
@@ -1486,10 +1488,17 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False}
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False, "enable_cluster_qos": True}
         for key in params:
             expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(params[key]), mode='binary')
         assert out == expected_out
+        cluster.global_cluster_qos_action(self.cluster_id, 'enable', 200)
+        expected_out.update({'enable_cluster_qos': True, 'cqos_msg_interval': 200})
+        assert cluster.get_cluster_qos(self.cluster_id) == expected_out
+        cluster.global_cluster_qos_action(self.cluster_id, 'disable')
+        expected_out.update({'enable_cluster_qos': False})
+        del expected_out['cqos_msg_interval']
+        assert cluster.get_cluster_qos(self.cluster_id) == expected_out
         cluster.disable_cluster_qos_bw(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
         assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
@@ -1587,10 +1596,16 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": qos_type.name, "enable_iops_control": True}
+        expected_out = {"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": qos_type.name, "enable_iops_control": True, "enable_cluster_qos": True}
         for key in params:
             expected_out[QOSParams[key].value] = params[key]
         assert out == expected_out
+        cluster.global_cluster_qos_action(self.cluster_id, 'enable', 200)
+        expected_out.update({'enable_cluster_qos': True, 'cqos_msg_interval': 200})
+        assert cluster.get_cluster_qos(self.cluster_id) == expected_out
+        cluster.global_cluster_qos_action(self.cluster_id, 'disable')
+        expected_out.update({'enable_cluster_qos': False})
+        del expected_out['cqos_msg_interval']
         cluster.disable_cluster_qos_ops(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
         assert out == {"enable_bw_control": False, "enable_qos": False, "combined_rw_bw_control": False, "enable_iops_control": False}
@@ -1670,7 +1685,7 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC passed but it was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": ops_qos_type.name, "enable_iops_control": True}
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": ops_qos_type.name, "enable_iops_control": True, "enable_cluster_qos":True}
         bw_out = {}
         ops_out = {}
         for key in bw_params:
@@ -1683,7 +1698,7 @@ EXPORT {
         # disable bandwidth control
         cluster.disable_cluster_qos_bw(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
-        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True, "qos_type": ops_qos_type.name})
+        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True, "qos_type": ops_qos_type.name, "enable_cluster_qos": True})
         assert out == ops_out
         # disable ops control
         cluster.disable_cluster_qos_ops(self.cluster_id)

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 EXPORT_PREFIX: str = "export-"
 CONF_PREFIX: str = "conf-nfs."
 USER_CONF_PREFIX: str = "userconf-nfs."
+QOS_CONF_PREFIX: str = "qosconf-nfs."
 
 log = logging.getLogger(__name__)
 
@@ -57,8 +58,13 @@ def conf_obj_name(cluster_id: str) -> str:
 
 
 def user_conf_obj_name(cluster_id: str) -> str:
-    """Returna a rados object name for the user config."""
+    """Return a rados object name for the user config."""
     return f"{USER_CONF_PREFIX}{cluster_id}"
+
+
+def qos_conf_obj_name(cluster_id: str) -> str:
+    """Return a rados object name for the qos config."""
+    return f"{QOS_CONF_PREFIX}{cluster_id}"
 
 
 def available_clusters(mgr: 'Module') -> List[str]:

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -118,8 +118,7 @@ def nfs_rados_configs(rados: 'Rados', nfs_pool: str = POOL_NAME) -> List[str]:
                     ns.append(obj.nspace)
     except ObjectNotFound:
         log.debug("Failed to open pool %s", nfs_pool)
-    finally:
-        return ns
+    return ns
 
 
 def restart_nfs_service(mgr: 'Module', cluster_id: str) -> None:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1376,6 +1376,7 @@ class NFSServiceSpec(ServiceSpec):
                  idmap_conf: Optional[Dict[str, Dict[str, str]]] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
                  cluster_qos_config: Optional[Dict[str, Union[str, bool, int]]] = None,
+                 cluster_qos_port: Optional[int] = None,
                  ssl: bool = False,
                  ssl_cert: Optional[str] = None,
                  ssl_key: Optional[str] = None,
@@ -1414,6 +1415,7 @@ class NFSServiceSpec(ServiceSpec):
         self.enable_rdma = enable_rdma
         self.rdma_port = rdma_port
         self.cluster_qos_config = cluster_qos_config
+        self.cluster_qos_port = cluster_qos_port
 
         # colocation_ports is a list of port dicts for ADDITIONAL colocated daemons
         # The first daemon always uses port and monitoring_port from the spec
@@ -1433,7 +1435,7 @@ class NFSServiceSpec(ServiceSpec):
         return self.COLOCATION_PORT_FIELDS
 
     def get_port_start(self) -> List[int]:
-        ports = [self.port or 2049, self.monitoring_port or 9587]
+        ports = [self.port or 2049, self.monitoring_port or 9587, self.cluster_qos_port or 31311]
         if self.enable_rdma:
             ports.append(self.rdma_port or 20049)
         return ports
@@ -1521,18 +1523,24 @@ class NFSServiceSpec(ServiceSpec):
             qos_type = self.cluster_qos_config.get('qos_type')
             valid_qos_types = ['PerShare', 'PerClient', 'PerShare_PerClient']
             if not qos_type:
-                raise SpecValidationError('Invalid NFS spec: to set cluster-level QoS, "qos_type" must be provided.')
+                raise SpecValidationError(
+                    'Invalid NFS spec: to set cluster-level QoS, "qos_type" must be provided.'
+                )
             if qos_type not in valid_qos_types:
                 raise SpecValidationError(
-                    f'Invalid NFS spec: "{qos_type}" is not a valid qos_type. Valid types are: {"|".join(valid_qos_types)}.'
+                    f'Invalid NFS spec: "{qos_type}" is not a valid qos_type. '
+                    f'Valid types are: {"|".join(valid_qos_types)}.'
                 )
 
             # Verify bandwidth and IOPS types
             for key, value in self.cluster_qos_config.items():
                 if key.endswith('bw') and not isinstance(value, str):
-                    raise SpecValidationError(f"Invalid NFS spec: bandwidth '{key}' should be a string")
+                    raise SpecValidationError(
+                        f"Invalid NFS spec: bandwidth '{key}' should be a string"
+                    )
                 if key.endswith('iops') and not isinstance(value, int):
-                    raise SpecValidationError(f"Invalid NFS spec: IOPS '{key}' should be an integer")
+                    raise SpecValidationError(
+                        f"Invalid NFS spec: IOPS '{key}' should be an integer")
 
         # TLS certificate validation
         if self.ssl and not self.certificate_source:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1350,8 +1350,13 @@ yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)
 
 
 class NFSServiceSpec(ServiceSpec):
-    COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port']
-    COLOCATION_PORT_FIELDS_WITH_RDMA = ['data_port', 'monitoring_port', 'rdma_port']
+    COLOCATION_PORT_FIELDS = ['data_port', 'monitoring_port', 'cluster_qos_port']
+    COLOCATION_PORT_FIELDS_WITH_RDMA = [
+        'data_port',
+        'monitoring_port',
+        'cluster_qos_port',
+        'rdma_port'
+    ]
 
     def __init__(self,
                  service_type: str = 'nfs',

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1375,6 +1375,7 @@ class NFSServiceSpec(ServiceSpec):
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  idmap_conf: Optional[Dict[str, Dict[str, str]]] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
+                 cluster_qos_config: Optional[Dict[str, Union[str, bool, int]]] = None,
                  ssl: bool = False,
                  ssl_cert: Optional[str] = None,
                  ssl_key: Optional[str] = None,
@@ -1412,6 +1413,7 @@ class NFSServiceSpec(ServiceSpec):
         self.enable_nlm = enable_nlm
         self.enable_rdma = enable_rdma
         self.rdma_port = rdma_port
+        self.cluster_qos_config = cluster_qos_config
 
         # colocation_ports is a list of port dicts for ADDITIONAL colocated daemons
         # The first daemon always uses port and monitoring_port from the spec
@@ -1500,6 +1502,37 @@ class NFSServiceSpec(ServiceSpec):
 
         # Validate colocation_ports
         self.validate_colocation_ports()
+
+        # validate qos dict
+        if self.cluster_qos_config:
+            qos_enable = self.cluster_qos_config.get('enable_qos', True)
+            enable_bw_ctrl = self.cluster_qos_config.get('enable_bw_control', False)
+            combined_bw_ctrl = self.cluster_qos_config.get('combined_rw_bw_control', False)
+            enable_ops_ctrl = self.cluster_qos_config.get('enable_iops_control', False)
+            for key in [qos_enable, enable_bw_ctrl, combined_bw_ctrl, enable_ops_ctrl]:
+                if not isinstance(key, bool):
+                    raise SpecValidationError('Invalid NFS spec: cluster_qos_config is not correct')
+            if not qos_enable or not (enable_bw_ctrl or enable_ops_ctrl):
+                # this means bandwidth or iops qos won't be enable, we don't need to set qos
+                self.cluster_qos_config = None
+                return
+
+            # Verify qos_type
+            qos_type = self.cluster_qos_config.get('qos_type')
+            valid_qos_types = ['PerShare', 'PerClient', 'PerShare_PerClient']
+            if not qos_type:
+                raise SpecValidationError('Invalid NFS spec: to set cluster-level QoS, "qos_type" must be provided.')
+            if qos_type not in valid_qos_types:
+                raise SpecValidationError(
+                    f'Invalid NFS spec: "{qos_type}" is not a valid qos_type. Valid types are: {"|".join(valid_qos_types)}.'
+                )
+
+            # Verify bandwidth and IOPS types
+            for key, value in self.cluster_qos_config.items():
+                if key.endswith('bw') and not isinstance(value, str):
+                    raise SpecValidationError(f"Invalid NFS spec: bandwidth '{key}' should be a string")
+                if key.endswith('iops') and not isinstance(value, int):
+                    raise SpecValidationError(f"Invalid NFS spec: IOPS '{key}' should be an integer")
 
         # TLS certificate validation
         if self.ssl and not self.certificate_source:

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -558,8 +558,8 @@ def test_nfs_spec_rdma_default():
     spec = NFSServiceSpec(service_id='mynfs', placement=PlacementSpec(count=1))
     assert spec.enable_rdma is False
     assert spec.rdma_port is None
-    assert spec.get_port_start() == [2049, 9587]
-    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port']
+    assert spec.get_port_start() == [2049, 9587, 31311]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port']
 
 
 def test_nfs_spec_rdma_enabled():
@@ -571,8 +571,8 @@ def test_nfs_spec_rdma_enabled():
     )
     assert spec.enable_rdma is True
     assert spec.rdma_port is None
-    assert spec.get_port_start() == [2049, 9587, 20049]
-    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'rdma_port']
+    assert spec.get_port_start() == [2049, 9587, 31311, 20049]
+    assert spec.get_colocation_port_fields() == ['data_port', 'monitoring_port', 'cluster_qos_port', 'rdma_port']
 
 
 def test_nfs_spec_rdma_custom_port():
@@ -587,7 +587,7 @@ def test_nfs_spec_rdma_custom_port():
     )
     assert spec.enable_rdma is True
     assert spec.rdma_port == 20050
-    assert spec.get_port_start() == [3049, 9588, 20050]
+    assert spec.get_port_start() == [3049, 9588, 31311, 20050]
 
 
 def test_nfs_spec_from_json_rdma():

--- a/src/python-common/ceph/utils.py
+++ b/src/python-common/ceph/utils.py
@@ -215,3 +215,51 @@ def size_to_bytes(v: Union[str, int]) -> int:
         }[unit]
         return num * mult
     raise ValueError(f'invalid size type {type(v)} (expected int or str)')
+
+
+def bytes_to_human(num: float, mode: str = 'decimal') -> str:
+    """Convert a bytes value into it's human-readable form.
+
+    :param num: number, in bytes, to convert
+    :param mode: Either decimal (default) or binary to determine divisor
+    :returns: string representing the bytes value in a more readable format
+    """
+    unit_list = ['', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
+    divisor = 1000.0
+    yotta = 'YB'
+
+    if mode == 'binary':
+        unit_list = ['', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
+        divisor = 1024.0
+        yotta = 'YiB'
+
+    for unit in unit_list:
+        if abs(num) < divisor:
+            return '%3.1f%s' % (num, unit)
+        num /= divisor
+    return '%.1f%s' % (num, yotta)
+
+
+def with_units_to_int(v: str) -> int:
+    if not v:
+        return 0
+    if v.endswith('iB'):
+        v = v[:-2]
+        bytes_mult = 1024
+    elif v.endswith('B'):
+        v = v[:-1]
+        bytes_mult = 1000
+    mult = 1
+    if v[-1].upper() == 'K':
+        mult = bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'M':
+        mult = bytes_mult * bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'G':
+        mult = bytes_mult * bytes_mult * bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'T':
+        mult = bytes_mult * bytes_mult * bytes_mult * bytes_mult
+        v = v[:-1]
+    return int(float(v) * mult)


### PR DESCRIPTION
mgr/nfs: NFS cluster and export commands to enable and disable ops/s control

Fixes: https://tracker.ceph.com/issues/69861
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

For bandwidth control description, check https://github.com/ceph/ceph/pull/61283

**Cluster commands:**
1. _nfs cluster qos enable ops_control <cluster_id> <qos_type:PerShare|PerClient|PerShare_PerClient> [<max_export_iops:int>] [<max_client_iops:int>]_
2. _nfs cluster qos disable ops_control <cluster_id>_

For enable command:
a. If qos_type is pershare, then max_export_iops is  compulsory
b. If qos_type is perclient, then max_client_iops is compulsory
c. If qos_type is pershare_perclient then both max_export_iops and max_client_iops are compulsory parameters

**Export commands:**
1. _nfs export qos enable ops_control <cluster_id> <pseudo_path> [<max_export_iops:int>] [<max_client_iops:int>]_
2. _nfs export qos disable ops_control <cluster_id> <pseudo_path>_

For enable command:
a. If qos_type is pershare, then max_export_iops is  compulsory
b. If qos_type is perclient, then ops control enable is not allowed at export level.
c. If qos_type is pershare_perclient then both max_export_iops and max_client_iops are compulsory parameters

Qos_type is the common parameter of both bandwidths and ops control the command. So if it is set, then the enable command will fail if different qos_type is passed.

Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos get mynfs
{}
[ceph: root@ceph-node-0 /]#
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos enable bandwidth_control mynfs PerShare --max_export_write_bw 10MB --max_export_read_bw 20MB
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos enable ops_control mynfs PerClient
Error EINVAL: Bandwidth control is using PerShare qos type, please update that qos type for Bandwidth first.
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos enable ops_control mynfs PerShare --max_export_iops 10000
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos get mynfs
{
  "combined_rw_bw_control": false,
  "enable_bw_control": true,
  "enable_ops_control": true,
  "enable_qos": true,
  "max_export_iops": 10000,
  "max_export_read_bw": "20.0MB",
  "max_export_write_bw": "10.0MB",
  "qos_type": "PerShare"
}
[ceph: root@ceph-node-0 /]# 


[ceph: root@ceph-node-0 /]# ceph nfs export qos get mynfs /export1
{}
[ceph: root@ceph-node-0 /]# ceph nfs export qos enable ops_control mynfs /export1 --max_export_iops 20000
[ceph: root@ceph-node-0 /]# ceph nfs export qos get mynfs /export1
{
  "enable_ops_control": true,
  "enable_qos": true,
  "max_export_iops": 20000
}
[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# ceph nfs cluster qos disable ops_control mynfs                                  
[ceph: root@ceph-node-0 /]# ceph nfs export qos enable ops_control mynfs /export1 --max_export_iops 20000
Error EINVAL: To configure IOPS control for export, you must first enable IOPS control at the cluster level mynfs.
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph nfs cluster qos enable ops_control mynfs PerShare --max_export_iops 10000
[ceph: root@ceph-node-0 /]# ceph nfs export qos enable bandwidth_control mynfs /export1  --max_export_write_bw 10MB --max_export_read_bw 20MB
[ceph: root@ceph-node-0 /]# ceph nfs export qos get mynfs /export1
{
  "combined_rw_bw_control": false,
  "enable_bw_control": true,
  "enable_ops_control": true,
  "enable_qos": true,
  "max_export_iops": 20000,
  "max_export_read_bw": "20.0MB",
  "max_export_write_bw": "10.0MB"
}
[ceph: root@ceph-node-0 /]# 
```
```
[ceph: root@ceph-node-0 /]# cat export2.json 
{
  "access_type": "RW",
  "clients": [],
  "cluster_id": "mynfs",
  "export_id": 2,
  "fsal": {
    "cmount_path": "/",
    "fs_name": "myfs",
    "name": "CEPH",
    "user_id": "nfs.mynfs.myfs.126d1904"
  },
  "path": "/",
  "protocols": [
    3,
    4
  ],
  "pseudo": "/export2",
  "security_label": true,
  "squash": "none",
  "transports": [
    "TCP"
  ],
  "qos_block": {
    "combined_rw_bw_control": false,
    "enable_bw_control": true,
    "enable_ops_control": true,
    "enable_qos": true,
    "max_export_iops": 30000,
    "max_export_read_bw": "30.0MB",
    "max_export_write_bw": "30.0MB"
  }
}
[ceph: root@ceph-node-0 /]# ceph nfs export apply mynfs -i export2.json 
[
  {
    "pseudo": "/export2",
    "state": "updated"
  }
]
[ceph: root@ceph-node-0 /]# 

```
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
