### PR TITLE
reef: librbd: fix mirror image status summary in a namespace

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_bootstrap.sh
+++ b/qa/workunits/rbd/rbd_mirror_bootstrap.sh
@@ -62,12 +62,8 @@ testlog "TEST: verify rx-tx direction"
 rbd --cluster ${CLUSTER1} --pool ${PARENT_POOL} mirror pool info --format json | jq -e '.peers[0].direction == "rx-tx"'
 rbd --cluster ${CLUSTER2} --pool ${PARENT_POOL} mirror pool info --format json | jq -e '.peers[0].direction == "rx-tx"'
 
-create_image ${CLUSTER1} ${PARENT_POOL} image1
-create_image ${CLUSTER2} ${PARENT_POOL} image2
-
-enable_mirror ${CLUSTER1} ${PARENT_POOL} image1
-enable_mirror ${CLUSTER2} ${PARENT_POOL} image2
-
+create_image_and_enable_mirror ${CLUSTER1} ${PARENT_POOL} image1
+create_image_and_enable_mirror ${CLUSTER2} ${PARENT_POOL} image2
 create_image_and_enable_mirror ${CLUSTER1} ${PARENT_POOL}/${NS1} image1
 create_image_and_enable_mirror ${CLUSTER2} ${PARENT_POOL}/${NS1} image2
 

--- a/qa/workunits/rbd/rbd_mirror_bootstrap.sh
+++ b/qa/workunits/rbd/rbd_mirror_bootstrap.sh
@@ -35,11 +35,27 @@ done
 rbd --cluster ${CLUSTER1} --pool ${POOL} mirror pool info --format json | jq -e '.peers[0].direction == "tx-only"'
 
 create_image_and_enable_mirror ${CLUSTER1} ${POOL} image1
+create_image_and_enable_mirror ${CLUSTER1} ${POOL}/${NS1} image1
 
 wait_for_image_replay_started ${CLUSTER2} ${POOL} image1
 write_image ${CLUSTER1} ${POOL} image1 100
 wait_for_replay_complete ${CLUSTER2} ${CLUSTER1} ${POOL} image1
 wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} image1 'up+replaying'
+
+POOL_STATUS=$(get_pool_status_json ${CLUSTER1} ${POOL})
+jq -e '.summary.states == {"replaying": 1}' <<< ${POOL_STATUS}
+POOL_STATUS=$(get_pool_status_json ${CLUSTER2} ${POOL})
+jq -e '.summary.states == {"replaying": 1}' <<< ${POOL_STATUS}
+
+wait_for_image_replay_started ${CLUSTER2} ${POOL}/${NS1} image1
+write_image ${CLUSTER1} ${POOL}/${NS1} image1 100
+wait_for_replay_complete ${CLUSTER2} ${CLUSTER1} ${POOL}/${NS1} image1
+wait_for_status_in_pool_dir ${CLUSTER2} ${POOL}/${NS1} image1 'up+replaying'
+
+POOL_STATUS=$(get_pool_status_json ${CLUSTER1} ${POOL}/${NS1})
+jq -e '.summary.states == {"replaying": 1}' <<< ${POOL_STATUS}
+POOL_STATUS=$(get_pool_status_json ${CLUSTER2} ${POOL}/${NS1})
+jq -e '.summary.states == {"replaying": 1}' <<< ${POOL_STATUS}
 
 testlog "TEST: verify rx-tx direction"
 # both rx-tx peers are added immediately by "rbd mirror pool peer bootstrap import"
@@ -52,6 +68,9 @@ create_image ${CLUSTER2} ${PARENT_POOL} image2
 enable_mirror ${CLUSTER1} ${PARENT_POOL} image1
 enable_mirror ${CLUSTER2} ${PARENT_POOL} image2
 
+create_image_and_enable_mirror ${CLUSTER1} ${PARENT_POOL}/${NS1} image1
+create_image_and_enable_mirror ${CLUSTER2} ${PARENT_POOL}/${NS1} image2
+
 wait_for_image_replay_started ${CLUSTER2} ${PARENT_POOL} image1
 write_image ${CLUSTER1} ${PARENT_POOL} image1 100
 wait_for_replay_complete ${CLUSTER2} ${CLUSTER1} ${PARENT_POOL} image1
@@ -61,6 +80,26 @@ wait_for_image_replay_started ${CLUSTER1} ${PARENT_POOL} image2
 write_image ${CLUSTER2} ${PARENT_POOL} image2 100
 wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${PARENT_POOL} image2
 wait_for_status_in_pool_dir ${CLUSTER1} ${PARENT_POOL} image2 'up+replaying'
+
+POOL_STATUS=$(get_pool_status_json ${CLUSTER1} ${PARENT_POOL})
+jq -e '.summary.states == {"replaying": 2}' <<< ${POOL_STATUS}
+POOL_STATUS=$(get_pool_status_json ${CLUSTER2} ${PARENT_POOL})
+jq -e '.summary.states == {"replaying": 2}' <<< ${POOL_STATUS}
+
+wait_for_image_replay_started ${CLUSTER2} ${PARENT_POOL}/${NS1} image1
+write_image ${CLUSTER1} ${PARENT_POOL}/${NS1} image1 100
+wait_for_replay_complete ${CLUSTER2} ${CLUSTER1} ${PARENT_POOL}/${NS1} image1
+wait_for_status_in_pool_dir ${CLUSTER2} ${PARENT_POOL}/${NS1} image1 'up+replaying'
+
+wait_for_image_replay_started ${CLUSTER1} ${PARENT_POOL}/${NS1} image2
+write_image ${CLUSTER2} ${PARENT_POOL}/${NS1} image2 100
+wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${PARENT_POOL}/${NS1} image2
+wait_for_status_in_pool_dir ${CLUSTER1} ${PARENT_POOL}/${NS1} image2 'up+replaying'
+
+POOL_STATUS=$(get_pool_status_json ${CLUSTER1} ${PARENT_POOL}/${NS1})
+jq -e '.summary.states == {"replaying": 2}' <<< ${POOL_STATUS}
+POOL_STATUS=$(get_pool_status_json ${CLUSTER2} ${PARENT_POOL}/${NS1})
+jq -e '.summary.states == {"replaying": 2}' <<< ${POOL_STATUS}
 
 testlog "TEST: pool replayer and callout cleanup when peer is updated"
 test_health_state ${CLUSTER1} ${PARENT_POOL} 'OK'

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -299,9 +299,11 @@ setup_pools()
 
     rbd --cluster ${cluster} namespace create ${POOL}/${NS1}
     rbd --cluster ${cluster} namespace create ${POOL}/${NS2}
+    rbd --cluster ${cluster} namespace create ${PARENT_POOL}/${NS1}
 
     rbd --cluster ${cluster} mirror pool enable ${POOL}/${NS1} ${MIRROR_POOL_MODE}
     rbd --cluster ${cluster} mirror pool enable ${POOL}/${NS2} image
+    rbd --cluster ${cluster} mirror pool enable ${PARENT_POOL}/${NS1} ${MIRROR_POOL_MODE}
 
     if [ -z ${RBD_MIRROR_MANUAL_PEERS} ]; then
       if [ -z ${RBD_MIRROR_CONFIG_KEY} ]; then

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -1945,8 +1945,11 @@ int Mirror<I>::image_status_summary(librados::IoCtx& io_ctx,
                                     MirrorImageStatusStates *states) {
   CephContext *cct = reinterpret_cast<CephContext *>(io_ctx.cct());
 
+  librados::IoCtx default_ns_io_ctx;
+  default_ns_io_ctx.dup(io_ctx);
+  default_ns_io_ctx.set_namespace("");
   std::vector<cls::rbd::MirrorPeer> mirror_peers;
-  int r = cls_client::mirror_peer_list(&io_ctx, &mirror_peers);
+  int r = cls_client::mirror_peer_list(&default_ns_io_ctx, &mirror_peers);
   if (r < 0 && r != -ENOENT) {
     lderr(cct) << "failed to list mirror peers: " << cpp_strerror(r) << dendl;
     return r;

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -314,12 +314,8 @@ int execute_status(const po::variables_map &vm,
     return r;
   }
 
-  librados::IoCtx default_ns_io_ctx;
-  default_ns_io_ctx.dup(io_ctx);
-  default_ns_io_ctx.set_namespace("");
-
   std::vector<librbd::mirror_peer_site_t> mirror_peers;
-  utils::get_mirror_peer_sites(default_ns_io_ctx, &mirror_peers);
+  utils::get_mirror_peer_sites(io_ctx, &mirror_peers);
 
   std::map<std::string, std::string> peer_mirror_uuids_to_name;
   utils::get_mirror_peer_mirror_uuids_to_names(mirror_peers,

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -1595,11 +1595,8 @@ int execute_status(const po::variables_map &vm,
     }
 
     // dump per-image status
-    librados::IoCtx default_ns_io_ctx;
-    default_ns_io_ctx.dup(io_ctx);
-    default_ns_io_ctx.set_namespace("");
     std::vector<librbd::mirror_peer_site_t> mirror_peers;
-    utils::get_mirror_peer_sites(default_ns_io_ctx, &mirror_peers);
+    utils::get_mirror_peer_sites(io_ctx, &mirror_peers);
 
     std::map<std::string, std::string> peer_mirror_uuids_to_name;
     utils::get_mirror_peer_mirror_uuids_to_names(mirror_peers,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69968

---

backport of https://github.com/ceph/ceph/pull/61768
parent tracker: https://tracker.ceph.com/issues/69911