### PR TITLE
cephadm: ingress- Add v4v6 flag to HAProxy bind directive

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -196,6 +196,8 @@ class IngressService(CephService):
             server_opts.append("send-proxy-v2")
         logger.debug("enabled default server opts: %r", server_opts)
         ip = '[::]' if spec.virtual_ips_list else str(spec.virtual_ip).split('/')[0] or daemon_spec.ip or '[::]'
+        v4v6_flag = "v4v6" if ip == "[::]" else ""
+
         frontend_port = daemon_spec.ports[0] if daemon_spec.ports else spec.frontend_port
         if ip != '[::]' and frontend_port:
             daemon_spec.port_ips = {str(frontend_port): ip}
@@ -214,6 +216,7 @@ class IngressService(CephService):
                 'local_host_ip': host_ip,
                 'default_server_opts': server_opts,
                 'health_check_interval': spec.health_check_interval or '2s',
+                'v4v6_flag': v4v6_flag,
             }
         )
         config_files = {

--- a/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
@@ -58,9 +58,9 @@ frontend stats
 
 frontend frontend
 {% if spec.ssl_cert %}
-    bind {{ ip }}:{{ frontend_port }} ssl crt /var/lib/haproxy/haproxy.pem
+    bind {{ ip }}:{{ frontend_port }} ssl crt /var/lib/haproxy/haproxy.pem {{ v4v6_flag }}
 {% else %}
-    bind {{ ip }}:{{ frontend_port }}
+    bind {{ ip }}:{{ frontend_port }} {{ v4v6_flag }}
 {% endif %}
     default_backend backend
 


### PR DESCRIPTION
cephadm: ingress- Add v4v6 flag to HAProxy bind directive

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2330898 
Tracker: https://tracker.ceph.com/issues/69974

Logs:
```
[ceph: root@ceph-node-0 ~]# ceph orch apply -i ingress.yaml 
Scheduled ingress.rgw.test update...

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS        RUNNING  REFRESHED  AGE  PLACEMENT                
crash                                       3/3  92s ago    27h  *                        
ingress.rgw.test           ?:1967,8083      4/4  27s ago    37s  ceph-node-0;ceph-node-1  
mgr                                         2/2  27s ago    27h  count:2                  
mon                                         3/5  92s ago    27h  count:5                  
osd.all-available-devices                     4  92s ago    27h  *                        
rgw.test                   ?:80             2/2  27s ago    94m  ceph-node-0;ceph-node-1 

[ceph: root@ceph-node-0 ~]# curl -v http://192.168.100.100:8083
*   Trying 192.168.100.100:8083...
* Connected to 192.168.100.100 (192.168.100.100) port 8083 (#0)
> GET / HTTP/1.1
> Host: 192.168.100.100:8083
> User-Agent: curl/7.76.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< transfer-encoding: chunked
< x-amz-request-id: tx0000000ee64f8c2949bef-0067af740d-15453-default
< content-type: application/xml
< server: Ceph Object Gateway (squid)
< date: Fri, 14 Feb 2025 16:49:17 GMT
```

How to reproduce:

```
Modified the bindonly to 1 :
[root@ceph-node-0 ~]# sysctl -w net.ipv6.bindv6only=1 

net.ipv6.bindv6only = 1 

[ceph: root@ceph-node-0 /]# sysctl net.ipv6.bindv6only 

net.ipv6.bindv6only = 1 

[ceph: root@ceph-node-0 ~]# ceph orch apply -i ingress.yaml  
Scheduled ingress.rgw.test update... 

[ceph: root@ceph-node-0 ~]# curl -v http://192.168.100.200:8083 

*   Trying 192.168.100.200:8083... 
* connect to 192.168.100.200 port 8083 failed: Connection refused 
* Failed to connect to 192.168.100.200 port 8083: Connection refused 
* Closing connection 0 

```
curl: (7) Failed to connect to 192.168.100.200 port 8083: Connection refused 
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
