### PR TITLE
os/bluestore: fix bdev expansion and more

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -21,6 +21,7 @@ Synopsis
 | **ceph-bluestore-tool** allocmap    --path *osd path*
 | **ceph-bluestore-tool** restore_cfb --path *osd path*
 | **ceph-bluestore-tool** show-label --dev *device* ...
+| **ceph-bluestore-tool** show-label-at --dev *device* --offset *lba*...
 | **ceph-bluestore-tool** prime-osd-dir --dev *device* --path *osd path*
 | **ceph-bluestore-tool** bluefs-export --path *osd path* --out-dir *dir*
 | **ceph-bluestore-tool** bluefs-bdev-new-wal --path *osd path* --dev-target *new-device*
@@ -112,6 +113,13 @@ Commands
 :command:`show-label` --dev *device* [...]
 
    Show device label(s).
+   The label may be printed while an OSD is running.
+
+:command:`show-label-at` --dev *device* --offset *lba*[...]
+
+   Show device label at specific disk location. Dedicated DB/WAL volumes have a single label at offset 0.
+   Main device could have valid labels at multiple locations: 0/1GiB/10GiB/100GiB/1000GiB.
+   The labels at some locations might not exist though. 
    The label may be printed while an OSD is running.
 
 :command:`free-dump` --path *osd path* [ --allocator block/bluefs-wal/bluefs-db/bluefs-slow ]
@@ -219,6 +227,8 @@ Device labels
 =============
 
 Every BlueStore block device has a block label at the beginning of the device.
+Main device might optionaly have additional labels at different locations
+for the sake of OSD robustness.
 You can dump the contents of the label with::
 
   ceph-bluestore-tool show-label --dev *device*
@@ -227,7 +237,7 @@ The main device will have a lot of metadata, including information
 that used to be stored in small files in the OSD data directory.  The
 auxiliary devices (db and wal) will only have the minimum required
 fields (OSD UUID, size, device type, birth time).
-The main device contains additional label copies at offsets: 1G, 10G, 100G and 1000G.
+The main device contains additional label copies at offsets: 1GiB, 10GiB, 100GiB and 1000GiB.
 Corrupted labels are fixed as part of repair::
 
   ceph-bluestore-tool repair --dev *device*

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -637,16 +637,17 @@ void BlueFS::dump_perf_counters(Formatter *f)
 void BlueFS::dump_block_extents(ostream& out)
 {
   for (unsigned i = 0; i < MAX_BDEV; ++i) {
-    if (!bdev[i]) {
+    if (!bdev[i] || !alloc[i]) {
       continue;
     }
-    auto total = get_total(i);
+    auto total = get_total(i) + block_reserved[i];
     auto free = get_free(i);
 
     out << i << " : device size 0x" << std::hex << total
+        << "(" << byte_u_t(total) << ")"
         << " : using 0x" << total - free
-	<< std::dec << "(" << byte_u_t(total - free) << ")";
-    out << "\n";
+        << "(" << byte_u_t(total - free) << ")"
+        << std::dec << std::endl;
   }
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6685,7 +6685,7 @@ int BlueStore::_read_bdev_label(
     decode(expected_crc, p);
   }
   catch (ceph::buffer::error& e) {
-    derr << __func__ << " " << path.c_str() << " data at " << std::hex << disk_position
+    derr << __func__ << " " << path.c_str() << " data at 0x" << std::hex << disk_position
       << std::dec << ", " << "unable to decode label " << dendl;
     return -ENOENT;
   }
@@ -8949,6 +8949,10 @@ int BlueStore::_set_bdev_label_size(const string& path, uint64_t size)
 
 int BlueStore::expand_devices(ostream& out)
 {
+  // let's open in read-only mode first to be able to recover
+  // from the out-of-space state at DB/shared volume(s)
+  // Opening in R/W mode might cause extra space allocation
+  // which is effectively a show stopper for volume expansion then.
   int r = _open_db_and_around(true);
   ceph_assert(r == 0);
   bluefs->dump_block_extents(out);
@@ -8988,32 +8992,36 @@ int BlueStore::expand_devices(ostream& out)
       << size0 << " to 0x" << size << std::dec << std::endl;
     _write_out_fm_meta(size);
     if (bdev->supported_bdev_label()) {
-      if (_set_bdev_label_size(path, size) >= 0) {
-        out << bluefs_layout.shared_bdev
+      out << bluefs_layout.shared_bdev
           << " : size label updated to " << size
           << std::endl;
-      }
-      if (bdev_label_multi) {
-        uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
-        for (uint64_t loc : bdev_label_positions) {
-          if ((loc >= size0) && (loc + lsize <= size)) {
-            bdev_label_valid_locations.push_back(loc);
+      bdev_label.size = size;
+
+      uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+      for (uint64_t loc : bdev_label_positions) {
+        if ((loc >= size0) && (loc + lsize <= size)) {
+          bdev_label_valid_locations.push_back(loc);
+          if (!bdev_label_multi) {
+            break;
           }
         }
-        _write_bdev_label(cct, bdev, path + "/block", bdev_label, bdev_label_valid_locations);
       }
+      _write_bdev_label(cct, bdev,
+         get_device_path(bluefs_layout.shared_bdev),
+         bdev_label, bdev_label_valid_locations);
     }
     _close_db_and_around();
 
-    // mount in read/write to sync expansion changes
-    if (bdev_label_multi) {
-      // We need not do fsck, because we can be broken - size is increased,
-      // but we might not have labels set.
-      cct->_conf.set_val_or_die("bluestore_fsck_on_mount", "false");
-    }
+    // FIXME minor: try to get rid off the following mount 
+    // when possible, it looks like we don't really need it
+    //
+    // Mount in read/write to sync expansion changes
+    //
     r = _mount();
     ceph_assert(r == 0);
     if (fm && fm->is_null_manager()) {
+      // FIXME: move this stuff to fm's init phase when possible.
+      //
       // we grow the allocation range, must reflect it in the allocation file
       alloc->init_add_free(size0, size - size0);
       need_to_destage_allocation_file = true;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6796,7 +6796,9 @@ int BlueStore::_read_multi_bdev_label(
     return -ENOENT;
   }
   done:
-  dout(10) << __func__ << " got " << *out_label << dendl;
+  dout(10) << __func__ << " got " << *out_label
+           << (all_labels_valid ? " all labels valid " : " some labels missing ")
+           << dendl;
   return all_labels_valid ? 0 : 1;
 }
 
@@ -6811,6 +6813,7 @@ void BlueStore::_main_bdev_label_try_reserve()
   ceph_assert(bdev_label_multi == true);
   vector<uint64_t> candidate_positions;
   vector<uint64_t> accepted_positions;
+  dout(20) << __func__ << " input " << bdev_label_valid_locations << dendl;
   uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
   for (uint64_t location : bdev_label_valid_locations) {
     if (location != BDEV_FIRST_LABEL_POSITION) {
@@ -6844,6 +6847,7 @@ void BlueStore::_main_bdev_label_try_reserve()
          << " occupied by BlueStore object or BlueFS file, disabling" << dendl;
     std::erase(bdev_label_valid_locations, candidate_positions[i]);
   }
+  dout(20) << __func__ << " result " << bdev_label_valid_locations << dendl;
 }
 
 void BlueStore::_main_bdev_label_remove(Allocator* an_alloc)
@@ -6939,7 +6943,9 @@ int BlueStore::_check_main_bdev_label()
       }
     }
     if (valid_locations > bdev_label_valid_locations.size()) {
-      derr << __func__ << " not all labels read properly" << dendl;
+      derr << __func__ << " not all labels read properly, "
+           << valid_locations << "!=" << bdev_label_valid_locations.size()
+           << dendl;
       return -EIO;
     }
   }
@@ -7299,7 +7305,16 @@ int BlueStore::_init_alloc()
 	return -ENOTRECOVERABLE;
       }
     }
+    if (before_expansion_bdev_size > 0 &&
+        before_expansion_bdev_size < bdev_label.size) {
+      // we grow the allocation range, must reflect it in the allocation file
+      alloc->init_add_free(before_expansion_bdev_size,
+                           bdev_label.size - before_expansion_bdev_size);
+      need_to_destage_allocation_file = true;    
+    }
   }
+  before_expansion_bdev_size = 0;
+
   dout(1) << __func__
           << " loaded " << byte_u_t(bytes) << " in " << num << " extents"
           << std::hex
@@ -8958,7 +8973,7 @@ int BlueStore::expand_devices(ostream& out)
   // let's open in read-only mode first to be able to recover
   // from the out-of-space state at DB/shared volume(s)
   // Opening in R/W mode might cause extra space allocation
-  // which is effectively a show stopper for volume expansion then.
+  // which is effectively a show stopper for volume expansion.
   int r = _open_db_and_around(true);
   ceph_assert(r == 0);
   bluefs->dump_block_extents(out);
@@ -9010,24 +9025,18 @@ int BlueStore::expand_devices(ostream& out)
     }
     _close_db_and_around();
 
-    // FIXME minor: try to get rid off the following mount 
-    // when possible, it looks like we don't really need it
     //
     // Mount in read/write to sync expansion changes
+    // and make sure everything is all right.
     //
-    r = _mount();
+    before_expansion_bdev_size = size0; //preserve orignal size to permit following
+                                        // _db_open_and_around() do some post-init stuff
+                                        // on opened allocator
+
+    r = _open_db_and_around(false);
     ceph_assert(r == 0);
-    if (fm && fm->is_null_manager()) {
-      // FIXME: move this stuff to fm's init phase when possible.
-      //
-      // we grow the allocation range, must reflect it in the allocation file
-      alloc->init_add_free(size0, size - size0);
-      need_to_destage_allocation_file = true;
-    }
-    umount();
-  } else {
-    _close_db_and_around();
   }
+  _close_db_and_around();
   return r;
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8949,30 +8949,6 @@ string BlueStore::get_device_path(unsigned id)
   return res;
 }
 
-int BlueStore::_set_bdev_label_size(unsigned id, uint64_t size)
-{
-  ceph_assert(bluefs);
-  BlockDevice* my_bdev = bluefs->get_block_device(id);
-  int r = -1;
-  if (my_bdev != nullptr) {
-    string my_path = get_device_path(id);
-    bluestore_bdev_label_t label;
-    r = _read_bdev_label(cct, my_bdev, my_path, &label);
-    if (r < 0) {
-      derr << "unable to read label for " << my_path << ": "
-            << cpp_strerror(r) << dendl;
-    } else {
-      label.size = size;
-      r = _write_bdev_label(cct, my_bdev, my_path, label);
-      if (r < 0) {
-        derr << "unable to write label for " << my_path << ": "
-              << cpp_strerror(r) << dendl;
-      }
-    }
-  }
-  return r;
-}
-
 int BlueStore::expand_devices(ostream& out)
 {
   // let's open in read-only mode first to be able to recover
@@ -8983,38 +8959,85 @@ int BlueStore::expand_devices(ostream& out)
   ceph_assert(r == 0);
   bluefs->dump_block_extents(out);
   out << "Expanding DB/WAL..." << std::endl;
+  // updating dedicated devices first
   for (auto devid : { BlueFS::BDEV_WAL, BlueFS::BDEV_DB}) {
-    if (devid == bluefs_layout.shared_bdev ) {
+    if (devid == bluefs_layout.shared_bdev) {
       continue;
     }
-    uint64_t size = bluefs->get_block_device_size(devid);
+    auto my_bdev = bluefs->get_block_device(devid);
+    uint64_t size = my_bdev ? my_bdev->get_size() : 0;
     if (size == 0) {
       // no bdev
       continue;
     }
-    out << devid
-	<<" : expanding " << " to 0x" << size << std::dec << std::endl;
-    if (bluefs->bdev_support_label(devid)) {
-      if (_set_bdev_label_size(devid, size) >= 0) {
-        out << devid
-          << " : size label updated to " << size
-          << std::endl;
+    if (my_bdev->supported_bdev_label()) {
+      string my_path = get_device_path(devid);
+      bluestore_bdev_label_t my_label;
+      int r = _read_bdev_label(cct, my_bdev, my_path, &my_label);
+      if (r < 0) {
+        derr << "unable to read label for " << my_path << ": "
+              << cpp_strerror(r) << dendl;
+        continue;
+      } else {
+        if (size == my_label.size) {
+          // no need to expand
+          out << devid
+	      << " : nothing to do, skipped"
+	      << std::endl;
+          continue;
+        } else if (size < my_label.size) {
+          // something weird in bdev label
+          out << devid
+	      <<" : ERROR: bdev label is above device size, skipped"
+	      << std::endl;
+          continue;
+        } else {
+          my_label.size = size;
+          out << devid
+	      << " : Expanding to 0x" << std::hex << size
+	      << std::dec << "(" << byte_u_t(size) << ")"
+	      << std::endl;
+          r = _write_bdev_label(cct, my_bdev, my_path, my_label);
+          if (r < 0) {
+            derr << "unable to write label for " << my_path << ": "
+                  << cpp_strerror(r) << dendl;
+          } else {
+            out << devid
+                << " : size updated to 0x" << std::hex << size
+                << std::dec << "(" << byte_u_t(size) << ")"
+                << std::endl;
+          }
+        }
       }
     }
   }
+  // now proceed with a shared device
   uint64_t size0 = fm->get_size();
   uint64_t size = bdev->get_size();
-  if (size0 < size) {
-    out << bluefs_layout.shared_bdev
-      << " : expanding " << " from 0x" << std::hex
-      << size0 << " to 0x" << size << std::dec << std::endl;
-    _write_out_fm_meta(size);
-    if (bdev->supported_bdev_label()) {
-      out << bluefs_layout.shared_bdev
-          << " : size label updated to " << size
-          << std::endl;
+  auto devid = bluefs_layout.shared_bdev;
+  auto aligned_size = p2align(size, min_alloc_size);
+  if (aligned_size == size0) {
+    // no need to expand
+    out << devid
+        << " : nothing to do, skipped"
+        << std::endl;
+  } else if (aligned_size < size0) {
+    // something weird in bdev label
+    out << devid
+        << " : ERROR: previous device size is above the current one, skipped"
+	<< std::endl;
+  } else {
+    auto my_path = get_device_path(devid);
+    out << devid
+	<<" : Expanding to 0x" << std::hex << size
+	<< std::dec << "(" << byte_u_t(size) << ")"
+	<< std::endl;  
+    r = _write_out_fm_meta(size);
+    if (r != 0) {
+      derr << "unable to write out fm meta for " << my_path << ": "
+           << cpp_strerror(r) << dendl;
+    } else if (bdev->supported_bdev_label()) {
       bdev_label.size = size;
-
       uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
       for (uint64_t loc : bdev_label_positions) {
         if ((loc >= size0) && (loc + lsize <= size)) {
@@ -9024,22 +9047,32 @@ int BlueStore::expand_devices(ostream& out)
           }
         }
       }
-      _write_bdev_label(cct, bdev,
-         get_device_path(bluefs_layout.shared_bdev),
-         bdev_label, bdev_label_valid_locations);
+      r = _write_bdev_label(cct, bdev, my_path,
+        bdev_label, bdev_label_valid_locations);
+      if (r != 0) {
+        derr << "unable to write label(s) for " << my_path << ": "
+             << cpp_strerror(r) << dendl;
+      }
     }
-    _close_db_and_around();
+    if (r == 0) {
+      out << devid
+          << " : size updated to 0x" << std::hex << size
+          << std::dec << "(" << byte_u_t(size) << ")"
+          << std::endl;
+      _close_db_and_around();
 
-    //
-    // Mount in read/write to sync expansion changes
-    // and make sure everything is all right.
-    //
-    before_expansion_bdev_size = size0; //preserve orignal size to permit following
-                                        // _db_open_and_around() do some post-init stuff
-                                        // on opened allocator
+       //
+      // Mount in read/write to sync expansion changes
+      // and make sure everything is all right.
+      //
+      before_expansion_bdev_size = size0; // preserve orignal size to permit
+                                          // following _db_open_and_around()
+                                          // do some post-init stuff on opened
+                                          // allocator.
 
-    r = _open_db_and_around(false);
-    ceph_assert(r == 0);
+      r = _open_db_and_around(false);
+      ceph_assert(r == 0);
+    }
   }
   _close_db_and_around();
   return r;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10793,7 +10793,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   if (bdev->supported_bdev_label() && bdev_label_multi) {
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t location = bdev_label_positions[i];
-      if (location + BDEV_LABEL_BLOCK_SIZE > bdev->get_size()) {
+      if (location + BDEV_LABEL_BLOCK_SIZE > bdev_label.size) {
         continue;
       }
       if (std::find(
@@ -10816,7 +10816,6 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 
   if (bluefs) {
     interval_set<uint64_t> bluefs_extents;
-
     bluefs->foreach_block_extents(
       bluefs_layout.shared_bdev,
       [&](uint64_t start, uint32_t len) {
@@ -10860,7 +10859,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t position = bdev_label_positions[i];
       uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
-      if (position + length <= bdev->get_size()) {
+      if (position + length <= bdev_label.size) {
         apply_for_bitset_range(position, length, alloc_size, used_blocks,
           [&](uint64_t pos, mempool_dynamic_bitset& bs) {
             bs.set(pos);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6938,7 +6938,7 @@ int BlueStore::_check_main_bdev_label()
         ++valid_locations;
       }
     }
-    if (valid_locations != bdev_label_valid_locations.size()) {
+    if (valid_locations > bdev_label_valid_locations.size()) {
       derr << __func__ << " not all labels read properly" << dendl;
       return -EIO;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6946,6 +6946,26 @@ int BlueStore::_check_main_bdev_label()
   return 0;
 }
 
+int BlueStore::read_bdev_label_at_pos(
+  CephContext* cct,
+  const std::string &bdev_path,
+  uint64_t disk_position,
+  bluestore_bdev_label_t *label)
+{
+  unique_ptr<BlockDevice> bdev(BlockDevice::create(
+    cct, bdev_path, nullptr, nullptr, nullptr, nullptr));
+  if (!bdev) {
+    return -EIO;
+  }
+  bdev->set_no_exclusive_lock();
+  int r = bdev->open(bdev_path);
+  if (r < 0)
+    return r;
+  r = _read_bdev_label(cct, bdev.get(), bdev_path, label, disk_position);
+  bdev->close();
+  return r;
+}
+
 int BlueStore::read_bdev_label(
   CephContext* cct,
   const std::string &path,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8929,19 +8929,25 @@ string BlueStore::get_device_path(unsigned id)
   return res;
 }
 
-int BlueStore::_set_bdev_label_size(const string& path, uint64_t size)
+int BlueStore::_set_bdev_label_size(unsigned id, uint64_t size)
 {
-  bluestore_bdev_label_t label;
-  int r = _read_bdev_label(cct, bdev, path, &label);
-  if (r < 0) {
-    derr << "unable to read label for " << path << ": "
-          << cpp_strerror(r) << dendl;
-  } else {
-    label.size = size;
-    r = _write_bdev_label(cct, bdev, path, label);
+  ceph_assert(bluefs);
+  BlockDevice* my_bdev = bluefs->get_block_device(id);
+  int r = -1;
+  if (my_bdev != nullptr) {
+    string my_path = get_device_path(id);
+    bluestore_bdev_label_t label;
+    r = _read_bdev_label(cct, my_bdev, my_path, &label);
     if (r < 0) {
-      derr << "unable to write label for " << path << ": "
+      derr << "unable to read label for " << my_path << ": "
             << cpp_strerror(r) << dendl;
+    } else {
+      label.size = size;
+      r = _write_bdev_label(cct, my_bdev, my_path, label);
+      if (r < 0) {
+        derr << "unable to write label for " << my_path << ": "
+              << cpp_strerror(r) << dendl;
+      }
     }
   }
   return r;
@@ -8966,18 +8972,10 @@ int BlueStore::expand_devices(ostream& out)
       // no bdev
       continue;
     }
-
     out << devid
 	<<" : expanding " << " to 0x" << size << std::dec << std::endl;
-    string p = get_device_path(devid);
-    const char* path = p.c_str();
-    if (path == nullptr) {
-      derr << devid
-	    <<": can't find device path " << dendl;
-      continue;
-    }
     if (bluefs->bdev_support_label(devid)) {
-      if (_set_bdev_label_size(p, size) >= 0) {
+      if (_set_bdev_label_size(devid, size) >= 0) {
         out << devid
           << " : size label updated to " << size
           << std::endl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6685,13 +6685,18 @@ int BlueStore::_read_bdev_label(
     decode(expected_crc, p);
   }
   catch (ceph::buffer::error& e) {
-    derr << __func__ << " " << path.c_str() << " data at 0x" << std::hex << disk_position
-      << std::dec << ", " << "unable to decode label " << dendl;
+    // We can still get here in non-erroneous scenarios,
+    // hence do not log that as an error
+    dout(0) << __func__ << " " << path.c_str() << " data at 0x" << std::hex << disk_position
+      << std::dec << ", " << "unable to decode label "
+      << dendl;
     return -ENOENT;
   }
   if (crc != expected_crc) {
-    derr << __func__ << " bad crc on label, expected " << expected_crc
-	 << " != actual " << crc << dendl;
+    // We can still get here in non-erroneousscenarios,
+    // hence do not log that as an error
+    dout(0) << __func__ << " bad crc on label, expected " << expected_crc
+	    << " != actual " << crc << dendl;
     return -EIO;
   }
   dout(10) << __func__ << " got " << *label << dendl;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3557,7 +3557,7 @@ public:
     const std::string &path,
     bluestore_bdev_label_t *out_label,
     std::vector<uint64_t>* out_valid_positions = nullptr,
-    bool* out_is_cloned = nullptr,
+    bool* out_is_multi = nullptr,
     int64_t* out_epoch = nullptr);
   static int write_bdev_label(
     CephContext* cct, const std::string &path,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2876,7 +2876,7 @@ private:
     std::vector<uint64_t>* out_valid_positions = nullptr,
     bool* out_is_multi = nullptr,
     int64_t* out_epoch = nullptr);
-  int _set_bdev_label_size(const std::string& path, uint64_t size);
+  int _set_bdev_label_size(unsigned id, uint64_t size);
   void _main_bdev_label_try_reserve();
   void _main_bdev_label_remove(Allocator* alloc);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2533,6 +2533,11 @@ private:
   bool bdev_label_multi = false;
   int64_t bdev_label_epoch = -1;
   bool bluestore_bdev_label_require_all = false;
+  uint64_t before_expansion_bdev_size = 0; // having non-zero indicates we need
+                                           // to expand allocator in NCB mode,
+                                           // perhaps could be removed when
+                                           // https://tracker.ceph.com/issues/70008
+                                           // is resolved.
 
   typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2881,7 +2881,6 @@ private:
     std::vector<uint64_t>* out_valid_positions = nullptr,
     bool* out_is_multi = nullptr,
     int64_t* out_epoch = nullptr);
-  int _set_bdev_label_size(unsigned id, uint64_t size);
   void _main_bdev_label_try_reserve();
   void _main_bdev_label_remove(Allocator* alloc);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -237,6 +237,8 @@ enum {
 #define META_POOL_ID ((uint64_t)-1ull)
 using bptr_c_it_t = buffer::ptr::const_iterator;
 
+extern const std::vector<uint64_t> bdev_label_positions;
+
 class BlueStore : public ObjectStore,
 		  public md_config_obs_t {
   // -----------------------------------------------------
@@ -3541,17 +3543,17 @@ public:
     _wctx_finish(&txc, c, o, &wctx, nullptr);
   }
 
-  static int debug_read_bdev_label(
-    CephContext* cct, BlockDevice* bdev, const std::string &path,
-    bluestore_bdev_label_t *label, uint64_t disk_position) {
-      return _read_bdev_label(cct, bdev, path, label, disk_position);
-    }
   static int debug_write_bdev_label(
     CephContext* cct, BlockDevice* bdev, const std::string &path,
     const bluestore_bdev_label_t& label, uint64_t disk_position) {
       return _write_bdev_label(cct, bdev, path, label,
         std::vector<uint64_t>({disk_position}));
     }
+  static int read_bdev_label_at_pos(
+    CephContext* cct,
+    const std::string &bdev_path,
+    uint64_t disk_position,
+    bluestore_bdev_label_t *label);
   static int read_bdev_label(
     CephContext* cct,
     const std::string &path,

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -750,13 +750,19 @@ int main(int argc, char **argv)
     for (auto& i : devs) {
       jf.open_object_section(i.c_str());
       bluestore_bdev_label_t label;
-      int r = BlueStore::read_bdev_label(cct.get(), i, &label);
+      std::vector<uint64_t> valid_positions;
+      int r = BlueStore::read_bdev_label(cct.get(), i, &label, &valid_positions);
       if (r < 0) {
         cerr << "unable to read label for " << i << ": "
              << cpp_strerror(r) << std::endl;
       } else {
         any_success = true;
         label.dump(&jf);
+        jf.open_array_section("locations");
+        for (int64_t pos : valid_positions) {
+          jf.dump_format("", "0x%llx", pos);
+        }
+        jf.close_section();
       }
       jf.close_section();
     }

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -291,6 +291,7 @@ int main(int argc, char **argv)
   string resharding_ctrl;
   int log_level = 30;
   bool fsck_deep = false;
+  uint64_t disk_offset;
   po::options_description po_options("Options");
   po_options.add_options()
     ("help,h", "produce help message")
@@ -314,6 +315,7 @@ int main(int argc, char **argv)
     ("yes-i-really-really-mean-it", "additional confirmation for dangerous commands")
     ("sharding", po::value<string>(&new_sharding), "new sharding to apply")
     ("resharding-ctrl", po::value<string>(&resharding_ctrl), "gives control over resharding procedure details")
+    ("offset", po::value<uint64_t>(&disk_offset), "disk location")
     ("op", po::value<string>(&action_aux),
       "--command alias, ignored if the latter is present")
     ;
@@ -334,6 +336,7 @@ int main(int argc, char **argv)
         "bluefs-bdev-new-wal, "
         "bluefs-bdev-migrate, "
         "show-label, "
+        "show-label-at, "
         "set-label-key, "
         "rm-label-key, "
         "prime-osd-dir, "
@@ -501,6 +504,12 @@ int main(int argc, char **argv)
     }
     if (devs.empty())
       inferring_bluefs_devices(devs, path);
+  }
+  if (action == "show-label-at") {
+    if (devs.empty()) {
+      cerr << "must specify bluestore raw device" << std::endl;
+      exit(EXIT_FAILURE);
+    }
   }
   if (action == "bluefs-export" || 
       action == "bluefs-import" || 
@@ -771,6 +780,35 @@ int main(int argc, char **argv)
     if (!any_success) {
       exit(EXIT_FAILURE);
     }
+  }
+  else if (action == "show-label-at") {
+    JSONFormatter jf(true);
+    bluestore_bdev_label_t label;
+    bool valid_offset = false;
+    for (auto o : bdev_label_positions) {
+      if (disk_offset == o) {
+        valid_offset = true;
+        break;
+      }
+    }
+    if (!valid_offset) {
+      cerr << "Suspicious offset: " << disk_offset
+           << ", expected locations: " << bdev_label_positions
+           << std::endl;
+    }
+    int r = BlueStore::read_bdev_label_at_pos(cct.get(), devs[0], disk_offset, &label);
+    if (r < 0) {
+      cerr << "unable to read label for " << devs[0] << ": "
+           << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    jf.open_object_section(devs[0].c_str());
+    label.dump(&jf);
+    jf.open_array_section("locations");
+    jf.dump_format("", "0x%llx", disk_offset);
+    jf.close_section();
+    jf.close_section();
+    jf.flush(cout);
   }
   else if (action == "set-label-key") {
     bluestore_bdev_label_t label;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -241,13 +241,7 @@ class MultiLabelTest : public StoreTestDeferredSetup {
   }
   bool read_bdev_label(bluestore_bdev_label_t* label, uint64_t position) {
     string bdev_path = get_data_dir() + "/block";
-    unique_ptr<BlockDevice> bdev(BlockDevice::create(
-      g_ceph_context, bdev_path, nullptr, nullptr, nullptr, nullptr));
-    int r = bdev->open(bdev_path);
-    if (r < 0)
-      return r;
-    r = BlueStore::debug_read_bdev_label(g_ceph_context, bdev.get(), bdev_path, label, position);
-    bdev->close();
+    int r = BlueStore::read_bdev_label_at_pos(g_ceph_context, bdev_path, position, label);
     return r;
   }
   bool write_bdev_label(const bluestore_bdev_label_t& label, uint64_t position) {


### PR DESCRIPTION
Adds printing label locations in show-label cmd output.
Adds "show-label-at" command.
Fixes crashing fsck on "incompletely" expanded device.

Fixes: https://tracker.ceph.com/issues/67966
Fixes: https://tracker.ceph.com/issues/69981
Fixes: https://tracker.ceph.com/issues/69997
Fixes: https://tracker.ceph.com/issues/69999

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
