### PR TITLE
qa: avoid snap-schedule test timeouts at the top of the minute

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -533,4 +533,7 @@ print(_find_admin_socket("{client_name}"))
     def get_op_read_count(self):
         return self.admin_socket(['perf', 'dump', 'objecter'])['objecter']['osdop_read']
 
+    def get_snap_dir_name(self):
+        return self.client_config.get('client_snapdir', '.snap')
+
 FuseMount = FuseMountBase

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -389,4 +389,7 @@ echo '{fdata}' | sudo tee /sys/kernel/debug/dynamic_debug/control
                 return 0
         return int(re.findall(r'read.*', buf)[0].split()[1])
 
+    def get_snap_dir_name(self):
+        return self.client_config.get('snapdirname', '.snap')
+
 KernelMount = KernelMountBase

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1659,4 +1659,7 @@ class CephFSMountBase(object):
             path_to_mount = subvol_paths[mount_subvol_num]
             self.cephfs_mntpt = path_to_mount
 
+    def get_snap_dir_name(self):
+        raise NotImplementedError()
+
 CephFSMount = CephFSMountBase

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -1094,8 +1094,12 @@ class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):
 
 
 class TestSnapSchedulesFetchForeignConfig(TestSnapSchedulesHelper):
+    def _get_seconds_until_minutes_pass(self, minutes):
+        now = int(time.time())
+        return (((now // 60) + minutes) * 60) - now
+
     def test_fetch_for_mds_max_snaps_per_dir(self):
-        """Test the correctness of snap directory name"""
+        """Test fetching of config mds_max_snaps_per_dir from the mds."""
         dir_path = TestSnapSchedulesHelper.TEST_DIRECTORY
         sdn = self.get_snap_dir_name()
 
@@ -1106,7 +1110,8 @@ class TestSnapSchedulesFetchForeignConfig(TestSnapSchedulesHelper):
 
         self.config_set('mds', 'mds_max_snaps_per_dir', 10)
 
-        time.sleep(11*60)  # wait for 9 snaps to be retained
+        sleep_duration = self._get_seconds_until_minutes_pass(11)
+        time.sleep(sleep_duration + 10)  # wait for 9 snaps to be retained
 
         snap_path = f"{dir_path}/{sdn}"
         snapshots = self.mount_a.ls(path=snap_path)
@@ -1116,7 +1121,8 @@ class TestSnapSchedulesFetchForeignConfig(TestSnapSchedulesHelper):
 
         self.config_set('mds', 'mds_max_snaps_per_dir', 8)
 
-        time.sleep(1*60 + 10)  # wait for max_snaps_per_dir limit to be breached
+        sleep_duration = self._get_seconds_until_minutes_pass(1)
+        time.sleep(sleep_duration + 10)  # wait for max_snaps_per_dir limit to be breached
 
         snap_path = f"{dir_path}/{sdn}"
         snapshots = self.mount_a.ls(path=snap_path)
@@ -1126,7 +1132,8 @@ class TestSnapSchedulesFetchForeignConfig(TestSnapSchedulesHelper):
 
         self.config_set('mds', 'mds_max_snaps_per_dir', 10)
 
-        time.sleep(2*60 + 10)  # wait for more snaps to be created
+        sleep_duration = self._get_seconds_until_minutes_pass(2)
+        time.sleep(sleep_duration + 10)  # wait for more snaps to be created
 
         snap_path = f"{dir_path}/{sdn}"
         snapshots = self.mount_a.ls(path=snap_path)

--- a/qa/tasks/cephfs_test_runner.py
+++ b/qa/tasks/cephfs_test_runner.py
@@ -120,8 +120,20 @@ def task(ctx, config):
            fail_on_skip: false
 
     """
+    def _get_client_snapdir(ctx):
+        overrides = ctx.config.get('overrides', {})
+        ceph = overrides.get('ceph', {})
+        conf = ceph.get('conf', {})
+        client_conf = conf.get('client', {})
+        client_snapdir = client_conf.get('client_snapdir', '.snap')
+        return client_snapdir
 
     ceph_cluster = CephCluster(ctx)
+
+    # dump the overridden 'client snapdir' into the ceph conf so that the
+    # fuse client picks it up when mounting
+    sdn = _get_client_snapdir(ctx)
+    ceph_cluster.set_ceph_conf('client', 'client snapdir', sdn)
 
     if len(list(misc.all_roles_of_type(ctx.cluster, 'mds'))):
         mds_cluster = MDSCluster(ctx)

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1536,6 +1536,19 @@ def exec_test():
     ceph_cluster.set_ceph_conf("global", "mds root ino uid", "%s" % os.getuid())
     ceph_cluster.set_ceph_conf("global", "mds root ino gid", "%s" % os.getgid())
 
+    # dump the overridden 'client snapdir' into the ceph conf so that the
+    # fuse client picks it up when mounting
+    def _get_client_snapdir(ctx):
+        overrides = ctx.config.get('overrides', {})
+        ceph = overrides.get('ceph', {})
+        conf = ceph.get('conf', {})
+        client_conf = conf.get('client', {})
+        client_snapdir = client_conf.get('client_snapdir', '.snap')
+        return client_snapdir
+
+    sdn = _get_client_snapdir(ctx)
+    ceph_cluster.set_ceph_conf('client', 'client snapdir', sdn)
+
     # Monkeypatch get_package_version to avoid having to work out what kind of distro we're on
     def _get_package_version(remote, pkg_name):
         # Used in cephfs tests to find fuse version.  Your development workstation *does* have >=2.9, right?


### PR DESCRIPTION
* avoid test timeouts at top of the minute to mitigate race between `ls .snap` and snapshot retention logic
* reorg code to do away with `from .fuse_mount import FuseMount` and `from .kernel_mount import KernelMount`

Note: **Read commit message of the last commit**

Fixes: https://tracker.ceph.com/issues/69898
Signed-off-by: Milind Changire <mchangir@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
