### PR TITLE
test/rbd_mirror: flush watch/notify callbacks in TestImageReplayer

### DIFF
--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -245,6 +245,7 @@ public:
   void unwatch() {
     if (m_watch_handle != 0) {
       m_remote_ioctx.unwatch2(m_watch_handle);
+      m_remote_cluster.watch_flush();
       delete m_watch_ctx;
       m_watch_ctx = nullptr;
       m_watch_handle = 0;


### PR DESCRIPTION
TestImageReplayer establishes its own (i.e. outside of the SUT code) watch on the header of the remote image to be able to synchronize the execution of the test with certain notifications.  This watch is established before the remote image is opened and is teared down until after the remote image is closed but while the image replayer is still running.  The flush that is part of image close sequence thus isn't guaranteed to cover all callbacks, especially for snapshot-based mirroring where UnlinkPeerRequest spawned from Replayer::unlink_peer() generates a notification on the remote image for each completed unlink. Since TestImageReplayer further immediately deletes C_WatchCtx, pretty much any test can segfault when C_WatchCtx::handle_notify() is invoked by TestWatchNotify infrastructure.  Because it's a virtual method, the segfault often involves a completely bogus instruction pointer:

  fn_anonymous[3176255]: segfault at b ip 000000000000000b sp 00007fffbceba7a8 error 14 in unittest_rbd_mirror[555555554000+96a000]
  Code: Bad RIP value.

Fixes: https://tracker.ceph.com/issues/63798





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
