### PR TITLE
rgw: be explicit on moving rados op in APIs

### DIFF
--- a/src/rgw/driver/rados/account.cc
+++ b/src/rgw/driver/rados/account.cc
@@ -455,7 +455,7 @@ int resource_count(const DoutPrefixProvider* dpp,
   int ret = 0;
   op.omap_get_header(&bl, &ret);
 
-  r = ref.operate(dpp, &op, nullptr, y);
+  r = ref.operate(dpp, std::move(op), nullptr, y);
   if (r == -ENOENT) { // doesn't exist yet
     count = 0;
     return 0;

--- a/src/rgw/driver/rados/buckets.cc
+++ b/src/rgw/driver/rados/buckets.cc
@@ -39,7 +39,7 @@ static int set(const DoutPrefixProvider* dpp, optional_yield y,
 
   librados::ObjectWriteOperation op;
   ::cls_user_set_buckets(op, entries, add);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int add(const DoutPrefixProvider* dpp, optional_yield y,
@@ -74,7 +74,7 @@ int remove(const DoutPrefixProvider* dpp, optional_yield y,
 
   librados::ObjectWriteOperation op;
   ::cls_user_remove_bucket(op, clsbucket);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int list(const DoutPrefixProvider* dpp, optional_yield y,
@@ -104,7 +104,7 @@ int list(const DoutPrefixProvider* dpp, optional_yield y,
                            entries, &marker, &truncated, &rc);
 
     bufferlist bl;
-    int r = ref.operate(dpp, &op, &bl, y);
+    int r = ref.operate(dpp, std::move(op), &bl, y);
     if (r == -ENOENT) {
       listing.next_marker.clear();
       return 0;
@@ -166,7 +166,7 @@ int read_stats(const DoutPrefixProvider* dpp, optional_yield y,
   ::cls_user_get_header(op, &header, nullptr);
 
   bufferlist bl;
-  r = ref.operate(dpp, &op, &bl, y);
+  r = ref.operate(dpp, std::move(op), &bl, y);
   if (r < 0 && r != -ENOENT) {
     return r;
   }
@@ -243,7 +243,7 @@ int reset_stats(const DoutPrefixProvider* dpp, optional_yield y,
 
     encode(call, in);
     op.exec("user", "reset_user_stats2", in, &out, &rval);
-    r = ref.operate(dpp, &op, y, librados::OPERATION_RETURNVEC);
+    r = ref.operate(dpp, std::move(op), y, librados::OPERATION_RETURNVEC);
     if (r < 0) {
       return r;
     }
@@ -269,7 +269,7 @@ int complete_flush_stats(const DoutPrefixProvider* dpp, optional_yield y,
 
   librados::ObjectWriteOperation op;
   ::cls_user_complete_stats_sync(op);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 } // namespace rgwrados::buckets

--- a/src/rgw/driver/rados/cls_fifo_legacy.cc
+++ b/src/rgw/driver/rados/cls_fifo_legacy.cc
@@ -80,7 +80,7 @@ int get_meta(const DoutPrefixProvider *dpp, lr::IoCtx& ioctx, const std::string&
 
   op.exec(fifo::op::CLASS, fifo::op::GET_META, in,
 	  &bl, nullptr);
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, nullptr, y);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), nullptr, y);
   if (r >= 0) try {
       fifo::op::get_meta_reply reply;
       auto iter = bl.cbegin();
@@ -153,7 +153,7 @@ int push_part(const DoutPrefixProvider *dpp, lr::IoCtx& ioctx, const std::string
   encode(pp, in);
   auto retval = 0;
   op.exec(fifo::op::CLASS, fifo::op::PUSH_PART, in, nullptr, &retval);
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, y, lr::OPERATION_RETURNVEC);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y, lr::OPERATION_RETURNVEC);
   if (r < 0) {
     ldpp_dout(dpp, -1)
       << __PRETTY_FUNCTION__ << ":" << __LINE__
@@ -219,7 +219,7 @@ int list_part(const DoutPrefixProvider *dpp, lr::IoCtx& ioctx, const std::string
   encode(lp, in);
   cb::list bl;
   op.exec(fifo::op::CLASS, fifo::op::LIST_PART, in, &bl, nullptr);
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, nullptr, y);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), nullptr, y);
   if (r >= 0) try {
       fifo::op::list_part_reply reply;
       auto iter = bl.cbegin();
@@ -312,7 +312,7 @@ int get_part_info(const DoutPrefixProvider *dpp, lr::IoCtx& ioctx, const std::st
   cb::list bl;
   encode(gpi, in);
   op.exec(fifo::op::CLASS, fifo::op::GET_PART_INFO, in, &bl, nullptr);
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, nullptr, y);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), nullptr, y);
   if (r >= 0) try {
       fifo::op::get_part_info_reply reply;
       auto iter = bl.cbegin();
@@ -439,7 +439,7 @@ int FIFO::_update_meta(const DoutPrefixProvider *dpp, const fifo::update& update
   lr::ObjectWriteOperation op;
   bool canceled = false;
   update_meta(&op, version, update);
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
   if (r >= 0 || r == -ECANCELED) {
     canceled = (r == -ECANCELED);
     if (!canceled) {
@@ -565,7 +565,7 @@ int FIFO::create_part(const DoutPrefixProvider *dpp, int64_t part_num, std::uint
   part_init(&op, info.params);
   auto oid = info.part_oid(part_num);
   l.unlock();
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
   if (r < 0) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
 	       << " part_init failed: r=" << r << " tid="
@@ -584,7 +584,7 @@ int FIFO::remove_part(const DoutPrefixProvider *dpp, int64_t part_num, std::uint
   std::unique_lock l(m);
   auto oid = info.part_oid(part_num);
   l.unlock();
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
   if (r < 0) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
 	       << " remove failed: r=" << r << " tid="
@@ -1139,7 +1139,7 @@ int FIFO::trim_part(const DoutPrefixProvider *dpp, int64_t part_num, uint64_t of
   const auto part_oid = info.part_oid(part_num);
   l.unlock();
   rgw::cls::fifo::trim_part(&op, ofs, exclusive);
-  auto r = rgw_rados_operate(dpp, ioctx, part_oid, &op, y);
+  auto r = rgw_rados_operate(dpp, ioctx, part_oid, std::move(op), y);
   if (r < 0) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
 	       << " trim_part failed: r=" << r << " tid=" << tid << dendl;
@@ -1214,7 +1214,7 @@ int FIFO::create(const DoutPrefixProvider *dpp, lr::IoCtx ioctx, std::string oid
   lr::ObjectWriteOperation op;
   create_meta(&op, oid, objv, oid_prefix, exclusive, max_part_size,
 	      max_entry_size);
-  auto r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
   if (r < 0) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
 	       << " create_meta failed: r=" << r << dendl;

--- a/src/rgw/driver/rados/config/impl.cc
+++ b/src/rgw/driver/rados/config/impl.cc
@@ -59,7 +59,7 @@ int ConfigImpl::read(const DoutPrefixProvider* dpp, optional_yield y,
     objv->prepare_op_for_read(&op);
   }
   op.read(0, 0, &bl, nullptr);
-  return rgw_rados_operate(dpp, ioctx, oid, &op, nullptr, y);
+  return rgw_rados_operate(dpp, ioctx, oid, std::move(op), nullptr, y);
 }
 
 int ConfigImpl::write(const DoutPrefixProvider* dpp, optional_yield y,
@@ -84,7 +84,7 @@ int ConfigImpl::write(const DoutPrefixProvider* dpp, optional_yield y,
   }
   op.write_full(bl);
 
-  r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
   if (r >= 0 && objv) {
     objv->apply_write();
   }
@@ -107,7 +107,7 @@ int ConfigImpl::remove(const DoutPrefixProvider* dpp, optional_yield y,
   }
   op.remove();
 
-  r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
   if (r >= 0 && objv) {
     objv->apply_write();
   }

--- a/src/rgw/driver/rados/groups.cc
+++ b/src/rgw/driver/rados/groups.cc
@@ -46,7 +46,7 @@ int add(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_add(op, resource, exclusive, limit);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int remove(const DoutPrefixProvider* dpp,
@@ -63,7 +63,7 @@ int remove(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_rm(op, name);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int list(const DoutPrefixProvider* dpp,
@@ -89,7 +89,7 @@ int list(const DoutPrefixProvider* dpp,
   ::cls_user_account_resource_list(op, marker, path_prefix, max_items,
                                    entries, &truncated, &next_marker, &ret);
 
-  r = ref.operate(dpp, &op, nullptr, y);
+  r = ref.operate(dpp, std::move(op), nullptr, y);
   if (r == -ENOENT) {
     next_marker.clear();
     return 0;

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -802,7 +802,7 @@ static int is_versioned_instance_listable(const DoutPrefixProvider *dpp,
     cls_rgw_bucket_list_op(op, marker, key.name, empty_delim, 1000,
                            true, &result);
     bufferlist ibl;
-    int r = bs.bucket_obj.operate(dpp, &op, &ibl, y);
+    int r = bs.bucket_obj.operate(dpp, std::move(op), &ibl, y);
     if (r < 0) {
       return r;
     }

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -129,7 +129,7 @@ public:
   int push(const DoutPrefixProvider *dpp, int index, entries&& items, optional_yield y) override {
     lr::ObjectWriteOperation op;
     cls_log_add(op, std::get<centries>(items), true);
-    auto r = rgw_rados_operate(dpp, ioctx, oids[index], &op, y);
+    auto r = rgw_rados_operate(dpp, ioctx, oids[index], std::move(op), y);
     if (r < 0) {
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": failed to push to " << oids[index] << cpp_strerror(-r)
@@ -142,7 +142,7 @@ public:
 	   optional_yield y) override {
     lr::ObjectWriteOperation op;
     cls_log_add(op, utime_t(now), {}, key, bl);
-    auto r = rgw_rados_operate(dpp, ioctx, oids[index], &op, y);
+    auto r = rgw_rados_operate(dpp, ioctx, oids[index], std::move(op), y);
     if (r < 0) {
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 		 << ": failed to push to " << oids[index]
@@ -159,7 +159,7 @@ public:
     lr::ObjectReadOperation op;
     cls_log_list(op, {}, {}, std::string(marker.value_or("")),
 		 max_entries, log_entries, out_marker, truncated);
-    auto r = rgw_rados_operate(dpp, ioctx, oids[index], &op, nullptr, y);
+    auto r = rgw_rados_operate(dpp, ioctx, oids[index], std::move(op), nullptr, y);
     if (r == -ENOENT) {
       *truncated = false;
       return 0;
@@ -193,7 +193,7 @@ public:
     cls_log_header header;
     lr::ObjectReadOperation op;
     cls_log_info(op, &header);
-    auto r = rgw_rados_operate(dpp, ioctx, oids[index], &op, nullptr, y);
+    auto r = rgw_rados_operate(dpp, ioctx, oids[index], std::move(op), nullptr, y);
     if (r == -ENOENT) r = 0;
     if (r < 0) {
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
@@ -209,7 +209,7 @@ public:
 	   optional_yield y) override {
     lr::ObjectWriteOperation op;
     cls_log_trim(op, {}, {}, {}, std::string(marker));
-    auto r = rgw_rados_operate(dpp, ioctx, oids[index], &op, y);
+    auto r = rgw_rados_operate(dpp, ioctx, oids[index], std::move(op), y);
     if (r == -ENOENT) r = -ENODATA;
     if (r < 0 && r != -ENODATA) {
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
@@ -241,7 +241,7 @@ public:
       std::string out_marker;
       bool truncated;
       cls_log_list(op, {}, {}, {}, 1, log_entries, &out_marker, &truncated);
-      auto r = rgw_rados_operate(dpp, ioctx, oids[shard], &op, nullptr, y);
+      auto r = rgw_rados_operate(dpp, ioctx, oids[shard], std::move(op), nullptr, y);
       if (r == -ENOENT) {
 	continue;
       }

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -51,7 +51,7 @@ void RGWGC::initialize(CephContext *_cct, RGWRados *_store, optional_yield y) {
     op.create(false);
     const uint64_t queue_size = cct->_conf->rgw_gc_max_queue_size, num_deferred_entries = cct->_conf->rgw_gc_max_deferred;
     gc_log_init2(op, queue_size, num_deferred_entries);
-    store->gc_operate(this, obj_names[i], &op, y);
+    store->gc_operate(this, obj_names[i], std::move(op), y);
   }
 }
 
@@ -129,13 +129,13 @@ int RGWGC::send_chain(const cls_rgw_obj_chain& chain, const string& tag, optiona
 
   ldpp_dout(this, 20) << "RGWGC::send_chain - on object name: " << obj_names[i] << "tag is: " << tag << dendl;
 
-  auto ret = store->gc_operate(this, obj_names[i], &op, y);
+  auto ret = store->gc_operate(this, obj_names[i], std::move(op), y);
   if (ret != -ECANCELED && ret != -EPERM) {
     return ret;
   }
   ObjectWriteOperation set_entry_op;
   cls_rgw_gc_set_entry(set_entry_op, cct->_conf->rgw_gc_obj_min_wait, info);
-  return store->gc_operate(this, obj_names[i], &set_entry_op, y);
+  return store->gc_operate(this, obj_names[i], std::move(set_entry_op), y);
 }
 
 struct defer_chain_state {
@@ -241,7 +241,7 @@ int RGWGC::remove(int index, int num_entries, optional_yield y)
   ObjectWriteOperation op;
   cls_rgw_gc_queue_remove_entries(op, num_entries);
 
-  return store->gc_operate(this, obj_names[index], &op, y);
+  return store->gc_operate(this, obj_names[index], std::move(op), y);
 }
 
 static int gc_list(const DoutPrefixProvider* dpp, optional_yield y, librados::IoCtx& io_ctx,
@@ -251,7 +251,7 @@ static int gc_list(const DoutPrefixProvider* dpp, optional_yield y, librados::Io
   librados::ObjectReadOperation op;
   bufferlist bl;
   cls_rgw_gc_list(op, marker, max, expired_only, bl);
-  int ret = rgw_rados_operate(dpp, io_ctx, oid, &op, nullptr, y);
+  int ret = rgw_rados_operate(dpp, io_ctx, oid, std::move(op), nullptr, y);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/driver/rados/rgw_log_backing.cc
+++ b/src/rgw/driver/rados/rgw_log_backing.cc
@@ -175,7 +175,7 @@ bs::error_code log_remove(const DoutPrefixProvider *dpp,
 	librados::ObjectWriteOperation op;
 	op.remove();
 	auto part_oid = info.part_oid(j);
-	auto subr = rgw_rados_operate(dpp, ioctx, part_oid, &op, y);
+	auto subr = rgw_rados_operate(dpp, ioctx, part_oid, std::move(op), y);
 	if (subr < 0 && subr != -ENOENT) {
 	  if (!ec)
 	    ec = bs::error_code(-subr, bs::system_category());
@@ -203,7 +203,7 @@ bs::error_code log_remove(const DoutPrefixProvider *dpp,
     } else {
       op.remove();
     }
-    r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+    r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
     if (r < 0 && r != -ENOENT) {
       if (!ec)
 	ec = bs::error_code(-r, bs::system_category());
@@ -268,7 +268,7 @@ bs::error_code logback_generations::setup(const DoutPrefixProvider *dpp,
       lock.unlock();
 
       op.write_full(bl);
-      auto r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+      auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
       if (r < 0 && r != -EEXIST) {
 	ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		   << ": failed writing oid=" << oid
@@ -404,7 +404,7 @@ auto logback_generations::read(const DoutPrefixProvider *dpp, optional_yield y) 
     cls_version_read(op, &v2);
     cb::list bl;
     op.read(0, 0, &bl, nullptr);
-    auto r = rgw_rados_operate(dpp, ioctx, oid, &op, nullptr, y);
+    auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), nullptr, y);
     if (r < 0) {
       if (r == -ENOENT) {
 	ldpp_dout(dpp, 5) << __PRETTY_FUNCTION__ << ":" << __LINE__
@@ -446,7 +446,7 @@ bs::error_code logback_generations::write(const DoutPrefixProvider *dpp, entries
     cls_version_inc(op);
     auto oldv = version;
     l.unlock();
-    auto r = rgw_rados_operate(dpp, ioctx, oid, &op, y);
+    auto r = rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
     if (r == 0) {
       if (oldv != version) {
 	return { ECANCELED, bs::system_category() };

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -112,7 +112,7 @@ private:
       librados::ObjectReadOperation op;
       queues_t queues_chunk;
       op.omap_get_keys2(start_after, max_chunk, &queues_chunk, &more, &rval);
-      const auto ret = rgw_rados_operate(this, rados_store.getRados()->get_notif_pool_ctx(), Q_LIST_OBJECT_NAME, &op, nullptr, y);
+      const auto ret = rgw_rados_operate(this, rados_store.getRados()->get_notif_pool_ctx(), Q_LIST_OBJECT_NAME, std::move(op), nullptr, y);
       if (ret == -ENOENT) {
         // queue list object was not created - nothing to do
         return 0;
@@ -278,7 +278,7 @@ private:
         "" /*no tag*/);
       cls_2pc_queue_expire_reservations(op, stale_time);
       // check ownership and do reservation cleanup in one batch
-      auto ret = rgw_rados_operate(this, rados_store.getRados()->get_notif_pool_ctx(), queue_name, &op, yield);
+      auto ret = rgw_rados_operate(this, rados_store.getRados()->get_notif_pool_ctx(), queue_name, std::move(op), yield);
       if (ret == -ENOENT) {
         // queue was deleted
         ldpp_dout(this, 10) << "INFO: queue: " << queue_name
@@ -310,7 +310,7 @@ private:
     op.assert_exists();
     rados::cls::lock::unlock(&op, queue_name+"_lock", lock_cookie);
     auto& rados_ioctx = rados_store.getRados()->get_notif_pool_ctx();
-    const auto ret = rgw_rados_operate(this, rados_ioctx, queue_name, &op, yield);
+    const auto ret = rgw_rados_operate(this, rados_ioctx, queue_name, std::move(op), yield);
     if (ret == -ENOENT) {
       ldpp_dout(this, 10) << "INFO: queue: " << queue_name
         << ". was removed. nothing to unlock" << dendl;
@@ -403,7 +403,7 @@ private:
           "" /*no tag*/);
         cls_2pc_queue_list_entries(op, start_marker, max_elements, &obl, &rval);
         // check ownership and list entries in one batch
-        auto ret = rgw_rados_operate(this, rados_ioctx, queue_name, &op, nullptr, yield);
+        auto ret = rgw_rados_operate(this, rados_ioctx, queue_name, std::move(op), nullptr, yield);
         if (ret == -ENOENT) {
           // queue was deleted
           topics_persistency_tracker.erase(queue_name);
@@ -533,7 +533,7 @@ private:
           "" /*no tag*/);
         cls_2pc_queue_remove_entries(op, end_marker, entries_to_remove);
         // check ownership and deleted entries in one batch
-        auto ret = rgw_rados_operate(this, rados_ioctx, queue_name, &op, yield);
+        auto ret = rgw_rados_operate(this, rados_ioctx, queue_name, std::move(op), yield);
         if (ret == -ENOENT) {
           // queue was deleted
           ldpp_dout(this, 10) << "INFO: queue: " << queue_name
@@ -596,8 +596,9 @@ private:
           cls_2pc_reservation::id_t reservation_id;
           buffer::list obl;
           int rval;
+          op = librados::ObjectWriteOperation();
           cls_2pc_queue_reserve(op, size_to_migrate, migration_vector.size(), &obl, &rval);
-          ret = rgw_rados_operate(this, rados_ioctx, queue_name, &op, yield, librados::OPERATION_RETURNVEC);
+          ret = rgw_rados_operate(this, rados_ioctx, queue_name, std::move(op), yield, librados::OPERATION_RETURNVEC);
           if (ret < 0) {
             ldpp_dout(this, 1) << "ERROR: failed to reserve migration space on queue: " << queue_name << ". error: " << ret << dendl;
             return;
@@ -608,8 +609,9 @@ private:
             return;
           }
 
+          op = librados::ObjectWriteOperation();
           cls_2pc_queue_commit(op, migration_vector, reservation_id);
-          ret = rgw_rados_operate(this, rados_ioctx, queue_name, &op, yield);
+          ret = rgw_rados_operate(this, rados_ioctx, queue_name, std::move(op), yield);
           reservation_id = cls_2pc_reservation::NO_ID;
           if (ret < 0) {
             ldpp_dout(this, 1) << "ERROR: failed to commit reservation to queue: " << queue_name << ". error: " << ret << dendl;
@@ -683,7 +685,7 @@ private:
               failover_time,
               LOCK_FLAG_MAY_RENEW);
 
-        ret = rgw_rados_operate(this, rados_ioctx, queue_name, &op, yield);
+        ret = rgw_rados_operate(this, rados_ioctx, queue_name, std::move(op), yield);
         if (ret == -EBUSY) {
           // lock is already taken by another RGW
           ldpp_dout(this, 20) << "INFO: queue: " << queue_name << " owned (locked) by another daemon" << dendl;
@@ -854,7 +856,7 @@ int add_persistent_topic(const DoutPrefixProvider* dpp, librados::IoCtx& rados_i
   librados::ObjectWriteOperation op;
   op.create(true);
   cls_2pc_queue_init(op, topic_queue, MAX_QUEUE_SIZE);
-  auto ret = rgw_rados_operate(dpp, rados_ioctx, topic_queue, &op, y);
+  auto ret = rgw_rados_operate(dpp, rados_ioctx, topic_queue, std::move(op), y);
   if (ret == -EEXIST) {
     // queue already exists - nothing to do
     ldpp_dout(dpp, 20) << "INFO: queue for topic: " << topic_queue << " already exists. nothing to do" << dendl;
@@ -868,8 +870,9 @@ int add_persistent_topic(const DoutPrefixProvider* dpp, librados::IoCtx& rados_i
 
   bufferlist empty_bl;
   std::map<std::string, bufferlist> new_topic{{topic_queue, empty_bl}};
+  op = librados::ObjectWriteOperation();
   op.omap_set(new_topic);
-  ret = rgw_rados_operate(dpp, rados_ioctx, Q_LIST_OBJECT_NAME, &op, y);
+  ret = rgw_rados_operate(dpp, rados_ioctx, Q_LIST_OBJECT_NAME, std::move(op), y);
   if (ret < 0) {
     ldpp_dout(dpp, 1) << "ERROR: failed to add queue: " << topic_queue << " to queue list. error: " << ret << dendl;
     return ret;
@@ -881,7 +884,7 @@ int add_persistent_topic(const DoutPrefixProvider* dpp, librados::IoCtx& rados_i
 int remove_persistent_topic(const DoutPrefixProvider* dpp, librados::IoCtx& rados_ioctx, const std::string& topic_queue, optional_yield y) {
   librados::ObjectWriteOperation op;
   op.remove();
-  auto ret = rgw_rados_operate(dpp, rados_ioctx, topic_queue, &op, y);
+  auto ret = rgw_rados_operate(dpp, rados_ioctx, topic_queue, std::move(op), y);
   if (ret == -ENOENT) {
     // queue already removed - nothing to do
     ldpp_dout(dpp, 20) << "INFO: queue for topic: " << topic_queue << " already removed. nothing to do" << dendl;
@@ -894,8 +897,9 @@ int remove_persistent_topic(const DoutPrefixProvider* dpp, librados::IoCtx& rado
   }
 
   std::set<std::string> topic_to_remove{{topic_queue}};
+  op = librados::ObjectWriteOperation();
   op.omap_rm_keys(topic_to_remove);
-  ret = rgw_rados_operate(dpp, rados_ioctx, Q_LIST_OBJECT_NAME, &op, y);
+  ret = rgw_rados_operate(dpp, rados_ioctx, Q_LIST_OBJECT_NAME, std::move(op), y);
   if (ret < 0) {
     ldpp_dout(dpp, 1) << "ERROR: failed to remove queue: " << topic_queue << " from queue list. error: " << ret << dendl;
     return ret;
@@ -1141,7 +1145,7 @@ int publish_reserve(const DoutPrefixProvider* dpp,
         cls_2pc_queue_reserve(op, res.size, 1, &obl, &rval);
         auto ret = rgw_rados_operate(
             res.dpp, res.store->getRados()->get_notif_pool_ctx(), queue_name,
-            &op, res.yield, librados::OPERATION_RETURNVEC);
+            std::move(op), res.yield, librados::OPERATION_RETURNVEC);
         if (ret < 0) {
           ldpp_dout(res.dpp, 1)
               << "ERROR: failed to reserve notification on queue: "
@@ -1207,7 +1211,7 @@ int publish_commit(rgw::sal::Object* obj,
         cls_2pc_queue_abort(op, topic.res_id);
         auto ret = rgw_rados_operate(
 	  dpp, res.store->getRados()->get_notif_pool_ctx(),
-	  queue_name, &op,
+	  queue_name, std::move(op),
 	  res.yield);
         if (ret < 0) {
           ldpp_dout(dpp, 1) << "ERROR: failed to abort reservation: "
@@ -1219,10 +1223,11 @@ int publish_commit(rgw::sal::Object* obj,
         // now try to make a bigger one
 	buffer::list obl;
         int rval;
+        op = librados::ObjectWriteOperation();
         cls_2pc_queue_reserve(op, bl.length(), 1, &obl, &rval);
         ret = rgw_rados_operate(
 	  dpp, res.store->getRados()->get_notif_pool_ctx(),
-          queue_name, &op, res.yield, librados::OPERATION_RETURNVEC);
+          queue_name, std::move(op), res.yield, librados::OPERATION_RETURNVEC);
         if (ret < 0) {
           ldpp_dout(dpp, 1) << "ERROR: failed to reserve extra space on queue: "
 			    << queue_name
@@ -1293,7 +1298,7 @@ int publish_abort(reservation_t& res) {
     cls_2pc_queue_abort(op, topic.res_id);
     const auto ret = rgw_rados_operate(
       res.dpp, res.store->getRados()->get_notif_pool_ctx(),
-      queue_name, &op, res.yield);
+      queue_name, std::move(op), res.yield);
     if (ret < 0) {
       ldpp_dout(res.dpp, 1) << "ERROR: failed to abort reservation: "
 			    << topic.res_id <<

--- a/src/rgw/driver/rados/rgw_object_expirer_core.cc
+++ b/src/rgw/driver/rados/rgw_object_expirer_core.cc
@@ -116,7 +116,7 @@ int RGWObjExpStore::objexp_hint_add(const DoutPrefixProvider *dpp,
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ << "(): failed to open obj=" << obj << " (r=" << r << ")" << dendl;
     return r;
   }
-  return obj.operate(dpp, &op, null_yield);
+  return obj.operate(dpp, std::move(op), null_yield);
 }
 
 int RGWObjExpStore::objexp_hint_list(const DoutPrefixProvider *dpp, 
@@ -142,7 +142,7 @@ int RGWObjExpStore::objexp_hint_list(const DoutPrefixProvider *dpp,
     return r;
   }
   bufferlist obl;
-  int ret = obj.operate(dpp, &op, &obl, null_yield);
+  int ret = obj.operate(dpp, std::move(op), &obl, null_yield);
 
   if ((ret < 0 ) && (ret != -ENOENT)) {
     return ret;
@@ -167,7 +167,7 @@ static int cls_timeindex_trim_repeat(const DoutPrefixProvider *dpp,
   do {
     librados::ObjectWriteOperation op;
     cls_timeindex_trim(op, from_time, to_time, from_marker, to_marker);
-    int r = rgw_rados_operate(dpp, ref.ioctx, oid, &op, null_yield);
+    int r = rgw_rados_operate(dpp, ref.ioctx, oid, std::move(op), null_yield);
     if (r == -ENODATA)
       done = true;
     else if (r < 0)

--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -578,7 +578,7 @@ int MultipartObjectProcessor::complete(
   op.assert_exists();
   cls_rgw_mp_upload_part_info_update(op, p, info);
   cls_version_inc(op);
-  r = rgw_rados_operate(rctx.dpp, meta_obj_ref.ioctx, meta_obj_ref.obj.oid, &op, rctx.y);
+  r = rgw_rados_operate(rctx.dpp, meta_obj_ref.ioctx, meta_obj_ref.obj.oid, std::move(op), rctx.y);
   ldpp_dout(rctx.dpp, 20) << "Update meta: " << meta_obj_ref.obj.oid << " part " << p << " prefix " << info.manifest.get_prefix() << " return " << r << dendl;
 
   if (r == -EOPNOTSUPP) {
@@ -593,7 +593,7 @@ int MultipartObjectProcessor::complete(
     op.assert_exists(); // detect races with abort
     op.omap_set(m);
     cls_version_inc(op);
-    r = rgw_rados_operate(rctx.dpp, meta_obj_ref.ioctx, meta_obj_ref.obj.oid, &op, rctx.y);
+    r = rgw_rados_operate(rctx.dpp, meta_obj_ref.ioctx, meta_obj_ref.obj.oid, std::move(op), rctx.y);
   }
 
   if (r < 0) {

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1350,8 +1350,8 @@ int restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
                    std::map<std::string, bufferlist> *attrs, bufferlist *first_chunk,
                    RGWObjVersionTracker *objv_tracker, optional_yield y);
 
-  int obj_operate(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::ObjectWriteOperation *op, optional_yield y);
-  int obj_operate(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::ObjectReadOperation *op, optional_yield y);
+  int obj_operate(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::ObjectWriteOperation&& op, optional_yield y);
+  int obj_operate(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::ObjectReadOperation&& op, optional_yield y);
 
   int guard_reshard(const DoutPrefixProvider *dpp,
                     BucketShard *bs,
@@ -1580,10 +1580,10 @@ public:
   std::tuple<int, std::optional<cls_rgw_obj_chain>> send_chain_to_gc(cls_rgw_obj_chain& chain, const std::string& tag, optional_yield y);
   void delete_objs_inline(const DoutPrefixProvider *dpp, cls_rgw_obj_chain& chain,
                           const std::string& tag, optional_yield y);
-  int gc_operate(const DoutPrefixProvider *dpp, std::string& oid, librados::ObjectWriteOperation *op, optional_yield y);
+  int gc_operate(const DoutPrefixProvider *dpp, std::string& oid, librados::ObjectWriteOperation&& op, optional_yield y);
   int gc_aio_operate(const std::string& oid, librados::AioCompletion *c,
                      librados::ObjectWriteOperation *op);
-  int gc_operate(const DoutPrefixProvider *dpp, std::string& oid, librados::ObjectReadOperation *op, bufferlist *pbl, optional_yield y);
+  int gc_operate(const DoutPrefixProvider *dpp, std::string& oid, librados::ObjectReadOperation&& op, bufferlist *pbl, optional_yield y);
 
   int list_gc_objs(int *index, std::string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue);
   int process_gc(bool expired_only, optional_yield y);

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1400,7 +1400,7 @@ int RGWReshard::add(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry,
 
   cls_rgw_reshard_add(op, entry, create_only);
 
-  int ret = rgw_rados_operate(dpp, store->getRados()->reshard_pool_ctx, logshard_oid, &op, y);
+  int ret = rgw_rados_operate(dpp, store->getRados()->reshard_pool_ctx, logshard_oid, std::move(op), y);
   if (create_only && ret == -EEXIST) {
     ldpp_dout(dpp, 20) <<
       "INFO: did not write reshard queue entry for oid=" <<
@@ -1495,7 +1495,7 @@ int RGWReshard::remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entr
   librados::ObjectWriteOperation op;
   cls_rgw_reshard_remove(op, entry);
 
-  int ret = rgw_rados_operate(dpp, store->getRados()->reshard_pool_ctx, logshard_oid, &op, y);
+  int ret = rgw_rados_operate(dpp, store->getRados()->reshard_pool_ctx, logshard_oid, std::move(op), y);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed to remove entry from reshard log, oid=" << logshard_oid << " tenant=" << entry.tenant << " bucket=" << entry.bucket_name << dendl;
     return ret;

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -893,7 +893,6 @@ protected:
 class MPRadosSerializer : public StoreMPSerializer {
   librados::IoCtx ioctx;
   ::rados::cls::lock::Lock lock;
-  librados::ObjectWriteOperation op;
 
 public:
   MPRadosSerializer(const DoutPrefixProvider *dpp, RadosStore* store, RadosObject* obj, const std::string& lock_name);

--- a/src/rgw/driver/rados/rgw_tools.h
+++ b/src/rgw/driver/rados/rgw_tools.h
@@ -92,11 +92,11 @@ void rgw_filter_attrset(std::map<std::string, bufferlist>& unfiltered_attrset, c
 
 /// perform the rados operation, using the yield context when given
 int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
-                      librados::ObjectReadOperation *op, bufferlist* pbl,
+                      librados::ObjectReadOperation&& op, bufferlist* pbl,
                       optional_yield y, int flags = 0, const jspan_context* trace_info = nullptr,
                       version_t* pver = nullptr);
 int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
-                      librados::ObjectWriteOperation *op, optional_yield y,
+                      librados::ObjectWriteOperation&& op, optional_yield y,
 		      int flags = 0, const jspan_context* trace_info = nullptr,
                       version_t* pver = nullptr);
 int rgw_rados_notify(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
@@ -108,14 +108,14 @@ struct rgw_rados_ref {
   rgw_raw_obj obj;
 
 
-  int operate(const DoutPrefixProvider* dpp, librados::ObjectReadOperation* op,
+  int operate(const DoutPrefixProvider* dpp, librados::ObjectReadOperation&& op,
 	      bufferlist* pbl, optional_yield y, int flags = 0) {
-    return rgw_rados_operate(dpp, ioctx, obj.oid, op, pbl, y, flags);
+    return rgw_rados_operate(dpp, ioctx, obj.oid, std::move(op), pbl, y, flags);
   }
 
-  int operate(const DoutPrefixProvider* dpp, librados::ObjectWriteOperation* op,
+  int operate(const DoutPrefixProvider* dpp, librados::ObjectWriteOperation&& op,
 	      optional_yield y, int flags = 0) {
-    return rgw_rados_operate(dpp, ioctx, obj.oid, op, y, flags);
+    return rgw_rados_operate(dpp, ioctx, obj.oid, std::move(op), y, flags);
   }
 
   int aio_operate(librados::AioCompletion* c,

--- a/src/rgw/driver/rados/roles.cc
+++ b/src/rgw/driver/rados/roles.cc
@@ -47,7 +47,7 @@ int add(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_add(op, resource, exclusive, limit);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int get(const DoutPrefixProvider* dpp,
@@ -69,7 +69,7 @@ int get(const DoutPrefixProvider* dpp,
   int ret = 0;
   ::cls_user_account_resource_get(op, name, resource, &ret);
 
-  r = ref.operate(dpp, &op, nullptr, y);
+  r = ref.operate(dpp, std::move(op), nullptr, y);
   if (r < 0) {
     return r;
   }
@@ -102,7 +102,7 @@ int remove(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_rm(op, name);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int list(const DoutPrefixProvider* dpp,
@@ -128,7 +128,7 @@ int list(const DoutPrefixProvider* dpp,
   ::cls_user_account_resource_list(op, marker, path_prefix, max_items,
                                    entries, &truncated, &next_marker, &ret);
 
-  r = ref.operate(dpp, &op, nullptr, y);
+  r = ref.operate(dpp, std::move(op), nullptr, y);
   if (r == -ENOENT) {
     next_marker.clear();
     return 0;

--- a/src/rgw/driver/rados/topic.cc
+++ b/src/rgw/driver/rados/topic.cc
@@ -195,7 +195,7 @@ int link_bucket(const DoutPrefixProvider* dpp, optional_yield y,
   librados::ObjectWriteOperation op;
   op.omap_set({{bucket_key, bufferlist{}}});
 
-  return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, &op, y);
+  return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), y);
 }
 
 int unlink_bucket(const DoutPrefixProvider* dpp, optional_yield y,
@@ -214,7 +214,7 @@ int unlink_bucket(const DoutPrefixProvider* dpp, optional_yield y,
   librados::ObjectWriteOperation op;
   op.omap_rm_keys({{bucket_key}});
 
-  return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, &op, y);
+  return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), y);
 }
 
 int list_buckets(const DoutPrefixProvider* dpp, optional_yield y,
@@ -237,7 +237,7 @@ int list_buckets(const DoutPrefixProvider* dpp, optional_yield y,
   bool more = false;
   int rval = 0;
   op.omap_get_keys2(marker, max_items, &keys, &more, &rval);
-  r = rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, &op, nullptr, y);
+  r = rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), nullptr, y);
   if (r == -ENOENT) {
     return 0;
   }

--- a/src/rgw/driver/rados/topics.cc
+++ b/src/rgw/driver/rados/topics.cc
@@ -41,7 +41,7 @@ int add(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_add(op, resource, exclusive, limit);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int remove(const DoutPrefixProvider* dpp,
@@ -58,7 +58,7 @@ int remove(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_rm(op, name);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int list(const DoutPrefixProvider* dpp,
@@ -84,7 +84,7 @@ int list(const DoutPrefixProvider* dpp,
   ::cls_user_account_resource_list(op, marker, path_prefix, max_items,
                                    entries, &truncated, &next_marker, &ret);
 
-  r = ref.operate(dpp, &op, nullptr, y);
+  r = ref.operate(dpp, std::move(op), nullptr, y);
   if (r == -ENOENT) {
     next_marker.clear();
     return 0;

--- a/src/rgw/driver/rados/users.cc
+++ b/src/rgw/driver/rados/users.cc
@@ -47,7 +47,7 @@ int add(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_add(op, resource, exclusive, limit);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int get(const DoutPrefixProvider* dpp,
@@ -69,7 +69,7 @@ int get(const DoutPrefixProvider* dpp,
   int ret = 0;
   ::cls_user_account_resource_get(op, name, resource, &ret);
 
-  r = ref.operate(dpp, &op, nullptr, y);
+  r = ref.operate(dpp, std::move(op), nullptr, y);
   if (r < 0) {
     return r;
   }
@@ -102,7 +102,7 @@ int remove(const DoutPrefixProvider* dpp,
 
   librados::ObjectWriteOperation op;
   ::cls_user_account_resource_rm(op, name);
-  return ref.operate(dpp, &op, y);
+  return ref.operate(dpp, std::move(op), y);
 }
 
 int list(const DoutPrefixProvider* dpp,
@@ -128,7 +128,7 @@ int list(const DoutPrefixProvider* dpp,
   ::cls_user_account_resource_list(op, marker, path_prefix, max_items,
                                    entries, &truncated, &next_marker, &ret);
 
-  r = ref.operate(dpp, &op, nullptr, y);
+  r = ref.operate(dpp, std::move(op), nullptr, y);
   if (r == -ENOENT) {
     next_marker.clear();
     return 0;

--- a/src/rgw/radosgw-admin/orphan.cc
+++ b/src/rgw/radosgw-admin/orphan.cc
@@ -172,7 +172,7 @@ int RGWOrphanStore::store_entries(const DoutPrefixProvider *dpp, const string& o
   for (map<string, bufferlist>::const_iterator iter = entries.begin(); iter != entries.end(); ++iter) {
     ldpp_dout(dpp, 20) << " > " << iter->first << dendl;
   }
-  int ret = rgw_rados_operate(dpp, ioctx, oid, &op, null_yield);
+  int ret = rgw_rados_operate(dpp, ioctx, oid, std::move(op), null_yield);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: " << __func__ << "(" << oid << ") returned ret=" << ret << dendl;
   }

--- a/src/rgw/services/svc_cls.cc
+++ b/src/rgw/services/svc_cls.cc
@@ -98,7 +98,7 @@ int RGWSI_Cls::MFA::create_mfa(const DoutPrefixProvider *dpp, const rgw_user& us
   librados::ObjectWriteOperation op;
   prepare_mfa_write(&op, objv_tracker, mtime);
   rados::cls::otp::OTP::create(&op, config);
-  r = obj.operate(dpp, &op, y);
+  r = obj.operate(dpp, std::move(op), y);
   if (r < 0) {
     ldpp_dout(dpp, 20) << "OTP create, otp_id=" << config.id << " result=" << (int)r << dendl;
     return r;
@@ -122,7 +122,7 @@ int RGWSI_Cls::MFA::remove_mfa(const DoutPrefixProvider *dpp,
   librados::ObjectWriteOperation op;
   prepare_mfa_write(&op, objv_tracker, mtime);
   rados::cls::otp::OTP::remove(&op, id);
-  r = obj.operate(dpp, &op, y);
+  r = obj.operate(dpp, std::move(op), y);
   if (r < 0) {
     ldpp_dout(dpp, 20) << "OTP remove, otp_id=" << id << " result=" << (int)r << dendl;
     return r;
@@ -206,7 +206,7 @@ int RGWSI_Cls::MFA::set_mfa(const DoutPrefixProvider *dpp, const string& oid, co
   }
   prepare_mfa_write(&op, objv_tracker, mtime);
   rados::cls::otp::OTP::set(&op, entries);
-  r = obj.operate(dpp, &op, y);
+  r = obj.operate(dpp, std::move(op), y);
   if (r < 0) {
     ldpp_dout(dpp, 20) << "OTP set entries.size()=" << entries.size() << " result=" << (int)r << dendl;
     return r;
@@ -277,7 +277,7 @@ int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
   utime_t t(ut);
   cls_log_add(op, t, section, key, bl);
 
-  return obj.operate(dpp, &op, y);
+  return obj.operate(dpp, std::move(op), y);
 }
 
 int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp, 
@@ -298,7 +298,7 @@ int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
   cls_log_add(op, entries, monotonic_inc);
 
   if (!completion) {
-    r = obj.operate(dpp, &op, y);
+    r = obj.operate(dpp, std::move(op), y);
   } else {
     r = obj.aio_operate(completion, &op);
   }
@@ -332,7 +332,7 @@ int RGWSI_Cls::TimeLog::list(const DoutPrefixProvider *dpp,
 
   bufferlist obl;
 
-  int ret = obj.operate(dpp, &op, &obl, y);
+  int ret = obj.operate(dpp, std::move(op), &obl, y);
   if (ret < 0)
     return ret;
 
@@ -357,7 +357,7 @@ int RGWSI_Cls::TimeLog::info(const DoutPrefixProvider *dpp,
 
   bufferlist obl;
 
-  int ret = obj.operate(dpp, &op, &obl, y);
+  int ret = obj.operate(dpp, std::move(op), &obl, y);
   if (ret < 0)
     return ret;
 
@@ -409,7 +409,7 @@ int RGWSI_Cls::TimeLog::trim(const DoutPrefixProvider *dpp,
   cls_log_trim(op, st, et, from_marker, to_marker);
 
   if (!completion) {
-    r = obj.operate(dpp, &op, y);
+    r = obj.operate(dpp, std::move(op), y);
   } else {
     r = obj.aio_operate(completion, &op);
   }

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -219,7 +219,7 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
     librados::ObjectWriteOperation op;
     op.create(false);
 
-    r = notify_obj.operate(dpp, &op, y);
+    r = notify_obj.operate(dpp, std::move(op), y);
     if (r < 0 && r != -EEXIST) {
       ldpp_dout(dpp, 0) << "ERROR: notify_obj.operate() returned r=" << r << dendl;
       return r;

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -74,7 +74,7 @@ int RGWSI_SysObj_Core::raw_stat(const DoutPrefixProvider *dpp, const rgw_raw_obj
     op.stat2(&size, &mtime_ts, nullptr);
   }
   bufferlist outbl;
-  r = rados_obj.operate(dpp, &op, &outbl, y);
+  r = rados_obj.operate(dpp, std::move(op), &outbl, y);
   if (r < 0)
     return r;
 
@@ -177,7 +177,7 @@ int RGWSI_SysObj_Core::read(const DoutPrefixProvider *dpp,
   }
 
   version_t op_ver = 0;
-  r = rgw_rados_operate(dpp, ref.ioctx, obj.oid, &op, nullptr, y, 0, nullptr, &op_ver);
+  r = rgw_rados_operate(dpp, ref.ioctx, obj.oid, std::move(op), nullptr, y, 0, nullptr, &op_ver);
   if (r < 0) {
     ldpp_dout(dpp, 20) << "rados_obj.operate() r=" << r << " bl.length=" << bl->length() << dendl;
     return r;
@@ -227,7 +227,7 @@ int RGWSI_SysObj_Core::get_attr(const DoutPrefixProvider *dpp,
   int rval;
   op.getxattr(name, dest, &rval);
 
-  r = rados_obj.operate(dpp, &op, nullptr, y);
+  r = rados_obj.operate(dpp, std::move(op), nullptr, y);
   if (r < 0)
     return r;
 
@@ -280,7 +280,7 @@ int RGWSI_SysObj_Core::set_attrs(const DoutPrefixProvider *dpp,
 
   bufferlist bl;
 
-  r = rados_obj.operate(dpp, &op, y);
+  r = rados_obj.operate(dpp, std::move(op), y);
   if (r < 0)
     return r;
 
@@ -315,7 +315,7 @@ int RGWSI_SysObj_Core::omap_get_vals(const DoutPrefixProvider *dpp,
     int rval;
     op.omap_get_vals2(start_after, count, &t, &more, &rval);
   
-    r = rados_obj.operate(dpp, &op, nullptr, y);
+    r = rados_obj.operate(dpp, std::move(op), nullptr, y);
     if (r < 0) {
       return r;
     }
@@ -357,7 +357,7 @@ int RGWSI_SysObj_Core::omap_get_all(const DoutPrefixProvider *dpp,
     int rval;
     op.omap_get_vals2(start_after, count, &t, &more, &rval);
 
-    r = rados_obj.operate(dpp, &op, nullptr, y);
+    r = rados_obj.operate(dpp, std::move(op), nullptr, y);
     if (r < 0) {
       return r;
     }
@@ -389,7 +389,7 @@ int RGWSI_SysObj_Core::omap_set(const DoutPrefixProvider *dpp, const rgw_raw_obj
   if (must_exist)
     op.assert_exists();
   op.omap_set(m);
-  r = rados_obj.operate(dpp, &op, y);
+  r = rados_obj.operate(dpp, std::move(op), y);
   return r;
 }
 
@@ -408,7 +408,7 @@ int RGWSI_SysObj_Core::omap_set(const DoutPrefixProvider *dpp, const rgw_raw_obj
   if (must_exist)
     op.assert_exists();
   op.omap_set(m);
-  r = rados_obj.operate(dpp, &op, y);
+  r = rados_obj.operate(dpp, std::move(op), y);
   return r;
 }
 
@@ -429,7 +429,7 @@ int RGWSI_SysObj_Core::omap_del(const DoutPrefixProvider *dpp, const rgw_raw_obj
 
   op.omap_rm_keys(k);
 
-  r = rados_obj.operate(dpp, &op, y);
+  r = rados_obj.operate(dpp, std::move(op), y);
   return r;
 }
 
@@ -467,7 +467,7 @@ int RGWSI_SysObj_Core::remove(const DoutPrefixProvider *dpp,
   }
 
   op.remove();
-  r = rados_obj.operate(dpp, &op, y);
+  r = rados_obj.operate(dpp, std::move(op), y);
   if (r < 0)
     return r;
 
@@ -525,7 +525,7 @@ int RGWSI_SysObj_Core::write(const DoutPrefixProvider *dpp,
     op.setxattr(name.c_str(), bl);
   }
 
-  r = rados_obj.operate(dpp, &op, y);
+  r = rados_obj.operate(dpp, std::move(op), y);
   if (r < 0) {
     return r;
   }
@@ -566,7 +566,7 @@ int RGWSI_SysObj_Core::write_data(const DoutPrefixProvider *dpp,
     objv_tracker->prepare_op_for_write(&op);
   }
   op.write_full(bl);
-  r = rados_obj.operate(dpp, &op, y);
+  r = rados_obj.operate(dpp, std::move(op), y);
   if (r < 0)
     return r;
 

--- a/src/test/rgw/test_cls_fifo_legacy.cc
+++ b/src/test/rgw/test_cls_fifo_legacy.cc
@@ -55,7 +55,7 @@ int fifo_create(const DoutPrefixProvider *dpp, R::IoCtx& ioctx,
   R::ObjectWriteOperation op;
   RCf::create_meta(&op, id, objv, oid_prefix, exclusive, max_part_size,
 		   max_entry_size);
-  return rgw_rados_operate(dpp, ioctx, oid, &op, y);
+  return rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
 }
 }
 

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -74,7 +74,7 @@ protected:
       cb::list bl;
       encode(i, bl);
       cls_log_add(op, ceph_clock_now(), {}, "meow", bl);
-      auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), &op, null_yield);
+      auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), std::move(op), null_yield);
       ASSERT_GE(r, 0);
     }
   }
@@ -85,7 +85,7 @@ protected:
     cb::list bl;
     encode(i, bl);
     cls_log_add(op, ceph_clock_now(), {}, "meow", bl);
-    auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), &op, null_yield);
+    auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), std::move(op), null_yield);
     ASSERT_GE(r, 0);
   }
 
@@ -98,14 +98,14 @@ protected:
 	std::list<cls_log_entry> entries;
 	bool truncated = false;
 	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
-	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);
+	auto r = rgw_rados_operate(&dp, ioctx, oid, std::move(op), nullptr, null_yield);
 	ASSERT_GE(r, 0);
 	ASSERT_FALSE(entries.empty());
       }
       {
 	lr::ObjectWriteOperation op;
 	cls_log_trim(op, {}, {}, {}, to_marker);
-	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, null_yield);
+	auto r = rgw_rados_operate(&dp, ioctx, oid, std::move(op), null_yield);
 	ASSERT_GE(r, 0);
       }
       {
@@ -113,7 +113,7 @@ protected:
 	std::list<cls_log_entry> entries;
 	bool truncated = false;
 	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
-	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);
+	auto r = rgw_rados_operate(&dp, ioctx, oid, std::move(op), nullptr, null_yield);
 	ASSERT_GE(r, 0);
 	ASSERT_TRUE(entries.empty());
       }


### PR DESCRIPTION
issue was probably there all the time (using the same op object more than once). but was exposed in:
8b3479e2bd70bc036dc0ca527636b71ea233c395

Fixes: https://tracker.ceph.com/issues/69944

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
