### PR TITLE
squid: pybind/mgr/mgr_module: turn off all automatic transactions

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1293,10 +1293,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             self.create_mgr_pool()
         uri = f"file:///{self.MGR_POOL_NAME}:{self.module_name}/main.db?vfs=ceph";
         self.log.debug(f"using uri {uri}")
-        try:
-            db = sqlite3.connect(uri, check_same_thread=False, uri=True, autocommit=False) # type: ignore[call-arg]
-        except TypeError:
-            db = sqlite3.connect(uri, check_same_thread=False, uri=True, isolation_level=None)
+        db = sqlite3.connect(uri, check_same_thread=False, uri=True, isolation_level=None)  # type: ignore[call-arg]
         # if libcephsqlite reconnects, update the addrv for blocklist
         with db:
             cur = db.execute('SELECT json_extract(ceph_status(), "$.addr");')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69960

---

backport of https://github.com/ceph/ceph/pull/61763
parent tracker: https://tracker.ceph.com/issues/69912

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh