### PR TITLE
squid: mds: do not path traverse a damaged dirfrag

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8449,6 +8449,13 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
       }
     }
     ceph_assert(curdir);
+
+    if (mds->damage_table.is_dirfrag_damaged(curdir)) {
+      dout(4) << "traverse: stopped lookup at dirfrag "
+              << *curdir << "/" << path[depth] << " snap=" << snapid << dendl;
+      return -EIO;
+    }
+
     if (pdir) {
       *pdir = curdir;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69850

---

backport of https://github.com/ceph/ceph/pull/61555
parent tracker: https://tracker.ceph.com/issues/69695

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh