### PR TITLE
squid: qa: do read checks with non-empty file

### DIFF
--- a/qa/tasks/cephfs/test_pool_perm.py
+++ b/qa/tasks/cephfs/test_pool_perm.py
@@ -6,7 +6,7 @@ import os
 
 class TestPoolPerm(CephFSTestCase):
     def test_pool_perm(self):
-        self.mount_a.run_shell(["touch", "test_file"])
+        self.mount_a.run_shell_payload("dd if=/dev/urandom of=test_file bs=4k count=1")
 
         file_path = os.path.join(self.mount_a.mountpoint, "test_file")
 
@@ -14,12 +14,12 @@ class TestPoolPerm(CephFSTestCase):
             import os
             import errno
 
-            fd = os.open("{path}", os.O_RDWR)
+            fd = os.open("{path}", os.O_RDWR | os.O_SYNC)
             try:
                 if {check_read}:
                     ret = os.read(fd, 1024)
                 else:
-                    os.write(fd, b'content')
+                    os.pwrite(fd, b'content', 0)
             except OSError as e:
                 if e.errno != errno.EPERM:
                     raise


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69958

---

backport of https://github.com/ceph/ceph/pull/61675
parent tracker: https://tracker.ceph.com/issues/53859

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh