### PR TITLE
reef: mds: do not path traverse a damaged dirfrag

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8388,6 +8388,12 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
     }
     ceph_assert(curdir);
 
+    if (mds->damage_table.is_dirfrag_damaged(curdir)) {
+      dout(4) << "traverse: stopped lookup at dirfrag "
+              << *curdir << "/" << path[depth] << " snap=" << snapid << dendl;
+      return -CEPHFS_EIO;
+    }
+
 #ifdef MDS_VERIFY_FRAGSTAT
     if (curdir->is_complete())
       curdir->verify_fragstat();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69849

---

backport of https://github.com/ceph/ceph/pull/61555
parent tracker: https://tracker.ceph.com/issues/69695

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh