### PR TITLE
rgw: add multisite configuration for cross-zonegroup replication

### DIFF
--- a/src/rgw/driver/rados/rgw_zone.h
+++ b/src/rgw/driver/rados/rgw_zone.h
@@ -944,4 +944,15 @@ bool all_zonegroups_support(const SiteConfig& site, std::string_view feature);
 
 std::string gen_random_uuid();
 
+/// Test whether a destination zonegroup should sync from the given source
+/// zonegroup.
+bool should_sync_from(const RGWRealm& realm,
+                      const RGWZoneGroup& dest,
+                      const RGWZoneGroup& source);
+
+/// Test whether a destination bucket should sync from the given source bucket.
+bool should_sync_from(const SiteConfig& site,
+                      const RGWBucketInfo& dest,
+                      const RGWBucketInfo& source);
+
 } // namespace rgw

--- a/src/rgw/rgw_realm.cc
+++ b/src/rgw/rgw_realm.cc
@@ -96,8 +96,9 @@ void RGWRealm::dump(Formatter *f) const
   encode_json("name", name , f);
   encode_json("current_period", current_period, f);
   encode_json("epoch", epoch, f);
+  encode_json("cross_zonegroup", to_string(cross_zonegroup), f);
+  encode_json("same_zonegroup", to_string(same_zonegroup), f);
 }
-
 
 void RGWRealm::decode_json(JSONObj *obj)
 {
@@ -105,5 +106,10 @@ void RGWRealm::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("name", name, obj);
   JSONDecoder::decode_json("current_period", current_period, obj);
   JSONDecoder::decode_json("epoch", epoch, obj);
+  if (std::string str; JSONDecoder::decode_json("cross_zonegroup", str, obj)) {
+    cross_zonegroup = rgw::parse_can_sync(str);
+  }
+  if (std::string str; JSONDecoder::decode_json("same_zonegroup", str, obj)) {
+    same_zonegroup = rgw::parse_can_sync(str);
+  }
 }
-

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -113,6 +113,25 @@ rgw_pool RGWZoneGroup::get_pool(CephContext *cct_) const
   return rgw_pool(cct_->_conf->rgw_zonegroup_root_pool);
 }
 
+
+void RGWCrossZoneGroup::dump(Formatter *f) const
+{
+  encode_json("enable", enable, f);
+  encode_json("forbid", forbid, f);
+}
+void RGWCrossZoneGroup::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("enable", enable, obj);
+  JSONDecoder::decode_json("forbid", forbid, obj);
+}
+void RGWCrossZoneGroup::generate_test_instances(list<RGWCrossZoneGroup*>& o)
+{
+  o.push_back(new RGWCrossZoneGroup);
+  o.push_back(new RGWCrossZoneGroup);
+  o.back()->enable.insert("a");
+  o.back()->forbid.insert("b");
+}
+
 void RGWZoneGroup::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("id", id, obj);
@@ -136,6 +155,11 @@ void RGWZoneGroup::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("realm_id", realm_id, obj);
   JSONDecoder::decode_json("sync_policy", sync_policy, obj);
   JSONDecoder::decode_json("enabled_features", enabled_features, obj);
+  JSONDecoder::decode_json("cross_zonegroup_export", cross_zonegroup_export, obj);
+  JSONDecoder::decode_json("cross_zonegroup_import", cross_zonegroup_import, obj);
+  if (std::string str; JSONDecoder::decode_json("same_zonegroup", str, obj)) {
+    same_zonegroup = rgw::parse_can_sync(str);
+  }
 }
 
 void RGWZoneParams::decode_json(JSONObj *obj)
@@ -330,6 +354,9 @@ void RGWZoneGroup::dump(Formatter *f) const
   encode_json("realm_id", realm_id, f);
   encode_json("sync_policy", sync_policy, f);
   encode_json("enabled_features", enabled_features, f);
+  encode_json("cross_zonegroup_export", cross_zonegroup_export, f);
+  encode_json("cross_zonegroup_import", cross_zonegroup_import, f);
+  encode_json("same_zonegroup", to_string(same_zonegroup), f);
 }
 
 void RGWZoneGroupPlacementTarget::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -829,5 +829,28 @@ int add_zone_to_group(const DoutPrefixProvider* dpp, RGWZoneGroup& zonegroup,
   return 0;
 }
 
-} // namespace rgw
+std::string to_string(CanSync value)
+{
+  switch (value) {
+    case CanSync::Allowed:
+      return "allowed";
+    case CanSync::Enabled:
+      return "enabled";
+    case CanSync::Forbidden:
+    default:
+      return "forbidden";
+  }
+}
 
+CanSync parse_can_sync(std::string_view str)
+{
+  if (str == "allowed") {
+    return CanSync::Allowed;
+  } else if (str == "enabled") {
+    return CanSync::Enabled;
+  } else { // unrecognized values default to Forbidden
+    return CanSync::Forbidden;
+  }
+}
+
+} // namespace rgw

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -75,6 +75,9 @@ std::string to_string(CanSync value);
 /// Parse CanSync from a string. Unrecognized values default to Forbidden.
 CanSync parse_can_sync(std::string_view str);
 
+/// Set of cross-zonegroup replication peer ids. Wildcard "*" matches any peer.
+using SyncPeerSet = boost::container::flat_set<std::string, std::less<>>;
+
 } // namespace rgw
 
 struct RGWNameToId {

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -62,6 +62,21 @@ extern std::string default_storage_pool_suffix;
 
 } /* namespace rgw_zone_defaults */
 
+namespace rgw {
+
+/// Tristate to control whether a cross-zonegroup replication path is enabled.
+enum class CanSync : uint8_t {
+  Allowed, //< Not enabled or forbidden, but individual zonegroups can opt in.
+  Enabled, //< Enabled by default, but individual zonegroups can opt out.
+  Forbidden, //< Forbidden by default, and individual zonegroups cannot enable.
+};
+/// Return CanSync as a string.
+std::string to_string(CanSync value);
+/// Parse CanSync from a string. Unrecognized values default to Forbidden.
+CanSync parse_can_sync(std::string_view str);
+
+} // namespace rgw
+
 struct RGWNameToId {
   std::string obj_id;
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -93,6 +93,12 @@
     realm default                    set realm as default
     realm default rm                 clear the current default realm
     realm pull                       pull a realm and its current period
+    realm cross-zonegroup enable     enable cross-zonegroup replication policy
+    realm cross-zonegroup allow      allow cross-zonegroup replication policy
+    realm cross-zonegroup forbid     forbid cross-zonegroup replication policy
+    realm same-zonegroup enable      enable same-zonegroup replication policy
+    realm same-zonegroup allow       allow same-zonegroup replication policy
+    realm same-zonegroup forbid      forbid same-zonegroup replication policy
     zonegroup add                    add a zone to a zonegroup
     zonegroup create                 create a new zone group info
     zonegroup default                set default zone group
@@ -109,6 +115,17 @@
     zonegroup placement modify       modify a placement target of a specific zonegroup
     zonegroup placement rm           remove a placement target from a zonegroup
     zonegroup placement default      set a zonegroup's default placement target
+    zonegroup export enable [rm]     add/remove the --peer-zonegroup-id from the set of enabled
+                                     destinations for cross-zonegroup replication policy
+    zonegroup export forbid [rm]     add/remove the --peer-zonegroup-id from the set of forbidden
+                                     destinations for cross-zonegroup replication policy
+    zonegroup import enable [rm]     add/remove the --peer-zonegroup-id from the set of enabled
+                                     sources for cross-zonegroup replication policy
+    zonegroup import forbid [rm]     add/remove the --peer-zonegroup-id from the set of forbidden
+                                     sources for cross-zonegroup replication policy
+    zonegroup same-zonegroup enable  enable same-zonegroup replication policy
+    zonegroup same-zonegroup allow   allow same-zonegroup replication policy
+    zonegroup same-zonegroup forbid  forbid same-zonegroup replication policy
     zone create                      create a new zone
     zone rm                          remove a zone
     zone get                         show zone cluster params
@@ -304,6 +321,7 @@
      --sync-from-all[=false]           set/reset whether zone syncs from all zonegroup peers
      --sync-from=[zone-name][,...]     set list of zones to sync from
      --sync-from-rm=[zone-name][,...]  remove zones from list of zones to sync from
+     --peer-zonegroup-id               zonegroup id or wildcard '*' for zonegroup import/export
      --bucket-index-max-shards         override a zone/zonegroup's default bucket index shard count
      --fix                             besides checking bucket index, will also fix it
      --check-objects                   bucket check: rebuilds bucket index according to actual objects state


### PR DESCRIPTION
# realm default and zonegroup overrides

defines the configuration for cross-zonegroup replication at the realm and zonegroup level. the default behavior is set by the realm, and individual zonegroups can override this to enable/disable cross-zonegroup replication to/from other zonegroups

# opt-in vs opt-out

the realm configuration supports three models:
* opt-out model where cross-zonegroup replication is "enabled" in the realm but "forbidden" for specific zonegroup pairs
* opt-in model where replication is "allowed" in the realm but only "enabled" for specific zonegroup pairs
* no cross-zonegroup replication when "forbidden" by the realm

the realm uses a tristate `enum CanSync` to represent the default, while the zonegroup uses two sets ("enable" and "forbid") to represent the overrides

# import vs export

zonegroups can override the realm behavior both for import and export. while this can duplicate information (that is, disabling A's import from B is the same as disabling B's export to A), one form will generally be simpler than the other. for example, consider a realm with zonegroups A, B, C with cross-zonegroup replication disabled to/from C. to represent this with imports only:
```
realm:
  "cross_zonegroup": "enabled"
zonegroup A:
  "cross_zonegroup_import": { "forbid": {"C"} }
zonegroup B:
  "cross_zonegroup_import": { "forbid": {"C"} }
zonegroup C:
  "cross_zonegroup_import": { "forbid": {"A", "B"} }
```
using both imports and exports, the configuration can be localized to zonegroup C:
```
realm:
  "cross_zonegroup": "enabled"
zonegroup C:
  "cross_zonegroup_export": { "forbid": {"A", "B"} },
  "cross_zonegroup_import": { "forbid": {"A", "B"} }
```

# wildcards

the wildcard string "*" can be used to match all peers, allowing the example above to be simplified as `"forbid": {"*"}`. but more importantly, wildcards adapt as zonegroups are added/removed from the realm. so if another zonegroup D is added to the realm above, that use of wildcards would automatically disable its replication to/from C

# TODO:
- [x] add similar configuration for same_zonegroup replication policy
- [x] radosgw-admin commands to modify this configuration

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
