### PR TITLE
[ceph-exporter] Fix instanceid extraction logic

### DIFF
--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -359,16 +359,11 @@ labels_t DaemonMetricCollector::get_extra_labels(std::string daemon_name) {
     labels["instance_id"] = quote(tmp);
   }
   else if (daemon_name.find("rgw") != std::string::npos) {
-    // fetch intance_id for e.g. "hrgsea" from daemon_name=rgw.foo.ceph-node-00.hrgsea.2.94739968030880
-    std::vector<std::string> elems;
-    std::stringstream ss;
-    ss.str(daemon_name);
-    std::string item;
-    while (std::getline(ss, item, '.')) {
-        elems.push_back(item);
-    }
-    if (elems.size() >= 4) {
-      labels["instance_id"] = quote(elems[3]);
+    // fetch intance_id for e.g. "foo.ceph-node-00.hrgsea" from daemon_name=rgw.foo.ceph-node-00.hrgsea.2.94739968030880
+    auto instance_id = get_instance_id_from_rgw_socket_name(daemon_name);
+    std::cout << "instance id: " << instance_id << std::endl;
+    if (!instance_id.empty()) {
+      labels["instance_id"] = instance_id;
     } else {
       return labels_t();
     }
@@ -376,6 +371,26 @@ labels_t DaemonMetricCollector::get_extra_labels(std::string daemon_name) {
     labels.insert({"ceph_daemon", quote(daemon_name)});
   }
   return labels;
+}
+
+std::string DaemonMetricCollector::get_instance_id_from_rgw_socket_name(std::string daemon_socket_file) {
+  if (daemon_socket_file.find('.') != std::string::npos) {
+    // Remove .<number>.<number> at the end i.e, version.rgw instance id
+    size_t lastDot = daemon_socket_file.rfind('.');
+    auto daemon_name = daemon_socket_file.substr(0, lastDot);
+    lastDot = daemon_socket_file.rfind('.');
+    // Extract the substring up to the second last dot
+    daemon_name = daemon_socket_file.substr(0, lastDot);
+
+    // remove service type
+    const std::string rgw_service_type_prefix = "rgw.";
+    if (daemon_name.rfind(rgw_service_type_prefix, 0) == 0) {
+      daemon_name = daemon_name.substr(rgw_service_type_prefix.size());
+    }
+    return daemon_name;
+  } else {
+    return daemon_socket_file;
+  }
 }
 
 // Add fixed name metrics from existing ones that have details in their names

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -65,6 +65,7 @@ private:
                           int64_t prio_limit, const std::string &daemon_name);
   void get_process_metrics(std::vector<std::pair<std::string, int>> daemon_pids);
   std::string asok_request(AdminSocketClient &asok, std::string command, std::string daemon_name);
+  std::string get_instance_id_from_rgw_socket_name(std::string daemon_socket_file);
 };
 
 class Metric {

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1284,7 +1284,7 @@ class Module(MgrModule, OrchestratorClientMixin):
             daemons = raise_if_exception(self.list_daemons(daemon_type='rgw'))
             for daemon in daemons:
                 if daemon.daemon_id and '.' in daemon.daemon_id:
-                    instance_id = daemon.daemon_id.split(".")[2]
+                    instance_id = daemon.daemon_id
                 else:
                     instance_id = daemon.daemon_id if daemon.daemon_id else ""
                 self.metrics['rgw_metadata'].set(1,
@@ -1299,7 +1299,7 @@ class Module(MgrModule, OrchestratorClientMixin):
                 self.metrics['rgw_metadata'].set(
                     1,
                     ('{}.{}'.format(service_type, name),
-                     hostname, version, service_id)
+                     hostname, version, name)
                 )
             elif service_type == 'rbd-mirror':
                 mirror_metadata = self.get_metadata('rbd-mirror', service_id)


### PR DESCRIPTION
Currently the ceph-exporter extracts RGW instance_id from the RGW daemon socket file name. The socket file is named as: ceph-client.rgw.<service_name>.<random 6 char string>.<floating_value>.asok Examples of rgw socket file path:
1. ceph-client.rgw.anmolrgw.ceph-node.bfdfzq.2.187651512351080.asok
2. ceph-client.rgw.realm.zone.ceph01.smfgpn.2.187651512351080.asok
3. ceph-client.rgw.reg.www.aaaaa-ceph-cluster-bootstrap.baawsj.2.187651512351080.asok Until this PR, the code did the following:
1. Remove the prefixes ceph-client and rgw
2. Extracted string index from the string broken on `.` from string in 1
3. Used string in 2 as instance_id as can be seen, the above logic results in faulty extraction of instance_id as below:
1. Example 1, bfdfzq
2. Example 2 returns, ceph01
3. Example 3 returns baawsj The above resulted in an issue where customer had their RGW instance id extracted as ceph01 both pre and post-upgrades although the daemon's 6 char string had changed. This resulted in multiple combinations of meta-data rows for the same RGW instance and caused many-to-many joins in the RGW grafana dashboards causing a break in the dashboard.

This PR aims to retain the uniqueness of the daemon instance ids by sanitizing the socket filename as:
1. Remove standard prefixes ceph-client and rgw
2. Remove the trailing numeric values
3. Use the remainder of the string as instance_id The new approach is consistent with the way its done in other ceph code blocks.

fixes: https://tracker.ceph.com/issues/69589





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
