### PR TITLE
mgr/dashboard: python 3.13 does not work with tox tests

### DIFF
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -17,6 +17,9 @@ addopts =
     --ignore=services/proto/
     --instafail
 
+[base-env]
+basepython=py39, py310, py311, py312
+
 [base]
 deps =
     -rrequirements.txt
@@ -31,7 +34,7 @@ deps =
     -rrequirements-lint.txt
 
 [testenv]
-basepython=python3
+basepython={[base-env]basepython}
 deps =
     {[base]deps}
     {[base-test]deps}
@@ -49,6 +52,7 @@ commands =
     pytest {posargs}
 
 [testenv:run]
+basepython={[base-env]basepython}
 deps =
     {[base]deps}
     {[base-test]deps}
@@ -102,6 +106,7 @@ commands =
     rstcheck --report info --debug -- {[rstlint]dirs}
 
 [testenv:lint]
+basepython={[base-env]basepython}
 deps =
     {[base]deps}
     {[base-lint]deps}
@@ -114,11 +119,13 @@ commands =
     {[base-rst]commands}
 
 [testenv:flake8]
+basepython={[base-env]basepython}
 deps = {[base-lint]deps}
 commands =
     flake8 --config=tox.ini {posargs}
 
 [testenv:pylint]
+basepython={[base-env]basepython}
 deps =
     {[base]deps}
     {[base-lint]deps}
@@ -126,6 +133,7 @@ commands =
     pylint {[pylint]addopts} {posargs:{[pylint]dirs}}
 
 [testenv:rst]
+basepython={[base-env]basepython}
 deps = {[base-lint]deps}
 commands =
     rstcheck --report info --debug -- {posargs:{[rstlint]dirs}}
@@ -141,6 +149,7 @@ addopts =
 #    --aggressive
 
 [testenv:fix]
+basepython={[base-env]basepython}
 deps =
     {[base-lint]deps}
 commands =
@@ -150,10 +159,12 @@ commands =
     isort ../../../../qa/tasks/mgr/dashboard
 
 [testenv:check]
+basepython={[base-env]basepython}
 commands =
     python ci/check_grafana_dashboards.py frontend/src/app ../../../../monitoring/ceph-mixin/dashboards_out
 
 [testenv:openapi-{check,fix}]
+basepython={[base-env]basepython}
 allowlist_externals = diff
 description =
     check: Ensure that auto-generated OpenAPI Specification matches the current version
@@ -173,6 +184,7 @@ commands =
      check: diff -au {env:OPENAPI_FILE} {env:OPENAPI_FILE_TMP}
 
 [testenv:openapi-doc]
+basepython={[base-env]basepython}
 description = Generate Sphinx documentation from OpenAPI specification
 deps = -r../../../../admin/doc-requirements.txt
 changedir = ../../../../doc


### PR DESCRIPTION
- cgi support is removed in 3.13 but cherrypy still lagging behind
- importlib-metadata support for flake8

Due to these issues setting python supported versions for tests to be 9, 10, 11, 12.

It will take sometime for python 3.13 to be fully supported in all packages. For our dev environments setting them up.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
