### PR TITLE
crush/CrushWrapper: un-inline methods to fix linker errors

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -30,6 +30,25 @@ using ceph::decode_nohead;
 using ceph::encode;
 using ceph::Formatter;
 
+CrushWrapper::~CrushWrapper()
+{
+  if (crush)
+    crush_destroy(crush);
+  choose_args_clear();
+}
+
+void CrushWrapper::create()
+{
+  if (crush)
+    crush_destroy(crush);
+  crush = crush_create();
+  choose_args_clear();
+  ceph_assert(crush);
+  have_rmaps = false;
+
+  set_tunables_default();
+}
+
 bool CrushWrapper::has_non_straw2_buckets() const
 {
   for (int i=0; i<crush->max_buckets; ++i) {

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -93,25 +93,12 @@ public:
   CrushWrapper() {
     create();
   }
-  ~CrushWrapper() {
-    if (crush)
-      crush_destroy(crush);
-    choose_args_clear();
-  }
+  ~CrushWrapper();
 
   crush_map *get_crush_map() { return crush; }
 
   /* building */
-  void create() {
-    if (crush)
-      crush_destroy(crush);
-    crush = crush_create();
-    choose_args_clear();
-    ceph_assert(crush);
-    have_rmaps = false;
-
-    set_tunables_default();
-  }
+  void create();
 
   /// true if any buckets that aren't straw2
   bool has_non_straw2_buckets() const;


### PR DESCRIPTION
The `crush_objs` library is not part of the `libceph-common` ABI, so applications linking with `libceph-common` may fail to build because the linker cannot find `crush_destroy()`.

See https://github.com/ceph/ceph/pull/61697#discussion_r1958810091 for an instance of the bug fixed by this PR. (@batrick)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
