### PR TITLE
libcephfs_proxy: add support for nonblocking read/write

### DIFF
--- a/doc/dev/libcephfs_proxy.rst
+++ b/doc/dev/libcephfs_proxy.rst
@@ -70,6 +70,30 @@ overhead for encoding and decoding, and would provide an easy way to support
 backward compatibility if the network protocol needs to be modified in the
 future.
 
+**Feature negotiation**
+
+During the initial connection through the UNIX socket, the client will
+initiate a negotiation of the features that it want to enable. Currently it
+supports a bitmap of features supported/required/desired, but it allows the
+structure containing the negotiated data to be extended by adding more fields
+without breaking backward compatibility.
+
+The structure itself contains the version and size of the structure, as well as
+the minimum required version supported, allowing the other peer to read the
+transmitted data even if it doesn't fully understand its contents, and adjust
+to the highest possible version known by both peers.
+
+The client will send the bitmap of supported features, the bitmap of features
+that must be available (otherwise the connection cannot proceed), and the
+bitmap of features the client would like to enable. When the server receives
+it, it will create a bitmap of the supported features on both sides, and verify
+that all required features by the server are supported by the client. It will
+also add its desired features to the features desired by the client. This data
+will be sent back to the client, who will do a final check and decide the
+final set of enabled features. Once this feature set is sent to the server,
+both peers can start using the enabled features.
+
+
 Design of the *libcephfs_proxy.so* library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/libcephfs_proxy/CMakeLists.txt
+++ b/src/libcephfs_proxy/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(proxy_common_srcs proxy_link.c proxy_log.c)
+set(proxy_common_srcs proxy_link.c proxy_async.c proxy_log.c)
 set(libcephfsd_srcs libcephfsd.c proxy_manager.c proxy_mount.c proxy_helpers.c ${proxy_common_srcs})
 set(libcephfs_proxy_srcs libcephfs_proxy.c ${proxy_common_srcs})
 

--- a/src/libcephfs_proxy/libcephfsd.c
+++ b/src/libcephfs_proxy/libcephfsd.c
@@ -54,68 +54,6 @@ static int32_t send_error(proxy_client_t *client, int32_t error)
 	return proxy_link_ans_send(client->sd, error, iov, 1);
 }
 
-static uint64_t uint64_checksum(uint64_t value)
-{
-	value = (value & 0xff00ff00ff00ffULL) +
-		((value >> 8) & 0xff00ff00ff00ffULL);
-	value += value >> 16;
-	value += value >> 32;
-
-	return value & 0xff;
-}
-
-static uint64_t ptr_checksum(proxy_random_t *rnd, void *ptr)
-{
-	uint64_t value;
-
-	if (ptr == NULL) {
-		return 0;
-	}
-
-	value = (uint64_t)(uintptr_t)ptr;
-	/* Many current processors don't use the full 64-bits for the virtual
-         * address space, and Linux assigns the lower 128 TiB (47 bits) for
-         * user-space applications on most architectures, so the highest 8 bits
-         * of all valid addressess are always 0.
-         *
-         * We use this to encode a checksum in the high byte of the address to
-         * be able to do a verification before dereferencing the pointer,
-	 * avoiding crashes if the client passes an invalid or corrupted pointer
-	 * value.
-         *
-         * Alternatives like using indexes in a table or registering valid
-	 * pointers require access to a shared data structure that will require
-	 * thread synchronization, making it slower. */
-	if ((value & 0xff00000000000007ULL) != 0) {
-		proxy_log(LOG_ERR, EINVAL,
-			  "Unexpected pointer value");
-		abort();
-	}
-
-	value -= uint64_checksum(value) << 56;
-
-	return random_scramble(rnd, value);
-}
-
-static int32_t ptr_check(proxy_random_t *rnd, uint64_t value, void **pptr)
-{
-	if (value == 0) {
-		*pptr = NULL;
-		return 0;
-	}
-
-	value = random_unscramble(rnd, value);
-
-	if ((uint64_checksum(value) != 0) || ((value & 7) != 0)) {
-		proxy_log(LOG_ERR, EFAULT, "Unexpected pointer value");
-		return -EFAULT;
-	}
-
-	*pptr = (void *)(uintptr_t)(value & 0xffffffffffffffULL);
-
-	return 0;
-}
-
 /* Macro to simplify request handling. */
 #define CEPH_COMPLETE(_client, _err, _ans)                          \
 	({                                                          \

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -26,8 +26,11 @@
 	((_type *)((uintptr_t)(_ptr) - offset_of(_type, _field)))
 
 enum {
+	/* Mask of all features requiring the asynchronous callback handling. */
+	PROXY_FEAT_ASYNC_CBK = 0x00000001,
+
 	/* Mask of all supported/known features. */
-	PROXY_FEAT_ALL = 0x00000000
+	PROXY_FEAT_ALL = 0x00000001
 };
 
 struct _list;

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -45,6 +45,9 @@ typedef struct _proxy_manager proxy_manager_t;
 struct _proxy_link;
 typedef struct _proxy_link proxy_link_t;
 
+struct _proxy_link_negotiate;
+typedef struct _proxy_link_negotiate proxy_link_negotiate_t;
+
 typedef int32_t (*proxy_output_write_t)(proxy_output_t *);
 typedef int32_t (*proxy_output_full_t)(proxy_output_t *);
 

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -26,6 +26,9 @@
 	((_type *)((uintptr_t)(_ptr) - offset_of(_type, _field)))
 
 enum {
+	/* Support for ceph_ll_nonblocking_readv_writev */
+	PROXY_FEAT_ASYNC_IO = 0x00000001,
+
 	/* Mask of all features requiring the asynchronous callback handling. */
 	PROXY_FEAT_ASYNC_CBK = 0x00000001,
 

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -9,7 +9,11 @@
 #include <stdbool.h>
 
 #define LIBCEPHFSD_MAJOR 0
+
+// Legacy version without negotiation support
 #define LIBCEPHFSD_MINOR 2
+// Current version with negotiation support
+#define LIBCEPHFSD_MINOR_NEG 3
 
 #define LIBCEPHFS_LIB_CLIENT 0xe3e5f0e8 // 'ceph' xor 0x80808080
 

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -57,6 +57,9 @@ typedef struct _proxy_link proxy_link_t;
 struct _proxy_link_negotiate;
 typedef struct _proxy_link_negotiate proxy_link_negotiate_t;
 
+struct _proxy_async;
+typedef struct _proxy_async proxy_async_t;
+
 typedef int32_t (*proxy_output_write_t)(proxy_output_t *);
 typedef int32_t (*proxy_output_full_t)(proxy_output_t *);
 

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -25,6 +25,11 @@
 #define container_of(_ptr, _type, _field) \
 	((_type *)((uintptr_t)(_ptr) - offset_of(_type, _field)))
 
+enum {
+	/* Mask of all supported/known features. */
+	PROXY_FEAT_ALL = 0x00000000
+};
+
 struct _list;
 typedef struct _list list_t;
 

--- a/src/libcephfs_proxy/proxy_async.c
+++ b/src/libcephfs_proxy/proxy_async.c
@@ -1,0 +1,124 @@
+
+#include <unistd.h>
+
+#include "include/cephfs/libcephfs.h"
+
+#include "proxy_async.h"
+#include "proxy_requests.h"
+#include "proxy_log.h"
+
+typedef int32_t (*proxy_cbk_handler_t)(proxy_async_t *, proxy_cbk_t *, void *,
+				       uint32_t);
+
+static proxy_cbk_handler_t libcephfsd_cbk_handlers[LIBCEPHFSD_CBK_TOTAL_OPS] = {
+};
+
+static void *
+proxy_async_worker(void *arg)
+{
+	proxy_cbk_t cbk;
+	proxy_async_t *async;
+	struct iovec iov[2];
+	int32_t err;
+
+	async = arg;
+
+	while (true) {
+		iov[0].iov_base = &cbk;
+		iov[0].iov_len = sizeof(cbk);
+		iov[1].iov_base = NULL;
+		iov[1].iov_len = 0;
+
+		err = proxy_link_req_recv(async->fd, iov, 2);
+		if (err <= 0) {
+			break;
+		}
+
+		if (cbk.header.op >= LIBCEPHFSD_CBK_TOTAL_OPS) {
+			proxy_log(LOG_ERR, ENOSYS,
+				  "Unknown asynchronous callback");
+		} else if (libcephfsd_cbk_handlers[cbk.header.op] == NULL) {
+			proxy_log(LOG_ERR, EOPNOTSUPP,
+				  "Unsupported asynchronous callback");
+		} else {
+			err = libcephfsd_cbk_handlers[cbk.header.op](
+				async, &cbk, iov[1].iov_base, iov[1].iov_len);
+		}
+
+		if (iov[1].iov_base != NULL) {
+			proxy_free(iov[1].iov_base);
+		}
+
+		if (err < 0) {
+			break;
+		}
+	}
+
+	if (err < 0) {
+		proxy_log(LOG_ERR, -err, "Asynchronous worker found an error");
+
+		/* Force disconnection from main connection. */
+		proxy_link_close(async->link);
+	}
+
+	proxy_log(LOG_INFO, 0, "Asynchronous worker stopped");
+
+	return NULL;
+}
+
+int32_t proxy_async_client(proxy_async_t *async, proxy_link_t *link, int32_t sd)
+{
+	int32_t err, data, fd, size;
+
+	size = sizeof(fd);
+	err = proxy_link_ctrl_recv(sd, &data, sizeof(data), SCM_RIGHTS, &fd,
+				   &size);
+	if (err < 0) {
+		return err;
+	}
+        if (size < sizeof(fd)) {
+                return proxy_log(LOG_ERR, ENODATA,
+                                 "Failed to receive the asynchronous socket");
+        }
+
+	random_init(&async->random);
+	async->fd = fd;
+        async->link = link;
+
+	err = pthread_create(&async->thread, NULL, proxy_async_worker, async);
+	if (err < 0) {
+		close(fd);
+		return proxy_log(LOG_ERR, err,
+				 "Failed to create asynchronous worker");
+	}
+
+	return 0;
+}
+
+int32_t proxy_async_server(proxy_async_t *async, int32_t sd)
+{
+	int32_t fds[2];
+	int32_t err, data;
+
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) < 0) {
+		return proxy_log(LOG_ERR, errno,
+				 "Failed to create a socket pair");
+	}
+
+	data = 0;
+	err = proxy_link_ctrl_send(sd, &data, sizeof(data), SCM_RIGHTS, fds,
+				   sizeof(int32_t));
+	close(fds[0]);
+	if (err < 0) {
+		goto failed;
+	}
+
+	async->fd = fds[1];
+
+	return 0;
+
+failed:
+	close(fds[1]);
+
+	return err;
+}

--- a/src/libcephfs_proxy/proxy_async.h
+++ b/src/libcephfs_proxy/proxy_async.h
@@ -1,0 +1,23 @@
+
+#ifndef __LIBCEPHFS_PROXY_ASYNC_H__
+#define __LIBCEPHFS_PROXY_ASYNC_H__
+
+#include "proxy.h"
+#include "proxy_link.h"
+#include "proxy_helpers.h"
+
+#include <pthread.h>
+
+struct _proxy_async {
+	pthread_t thread;
+	proxy_random_t random;
+	proxy_link_t *link;
+	int32_t fd;
+};
+
+int32_t proxy_async_client(proxy_async_t *async, proxy_link_t *link,
+			   int32_t sd);
+
+int32_t proxy_async_server(proxy_async_t *async, int32_t sd);
+
+#endif /* __LIBCEPHFS_PROXY_ASYNC_H__ */

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -109,6 +109,10 @@ int32_t proxy_link_ctrl_send(int32_t sd, void *data, int32_t size, int32_t type,
 int32_t proxy_link_ctrl_recv(int32_t sd, void *data, int32_t size, int32_t type,
 			     void *ctrl, int32_t *ctrl_size);
 
+int32_t proxy_link_handshake_server(proxy_link_t *link, int32_t sd,
+				    proxy_link_negotiate_t *neg,
+				    proxy_link_negotiate_cbk_t cbk);
+
 int32_t proxy_link_handshake_client(proxy_link_t *link, int32_t sd,
 				    proxy_link_negotiate_t *neg,
 				    proxy_link_negotiate_cbk_t cbk);

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -72,6 +72,28 @@ typedef struct _proxy_link_ans {
 	 sizeof(proxy_link_negotiate_v##_ver##_t))
 #define NEG_VERSION_SIZE(_ver) NEG_VERSION_SIZE_1(_ver)
 
+#define proxy_link_negotiate_init_v0(_neg, _ver, _min) \
+	do { \
+		(_neg)->v0.size = NEG_VERSION_SIZE(_ver); \
+		(_neg)->v0.version = (_ver); \
+		(_neg)->v0.min_version = (_min); \
+		(_neg)->v0.flags = 0; \
+	} while (0)
+
+/* NEG_VERSION: Add new arguments and initialize the link->neg.vX with them. */
+static inline void proxy_link_negotiate_init(proxy_link_negotiate_t *neg,
+					     uint32_t min_version,
+					     uint32_t supported,
+					     uint32_t required,
+					     uint32_t enabled)
+{
+	proxy_link_negotiate_init_v0(neg, PROXY_LINK_NEGOTIATE_VERSION,
+				     min_version);
+	neg->v1.supported = supported;
+	neg->v1.required = required;
+	neg->v1.enabled = enabled;
+}
+
 static inline bool proxy_link_is_connected(proxy_link_t *link)
 {
 	return link->sd >= 0;

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -109,4 +109,8 @@ int32_t proxy_link_ctrl_send(int32_t sd, void *data, int32_t size, int32_t type,
 int32_t proxy_link_ctrl_recv(int32_t sd, void *data, int32_t size, int32_t type,
 			     void *ctrl, int32_t *ctrl_size);
 
+int32_t proxy_link_handshake_client(proxy_link_t *link, int32_t sd,
+				    proxy_link_negotiate_t *neg,
+				    proxy_link_negotiate_cbk_t cbk);
+
 #endif

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -40,12 +40,6 @@ void proxy_link_close(proxy_link_t *link);
 int32_t proxy_link_server(proxy_link_t *link, const char *path,
 			  proxy_link_start_t start, proxy_link_stop_t stop);
 
-int32_t proxy_link_read(proxy_link_t *link, int32_t sd, void *buffer,
-			int32_t size);
-
-int32_t proxy_link_write(proxy_link_t *link, int32_t sd, void *buffer,
-			 int32_t size);
-
 int32_t proxy_link_send(int32_t sd, struct iovec *iov, int32_t count);
 
 int32_t proxy_link_recv(int32_t sd, struct iovec *iov, int32_t count);

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -9,6 +9,46 @@
 
 #define PROXY_LINK_DISCONNECTED { NULL, -1 }
 
+/* To define newer versions of the negotiate structure, look for comments
+ * starting with "NEG_VERSION" and do the appropriate changes in each place. */
+
+/* NEG_VERSION: Update this value to the latest implemented version. */
+#define PROXY_LINK_NEGOTIATE_VERSION 1
+
+/* Version 0 structure will be used to handle legacy clients that don't support
+ * negotiation. */
+typedef struct _proxy_link_negotiate_v0 {
+	/* Size of the entire structure. Don't use sizeof() to compute it, use
+	 * NEG_VERSION_SIZE() to avoid alignement issues. */
+	uint16_t size;
+
+	/* Version of the negotiation structure. */
+	uint16_t version;
+
+	/* Minimum version that the peer needs to support to proceed. */
+	uint16_t min_version;
+
+	/* Reserved. Must be 0. */
+	uint16_t flags;
+} proxy_link_negotiate_v0_t;
+
+typedef struct _proxy_link_negotiate_v1 {
+	uint32_t supported;
+	uint32_t required;
+	uint32_t enabled;
+} proxy_link_negotiate_v1_t;
+
+/* NEG_VERSION: Add typedefs for new negotiate extensions above this comment. */
+
+struct _proxy_link_negotiate {
+	proxy_link_negotiate_v0_t v0;
+	proxy_link_negotiate_v1_t v1;
+
+	/* NEG_VERSION: Add newly defined typedefs above this comment. */
+};
+
+typedef int32_t (*proxy_link_negotiate_cbk_t)(proxy_link_negotiate_t *);
+
 struct _proxy_link {
 	proxy_link_stop_t stop;
 	int32_t sd;
@@ -26,6 +66,11 @@ typedef struct _proxy_link_ans {
 	int32_t result;
 	uint32_t data_len;
 } proxy_link_ans_t;
+
+#define NEG_VERSION_SIZE_1(_ver) \
+	(offset_of(proxy_link_negotiate_t, v##_ver) + \
+	 sizeof(proxy_link_negotiate_v##_ver##_t))
+#define NEG_VERSION_SIZE(_ver) NEG_VERSION_SIZE_1(_ver)
 
 static inline bool proxy_link_is_connected(proxy_link_t *link)
 {

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -58,4 +58,10 @@ int32_t proxy_link_request(int32_t sd, int32_t op, struct iovec *req_iov,
 			   int32_t req_count, struct iovec *ans_iov,
 			   int32_t ans_count);
 
+int32_t proxy_link_ctrl_send(int32_t sd, void *data, int32_t size, int32_t type,
+			     void *ctrl, int32_t ctrl_size);
+
+int32_t proxy_link_ctrl_recv(int32_t sd, void *data, int32_t size, int32_t type,
+			     void *ctrl, int32_t *ctrl_size);
+
 #endif

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -48,9 +48,15 @@
 	CEPH_DATA(_name, _req, _req_count);                 \
 	CEPH_DATA(_name, _ans, _ans_count)
 
+#define CEPH_CBK(_name, _cbk, _cbk_count) \
+	CEPH_DATA(_name, _cbk, _cbk_count)
+
 #define CEPH_CALL(_sd, _op, _req, _ans)                                      \
 	proxy_link_request((_sd), _op, _req##_iov, _req##_count, _ans##_iov, \
 			   _ans##_count)
+
+#define CEPH_CALL_CBK(_sd, _op, _cbk) \
+	proxy_link_req_send((_sd), _op, _cbk##_iov, _cbk##_count)
 
 #define CEPH_RET(_sd, _res, _ans) \
 	proxy_link_ans_send((_sd), (_res), _ans##_iov, _ans##_count)
@@ -133,11 +139,19 @@ enum {
 		_fields                                            \
 	}
 
+#define CEPH_TYPE_CBK(_name, _fields...)                           \
+	struct _proxy_##_name##_cbk;                               \
+	typedef struct _proxy_##_name##_cbk proxy_##_name##_cbk_t; \
+	struct _proxy_##_name##_cbk {                              \
+		_fields                                            \
+	}
+
 #define FIELDS(_fields...) _fields
 #define REQ(_fields...) FIELDS(proxy_link_req_t header; _fields)
 #define REQ_CMOUNT(_fields...) REQ(uint64_t cmount; _fields)
 #define ANS(_fields...) FIELDS(proxy_link_ans_t header; _fields)
 #define ANS_CMOUNT(_fields...) ANS(uint64_t cmount; _fields)
+#define CBK(_fields...) FIELDS(proxy_link_req_t header; _fields)
 
 #define CEPH_TYPE(_name, _req, _ans) \
 	CEPH_TYPE_REQ(_name, _req);  \

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -106,7 +106,17 @@ enum {
 	LIBCEPHFSD_OP_LL_RELEASEDIR,
 	LIBCEPHFSD_OP_MOUNT_PERMS,
 
+	/* Add more operations above this comment. */
+
 	LIBCEPHFSD_OP_TOTAL_OPS
+};
+
+enum {
+	LIBCEPHFSD_CBK_NULL = 0,
+
+	/* Add more callbacks above this comment. */
+
+	LIBCEPHFSD_CBK_TOTAL_OPS
 };
 
 #define CEPH_TYPE_REQ(_name, _fields...)                           \
@@ -337,5 +347,9 @@ typedef union _proxy_req {
 	proxy_ceph_ll_releasedir_req_t ll_releasedir;
 	proxy_ceph_mount_perms_req_t mount_perms;
 } proxy_req_t;
+
+typedef union _proxy_cbk {
+	proxy_link_req_t header;
+} proxy_cbk_t;
 
 #endif

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -40,7 +40,7 @@
 
 #define CEPH_DATA(_name, _data, _data_count)       \
 	proxy_##_name##_##_data##_t _data;         \
-	struct iovec _data##_iov[_data_count + 1]; \
+	struct iovec _data##_iov[(_data_count) + 1]; \
 	int32_t _data##_count = 0;                 \
 	CEPH_BUFF_ADD(_data, &_data, sizeof(_data))
 

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -135,8 +135,6 @@ enum {
 
 /* Declaration of types used to transder requests and answers. */
 
-CEPH_TYPE(hello, FIELDS(uint32_t id;), FIELDS(int16_t major; int16_t minor;));
-
 CEPH_TYPE(ceph_version, REQ(),
 	  ANS(int32_t major; int32_t minor; int32_t patch; int16_t text;));
 

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -111,6 +111,7 @@ enum {
 	LIBCEPHFSD_OP_LL_RMDIR,
 	LIBCEPHFSD_OP_LL_RELEASEDIR,
 	LIBCEPHFSD_OP_MOUNT_PERMS,
+	LIBCEPHFSD_OP_LL_NONBLOCKING_RW,
 
 	/* Add more operations above this comment. */
 
@@ -119,6 +120,7 @@ enum {
 
 enum {
 	LIBCEPHFSD_CBK_NULL = 0,
+	LIBCEPHFSD_CBK_LL_NONBLOCKING_RW,
 
 	/* Add more callbacks above this comment. */
 
@@ -310,6 +312,11 @@ CEPH_TYPE(ceph_ll_releasedir, REQ_CMOUNT(uint64_t dir;), ANS());
 
 CEPH_TYPE(ceph_mount_perms, REQ_CMOUNT(), ANS(uint64_t userperm;));
 
+CEPH_TYPE(ceph_ll_nonblocking_readv_writev,
+	  REQ_CMOUNT(uint64_t info; uint64_t fh; int64_t off; uint64_t size;
+		     bool write; bool fsync; bool syncdataonly;),
+	  ANS(int64_t res;));
+
 typedef union _proxy_req {
 	proxy_link_req_t header;
 
@@ -360,10 +367,15 @@ typedef union _proxy_req {
 	proxy_ceph_ll_rmdir_req_t ll_rmdir;
 	proxy_ceph_ll_releasedir_req_t ll_releasedir;
 	proxy_ceph_mount_perms_req_t mount_perms;
+	proxy_ceph_ll_nonblocking_readv_writev_req_t ll_nonblocking_rw;
 } proxy_req_t;
+
+CEPH_TYPE_CBK(ceph_ll_nonblocking_readv_writev,
+	      CBK(uint64_t info; int64_t res;));
 
 typedef union _proxy_cbk {
 	proxy_link_req_t header;
+	proxy_ceph_ll_nonblocking_readv_writev_cbk_t ll_nonblocking_rw;
 } proxy_cbk_t;
 
 #endif


### PR DESCRIPTION
This PR implements a callback mechanism that allows the proxy daemon to send notifications to the clients. This mechanism is used to implement the `ceph_ll_nonblocking_readv_writev()` function.

The client side, when the feature is also supported by the server, creates a new thread that will wait for incoming notifications from the daemon. When the daemon receives a nonblocking rw opeation, it processes the request normally using libcephfs, and then it sends back a notification with the result to the client when libcephfs executes the callback.

This PR depends on #61757.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
