### PR TITLE
reef: doc/mgr: Add root CA cert instructions to rgw.rst

### DIFF
--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -139,3 +139,43 @@ Join an existing realm by creating a new secondary zone (using the realm token)
   ceph rgw admin [*]
 
 RGW admin command
+
+Upgrading root ca certificates
+------------------------------
+
+#. Make sure that the RGW service is running.
+#. Make sure that the RGW service is up.
+#. Make sure that the RGW service has been upgraded to the latest release.
+#. From the Primary cluster on the Manager node, run the following command:
+
+   .. prompt:: bash #
+
+      ceph orch cert-store get cert cephadm_root_ca_cert
+
+#. On the node where the RGW service is running, store the certificate on the
+   following path::
+
+      /etc/pki/ca-trust/source/anchors/<cert_name>.crt
+
+#. Verify the certificate by running the following command:
+
+   .. prompt:: bash #
+
+      openssl x509 -in <cert_name>.crt -noout -text
+
+#. Perform the above steps on the MGR node and on the RGW node of all secondary
+   clusters.
+
+#. After the certificates have been validated on all clusters, run the
+   following command on all clusters that generate certificates: 
+
+   .. prompt:: bash #
+
+      update-ca-trust
+
+#. From the primary node, ensure that the ``curl`` command can be run by the
+   user:
+
+   .. prompt:: bash [root@primary-node]# 
+
+      curl https://<host_ip>:443


### PR DESCRIPTION
Add documentation for adding fs_id in root_ca_cert upgrade path

Fixes: https://tracker.ceph.com/issues/70014

Signed-off-by: Anuradha Gadge <anuradha.gadge@ibm.com>
(cherry picked from commit 76106dd9890fdbd9440a5f7de85e9d5de6d0a2b4)

doc/mgr: edit grammar and formatting of rgw.rst

Improve the grammar and correct the formatting of the "Upgrading root ca certificates" procedure that was added to the documentation in https://github.com/ceph/ceph/pull/61867

Fixes: https://tracker.ceph.com/issues/70014

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 7d9298e3de74e91db116c79a7087f559464ae52d)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

