### PR TITLE
reef: mon: resolve warning about inconsistent variable types

### DIFF
--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -778,7 +778,7 @@ void Elector::notify_rank_removed(unsigned rank_removed, unsigned new_rank)
      In the case where we are removing the highest rank,
      we erase the removed rank from all sets.
    */
-  if (rank_removed < paxos_size()) {
+  if (std::cmp_less(rank_removed, paxos_size())) {
     for (unsigned i = rank_removed + 1; i <= paxos_size() ; ++i) {
       if (live_pinging.count(i)) {
         dead_pinging.erase(i-1);

--- a/src/test/common/test_fair_mutex.cc
+++ b/src/test/common/test_fair_mutex.cc
@@ -47,7 +47,7 @@ TEST(FairMutex, fair)
                                        scoreboard.end(),
                                        0);
       for (unsigned score : scoreboard) {
-        if (total < NR_ROUNDS) {
+        if (std::cmp_less(total, NR_ROUNDS)) {
           // not quite statistically significant. to reduce the false positive,
           // just consider it fair
           continue;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70054

---

backport of https://github.com/ceph/ceph/pull/54116
parent tracker: https://tracker.ceph.com/issues/63917

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh