### PR TITLE
squid: os/bluestore: fix the problem that _estimate_log_size_N calculates the log size incorrectly

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2437,7 +2437,7 @@ uint64_t BlueFS::_estimate_log_size_N()
   int avg_file_size = 12;
   uint64_t size = 4096 * 2;
   size += nodes.file_map.size() * (1 + sizeof(bluefs_fnode_t));
-  size += nodes.dir_map.size() + (1 + avg_dir_size);
+  size += nodes.dir_map.size() * (1 + avg_dir_size);
   size += nodes.file_map.size() * (1 + avg_dir_size + avg_file_size);
   return round_up_to(size, super.block_size);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70067

---

backport of https://github.com/ceph/ceph/pull/56515
parent tracker: https://tracker.ceph.com/issues/65176

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh