### PR TITLE
reef: pybind/rados: fix the incorrect order of offset,length in WriteOp.zero

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -41,6 +41,22 @@
   by disabling async recovery by setting osd_async_recovery_min_cost to a very
   large value on all OSDs until the upgrade is complete:
   ``ceph config set osd osd_async_recovery_min_cost 1099511627776``
+* mgr/restful, mgr/zabbix: both modules, already deprecated since 2020, have been
+  finally removed. They have not been actively maintenance in the last years,
+  and started suffering from vulnerabilities in their dependency chain (e.g.:
+  CVE-2023-46136).  As alternatives, for the `restful` module, the `dashboard` module
+  provides a richer and better maintained RESTful API. Regarding the `zabbix` module,
+  there are alternative monitoring solutions, like `prometheus`, which is the most
+  widely adopted among the Ceph user community.
+
+* CephFS: EOPNOTSUPP (Operation not supported ) is now returned by the CephFS
+  fuse client for `fallocate` for the default case (i.e. mode == 0) since
+  CephFS does not support disk space reservation. The only flags supported are
+  `FALLOC_FL_KEEP_SIZE` and `FALLOC_FL_PUNCH_HOLE`.
+* pybind/rados: Fixes WriteOp.zero() in the original reversed order of arguments
+  `offset` and `length`. When pybind calls WriteOp.zero(), the argument passed
+  does not match rados_write_op_zero, and offset and length are swapped, which
+  results in an unexpected response.
 
 >=19.0.0
 

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -1870,7 +1870,7 @@ cdef class WriteOp(object):
             uint64_t _offset = offset
 
         with nogil:
-            rados_write_op_zero(self.write_op, _length, _offset)
+            rados_write_op_zero(self.write_op, _offset, _length)
 
     def truncate(self, offset: int):
         """

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -516,6 +516,11 @@ class TestIoctx(object):
             eq(self.ioctx.read('write_ops'), b'12\x00\x005')
 
             write_op.write_full(b'12345')
+            write_op.zero(0, 2)
+            self.ioctx.operate_write_op(write_op, "write_ops")
+            eq(self.ioctx.read('write_ops'), b'\x00\x00345')
+
+            write_op.write_full(b'12345')
             write_op.truncate(2)
             self.ioctx.operate_write_op(write_op, "write_ops")
             eq(self.ioctx.read('write_ops'), b'12')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69685

---

backport of https://github.com/ceph/ceph/pull/59143
parent tracker: https://tracker.ceph.com/issues/67471

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh