### PR TITLE
squid: mgr/cephadm: fix typo with vrrp_interfaces in keepalive setup

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -351,10 +351,10 @@ class IngressService(CephService):
         else:
             for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
                 if subnet == spec.vrrp_interface_network:
-                    vrrp_interface = [list(ifaces.keys())[0]] * len(interfaces)
+                    vrrp_interfaces = [list(ifaces.keys())[0]] * len(interfaces)
                     logger.info(
                         f'vrrp will be configured on {host} interface '
-                        f'{vrrp_interface} (which is in subnet {subnet})'
+                        f'{vrrp_interfaces} (which is in subnet {subnet})'
                     )
                     break
             else:


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/61663

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
