### PR TITLE
crimson/osd: replace obsolete get_tracked_conf_keys()

### DIFF
--- a/src/crimson/osd/object_context.cc
+++ b/src/crimson/osd/object_context.cc
@@ -8,6 +8,8 @@
 #include "common/Formatter.h"
 #include "crimson/common/config_proxy.h"
 
+using namespace std::string_literals;
+
 namespace {
   seastar::logger& logger() {
     return crimson::get_logger(ceph_subsys_osd);
@@ -28,13 +30,9 @@ ObjectContextRegistry::~ObjectContextRegistry()
   obc_lru.set_target_size(0UL);
 }
 
-const char** ObjectContextRegistry::get_tracked_conf_keys() const
+std::vector<std::string> ObjectContextRegistry::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
-    "crimson_osd_obc_lru_size",
-    nullptr
-  };
-  return KEYS;
+  return {"crimson_osd_obc_lru_size"s};
 }
 
 void ObjectContextRegistry::handle_conf_change(

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -250,7 +250,7 @@ public:
     obc_lru.for_each(std::forward<F>(f));
   }
 
-  const char** get_tracked_conf_keys() const final;
+  std::vector<std::string> get_tracked_keys() const noexcept final;
   void handle_conf_change(const crimson::common::ConfigProxy& conf,
                           const std::set <std::string> &changed) final;
 };

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -76,6 +76,8 @@ using std::vector;
 using crimson::common::local_conf;
 using crimson::os::FuturizedStore;
 
+using namespace std::string_literals;
+
 namespace crimson::osd {
 
 OSD::OSD(int id, uint32_t nonce,
@@ -964,13 +966,9 @@ void OSD::handle_authentication(const EntityName& name,
   }
 }
 
-const char** OSD::get_tracked_conf_keys() const
+std::vector<std::string> OSD::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
-    "osd_beacon_report_interval",
-    nullptr
-  };
-  return KEYS;
+  return {"osd_beacon_report_interval"s};
 }
 
 void OSD::handle_conf_change(

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -131,7 +131,7 @@ class OSD final : public crimson::net::Dispatcher,
   seastar::timer<seastar::lowres_clock> stats_timer;
   std::vector<ShardServices::shard_stats_t> shard_stats;
 
-  const char** get_tracked_conf_keys() const final;
+  std::vector<std::string> get_tracked_keys() const noexcept final;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string> &changed) final;
 

--- a/src/crimson/osd/osd_operation.cc
+++ b/src/crimson/osd/osd_operation.cc
@@ -6,6 +6,8 @@
 #include "crimson/common/log.h"
 #include "crimson/osd/osd_operations/client_request.h"
 
+using namespace std::string_literals;
+
 namespace {
   seastar::logger& logger() {
     return crimson::get_logger(ceph_subsys_osd);
@@ -198,13 +200,9 @@ void OperationThrottler::update_from_config(const ConfigProxy &conf)
   wake();
 }
 
-const char** OperationThrottler::get_tracked_conf_keys() const
+std::vector<std::string> OperationThrottler::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
-    "crimson_osd_scheduler_concurrency",
-    NULL
-  };
-  return KEYS;
+  return {"crimson_osd_scheduler_concurrency"s};
 }
 
 void OperationThrottler::handle_conf_change(

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -329,7 +329,7 @@ class OperationThrottler : public BlockerT<OperationThrottler>,
 public:
   OperationThrottler(ConfigProxy &conf);
 
-  const char** get_tracked_conf_keys() const final;
+  std::vector<std::string> get_tracked_keys() const noexcept final;
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set<std::string> &changed) final;
   void update_from_config(const ConfigProxy &conf);

--- a/src/crimson/osd/scheduler/mclock_scheduler.cc
+++ b/src/crimson/osd/scheduler/mclock_scheduler.cc
@@ -21,6 +21,7 @@
 
 namespace dmc = crimson::dmclock;
 using namespace std::placeholders;
+using namespace std::string_literals;
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
@@ -138,22 +139,21 @@ item_t mClockScheduler::dequeue()
   }
 }
 
-const char** mClockScheduler::get_tracked_conf_keys() const
+std::vector<std::string> mClockScheduler::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
-    "osd_mclock_scheduler_client_res",
-    "osd_mclock_scheduler_client_wgt",
-    "osd_mclock_scheduler_client_lim",
-    "osd_mclock_scheduler_background_recovery_res",
-    "osd_mclock_scheduler_background_recovery_wgt",
-    "osd_mclock_scheduler_background_recovery_lim",
-    "osd_mclock_scheduler_background_best_effort_res",
-    "osd_mclock_scheduler_background_best_effort_wgt",
-    "osd_mclock_scheduler_background_best_effort_lim",
-    NULL
+  return {
+    "osd_mclock_scheduler_client_res"s,
+    "osd_mclock_scheduler_client_wgt"s,
+    "osd_mclock_scheduler_client_lim"s,
+    "osd_mclock_scheduler_background_recovery_res"s,
+    "osd_mclock_scheduler_background_recovery_wgt"s,
+    "osd_mclock_scheduler_background_recovery_lim"s,
+    "osd_mclock_scheduler_background_best_effort_res"s,
+    "osd_mclock_scheduler_background_best_effort_wgt"s,
+    "osd_mclock_scheduler_background_best_effort_lim"s
   };
-  return KEYS;
 }
+
 
 void mClockScheduler::handle_conf_change(
   const ConfigProxy& conf,

--- a/src/crimson/osd/scheduler/mclock_scheduler.h
+++ b/src/crimson/osd/scheduler/mclock_scheduler.h
@@ -117,7 +117,8 @@ public:
     ostream << "mClockScheduler";
   }
 
-  const char** get_tracked_conf_keys() const final;
+  std::vector<std::string> get_tracked_keys() const noexcept final;
+
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set<std::string> &changed) final;
 };

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -27,6 +27,7 @@
 SET_SUBSYS(osd);
 
 using std::vector;
+using namespace std::string_literals;
 
 namespace crimson::osd {
 
@@ -327,15 +328,13 @@ seastar::future<> OSDSingletonState::send_alive(const epoch_t want)
   }
 }
 
-const char** OSDSingletonState::get_tracked_conf_keys() const
+std::vector<std::string> OSDSingletonState::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
-    "osd_max_backfills",
-    "osd_min_recovery_priority",
-    "osd_max_trimming_pgs",
-    nullptr
+  return {
+    "osd_max_backfills"s,
+    "osd_min_recovery_priority"s,
+    "osd_max_trimming_pgs"s
   };
-  return KEYS;
 }
 
 void OSDSingletonState::handle_conf_change(

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -318,7 +318,7 @@ private:
   epoch_t up_thru_wanted = 0;
   seastar::future<> send_alive(epoch_t want);
 
-  const char** get_tracked_conf_keys() const final;
+  std::vector<std::string> get_tracked_keys() const noexcept final;
   void handle_conf_change(
     const ConfigProxy& conf,
     const std::set <std::string> &changed) final;


### PR DESCRIPTION
.. with get_tracked_keys().

This PR is but one of a set. Following
https://github.com/ceph/ceph/pull/61394, all uses of the deprecated interface will be updated, and that old interface will be removed.
