### PR TITLE
include,dpdk: fix two usages of std::iterator (deprecated)

### DIFF
--- a/src/include/rangeset.h
+++ b/src/include/rangeset.h
@@ -55,9 +55,14 @@ struct _rangeset_base {
 
 
 template <class T>
-class rangeset_iterator :
-  public std::iterator<std::input_iterator_tag, T>
+class rangeset_iterator
 {
+    using iterator_category = std::input_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T*;
+    using reference = T&;
+
   //typedef typename map<T,T>::iterator mapit;
 
   map<T,T> ranges;

--- a/src/msg/async/dpdk/circular_buffer.h
+++ b/src/msg/async/dpdk/circular_buffer.h
@@ -89,8 +89,12 @@ class circular_buffer {
   size_t mask(size_t idx) const;
 
   template<typename CB, typename ValueType>
-  struct cbiterator : std::iterator<std::random_access_iterator_tag, ValueType> {
-    typedef std::iterator<std::random_access_iterator_tag, ValueType> super_t;
+  struct cbiterator {
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = ValueType;
+    using difference_type = std::ptrdiff_t;
+    using pointer = ValueType*;
+    using reference = ValueType&;
 
     ValueType& operator*() const { return cb->_impl.storage[cb->mask(idx)]; }
     ValueType* operator->() const { return &cb->_impl.storage[cb->mask(idx)]; }
@@ -116,17 +120,17 @@ class circular_buffer {
       idx--;
       return v;
     }
-    cbiterator<CB, ValueType> operator+(typename super_t::difference_type n) const {
+    cbiterator<CB, ValueType> operator+(difference_type n) const {
       return cbiterator<CB, ValueType>(cb, idx + n);
     }
-    cbiterator<CB, ValueType> operator-(typename super_t::difference_type n) const {
+    cbiterator<CB, ValueType> operator-(difference_type n) const {
       return cbiterator<CB, ValueType>(cb, idx - n);
     }
-    cbiterator<CB, ValueType>& operator+=(typename super_t::difference_type n) {
+    cbiterator<CB, ValueType>& operator+=(difference_type n) {
       idx += n;
       return *this;
     }
-    cbiterator<CB, ValueType>& operator-=(typename super_t::difference_type n) {
+    cbiterator<CB, ValueType>& operator-=(difference_type n) {
       idx -= n;
       return *this;
     }
@@ -148,7 +152,7 @@ class circular_buffer {
     bool operator<=(const cbiterator<CB, ValueType>& rhs) const {
       return idx <= rhs.idx;
     }
-    typename super_t::difference_type operator-(const cbiterator<CB, ValueType>& rhs) const {
+    difference_type operator-(const cbiterator<CB, ValueType>& rhs) const {
       return idx - rhs.idx;
     }
    private:


### PR DESCRIPTION
This trait has been deprecated in C++17, with users instructed to migrate to defining each associated type when implementing an iterator.

This quiets the _GLIBCXX17_DEPRECATED warnings when compiling the project on a sufficiently new gcc.

This follows on from previous efforts in 8b8a96d (#45198).

- https://github.com/ceph/ceph/pull/45198
- https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
