### PR TITLE
reef: cephadm: Support Docker Live Restore

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -24,6 +24,10 @@ Requirements
 Any modern Linux distribution should be sufficient.  Dependencies
 are installed automatically by the bootstrap process below.
 
+See `Docker Live Restore <https://docs.docker.com/engine/daemon/live-restore/>`_
+for an optional feature that allows restarting Docker Engine without restarting
+all running containers.
+
 See the section :ref:`Compatibility With Podman
 Versions<cephadm-compatibility-with-podman>` for a table of Ceph versions that
 are compatible with Podman. Not every version of Podman is compatible with

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -4610,7 +4610,7 @@ Description=Ceph %i for {fsid}
 # configuration.
 After=network-online.target local-fs.target time-sync.target{docker_after}
 Wants=network-online.target local-fs.target time-sync.target
-{docker_requires}
+{docker_wants}
 
 PartOf=ceph-{fsid}.target
 Before=ceph-{fsid}.target
@@ -4637,7 +4637,7 @@ WantedBy=ceph-{fsid}.target
            extra_args=extra_args,
            # if docker, we depend on docker.service
            docker_after=' docker.service' if docker else '',
-           docker_requires='Requires=docker.service\n' if docker else '')
+           docker_wants='Wants=docker.service\n' if docker else '')
 
     return u
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -41,10 +41,10 @@ class TestCephAdm(object):
         ctx = _cephadm.CephadmContext()
         ctx.container_engine = mock_docker()
         r = _cephadm.get_unit_file(ctx, '9b9d7609-f4d5-4aba-94c8-effa764d96c9')
-        assert 'Requires=docker.service' in r
+        assert 'Wants=docker.service' in r
         ctx.container_engine = mock_podman()
         r = _cephadm.get_unit_file(ctx, '9b9d7609-f4d5-4aba-94c8-effa764d96c9')
-        assert 'Requires=docker.service' not in r
+        assert 'Wants=docker.service' not in r
 
     @mock.patch('cephadm.logger')
     def test_attempt_bind(self, _logger):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68158

---

backport of https://github.com/ceph/ceph/pull/59730
parent tracker: https://tracker.ceph.com/issues/68028

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh