### PR TITLE
qa/cephadm: add timeouts and debug commands to rgw-ingress test

### DIFF
--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/rgw-ingress.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/rgw-ingress.yaml
@@ -41,20 +41,20 @@ tasks:
         echo "Check with each rgw stopped in turn..."
         for rgw in `ceph orch ps | grep ^rgw.foo. | awk '{print $1}'`; do
           ceph orch daemon stop $rgw
-          while ! ceph orch ps | grep $rgw | grep stopped; do sleep 1 ; done
-          while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done
+          timeout 300 bash -c "while ! ceph orch ps | grep $rgw | grep stopped; do echo 'Waiting for $rgw to stop'; ceph orch ps --daemon-type rgw; ceph health detail; sleep 5 ; done"
+          timeout 300 bash -c "while ! curl http://{{VIP0}}:9000/ ; do echo 'Waiting for http://{{VIP0}}:9000/ to be available'; sleep 1 ; done"
           ceph orch daemon start $rgw
-          while ! ceph orch ps | grep $rgw | grep running; do sleep 1 ; done
+          timeout 300 bash -c "while ! ceph orch ps | grep $rgw | grep running; do echo 'Waiting for $rgw to start'; ceph orch ps --daemon-type rgw; ceph health detail; sleep 5 ; done"
         done
 
         # stop each haproxy in turn
         echo "Check with each haproxy down in turn..."
         for haproxy in `ceph orch ps | grep ^haproxy.rgw.foo. | awk '{print $1}'`; do
           ceph orch daemon stop $haproxy
-          while ! ceph orch ps | grep $haproxy | grep stopped; do sleep 1 ; done
-          while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done
+          timeout 300 bash -c "while ! ceph orch ps | grep $haproxy | grep stopped; do echo 'Waiting for $haproxy to stop'; ceph orch ps --daemon-type haproxy; ceph health detail; sleep 5 ; done"
+          timeout 300 bash -c "while ! curl http://{{VIP0}}:9000/ ; do echo 'Waiting for http://{{VIP0}}:9000/ to be available'; sleep 1 ; done"
           ceph orch daemon start $haproxy
-          while ! ceph orch ps | grep $haproxy | grep running; do sleep 1 ; done
+          timeout 300 bash -c "while ! ceph orch ps | grep $haproxy | grep running; do echo 'Waiting for $haproxy to start'; ceph orch ps --daemon-type haproxy; ceph health detail; sleep 5 ; done"
         done
 
-        while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done
+        timeout 300 bash -c "while ! curl http://{{VIP0}}:9000/ ; do echo 'Waiting for http://{{VIP0}}:9000/ to be available'; sleep 1 ; done"


### PR DESCRIPTION
This ~~won't~~ shouldn't make the test pass in and of itself, but it should stop the test from running until it hits the max job timeout and should help see where it's failing





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
