### PR TITLE
reef: mgr/cephadm: use double quotes for NFSv4 RecoveryBackend in ganesha conf

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -14,7 +14,7 @@ NFS_CORE_PARAM {
 
 NFSv4 {
         Delegations = false;
-        RecoveryBackend = 'rados_cluster';
+        RecoveryBackend = "rados_cluster";
         Minor_Versions = 1, 2;
 {% if nfs_idmap_conf %}
         IdmapConf = "{{ nfs_idmap_conf }}";

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -2540,7 +2540,7 @@ class TestIngressService:
             '\n'
             'NFSv4 {\n'
             '        Delegations = false;\n'
-            "        RecoveryBackend = 'rados_cluster';\n"
+            '        RecoveryBackend = "rados_cluster";\n'
             '        Minor_Versions = 1, 2;\n'
             '        IdmapConf = "/etc/ganesha/idmap.conf";\n'
             '}\n'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70088

---

backport of https://github.com/ceph/ceph/pull/61778
parent tracker: https://tracker.ceph.com/issues/69930

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh