### PR TITLE
crimson/os/seastore/omap_manager: apply linked tree nodes to omap trees

### DIFF
--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -91,6 +91,7 @@ class BackrefInternalNode
     "INTERNAL_NODE_CAPACITY doesn't fit in BACKREF_NODE_SIZE");
 public:
   using key_type = paddr_t;
+  static constexpr uint32_t CHILD_VEC_UNIT = 0;
   template <typename... T>
   BackrefInternalNode(T&&... t) :
     FixedKVInternalNode(std::forward<T>(t)...) {}

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1503,6 +1503,7 @@ private:
         return on_found(child->template cast<internal_node_t>());
       });
     }
+    c.cache.account_absent_access(c.trans.get_src());
 
     auto child_pos = v.get_child_pos();
     auto next_iter = node_iter + 1;
@@ -1574,6 +1575,7 @@ private:
         return on_found(child->template cast<leaf_node_t>());
       });
     }
+    c.cache.account_absent_access(c.trans.get_src());
 
     auto child_pos = v.get_child_pos();
     auto next_iter = node_iter + 1;
@@ -2133,6 +2135,7 @@ private:
         return do_merge(child->template cast<NodeType>());
       });
     }
+    c.cache.account_absent_access(c.trans.get_src());
 
     auto child_pos = v.get_child_pos();
     return get_node<NodeType>(

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -139,7 +139,7 @@ struct FixedKVInternalNode
     node_size,
     node_type_t>;
   using parent_node_t = ParentNode<node_type_t, NODE_KEY>;
-  using base_child_node_t = BaseChildNode<node_type_t, NODE_KEY>;
+  using base_child_t = BaseChildNode<node_type_t, NODE_KEY>;
   using child_node_t = ChildNode<node_type_t, node_type_t, NODE_KEY>;
   using root_node_t = RootChildNode<RootBlock, node_type_t>;
 
@@ -236,7 +236,7 @@ struct FixedKVInternalNode
   void update(
     internal_const_iterator_t iter,
     paddr_t addr,
-    base_child_node_t* nextent) {
+    base_child_t* nextent) {
     LOG_PREFIX(FixedKVInternalNode::update);
     SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, {}",
       this->pending_for_transaction,
@@ -253,7 +253,7 @@ struct FixedKVInternalNode
     internal_const_iterator_t iter,
     NODE_KEY pivot,
     paddr_t addr,
-    base_child_node_t* nextent) {
+    base_child_t* nextent) {
     LOG_PREFIX(FixedKVInternalNode::insert);
     SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, key {}, {}",
       this->pending_for_transaction,
@@ -284,7 +284,7 @@ struct FixedKVInternalNode
     internal_const_iterator_t iter,
     NODE_KEY pivot,
     paddr_t addr,
-    base_child_node_t* nextent) {
+    base_child_t* nextent) {
     LOG_PREFIX(FixedKVInternalNode::replace);
     SUBTRACE(seastore_fixedkv_tree, "trans.{}, pos {}, old key {}, key {}, {}",
       this->pending_for_transaction,

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -49,6 +49,10 @@ struct FixedKVNode : CachedExtent {
   virtual ~FixedKVNode() = default;
   virtual void do_on_rewrite(Transaction &t, CachedExtent &extent) = 0;
 
+  bool is_in_range(const node_key_t key) const {
+    return get_node_meta().is_in_range(key);
+  }
+
   void on_rewrite(Transaction &t, CachedExtent &extent, extent_len_t off) final {
     assert(get_type() == extent.get_type());
     assert(off == 0);
@@ -515,6 +519,7 @@ struct FixedKVLeafNode
   using base_t = FixedKVNode<NODE_KEY>;
   using child_node_t = ChildNode<internal_node_type_t, node_type_t, NODE_KEY>;
   using root_node_t = RootChildNode<RootBlock, node_type_t>;
+  using base_child_t = BaseChildNode<node_type_t, NODE_KEY>;
   explicit FixedKVLeafNode(ceph::bufferptr &&ptr)
     : FixedKVNode<NODE_KEY>(std::move(ptr)) {
     this->set_layout_buf(this->get_bptr().c_str());

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -186,7 +186,7 @@ public:
     return t.root;
   }
 
-  void account_absent_access(Transaction::src_t src) final {
+  void account_absent_access(Transaction::src_t src) {
     ++(get_by_src(stats.cache_absent_by_src, src));
     ++stats.access.cache_absent;
   }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1388,11 +1388,14 @@ public:
   template <typename... T>
   LogicalCachedExtent(T&&... t) : CachedExtent(std::forward<T>(t)...) {}
 
-  void on_rewrite(Transaction&, CachedExtent &extent, extent_len_t off) final {
+  void on_rewrite(Transaction &t, CachedExtent &extent, extent_len_t off) final {
     assert(get_type() == extent.get_type());
     auto &lextent = (LogicalCachedExtent&)extent;
     set_laddr((lextent.get_laddr() + off).checked_to_laddr());
+    do_on_rewrite(t, lextent);
   }
+
+  virtual void do_on_rewrite(Transaction &t, LogicalCachedExtent &extent) {}
 
   bool has_laddr() const {
     return laddr != L_ADDR_NULL;

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -103,6 +103,7 @@ BtreeLBAMapping::get_logical_extent(Transaction &t)
     : get_key();
   auto v = p.template get_child<LogicalChildNode>(ctx.trans, ctx.cache, pos, k);
   if (!v.has_child()) {
+    ctx.cache.account_absent_access(ctx.trans.get_src());
     this->child_pos = v.get_child_pos();
   }
   return v;

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -94,6 +94,7 @@ struct LBAInternalNode
   template <typename... T>
   LBAInternalNode(T&&... t) :
     FixedKVInternalNode(std::forward<T>(t)...) {}
+  static constexpr uint32_t CHILD_VEC_UNIT = 0;
 
   static constexpr extent_types_t TYPE = extent_types_t::LADDR_INTERNAL;
 
@@ -173,6 +174,7 @@ struct LBALeafNode
   using key_type = laddr_t;
   using parent_node_t = ParentNode<LBALeafNode, laddr_t>;
   using child_t = LogicalChildNode;
+  static constexpr uint32_t CHILD_VEC_UNIT = 0;
   LBALeafNode(ceph::bufferptr &&ptr)
     : parent_type_t(std::move(ptr)),
       parent_node_t(LEAF_NODE_CAPACITY) {}

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -250,7 +250,6 @@ public:
       return ext->template cast<T>();
     });
   }
-  virtual void account_absent_access(Transaction::src_t) = 0;
   virtual bool is_viewable_extent_data_stable(Transaction &, CachedExtentRef) = 0;
   virtual bool is_viewable_extent_stable(Transaction &, CachedExtentRef) = 0;
   virtual ~ExtentTransViewRetriever() {}
@@ -350,11 +349,9 @@ public:
 	return etvr.get_extent_viewable_by_trans<ChildT>(
 	  t, static_cast<ChildT*>(child));
       } else {
-        etvr.account_absent_access(t.get_src());
 	return child_pos_t<T>(&sparent, spos);
       }
     } else {
-      etvr.account_absent_access(t.get_src());
       return child_pos_t<T>(&me, pos);
     }
   }

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -314,11 +314,11 @@ public:
     ceph_assert(iter != copy_dests_by_trans.end());
     auto &copy_dests = static_cast<copy_dests_t&>(*iter);
     auto it = copy_dests.dests_by_key.lower_bound(key);
-    if (it == copy_dests.dests_by_key.end() || (*it)->range.begin > key) {
+    if (it == copy_dests.dests_by_key.end() || (*it)->get_begin() > key) {
       ceph_assert(it != copy_dests.dests_by_key.begin());
       --it;
     }
-    ceph_assert((*it)->range.begin <= key && key < (*it)->range.end);
+    ceph_assert((*it)->get_begin() <= key && key < (*it)->get_end());
     return *it;
   }
 

--- a/src/crimson/os/seastore/logical_child_node.h
+++ b/src/crimson/os/seastore/logical_child_node.h
@@ -14,7 +14,7 @@ class LogicalChildNode : public LogicalCachedExtent,
 			 public ChildNode<lba_manager::btree::LBALeafNode,
 					  LogicalChildNode,
 					  laddr_t> {
-  using child_node_t = ChildNode<
+  using lba_child_node_t = ChildNode<
     lba_manager::btree::LBALeafNode, LogicalChildNode, laddr_t>;
 public:
   template <typename... T>
@@ -24,7 +24,7 @@ public:
     if (this->has_parent_tracker() &&
 	this->is_valid() &&
 	!this->is_pending()) {
-      child_node_t::destroy();
+      lba_child_node_t::destroy();
     }
   }
 
@@ -41,7 +41,7 @@ public:
   }
 protected:
   void on_replace_prior() final {
-    child_node_t::on_replace_prior();
+    lba_child_node_t::on_replace_prior();
     do_on_replace_prior();
   }
   virtual void do_on_replace_prior() {}

--- a/src/crimson/os/seastore/logical_child_node.h
+++ b/src/crimson/os/seastore/logical_child_node.h
@@ -21,8 +21,7 @@ public:
   LogicalChildNode(T&&... t) : LogicalCachedExtent(std::forward<T>(t)...) {}
 
   virtual ~LogicalChildNode() {
-    if (this->has_parent_tracker() &&
-	this->is_valid() &&
+    if (this->is_valid() &&
 	!this->is_pending()) {
       lba_child_node_t::destroy();
     }

--- a/src/crimson/os/seastore/logical_child_node.h
+++ b/src/crimson/os/seastore/logical_child_node.h
@@ -42,7 +42,9 @@ public:
 protected:
   void on_replace_prior() final {
     child_node_t::on_replace_prior();
+    do_on_replace_prior();
   }
+  virtual void do_on_replace_prior() {}
 };
 using LogicalChildNodeRef = TCachedExtentRef<LogicalChildNode>;
 } // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
@@ -106,15 +106,6 @@ public:
   omap_clear_ret omap_clear(
     omap_root_t &omap_root,
     Transaction &t) final;
-
-  static extent_len_t get_leaf_size(omap_type_t type) {
-    if (type == omap_type_t::LOG) {
-      return LOG_LEAF_BLOCK_SIZE;
-    }
-    ceph_assert(type == omap_type_t::OMAP ||
-		type == omap_type_t::XATTR);
-    return OMAP_LEAF_BLOCK_SIZE;
-  }
 };
 using BtreeOMapManagerRef = std::unique_ptr<BtreeOMapManager>;
 

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -29,8 +29,14 @@ std::ostream &operator<<(std::ostream &out, const omap_leaf_key_t &rhs)
 
 std::ostream &OMapInnerNode::print_detail_l(std::ostream &out) const
 {
-  return out << ", size=" << get_size()
-	     << ", depth=" << get_meta().depth;
+  out << ", size=" << get_size()
+      << ", depth=" << get_meta().depth
+      << ", is_root=" << is_btree_root();
+  if (get_size() > 0) {
+    out << ", begin=" << get_begin()
+	<< ", end=" << get_end();
+  }
+  return out;
 }
 
 using dec_ref_iertr = OMapInnerNode::base_iertr;
@@ -54,23 +60,35 @@ dec_ref_ret dec_ref(omap_context_t oc, T&& addr) {
 OMapInnerNode::make_split_insert_ret
 OMapInnerNode::make_split_insert(
   omap_context_t oc,
-  internal_iterator_t iter,
+  internal_const_iterator_t iter,
   std::string key,
-  laddr_t laddr)
+  OMapNodeRef &node)
 {
   LOG_PREFIX(OMapInnerNode::make_split_insert);
   DEBUGT("this: {}, key: {}", oc.t, *this, key);
-  return make_split_children(oc).si_then([=] (auto tuple) {
+  return make_split_children(oc).si_then(
+    [FNAME, oc, iter=std::move(iter),
+    key=std::move(key), node, this] (auto tuple) {
     auto [left, right, pivot] = tuple;
+    DEBUGT("this: {}, key: {}, pivot {}", oc.t, *this, key, pivot);
+    left->init_range(get_begin(), pivot);
+    right->init_range(pivot, get_end());
     if (pivot > key) {
       auto liter = left->iter_idx(iter.get_offset());
-      left->journal_inner_insert(liter, laddr, key,
+      left->insert_child_ptr(
+	liter.get_offset(),
+	dynamic_cast<base_child_t*>(node.get()));
+      left->journal_inner_insert(liter, node->get_laddr(), key,
                                  left->maybe_get_delta_buffer());
     } else {  //right
       auto riter = right->iter_idx(iter.get_offset() - left->get_node_size());
-      right->journal_inner_insert(riter, laddr, key,
+      right->insert_child_ptr(
+	riter.get_offset(),
+	dynamic_cast<base_child_t*>(node.get()));
+      right->journal_inner_insert(riter, node->get_laddr(), key,
                                   right->maybe_get_delta_buffer());
     }
+    this->adjust_copy_src_dest_on_split(oc.t, *left, *right);
     ++(oc.t.get_omap_tree_stats().extents_num_delta);
     return make_split_insert_ret(
            interruptible::ready_future_marker{},
@@ -83,7 +101,7 @@ OMapInnerNode::make_split_insert(
 OMapInnerNode::handle_split_ret
 OMapInnerNode::handle_split(
   omap_context_t oc,
-  internal_iterator_t iter,
+  internal_const_iterator_t iter,
   mutation_result_t mresult)
 {
   LOG_PREFIX(OMapInnerNode::handle_split);
@@ -94,25 +112,34 @@ OMapInnerNode::handle_split(
     return mut->handle_split(oc, mut_iter, mresult);
   }
   auto [left, right, pivot] = *(mresult.split_tuple);
+  DEBUGT("this: {} {} {}",  oc.t, *left, *right, pivot);
   //update operation will not cause node overflow, so we can do it first.
+  this->update_child_ptr(
+    iter.get_offset(),
+    dynamic_cast<base_child_t*>(left.get()));
   journal_inner_update(iter, left->get_laddr(), maybe_get_delta_buffer());
   bool overflow = extent_will_overflow(pivot.size(), std::nullopt);
+  auto right_iter = iter + 1;
   if (!overflow) {
-    journal_inner_insert(iter + 1, right->get_laddr(), pivot,
+    this->insert_child_ptr(
+      right_iter.get_offset(),
+      dynamic_cast<base_child_t*>(right.get()));
+    journal_inner_insert(right_iter, right->get_laddr(), pivot,
                          maybe_get_delta_buffer());
     return insert_ret(
            interruptible::ready_future_marker{},
            mutation_result_t(mutation_status_t::SUCCESS, std::nullopt, std::nullopt));
   } else {
-    return make_split_insert(oc, iter + 1, pivot, right->get_laddr())
-      .si_then([this, oc] (auto m_result) {
-       return dec_ref(oc, get_laddr())
-         .si_then([m_result = std::move(m_result)] {
-          return insert_ret(
-                 interruptible::ready_future_marker{},
-                 m_result);
-       });
-   });
+    return make_split_insert(
+      oc, right_iter, pivot, right
+    ).si_then([this, oc] (auto m_result) {
+      return dec_ref(oc, get_laddr()
+      ).si_then([m_result = std::move(m_result)] {
+	return insert_ret(
+	       interruptible::ready_future_marker{},
+	       m_result);
+      });
+    });
   }
 }
 
@@ -123,11 +150,9 @@ OMapInnerNode::get_value(
 {
   LOG_PREFIX(OMapInnerNode::get_value);
   DEBUGT("key = {}, this: {}", oc.t, key, *this);
-  auto child_pt = get_containing_child(key);
-  assert(child_pt != iter_cend());
-  auto laddr = child_pt->get_val();
-  return omap_load_extent(oc, laddr, get_meta().depth - 1).si_then(
+  return get_child_node(oc, key).si_then(
     [oc, &key] (auto extent) {
+    ceph_assert(!extent->is_btree_root());
     return extent->get_value(oc, key);
   }).finally([ref = OMapNodeRef(this)] {});
 }
@@ -141,10 +166,9 @@ OMapInnerNode::insert(
   LOG_PREFIX(OMapInnerNode::insert);
   DEBUGT("{}->{}, this: {}",  oc.t, key, value, *this);
   auto child_pt = get_containing_child(key);
-  assert(child_pt != iter_cend());
-  auto laddr = child_pt->get_val();
-  return omap_load_extent(oc, laddr, get_meta().depth - 1).si_then(
+  return get_child_node(oc, child_pt).si_then(
     [oc, &key, &value] (auto extent) {
+    ceph_assert(!extent->is_btree_root());
     return extent->insert(oc, key, value);
   }).si_then([this, oc, child_pt] (auto mresult) {
     if (mresult.status == mutation_status_t::SUCCESS) {
@@ -165,10 +189,9 @@ OMapInnerNode::rm_key(omap_context_t oc, const std::string &key)
   LOG_PREFIX(OMapInnerNode::rm_key);
   DEBUGT("key={}, this: {}", oc.t, key, *this);
   auto child_pt = get_containing_child(key);
-  assert(child_pt != iter_cend());
-  auto laddr = child_pt->get_val();
-  return omap_load_extent(oc, laddr, get_meta().depth - 1).si_then(
+  return get_child_node(oc, child_pt).si_then(
     [this, oc, &key, child_pt] (auto extent) {
+    ceph_assert(!extent->is_btree_root());
     return extent->rm_key(oc, key)
       .si_then([this, oc, child_pt, extent = std::move(extent)] (auto mresult) {
       switch (mresult.status) {
@@ -242,11 +265,9 @@ OMapInnerNode::list(
             seastar::stop_iteration::yes);
         }
 	assert(result.size() < config.max_result_size);
-        auto laddr = iter->get_val();
-        return omap_load_extent(
-          oc, laddr,
-          get_meta().depth - 1
+        return get_child_node(oc, iter
         ).si_then([&, config, oc](auto &&extent) {
+	  ceph_assert(!extent->is_btree_root());
 	  return seastar::do_with(
 	    iter == fiter ? first : std::optional<std::string>(std::nullopt),
 	    iter == liter - 1 ? last : std::optional<std::string>(std::nullopt),
@@ -306,8 +327,9 @@ OMapInnerNode::clear(omap_context_t oc)
     auto laddr = iter->get_val();
     auto ndepth = get_meta().depth - 1;
     if (ndepth > 1) {
-      return omap_load_extent(oc, laddr, ndepth
+      return get_child_node(oc, iter
       ).si_then([oc](auto &&extent) {
+	ceph_assert(!extent->is_btree_root());
 	return extent->clear(oc);
       }).si_then([oc, laddr] {
 	return dec_ref(oc, laddr);
@@ -325,7 +347,7 @@ OMapInnerNode::clear(omap_context_t oc)
 }
 
 OMapInnerNode::split_children_ret
-OMapInnerNode:: make_split_children(omap_context_t oc)
+OMapInnerNode::make_split_children(omap_context_t oc)
 {
   LOG_PREFIX(OMapInnerNode::make_split_children);
   DEBUGT("this: {}", oc.t, *this);
@@ -336,6 +358,7 @@ OMapInnerNode:: make_split_children(omap_context_t oc)
       auto left = ext_pair.front();
       auto right = ext_pair.back();
       DEBUGT("this: {}, split into: l {} r {}", oc.t, *this, *left, *right);
+      this->split_child_ptrs(oc.t, *left, *right);
       return split_children_ret(
              interruptible::ready_future_marker{},
              std::make_tuple(left, right, split_into(*left, *right)));
@@ -352,7 +375,9 @@ OMapInnerNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
   DEBUGT("", oc.t);
   return oc.tm.alloc_non_data_extent<OMapInnerNode>(oc.t, oc.hint,
     OMAP_INNER_BLOCK_SIZE)
-    .si_then([this, right] (auto &&replacement) {
+    .si_then([this, right, oc] (auto &&replacement) {
+      replacement->merge_child_ptrs(
+	oc.t, *this, *right->cast<OMapInnerNode>());
       replacement->merge_from(*this, *right->cast<OMapInnerNode>());
       return full_merge_ret(
         interruptible::ready_future_marker{},
@@ -371,10 +396,12 @@ OMapInnerNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
   ceph_assert(_right->get_type() == TYPE);
   return oc.tm.alloc_extents<OMapInnerNode>(oc.t, oc.hint,
     OMAP_INNER_BLOCK_SIZE, 2)
-    .si_then([this, _right] (auto &&replacement_pair){
+    .si_then([this, _right, oc] (auto &&replacement_pair){
       auto replacement_left = replacement_pair.front();
       auto replacement_right = replacement_pair.back();
       auto &right = *_right->cast<OMapInnerNode>();
+      this->balance_child_ptrs(oc.t, *this, right, true,
+			       *replacement_left, *replacement_right);
       return make_balanced_ret(
              interruptible::ready_future_marker{},
              std::make_tuple(replacement_left, replacement_right,
@@ -389,7 +416,7 @@ OMapInnerNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
 OMapInnerNode::merge_entry_ret
 OMapInnerNode::merge_entry(
   omap_context_t oc,
-  internal_iterator_t iter,
+  internal_const_iterator_t iter,
   OMapNodeRef entry)
 {
   LOG_PREFIX(OMapInnerNode::merge_entry);
@@ -401,36 +428,53 @@ OMapInnerNode::merge_entry(
   }
   auto is_left = (iter + 1) == iter_cend();
   auto donor_iter = is_left ? iter - 1 : iter + 1;
-  return omap_load_extent(oc, donor_iter->get_val(), get_meta().depth - 1
+  return get_child_node(oc, donor_iter
   ).si_then([=, this](auto &&donor) mutable {
+    ceph_assert(!donor->is_btree_root());
     LOG_PREFIX(OMapInnerNode::merge_entry);
     auto [l, r] = is_left ?
       std::make_pair(donor, entry) : std::make_pair(entry, donor);
     auto [liter, riter] = is_left ?
       std::make_pair(donor_iter, iter) : std::make_pair(iter, donor_iter);
     if (l->can_merge(r)) {
-      DEBUGT("make_full_merge l {} r {}", oc.t, *l, *r);
+      DEBUGT("make_full_merge l {} r {} liter {} riter {}",
+	oc.t, *l, *r, liter->get_key(), riter->get_key());
       assert(entry->extent_is_below_min());
       return l->make_full_merge(oc, r
       ).si_then([liter=liter, riter=riter, l=l, r=r, oc, this]
 		(auto &&replacement) {
 	LOG_PREFIX(OMapInnerNode::merge_entry);
 	DEBUGT("to update parent: {}", oc.t, *this);
+	this->update_child_ptr(
+	  liter.get_offset(),
+	  dynamic_cast<base_child_t*>(replacement.get()));
         journal_inner_update(
 	  liter,
 	  replacement->get_laddr(),
 	  maybe_get_delta_buffer());
+	this->remove_child_ptr(riter.get_offset());
         journal_inner_remove(riter, maybe_get_delta_buffer());
         //retire extent
         std::vector<laddr_t> dec_laddrs {l->get_laddr(), r->get_laddr()};
+	auto next = liter + 1;
+	auto end = next == iter_cend() ? get_end() : next.get_key();
+	assert(end == r->get_end());
+	replacement->init_range(liter.get_key(), std::move(end));
+	if (get_meta().depth > 2) { // replacement is an inner node
+	  auto &rep = *replacement->template cast<OMapInnerNode>();
+	  rep.adjust_copy_src_dest_on_merge(
+	    oc.t,
+	    *l->template cast<OMapInnerNode>(),
+	    *r->template cast<OMapInnerNode>());
+	}
         return dec_ref(oc, dec_laddrs
-	).si_then([this, oc] {
+	).si_then([this, oc, r=std::move(replacement)] {
 	  --(oc.t.get_omap_tree_stats().extents_num_delta);
           if (extent_is_below_min()) {
             return merge_entry_ret(
                    interruptible::ready_future_marker{},
-                   mutation_result_t(mutation_status_t::NEED_MERGE,
-		     std::nullopt, this));
+		   mutation_result_t(mutation_status_t::NEED_MERGE,
+				     std::nullopt, this));
           } else {
             return merge_entry_ret(
                    interruptible::ready_future_marker{},
@@ -439,14 +483,30 @@ OMapInnerNode::merge_entry(
           }
         });
       });
-    } else {
-      DEBUGT("balanced l {} r {}", oc.t, *l, *r);
+    } else { // !l->can_merge(r)
+      DEBUGT("balanced l {} r {} liter {} riter {}",
+	oc.t, *l, *r, liter->get_key(), riter->get_key());
       return l->make_balanced(oc, r
       ).si_then([liter=liter, riter=riter, l=l, r=r, oc, this](auto tuple) {
 	LOG_PREFIX(OMapInnerNode::merge_entry);
-	DEBUGT("to update parent: {}", oc.t, *this);
         auto [replacement_l, replacement_r, replacement_pivot] = tuple;
+	DEBUGT("to update parent: {} {} {}",
+	  oc.t, *this, *replacement_l, *replacement_r);
+	replacement_l->init_range(l->get_begin(), replacement_pivot);
+	replacement_r->init_range(replacement_pivot, r->get_end());
+	if (get_meta().depth > 2) { // l and r are inner nodes
+	  auto &left = *l->template cast<OMapInnerNode>();
+	  auto &right = *r->template cast<OMapInnerNode>();
+	  auto &rep_left = *replacement_l->template cast<OMapInnerNode>();
+	  auto &rep_right = *replacement_r->template cast<OMapInnerNode>();
+	  this->adjust_copy_src_dest_on_balance(
+	    oc.t, left, right, true, rep_left, rep_right);
+	}
+
         //update operation will not cuase node overflow, so we can do it first
+	this->update_child_ptr(
+	  liter.get_offset(),
+	  dynamic_cast<base_child_t*>(replacement_l.get()));
         journal_inner_update(
 	  liter,
 	  replacement_l->get_laddr(),
@@ -454,6 +514,9 @@ OMapInnerNode::merge_entry(
         bool overflow = extent_will_overflow(replacement_pivot.size(),
 	  std::nullopt);
         if (!overflow) {
+	  this->update_child_ptr(
+	    riter.get_offset(),
+	    dynamic_cast<base_child_t*>(replacement_r.get()));
           journal_inner_remove(riter, maybe_get_delta_buffer());
           journal_inner_insert(
 	    riter,
@@ -469,12 +532,14 @@ OMapInnerNode::merge_entry(
 		     std::nullopt, std::nullopt));
           });
         } else {
-          DEBUGT("balanced and split {} r {}", oc.t, *l, *r);
+          DEBUGT("balanced and split {} r {} riter {}",
+	    oc.t, *l, *r, riter.get_key());
           //use remove and insert to instead of replace,
           //remove operation will not cause node split, so we can do it first
+	  this->remove_child_ptr(riter.get_offset());
           journal_inner_remove(riter, maybe_get_delta_buffer());
-          return make_split_insert(oc, riter, replacement_pivot,
-	    replacement_r->get_laddr()
+          return make_split_insert(
+	    oc, riter, replacement_pivot, replacement_r
 	  ).si_then([this, oc, l = l, r = r](auto mresult) {
 	    std::vector<laddr_t> dec_laddrs{
 	      l->get_laddr(),
@@ -493,21 +558,28 @@ OMapInnerNode::merge_entry(
 
 }
 
-OMapInnerNode::internal_iterator_t
+OMapInnerNode::internal_const_iterator_t
 OMapInnerNode::get_containing_child(const std::string &key)
 {
-  auto iter = string_lower_bound(key);
-  if (iter == iter_end() || (iter != iter_begin() && iter.get_key() > key)) {
-    iter--;
-  }
+  auto iter = string_upper_bound(key);
+  iter--;
   assert(iter.contains(key));
   return iter;
 }
 
 std::ostream &OMapLeafNode::print_detail_l(std::ostream &out) const
 {
-  return out << ", size=" << get_size()
-         << ", depth=" << get_meta().depth;
+  out << ", size=" << get_size()
+         << ", depth=" << get_meta().depth
+	 << ", is_root=" << is_btree_root();
+  if (get_size() > 0) {
+    out << ", begin=" << get_begin()
+	<< ", end=" << get_end();
+  }
+  if (this->child_node_t::is_parent_valid())
+    return out << ", parent=" << (void*)this->child_node_t::get_parent_node().get();
+  else
+    return out;
 }
 
 OMapLeafNode::get_value_ret
@@ -559,6 +631,8 @@ OMapLeafNode::insert(
   } else {
     return make_split_children(oc).si_then([this, oc, &key, &value] (auto tuple) {
       auto [left, right, pivot] = tuple;
+      left->init_range(get_begin(), pivot);
+      right->init_range(pivot, get_end());
       auto replace_pt = find_string_key(key);
       if (replace_pt != iter_end()) {
         ++(oc.t.get_omap_tree_stats().num_updates);
@@ -732,36 +806,71 @@ OMapLeafNode::make_balanced(omap_context_t oc, OMapNodeRef _right)
   );
 }
 
-
-omap_load_extent_iertr::future<OMapNodeRef>
-omap_load_extent(omap_context_t oc, laddr_t laddr, depth_t depth)
+OMapInnerNode::get_child_node_ret
+OMapInnerNode::get_child_node(
+  omap_context_t oc,
+  internal_const_iterator_t child_pt)
 {
-  ceph_assert(depth > 0);
-  if (depth > 1) {
-    return oc.tm.read_extent<OMapInnerNode>(
-        oc.t, laddr, OMAP_INNER_BLOCK_SIZE
-    ).handle_error_interruptible(
-      omap_load_extent_iertr::pass_further{},
-      crimson::ct_error::assert_all{ "Invalid error in omap_load_extent" }
-    ).si_then([](auto maybe_indirect_extent) {
-      assert(!maybe_indirect_extent.is_indirect());
-      assert(!maybe_indirect_extent.is_clone);
-      return seastar::make_ready_future<OMapNodeRef>(
-          std::move(maybe_indirect_extent.extent));
+  assert(get_meta().depth > 1);
+  child_pos_t<OMapInnerNode> child_pos(nullptr, 0);
+  auto laddr = child_pt->get_val();
+  auto next = child_pt + 1;
+  if (get_meta().depth == 2) {
+    auto ret = this->get_child<OMapLeafNode>(
+      oc.t, oc.tm.get_etvr(), child_pt.get_offset(), child_pt.get_key());
+    if (ret.has_child()) {
+      return ret.get_child_fut(
+      ).si_then([](auto extent) {
+	return extent->template cast<OMapNode>();
+      });
+    } else {
+      child_pos = ret.get_child_pos();
+    }
+    return omap_load_extent<OMapLeafNode>(
+      oc,
+      laddr,
+      get_meta().depth - 1,
+      child_pt->get_key(),
+      next == iter_cend()
+	? this->get_end()
+	: next->get_key(),
+      std::move(child_pos)
+    ).si_then([](auto extent) {
+      return extent->template cast<OMapNode>();
     });
   } else {
-    return oc.tm.read_extent<OMapLeafNode>(
-        oc.t, laddr,
-	BtreeOMapManager::get_leaf_size(oc.type)
-    ).handle_error_interruptible(
-      omap_load_extent_iertr::pass_further{},
-      crimson::ct_error::assert_all{ "Invalid error in omap_load_extent" }
-    ).si_then([](auto maybe_indirect_extent) {
-      assert(!maybe_indirect_extent.is_indirect());
-      assert(!maybe_indirect_extent.is_clone);
-      return seastar::make_ready_future<OMapNodeRef>(
-          std::move(maybe_indirect_extent.extent));
+    auto ret = this->get_child<OMapInnerNode>(
+      oc.t, oc.tm.get_etvr(), child_pt.get_offset(), child_pt.get_key());
+    if (ret.has_child()) {
+      return ret.get_child_fut(
+      ).si_then([](auto extent) {
+	return extent->template cast<OMapNode>();
+      });
+    } else {
+      child_pos = ret.get_child_pos();
+    }
+    return omap_load_extent<OMapInnerNode>(
+      oc,
+      laddr,
+      get_meta().depth - 1,
+      child_pt->get_key(),
+      next == iter_cend()
+	? this->get_end()
+	: next->get_key(),
+      std::move(child_pos)
+    ).si_then([](auto extent) {
+      return extent->template cast<OMapNode>();
     });
   }
 }
+
+extent_len_t get_leaf_size(omap_type_t type) {
+  if (type == omap_type_t::LOG) {
+    return LOG_LEAF_BLOCK_SIZE;
+  }
+  ceph_assert(type == omap_type_t::OMAP ||
+	      type == omap_type_t::XATTR);
+  return OMAP_LEAF_BLOCK_SIZE;
+}
+
 }

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -63,11 +63,11 @@ OMapInnerNode::make_split_insert(
   return make_split_children(oc).si_then([=] (auto tuple) {
     auto [left, right, pivot] = tuple;
     if (pivot > key) {
-      auto liter = left->iter_idx(iter.get_index());
+      auto liter = left->iter_idx(iter.get_offset());
       left->journal_inner_insert(liter, laddr, key,
                                  left->maybe_get_delta_buffer());
     } else {  //right
-      auto riter = right->iter_idx(iter.get_index() - left->get_node_size());
+      auto riter = right->iter_idx(iter.get_offset() - left->get_node_size());
       right->journal_inner_insert(riter, laddr, key,
                                   right->maybe_get_delta_buffer());
     }
@@ -90,7 +90,7 @@ OMapInnerNode::handle_split(
   DEBUGT("this: {}",  oc.t, *this);
   if (!is_mutable()) {
     auto mut = oc.tm.get_mutable_extent(oc.t, this)->cast<OMapInnerNode>();
-    auto mut_iter = mut->iter_idx(iter.get_index());
+    auto mut_iter = mut->iter_idx(iter.get_offset());
     return mut->handle_split(oc, mut_iter, mresult);
   }
   auto [left, right, pivot] = *(mresult.split_tuple);
@@ -396,7 +396,7 @@ OMapInnerNode::merge_entry(
   DEBUGT("{}, parent: {}", oc.t, *entry, *this);
   if (!is_mutable()) {
     auto mut = oc.tm.get_mutable_extent(oc.t, this)->cast<OMapInnerNode>();
-    auto mut_iter = mut->iter_idx(iter->get_index());
+    auto mut_iter = mut->iter_idx(iter->get_offset());
     return mut->merge_entry(oc, mut_iter, entry);
   }
   auto is_left = (iter + 1) == iter_cend();
@@ -563,20 +563,20 @@ OMapLeafNode::insert(
       if (replace_pt != iter_end()) {
         ++(oc.t.get_omap_tree_stats().num_updates);
         if (key < pivot) {  //left
-          auto mut_iter = left->iter_idx(replace_pt->get_index());
+          auto mut_iter = left->iter_idx(replace_pt->get_offset());
           left->journal_leaf_update(mut_iter, key, value, left->maybe_get_delta_buffer());
         } else if (key >= pivot) { //right
-          auto mut_iter = right->iter_idx(replace_pt->get_index() - left->get_node_size());
+          auto mut_iter = right->iter_idx(replace_pt->get_offset() - left->get_node_size());
           right->journal_leaf_update(mut_iter, key, value, right->maybe_get_delta_buffer());
         }
       } else {
         ++(oc.t.get_omap_tree_stats().num_inserts);
         auto insert_pt = string_lower_bound(key);
         if (key < pivot) {  //left
-          auto mut_iter = left->iter_idx(insert_pt->get_index());
+          auto mut_iter = left->iter_idx(insert_pt->get_offset());
           left->journal_leaf_insert(mut_iter, key, value, left->maybe_get_delta_buffer());
         } else {
-          auto mut_iter = right->iter_idx(insert_pt->get_index() - left->get_node_size());
+          auto mut_iter = right->iter_idx(insert_pt->get_offset() - left->get_node_size());
           right->journal_leaf_insert(mut_iter, key, value, right->maybe_get_delta_buffer());
         }
       }

--- a/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
+++ b/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
@@ -504,7 +504,7 @@ public:
     inner_remove(iter);
   }
 
-  StringKVInnerNodeLayout() : buf(nullptr) {}
+  StringKVInnerNodeLayout(char *buf) : buf(buf) {}
 
   void set_layout_buf(char *_buf) {
     assert(buf == nullptr);

--- a/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
+++ b/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
@@ -440,7 +440,7 @@ public:
     }
 
   public:
-    uint16_t get_index() const {
+    uint16_t get_offset() const {
       return index;
     }
 
@@ -762,7 +762,7 @@ public:
         auto node_key = ite->get_node_key();
         size += node_key.key_len;
         if (size >= pivot_size){
-          pivot_idx = ite.get_index();
+          pivot_idx = ite.get_offset();
           break;
         }
       }
@@ -773,7 +773,7 @@ public:
         auto node_key = ite->get_node_key();
         size += node_key.key_len;
         if (size >= more_size){
-          pivot_idx = ite.get_index() + left.get_size();
+          pivot_idx = ite.get_offset() + left.get_size();
           break;
         }
       }
@@ -1056,7 +1056,7 @@ public:
     }
 
   public:
-    uint16_t get_index() const {
+    uint16_t get_offset() const {
       return index;
     }
 
@@ -1387,7 +1387,7 @@ public:
         auto node_key = ite->get_node_key();
         size += node_key.key_len + node_key.val_len;
         if (size >= pivot_size){
-          pivot_idx = ite.get_index();
+          pivot_idx = ite.get_offset();
           break;
         }
       }
@@ -1398,7 +1398,7 @@ public:
         auto node_key = ite->get_node_key();
         size += node_key.key_len + node_key.val_len;
         if (size >= more_size){
-          pivot_idx = ite.get_index() + left.get_size();
+          pivot_idx = ite.get_offset() + left.get_size();
           break;
         }
       }

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -26,7 +26,8 @@ struct onode_layout_t {
   // snapshots.
   // TODO: implement flexible-sized onode value to store inline ss_attr
   // effectively.
-  static constexpr int MAX_SS_LENGTH = 1;
+  // The expected decode size of SnapSet when there's no snapshot
+  static constexpr int MAX_SS_LENGTH = 35;
 
   ceph_le32 size{0};
   ceph_le32 oi_size{0};

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -188,6 +188,8 @@ public:
     }
   };
 
+  template <typename T>
+  using lextent_init_func_t = std::function<void (T&)>;
   /**
    * read_extent
    *
@@ -201,20 +203,22 @@ public:
   read_extent_ret<T> read_extent(
     Transaction &t,
     laddr_t offset,
-    extent_len_t length) {
+    extent_len_t length,
+    lextent_init_func_t<T> maybe_init = [](T&) {}) {
     LOG_PREFIX(TransactionManager::read_extent);
     SUBDEBUGT(seastore_tm, "{}~0x{:x} {} ...",
               t, offset, length, T::TYPE);
     return get_pin(
       t, offset
-    ).si_then([this, FNAME, &t, offset, length] (auto pin)
+    ).si_then([this, FNAME, &t, offset, length,
+	      maybe_init=std::move(maybe_init)] (auto pin) mutable
       -> read_extent_ret<T> {
       if (length != pin->get_length() || !pin->get_val().is_real()) {
         SUBERRORT(seastore_tm, "{}~0x{:x} {} got wrong pin {}",
                   t, offset, length, T::TYPE, *pin);
         ceph_abort("Impossible");
       }
-      return this->read_pin<T>(t, std::move(pin));
+      return this->read_pin<T>(t, std::move(pin), std::move(maybe_init));
     });
   }
 
@@ -226,20 +230,22 @@ public:
   template <typename T>
   read_extent_ret<T> read_extent(
     Transaction &t,
-    laddr_t offset) {
+    laddr_t offset,
+    lextent_init_func_t<T> maybe_init = [](T&) {}) {
     LOG_PREFIX(TransactionManager::read_extent);
     SUBDEBUGT(seastore_tm, "{} {} ...",
               t, offset, T::TYPE);
     return get_pin(
       t, offset
-    ).si_then([this, FNAME, &t, offset] (auto pin)
+    ).si_then([this, FNAME, &t, offset,
+	      maybe_init=std::move(maybe_init)] (auto pin) mutable
       -> read_extent_ret<T> {
       if (!pin->get_val().is_real()) {
         SUBERRORT(seastore_tm, "{} {} got wrong pin {}",
                   t, offset, T::TYPE, *pin);
         ceph_abort("Impossible");
       }
-      return this->read_pin<T>(t, std::move(pin));
+      return this->read_pin<T>(t, std::move(pin), std::move(maybe_init));
     });
   }
 
@@ -248,7 +254,8 @@ public:
     Transaction &t,
     LBAMappingRef pin,
     extent_len_t partial_off,
-    extent_len_t partial_len)
+    extent_len_t partial_len,
+    lextent_init_func_t<T> maybe_init = [](T&) {})
   {
     static_assert(is_logical_type(T::TYPE));
     assert(is_aligned(partial_off, get_block_size()));
@@ -284,7 +291,8 @@ public:
       pin->maybe_fix_pos();
       fut = base_iertr::make_ready_future<LBAMappingRef>(std::move(pin));
     }
-    return fut.si_then([&t, this, direct_partial_off, partial_len](auto npin) {
+    return fut.si_then([&t, this, direct_partial_off, partial_len,
+			maybe_init=std::move(maybe_init)](auto npin) mutable {
       // checking the lba child must be atomic with creating
       // and linking the absent child
       auto ret = get_extent_if_linked<T>(t, std::move(npin));
@@ -293,10 +301,15 @@ public:
         ).si_then([direct_partial_off, partial_len, this, &t](auto extent) {
           return cache->read_extent_maybe_partial(
             t, std::move(extent), direct_partial_off, partial_len);
-        });
+        }).si_then([maybe_init=std::move(maybe_init)](auto extent) {
+	  maybe_init(*extent);
+	  return extent;
+	});
       } else {
 	return this->pin_to_extent<T>(
-          t, std::move(std::get<0>(ret)), direct_partial_off, partial_len);
+          t, std::move(std::get<0>(ret)),
+	  direct_partial_off, partial_len,
+	  std::move(maybe_init));
       }
     }).si_then([FNAME, maybe_indirect_info, is_clone, &t](TCachedExtentRef<T> ext) {
       if (maybe_indirect_info.has_value()) {
@@ -314,10 +327,14 @@ public:
   template <typename T>
   base_iertr::future<maybe_indirect_extent_t<T>> read_pin(
     Transaction &t,
-    LBAMappingRef pin)
+    LBAMappingRef pin,
+    lextent_init_func_t<T> maybe_init = [](T&) {})
   {
     auto& pin_ref = *pin;
-    return read_pin<T>(t, std::move(pin), 0, pin_ref.get_length());
+    return read_pin<T>(
+      t, std::move(pin), 0,
+      pin_ref.get_length(),
+      std::move(maybe_init));
   }
 
   /// Obtain mutable copy of extent
@@ -1010,7 +1027,8 @@ private:
     Transaction &t,
     LBAMappingRef pin,
     extent_len_t direct_partial_off,
-    extent_len_t partial_len) {
+    extent_len_t partial_len,
+    lextent_init_func_t<T> &&maybe_init) {
     static_assert(is_logical_type(T::TYPE));
     using ret = pin_to_extent_ret<T>;
     auto &pref = *pin;
@@ -1030,7 +1048,7 @@ private:
       direct_length,
       direct_partial_off,
       partial_len,
-      [&pref]
+      [&pref, maybe_init=std::move(maybe_init)]
       (T &extent) mutable {
 	assert(extent.is_logical());
 	assert(!extent.has_laddr());
@@ -1039,6 +1057,7 @@ private:
 	assert(pref.get_parent());
 	pref.link_child(&extent);
 	extent.maybe_set_intermediate_laddr(pref);
+	maybe_init(extent);
       }
     ).si_then([FNAME, &t, pin=std::move(pin), this](auto ref) mutable -> ret {
       if (ref->is_fully_loaded()) {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -931,6 +931,10 @@ public:
     return epm->get_stat();
   }
 
+  ExtentTransViewRetriever& get_etvr() {
+    return *cache;
+  }
+
   ~TransactionManager();
 
 private:


### PR DESCRIPTION
This PR is based on https://github.com/ceph/ceph/pull/61866.

Compared to https://github.com/ceph/ceph/pull/61866, this PR offers about 20% perf improvement.

This test was done as follows:
1. Only one single-core crimson osd was involved.
2. The size of the SeaStore device was 1TB.
3. The test rbd image was 10GB in its size.
4. We used FIO to issue 64-depth uniformal random writes to the rbd image

The result was as follows:

The fio result of https://github.com/ceph/ceph/pull/61866:
```
randwrite-4k: (groupid=0, jobs=1): err= 0: pid=1587874: Fri Feb 21 10:11:23 2025
  write: IOPS=2926, BW=11.4MiB/s (12.0MB/s)(14.7GiB/1319635msec); 0 zone resets
    slat (usec): min=2, max=2006, avg= 6.11, stdev= 2.53
    clat (usec): min=604, max=2074.8k, avg=21860.05, stdev=20657.49
     lat (usec): min=614, max=2074.8k, avg=21866.16, stdev=20657.48
    clat percentiles (msec):
     |  1.00th=[    3],  5.00th=[    4], 10.00th=[    5], 20.00th=[    7],
     | 30.00th=[    9], 40.00th=[   12], 50.00th=[   16], 60.00th=[   21],
     | 70.00th=[   27], 80.00th=[   35], 90.00th=[   49], 95.00th=[   62],
     | 99.00th=[   86], 99.50th=[   96], 99.90th=[  127], 99.95th=[  140],
     | 99.99th=[  171]
   bw (  KiB/s): min= 3520, max=16984, per=100.00%, avg=11724.31, stdev=724.96, samples=2636
   iops        : min=  880, max= 4246, avg=2931.02, stdev=181.25, samples=2636
  lat (usec)   : 750=0.01%, 1000=0.01%
  lat (msec)   : 2=0.07%, 4=6.14%, 10=27.06%, 20=26.74%, 50=30.83%
  lat (msec)   : 100=8.80%, 250=0.37%, 500=0.01%, 2000=0.01%, >=2000=0.01%
  cpu          : usr=2.30%, sys=1.88%, ctx=1820431, majf=0, minf=7503
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=0.1%, >=64=100.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.1%, >=64=0.0%
     issued rwts: total=0,3862184,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=64

Run status group 0 (all jobs):
  WRITE: bw=11.4MiB/s (12.0MB/s), 11.4MiB/s-11.4MiB/s (12.0MB/s-12.0MB/s), io=14.7GiB (15.8GB), run=1319635-1319635msec

Disk stats (read/write):
  nvme2n1: ios=0/10798, sectors=0/211724, merge=0/627, ticks=0/973, in_queue=973, util=0.59%

```

The FIO result of this PR:
```
randwrite-4k: (g=0): rw=randwrite, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=64
fio-3.37-124-gbcd4
Starting 1 process
Jobs: 1 (f=1): [w(1)][100.0%][w=13.2MiB/s][w=3371 IOPS][eta 00m:00s]
randwrite-4k: (groupid=0, jobs=1): err= 0: pid=2367017: Mon Feb 24 10:24:30 2025
  write: IOPS=3492, BW=13.6MiB/s (14.3MB/s)(16.0GiB/1200017msec); 0 zone resets
    slat (nsec): min=1986, max=679958, avg=5679.43, stdev=2280.91
    clat (usec): min=439, max=2183.8k, avg=18315.71, stdev=19428.06
     lat (usec): min=446, max=2183.8k, avg=18321.39, stdev=19428.06
    clat percentiles (msec):
     |  1.00th=[    3],  5.00th=[    4], 10.00th=[    4], 20.00th=[    6],
     | 30.00th=[    7], 40.00th=[   10], 50.00th=[   12], 60.00th=[   16],
     | 70.00th=[   21], 80.00th=[   29], 90.00th=[   44], 95.00th=[   57],
     | 99.00th=[   80], 99.50th=[   87], 99.90th=[  118], 99.95th=[  130],
     | 99.99th=[  150]
   bw (  KiB/s): min=  464, max=18144, per=100.00%, avg=13994.49, stdev=775.89, samples=2396
   iops        : min=  116, max= 4536, avg=3498.59, stdev=194.00, samples=2396
  lat (usec)   : 500=0.01%, 750=0.01%, 1000=0.01%
  lat (msec)   : 2=0.24%, 4=11.15%, 10=32.14%, 20=25.85%, 50=23.43%
  lat (msec)   : 100=6.96%, 250=0.23%, >=2000=0.01%
  cpu          : usr=2.46%, sys=2.05%, ctx=1968707, majf=0, minf=11933
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=0.1%, >=64=100.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.1%, >=64=0.0%
     issued rwts: total=0,4191602,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=64

Run status group 0 (all jobs):
  WRITE: bw=13.6MiB/s (14.3MB/s), 13.6MiB/s-13.6MiB/s (14.3MB/s-14.3MB/s), io=16.0GiB (17.2GB), run=1200017-1200017msec

Disk stats (read/write):
  nvme0n1: ios=0/15225, sectors=0/321872, merge=0/19120, ticks=0/1025, in_queue=1025, util=0.63%
```

According to the results above, this PR offers 19.36% perf improvement

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
