### PR TITLE
rgw: add parameter for clients to time out incase they hit wrong url

### DIFF
--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -101,6 +101,8 @@ public:
     }
     bufferlist read_bl;
     RGWPostHTTPData request(cct, "POST", endpoint, &read_bl, verify_ssl);
+    //default to 3 seconds for wrong url hits - if wrong endpoint configured
+    request.set_req_connect_timeout(3);
     const auto post_data = json_format_pubsub_event(event);
     if (cloudevents) {
       // following: https://github.com/cloudevents/spec/blob/v1.0.1/http-protocol-binding.md

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -635,6 +635,7 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
   }
   curl_easy_setopt(easy_handle, CURLOPT_PRIVATE, (void *)req_data);
   curl_easy_setopt(easy_handle, CURLOPT_TIMEOUT, req_timeout);
+  curl_easy_setopt(easy_handle, CURLOPT_CONNECTTIMEOUT, req_connect_timeout);
 
   return 0;
 }

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -64,7 +64,7 @@ protected:
   param_vec_t headers;
 
   long  req_timeout{0L};
-  long  req_connect_timeout{3L};
+  long  req_connect_timeout{0L};
 
   void init();
 

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -64,6 +64,7 @@ protected:
   param_vec_t headers;
 
   long  req_timeout{0L};
+  long  req_connect_timeout{3L};
 
   void init();
 
@@ -149,6 +150,12 @@ public:
   // zero (default) mean that request will never timeout
   void set_req_timeout(long timeout) {
     req_timeout = timeout;
+  }
+
+  // set request for connect phase timeout in seconds. 
+  // ensures wrong url hits don't stay alive post this limit
+  void set_req_connect_timeout(long connect_timeout) {
+    req_connect_timeout = connect_timeout;
   }
 
   int process(const DoutPrefixProvider* dpp, optional_yield y);


### PR DESCRIPTION
this fix ensures clients gracefully time out when the endpoint url is wrongly configured.

Fixes: https://tracker.ceph.com/issues/51855
Signed-off-by: Adarsh Ashokan <dev.9401adarsh@gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
