### PR TITLE
rgw/log: Fix crash during shutdown with ops-log enable.

### DIFF
--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -407,7 +407,7 @@ void rgw::AppMain::init_opslog()
     olog_manifold->add_sink(ops_log_file);
   }
   olog_manifold->add_sink(new OpsLogRados(env.driver));
-  olog = olog_manifold;
+  env.olog.reset(olog_manifold);
 } /* init_opslog */
 
 int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
@@ -449,7 +449,6 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
 
   // initialize RGWProcessEnv
   env.rest = &rest;
-  env.olog = olog;
   env.auth_registry = rgw::auth::StrategyRegistry::create(
       dpp->get_cct(), *implicit_tenant_context, env.driver);
   env.ratelimiting = ratelimiter.get();
@@ -596,8 +595,6 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
 
   ldh.reset(nullptr); // deletes ldap helper if it was created
   rgw_log_usage_finalize();
-
-  delete olog;
 
   if (lua_background) {
     lua_background->shutdown();

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -316,7 +316,7 @@ namespace rgw {
               << e.what() << dendl;
     }
     if (should_log) {
-      rgw_log_op(nullptr /* !rest */, s, op, env.olog);
+      rgw_log_op(nullptr /* !rest */, s, op, env.olog.get());
     }
 
     int http_ret = s->err.http_ret;

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -67,7 +67,6 @@ class AppMain {
   std::vector<RGWFrontendConfig*> fe_configs;
   std::multimap<string, RGWFrontendConfig*> fe_map;
   std::unique_ptr<rgw::LDAPHelper> ldh;
-  OpsLogSink* olog = nullptr;
   RGWREST rest;
   std::unique_ptr<rgw::lua::Background> lua_background;
   std::unique_ptr<rgw::auth::ImplicitTenants> implicit_tenant_context;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -342,7 +342,8 @@ int process_request(const RGWProcessEnv& penv,
           "WARNING: failed to execute pre request script. "
           "error: " << rc << dendl;
       } else {
-        rc = rgw::lua::request::execute(driver, rest, penv.olog, s, op, script);
+        rc = rgw::lua::request::execute(driver, rest, penv.olog.get(), s, op,
+                                        script);
         if (rc < 0) {
           ldpp_dout(op, 5) <<
             "WARNING: failed to execute pre request script. "
@@ -440,7 +441,8 @@ done:
           "WARNING: failed to read post request script. "
           "error: " << rc << dendl;
       } else {
-        rc = rgw::lua::request::execute(driver, rest, penv.olog, s, op, script);
+        rc = rgw::lua::request::execute(driver, rest, penv.olog.get(), s, op,
+                                        script);
         if (rc < 0) {
           ldpp_dout(op, 5) <<
             "WARNING: failed to execute post request script. "
@@ -459,7 +461,7 @@ done:
     perfcounter->inc(l_rgw_qactive, -1);
   }
   if (should_log) {
-    rgw_log_op(rest, s, op, penv.olog);
+    rgw_log_op(rest, s, op, penv.olog.get());
   }
 
   if (op) {

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -42,7 +42,7 @@ struct RGWProcessEnv {
   rgw::sal::Driver* driver = nullptr;
   rgw::SiteConfig* site = nullptr;
   RGWREST *rest = nullptr;
-  OpsLogSink *olog = nullptr;
+  std::unique_ptr<OpsLogSink> olog;
   std::unique_ptr<rgw::auth::StrategyRegistry> auth_registry;
   ActiveRateLimiter* ratelimiting = nullptr;
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/70104

This was regression due to this [commit](https://github.com/ceph/ceph/commit/dc262061fed890f1c69a5569b040cddbbeb8c741), which moved the frontend destruction at bottom without moving the other destructions that need to happen after frontend is stopped.

Ensure the olog member variable is destructed at last, once all the frontends have stopped accepting new connections and have finished processing the existing connections.  Hence convert the olog from raw pointer to unique_ptr, so its destructed last.

Currently there were 2 olog ptr maintained, 1 inside the `AppMain` class and other inside the `RGWProcessEnv` class and both pointer pointed at same object and only `env.olog` was used in the code. So remove the olog from the AppMain class and use the RGWProcessEnv olog by making it unique_ptr.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
