### PR TITLE
rgw: PutObjectLockConfiguration can enable object lock on existing buckets

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -72,6 +72,9 @@
   headers only when the `read-stats` querystring is explicitly included in the
   API request.
 
+* RGW: PutObjectLockConfiguration can now be used to enable S3 Object Lock on an
+  existing versioning-enabled bucket that was not created with Object Lock enabled.
+
 * RADOS: The ceph df command reports incorrect MAX AVAIL for stretch mode pools when
   CRUSH rules use multiple take steps for datacenters. PGMap::get_rule_avail
   incorrectly calculates available space from only one datacenter.

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8651,8 +8651,9 @@ int RGWPutBucketObjectLock::verify_permission(optional_yield y)
 
 void RGWPutBucketObjectLock::execute(optional_yield y)
 {
-  if (!s->bucket->get_info().obj_lock_enabled()) {
-    s->err.message = "object lock configuration can't be set if bucket object lock not enabled";
+  if (!s->bucket->get_info().versioning_enabled()) {
+    s->err.message = "Object lock cannot be enabled unless the "
+        "bucket has versioning enabled";
     ldpp_dout(this, 4) << "ERROR: " << s->err.message << dendl;
     op_ret = -ERR_INVALID_BUCKET_STATE;
     return;
@@ -8695,6 +8696,17 @@ void RGWPutBucketObjectLock::execute(optional_yield y)
   }
 
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this, y] {
+    if (!s->bucket->get_info().obj_lock_enabled()) {
+      // automatically enable object lock if the bucket is versioning-enabled
+      if (!s->bucket->get_info().versioning_enabled()) {
+        s->err.message = "Object lock cannot be enabled unless the "
+            "bucket has versioning enabled";
+        ldpp_dout(this, 4) << "ERROR: " << s->err.message << dendl;
+        return -ERR_INVALID_BUCKET_STATE;
+      }
+      s->bucket->get_info().flags |= BUCKET_OBJ_LOCK_ENABLED;
+    }
+
     s->bucket->get_info().obj_lock = obj_lock;
     op_ret = s->bucket->put_info(this, false, real_time(), y);
     return op_ret;


### PR DESCRIPTION
AWS now allows `PutObjectLockConfiguration` on existing buckets, even if `x-amz-bucket-object-lock-enabled` was not specified on bucket creation: https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-s3-enabling-object-lock-buckets/

object lock still requires the bucket to be versioning-enabled, so such requests are rejected otherwise. if the bucket is versioning-enabled but not object-lock-enabled, enable the `BUCKET_OBJ_LOCK_ENABLED` flag

this logic was moved into `retry_raced_bucket_write()` in case the request races with `PutBucketVersioning`

Fixes: https://tracker.ceph.com/issues/70013

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
