### PR TITLE
reef: python-common: fix valid_addr on python 3.11

### DIFF
--- a/src/python-common/ceph/deployment/utils.py
+++ b/src/python-common/ceph/deployment/utils.py
@@ -70,6 +70,9 @@ def valid_addr(addr: str) -> Tuple[bool, str]:
     colons = addr.count(':')
     addr_as_url = f'http://{addr}'
 
+    if addr.startswith('[') and dots:
+        return False, "IPv4 address wrapped in brackets is invalid"
+
     try:
         res = urlparse(addr_as_url)
     except ValueError as e:
@@ -88,9 +91,6 @@ def valid_addr(addr: str) -> Tuple[bool, str]:
             return False, 'Port must be numeric'
         elif ']:' in addr:
             return False, 'Port must be numeric'
-
-    if addr.startswith('[') and dots:
-        return False, "IPv4 address wrapped in brackets is invalid"
 
     # catch partial address like 10.8 which would be valid IPaddress schemes
     # but are classed as invalid here since they're not usable


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/52678 as I saw this start happening in make check on reef

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
