### PR TITLE
pybind/mgr/dashboard: prevent installing grpc-tools every time when running ninja

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -1,9 +1,12 @@
 # Required for building the dashboard grpc protos at build time
 set(CEPH_GRPC_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-grpc-virtualenv)
 set(CEPH_NVME_GATEWAY_PROTO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/nvmeof/gateway/control/proto)
+set(GRPC_TOOLS_DIR ${CEPH_GRPC_VIRTUALENV}/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/grpc_tools)
+
+message(STATUS "install grpc-tools into ${GRPC_TOOLS_DIR}")
 
 add_custom_command(
-  OUTPUT ${CEPH_GRPC_VIRTUALENV}/lib/python*/site-packages/grpc_tools
+  OUTPUT ${GRPC_TOOLS_DIR}
   COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${Python3_EXECUTABLE} ${CEPH_GRPC_VIRTUALENV}
   COMMAND ${CEPH_GRPC_VIRTUALENV}/bin/pip install grpcio-tools
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15,7 +18,7 @@ add_custom_command(
   COMMAND cp ${CEPH_NVME_GATEWAY_PROTO_DIR}/gateway.proto dashboard/services/proto/gateway.proto
   COMMAND . ${CEPH_GRPC_VIRTUALENV}/bin/activate && ${CEPH_GRPC_VIRTUALENV}/bin/python -m grpc_tools.protoc --proto_path=. --python_out=. --grpc_python_out=. dashboard/services/proto/gateway.proto && deactivate
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
-  DEPENDS ${CEPH_NVME_GATEWAY_PROTO_DIR}/gateway.proto ${CEPH_GRPC_VIRTUALENV}/lib/python*/site-packages/grpc_tools
+  DEPENDS ${CEPH_NVME_GATEWAY_PROTO_DIR}/gateway.proto ${GRPC_TOOLS_DIR}
   COMMENT "proto generation for grpc deps")
 add_custom_target(mgr-dashboard-services-deps
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/services/proto/gateway_pb2.py ${CMAKE_CURRENT_SOURCE_DIR}/services/proto/gateway_pb2_grpc.py


### PR DESCRIPTION
It seems the globstar matching symbol causes it to always be executed when running Ninja. Let's set it explicitly.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
