### PR TITLE
squid: test/rbd_mirror: flush watch/notify callbacks in TestImageReplayer

### DIFF
--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -243,6 +243,7 @@ public:
   void unwatch() {
     if (m_watch_handle != 0) {
       m_remote_ioctx.unwatch2(m_watch_handle);
+      m_remote_cluster.watch_flush();
       delete m_watch_ctx;
       m_watch_ctx = nullptr;
       m_watch_handle = 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70039

---

backport of https://github.com/ceph/ceph/pull/61847
parent tracker: https://tracker.ceph.com/issues/63798