### PR TITLE
squid: test/rbd_mirror: clear Namespace::s_instance at the end of a test

### DIFF
--- a/src/test/rbd_mirror/test_mock_PoolReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_PoolReplayer.cc
@@ -56,7 +56,13 @@ public:
   }
 
   Namespace() {
+    ceph_assert(s_instance == nullptr);
     s_instance = this;
+  }
+
+  ~Namespace() {
+    ceph_assert(s_instance == this);
+    s_instance = nullptr;
   }
 
   void add(const std::string &name) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70101

---

backport of https://github.com/ceph/ceph/pull/61880
parent tracker: https://tracker.ceph.com/issues/70041