### PR TITLE
rgw: add support replication actions in policy

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -138,6 +138,13 @@
   allowed.  `rbd trash mv` command now behaves the same way as `rbd rm` in this
   scenario.
 
+* RGW: Replication policies now validate permissions using `s3:ReplicateObject`,
+  `s3:ReplicateDelete`, and `s3:ReplicateTags` for destination buckets. For source
+  buckets, both `s3:GetObjectVersionForReplication` and `s3:GetObject(Version)`
+  are supported. Actions like `s3:GetObjectAcl`, `s3:GetObjectLegalHold`, and
+  `s3:GetObjectRetention` are also considered when fetching the source object.
+  Replication of tags is controlled by the `s3:GetObject(Version)Tagging` permission.
+
 >=19.2.1
 
 * CephFS: Command `fs subvolume create` now allows tagging subvolumes through option

--- a/src/rgw/driver/rados/rgw_bucket_sync.h
+++ b/src/rgw/driver/rados/rgw_bucket_sync.h
@@ -415,3 +415,31 @@ public:
   }
 };
 
+struct rgw_bucket_sync_pair_info {
+  RGWBucketSyncFlowManager::pipe_handler handler; /* responsible for sync filters */
+  rgw_bucket_shard source_bs;
+  rgw_bucket dest_bucket;
+};
+
+inline std::ostream& operator<<(std::ostream& out, const rgw_bucket_sync_pair_info& p) {
+  if (p.source_bs.bucket == p.dest_bucket) {
+    return out << p.source_bs;
+  }
+  return out << p.source_bs << "->" << p.dest_bucket;
+}
+
+struct rgw_bucket_sync_pipe {
+  rgw_bucket_sync_pair_info info;
+  RGWBucketInfo source_bucket_info;
+  std::map<std::string, bufferlist> source_bucket_attrs;
+  RGWBucketInfo dest_bucket_info;
+  std::map<std::string, bufferlist> dest_bucket_attrs;
+
+  RGWBucketSyncFlowManager::pipe_rules_ref& get_rules() {
+    return info.handler.rules;
+  }
+};
+
+inline std::ostream& operator<<(std::ostream& out, const rgw_bucket_sync_pipe& p) {
+  return out << p.info;
+}

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -813,7 +813,8 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
   std::optional<uint64_t> bytes_transferred;
   const req_context rctx{dpp, null_yield, nullptr};
   int r = store->getRados()->fetch_remote_obj(obj_ctx,
-                       user_id.value_or(rgw_user()),
+                       NULL, /* uid */
+                       user_id ? &*user_id : nullptr, /* replication uid */
                        NULL, /* req_info */
                        source_zone,
                        dest_obj.get_obj(),
@@ -875,7 +876,6 @@ int RGWAsyncStatRemoteObj::_send_request(const DoutPrefixProvider *dpp)
 {
   RGWObjectCtx obj_ctx(store);
 
-  string user_id;
   char buf[16];
   snprintf(buf, sizeof(buf), ".%lld", (long long)store->getRados()->instance_id());
 
@@ -884,7 +884,7 @@ int RGWAsyncStatRemoteObj::_send_request(const DoutPrefixProvider *dpp)
 
   int r = store->getRados()->stat_remote_obj(dpp,
                        obj_ctx,
-                       rgw_user(user_id),
+                       nullptr, /* user_id */
                        nullptr, /* req_info */
                        source_zone,
                        src_obj,

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -950,21 +950,21 @@ int RGWAsyncRemoveObj::_send_request(const DoutPrefixProvider *dpp)
     std::optional<RGWUserPermHandler> user_perms;
     RGWUserPermHandler::Bucket dest_bucket_perms;
 
-    if (params.user.empty()) {
+    if (!params.user.has_value()) {
       ldpp_dout(dpp, 20) << "ERROR: " << __func__ << ": user level sync but user param not set" << dendl;
       return -EPERM;
     }
-    user_perms.emplace(dpp, store, dpp->get_cct(), params.user);
+    user_perms.emplace(dpp, store, dpp->get_cct(), *params.user);
 
     ret = user_perms->init();
     if (ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": failed to init user perms for uid=" << params.user << " ret=" << ret << dendl;
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": failed to init user perms for uid=" << *params.user << " ret=" << ret << dendl;
       return ret;
     }
 
     ret = user_perms->init_bucket(sync_pipe.dest_bucket_info, sync_pipe.dest_bucket_attrs, &dest_bucket_perms);
     if (ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": failed to init bucket perms for uid=" << params.user << " bucket=" << bucket->get_key() << " ret=" << ret << dendl;
+      ldpp_dout(dpp, 0) << "ERROR: " << __func__ << ": failed to init bucket perms for uid=" << *params.user << " bucket=" << bucket->get_key() << " ret=" << ret << dendl;
       return ret;
     }
 

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -12,6 +12,7 @@
 #include "rgw_cr_rest.h"
 #include "rgw_rest_conn.h"
 #include "rgw_rados.h"
+#include "rgw_data_sync.h"
 
 #include "services/svc_zone.h"
 #include "services/svc_zone_utils.h"
@@ -843,7 +844,8 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
                        stat_dest_obj,
                        source_trace_entry,
                        &zones_trace,
-                       &bytes_transferred);
+                       &bytes_transferred,
+                       keep_tags);
 
   if (r < 0) {
     ldpp_dout(dpp, 0) << "store->fetch_remote_obj() returned r=" << r << dendl;

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2701,7 +2701,7 @@ int RGWUserPermHandler::Bucket::init(RGWUserPermHandler *handler,
   return 0;
 }
 
-bool RGWUserPermHandler::Bucket::verify_bucket_permission(const rgw_obj_key& obj_key, const uint64_t op)
+bool RGWUserPermHandler::Bucket::verify_bucket_permission(const rgw_obj_key& obj_key, const uint64_t op) const
 {
   const rgw_obj obj(ps->bucket_info.bucket, obj_key);
   const auto arn = rgw::ARN(obj);
@@ -2732,7 +2732,7 @@ bool RGWUserPermHandler::Bucket::verify_bucket_permission(const rgw_obj_key& obj
                                   {}, op);
 }
 
-rgw::IAM::Effect RGWUserPermHandler::Bucket::evaluate_iam_policies(const rgw_obj_key& obj_key, const uint64_t op)
+rgw::IAM::Effect RGWUserPermHandler::Bucket::evaluate_iam_policies(const rgw_obj_key& obj_key, const uint64_t op) const
 {
   const rgw_obj obj(ps->bucket_info.bucket, obj_key);
   const auto arn = rgw::ARN(obj);

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2703,6 +2703,11 @@ int RGWUserPermHandler::Bucket::init(RGWUserPermHandler *handler,
 
 bool RGWUserPermHandler::Bucket::verify_bucket_permission(const rgw_obj_key& obj_key, const uint64_t op) const
 {
+  if (ps->identity->is_admin()) {
+    ldpp_dout(dpp, 4) << "admin user, no need to check permissions" << dendl;
+    return true;
+  }
+
   const rgw_obj obj(ps->bucket_info.bucket, obj_key);
   const auto arn = rgw::ARN(obj);
 
@@ -2734,6 +2739,11 @@ bool RGWUserPermHandler::Bucket::verify_bucket_permission(const rgw_obj_key& obj
 
 rgw::IAM::Effect RGWUserPermHandler::Bucket::evaluate_iam_policies(const rgw_obj_key& obj_key, const uint64_t op) const
 {
+  if (ps->identity->is_admin()) {
+    ldpp_dout(dpp, 4) << "admin user, no need to check permissions" << dendl;
+    return rgw::IAM::Effect::Allow;
+  }
+
   const rgw_obj obj(ps->bucket_info.bucket, obj_key);
   const auto arn = rgw::ARN(obj);
   const bool account_root = (ps->identity->get_identity_type() == TYPE_ROOT);

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2986,7 +2986,7 @@ public:
             return set_cr_error(retcode);
           }
 
-          if (!dest_bucket_perms.verify_bucket_permission(dest_key.value_or(key), rgw::IAM::s3PutObject)) {
+          if (!dest_bucket_perms.verify_bucket_permission(dest_key.value_or(key), rgw::IAM::s3ReplicateObject)) {
             ldout(cct, 0) << "ERROR: " << __func__ << ": permission check failed: user not allowed to write into bucket (bucket=" << sync_pipe.info.dest_bucket.get_key() << ")" << dendl;
             return set_cr_error(-EPERM);
           }

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -3045,7 +3045,7 @@ RGWCoroutine *RGWDefaultDataSyncModule::remove_object(const DoutPrefixProvider *
 {
   auto sync_env = sc->env;
   return new RGWRemoveObjCR(sync_env->dpp, sync_env->async_rados, sync_env->driver, sc->source_zone,
-                            sync_pipe.dest_bucket_info, key, versioned, versioned_epoch,
+                            sync_pipe, key, versioned, versioned_epoch,
                             NULL, NULL, false, &mtime, zones_trace);
 }
 
@@ -3054,7 +3054,7 @@ RGWCoroutine *RGWDefaultDataSyncModule::create_delete_marker(const DoutPrefixPro
 {
   auto sync_env = sc->env;
   return new RGWRemoveObjCR(sync_env->dpp, sync_env->async_rados, sync_env->driver, sc->source_zone,
-                            sync_pipe.dest_bucket_info, key, versioned, versioned_epoch,
+                            sync_pipe, key, versioned, versioned_epoch,
                             &owner.id, &owner.display_name, true, &mtime, zones_trace);
 }
 
@@ -3147,7 +3147,7 @@ RGWCoroutine *RGWArchiveDataSyncModule::create_delete_marker(const DoutPrefixPro
 	                            << " versioned=" << versioned << " versioned_epoch=" << versioned_epoch << dendl;
   auto sync_env = sc->env;
   return new RGWRemoveObjCR(sync_env->dpp, sync_env->async_rados, sync_env->driver, sc->source_zone,
-                            sync_pipe.dest_bucket_info, key, versioned, versioned_epoch,
+                            sync_pipe, key, versioned, versioned_epoch,
                             &owner.id, &owner.display_name, true, &mtime, zones_trace);
 }
 

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2934,11 +2934,7 @@ class RGWObjFetchCR : public RGWCoroutine {
   bool need_more_info{false};
   bool check_change{false};
 
-  ceph::real_time src_mtime;
-  uint64_t src_size;
-  string src_etag;
   map<string, bufferlist> src_attrs;
-  map<string, string> src_headers;
 
   std::optional<rgw_user> param_user;
   rgw_sync_pipe_params::Mode param_mode;
@@ -3003,11 +2999,11 @@ public:
                                             sc->source_zone,
                                             sync_pipe.info.source_bs.bucket,
                                             key,
-                                            &src_mtime,
-                                            &src_size,
-                                            &src_etag,
+                                            nullptr,
+                                            nullptr,
+                                            nullptr,
                                             &src_attrs,
-                                            &src_headers));
+                                            nullptr));
           if (retcode < 0) {
             return set_cr_error(retcode);
           }

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -828,3 +828,99 @@ public:
   bool supports_data_export() override { return false; }
   int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
 };
+
+class RGWUserPermHandler {
+  friend struct Init;
+  friend class Bucket;
+
+  const DoutPrefixProvider *dpp;
+  rgw::sal::Driver *driver;
+  CephContext *cct;
+  rgw_user uid;
+
+  struct _info {
+    rgw::IAM::Environment env;
+    std::unique_ptr<rgw::auth::Identity> identity;
+    RGWAccessControlPolicy user_acl;
+    std::vector<rgw::IAM::Policy> user_policies;
+  };
+
+  std::shared_ptr<_info> info;
+
+  struct Init;
+
+  std::shared_ptr<Init> init_action;
+
+  struct Init : public RGWGenericAsyncCR::Action {
+    const DoutPrefixProvider *dpp;
+    rgw::sal::Driver *driver;
+    CephContext *cct;
+
+    rgw_user uid;
+    std::shared_ptr<RGWUserPermHandler::_info> info;
+
+    int ret{0};
+
+    Init(RGWUserPermHandler *handler) : dpp(handler->dpp),
+                                        driver(handler->driver),
+                                        cct(handler->cct),
+                                        uid(handler->uid),
+                                        info(handler->info) {}
+    int operate() override;
+  };
+
+public:
+  RGWUserPermHandler(const DoutPrefixProvider *_dpp,
+                     rgw::sal::Driver *_driver,
+                     CephContext *_cct,
+                     const rgw_user& _uid) : dpp(_dpp),
+                                             driver(_driver),
+                                             cct(_cct),
+                                             uid(_uid) {
+    info = std::make_shared<_info>();
+    init_action = std::make_shared<Init>(this);
+  }
+
+  RGWUserPermHandler(RGWDataSyncEnv *_sync_env,
+                     const rgw_user& _uid) : RGWUserPermHandler(_sync_env->dpp,
+                                                                _sync_env->driver,
+                                                                _sync_env->cct,
+                                                                _uid) {}
+
+  RGWCoroutine *init_cr(RGWDataSyncEnv *sync_env) {
+    return new RGWGenericAsyncCR(sync_env->cct,
+                                 sync_env->async_rados,
+                                 init_action);
+  }
+
+  int init() {
+    return init_action->operate();
+  }
+
+  class Bucket {
+    const DoutPrefixProvider *dpp;
+    CephContext *cct;
+    std::shared_ptr<_info> info;
+    RGWAccessControlPolicy bucket_acl;
+    std::optional<perm_state> ps;
+    boost::optional<rgw::IAM::Policy> bucket_policy;
+  public:
+    Bucket() {}
+
+    int init(RGWUserPermHandler *handler,
+             const RGWBucketInfo& bucket_info,
+             const std::map<std::string, bufferlist>& bucket_attrs);
+
+    bool verify_bucket_permission(const rgw_obj_key& obj_key, const uint64_t op);
+  };
+
+  static int policy_from_attrs(CephContext *cct,
+                               const std::map<std::string, bufferlist>& attrs,
+                               RGWAccessControlPolicy *acl);
+
+  int init_bucket(const RGWBucketInfo& bucket_info,
+                  const std::map<std::string, bufferlist>& bucket_attrs,
+                  Bucket *bs) {
+    return bs->init(this, bucket_info, bucket_attrs);
+  }
+};

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -912,6 +912,7 @@ public:
              const std::map<std::string, bufferlist>& bucket_attrs);
 
     bool verify_bucket_permission(const rgw_obj_key& obj_key, const uint64_t op);
+    rgw::IAM::Effect evaluate_iam_policies(const rgw_obj_key& obj_key, const uint64_t op);
   };
 
   static int policy_from_attrs(CephContext *cct,

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -54,35 +54,6 @@ inline std::ostream& operator<<(std::ostream& out, const rgw_data_sync_obligatio
 class JSONObj;
 struct rgw_sync_bucket_pipe;
 
-struct rgw_bucket_sync_pair_info {
-  RGWBucketSyncFlowManager::pipe_handler handler; /* responsible for sync filters */
-  rgw_bucket_shard source_bs;
-  rgw_bucket dest_bucket;
-};
-
-inline std::ostream& operator<<(std::ostream& out, const rgw_bucket_sync_pair_info& p) {
-  if (p.source_bs.bucket == p.dest_bucket) {
-    return out << p.source_bs;
-  }
-  return out << p.source_bs << "->" << p.dest_bucket;
-}
-
-struct rgw_bucket_sync_pipe {
-  rgw_bucket_sync_pair_info info;
-  RGWBucketInfo source_bucket_info;
-  std::map<std::string, bufferlist> source_bucket_attrs;
-  RGWBucketInfo dest_bucket_info;
-  std::map<std::string, bufferlist> dest_bucket_attrs;
-
-  RGWBucketSyncFlowManager::pipe_rules_ref& get_rules() {
-    return info.handler.rules;
-  }
-};
-
-inline std::ostream& operator<<(std::ostream& out, const rgw_bucket_sync_pipe& p) {
-  return out << p.info;
-}
-
 struct rgw_datalog_info {
   uint32_t num_shards;
 

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -911,8 +911,8 @@ public:
              const RGWBucketInfo& bucket_info,
              const std::map<std::string, bufferlist>& bucket_attrs);
 
-    bool verify_bucket_permission(const rgw_obj_key& obj_key, const uint64_t op);
-    rgw::IAM::Effect evaluate_iam_policies(const rgw_obj_key& obj_key, const uint64_t op);
+    bool verify_bucket_permission(const rgw_obj_key& obj_key, const uint64_t op) const;
+    rgw::IAM::Effect evaluate_iam_policies(const rgw_obj_key& obj_key, const uint64_t op) const;
   };
 
   static int policy_from_attrs(CephContext *cct,

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -822,10 +822,8 @@ void RGWLCCloudStreamPut::send_ready(const DoutPrefixProvider *dpp, const rgw_re
 }
 
 void RGWLCCloudStreamPut::handle_headers(const map<string, string>& headers) {
-  for (const auto& h : headers) {
-    if (h.first == "ETAG") {
-      etag = h.second;
-    }
+  if (auto h = headers.find("ETAG"); h != headers.end()) {
+    etag = h->second;
   }
 }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3509,7 +3509,6 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
 {
   const DoutPrefixProvider *dpp;
   CephContext* cct;
-  rgw_obj obj;
   rgw::sal::DataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
   bool try_etag_verify;
@@ -3528,6 +3527,18 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   uint64_t ofs{0};
   uint64_t lofs{0}; /* logical ofs */
   std::function<int(map<string, bufferlist>&)> attrs_handler;
+  /*
+    src_bucket_perms, if provided, serves as a fallback mechanism to validate the
+    source bucket's ACL before initiating the fetch operation. It ensures
+    backward compatibility with legacy implementations where the `rgwx-perm-check-uid`
+    arg might not be honored, and the destination zone does not return the
+    `x-rgw-perm-checked` header, which confirms that the source object's
+    permissions were validated against the specified `rgwx-perm-check-uid`.
+
+    @todo drop src_bucket_perms and src_obj in T+2 release.
+  */
+ const rgw_obj& src_obj;
+ const std::optional<RGWUserPermHandler::Bucket>& src_bucket_perms;
 
 public:
   RGWRadosPutObj(const DoutPrefixProvider *dpp,
@@ -3537,7 +3548,9 @@ public:
                  rgw::sal::ObjectProcessor *p,
                  void (*_progress_cb)(off_t, void *),
                  void *_progress_data,
-                 std::function<int(map<string, bufferlist>&)> _attrs_handler) :
+                 std::function<int(map<string, bufferlist>&)> _attrs_handler,
+                 const rgw_obj& src_obj,
+                 const std::optional<RGWUserPermHandler::Bucket>& _src_bucket_perms = std::nullopt) :
                        dpp(dpp),
                        cct(cct),
                        filter(p),
@@ -3547,7 +3560,9 @@ public:
                        processor(p),
                        progress_cb(_progress_cb),
                        progress_data(_progress_data),
-                       attrs_handler(_attrs_handler) {}
+                       attrs_handler(_attrs_handler),
+                       src_obj(src_obj),
+                       src_bucket_perms(_src_bucket_perms) {}
 
 
   int process_attrs(void) {
@@ -3729,6 +3744,23 @@ public:
     } else {
       return "";
     }
+  }
+
+  int handle_headers(const map<string, string>& headers, int http_status) override {
+    if (src_bucket_perms && http_status != 403 && http_status != 401) {
+      auto iter = headers.find("RGWX_PERM_CHECKED");
+      // if the header is not present, we need to check the ACL
+      // of the source bucket against the fallback UID
+      if (iter == headers.end()) {
+        // old ACL should still win s3:ReplicateObject
+        if (!src_bucket_perms->verify_bucket_permission(src_obj.key, rgw::IAM::s3ReplicateObject)) {
+          ldpp_dout(dpp, 4) << "ERROR: " << __func__ << "(): fallback permission check denied" << dendl;
+          return -EACCES;
+        }
+      }
+    }
+
+    return 0;
   }
 };
 
@@ -4381,6 +4413,32 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
 
   std::optional<rgw_user> override_owner;
 
+  // load src bucket perm handler for backward compatibility
+  // @todo drop me in t+2 release.
+  std::optional<RGWUserPermHandler::Bucket> src_bucket_perms;
+  if (perm_check_uid) {
+    std::unique_ptr<rgw::sal::Bucket> src_bucket;
+    ret = driver->load_bucket(rctx.dpp, src_obj.bucket, &src_bucket, rctx.y);
+    if (ret < 0) {
+      ldpp_dout(rctx.dpp, 0) << "ERROR: failed to load src bucket=" << src_obj << " ret=" << ret << dendl;
+      return ret;
+    }
+
+    RGWUserPermHandler user_perms(rctx.dpp, driver, cct, *perm_check_uid);
+    ret = user_perms.init();
+    if (ret < 0) {
+      ldpp_dout(rctx.dpp, 0) << "ERROR: failed to init user perms for: " << src_obj << " ret=" << ret << dendl;
+      return ret;
+    }
+
+    src_bucket_perms.emplace();
+    ret = user_perms.init_bucket(src_bucket->get_info(), src_bucket->get_attrs(), &*src_bucket_perms);
+    if (ret < 0) {
+      ldpp_dout(rctx.dpp, 0) << "ERROR: failed to init bucket perms for: " << src_obj << " ret=" << ret << dendl;
+      return ret;
+    }
+  }
+
   RGWRadosPutObj cb(rctx.dpp, cct, plugin, compressor, &processor, progress_cb, progress_data,
                     [&](map<string, bufferlist>& obj_attrs) {
                       const rgw_placement_rule *ptail_rule;
@@ -4414,7 +4472,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
                         return ret;
                       }
                       return 0;
-                    });
+                    }, src_obj, src_bucket_perms);
 
   string etag;
   real_time set_mtime;
@@ -5349,7 +5407,7 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
                       }
                       cb_processed = true;
                       return 0;
-                    });
+                    }, dest_obj);
 
   // fetch mtime of the object and other attrs of the object
   // to check for restore_status

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4891,7 +4891,7 @@ int RGWRados::copy_obj(RGWObjectCtx& src_obj_ctx,
     // that only one thread tries to suspend that coroutine
     const req_context rctx{dpp, null_yield, nullptr};
     const rgw_owner remote_user_owner(remote_user);
-    return fetch_remote_obj(dest_obj_ctx, &remote_user_owner, nullptr, info, source_zone,
+    return fetch_remote_obj(dest_obj_ctx, &remote_user_owner, &remote_user, info, source_zone,
                dest_obj, src_obj, dest_bucket_info, &src_bucket_info,
                dest_placement, src_mtime, mtime, mod_ptr,
                unmod_ptr, high_precision_time,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4319,7 +4319,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
                const rgw_obj& stat_dest_obj,
                std::optional<rgw_zone_set_entry> source_trace_entry,
                rgw_zone_set *zones_trace,
-               std::optional<uint64_t>* bytes_transferred)
+               std::optional<uint64_t>* bytes_transferred,
+               bool keep_tags)
 {
   /* source is in a different zonegroup, copy from there */
 
@@ -4598,6 +4599,10 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
     set_copy_attrs(cb.get_attrs(), attrs, attrs_mod);
   } else {
     attrs = cb.get_attrs();
+  }
+
+  if (!keep_tags) {
+    attrs.erase(RGW_ATTR_TAGS);
   }
 
   if (copy_if_newer) {

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1129,7 +1129,7 @@ public:
 
   int stat_remote_obj(const DoutPrefixProvider *dpp,
                RGWObjectCtx& obj_ctx,
-               const rgw_user& user_id,
+               const rgw_owner* user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
                const rgw_obj& src_obj,
@@ -1148,7 +1148,8 @@ public:
                std::string *petag, optional_yield y);
 
   int fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
-                       const rgw_user& user_id,
+                       const rgw_owner* user_id,
+                       const rgw_user* perm_check_uid,
                        req_info *info,
                        const rgw_zone_id& source_zone,
                        const rgw_obj& dest_obj,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1179,7 +1179,8 @@ public:
                        const rgw_obj& stat_dest_obj,
                        std::optional<rgw_zone_set_entry> source_trace_entry,
                        rgw_zone_set *zones_trace = nullptr,
-                       std::optional<uint64_t>* bytes_transferred = 0);
+                       std::optional<uint64_t>* bytes_transferred = 0,
+                       bool keep_tags = true);
   /**
    * Copy an object.
    * dest_obj: the object to copy into

--- a/src/rgw/driver/rados/rgw_rest_user.cc
+++ b/src/rgw/driver/rados/rgw_rest_user.cc
@@ -122,7 +122,7 @@ void RGWOp_User_Info::execute(optional_yield y)
   // dump_keys is false if user-info-without-keys is 'read' and
   // the user is not the system user or an admin user
   int keys_perm = s->user->get_info().caps.check_cap("users", RGW_CAP_READ);
-  if (keys_perm == 0 || op_state.system || s->auth.identity->is_admin_of(uid)) {
+  if (keys_perm == 0 || op_state.system || s->auth.identity->is_admin()) {
     dump_keys = true;
     ldpp_dout(s, 20) << "dump_keys is set to true" << dendl;
   }

--- a/src/rgw/driver/rados/rgw_sync_module_aws.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_aws.cc
@@ -987,10 +987,8 @@ public:
   }
 
   void handle_headers(const map<string, string>& headers) {
-    for (auto h : headers) {
-      if (h.first == "ETAG") {
-        etag = h.second;
-      }
+    if (auto h = headers.find("ETAG"); h != headers.end()) {
+      etag = h->second;
     }
   }
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -10716,7 +10716,7 @@ next:
     if (!rgw::sal::User::empty(user)) {
       pipe->params.user = user->get_id();
     } else if (pipe->params.mode == rgw_sync_pipe_params::MODE_USER &&
-               pipe->params.user.empty()) {
+               !pipe->params.user.has_value()) {
       cerr << "ERROR: missing --uid for --mode=user" << std::endl;
       return EINVAL;
     }

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -1325,7 +1325,8 @@ rgw::auth::AnonymousEngine::authenticate(const DoutPrefixProvider* dpp, const re
     auto apl = \
       apl_factory->create_apl_local(cct, s, std::move(user), std::nullopt, {},
                                     rgw::auth::LocalApplier::NO_SUBUSER,
-                                    std::nullopt, rgw::auth::LocalApplier::NO_ACCESS_KEY);
+                                    std::nullopt, rgw::auth::LocalApplier::NO_ACCESS_KEY,
+                                    false /* is_impersonating */);
     return result_t::grant(std::move(apl));
   }
 }

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -1307,9 +1307,6 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   for (auto& it : token_attrs.token_claims) {
     s->token_claims.emplace_back(it);
   }
-  if (is_system_request) {
-    s->system_request = true;
-  }
 }
 
 rgw::auth::Engine::result_t

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -216,7 +216,7 @@ static auto transform_old_authinfo(const RGWUserInfo& user,
         id(user.user_id),
         display_name(user.display_name),
         path(user.path),
-        user_is_admin(user.admin),
+        user_is_admin(user.admin || user.system),
         type(user.type),
         account(std::move(account)),
         policies(std::move(policies))

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -203,7 +203,7 @@ static auto transform_old_authinfo(const RGWUserInfo& user,
     const rgw_user id;
     const std::string display_name;
     const std::string path;
-    const bool is_admin;
+    const bool user_is_admin;
     const uint32_t type;
     const std::optional<RGWAccountInfo> account;
     const std::vector<IAM::Policy> policies;
@@ -216,7 +216,7 @@ static auto transform_old_authinfo(const RGWUserInfo& user,
         id(user.user_id),
         display_name(user.display_name),
         path(user.path),
-        is_admin(user.admin),
+        user_is_admin(user.admin),
         type(user.type),
         account(std::move(account)),
         policies(std::move(policies))
@@ -238,8 +238,8 @@ static auto transform_old_authinfo(const RGWUserInfo& user,
       return rgw_perms_from_aclspec_default_strategy(id.to_str(), aclspec, dpp);
     }
 
-    bool is_admin_of(const rgw_owner& o) const override {
-      return is_admin;
+    bool is_admin() const override {
+      return user_is_admin;
     }
 
     bool is_owner_of(const rgw_owner& o) const override {
@@ -302,7 +302,7 @@ static auto transform_old_authinfo(const RGWUserInfo& user,
 
     void to_str(std::ostream& out) const override {
       out << "RGWDummyIdentityApplier(auth_id=" << id
-          << ", is_admin=" << is_admin << ")";
+          << ", is_admin=" << user_is_admin << ")";
     }
 
     auto load_acct_info(const DoutPrefixProvider* dpp) const -> std::unique_ptr<rgw::sal::User> override {
@@ -826,7 +826,7 @@ uint32_t rgw::auth::RemoteApplier::get_perms_from_aclspec(const DoutPrefixProvid
   return perm;
 }
 
-bool rgw::auth::RemoteApplier::is_admin_of(const rgw_owner& o) const
+bool rgw::auth::RemoteApplier::is_admin() const
 {
   return info.is_admin;
 }
@@ -1067,7 +1067,7 @@ uint32_t rgw::auth::LocalApplier::get_perms_from_aclspec(const DoutPrefixProvide
   return mask;
 }
 
-bool rgw::auth::LocalApplier::is_admin_of(const rgw_owner& o) const
+bool rgw::auth::LocalApplier::is_admin() const
 {
   return user_info.admin || user_info.system;
 }

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -798,20 +798,17 @@ protected:
   rgw::sal::Driver* driver;
   Role role;
   TokenAttrs token_attrs;
-  bool is_system_request;
 
 public:
 
   RoleApplier(CephContext* const cct,
                rgw::sal::Driver* driver,
                const Role& role,
-               const TokenAttrs& token_attrs,
-               bool is_system_request)
+               const TokenAttrs& token_attrs)
     : cct(cct),
       driver(driver),
       role(role),
-      token_attrs(token_attrs),
-      is_system_request(is_system_request) {}
+      token_attrs(token_attrs) {}
 
   ACLOwner get_aclowner() const override;
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
@@ -847,7 +844,7 @@ public:
                                       const req_state* s,
                                       Role role,
                                       TokenAttrs token_attrs,
-                                      bool is_system_request) const = 0;
+                                      bool is_impersonating) const = 0;
     };
 };
 

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -48,9 +48,9 @@ public:
    * applier that is being used. */
   virtual uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const = 0;
 
-  /* Verify whether a given identity *can be treated as* an admin of rgw_owner
-  * specified in @o. On error throws rgw::auth::Exception storing the reason. */
-  virtual bool is_admin_of(const rgw_owner& o) const = 0;
+  /* Verify whether a given identity *can be treated as* an admin.
+   * On error throws rgw::auth::Exception storing the reason. */
+  virtual bool is_admin() const = 0;
 
   /* Verify whether a given identity is the rgw_owner specified in @o.
    * On internal error throws rgw::auth::Exception storing the reason. */
@@ -480,7 +480,7 @@ public:
     return RGW_PERM_NONE;
   }
 
-  bool is_admin_of(const rgw_owner& o) const override {
+  bool is_admin() const override {
     return false;
   }
 
@@ -668,7 +668,7 @@ public:
 
   ACLOwner get_aclowner() const override;
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override;
-  bool is_admin_of(const rgw_owner& o) const override;
+  bool is_admin() const override;
   bool is_owner_of(const rgw_owner& o) const override;
   bool is_root() const override;
   bool is_identity(const Principal& p) const override;
@@ -734,7 +734,7 @@ public:
 
   ACLOwner get_aclowner() const override;
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override;
-  bool is_admin_of(const rgw_owner& o) const override;
+  bool is_admin() const override;
   bool is_owner_of(const rgw_owner& o) const override;
   bool is_root() const override;
   bool is_identity(const Principal& p) const override;
@@ -817,7 +817,7 @@ public:
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
     return 0;
   }
-  bool is_admin_of(const rgw_owner& o) const override {
+  bool is_admin() const override {
     return false;
   }
   bool is_owner_of(const rgw_owner& o) const override;
@@ -865,7 +865,7 @@ public:
     return RGW_PERM_NONE;
   }
 
-  bool is_admin_of(const rgw_owner& o) const override {
+  bool is_admin() const override {
     return false;
   }
 

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -769,7 +769,8 @@ public:
                                       std::vector<IAM::Policy> policies,
                                       const std::string& subuser,
                                       const std::optional<uint32_t>& perm_mask,
-                                      const std::string& access_key_id) const = 0;
+                                      const std::string& access_key_id,
+                                      bool is_impersonating) const = 0;
     };
 };
 

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -73,8 +73,8 @@ public:
     return get_decoratee().get_perms_from_aclspec(dpp, aclspec);
   }
 
-  bool is_admin_of(const rgw_owner& o) const override {
-    return get_decoratee().is_admin_of(o);
+  bool is_admin() const override {
+    return get_decoratee().is_admin();
   }
 
   bool is_owner_of(const rgw_owner& o) const override {
@@ -281,12 +281,12 @@ public:
     return DecoratedApplier<T>::get_tenant();
   }
 
-  bool is_admin_of(const rgw_owner& o) const override {
+  bool is_admin() const override {
     if (is_system && !is_impersonating) {
       return true;
     }
 
-    return DecoratedApplier<T>::is_admin_of(o);
+    return DecoratedApplier<T>::is_admin();
   }
 };
 

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -240,7 +240,8 @@ class SysReqApplier : public DecoratedApplier<T> {
   CephContext* const cct;
   rgw::sal::Driver* driver;
   const RGWHTTPArgs& args;
-  mutable boost::tribool is_system;
+  mutable boost::tribool is_system = boost::logic::indeterminate;
+  mutable bool is_impersonating;
   mutable std::optional<ACLOwner> effective_owner;
   mutable std::optional<std::string> effective_tenant;
 
@@ -249,12 +250,17 @@ public:
   SysReqApplier(CephContext* const cct,
 		rgw::sal::Driver* driver,
                 const req_state* const s,
-                U&& decoratee)
+                U&& decoratee,
+                bool is_impersonating = false)
     : DecoratedApplier<T>(std::forward<T>(decoratee)),
       cct(cct),
       driver(driver),
       args(s->info.args),
-      is_system(boost::logic::indeterminate) {
+      is_impersonating(is_impersonating) {
+    if (is_impersonating) {
+      // we only accept impersonated requests from a system user
+      is_system = true;
+    }
   }
 
   void to_str(std::ostream& out) const override;
@@ -275,6 +281,13 @@ public:
     return DecoratedApplier<T>::get_tenant();
   }
 
+  bool is_admin_of(const rgw_owner& o) const override {
+    if (is_system && !is_impersonating) {
+      return true;
+    }
+
+    return DecoratedApplier<T>::is_admin_of(o);
+  }
 };
 
 template <typename T>
@@ -292,8 +305,13 @@ template <typename T>
 auto SysReqApplier<T>::load_acct_info(const DoutPrefixProvider* dpp) const -> std::unique_ptr<rgw::sal::User>
 {
   std::unique_ptr<rgw::sal::User> user = DecoratedApplier<T>::load_acct_info(dpp);
-  is_system = user->get_info().system;
 
+  // skip loading the account info if we already have it through impersonation
+  if (is_impersonating) {
+    return user;
+  }
+
+  is_system = user->get_info().system;
   if (is_system) {
     //ldpp_dout(dpp, 20) << "system request" << dendl;
 
@@ -320,7 +338,7 @@ auto SysReqApplier<T>::load_acct_info(const DoutPrefixProvider* dpp) const -> st
           throw -EACCES;
         }
         effective_tenant = info.tenant;
-     }
+      }
     }
   }
   return user;
@@ -344,8 +362,9 @@ template <typename T> static inline
 SysReqApplier<T> add_sysreq(CephContext* const cct,
 			    rgw::sal::Driver* driver,
                             const req_state* const s,
-                            T&& t) {
-  return SysReqApplier<T>(cct, driver, s, std::forward<T>(t));
+                            T&& t,
+                            bool is_impersonating = false) {
+  return SysReqApplier<T>(cct, driver, s, std::forward<T>(t), is_impersonating);
 }
 
 } /* namespace auth */

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -60,10 +60,11 @@ class STSAuthStrategy : public rgw::auth::Strategy,
                             std::vector<IAM::Policy> policies,
                             const std::string& subuser,
                             const std::optional<uint32_t>& perm_mask,
-                            const std::string& access_key_id) const override {
+                            const std::string& access_key_id,
+                            bool is_impersonating) const override {
     auto apl = rgw::auth::add_sysreq(cct, driver, s,
       LocalApplier(cct, std::move(user), std::move(account), std::move(policies),
-                   subuser, perm_mask, access_key_id));
+                   subuser, perm_mask, access_key_id), is_impersonating);
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 
@@ -182,10 +183,11 @@ class AWSAuthStrategy : public rgw::auth::Strategy,
                             std::vector<IAM::Policy> policies,
                             const std::string& subuser,
                             const std::optional<uint32_t>& perm_mask,
-                            const std::string& access_key_id) const override {
+                            const std::string& access_key_id,
+                            bool is_impersonating) const override {
     auto apl = rgw::auth::add_sysreq(cct, driver, s,
       LocalApplier(cct, std::move(user), std::move(account), std::move(policies),
-                   subuser, perm_mask, access_key_id));
+                   subuser, perm_mask, access_key_id), is_impersonating);
     /* TODO(rzarzynski): replace with static_ptr. */
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -72,9 +72,9 @@ class STSAuthStrategy : public rgw::auth::Strategy,
                             const req_state* const s,
                             RoleApplier::Role role,
                             RoleApplier::TokenAttrs token_attrs,
-                            bool is_system_request) const override {
+                            bool is_impersonating) const override {
     auto apl = rgw::auth::add_sysreq(cct, driver, s,
-      rgw::auth::RoleApplier(cct, driver, std::move(role), std::move(token_attrs), is_system_request));
+      rgw::auth::RoleApplier(cct, driver, std::move(role), std::move(token_attrs)), is_impersonating);
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1329,7 +1329,7 @@ bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
   return verify_user_permission_no_policy(dpp, &ps, s->user_acl, perm);
 }
 
-bool verify_requester_payer_permission(struct perm_state_base *s)
+bool verify_requester_payer_permission(const perm_state_base *s)
 {
   if (!s->bucket_info.requester_pays)
     return true;
@@ -1350,7 +1350,7 @@ bool verify_requester_payer_permission(struct perm_state_base *s)
 }
 
 bool verify_bucket_permission(const DoutPrefixProvider* dpp,
-                              struct perm_state_base * const s,
+                              const perm_state_base * const s,
                               const rgw::ARN& arn,
                               bool account_root,
                               const RGWAccessControlPolicy& user_acl,
@@ -1434,7 +1434,7 @@ bool verify_bucket_permission(const DoutPrefixProvider* dpp,
                                   session_policies, op);
 }
 
-bool verify_bucket_permission_no_policy(const DoutPrefixProvider* dpp, struct perm_state_base * const s,
+bool verify_bucket_permission_no_policy(const DoutPrefixProvider* dpp, const perm_state_base * const s,
 					const RGWAccessControlPolicy& user_acl,
 					const RGWAccessControlPolicy& bucket_acl,
 					const int perm)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1831,13 +1831,6 @@ extern bool verify_object_permission(
   const std::vector<rgw::IAM::Policy>& session_policies,
   const uint64_t op);
 extern bool verify_object_permission(const DoutPrefixProvider* dpp, req_state *s, uint64_t op);
-extern bool verify_object_permission_no_policy(
-  const DoutPrefixProvider* dpp,
-  req_state * const s,
-  const RGWAccessControlPolicy& user_acl,
-  const RGWAccessControlPolicy& bucket_acl,
-  const RGWAccessControlPolicy& object_acl,
-  int perm);
 extern bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp, req_state *s,
 					       int perm);
 extern int verify_object_lock(

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1751,7 +1751,7 @@ struct perm_state : public perm_state_base {
  * to do the requested action  */
 bool verify_bucket_permission_no_policy(
   const DoutPrefixProvider* dpp,
-  struct perm_state_base * const s,
+  const perm_state_base * const s,
   const RGWAccessControlPolicy& user_acl,
   const RGWAccessControlPolicy& bucket_acl,
   const int perm);
@@ -1787,7 +1787,7 @@ bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
                                       req_state * const s,
                                       int perm);
 bool verify_bucket_permission(const DoutPrefixProvider* dpp,
-                              struct perm_state_base * const s,
+                              const perm_state_base * const s,
                               const rgw::ARN& arn,
                               bool account_root,
                               const RGWAccessControlPolicy& user_acl,

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -139,6 +139,7 @@ static const actpair actpairs[] =
  { "s3:RestoreObject", s3RestoreObject },
  { "s3:DescribeJob", s3DescribeJob },
  { "s3:ReplicateDelete", s3ReplicateDelete },
+ { "s3:ReplicateObject", s3ReplicateObject },
  { "s3-object-lambda:GetObject", s3objectlambdaGetObject },
  { "s3-object-lambda:ListBucket", s3objectlambdaListBucket },
  { "iam:PutUserPolicy", iamPutUserPolicy },
@@ -1512,6 +1513,9 @@ const char* action_bit_string(uint64_t action) {
 
   case s3ReplicateDelete:
     return "s3:ReplicateDelete";
+
+  case s3ReplicateObject:
+    return "s3:ReplicateObject";
 
   case s3objectlambdaGetObject:
     return "s3-object-lambda:GetObject";

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -141,6 +141,7 @@ static const actpair actpairs[] =
  { "s3:ReplicateDelete", s3ReplicateDelete },
  { "s3:ReplicateObject", s3ReplicateObject },
  { "s3:ReplicateTags", s3ReplicateTags },
+ { "s3:GetObjectVersionForReplication", s3GetObjectVersionForReplication },
  { "s3-object-lambda:GetObject", s3objectlambdaGetObject },
  { "s3-object-lambda:ListBucket", s3objectlambdaListBucket },
  { "iam:PutUserPolicy", iamPutUserPolicy },
@@ -1519,6 +1520,9 @@ const char* action_bit_string(uint64_t action) {
 
   case s3ReplicateTags:
     return "s3:ReplicateTags";
+
+  case s3GetObjectVersionForReplication:
+    return "s3:GetObjectVersionForReplication";
 
   case s3objectlambdaGetObject:
     return "s3-object-lambda:GetObject";

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1302,7 +1302,6 @@ Effect Statement::eval_conditions(const Environment& e) const {
   return Effect::Deny;
 }
 
-namespace {
 const char* action_bit_string(uint64_t action) {
   switch (action) {
   case s3GetObject:
@@ -1764,6 +1763,7 @@ const char* action_bit_string(uint64_t action) {
   return "s3Invalid";
 }
 
+namespace {
 ostream& print_actions(ostream& m, const Action_t a) {
   bool begun = false;
   m << "[ ";

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -138,6 +138,7 @@ static const actpair actpairs[] =
  { "s3:PutReplicationConfiguration", s3PutReplicationConfiguration },
  { "s3:RestoreObject", s3RestoreObject },
  { "s3:DescribeJob", s3DescribeJob },
+ { "s3:ReplicateDelete", s3ReplicateDelete },
  { "s3-object-lambda:GetObject", s3objectlambdaGetObject },
  { "s3-object-lambda:ListBucket", s3objectlambdaListBucket },
  { "iam:PutUserPolicy", iamPutUserPolicy },
@@ -1508,6 +1509,9 @@ const char* action_bit_string(uint64_t action) {
 
   case s3DescribeJob:
     return "s3:DescribeJob";
+
+  case s3ReplicateDelete:
+    return "s3:ReplicateDelete";
 
   case s3objectlambdaGetObject:
     return "s3-object-lambda:GetObject";

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -140,6 +140,7 @@ static const actpair actpairs[] =
  { "s3:DescribeJob", s3DescribeJob },
  { "s3:ReplicateDelete", s3ReplicateDelete },
  { "s3:ReplicateObject", s3ReplicateObject },
+ { "s3:ReplicateTags", s3ReplicateTags },
  { "s3-object-lambda:GetObject", s3objectlambdaGetObject },
  { "s3-object-lambda:ListBucket", s3objectlambdaListBucket },
  { "iam:PutUserPolicy", iamPutUserPolicy },
@@ -1516,6 +1517,9 @@ const char* action_bit_string(uint64_t action) {
 
   case s3ReplicateObject:
     return "s3:ReplicateObject";
+
+  case s3ReplicateTags:
+    return "s3:ReplicateTags";
 
   case s3objectlambdaGetObject:
     return "s3-object-lambda:GetObject";

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -119,6 +119,7 @@ enum {
   s3GetObjectVersionAttributes,
   s3ReplicateDelete,
   s3ReplicateObject,
+  s3ReplicateTags,
   s3All,
 
   s3objectlambdaGetObject,
@@ -277,6 +278,7 @@ inline int op_to_perm(std::uint64_t op) {
   case s3BypassGovernanceRetention:
   case s3ReplicateDelete:
   case s3ReplicateObject:
+  case s3ReplicateTags:
     return RGW_PERM_WRITE;
 
   case s3GetAccelerateConfiguration:

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -118,6 +118,7 @@ enum {
   s3GetObjectAttributes,
   s3GetObjectVersionAttributes,
   s3ReplicateDelete,
+  s3ReplicateObject,
   s3All,
 
   s3objectlambdaGetObject,
@@ -275,6 +276,7 @@ inline int op_to_perm(std::uint64_t op) {
   case s3PutObjectLegalHold:
   case s3BypassGovernanceRetention:
   case s3ReplicateDelete:
+  case s3ReplicateObject:
     return RGW_PERM_WRITE;
 
   case s3GetAccelerateConfiguration:

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -119,6 +119,7 @@ enum {
   s3GetObjectVersionAttributes,
   s3ReplicateDelete,
   s3ReplicateObject,
+  s3GetObjectVersionForReplication,
   s3ReplicateTags,
   s3All,
 
@@ -260,6 +261,7 @@ inline int op_to_perm(std::uint64_t op) {
   case s3ListBucketMultipartUploads:
   case s3ListBucketVersions:
   case s3ListMultipartUploadParts:
+  case s3GetObjectVersionForReplication:
     return RGW_PERM_READ;
 
   case s3AbortMultipartUpload:

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -117,6 +117,7 @@ enum {
   s3DescribeJob,
   s3GetObjectAttributes,
   s3GetObjectVersionAttributes,
+  s3ReplicateDelete,
   s3All,
 
   s3objectlambdaGetObject,
@@ -273,6 +274,7 @@ inline int op_to_perm(std::uint64_t op) {
   case s3PutObjectRetention:
   case s3PutObjectLegalHold:
   case s3BypassGovernanceRetention:
+  case s3ReplicateDelete:
     return RGW_PERM_WRITE;
 
   case s3GetAccelerateConfiguration:

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -332,6 +332,8 @@ inline int op_to_perm(std::uint64_t op) {
 }
 }
 
+const char* action_bit_string(uint64_t action);
+
 enum class PolicyPrincipal {
   Role,
   Session,

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -283,7 +283,7 @@ namespace rgw {
       if (ret < 0) {
 	if (s->system_request) {
 	  ldpp_dout(op, 2) << "overriding permissions due to system operation" << dendl;
-	} else if (s->auth.identity->is_admin_of(s->user->get_id())) {
+	} else if (s->auth.identity->is_admin()) {
 	  ldpp_dout(op, 2) << "overriding permissions due to admin operation" << dendl;
 	} else {
 	  abort_req(s, op, ret);
@@ -420,7 +420,7 @@ namespace rgw {
     if (ret < 0) {
       if (s->system_request) {
 	ldpp_dout(op, 2) << "overriding permissions due to system operation" << dendl;
-      } else if (s->auth.identity->is_admin_of(s->user->get_id())) {
+      } else if (s->auth.identity->is_admin()) {
 	ldpp_dout(op, 2) << "overriding permissions due to admin operation" << dendl;
       } else {
 	abort_req(s, op, ret);

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -281,9 +281,7 @@ namespace rgw {
       ldpp_dout(s, 2) << "verifying op permissions" << dendl;
       ret = op->verify_permission(null_yield);
       if (ret < 0) {
-	if (s->system_request) {
-	  ldpp_dout(op, 2) << "overriding permissions due to system operation" << dendl;
-	} else if (s->auth.identity->is_admin()) {
+	if (s->auth.identity->is_admin()) {
 	  ldpp_dout(op, 2) << "overriding permissions due to admin operation" << dendl;
 	} else {
 	  abort_req(s, op, ret);
@@ -418,9 +416,7 @@ namespace rgw {
     ldpp_dout(s, 2) << "verifying op permissions" << dendl;
     ret = op->verify_permission(null_yield);
     if (ret < 0) {
-      if (s->system_request) {
-	ldpp_dout(op, 2) << "overriding permissions due to system operation" << dendl;
-      } else if (s->auth.identity->is_admin()) {
+      if (s->auth.identity->is_admin()) {
 	ldpp_dout(op, 2) << "overriding permissions due to admin operation" << dendl;
       } else {
 	abort_req(s, op, ret);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -428,7 +428,7 @@ static int read_obj_policy(const DoutPrefixProvider *dpp,
       return ret;
     }
 
-    if (s->auth.identity->is_admin_of(bucket_policy.get_owner().id)) {
+    if (s->auth.identity->is_admin()) {
       return -ENOENT;
     }
 
@@ -1858,7 +1858,7 @@ int RGWGetObj::read_user_manifest_part(rgw::sal::Bucket* bucket,
    * stored inside different accounts. */
   if (s->system_request) {
     ldpp_dout(this, 2) << "overriding permissions due to system operation" << dendl;
-  } else if (s->auth.identity->is_admin_of(s->user->get_id())) {
+  } else if (s->auth.identity->is_admin()) {
     ldpp_dout(this, 2) << "overriding permissions due to admin operation" << dendl;
   } else if (!verify_object_permission(this, s, part->get_obj(), s->user_acl,
 				       bucket_acl, obj_policy, bucket_policy,

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -227,9 +227,9 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
     std::swap(span, s->trace);
   }
   if (ret < 0) {
-    if (s->system_request) {
-      dout(2) << "overriding permissions due to system operation" << dendl;
-    } else if (s->auth.identity->is_admin_of(s->user->get_id())) {
+    // system requests may impersonate another user/role for permission checks
+    // so only rely on is_admin_of() to override permissions
+    if (s->auth.identity->is_admin_of(s->user->get_id())) {
       dout(2) << "overriding permissions due to admin operation" << dendl;
     } else {
       return ret;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -94,8 +94,7 @@ void RGWProcess::RGWWQ::_process(RGWRequest *req, ThreadPool::TPHandle &) {
 }
 bool rate_limit(rgw::sal::Driver* driver, req_state* s) {
   // we dont want to limit health check or system or admin requests
-  const auto& is_admin_or_system = s->user->get_info();
-  if ((s->op_type ==  RGW_OP_GET_HEALTH_CHECK) || is_admin_or_system.admin || is_admin_or_system.system)
+  if ((s->op_type ==  RGW_OP_GET_HEALTH_CHECK) || s->system_request)
     return false;
   std::string userfind;
   RGWRateLimitInfo global_user;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -226,7 +226,7 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
     ret = op->verify_permission(y);
     std::swap(span, s->trace);
   }
-  if (ret < 0) {
+  if (ret == -EACCES || ret == -EPERM || ret == -ERR_AUTHORIZATION) {
     // system requests may impersonate another user/role for permission checks
     // so only rely on is_admin_of() to override permissions
     if (s->auth.identity->is_admin_of(s->user->get_id())) {
@@ -234,6 +234,9 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
     } else {
       return ret;
     }
+  } else if (ret < 0) {
+    // other errors are not overridden as they might be invalid input
+    return ret;
   }
 
   ldpp_dout(op, 2) << "verifying op params" << dendl;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -228,8 +228,8 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
   }
   if (ret == -EACCES || ret == -EPERM || ret == -ERR_AUTHORIZATION) {
     // system requests may impersonate another user/role for permission checks
-    // so only rely on is_admin_of() to override permissions
-    if (s->auth.identity->is_admin_of(s->user->get_id())) {
+    // so only rely on is_admin() to override permissions
+    if (s->auth.identity->is_admin()) {
       dout(2) << "overriding permissions due to admin operation" << dendl;
     } else {
       return ret;

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -24,6 +24,7 @@ protected:
   bufferlist response;
 
   virtual int handle_header(const std::string& name, const std::string& val);
+  virtual int handle_headers(const std::map<std::string, std::string>& headers, int http_status) { return 0; }
   void get_params_str(std::map<std::string, std::string>& extra_args, std::string& dest);
 
 public:
@@ -123,6 +124,7 @@ protected:
   bufferlist outbl;
 
   int handle_header(const std::string& name, const std::string& val) override;
+  int handle_headers(const std::map<std::string, std::string>& headers, int http_status) override;
 public:
   int send_data(void *ptr, size_t len, bool *pause) override;
   int receive_data(void *ptr, size_t len, bool *pause) override;
@@ -134,6 +136,7 @@ public:
       ReceiveCB() = default;
       virtual ~ReceiveCB() = default;
       virtual int handle_data(bufferlist& bl, bool *pause = nullptr) = 0;
+      virtual int handle_headers(const std::map<std::string, std::string>& headers, int http_status) { return 0; }
       virtual void set_extra_data_len(uint64_t len) {
         extra_data_len = len;
       }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -296,7 +296,9 @@ static void set_header(T val, map<string, string>& headers, const string& header
 }
 
 
-int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_owner& uid, req_info *info /* optional */, const rgw_obj& obj,
+int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_owner *uid,
+                         const rgw_user *perm_check_uid,
+                         req_info *info /* optional */, const rgw_obj& obj,
                          const real_time *mod_ptr, const real_time *unmod_ptr,
                          uint32_t mod_zone_id, uint64_t mod_pg_ver,
                          bool prepend_metadata, bool get_op, bool rgwx_stat,
@@ -306,6 +308,7 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_owner& uid, re
 {
   get_obj_params params;
   params.uid = uid;
+  params.perm_check_uid = perm_check_uid;
   params.info = info;
   params.mod_ptr = mod_ptr;
   params.mod_pg_ver = mod_pg_ver;
@@ -328,7 +331,10 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, cons
     return ret;
 
   param_vec_t params;
-  populate_params(params, &in_params.uid, self_zone_group);
+  populate_params(params, in_params.uid, self_zone_group);
+  if (in_params.perm_check_uid) {
+    params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "perm-check-uid", to_string(*in_params.perm_check_uid)));
+  }
   if (in_params.prepend_metadata) {
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "prepend-metadata", "true"));
   }

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -145,7 +145,8 @@ public:
                        ceph::real_time *mtime, optional_yield y);
 
   struct get_obj_params {
-    rgw_owner uid;
+    const rgw_owner *uid{nullptr};
+    const rgw_user *perm_check_uid{nullptr};
     req_info *info{nullptr};
     const ceph::real_time *mod_ptr{nullptr};
     const ceph::real_time *unmod_ptr{nullptr};
@@ -173,7 +174,9 @@ public:
 
   int get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
 
-  int get_obj(const DoutPrefixProvider *dpp, const rgw_owner& uid, req_info *info /* optional */, const rgw_obj& obj,
+  int get_obj(const DoutPrefixProvider *dpp, const rgw_owner* uid,
+              const rgw_user* perm_check_uid,
+              req_info *info /* optional */, const rgw_obj& obj,
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
               bool prepend_metadata, bool get_op, bool rgwx_stat, bool sync_manifest,

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -411,6 +411,8 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
       total_len = 0;
     }
 
+    dump_header(s, "Rgwx-Perm-Checked", "true");
+
     // check for GetObject(Version)Tagging permission to include tags in response
     auto action = s->object->get_instance().empty() ? rgw::IAM::s3GetObjectTagging : rgw::IAM::s3GetObjectVersionTagging;
     // since we are already under s->system_request, if the request is not impersonating,

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -417,7 +417,7 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
     auto action = s->object->get_instance().empty() ? rgw::IAM::s3GetObjectTagging : rgw::IAM::s3GetObjectVersionTagging;
     // since we are already under s->system_request, if the request is not impersonating,
     // it can be assumed that it is not a user-mode replication.
-    bool keep_tags = s->auth.identity->is_admin_of(s->user->get_id()) || verify_object_permission(this, s, action);
+    bool keep_tags = s->auth.identity->is_admin() || verify_object_permission(this, s, action);
 
     // remove tags from attrs if the user doesn't have permission
     bufferlist tags_bl;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -7024,7 +7024,6 @@ rgw::auth::s3::STSEngine::authenticate(
   const req_state* const s,
   optional_yield y) const
 {
-  bool is_system_request{false};
   if (! s->info.args.exists("x-amz-security-token") &&
       ! s->info.env->exists("HTTP_X_AMZ_SECURITY_TOKEN") &&
       s->auth.s3_postobj_creds.x_amz_security_token.empty()) {
@@ -7036,6 +7035,7 @@ rgw::auth::s3::STSEngine::authenticate(
     return result_t::reject(ret);
   }
   //Authentication
+  bool is_impersonating = false;
   std::string secret_access_key;
   //Check if access key is not the same passed in by client
   if (token.access_key_id != _access_key_id) {
@@ -7059,7 +7059,7 @@ rgw::auth::s3::STSEngine::authenticate(
       }
       const RGWAccessKey& k = iter->second;
       secret_access_key = k.key;
-      is_system_request = true;
+      is_impersonating = true;
     } else {
       ldpp_dout(dpp, 0) << "Invalid access key" << dendl;
       return result_t::reject(-EPERM);
@@ -7150,7 +7150,7 @@ rgw::auth::s3::STSEngine::authenticate(
     t_attrs.token_issued_at = std::move(token.issued_at);
     t_attrs.principal_tags = std::move(token.principal_tags);
     auto apl = role_apl_factory->create_apl_role(cct, s, std::move(r),
-                                                 std::move(t_attrs), is_system_request);
+                                                 std::move(t_attrs), is_impersonating);
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   } else { // This is for all local users of type TYPE_RGW|ROOT|NONE
     if (token.user.empty()) {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -1159,6 +1159,7 @@ public:
 };
 
 class LocalEngine : public AWSEngine {
+  typedef rgw::auth::IdentityApplier::aplptr_t aplptr_t;
   rgw::sal::Driver* driver;
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -124,7 +124,7 @@ int Credentials::generateCredentials(const DoutPrefixProvider *dpp,
   if (identity) {
     token.acct_name = identity->get_acct_name();
     token.perm_mask = identity->get_perm_mask();
-    token.is_admin = identity->is_admin_of(token.user);
+    token.is_admin = identity->is_admin();
     token.acct_type = identity->get_identity_type();
   } else {
     token.acct_name = {};

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -525,7 +525,7 @@ ExternalTokenEngine::authenticate(const DoutPrefixProvider* dpp,
   auto apl = apl_factory->create_apl_local(
       cct, s, std::move(user), std::move(account),
       std::move(policies), extract_swift_subuser(swift_user),
-      std::nullopt, LocalApplier::NO_ACCESS_KEY);
+      std::nullopt, LocalApplier::NO_ACCESS_KEY, false /* is_impersonating */);
   return result_t::grant(std::move(apl));
 }
 
@@ -688,7 +688,7 @@ SignedTokenEngine::authenticate(const DoutPrefixProvider* dpp,
   auto apl = apl_factory->create_apl_local(
       cct, s, std::move(user), std::move(account),
       std::move(policies), extract_swift_subuser(swift_user),
-      std::nullopt, LocalApplier::NO_ACCESS_KEY);
+      std::nullopt, LocalApplier::NO_ACCESS_KEY, false /* is_impersonating */);
   return result_t::grant(std::move(apl));
 }
 

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -243,12 +243,13 @@ class DefaultStrategy : public rgw::auth::Strategy,
                             std::vector<IAM::Policy> policies,
                             const std::string& subuser,
                             const std::optional<uint32_t>& perm_mask,
-                            const std::string& access_key_id) const override {
+                            const std::string& access_key_id,
+                            bool is_impersonating) const override {
     auto apl = \
       rgw::auth::add_3rdparty(driver, rgw_user(s->account_name),
         rgw::auth::add_sysreq(cct, driver, s,
           LocalApplier(cct, std::move(user), std::move(account), std::move(policies),
-                       subuser, perm_mask, access_key_id)));
+                       subuser, perm_mask, access_key_id), is_impersonating));
     /* TODO(rzarzynski): replace with static_ptr. */
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -159,7 +159,7 @@ class SwiftAnonymousApplier : public rgw::auth::LocalApplier {
       : LocalApplier(cct, std::move(user), std::nullopt, {}, LocalApplier::NO_SUBUSER,
                      std::nullopt, LocalApplier::NO_ACCESS_KEY) {
     }
-    bool is_admin_of(const rgw_owner& o) const {return false;}
+    bool is_admin() const {return false;}
     bool is_owner_of(const rgw_owner& o) const {
       auto* uid = std::get_if<rgw_user>(&o);
       return uid && uid->id == RGW_USER_ANON_ID;

--- a/src/rgw/rgw_sync_policy.cc
+++ b/src/rgw/rgw_sync_policy.cc
@@ -635,7 +635,9 @@ void rgw_sync_pipe_params::dump(Formatter *f) const
       s = "user";
   }
   encode_json("mode", s, f);
-  encode_json("user", user, f);
+  if (user) {
+    encode_json("user", *user, f);
+  }
 }
 
 void rgw_sync_pipe_params::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_sync_policy.h
+++ b/src/rgw/rgw_sync_policy.h
@@ -342,7 +342,7 @@ struct rgw_sync_pipe_params {
     MODE_USER = 1,
   } mode{MODE_SYSTEM};
   int32_t priority{0};
-  rgw_user user;
+  std::optional<rgw_user> user;
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
@@ -350,7 +350,7 @@ struct rgw_sync_pipe_params {
     encode(dest, bl);
     encode(priority, bl);
     encode((uint8_t)mode, bl);
-    encode(user, bl);
+    encode(user.value_or(rgw_user()), bl);
     ENCODE_FINISH(bl);
   }
 
@@ -362,7 +362,13 @@ struct rgw_sync_pipe_params {
     uint8_t m;
     decode(m, bl);
     mode = (Mode)m;
-    decode(user, bl);
+    { // decode user
+      rgw_user _user;
+      decode(_user, bl);
+      if (!_user.empty()) {
+        user = _user;
+      }
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -4247,7 +4247,7 @@ def test_bucket_replication_reject_versioning_identical():
     assert e.response['ResponseMetadata']['HTTPStatusCode'] == 400
 
 @allow_bucket_replication
-def test_bucket_replicaion_reject_objectlock_identical():
+def test_bucket_replication_reject_objectlock_identical():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -80,6 +80,7 @@ using rgw::IAM::s3GetObjectAttributes;
 using rgw::IAM::s3GetObjectVersionAttributes;
 using rgw::IAM::s3GetPublicAccessBlock;
 using rgw::IAM::s3GetReplicationConfiguration;
+using rgw::IAM::s3GetObjectVersionForReplication;
 using rgw::IAM::s3ListAllMyBuckets;
 using rgw::IAM::s3ListBucket;
 using rgw::IAM::s3ListBucketMultipartUploads;
@@ -452,6 +453,7 @@ TEST_F(PolicyTest, Parse3) {
   act2[s3GetBucketPublicAccessBlock] = 1;
   act2[s3GetPublicAccessBlock] = 1;
   act2[s3GetBucketEncryption] = 1;
+  act2[s3GetObjectVersionForReplication] = 1;
 
   EXPECT_EQ(p->statements[2].action, act2);
   EXPECT_EQ(p->statements[2].notaction, None);
@@ -524,6 +526,7 @@ TEST_F(PolicyTest, Eval3) {
   s3allow[s3GetBucketPublicAccessBlock] = 1;
   s3allow[s3GetPublicAccessBlock] = 1;
   s3allow[s3GetBucketEncryption] = 1;
+  s3allow[s3GetObjectVersionForReplication] = 1;
 
   ARN arn1(Partition::aws, Service::s3,
 		       "", arbitrary_tenant, "mybucket");
@@ -920,6 +923,7 @@ TEST_F(ManagedPolicyTest, AmazonS3ReadOnlyAccess)
   act[s3GetPublicAccessBlock] = 1;
   act[s3GetBucketPublicAccessBlock] = 1;
   act[s3GetBucketEncryption] = 1;
+  act[s3GetObjectVersionForReplication] = 1;
   // s3:List*
   act[s3ListMultipartUploadParts] = 1;
   act[s3ListBucket] = 1;

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -160,7 +160,7 @@ public:
     return 0;
   };
 
-  bool is_admin_of(const rgw_owner& o) const override {
+  bool is_admin() const override {
     ceph_abort();
     return false;
   }

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -42,7 +42,7 @@ public:
     return 0;
   };
 
-  bool is_admin_of(const rgw_owner& o) const override {
+  bool is_admin() const override {
     return false;
   }
 


### PR DESCRIPTION
when replicating objects, the destination bucket needs to have a policy accepting replication actions like `s3:ReplicateObject`, `s3:ReplicateDelete`, `s3:ReplicateTags` for the given Role (for now we use the source bucket's owner uid) to allow the replication happen, otherwise it should reject replicating. https://docs.aws.amazon.com/AmazonS3/latest/userguide/setting-repl-config-perm-overview.html

This also closes the missing permission evaluation for delete and deletemarker replication.

~Require: https://github.com/ceph/ceph/pull/61828~
Fixes: https://tracker.ceph.com/issues/70093