### PR TITLE
rgw: add negative filter support for bucket notifications

### DIFF
--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -509,18 +509,21 @@ Parameters are XML encoded in the body of the request, in the following format:
                    <FilterRule>
                        <Name></Name>
                        <Value></Value>
+                       <Type></Type>
                    </FilterRule>
         	    </S3Key>
                 <S3Metadata>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Type></Type>
                     </FilterRule>
                 </S3Metadata>
                 <S3Tags>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Type></Type>
                     </FilterRule>
                 </S3Tags>
             </Filter>
@@ -556,16 +559,23 @@ Parameters are XML encoded in the body of the request, in the following format:
 |                               |           | All filter rules in the list must match the tags defined on the object. However,     |          |
 |                               |           | the object still match it it has other tags not listed in the filter.                |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Key.FilterRule``          | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would  be: ``prefix``, ``suffix``  | Yes      |
-|                               |           | or ``regex``. The ``Value`` would hold the key prefix, key suffix or a regular       |          |
-|                               |           | expression for matching the key, accordingly.                                        |          |
+| ``S3Key.FilterRule``          | Container | Holding ``Name``, ``Value`` and ``Type`` entities. ``Name`` would  be: ``prefix``,   | Yes      |
+|                               |           | ``suffix``, or ``regex``. The ``Value`` would hold the key prefix, key suffix        |          |
+|                               |           | or a regular expression for matching the key, accordingly. The ``Type`` entity is    |          |
+|                               |           | optional, and can hold ``IN`` or ``OUT``. It defaults to ``IN`` when not specified.  |          |
+|                               |           | ``IN`` means the key must match the rule, ``OUT`` means the key must not match the   |          |
+|                               |           | rule.                                                                                |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Metadata.FilterRule``     | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would be the name of the metadata  | Yes      |
-|                               |           | attribute (e.g. ``x-amz-meta-xxx``). The ``Value`` would be the expected value for   |          | 
-|                               |           | this attribute.                                                                      |          |
+| ``S3Metadata.FilterRule``     | Container | Holding ``Name``, ``Value`` and ``Type`` entities. ``Name`` would be the name of     | Yes      |
+|                               |           | the metadata attribute (e.g., ``x-amz-meta-xxx``). The ``Value`` would be the        |          |
+|                               |           | expected value for this attribute. The ``Type`` entity is optional, and can hold     |          |
+|                               |           | ``IN`` or ``OUT``. It defaults to ``IN`` when not specified. ``IN`` means the        |          |
+|                               |           | metadata must match the rule, ``OUT`` means the metadata must not match the rule.    |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Tags.FilterRule``         | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would be the tag key,              |  Yes     |
-|                               |           | and ``Value`` would be the tag value.                                                |          | 
+| ``S3Tags.FilterRule``         | Container | Holding ``Name``, ``Value`` and ``Type`` entities. ``Name`` would be the tag key,    | Yes      |
+|                               |           | and ``Value`` would be the tag value. The ``Type`` entity is optional, and can hold  |          |
+|                               |           | ``IN`` or ``OUT``. It defaults to ``IN`` when not specified. ``IN`` means the tag    |          |
+|                               |           | must match the rule, ``OUT`` means the tag must not match the rule.                  |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
 
 
@@ -661,18 +671,21 @@ Response is XML encoded in the body of the request, in the following format:
                    <FilterRule>
                        <Name></Name>
                        <Value></Value>
+                       <Type></Type>
                    </FilterRule>
         	    </S3Key>
                 <S3Metadata>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Type></Type>
                     </FilterRule>
                 </S3Metadata>
                 <S3Tags>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Type></Type>
                     </FilterRule>
                 </S3Tags>
             </Filter>

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -181,6 +181,10 @@
                 "Value":{
                     "shape":"FilterRuleValue",
                     "documentation":"<p>The value that the filter searches for in object key names.</p>"
+                }, 
+                "Type": {
+                    "shape":"FilterRuleType",
+                    "documentation":"<p>Type of the filter rule. The type can be <code>IN</code> or <code>OUT</code>. Defaults to <code>IN</code> by default, <code>IN</code> indicates filter is honoured, else it is a negative filter.</p>"
                 }
             },
             "documentation":"<p>Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix, prefix or regex of the key name.</p>"
@@ -191,6 +195,13 @@
                 "prefix",
                 "suffix",
                 "regex"
+            ]
+        },
+        "FilterRuleType":{
+            "type":"string",
+            "enum":[
+                "IN",
+                "OUT"
             ]
         },
         "NotificationConfigurationFilter":{

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -1040,7 +1040,7 @@ static inline bool notification_match(reservation_t& res,
     return false;
   }
 
-  if (!filter.s3_filter.metadata_filter.kv.empty()) {
+  if (filter.s3_filter.metadata_filter.has_content()) {
     // metadata filter exists
     if (res.s) {
       filter_amz_meta(res.x_meta_map, res.s->info.x_meta_map);
@@ -1051,7 +1051,7 @@ static inline bool notification_match(reservation_t& res,
     }
   }
 
-  if (!filter.s3_filter.tag_filter.kv.empty()) {
+  if (filter.s3_filter.tag_filter.has_content()) {
     // tag filter exists
     if (req_tags) {
       // tags in the request

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -25,18 +25,21 @@ struct rgw_pubsub_topic_filter;
         <FilterRule>
           <Name>suffix</Name>
           <Value>jpg</Value>
+          <Type></Type>
         </FilterRule>
       </S3Key>
       <S3Metadata>
         <FilterRule>
           <Name></Name>
           <Value></Value>
+          <Type></Type>
         </FilterRule>
       </S3Metadata>
       <S3Tags>
         <FilterRule>
           <Name></Name>
           <Value></Value>
+          <Type></Type>
         </FilterRule>
       </S3Tags>
     </Filter>

--- a/src/rgw/rgw_s3_filter.cc
+++ b/src/rgw/rgw_s3_filter.cc
@@ -19,18 +19,21 @@ void rgw_s3_key_filter::dump(Formatter *f) const {
     f->open_object_section("");
     ::encode_json("Name", "prefix", f);
     ::encode_json("Value", prefix_rule, f);
+    ::encode_json("Type", is_prefix_negative == true ? "OUT" : "IN", f);
     f->close_section();
   }
   if (!suffix_rule.empty()) {
     f->open_object_section("");
     ::encode_json("Name", "suffix", f);
     ::encode_json("Value", suffix_rule, f);
+    ::encode_json("Type", is_suffix_negative == true ? "OUT" : "IN", f);
     f->close_section();
   }
   if (!regex_rule.empty()) {
     f->open_object_section("");
     ::encode_json("Name", "regex", f);
     ::encode_json("Value", regex_rule, f);
+    ::encode_json("Type", is_regex_negative == true ? "OUT" : "IN", f);
     f->close_section();
   }
   f->close_section();
@@ -45,18 +48,28 @@ bool rgw_s3_key_filter::decode_xml(XMLObj* obj) {
   auto suffix_not_set = true;
   auto regex_not_set = true;
   std::string name;
+  std::string type; 
 
   while ((o = iter.get_next())) {
-    RGWXMLDecoder::decode_xml("Name", name, o, throw_if_missing);
+    RGWXMLDecoder::decode_xml("Name", name, o, throw_if_missing); 
     if (name == "prefix" && prefix_not_set) {
       prefix_not_set = false;
       RGWXMLDecoder::decode_xml("Value", prefix_rule, o, throw_if_missing);
+      if(RGWXMLDecoder::decode_xml("Type", type, o, !throw_if_missing)) {
+        is_prefix_negative = type == "OUT" ? true : false;
+      }
     } else if (name == "suffix" && suffix_not_set) {
       suffix_not_set = false;
       RGWXMLDecoder::decode_xml("Value", suffix_rule, o, throw_if_missing);
+      if(RGWXMLDecoder::decode_xml("Type", type, o, !throw_if_missing)) {
+        is_suffix_negative = type == "OUT" ? true : false;
+      }
     } else if (name == "regex" && regex_not_set) {
       regex_not_set = false;
       RGWXMLDecoder::decode_xml("Value", regex_rule, o, throw_if_missing);
+      if(RGWXMLDecoder::decode_xml("Type", type, o, !throw_if_missing)) {
+        is_regex_negative = type == "OUT" ? true : false;
+      }
     } else {
       throw RGWXMLDecoder::err("invalid/duplicate S3Key filter rule name: '" + name + "'");
     }
@@ -69,18 +82,21 @@ void rgw_s3_key_filter::dump_xml(Formatter *f) const {
     f->open_object_section("FilterRule");
     ::encode_xml("Name", "prefix", f);
     ::encode_xml("Value", prefix_rule, f);
+    ::encode_xml("Type",  is_prefix_negative == true ? "OUT" : "IN", f); 
     f->close_section();
   }
   if (!suffix_rule.empty()) {
     f->open_object_section("FilterRule");
     ::encode_xml("Name", "suffix", f);
     ::encode_xml("Value", suffix_rule, f);
+    ::encode_xml("Type", is_suffix_negative == true ? "OUT" : "IN", f); 
     f->close_section();
   }
   if (!regex_rule.empty()) {
     f->open_object_section("FilterRule");
     ::encode_xml("Name", "regex", f);
     ::encode_xml("Value", regex_rule, f);
+    ::encode_xml("Type", is_regex_negative == true ? "OUT" : "IN", f); 
     f->close_section();
   }
 }
@@ -94,17 +110,18 @@ void rgw_s3_key_value_filter::dump(Formatter *f) const {
     return;
   }
   f->open_array_section("FilterRules");
-  for (const auto& key_value : kv) {
+  for (const auto& key_value_type : kvt) {
     f->open_object_section("");
-    ::encode_json("Name", key_value.first, f);
-    ::encode_json("Value", key_value.second, f);
+    ::encode_json("Name", key_value_type.first, f);
+    ::encode_json("Value", key_value_type.second.first, f);
+    ::encode_json("Type", key_value_type.second.second == true ? "OUT" : "IN", f);
     f->close_section();
   }
   f->close_section();
 }
 
 bool rgw_s3_key_value_filter::decode_xml(XMLObj* obj) {
-  kv.clear();
+  kvt.clear();
   XMLObjIter iter = obj->find("FilterRule");
   XMLObj *o;
 
@@ -112,26 +129,33 @@ bool rgw_s3_key_value_filter::decode_xml(XMLObj* obj) {
 
   std::string key;
   std::string value;
+  std::string type;
+  bool is_negative; 
 
   while ((o = iter.get_next())) {
+    is_negative = false;
     RGWXMLDecoder::decode_xml("Name", key, o, throw_if_missing);
     RGWXMLDecoder::decode_xml("Value", value, o, throw_if_missing);
-    kv.emplace(key, value);
+    if(RGWXMLDecoder::decode_xml("Type", type, o, !throw_if_missing)) {
+      is_negative = type == "IN" ? false : true;
+    }
+    kvt.emplace(key, std::make_pair(value, is_negative));
   }
   return true;
 }
 
 void rgw_s3_key_value_filter::dump_xml(Formatter *f) const {
-  for (const auto& key_value : kv) {
+  for (const auto& key_value_type : kvt) {
     f->open_object_section("FilterRule");
-    ::encode_xml("Name", key_value.first, f);
-    ::encode_xml("Value", key_value.second, f);
+    ::encode_xml("Name", key_value_type.first, f);
+    ::encode_xml("Value", key_value_type.second.first, f);
+    ::encode_xml("Type", key_value_type.second.second == true ? "OUT" : "IN", f);
     f->close_section();
   }
 }
 
 bool rgw_s3_key_value_filter::has_content() const {
-  return !kv.empty();
+  return !kvt.empty();
 }
 
 void rgw_s3_filter::dump(Formatter *f) const {
@@ -170,29 +194,48 @@ bool match(const rgw_s3_key_filter& filter, const std::string& key) {
   const auto prefix_size = filter.prefix_rule.size();
   if (prefix_size != 0) {
     // prefix rule exists
+    bool is_negative = filter.is_prefix_negative == true;
     if (prefix_size > key_size) {
-      // if prefix is longer than key, we fail
-      return false;
+      // if prefix is longer than key, we fail if filter is positive, else continue
+      if(!is_negative) {
+        return false; 
+      }
     }
-    if (!std::equal(filter.prefix_rule.begin(), filter.prefix_rule.end(), key.begin())) {
-      return false;
+    // if prefix does not match, and if filter is positive, we fail or
+    // if prefix matches but filter is negative, we fail
+    // else continue
+    bool does_prefix_match = std::equal(filter.prefix_rule.begin(), filter.prefix_rule.end(), key.begin()); 
+    if (!(is_negative ^ does_prefix_match)) {
+      return false; 
     }
   }
   const auto suffix_size = filter.suffix_rule.size();
   if (suffix_size != 0) {
     // suffix rule exists
+    bool is_negative = filter.is_suffix_negative == true;
     if (suffix_size > key_size) {
-      // if suffix is longer than key, we fail
-      return false;
+      // if suffix is longer than key, we fail if filter is positive, else continue
+      if(!is_negative) {
+        return false; 
+      }
     }
-    if (!std::equal(filter.suffix_rule.begin(), filter.suffix_rule.end(), (key.end() - suffix_size))) {
+    // if suffix does not match, and if filter is positive, we fail or
+    // if suffix matches but filter is negative, we fail
+    // else continue
+    bool does_suffix_match = std::equal(filter.suffix_rule.begin(), filter.suffix_rule.end(), (key.end() - suffix_size));
+    if (!(is_negative ^ does_suffix_match)) {
       return false;
     }
   }
   if (!filter.regex_rule.empty()) {
     // TODO add regex caching in the filter
     const std::regex base_regex(filter.regex_rule);
-    if (!std::regex_match(key, base_regex)) {
+    // if regex does not match, and if filter is positive, we fail or
+    // if regex matches but filter is negative, we fail
+    // else continue
+    bool is_negative = filter.is_regex_negative == true; 
+    bool does_regex_match = std::regex_match(key, base_regex); 
+    if (!(is_negative ^ does_regex_match)) {
       return false;
     }
   }
@@ -201,19 +244,29 @@ bool match(const rgw_s3_key_filter& filter, const std::string& key) {
 
 bool match(const rgw_s3_key_value_filter& filter, const KeyValueMap& kv) {
   // all filter pairs must exist with the same value in the object's metadata/tags
-  // object metadata/tags may include items not in the filter
-  return std::includes(kv.begin(), kv.end(), filter.kv.begin(), filter.kv.end());
+  // object metadata/tags may include items not in the filter 
+  return std::all_of(filter.kvt.begin(), filter.kvt.end(), [&](const auto& p){ 
+    bool is_negative = p.second.second; 
+    auto it = kv.find(p.first);
+    bool match_negative = it == kv.end() || it->second != p.second.first; 
+    bool match_positive = it != kv.end() && it->second == p.second.first;
+    return is_negative ? match_negative : match_positive;
+  });
 }
 
 bool match(const rgw_s3_key_value_filter& filter, const KeyMultiValueMap& kv) {
   // all filter pairs must exist with the same value in the object's metadata/tags
   // object metadata/tags may include items not in the filter
-  for (auto& filter : filter.kv) {
+  for (auto& filter : filter.kvt) {
     auto result = kv.equal_range(filter.first);
-    if (std::any_of(result.first, result.second, [&filter](const std::pair<std::string, std::string>& p) { return p.second == filter.second;}))
-      continue;
-    else
+    bool is_negative = filter.second.second;
+    // For negative filters, all values must NOT match filter.second.first
+    // For positive filters, at least one value must match filter.second.first
+    bool match_negative = std::all_of(result.first, result.second, [&filter](const std::pair<std::string, std::string>&p){ return p.second != filter.second.first;}); 
+    bool match_positive = std::any_of(result.first, result.second, [&filter](const std::pair<std::string, std::string>&p){ return p.second == filter.second.first;});
+    if(is_negative && !match_negative || !is_negative && !match_positive) {
       return false;
+    }
   }
   return true;
 }
@@ -228,7 +281,7 @@ bool match(const rgw_s3_filter& s3_filter, const rgw::sal::Object* obj) {
   }
 
   const auto &attrs = obj->get_attrs();
-  if (!s3_filter.metadata_filter.kv.empty()) {
+  if (s3_filter.metadata_filter.has_content()) {
     KeyValueMap attrs_map;
     for (auto& attr : attrs) {
       if (boost::algorithm::starts_with(attr.first, RGW_ATTR_META_PREFIX)) {
@@ -244,7 +297,7 @@ bool match(const rgw_s3_filter& s3_filter, const rgw::sal::Object* obj) {
     }
   }
 
-  if (!s3_filter.tag_filter.kv.empty()) {
+  if (s3_filter.tag_filter.has_content()) {
     // tag filter exists
     // try to fetch tags from the attributes
     KeyMultiValueMap tags;

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -8,6 +8,7 @@ import socket
 import time
 import os
 import io
+import re
 import string
 # XXX this should be converted to use boto3
 import boto
@@ -2481,6 +2482,271 @@ def test_metadata_filter_ampq():
     """ test notification of filtering metadata, ampq endpoint """
     conn = connection()
     metadata_filter('amqp', conn)
+
+def metadata_negative_filter(endpoint_type, conn):
+    """ test notification of filtering metadata, negative test """
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = conn.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+
+    # start endpoint receiver
+    host = get_ip()
+    task = None
+    port = None
+    if endpoint_type == 'http':
+        # create random port for the http server
+        port = random.randint(10000, 20000)
+        # start an http server in a separate thread
+        receiver = HTTPServerWithEvents((host, port))
+        endpoint_address = 'http://'+host+':'+str(port)
+        endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    elif endpoint_type == 'kafka':
+        # start kafka receiver
+        task, receiver = create_kafka_receiver_thread(topic_name)
+        task.start()
+        endpoint_address = 'kafka://' + host
+        endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'
+    else:
+        return SkipTest('Unknown endpoint type: ' + endpoint_type)
+
+    # create s3 topic
+    zonegroup = get_config_zonegroup()
+    topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
+    # create s3 notification check meta data filter
+    notification_name = bucket_name + NOTIFICATION_SUFFIX + '_in'
+    meta_key_1= 'meta1'
+    meta_value_1 = 'This is my metadata value'
+    meta_key_2 = 'meta2'
+    meta_value_2 = 'kaboom'
+    topic_conf_list = [{'Id': notification_name, 'TopicArn': topic_arn,
+        'Events': ['s3:ObjectCreated:*', 's3:ObjectRemoved:*'],
+        'Filter': {
+            'Metadata': {
+                'FilterRules': [{'Name': META_PREFIX+meta_key_1, 'Value': meta_value_1, 'Type': 'OUT'}, {'Name': META_PREFIX+meta_key_2, 'Value': meta_value_2, 'Type': 'IN'}]
+            }
+        }
+    }]
+
+    s3_notification_conf = PSNotificationS3(conn, bucket_name, topic_conf_list)
+    _, status = s3_notification_conf.set_config()
+    assert_equal(status/100, 2)
+
+    expected_keys = []
+    # create objects in the bucket
+    key_name = 'foo'
+    key = bucket.new_key(key_name)
+    key.set_metadata(meta_key_1, "abccdef")
+    key.set_metadata(meta_key_2, meta_value_2)
+    key.set_contents_from_string('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    expected_keys.append(key_name)
+
+    # create objects in the bucket using COPY
+    key_name = 'copy_of_foo'
+    bucket.copy_key(key_name, bucket.name, key.name)
+    expected_keys.append(key_name)
+
+    # create another objects in the bucket using COPY
+    # but override the metadata value
+    key_name = 'another_copy_of_foo'
+    bucket.copy_key(key_name, bucket.name, key.name, metadata={meta_key_1: meta_value_1})
+    # this key is not in the expected keys due to the different meta value
+
+    # create objects in the bucket using multi-part upload
+    fp = tempfile.NamedTemporaryFile(mode='w+b')
+    chunk_size = 1024*1024*5 # 5MB
+    object_size = 10*chunk_size
+    content = bytearray(os.urandom(object_size))
+    fp.write(content)
+    fp.flush()
+    fp.seek(0)
+    key_name = 'multipart_foo'
+    uploader = bucket.initiate_multipart_upload(key_name,
+            metadata={meta_key_2: 'kaboom', meta_key_1: 'abcdef'})
+    for i in range(1,5):
+        uploader.upload_part_from_file(fp, i, size=chunk_size)
+        fp.seek(i*chunk_size)
+    uploader.complete_upload()
+    fp.close()
+    expected_keys.append(key_name)
+
+    print('wait for the messages...')
+    time.sleep(5)
+    wait_for_queue_to_drain(topic_name, http_port=port)
+    # check amqp receiver
+    events = receiver.get_and_reset_events()
+    assert_equal(len(events), len(expected_keys))
+    for event in events:
+        assert(event['Records'][0]['s3']['object']['key'] in expected_keys)
+
+    # delete objects
+    for key in bucket.list():
+        key.delete()
+    print('wait for the messages...')
+    wait_for_queue_to_drain(topic_name, http_port=port)
+    # check endpoint receiver
+    events = receiver.get_and_reset_events()
+    assert_equal(len(events), len(expected_keys))
+    for event in events:
+        assert(event['Records'][0]['s3']['object']['key'] in expected_keys)
+
+    # cleanup
+    receiver.close(task)
+    s3_notification_conf.del_config()
+    topic_conf.del_config()
+    # delete the bucket
+    conn.delete_bucket(bucket_name)
+
+def key_negative_filter(endpoint_type, conn):
+    """ test notification of filtering metadata, negative test """
+    # create bucket
+    bucket_name = gen_bucket_name()
+    bucket = conn.create_bucket(bucket_name)
+    topic_name = bucket_name + TOPIC_SUFFIX
+
+    # start endpoint receiver
+    host = get_ip()
+    task = None
+    port = None
+    if endpoint_type == 'http':
+        # create random port for the http server
+        port = random.randint(10000, 20000)
+        # start an http server in a separate thread
+        receiver = HTTPServerWithEvents((host, port))
+        endpoint_address = 'http://'+host+':'+str(port)
+        endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'
+    elif endpoint_type == 'kafka':
+        # start kafka receiver
+        task, receiver = create_kafka_receiver_thread(topic_name)
+        task.start()
+        endpoint_address = 'kafka://' + host
+        endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'
+    else:
+        return SkipTest('Unknown endpoint type: ' + endpoint_type)
+
+    # create s3 topic
+    zonegroup = get_config_zonegroup()
+    topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
+    
+    # create s3 notification
+    notification_name = bucket_name + NOTIFICATION_SUFFIX
+    topic_conf_list = [{'Id': notification_name+'_1',
+                        'TopicArn': topic_arn,
+                        'Events': ['s3:ObjectCreated:*'],
+                        'Filter': {
+                          'Key': {
+                            'FilterRules': [{'Name': 'prefix', 'Value': 'hello', 'Type': 'OUT'}]
+                          }
+                        }
+                       },
+                       {'Id': notification_name+'_2',
+                        'TopicArn': topic_arn,
+                        'Events': ['s3:ObjectCreated:*'],
+                        'Filter': {
+                          'Key': {
+                            'FilterRules': [{'Name': 'suffix', 'Value': 'log', 'Type': 'OUT'}, {'Name': 'prefix', 'Value': 'world', 'Type': 'IN'}]
+                          }
+                        }
+                       },
+                       {'Id': notification_name+'_3',
+                        'TopicArn': topic_arn,
+                        'Events': [],
+                        'Filter': {
+                          'Key': {
+                            'FilterRules': [{'Name': 'regex', 'Value': '([a-z]+)\\.txt', 'Type': 'OUT'}]
+                         }
+                        }
+                       }]
+
+    s3_notification_conf = PSNotificationS3(conn, bucket_name, topic_conf_list)
+    result, status = s3_notification_conf.set_config()
+    assert_equal(status/100, 2)
+
+    # get all notifications
+    result, status = s3_notification_conf.get_config()
+    assert_equal(status/100, 2)
+    for conf in result['TopicConfigurations']:
+        filter_name = conf['Filter']['Key']['FilterRules'][0]['Name']
+        assert filter_name == 'prefix' or filter_name == 'suffix' or filter_name == 'regex', filter_name
+
+    sample_space = ['hello.kaboom', 'hello.txt', 'hello123.txt', 'hello', 'world1.log', 'world2log', 'world3.log', 'hello.txt', 'hell.txt', 'worldlog.txt', 'kaboom.log', 'foobar.log', 'log', 'he123ll.txt', 'wo', 'h', 'txt', 'world.log.txt']
+    expected_in1 = [key for key in sample_space if key.startswith('hello') is False]
+    expected_in2 = [key for key in sample_space if key.endswith('log') is False and key.startswith('world') is True]
+    expected_in3 = [key for key in sample_space if re.match(r'([a-z]+)\.txt', key) is None]
+
+    # create objects in bucket
+    for key_name in sample_space:
+        key = bucket.new_key(key_name)
+        key.set_contents_from_string('bar')
+
+    print('wait for 5sec for the messages...')
+    time.sleep(5)
+
+    found_in1 = []
+    found_in2 = []
+    found_in3 = []
+
+    print('wait for the messages...')
+    # check kafka or http receiver
+    wait_for_queue_to_drain(topic_name, http_port=port)
+    events = receiver.get_and_reset_events()
+
+    for event in events:
+        notif_id = event['Records'][0]['s3']['configurationId']
+        key_name = event['Records'][0]['s3']['object']['key']
+        awsRegion = event['Records'][0]['awsRegion']
+        assert_equal(awsRegion, zonegroup)
+        bucket_arn = event['Records'][0]['s3']['bucket']['arn']
+        assert_equal(bucket_arn, "arn:aws:s3:"+awsRegion+"::"+bucket_name)
+        if notif_id == notification_name+'_1':
+            found_in1.append(key_name)
+        elif notif_id == notification_name+'_2':
+            found_in2.append(key_name)
+        elif notif_id == notification_name+'_3':
+            found_in3.append(key_name)
+        else:
+            assert False, 'invalid notification: ' + notif_id
+
+    assert_equal(set(found_in1), set(expected_in1))
+    assert_equal(set(found_in2), set(expected_in2))
+    assert_equal(set(found_in3), set(expected_in3))
+
+     # delete objects
+    for key in bucket.list():
+        key.delete()
+    
+    # cleanup
+    receiver.close(task)
+    s3_notification_conf.del_config()
+    topic_conf.del_config()
+    # delete the bucket
+    conn.delete_bucket(bucket_name)
+
+@attr('kafka_test')
+def test_negative_metadata_filter_kafka():
+    """ test notification of negative filter for metadata, kafka endpoint """
+    conn = connection()
+    metadata_negative_filter('kafka', conn)
+
+@attr('kafka_test')
+def test_negative_key_filter_kafka():
+    """ test notification of negative filter for object key, kafka endpoint """
+    conn = connection()
+    key_negative_filter('kafka', conn)
+
+@attr('http_test')
+def test_negative_metadata_filter_http():
+    """ test notification of negative filter for metadata, http endpoint """
+    conn = connection()
+    metadata_negative_filter('http', conn)
+
+@attr('http_test')
+def test_negative_key_filter_http():
+    """ test notification of negative filter for object key, http endpoint """
+    conn = connection()
+    key_negative_filter('http', conn)
 
 
 @attr('amqp_test')


### PR DESCRIPTION
Changes introduced:
- extended filter rule structs - key struct and key value struct to hold a boolean flag called negative_filter to diff. b/w the two modes
- modified base match functions, encode, decode, functions to accomodate this change

Fixes: https://tracker.ceph.com/issues/68788
Signed-off-by: Adarsh Ashokan <dev.9401adarsh@gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
