### PR TITLE
reef: mgr/dashboard: disable deleting bucket with objects

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -117,10 +117,20 @@ export class RgwBucketListComponent extends ListWithDetails implements OnInit, O
       permission: 'delete',
       icon: Icons.destroy,
       click: () => this.deleteAction(),
+      disable: () => this.isDeleteDisabled(),
       name: this.actionLabels.DELETE
     };
     this.tableActions = [addAction, editAction, deleteAction];
     this.setTableRefreshTimeout();
+  }
+
+  isDeleteDisabled(): boolean | string {
+    if (!this.selection.first()) {
+      return true;
+    }
+    return this.selection.first()?.num_objects > 0
+      ? $localize`Bucket is not empty. Remove all objects before deletion.`
+      : false;
   }
 
   getBucketList(context: CdTableFetchDataContext) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -97,19 +97,9 @@ describe('RgwBucketService', () => {
     expect(req.request.method).toBe('PUT');
   });
 
-  it('should call delete, with purgeObjects = true', () => {
+  it('should call delete', () => {
     service.delete('foo').subscribe();
-    const req = httpTesting.expectOne(
-      `api/rgw/bucket/foo?${RgwHelper.DAEMON_QUERY_PARAM}&purge_objects=true`
-    );
-    expect(req.request.method).toBe('DELETE');
-  });
-
-  it('should call delete, with purgeObjects = false', () => {
-    service.delete('foo', false).subscribe();
-    const req = httpTesting.expectOne(
-      `api/rgw/bucket/foo?${RgwHelper.DAEMON_QUERY_PARAM}&purge_objects=false`
-    );
+    const req = httpTesting.expectOne(`api/rgw/bucket/foo?${RgwHelper.DAEMON_QUERY_PARAM}`);
     expect(req.request.method).toBe('DELETE');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -184,9 +184,8 @@ export class RgwBucketService extends ApiClient {
     });
   }
 
-  delete(bucket: string, purgeObjects = true) {
+  delete(bucket: string) {
     return this.rgwDaemonService.request((params: HttpParams) => {
-      params = params.append('purge_objects', purgeObjects ? 'true' : 'false');
       return this.http.delete(`${this.url}/${bucket}`, { params: params });
     });
   }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9759,11 +9759,6 @@ paths:
         required: true
         schema:
           type: string
-      - default: 'true'
-        in: query
-        name: purge_objects
-        schema:
-          type: string
       - allowEmptyValue: true
         in: query
         name: daemon_name


### PR DESCRIPTION
NOTE:
===
Considering only single selection would be there for buckets with this https://github.com/ceph/ceph/pull/61961, so multiselection flows should be ignored while testing this PR

backport tracker: https://tracker.ceph.com/issues/70122
backport of: https://github.com/ceph/ceph/pull/61899
parent tracker: https://tracker.ceph.com/issues/70078
<hr  style="2px solid #eeeeee"/>
Fixes: https://tracker.ceph.com/issues/70078

Signed-off-by: Naman Munet <naman.munet@ibm.com>
(cherry picked from commit 11677c29ee6ee60d9191edfdbfbe37b5308eb45e)

 Conflicts:
	src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts



https://github.com/user-attachments/assets/8e21352b-4af3-4f80-ba12-dc78c6a99cf3




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
