### PR TITLE
squid: mds: dump next_snap when checking dentry corruption

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -717,7 +717,7 @@ bool CDentry::check_corruption(bool load)
       dout(1) << "loaded already corrupt dentry: " << *this << dendl;
       corrupt_first_loaded = true;
     } else {
-      derr << "newly corrupt dentry to be committed: " << *this << dendl;
+      derr << "newly corrupt dentry to be committed: " << *this << " with next_snap: " << next_snap << dendl;
     }
     if (g_conf().get_val<bool>("mds_go_bad_corrupt_dentry")) {
       dir->go_bad_dentry(last, get_name());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70065

---

backport of https://github.com/ceph/ceph/pull/59504
parent tracker: https://tracker.ceph.com/issues/67770

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh