### PR TITLE
doc/rgw: clarify path-style vs virtual-hosted-style access

### DIFF
--- a/doc/radosgw/s3/commons.rst
+++ b/doc/radosgw/s3/commons.rst
@@ -7,19 +7,19 @@
 
 Bucket and Host Name
 --------------------
-There are two different modes of accessing buckets. The first method identifies
-the bucket as the top-level directory in the URI::
+There are two different modes of accessing buckets: path-style and virtual-hosted-style.
+Path-style requests identify the bucket as the top-level directory of the request's path::
 
 	GET /mybucket HTTP/1.1
 	Host: cname.domain.com
 
-Most S3 clients nowadays rely on vhost-style access. The desired bucket is
-indicated by a DNS FQDN. For example::
+Most S3 clients default to virtual-hosted-style access, where the bucket name is instead
+indicated as part of the fully-qualified domain name::
 
 	GET / HTTP/1.1
 	Host: mybucket.cname.domain.com
 
-The second method is deprecated by AWS. See the `Amazon S3 Path Deprecation
+Path-style access is deprecated by AWS. See the `Amazon S3 Path Deprecation
 Plan`_ for more information.
 
 To configure virtual hosted buckets, you can either set ``rgw_dns_name =


### PR DESCRIPTION
instead of referring to "vhost-style", copy the "path-style" and "virtual-hosted-style" language from https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html

expand the FQDN acronym to avoid potential confusion

"The second method is deprecated by AWS" had incorrectly referred to the vhost-style method - clarify that it refers to path-style access

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
