### PR TITLE
squid: doc/rgw: clarify path-style vs virtual-hosted-style access

### DIFF
--- a/doc/radosgw/s3/commons.rst
+++ b/doc/radosgw/s3/commons.rst
@@ -7,19 +7,19 @@
 
 Bucket and Host Name
 --------------------
-There are two different modes of accessing buckets. The first method identifies
-the bucket as the top-level directory in the URI::
+There are two different modes of accessing buckets: path-style and virtual-hosted-style.
+Path-style requests identify the bucket as the top-level directory of the request's path::
 
 	GET /mybucket HTTP/1.1
 	Host: cname.domain.com
 
-Most S3 clients nowadays rely on vhost-style access. The desired bucket is
-indicated by a DNS FQDN. For example::
+Most S3 clients default to virtual-hosted-style access, where the bucket name is instead
+indicated as part of the fully-qualified domain name::
 
 	GET / HTTP/1.1
 	Host: mybucket.cname.domain.com
 
-The second method is deprecated by AWS. See the `Amazon S3 Path Deprecation
+Path-style access is deprecated by AWS. See the `Amazon S3 Path Deprecation
 Plan`_ for more information.
 
 To configure virtual hosted buckets, you can either set ``rgw_dns_name =


### PR DESCRIPTION
instead of referring to "vhost-style", copy the "path-style" and "virtual-hosted-style" language from https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html

expand the FQDN acronym to avoid potential confusion

"The second method is deprecated by AWS" had incorrectly referred to the vhost-style method - clarify that it refers to path-style access

Signed-off-by: Casey Bodley <cbodley@redhat.com>
(cherry picked from commit c61c314ed6482cc26cf69ed7e2af4af20bebd676)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
