### PR TITLE
os/bluestore: write_v2 resharding misplaced

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -17656,9 +17656,13 @@ int BlueStore::_do_write_v2(
   BlueStore::Writer wr(this, txc, &wctx, o);
   uint64_t start = p2align(offset, min_alloc_size);
   uint64_t end = p2roundup(offset + length, min_alloc_size);
+  wr.left_affected_range = start;
+  wr.right_affected_range = end;
   std::tie(wr.left_shard_bound, wr.right_shard_bound) =
     o->extent_map.fault_range_ex(db, start, end - start);
   wr.do_write(offset, bl);
+  o->extent_map.dirty_range(wr.left_affected_range, wr.right_affected_range - wr.left_affected_range);
+  o->extent_map.maybe_reshard(wr.left_affected_range, wr.right_affected_range);
   return r;
 }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1149,6 +1149,16 @@ public:
     /// ensure that a range of the map is loaded
     void fault_range(KeyValueDB *db,
 		     uint32_t offset, uint32_t length);
+    /// ensure that a range of the map is loaded
+    /// return range that is encompassed by affected shards
+    std::pair<uint32_t, uint32_t> fault_range_ex(
+      KeyValueDB *db,
+      uint32_t offset,
+      uint32_t length);
+    void maybe_load_shard(
+      KeyValueDB *db,
+      int begin_shard,
+      int end_shard);
 
     /// ensure a range of the map is marked dirty
     void dirty_range(uint32_t offset, uint32_t length);

--- a/src/os/bluestore/Writer.cc
+++ b/src/os/bluestore/Writer.cc
@@ -732,6 +732,7 @@ void BlueStore::Writer::_try_reuse_allocated_l(
   blob_data_t& bd)            // modified when consumed
 {
   uint32_t search_stop = p2align(logical_offset, (uint32_t)wctx->target_blob_size);
+  search_stop = std::max(left_shard_bound, search_stop);
   uint32_t au_size = bstore->min_alloc_size;
   uint32_t block_size = bstore->block_size;
   ceph_assert(!bd.is_compressed());
@@ -812,6 +813,7 @@ void BlueStore::Writer::_try_reuse_allocated_r(
   uint32_t block_size = bstore->block_size;
   uint32_t blob_size = wctx->target_blob_size;
   uint32_t search_end = p2roundup(end_offset, blob_size);
+  search_end = std::min(right_shard_bound, search_end);
   ceph_assert(!bd.is_compressed());
   ceph_assert(p2phase<uint32_t>(end_offset, au_size) != 0);
   BlueStore::ExtentMap& emap = onode->extent_map;

--- a/src/os/bluestore/Writer.h
+++ b/src/os/bluestore/Writer.h
@@ -50,7 +50,8 @@ public:
     virtual bufferlist read(uint32_t object_offset, uint32_t object_length) = 0;
   };
   Writer(BlueStore* bstore, TransContext* txc, WriteContext* wctx, OnodeRef o)
-    :bstore(bstore), txc(txc), wctx(wctx), onode(o) {
+    :left_shard_bound(0), right_shard_bound(OBJECT_MAX_SIZE)
+    , bstore(bstore), txc(txc), wctx(wctx), onode(o) {
       pp_mode = debug_level_to_pp_mode(bstore->cct);
     }
 public:
@@ -67,6 +68,8 @@ public:
   read_divertor* test_read_divertor = nullptr;
   std::vector<BlobRef> pruned_blobs;
   volatile_statfs statfs_delta;
+  uint32_t left_shard_bound;  // if sharding is in effect,
+  uint32_t right_shard_bound; // do not cross this line
 
 private:
   BlueStore* bstore;

--- a/src/os/bluestore/Writer.h
+++ b/src/os/bluestore/Writer.h
@@ -143,8 +143,13 @@ private:
   void _align_to_disk_block(
     uint32_t& location,
     uint32_t& ref_end,
-    blob_vec& blobs
-  );
+    blob_vec& blobs);
+
+  void _place_extent_in_blob(
+    Extent* target,
+    uint32_t map_begin,
+    uint32_t map_end,
+    uint32_t in_blob_offset);
 
   inline void _blob_put_data_subau(
     Blob* blob,

--- a/src/os/bluestore/Writer.h
+++ b/src/os/bluestore/Writer.h
@@ -70,7 +70,8 @@ public:
   volatile_statfs statfs_delta;
   uint32_t left_shard_bound;  // if sharding is in effect,
   uint32_t right_shard_bound; // do not cross this line
-
+  uint32_t left_affected_range;
+  uint32_t right_affected_range;
 private:
   BlueStore* bstore;
   TransContext* txc;

--- a/src/os/bluestore/Writer.h
+++ b/src/os/bluestore/Writer.h
@@ -152,6 +152,8 @@ private:
     uint32_t map_end,
     uint32_t in_blob_offset);
 
+  void _maybe_meld_with_prev_extent(exmp_it after_punch_it);
+
   inline void _blob_put_data_subau(
     Blob* blob,
     uint32_t in_blob_offset,

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -1004,10 +1004,14 @@ public:
   void add_tail(uint32_t new_len) {
     ceph_assert(!has_unused());
     ceph_assert(new_len > logical_length);
-    extents.emplace_back(
-      bluestore_pextent_t(
-        bluestore_pextent_t::INVALID_OFFSET,
-        new_len - logical_length));
+    if (extents.size() == 0 || extents.back().is_valid()) {
+      extents.emplace_back(
+        bluestore_pextent_t(
+          bluestore_pextent_t::INVALID_OFFSET,
+          new_len - logical_length));
+    } else {
+      extents.back().length += new_len - logical_length;
+    }
     logical_length = new_len;
     if (has_csum()) {
       ceph::buffer::ptr t;


### PR DESCRIPTION
We should mark dirty and signal for reshard region before we trim the data by _try_reuse_allocated.
Punching hole and writing to already existing blobs is still modification.

The problem was detected using:
`./bin/ceph_test_objectstore --log-to-stderr=false --bluestore_write_v2=true --plugin_dir=./lib --gtest_filter=\*SyntheticMatrixShardingLimited\*`

Problem was introduced in #61762

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
