### PR TITLE
test/test_not_before_queue: fix Signed-vs-Unsigned warnings

### DIFF
--- a/src/test/test_not_before_queue.cc
+++ b/src/test/test_not_before_queue.cc
@@ -216,15 +216,15 @@ TEST_F(NotBeforeTest, RemoveIfByClass_no_cond) {
   // removing less than / more than available matches
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  17, [](const tv_t &v) { return true; }, 1),
+	  17U, [](const tv_t &v) { return true; }, 1),
       1);
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  17, [](const tv_t &v) { return true; }, 10),
+	  17U, [](const tv_t &v) { return true; }, 10),
       3);
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  57, [](const tv_t &v) { return v.ordering_value == 41; }),
+	  57U, [](const tv_t &v) { return v.ordering_value == 41; }),
       3);
 }
 
@@ -237,17 +237,17 @@ TEST_F(NotBeforeTest, RemoveIfByClass_with_cond) {
   // rm from both eligible and non-eligible
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  57, [](const tv_t &v) { return v.ordering_value == 43; }),
+	  57U, [](const tv_t &v) { return v.ordering_value == 43; }),
       3);
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  53, [](const tv_t &v) { return v.ordering_value == 44; }),
+	  53U, [](const tv_t &v) { return v.ordering_value == 44; }),
       2);
 
   ASSERT_EQ(queue.total_count(), 17);
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  57, [](const tv_t &v) { return v.ordering_value > 10; }, 20),
+	  57U, [](const tv_t &v) { return v.ordering_value > 10; }, 20),
       5);
 }
 


### PR DESCRIPTION
Silencing
```
/mnt/igor/github/salieri11/ceph/src/common/not_before_queue.h:134:18: error: comparison of integer expressions of different signedness: 'const int' and 'const unsigned int' [-Werror=sign-compare]
  134 |       return lhs < project_removal_class(rhs.v);
      |              ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

Fixes: https://tracker.ceph.com/issues/69525