### PR TITLE
squid: mgr/dashboard: Add additional NVME API endpoints

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -50,6 +50,76 @@ else:
                 logger.error('Failed to fetch the gateway groups: %s', e)
                 return None
 
+        @ReadPermission
+        @Endpoint('GET', '/version')
+        @map_model(model.GatewayVersion)
+        @handle_nvmeof_error
+        def version(self, gw_group: Optional[str] = None):
+            gw_info = NVMeoFClient(gw_group=gw_group).stub.get_gateway_info(
+                NVMeoFClient.pb2.get_gateway_info_req()
+            )
+            return NVMeoFClient.pb2.gw_version(status=gw_info.status,
+                                               error_message=gw_info.error_message,
+                                               version=gw_info.version)
+
+        @ReadPermission
+        @Endpoint('GET', '/log_level')
+        @map_model(model.GatewayLogLevelInfo)
+        @handle_nvmeof_error
+        def get_log_level(self, gw_group: Optional[str] = None):
+            gw_log_level = NVMeoFClient(gw_group=gw_group).stub.get_gateway_log_level(
+                NVMeoFClient.pb2.get_gateway_log_level_req()
+            )
+            return gw_log_level
+
+        @ReadPermission
+        @Endpoint('PUT', '/log_level')
+        @map_model(model.RequestStatus)
+        @handle_nvmeof_error
+        def set_log_level(self, log_level: str, gw_group: Optional[str] = None):
+            log_level = log_level.lower()
+            gw_log_level = NVMeoFClient(gw_group=gw_group).stub.set_gateway_log_level(
+                NVMeoFClient.pb2.set_gateway_log_level_req(log_level=log_level)
+            )
+            return gw_log_level
+
+    @APIRouter("/nvmeof/spdk", Scope.NVME_OF)
+    @APIDoc("NVMe-oF SPDK Management API", "NVMe-oF SPDK")
+    class NVMeoFSpdk(RESTController):
+        @ReadPermission
+        @Endpoint('GET', '/log_level')
+        @map_model(model.SpdkNvmfLogFlagsAndLevelInfo)
+        @handle_nvmeof_error
+        def get_spdk_log_level(self, gw_group: Optional[str] = None):
+            spdk_log_level = NVMeoFClient(gw_group=gw_group).stub.get_spdk_nvmf_log_flags_and_level(
+                NVMeoFClient.pb2.get_spdk_nvmf_log_flags_and_level_req()
+            )
+            return spdk_log_level
+
+        @ReadPermission
+        @Endpoint('PUT', '/log_level')
+        @map_model(model.RequestStatus)
+        @handle_nvmeof_error
+        def set_spdk_log_level(self, log_level: Optional[str] = None,
+                               print_level: Optional[str] = None, gw_group: Optional[str] = None):
+            log_level = log_level.upper() if log_level else None
+            print_level = print_level.upper() if print_level else None
+            spdk_log_level = NVMeoFClient(gw_group=gw_group).stub.set_gateway_log_level(
+                NVMeoFClient.pb2.set_spdk_nvmf_logs_req(log_level=log_level,
+                                                        print_level=print_level)
+            )
+            return spdk_log_level
+
+        @ReadPermission
+        @Endpoint('PUT', '/log_level/disable')
+        @map_model(model.RequestStatus)
+        @handle_nvmeof_error
+        def disable_spdk_log_level(self, gw_group: Optional[str] = None):
+            spdk_log_level = NVMeoFClient(gw_group=gw_group).stub.disable_spdk_nvmf_logs(
+                NVMeoFClient.pb2.disable_spdk_nvmf_logs_req()
+            )
+            return spdk_log_level
+
     @APIRouter("/nvmeof/subsystem", Scope.NVME_OF)
     @APIDoc("NVMe-oF Subsystem Management API", "NVMe-oF Subsystem")
     class NVMeoFSubsystem(RESTController):

--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -12,6 +12,23 @@ class GatewayInfo(NamedTuple):
     spdk_version: Optional[str] = ""
 
 
+class GatewayVersion(NamedTuple):
+    version: str
+
+
+class GatewayLogLevelInfo(NamedTuple):
+    status: int
+    error_message: str
+    log_level: int
+
+
+class SpdkNvmfLogFlagsAndLevelInfo(NamedTuple):
+    status: int
+    error_message: str
+    log_level: int
+    log_print_level: int
+
+
 class Subsystem(NamedTuple):
     nqn: str
     enable_ha: bool
@@ -90,3 +107,8 @@ class Listener(NamedTuple):
 
 class Host(NamedTuple):
     nqn: str
+
+
+class RequestStatus(NamedTuple):
+    status: int
+    error_message: str

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -7871,6 +7871,198 @@ paths:
       - jwt: []
       tags:
       - NVMe-oF Gateway
+  /api/nvmeof/gateway/log_level:
+    get:
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: gw_group
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - NVMe-oF Gateway
+    put:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                gw_group:
+                  type: string
+                log_level:
+                  type: string
+              required:
+              - log_level
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '202':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - NVMe-oF Gateway
+  /api/nvmeof/gateway/version:
+    get:
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: gw_group
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - NVMe-oF Gateway
+  /api/nvmeof/spdk/log_level:
+    get:
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: gw_group
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - NVMe-oF SPDK
+    put:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                gw_group:
+                  type: string
+                log_level:
+                  type: string
+                print_level:
+                  type: string
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '202':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - NVMe-oF SPDK
+  /api/nvmeof/spdk/log_level/disable:
+    put:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                gw_group:
+                  type: string
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '202':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - NVMe-oF SPDK
   /api/nvmeof/subsystem:
     get:
       parameters:
@@ -14999,6 +15191,8 @@ tags:
   name: NFS-Ganesha
 - description: NVMe-oF Gateway Management API
   name: NVMe-oF Gateway
+- description: NVMe-oF SPDK Management API
+  name: NVMe-oF SPDK
 - description: NVMe-oF Subsystem Management API
   name: NVMe-oF Subsystem
 - description: NVMe-oF Subsystem Connection Management API


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70130

---

backport of https://github.com/ceph/ceph/pull/61545
parent tracker: https://tracker.ceph.com/issues/70126

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh