### PR TITLE
osd/scrub: tolerate non-monotonic scrub queue cutoff updates

### DIFF
--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -92,7 +92,15 @@ std::optional<Scrub::SchedEntry> ScrubQueue::pop_ready_entry(
   };
 
   std::unique_lock lck{jobs_lock};
-  to_scrub.advance_time(time_now);
+  if (!to_scrub.advance_time(time_now)) {
+    // the clock was not advanced
+    dout(5) << fmt::format(
+		   ": time now ({}) is earlier than the previous not-before "
+		   "cut-off time",
+		   time_now)
+	    << dendl;
+    // we still try to dequeue, mainly to handle possible corner cases
+  }
   return to_scrub.dequeue_by_pred(eligible_filtr);
 }
 

--- a/src/test/test_not_before_queue.cc
+++ b/src/test/test_not_before_queue.cc
@@ -111,7 +111,9 @@ TEST_F(NotBeforeTest, NotBefore) {
   ASSERT_EQ(queue.dequeue(), std::make_optional(e5));
   ASSERT_EQ(queue.dequeue(), std::nullopt);
 
-  queue.advance_time(1);
+  EXPECT_TRUE(queue.advance_time(1U));
+  // a 2'nd call using earlier time - should fail
+  EXPECT_FALSE(queue.advance_time(0U));
 
   EXPECT_EQ(queue.dequeue(), std::make_optional(e1));
   EXPECT_EQ(queue.dequeue(), std::make_optional(e2));
@@ -237,17 +239,17 @@ TEST_F(NotBeforeTest, RemoveIfByClass_with_cond) {
   // rm from both eligible and non-eligible
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  57, [](const tv_t &v) { return v.ordering_value == 43; }),
+	  57U, [](const tv_t &v) { return v.ordering_value == 43; }),
       3);
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  53, [](const tv_t &v) { return v.ordering_value == 44; }),
+	  53U, [](const tv_t &v) { return v.ordering_value == 44; }),
       2);
 
-  ASSERT_EQ(queue.total_count(), 17);
+  ASSERT_EQ(queue.total_count(), 17U);
   EXPECT_EQ(
       queue.remove_if_by_class(
-	  57, [](const tv_t &v) { return v.ordering_value > 10; }, 20),
+	  57U, [](const tv_t &v) { return v.ordering_value > 10; }, 20),
       5);
 }
 
@@ -294,14 +296,15 @@ TEST_F(NotBeforeTest, accumulate_1) {
   EXPECT_EQ(res_all, "abcdefgh");
 
   // set time to 20: the order changes: 2, 4, 1, 3
-  queue.advance_time(20);
+  EXPECT_TRUE(queue.advance_time(20));
+  EXPECT_FALSE(queue.advance_time(18));
   acc_just_elig = acc_just_elig_templ;
   res = queue.accumulate<std::string, decltype(acc_just_elig)>(
       std::move(acc_just_elig));
   EXPECT_EQ(res, "jpor");
 
   // at 35: 2, 4, 1, 7, 8, 3
-  queue.advance_time(35);
+  EXPECT_TRUE(queue.advance_time(35));
   acc_just_elig = acc_just_elig_templ;
   res = queue.accumulate<std::string, decltype(acc_just_elig)>(
       std::move(acc_just_elig));


### PR DESCRIPTION
The OSD's scrub queue uses a specialized container: not_before_queue_t.
The container maintains a cut-off point between "eligible" and "non-eligible" queue entries. In the
case of the scrub queue - the cutoff is based on the "Ceph clock".

The NBQ expects the cutoff updates to be monotonic-increasing. But the clock used by the
scrub queue may, in some rare cases, jump backwards a bit.
This PR modifies the NBQ to tolerate (and ignore) backward updates, and modifies the
scrub queue to log such failures to update the cutoff point.

Fixes: https://tracker.ceph.com/issues/70055
