### PR TITLE
crimson: revert coroutine workarounds 

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -867,19 +867,9 @@ OpsExecuter::flush_changes_and_submit(
     if (auto log_rit = log_entries.rbegin(); log_rit != log_entries.rend()) {
       ceph_assert(log_rit->version == osd_op_params->at_version);
     }
-
-    /*
-     * This works around the gcc bug causing the generated code to incorrectly
-     * execute unconditionally before the predicate.
-     *
-     * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101244
-     */
-    auto clone_obc = cloning_ctx
-      ? std::move(cloning_ctx->clone_obc)
-      : nullptr;
     auto [_submitted, _all_completed] = co_await pg->submit_transaction(
       std::move(obc),
-      std::move(clone_obc),
+      cloning_ctx ? std::move(cloning_ctx->clone_obc) : nullptr,
       std::move(txn),
       std::move(*osd_op_params),
       std::move(log_entries)

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -219,25 +219,8 @@ ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptib
   DEBUGDPP("{}.{}: pg active, entering process[_pg]_op",
 	   *pgref, *this, this_instance_id);
 
-  {
-    /* The following works around two different gcc bugs:
-     *  1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101244
-     *     This example isn't preciesly as described in the bug, but it seems
-     *     similar.  It causes the generated code to incorrectly execute
-     *     process_pg_op unconditionally before the predicate.  It seems to be
-     *     fixed in gcc 12.2.1.
-     *  2. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102217
-     *     This one appears to cause the generated code to double-free
-     *     awaiter holding the future.  This one seems to be fixed
-     *     in gcc 13.2.1.
-     *
-     * Assigning the intermediate result and moving it into the co_await
-     * expression bypasses both bugs.
-     */
-    auto fut = (is_pg_op() ? process_pg_op(pgref) :
-		process_op(ihref, pgref, this_instance_id));
-    co_await std::move(fut);
-  }
+  co_await (is_pg_op() ? process_pg_op(pgref) :
+	    process_op(ihref, pgref, this_instance_id));
 
   DEBUGDPP("{}.{}: process[_pg]_op complete, completing handle",
 	   *pgref, *this, this_instance_id);

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -70,21 +70,12 @@ RepRequest::interruptible_future<> RepRequest::with_pg_interruptible(
   LOG_PREFIX(RepRequest::with_pg_interruptible);
   DEBUGI("{}", *this);
   co_await this->template enter_stage<interruptor>(repop_pipeline(*pg).process);
-  {
-    /* Splitting this expression into a fut and a seperate co_await
-     * works around a gcc 11 bug (observed on 11.4.1 and gcc 11.5.0)
-     * which results in the pg ref captured by the lambda being
-     * destructed twice.  We can probably remove these workarounds
-     * once we disallow gcc 11 */
-    auto fut = interruptor::make_interruptible(
-      this->template with_blocking_event<
-      PG_OSDMapGate::OSDMapBlocker::BlockingEvent
-      >([this, pg](auto &&trigger) {
-	return pg->osdmap_gate.wait_for_map(
-	  std::move(trigger), req->min_epoch);
-      }));
-    co_await std::move(fut);
-  }
+  co_await interruptor::make_interruptible(this->template with_blocking_event<
+    PG_OSDMapGate::OSDMapBlocker::BlockingEvent
+    >([this, pg](auto &&trigger) {
+      return pg->osdmap_gate.wait_for_map(
+	std::move(trigger), req->min_epoch);
+    }));
 
   if (pg->can_discard_replica_op(*req)) {
     co_return;

--- a/src/test/crimson/test_interruptible_future.cc
+++ b/src/test/crimson/test_interruptible_future.cc
@@ -305,8 +305,6 @@ TEST_F(seastar_test_suite_t, interruptible_repeat_eagain)
   });
 }
 
-#if 0
-// This seems to cause a hang in the gcc-9 linker on bionic
 TEST_F(seastar_test_suite_t, handle_error)
 {
   run_async([] {
@@ -324,4 +322,3 @@ TEST_F(seastar_test_suite_t, handle_error)
     ret.unsafe_get();
   });
 }
-#endif


### PR DESCRIPTION
Now that we require for clang16/gcc13 for Crimson we can cleanup the workarounds used.

See: https://tracker.ceph.com/issues/64375
https://github.com/ceph/ceph/pull/61376
https://github.com/ceph/ceph/pull/61740



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
