### PR TITLE
container/build.sh: remove local container images

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -4,6 +4,8 @@
 # repo auth with write perms must be present (this script does not log into
 # repos named by CONTAINER_REPO_*).
 # If NO_PUSH is set, no login is necessary
+# If REMOVE_LOCAL_IMAGES is true (the default), local images are removed
+# after push.  If you want to save local image copies, set this to false.
 
 
 CFILE=${1:-Containerfile}
@@ -25,11 +27,13 @@ CONTAINER_REPO_USERNAME
 CONTAINER_REPO_PASSWORD
 PRERELEASE_USERNAME for download.ceph.com:/prerelease/ceph
 PRERELEASE_PASSWORD
+REMOVE_LOCAL_IMAGES set to 'false' if you want to keep local images
 
 For a release build: (from ceph.git, built and pushed to download.ceph.com)
 CI_CONTAINER: must be 'false'
 and you must also add
 VERSION (for instance, 19.1.0) for tagging the image
+REMOVE_LOCAL_IMAGES set to 'false' if you want to keep local images
 
 You can avoid the push step (for testing) by setting NO_PUSH to anything
 EOF
@@ -48,6 +52,7 @@ REPO_ARCH=amd64
 if [[ "${ARCH}" = arm64 ]] ; then
     REPO_ARCH=arm64
 fi
+REMOVE_LOCAL_IMAGES=${REMOVE_LOCAL_IMAGES:-true}
 
 if [[ ${CI_CONTAINER} == "true" ]] ; then
     CONTAINER_REPO_HOSTNAME=${CONTAINER_REPO_HOSTNAME:-quay.ceph.io}
@@ -67,6 +72,7 @@ fi
 : "${BRANCH:?}"
 : "${CEPH_SHA1:?}"
 : "${ARCH:?}"
+: "${REMOVE_LOCAL_IMAGES:?}"
 if [[ ${NO_PUSH} != "true" ]] ; then
     : "${CONTAINER_REPO_HOSTNAME:?}"
     : "${CONTAINER_REPO_ORGANIZATION:?}"
@@ -173,6 +179,9 @@ if [[ ${CI_CONTAINER} == "true" ]] ; then
         podman tag ${image_id} ${sha1_flavor_repo_tag}
         if [[ -z "${NO_PUSH}" ]] ; then
             podman push ${sha1_flavor_repo_tag}
+            if [[ ${REMOVE_LOCAL_IMAGES} == "true" ]] ; then
+                podman rmi -f ${sha1_flavor_repo_tag}
+            fi
         fi
         exit
     fi
@@ -181,6 +190,9 @@ if [[ ${CI_CONTAINER} == "true" ]] ; then
         podman push ${full_repo_tag}
         podman push ${branch_repo_tag}
         podman push ${sha1_repo_tag}
+        if [[ ${REMOVE_LOCAL_IMAGES} == "true" ]] ; then
+            podman rmi -f ${full_repo_tag} ${branch_repo_tag} ${sha1_repo_tag}
+        fi
     fi
 else
     #
@@ -192,7 +204,9 @@ else
     podman tag ${image_id} ${version_tag}
     if [[ -z "${NO_PUSH}" ]] ; then
         podman push ${version_tag}
+        if [[ ${REMOVE_LOCAL_IMAGES} == "true" ]] ; then
+            podman rmi -f ${version_tag}
+        fi
     fi
 fi
-
 


### PR DESCRIPTION
Optionally, for those that want to run build.sh locally and use the images.  The default is to remove, for Jenkins builders, which will build, push, and rmi.

Fixes: https://tracker.ceph.com/issues/70196





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
