### PR TITLE
squid: qa/rgw: configure 'iam root' accounts outside of rgw/verify

### DIFF
--- a/qa/suites/rgw/cloud-transition/overrides.yaml
+++ b/qa/suites/rgw/cloud-transition/overrides.yaml
@@ -14,3 +14,7 @@ overrides:
   rgw:
     storage classes: LUKEWARM, FROZEN
     frontend: beast
+  s3tests:
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/crypt/overrides.yaml
+++ b/qa/suites/rgw/crypt/overrides.yaml
@@ -1,0 +1,5 @@
+overrides:
+  s3tests:
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/lifecycle/overrides.yaml
+++ b/qa/suites/rgw/lifecycle/overrides.yaml
@@ -13,3 +13,7 @@ overrides:
         rgw lc debug interval: 10
   rgw:
     storage classes: LUKEWARM, FROZEN
+  s3tests:
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/multifs/overrides.yaml
+++ b/qa/suites/rgw/multifs/overrides.yaml
@@ -14,3 +14,6 @@ overrides:
     storage classes: LUKEWARM, FROZEN
   s3tests:
     storage classes: LUKEWARM, FROZEN
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/sts/overrides.yaml
+++ b/qa/suites/rgw/sts/overrides.yaml
@@ -18,3 +18,6 @@ overrides:
     storage classes: LUKEWARM, FROZEN
   s3tests:
     storage classes: LUKEWARM, FROZEN
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/tempest/tasks/s3tests.yaml
+++ b/qa/suites/rgw/tempest/tasks/s3tests.yaml
@@ -25,6 +25,10 @@ overrides:
         - name: member
           user: s3tests-main
           project: s3tests
+  s3tests:
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999
 
 tasks:
 - s3tests:

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -12,3 +12,7 @@ overrides:
         rgw crypt require ssl: false
         rgw sts key: abcdefghijklmnop
         rgw s3 auth use sts: true
+  s3tests:
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/website/overrides.yaml
+++ b/qa/suites/rgw/website/overrides.yaml
@@ -24,3 +24,6 @@ overrides:
         valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
   s3tests:
     calling-format: subdomain
+    accounts:
+      iam root: RGW88888888888888888
+      iam alt root: RGW99999999999999999


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70207

---

backport of https://github.com/ceph/ceph/pull/61897
parent tracker: https://tracker.ceph.com/issues/70077

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh