### PR TITLE
squid: rgw:lua: Skip the healthchecks and system requests from going to backend storage

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,7 @@
 >=20.0.0
 
+* RGW: Lua scripts will not run against health checks.
+
 * RBD: All Python APIs that produce timestamps now return "aware" `datetime`
   objects instead of "naive" ones (i.e. those including time zone information
   instead of those not including it).  All timestamps remain to be in UTC but


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70210

---

backport of https://github.com/ceph/ceph/pull/61504
parent tracker: https://tracker.ceph.com/issues/69616

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh