### PR TITLE
cephadm: update and improve container image infer function

### DIFF
--- a/src/cephadm/cephadmlib/container_lookup.py
+++ b/src/cephadm/cephadmlib/container_lookup.py
@@ -1,13 +1,20 @@
 # container_lookup.py - high-level functions for getting container info
 
-from typing import Optional
+from operator import itemgetter
+from typing import Optional, Tuple
 
 import logging
 
-from .container_engines import ContainerInfo, parsed_container_image_stats
+from .container_engines import (
+    ContainerInfo,
+    ImageInfo,
+    parsed_container_image_list,
+    parsed_container_image_stats,
+)
 from .container_types import get_container_stats
 from .context import CephadmContext
 from .daemon_identity import DaemonIdentity
+from .daemons.ceph import ceph_daemons
 from .listing import daemons_matching
 from .listing_updaters import CoreStatusUpdater
 
@@ -89,3 +96,79 @@ def get_container_info(
         'bad daemon state: no image, not running: %r', matched_deamon
     )
     return None
+
+
+def infer_local_ceph_image(
+    ctx: CephadmContext, container_path: str = ''
+) -> Optional[str]:
+    """Infer the best ceph image to use based on the following criteria:
+    Out of all images labeled as ceph that are non-dangling, prefer
+    1. the same image as the daemon container specified by -name arg (if provided).
+    2. the image used by any ceph container running on the host
+    3. the most ceph recent image on the host
+
+    :return: An image name or none
+    """
+    # enumerate ceph images on the system
+    images = parsed_container_image_list(
+        ctx,
+        filters=['dangling=false', 'label=ceph=True'],
+        container_path=container_path,
+    )
+    if not images:
+        logger.warning('No non-dangling ceph images found')
+        return None  # no images at all cached on host
+
+    # find running ceph daemons
+    _daemons = ceph_daemons()
+    daemon_name = getattr(ctx, 'name', '')
+    _cinfo_key = '_container_info'
+    _updater = CoreStatusUpdater(keep_container_info=_cinfo_key)
+    matching_daemons = [
+        itemgetter(_cinfo_key, 'name')(_updater.expand(ctx, entry))
+        for entry in daemons_matching(
+            ctx, fsid=ctx.fsid, daemon_type_predicate=lambda t: t in _daemons
+        )
+    ]
+    # collect the running ceph daemon image ids
+    images_in_use_by_daemon = set(
+        d.image_id for d, n in matching_daemons if n == daemon_name
+    )
+    images_in_use = set(d.image_id for d, _ in matching_daemons)
+
+    # prioritize images
+    def _keyfunc(image: ImageInfo) -> Tuple[bool, bool, str]:
+        return (
+            bool(
+                image.digest
+                and any(
+                    v.startswith(image.image_id)
+                    for v in images_in_use_by_daemon
+                )
+            ),
+            bool(
+                image.digest
+                and any(v.startswith(image.image_id) for v in images_in_use)
+            ),
+            image.created,
+        )
+
+    images.sort(key=_keyfunc, reverse=True)
+    best_image = images[0]
+    name_match, ceph_match, _ = _keyfunc(best_image)
+    reason = 'not in the list of non-dangling images with ceph=True label'
+    if images_in_use_by_daemon and not name_match:
+        expected = list(images_in_use_by_daemon)[0]
+        logger.warning(
+            'Not using image %r of named daemon: %s',
+            expected,
+            reason,
+        )
+    if images_in_use and not ceph_match:
+        expected = list(images_in_use)[0]
+        logger.warning(
+            'Not using image %r of ceph daemon: %s',
+            expected,
+            reason,
+        )
+    return best_image.name

--- a/src/cephadm/cephadmlib/listing.py
+++ b/src/cephadm/cephadmlib/listing.py
@@ -50,7 +50,17 @@
 import os
 import logging
 
-from typing import TypedDict, Union, Optional, Iterator, List, Any, Dict, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    TypedDict,
+    Union,
+    cast,
+)
 
 from .context import CephadmContext
 from .daemon_identity import DaemonIdentity
@@ -191,6 +201,7 @@ def daemons_matching(
     daemon_name: Optional[str] = None,
     daemon_type: Optional[str] = None,
     fsid: Optional[str] = None,
+    daemon_type_predicate: Optional[Callable[[str], bool]] = None,
 ) -> Iterator[Union[LegacyDaemonEntry, DaemonEntry]]:
     """Iterate over the daemons configured on the current node, matching daemon
     name or daemon type if supplied.
@@ -200,6 +211,11 @@ def daemons_matching(
             if fsid is not None and fsid != entry.fsid:
                 continue
             if daemon_type is not None and daemon_type != entry.daemon_type:
+                continue
+            if (
+                daemon_type_predicate is not None
+                and not daemon_type_predicate(entry.daemon_type)
+            ):
                 continue
         elif isinstance(entry, DaemonEntry):
             if fsid is not None and fsid != entry.identity.fsid:
@@ -212,6 +228,11 @@ def daemons_matching(
             if (
                 daemon_type is not None
                 and daemon_type != entry.identity.daemon_type
+            ):
+                continue
+            if (
+                daemon_type_predicate is not None
+                and not daemon_type_predicate(entry.identity.daemon_type)
             ):
                 continue
         else:

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -169,7 +169,7 @@ def with_cephadm_ctx(
     with contextlib.ExitStack() as stack:
         stack.enter_context(mock.patch('cephadmlib.net_utils.attempt_bind'))
         stack.enter_context(mock.patch('cephadmlib.exe_utils.find_executable', return_value='foo'))
-        stack.enter_context(mock.patch('cephadm.get_container_info', return_value=None))
+        stack.enter_context(mock.patch('cephadmlib.container_lookup.get_container_info', return_value=None))
         stack.enter_context(mock.patch('cephadm.is_available', return_value=True))
         stack.enter_context(mock.patch('cephadm.json_loads_retry', return_value={'epoch' : 1}))
         stack.enter_context(mock.patch('cephadm.logger'))

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -606,46 +606,61 @@ class TestCephAdm(object):
         result = dict_get_join({'a': 1}, 'a')
         assert result == 1
 
+    @pytest.mark.parametrize(
+        'params',
+        [
+            # make sure the right image is selected when container is found
+            {
+                'container_info': _container_info(
+                    '935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972',
+                    'registry.hub.docker.com/rkachach/ceph:custom-v0.5',
+                    '514e6a882f6e74806a5856468489eeff8d7106095557578da96935e4d0ba4d9d',
+                    '2022-04-19 13:45:20.97146228 +0000 UTC',
+                    '',
+                ),
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|main|2022-03-23 16:29:19 +0000 UTC
+        quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e|514e6a882f6e|pacific|2022-03-23 15:58:34 +0000 UTC
+        quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
+                ),
+                'expected': 'quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e',
+            },
+            # make sure first valid image is used when no container_info is found
+            {
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|main|2022-03-23 16:29:19 +0000 UTC
+        quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e|514e6a882f6e|pacific|2022-03-23 15:58:34 +0000 UTC
+        quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
+                ),
+                'expected': 'quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185',
+            },
+            # make sure images without digest are discarded (no container_info is found)
+            {
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@|||
+        quay.io/ceph/ceph@|||
+        quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
+                ),
+                'expected': 'quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508',
+            },
+        ],
+    )
     @mock.patch('os.listdir', return_value=[])
     @mock.patch('cephadm.logger')
-    def test_infer_local_ceph_image(self, _logger, _listdir):
+    def test_infer_local_ceph_image(self, _logger, _listdir, params):
         ctx = _cephadm.CephadmContext()
         ctx.fsid = '00000000-0000-0000-0000-0000deadbeez'
         ctx.container_engine = mock_podman()
 
-        # make sure the right image is selected when container is found
-        cinfo = _container_info('935b549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972',
-                                 'registry.hub.docker.com/rkachach/ceph:custom-v0.5',
-                                 '514e6a882f6e74806a5856468489eeff8d7106095557578da96935e4d0ba4d9d',
-                                 '2022-04-19 13:45:20.97146228 +0000 UTC',
-                                 '')
-        out = '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|main|2022-03-23 16:29:19 +0000 UTC
-        quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e|514e6a882f6e|pacific|2022-03-23 15:58:34 +0000 UTC
-        quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
+        cinfo = params.get('container_info', None)
+        out = params.get('images_output', '')
+        expected = params.get('expected', None)
         with mock.patch('cephadm.call_throws', return_value=(out, '', '')):
             with mock.patch('cephadm.get_container_info', return_value=cinfo):
-                image = _cephadm.infer_local_ceph_image(ctx, ctx.container_engine)
-                assert image == 'quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e'
-
-        # make sure first valid image is used when no container_info is found
-        out = '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|main|2022-03-23 16:29:19 +0000 UTC
-        quay.ceph.io/ceph-ci/ceph@sha256:b50b130fcda2a19f8507ddde3435bb4722266956e1858ac395c838bc1dcf1c0e|514e6a882f6e|pacific|2022-03-23 15:58:34 +0000 UTC
-        quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
-        with mock.patch('cephadm.call_throws', return_value=(out, '', '')):
-            with mock.patch('cephadm.get_container_info', return_value=None):
-                image = _cephadm.infer_local_ceph_image(ctx, ctx.container_engine)
-                assert image == 'quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185'
-
-        # make sure images without digest are discarded (no container_info is found)
-        out = '''quay.ceph.io/ceph-ci/ceph@|||
-        quay.io/ceph/ceph@|||
-        quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508|666bbfa87e8d|v15.2.5|2020-09-16 14:15:15 +0000 UTC'''
-        with mock.patch('cephadm.call_throws', return_value=(out, '', '')):
-            with mock.patch('cephadm.get_container_info', return_value=None):
-                image = _cephadm.infer_local_ceph_image(ctx, ctx.container_engine)
-                assert image == 'quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508'
-
-
+                image = _cephadm.infer_local_ceph_image(
+                    ctx, ctx.container_engine
+                )
+                assert image == expected
 
     @pytest.mark.parametrize('daemon_filter, by_name, daemon_list, container_stats, output',
         [

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -676,6 +676,101 @@ quay.ceph.io/ceph-ci/ceph@sha256:eeddcc536bb887b36b959e887d5984dd7a3f008a23aa1f2
                 ),
                 'expected': '1b58ca4f6dfd',  # YIKES!
             },
+            # multiple ceph deamons
+            {
+                'containers': [
+                    {
+                        'name': 'osd.8',
+                        '_container_info': _container_info(
+                            '7487e763ce4a103a60292a33269bb39d0abfaf688c7793a78251ce6489a9c52d',
+                            'quay.ceph.io/ceph-ci/ceph@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',
+                            '1b58ca4f6dfd7553d99b923e6b7e8fd0ab4f8ca4db802b81c68de9b6c362ee7a',
+                            '2025-01-17 11:00:44.361121326 -0500 EST',
+                            '',
+                        ),
+                    },
+                    {
+                        'name': 'mgr.cep0.aofdsasdi',
+                        '_container_info': _container_info(
+                            '44ec17226ffd4824cdfebf0f8d628be9acb942ecbad47ae1699cfea38fb17f48',
+                            'quay.ceph.io/ceph-ci/ceph@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',
+                            'c17226ffd4824c0f7dfebf0f8d628be9acb942ecbad47ae1699cfea38fb17f48',
+                            '2025-01-17 11:00:44.361121326 -0500 EST',
+                            '',
+                        ),
+                    },
+                ],
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@sha256:d6d1f4ab7148145467d9b632efc89d75710196434cba00aec5571b01e15b8a99|1e6f059b33d7|main|2025-01-21 16:54:41 +0000 UTC
+quay.ceph.io/ceph-ci/ceph@sha256:8eb43767c40d3e2d8cdb7577904f5f0b94373afe2dde29672c2b0001bd098789|c17226ffd482|test|2025-01-21 16:54:41 +0000 UTC
+                    '''
+                ),
+                'expected': 'quay.ceph.io/ceph-ci/ceph@sha256:8eb43767c40d3e2d8cdb7577904f5f0b94373afe2dde29672c2b0001bd098789',
+            },
+            # named ceph deamon
+            {
+                'name': 'osd.8',
+                'containers': [
+                    {
+                        'name': 'osd.8',
+                        '_container_info': _container_info(
+                            '7487e763ce4a103a60292a33269bb39d0abfaf688c7793a78251ce6489a9c52d',
+                            'quay.ceph.io/ceph-ci/ceph@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',
+                            '1b58ca4f6dfd7553d99b923e6b7e8fd0ab4f8ca4db802b81c68de9b6c362ee7a',
+                            '2025-01-17 11:00:44.361121326 -0500 EST',
+                            '',
+                        ),
+                    },
+                    {
+                        'name': 'mgr.cep0.aofdsasdi',
+                        '_container_info': _container_info(
+                            '44ec17226ffd4824cdfebf0f8d628be9acb942ecbad47ae1699cfea38fb17f48',
+                            'quay.ceph.io/ceph-ci/ceph@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',
+                            'c17226ffd4824c0f7dfebf0f8d628be9acb942ecbad47ae1699cfea38fb17f48',
+                            '2025-01-17 11:00:44.361121326 -0500 EST',
+                            '',
+                        ),
+                    },
+                ],
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@sha256:d6d1f4ab7148145467d9b632efc89d75710196434cba00aec5571b01e15b8a99|1b58ca4f6df|main|2025-01-21 16:54:41 +0000 UTC
+quay.ceph.io/ceph-ci/ceph@sha256:8eb43767c40d3e2d8cdb7577904f5f0b94373afe2dde29672c2b0001bd098789|c17226ffd482|test|2025-01-21 16:54:41 +0000 UTC
+                    '''
+                ),
+                'expected': 'quay.ceph.io/ceph-ci/ceph@sha256:d6d1f4ab7148145467d9b632efc89d75710196434cba00aec5571b01e15b8a99',
+            },
+            # named ceph deamon image unavailable
+            {
+                'name': 'osd.8',
+                'containers': [
+                    {
+                        'name': 'osd.8',
+                        '_container_info': _container_info(
+                            '7487e763ce4a103a60292a33269bb39d0abfaf688c7793a78251ce6489a9c52d',
+                            'quay.ceph.io/ceph-ci/ceph@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',
+                            'ccdb1b58cdfd7553d99b923e6b7e8fd0ab4f8ca4db802b81c68de9b6c362ee7a',
+                            '2025-01-17 11:00:44.361121326 -0500 EST',
+                            '',
+                        ),
+                    },
+                    {
+                        'name': 'mgr.cep0.aofdsasdi',
+                        '_container_info': _container_info(
+                            '44ec17226ffd4824cdfebf0f8d628be9acb942ecbad47ae1699cfea38fb17f48',
+                            'quay.ceph.io/ceph-ci/ceph@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',
+                            'c17226ffd4824c0f7dfebf0f8d628be9acb942ecbad47ae1699cfea38fb17f48',
+                            '2025-01-17 11:00:44.361121326 -0500 EST',
+                            '',
+                        ),
+                    },
+                ],
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@sha256:d6d1f4ab7148145467d9b632efc89d75710196434cba00aec5571b01e15b8a99|1b58ca4f6df|main|2025-01-21 16:54:41 +0000 UTC
+quay.ceph.io/ceph-ci/ceph@sha256:8eb43767c40d3e2d8cdb7577904f5f0b94373afe2dde29672c2b0001bd098789|c17226ffd482|test|2025-01-21 16:54:41 +0000 UTC
+                    '''
+                ),
+                'expected': 'quay.ceph.io/ceph-ci/ceph@sha256:8eb43767c40d3e2d8cdb7577904f5f0b94373afe2dde29672c2b0001bd098789',
+            },
         ],
     )
     def test_infer_local_ceph_image(self, params, funkypatch):
@@ -684,17 +779,29 @@ quay.ceph.io/ceph-ci/ceph@sha256:eeddcc536bb887b36b959e887d5984dd7a3f008a23aa1f2
         ctx.container_engine = mock_podman()
 
         cinfo = params.get('container_info', None)
+        containers = params.get('containers', [])
+        assert not (
+            cinfo and containers
+        ), "test params must only have either cinfo OR containers"
+        if not containers and cinfo:
+            containers = [{'_container_info': cinfo, 'name': 'mon.foo'}]
+        if params.get('name', None):
+            ctx.name = params['name']
+
         out = params.get('images_output', '')
         expected = params.get('expected', None)
-        funkypatch.patch('cephadmlib.call_wrappers.call').return_value = out, '', 0
-        funkypatch.patch('cephadmlib.listing_updaters.CoreStatusUpdater')().expand.return_value = {
-            '_container_info': cinfo,
-            'name': 'mon.foo',
-        }
-        funkypatch.patch('cephadmlib.listing.daemons_matching').return_value = [0] if cinfo else []
-        image = _cephadm.infer_local_ceph_image(
-            ctx, ctx.container_engine
+        funkypatch.patch('cephadmlib.call_wrappers.call').return_value = (
+            out,
+            '',
+            0,
         )
+        funkypatch.patch(
+            'cephadmlib.listing_updaters.CoreStatusUpdater'
+        )().expand.side_effect = lambda ctx, v: v
+        funkypatch.patch(
+            'cephadmlib.listing.daemons_matching'
+        ).return_value = containers
+        image = _cephadm.infer_local_ceph_image(ctx, ctx.container_engine)
         assert image == expected
 
     @pytest.mark.parametrize('daemon_filter, by_name, daemon_list, container_stats, output',

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -673,13 +673,11 @@ quay.ceph.io/ceph-ci/ceph@sha256:eeddcc536bb887b36b959e887d5984dd7a3f008a23aa1f2
 <none>@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29|1b58ca4f6dfd|<none>|2025-01-16 22:53:46 +0000 UTC
                     '''
                 ),
-                'expected': '<none>@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',  # YIKES!
+                'expected': '1b58ca4f6dfd',  # YIKES!
             },
         ],
     )
-    @mock.patch('os.listdir', return_value=[])
-    @mock.patch('cephadm.logger')
-    def test_infer_local_ceph_image(self, _logger, _listdir, params):
+    def test_infer_local_ceph_image(self, params, funkypatch):
         ctx = _cephadm.CephadmContext()
         ctx.fsid = '00000000-0000-0000-0000-0000deadbeez'
         ctx.container_engine = mock_podman()
@@ -687,12 +685,12 @@ quay.ceph.io/ceph-ci/ceph@sha256:eeddcc536bb887b36b959e887d5984dd7a3f008a23aa1f2
         cinfo = params.get('container_info', None)
         out = params.get('images_output', '')
         expected = params.get('expected', None)
-        with mock.patch('cephadm.call_throws', return_value=(out, '', '')):
-            with mock.patch('cephadm.get_container_info', return_value=cinfo):
-                image = _cephadm.infer_local_ceph_image(
-                    ctx, ctx.container_engine
-                )
-                assert image == expected
+        funkypatch.patch('cephadmlib.call_wrappers.call').return_value = out, '', 0
+        funkypatch.patch('cephadm.get_container_info').return_value = cinfo
+        image = _cephadm.infer_local_ceph_image(
+            ctx, ctx.container_engine
+        )
+        assert image == expected
 
     @pytest.mark.parametrize('daemon_filter, by_name, daemon_list, container_stats, output',
         [

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -659,6 +659,22 @@ quay.ceph.io/ceph-ci/ceph@sha256:eeddcc536bb887b36b959e887d5984dd7a3f008a23aa1f2
                 ),
                 'expected': None,
             },
+            # ceph image in store have been pulled (new image) since daemon started
+            {
+                'container_info': _container_info(
+                    '7487e763ce4a103a60292a33269bb39d0abfaf688c7793a78251ce6489a9c52d',
+                    'quay.ceph.io/ceph-ci/ceph@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',
+                    '1b58ca4f6dfd7553d99b923e6b7e8fd0ab4f8ca4db802b81c68de9b6c362ee7a',
+                    '2025-01-17 11:00:44.361121326 -0500 EST',
+                    '',
+                ),
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@sha256:d6d1f4ab7148145467d9b632efc89d75710196434cba00aec5571b01e15b8a99|1e6f059b33d7|main|2025-01-21 16:54:41 +0000 UTC
+<none>@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29|1b58ca4f6dfd|<none>|2025-01-16 22:53:46 +0000 UTC
+                    '''
+                ),
+                'expected': '<none>@sha256:863ae69e531b26a9cb609ecea17a477ef8f77aa11b2d398091d54c73a2464d29',  # YIKES!
+            },
         ],
     )
     @mock.patch('os.listdir', return_value=[])

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -643,6 +643,22 @@ class TestCephAdm(object):
                 ),
                 'expected': 'quay.io/ceph/ceph@sha256:939a46c06b334e094901560c8346de33c00309e3e3968a2db240eb4897c6a508',
             },
+            # ceph images in local store do not match running instance
+            {
+                'container_info': _container_info(
+                    'a1bb549714b8f007c6a4e29c758689cf9e8e69f2e0f51180506492974b90a972',
+                    'quay.io/customceph/ceph:foobar',
+                    'b2cc6a882f6e74806a5856468489eeff8d7106095557578da96935e4d0ba4d9d',
+                    '2024-04-19 11:54:23.97146228 +0000 UTC',
+                    '',
+                ),
+                'images_output': (
+                    '''quay.ceph.io/ceph-ci/ceph@sha256:87f200536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|main|2024-05-08 12:09:33 +0000 UTC
+quay.ceph.io/ceph-ci/ceph@sha256:eeddcc536bb887b36b959e887d5984dd7a3f008a23aa1f283ab55d48b22c6185|dad864ee21e9|pacific|2022-03-23 16:29:19 +0000 UTC
+                    '''
+                ),
+                'expected': None,
+            },
         ],
     )
     @mock.patch('os.listdir', return_value=[])


### PR DESCRIPTION
Depends on #61761 

Refactor the infer_local_ceph_image function to use the low level
daemons_matching function and avoid ever looping over the list of
running daemons multiple times. Clean up the logic in
infer_local_ceph_image such that it better matches the behavior
in the original doc string as well as cleaning up said doc string.

Fixes: https://tracker.ceph.com/issues/69278


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
