### PR TITLE
squid: src/mon/OSDMonitor.cc: [Stretch Mode] WRN non-existent CRUSH location assigned to MON

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1638,6 +1638,19 @@ We encourage you to fix this by making the weights even on both dividing buckets
 This can be done by making sure the combined weight of the OSDs on each dividing
 bucket are the same.
 
+NONEXISTENT_MON_CRUSH_LOC_STRETCH_MODE
+______________________________________
+
+The CRUSH location specified for the monitor must belong to one of the dividing
+buckets when stretch mode is enabled. With the ``tiebreaker`` monitor being the
+only exception.
+
+This warning suggests that one or more monitors have a CRUSH location that does
+not belong to any of the dividing buckets in stretch mode.
+
+We encourage you to fix this by making sure the CRUSH location of the monitor
+belongs to one of the dividing buckets.
+
 NVMeoF Gateway
 --------------
 

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -66,6 +66,7 @@ private:
   void check_for_older_version(health_check_map_t *checks);
   void check_for_mon_down(health_check_map_t *checks);
   void check_for_clock_skew(health_check_map_t *checks);
+  void check_mon_crush_loc_stretch_mode(health_check_map_t *checks);
   void check_if_msgr2_enabled(health_check_map_t *checks);
   bool check_leader_health();
   bool check_member_health();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -15282,7 +15282,10 @@ bool OSDMonitor::check_for_dead_crush_zones(const map<string,set<string>>& dead_
   bool really_down = false;
   for (auto dbi : dead_buckets) {
     const string& bucket_name = dbi.first;
-    ceph_assert(osdmap.crush->name_exists(bucket_name));
+    if (!osdmap.crush->name_exists(bucket_name)) {
+      dout(10) << "CRUSH bucket " << bucket_name << " does not exist" << dendl;
+      continue;
+    }
     int bucket_id = osdmap.crush->get_item_id(bucket_name);
     dout(20) << "Checking " << bucket_name << " id " << bucket_id
 	     << " to see if OSDs are also down" << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70220

---

backport of https://github.com/ceph/ceph/pull/55103
parent tracker: https://tracker.ceph.com/issues/63861

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh