### PR TITLE
reef: rbd-mirror: fix possible recursive lock of ImageReplayer::m_lock

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -716,10 +716,12 @@ void ImageReplayer<I>::handle_update_mirror_image_replay_status(int r) {
   auto ctx = new LambdaContext([this](int) {
       update_mirror_image_status(false, boost::none);
 
-      std::unique_lock locker{m_lock};
-      std::unique_lock timer_locker{m_threads->timer_lock};
+      {
+	std::unique_lock locker{m_lock};
+	std::unique_lock timer_locker{m_threads->timer_lock};
 
-      schedule_update_mirror_image_replay_status();
+	schedule_update_mirror_image_replay_status();
+      }
       m_in_flight_op_tracker.finish_op();
     });
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69983

---

backport of https://github.com/ceph/ceph/pull/61835
parent tracker: https://tracker.ceph.com/issues/69978

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh