### PR TITLE
squid: librbd: fix a crash in get_rollback_snap_id

### DIFF
--- a/qa/workunits/rbd/rbd_mirror.sh
+++ b/qa/workunits/rbd/rbd_mirror.sh
@@ -679,3 +679,36 @@ if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER1} osd blocklist ls 2>&1 | grep -q "listed 0 entries"
   CEPH_ARGS='--id admin' ceph --cluster ${CLUSTER2} osd blocklist ls 2>&1 | grep -q "listed 0 entries"
 fi
+
+testlog "TEST: force promote with a user snapshot"
+force_promote_image=test_force_promote_user
+create_image_and_enable_mirror ${CLUSTER2} ${POOL} ${force_promote_image} ${RBD_MIRROR_MODE} 10G
+write_image ${CLUSTER2} ${POOL} ${force_promote_image} 100
+wait_for_image_replay_stopped ${CLUSTER2} ${POOL} ${force_promote_image}
+wait_for_image_replay_started ${CLUSTER1} ${POOL} ${force_promote_image}
+wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${force_promote_image}
+wait_for_replaying_status_in_pool_dir ${CLUSTER1} ${POOL} ${force_promote_image}
+wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${force_promote_image} 'up+stopped'
+write_image ${CLUSTER2} ${POOL} ${force_promote_image} 100
+create_snapshot ${CLUSTER2} ${POOL} ${force_promote_image} 'snap1'
+write_image ${CLUSTER2} ${POOL} ${force_promote_image} 2560 4194304
+if [ "${RBD_MIRROR_MODE}" = "snapshot" ]; then
+  mirror_image_snapshot ${CLUSTER2} ${POOL} ${force_promote_image}
+fi
+wait_for_snap_present ${CLUSTER1} ${POOL} ${force_promote_image} 'snap1'
+sleep $((1 + RANDOM % 5))
+stop_mirrors ${CLUSTER1} -KILL
+if [ "${RBD_MIRROR_MODE}" = "snapshot" ]; then
+  SNAPS=$(get_snaps_json ${CLUSTER1} ${POOL} ${force_promote_image})
+  jq -e '.[-1].namespace["type"] == "mirror" and .[-1].namespace["state"] == "non-primary" and .[-1].namespace["complete"] == false' <<< ${SNAPS}
+fi
+promote_image ${CLUSTER1} ${POOL} ${force_promote_image} '--force'
+start_mirrors ${CLUSTER1}
+wait_for_image_replay_stopped ${CLUSTER1} ${POOL} ${force_promote_image}
+wait_for_image_replay_stopped ${CLUSTER2} ${POOL} ${force_promote_image}
+wait_for_status_in_pool_dir ${CLUSTER1} ${POOL} ${force_promote_image} 'up+stopped'
+wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${force_promote_image} 'up+stopped'
+write_image ${CLUSTER1} ${POOL} ${force_promote_image} 100
+write_image ${CLUSTER2} ${POOL} ${force_promote_image} 100
+remove_image_retry ${CLUSTER1} ${POOL} ${force_promote_image}
+remove_image_retry ${CLUSTER2} ${POOL} ${force_promote_image}

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -1258,6 +1258,15 @@ count_mirror_snaps()
         grep -c -F " mirror ("
 }
 
+get_snaps_json()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+
+    rbd --cluster ${cluster} snap ls ${pool}/${image} --all --format json
+}
+
 write_image()
 {
     local cluster=$1

--- a/src/librbd/mirror/snapshot/Utils.cc
+++ b/src/librbd/mirror/snapshot/Utils.cc
@@ -28,12 +28,15 @@ bool get_rollback_snap_id(
     uint64_t *rollback_snap_id) {
 
   for (; it != end; it++) {
-    auto mirror_ns = std::get<cls::rbd::MirrorSnapshotNamespace>(
-      it->second.snap_namespace);
-    if (mirror_ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY) {
+    auto mirror_ns = std::get_if<cls::rbd::MirrorSnapshotNamespace>(
+      &it->second.snap_namespace);
+    if (mirror_ns == nullptr) {
+      continue;
+    }
+    if (mirror_ns->state != cls::rbd::MIRROR_SNAPSHOT_STATE_NON_PRIMARY) {
       break;
     }
-    if (mirror_ns.complete) {
+    if (mirror_ns->complete) {
       break;
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70096

---

backport of https://github.com/ceph/ceph/pull/61906 and https://github.com/ceph/ceph/pull/61955
parent tracker: https://tracker.ceph.com/issues/70075

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh