### PR TITLE
reef: rgw/sts: fix to disallow unsupported JWT algorithms

### DIFF
--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -444,6 +444,9 @@ WebTokenEngine::validate_signature(const DoutPrefixProvider* dpp, const jwt::dec
                               .allow_algorithm(jwt::algorithm::ps512{cert});
 
                 verifier.verify(decoded);
+              } else {
+                ldpp_dout(dpp, 0) << "Unsupported algorithm: " << algorithm << dendl;
+                throw -EINVAL;
               }
             } catch (std::runtime_error& e) {
               ldpp_dout(dpp, 0) << "Signature validation failed: " << e.what() << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69257

---

backport of https://github.com/ceph/ceph/pull/60624
parent tracker: https://tracker.ceph.com/issues/68836

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh