### PR TITLE
squid: mgr/vol: print proper message when subvolume metadata filename is too long

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -4413,6 +4413,36 @@ class TestSubvolumes(TestVolumesHelper):
         # verify trash dir is clean.
         self._wait_for_trash_empty()
 
+    def test_create_when_subvol_name_is_too_long(self):
+        '''
+        255 chars of subvol name + 7 chars of (':', '_' and '.meta') and 0
+        chars for default group name is greater than 256 chars, therefore
+        subvol meta file issue should be tested.
+        '''
+        subvolname = 's' * 255
+        self.negtest_ceph_cmd(
+            f'fs subvolume create {self.volname} {subvolname}',
+            retval=errno.ENAMETOOLONG,
+            errmsgs='Error ENAMETOOLONG: use shorter group or subvol name, '
+                    'combination of both should be less than 249 characters')
+
+    def test_create_when_subvol_group_name_is_too_long(self):
+        '''
+        248 chars of group name + 7 chars of (':', '_' and '.meta') and 7
+        chars for subvol name is greater than 256 chars, therefore subvol
+        meta file issue should be tested.
+        '''
+        groupname = 'g' * 248
+        self.run_ceph_cmd(
+            f'fs subvolumegroup create {self.volname} {groupname}')
+        subvolname = 's' * 7
+        self.negtest_ceph_cmd(
+            f'fs subvolume create {self.volname} {subvolname} --group-name '
+            f'{groupname}',
+            retval=errno.ENAMETOOLONG,
+            errmsgs='Error ENAMETOOLONG: use shorter group or subvol name, '
+                    'combination of both should be less than 249 characters')
+
 class TestSubvolumeGroupSnapshots(TestVolumesHelper):
     """Tests for FS subvolume group snapshot operations."""
     @unittest.skip("skipping subvolumegroup snapshot tests")

--- a/src/pybind/mgr/volumes/fs/operations/versions/auth_metadata.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/auth_metadata.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import errno
 import os
 import fcntl
 import json
@@ -9,8 +10,12 @@ import uuid
 import cephfs
 
 from ..group import Group
+from ...exception import VolumeException
 
 log = logging.getLogger(__name__)
+
+
+FILE_NAME_MAX = 255
 
 
 class AuthMetadataError(Exception):
@@ -43,10 +48,17 @@ class AuthMetadataManager(object):
             return str(param).encode('utf-8')
 
     def _subvolume_metadata_path(self, group_name, subvol_name):
-        return os.path.join(self.volume_prefix, "_{0}:{1}{2}".format(
-            group_name if group_name != Group.NO_GROUP_NAME else "",
-            subvol_name,
-            self.META_FILE_EXT))
+        group_name = group_name if group_name != Group.NO_GROUP_NAME else ""
+        metadata_filename = f'_{group_name}:{subvol_name}{self.META_FILE_EXT}'
+        # in order to allow creation of this metadata file, 5 chars for ".meta"
+        # extension and 2 chars for "_" and ":" respectively. so that combina-
+        # -tion of group and subvolname should be shorter than 248 chars.
+        if len(metadata_filename) > FILE_NAME_MAX:
+            raise VolumeException(-errno.ENAMETOOLONG,
+                                 'use shorter group or subvol name, '
+                                 'combination of both should be less '
+                                 'than 249 characters')
+        return os.path.join(self.volume_prefix, metadata_filename)
 
     def _check_compat_version(self, compat_version):
         if self.version < compat_version:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70230

---

backport of https://github.com/ceph/ceph/pull/61706
parent tracker: https://tracker.ceph.com/issues/69865

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh