### PR TITLE
reef: tools: respect set features when adding addresses

### DIFF
--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -375,6 +375,10 @@ int main(int argc, const char **argv)
       return r;
   }
 
+  if (handle_features(features, monmap)) {
+    modified = true;
+  }
+
   if (min_mon_release != ceph_release_t::unknown) {
     monmap.min_mon_release = min_mon_release;
     cout << "setting min_mon_release = " << min_mon_release << std::endl;
@@ -457,10 +461,6 @@ int main(int argc, const char **argv)
       helpful_exit();
     }
     monmap.remove(p);
-  }
-
-  if (handle_features(features, monmap)) {
-    modified = true;
   }
 
   if (!print && !modified && !show_features) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69266

---

backport of https://github.com/ceph/ceph/pull/60197
parent tracker: https://tracker.ceph.com/issues/53751

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh