### PR TITLE
os/bluestore: Modify logic of bluefs persistent alloc unit sizes

### DIFF
--- a/src/include/intarith.h
+++ b/src/include/intarith.h
@@ -111,6 +111,17 @@ constexpr inline T p2roundup(T x, T align) {
   return -(-x & -align);
 }
 
+/*
+ * checks if x is power of 2
+ * eg, p2isp2(0x123)  == false
+ * eg, p2isp2(0)      == true
+ * eg, p2isp2(0x2000) == true
+ */
+template<typename T>
+constexpr inline T p2isp2(T x) {
+  return (x & (x - 1)) == 0;
+}
+
 // count bits (set + any 0's that follow)
 template<std::integral T>
 unsigned cbits(T v) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1845,6 +1845,29 @@ int BlueFS::log_dump()
   return r;
 }
 
+int BlueFS::super_dump(std::ostream* out)
+{
+  _init_logger();
+  _open_super();
+  *out << super.to_string();
+  _shutdown_logger();
+  return 0;
+}
+
+int BlueFS::set_alloc_size(uint8_t bdev_id, uint64_t alloc_size)
+{
+  if (bdev_id > BDEV_SLOW) {
+    return -1;
+  }
+  _init_logger();
+  _open_super();
+  super.required_alloc_size.resize(BDEV_REAL_CNT);
+  super.required_alloc_size[bdev_id] = alloc_size;
+  _write_super(BDEV_DB);
+  _shutdown_logger();
+  return 0;
+}
+
 int BlueFS::device_migrate_to_existing(
   CephContext *cct,
   const set<int>& devs_source,

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -660,6 +660,8 @@ public:
   int prepare_new_device(int id, const bluefs_layout_t& layout);
   
   int log_dump();
+  int super_dump(std::ostream* out);
+  int set_alloc_size(uint8_t bdev_id, uint64_t alloc_size);
 
   void collect_metadata(std::map<std::string,std::string> *pm, unsigned skip_bdev_id);
   void get_devices(std::set<std::string> *ls);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -220,6 +220,7 @@ class BlueFS {
 public:
   CephContext* cct;
   static constexpr unsigned MAX_BDEV = 5;
+  static constexpr unsigned BDEV_REAL_CNT = 3;
   static constexpr unsigned BDEV_WAL = 0;
   static constexpr unsigned BDEV_DB = 1;
   static constexpr unsigned BDEV_SLOW = 2;
@@ -506,6 +507,9 @@ private:
   inline bool is_shared_alloc(unsigned id) const {
     return id == shared_alloc_id;
   }
+  inline bool has_shared_alloc() const {
+    return shared_alloc_id != unsigned(-1);
+  }
   std::atomic<int64_t> cooldown_deadline = 0;
 
   class SocketHook;
@@ -616,6 +620,7 @@ private:
 
   int _open_super();
   int _write_super(int dev);
+  void _super_prepare_alloc_sizes();
   int _check_allocations(const bluefs_fnode_t& fnode,
     boost::dynamic_bitset<uint64_t>* used_blocks,
     bool is_alloc, //true when allocating, false when deallocating

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7515,6 +7515,39 @@ bool BlueStore::test_mount_in_use()
   return ret;
 }
 
+int BlueStore::open_bluefs_environment()
+{
+  int r = 0;
+  if (r = _open_path(); r < 0) {
+    return r;
+  }
+  auto close_path = make_scope_guard([&] {
+    if (r != 0) _close_path();
+  });
+  if (int r = _open_fsid(false); r < 0) {
+    return r;
+  }
+  auto close_fsid = make_scope_guard([&] {
+    if (r != 0) _close_fsid();
+  });
+  if (int r = _read_fsid(&fsid); r < 0) {
+    return r;
+  }
+  if (int r = _lock_fsid(); r < 0) {
+    return r;
+  }
+  return _minimal_open_bluefs(false);
+}
+
+int BlueStore::close_bluefs_environment()
+{
+  _close_fsid();
+  _close_path();
+  _minimal_close_bluefs();
+  return 0;
+}
+
+
 int BlueStore::_minimal_open_bluefs(bool create)
 {
   int r;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7562,6 +7562,16 @@ int BlueStore::_minimal_open_bluefs(bool create)
   // shared device
   bfn = path + "/block";
   // never trim here
+  if (create) {
+    ceph_assert(shared_alloc.alloc_unit != 0);
+  } else {
+    string au_size_str;
+    int r = read_meta("bfm_bytes_per_block", &au_size_str);
+    ceph_assert(r == 0);
+    uint64_t au_size = std::stoul(au_size_str);
+    ceph_assert(au_size > 0);
+    shared_alloc.alloc_unit = au_size;
+  }
   r = bluefs->add_block_device(bluefs_layout.shared_bdev, bfn, false,
                                &shared_alloc);
   if (r < 0) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3135,6 +3135,9 @@ public:
 
   int open_db_environment(KeyValueDB **pdb, bool read_only, bool to_repair);
   int close_db_environment();
+
+  int open_bluefs_environment();
+  int close_bluefs_environment();
   BlueFS* get_bluefs();
 
   int write_meta(const std::string& key, const std::string& value) override;

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -75,9 +75,7 @@ void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
 }
 
 // bluefs_super_t
-bluefs_super_t::bluefs_super_t() : version(0), block_size(4096) {
-  bluefs_max_alloc_size.resize(BlueFS::MAX_BDEV, 0);
-}
+bluefs_super_t::bluefs_super_t() : version(0), block_size(4096) {}
 
 void bluefs_super_t::encode(bufferlist& bl) const
 {
@@ -88,7 +86,7 @@ void bluefs_super_t::encode(bufferlist& bl) const
   encode(block_size, bl);
   encode(log_fnode, bl);
   encode(memorized_layout, bl);
-  encode(bluefs_max_alloc_size, bl);
+  encode(required_alloc_size, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -104,9 +102,9 @@ void bluefs_super_t::decode(bufferlist::const_iterator& p)
     decode(memorized_layout, p);
   }
   if (struct_v >= 3) {
-    decode(bluefs_max_alloc_size, p);
+    decode(required_alloc_size, p);
   } else {
-    std::fill(bluefs_max_alloc_size.begin(), bluefs_max_alloc_size.end(), 0);
+    std::fill(required_alloc_size.begin(), required_alloc_size.end(), 0);
   }
   DECODE_FINISH(p);
 }
@@ -118,7 +116,7 @@ void bluefs_super_t::dump(Formatter *f) const
   f->dump_unsigned("version", version);
   f->dump_unsigned("block_size", block_size);
   f->dump_object("log_fnode", log_fnode);
-  for (auto& p : bluefs_max_alloc_size)
+  for (auto& p : required_alloc_size)
     f->dump_unsigned("max_alloc_size", p);
 }
 
@@ -137,7 +135,7 @@ ostream& operator<<(ostream& out, const bluefs_super_t& s)
 	     << " v " << s.version
 	     << " block_size 0x" << std::hex << s.block_size
 	     << " log_fnode 0x" << s.log_fnode
-	     << " max_alloc_size " << s.bluefs_max_alloc_size
+	     << " req_alloc_size " << s.required_alloc_size
 	     << std::dec << ")";
 }
 

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -128,6 +128,23 @@ void bluefs_super_t::generate_test_instances(list<bluefs_super_t*>& ls)
   ls.back()->block_size = 4096;
 }
 
+std::string bluefs_super_t::to_string()
+{
+  std::stringstream str;
+  str << "uuid " << uuid << std::endl;
+  str << "osd " << osd_uuid << std::endl;
+  str << "version " << version << std::endl;
+  str << "block size 0x" << std::hex << block_size << std::endl;
+  str << "log fnode " << log_fnode << std::endl;
+  str << "alloc size WAL " << (required_alloc_size.size()>BlueFS::BDEV_WAL ?
+    required_alloc_size[BlueFS::BDEV_WAL] : 0) << std::endl;
+  str << "alloc size DB " << (required_alloc_size.size()>BlueFS::BDEV_DB ?
+    required_alloc_size[BlueFS::BDEV_DB] : 0) << std::endl;
+  str << "alloc size SLOW " << (required_alloc_size.size()>BlueFS::BDEV_SLOW ?
+    required_alloc_size[BlueFS::BDEV_SLOW] : 0) << std::endl;
+  return str.str();
+}
+
 ostream& operator<<(ostream& out, const bluefs_super_t& s)
 {
   return out << "super(uuid " << s.uuid

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -233,6 +233,7 @@ struct bluefs_super_t {
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<bluefs_super_t*>& ls);
+  std::string to_string();
 };
 WRITE_CLASS_ENCODER(bluefs_super_t)
 

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -220,7 +220,8 @@ struct bluefs_super_t {
 
   std::optional<bluefs_layout_t> memorized_layout;
 
-  std::vector<uint64_t> bluefs_max_alloc_size;
+  std::vector<uint64_t> required_alloc_size; ///< allocation sizes for devices
+                                             ///< empty means we need to initialize
 
   bluefs_super_t();
 


### PR DESCRIPTION
Work in https://github.com/ceph/ceph/pull/57015 introduces a very good concept - a persistence of disk allocators unit size.
BlueFS superblock got there extended with integer fields - one per device.

However, there was an automatic adaptation to smaller unit size, if configuration provides it.
But only smaller - there was no way to revert the change, even if it was done by mistake.
For example OSD restart when bluefs_alloc_size configuration has changed will automatically modify BlueFS alloc units.
Or, running ceph-bluestore-tool fsck could also change it.

With this PR, allocation unit sizes are captured, locked and persisted during mkfs.
They will not change.

Should need arise, one can change alloc unit with ceph-bluestore-tool new command:
`ceph-bluestore-tool --path <osd> --bdev-type bdev_wal --alloc_size 0x10000 bluefs-set-alloc-size`

Plus, new command lists bluefs superblock:
`ceph-bluestore-tool --path dev/osd0/ bluefs-super-dump`
->
```
uuid 999111b8-b5f6-45ea-a8ee-e67ac6718b18
osd d070345b-7a82-4e2e-9a7e-c1398bf65845
version 3
block size 0x1000
log fnode file(ino 1 size 0x0 mtime 2025-03-01T00:15:53.864253+0000 allocated 100000 alloc_commit 100000 extents [1:0xb02000~100000])
alloc size WAL 1048576
alloc size DB 1048576
alloc size SLOW 4096
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
