### PR TITLE
mon,mgr,auth,client: replace obsolete get_tracked_conf_keys()

### DIFF
--- a/src/auth/AuthRegistry.cc
+++ b/src/auth/AuthRegistry.cc
@@ -17,6 +17,7 @@
 #define dout_prefix *_dout << "AuthRegistry(" << this << ") "
 
 using std::string;
+using namespace std::literals;
 
 AuthRegistry::AuthRegistry(CephContext *cct)
   : cct(cct)
@@ -32,23 +33,21 @@ AuthRegistry::~AuthRegistry()
   }
 }
 
-const char** AuthRegistry::get_tracked_conf_keys() const
+std::vector<std::string> AuthRegistry::get_tracked_keys() const noexcept
 {
-  static const char *keys[] = {
-    "auth_supported",
-    "auth_client_required",
-    "auth_cluster_required",
-    "auth_service_required",
-    "ms_mon_cluster_mode",
-    "ms_mon_service_mode",
-    "ms_mon_client_mode",
-    "ms_cluster_mode",
-    "ms_service_mode",
-    "ms_client_mode",
-    "keyring",
-    NULL
+  return {
+    "auth_supported"s,
+    "auth_client_required"s,
+    "auth_cluster_required"s,
+    "auth_service_required"s,
+    "ms_mon_cluster_mode"s,
+    "ms_mon_service_mode"s,
+    "ms_mon_client_mode"s,
+    "ms_cluster_mode"s,
+    "ms_service_mode"s,
+    "ms_client_mode"s,
+    "keyring"s
   };
-  return keys;
 }
 
 void AuthRegistry::handle_conf_change(

--- a/src/auth/AuthRegistry.h
+++ b/src/auth/AuthRegistry.h
@@ -70,7 +70,7 @@ public:
 
   AuthAuthorizeHandler *get_handler(int peer_type, int method);
 
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string>& changed) override;
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -172,6 +172,7 @@ using std::vector;
 using namespace std::literals;
 
 using namespace TOPNSPC::common;
+using namespace std::literals;
 
 namespace bs = boost::system;
 namespace ca = ceph::async;
@@ -17332,38 +17333,26 @@ void Client::set_cap_epoch_barrier(epoch_t e)
   cap_epoch_barrier = e;
 }
 
-const char** Client::get_tracked_conf_keys() const
+std::vector<std::string> Client::get_tracked_keys() const noexcept
 {
-#define KEYS \
-    "client_acl_type", \
-    "client_cache_mid", \
-    "client_cache_size", \
-    "client_caps_release_delay", \
-    "client_deleg_break_on_open", \
-    "client_deleg_timeout", \
-    "client_mount_timeout", \
-    "client_oc_max_dirty", \
-    "client_oc_max_dirty_age", \
-    "client_oc_max_objects", \
-    "client_oc_size", \
-    "client_oc_target_dirty", \
-    "client_permissions", \
+  static constexpr auto as_sv = std::to_array<std::string_view>({
+    "client_acl_type",
+    "client_cache_mid",
+    "client_cache_size",
+    "client_caps_release_delay",
+    "client_deleg_break_on_open",
+    "client_deleg_timeout",
+    "client_mount_timeout",
+    "client_oc_max_dirty",
+    "client_oc_max_dirty_age",
+    "client_oc_max_objects",
+    "client_oc_size",
+    "client_oc_target_dirty",
+    "client_permissions",
     "fuse_default_permissions"
-
-  constexpr bool is_sorted = [] () constexpr {
-    constexpr auto arr = std::to_array<std::string_view>({KEYS});
-    for (unsigned long i = 0; i < arr.size()-1; ++i) {
-      if (arr[i] > arr[i+1]) {
-        return false;
-      }
-    }
-    return true;
-  }();
-  static_assert(is_sorted, "keys are not sorted!");
-
-  static char const* keys[] = {KEYS, nullptr};
-
-  return keys;
+  });
+  static_assert(std::is_sorted(begin(as_sv), end(as_sv)));
+  return {begin(as_sv), end(as_sv)};
 }
 
 void Client::handle_conf_change(const ConfigProxy& conf,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -696,7 +696,7 @@ public:
   int ll_register_callbacks2(struct ceph_client_callback_args *args);
   std::pair<int, bool> test_dentry_handling(bool can_invalidate);
 
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
 	                          const std::set <std::string> &changed) override;
   uint32_t get_deleg_timeout() { return deleg_timeout; }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -62,6 +62,7 @@
 #define dout_prefix *_dout << "mgr.server " << __func__ << " "
 
 using namespace TOPNSPC::common;
+using namespace std::literals;
 
 using std::list;
 using std::ostream;
@@ -3182,15 +3183,12 @@ void DaemonServer::got_mgr_map()
   daemon_state.cull("mgr", have);
 }
 
-const char** DaemonServer::get_tracked_conf_keys() const
+std::vector<std::string> DaemonServer::get_tracked_keys() const noexcept
 {
-  static const char *KEYS[] = {
-    "mgr_stats_threshold",
-    "mgr_stats_period",
-    nullptr
+  return {
+    "mgr_stats_threshold"s,
+    "mgr_stats_period"s
   };
-
-  return KEYS;
 }
 
 void DaemonServer::handle_conf_change(const ConfigProxy& conf,

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -309,8 +309,8 @@ public:
   void reregister_mds_perf_queries();
   int get_mds_perf_counters(MDSPerfCollector *collector);
 
-  virtual const char** get_tracked_conf_keys() const override;
-  virtual void handle_conf_change(const ConfigProxy& conf,
+  std::vector<std::string> get_tracked_keys() const noexcept override;
+  void handle_conf_change(const ConfigProxy& conf,
                           const std::set <std::string> &changed) override;
 
   void schedule_tick(double delay_sec);

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -40,6 +40,7 @@
 using std::map;
 using std::string;
 using std::vector;
+using namespace std::literals;
 
 MgrStandby::MgrStandby(int argc, const char **argv) :
   Dispatcher(g_ceph_context),
@@ -68,23 +69,21 @@ MgrStandby::MgrStandby(int argc, const char **argv) :
 
 MgrStandby::~MgrStandby() = default;
 
-const char** MgrStandby::get_tracked_conf_keys() const
+std::vector<std::string> MgrStandby::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
+  return {
     // clog & admin clog
-    "clog_to_monitors",
-    "clog_to_syslog",
-    "clog_to_syslog_facility",
-    "clog_to_syslog_level",
-    "clog_to_graylog",
-    "clog_to_graylog_host",
-    "clog_to_graylog_port",
-    "mgr_standby_modules",
-    "host",
-    "fsid",
-    NULL
+    "clog_to_monitors"s,
+    "clog_to_syslog"s,
+    "clog_to_syslog_facility"s,
+    "clog_to_syslog_level"s,
+    "clog_to_graylog"s,
+    "clog_to_graylog_host"s,
+    "clog_to_graylog_port"s,
+    "mgr_standby_modules"s,
+    "host"s,
+    "fsid"s
   };
-  return KEYS;
 }
 
 void MgrStandby::handle_conf_change(

--- a/src/mgr/MgrStandby.h
+++ b/src/mgr/MgrStandby.h
@@ -34,7 +34,7 @@ class MgrStandby : public Dispatcher,
 		   public md_config_obs_t {
 public:
   // config observer bits
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set <std::string> &changed) override;
 

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -1283,7 +1283,8 @@ std::vector<std::string> LogMonitor::get_tracked_keys() const noexcept
     "mon_cluster_log_to_graylog"s,
     "mon_cluster_log_to_graylog_host"s,
     "mon_cluster_log_to_graylog_port"s,
-    "mon_cluster_log_to_journald"s
+    "mon_cluster_log_to_journald"s,
+    "mon_cluster_log_to_file"s
   };}
 
 void LogMonitor::handle_conf_change(const ConfigProxy& conf,

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -66,6 +66,7 @@
 #define dout_subsys ceph_subsys_mon
 
 using namespace TOPNSPC::common;
+using namespace std::literals;
 
 using std::cerr;
 using std::cout;
@@ -1272,6 +1273,18 @@ void LogMonitor::update_log_channels()
   log_external_close_fds();
 }
 
+std::vector<std::string> LogMonitor::get_tracked_keys() const noexcept
+{
+  return {
+    "mon_cluster_log_to_syslog"s,
+    "mon_cluster_log_to_syslog_facility"s,
+    "mon_cluster_log_file"s,
+    "mon_cluster_log_level"s,
+    "mon_cluster_log_to_graylog"s,
+    "mon_cluster_log_to_graylog_host"s,
+    "mon_cluster_log_to_graylog_port"s,
+    "mon_cluster_log_to_journald"s
+  };}
 
 void LogMonitor::handle_conf_change(const ConfigProxy& conf,
                                     const std::set<std::string> &changed)

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -182,20 +182,7 @@ private:
     g_conf().remove_observer(this);
   }
 
-  const char **get_tracked_conf_keys() const override {
-    static const char* KEYS[] = {
-      "mon_cluster_log_to_syslog",
-      "mon_cluster_log_to_syslog_facility",
-      "mon_cluster_log_file",
-      "mon_cluster_log_level",
-      "mon_cluster_log_to_graylog",
-      "mon_cluster_log_to_graylog_host",
-      "mon_cluster_log_to_graylog_port",
-      "mon_cluster_log_to_journald",
-      NULL
-    };
-    return KEYS;
-  }
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string> &changed) override;
 };

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -106,6 +106,7 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 using namespace TOPNSPC::common;
+using namespace std::literals;
 
 using std::cout;
 using std::dec;
@@ -612,44 +613,42 @@ void Monitor::write_features(MonitorDBStore::TransactionRef t)
   t->put(MONITOR_NAME, COMPAT_SET_LOC, bl);
 }
 
-const char** Monitor::get_tracked_conf_keys() const
+std::vector<std::string> Monitor::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
-    "crushtool", // helpful for testing
-    "mon_election_timeout",
-    "mon_lease",
-    "mon_lease_renew_interval_factor",
-    "mon_lease_ack_timeout_factor",
-    "mon_accept_timeout_factor",
+  return {
+    "crushtool"s, // helpful for testing
+    "mon_election_timeout"s,
+    "mon_lease"s,
+    "mon_lease_renew_interval_factor"s,
+    "mon_lease_ack_timeout_factor"s,
+    "mon_accept_timeout_factor"s,
     // clog & admin clog
-    "clog_to_monitors",
-    "clog_to_syslog",
-    "clog_to_syslog_facility",
-    "clog_to_syslog_level",
-    "clog_to_graylog",
-    "clog_to_graylog_host",
-    "clog_to_graylog_port",
-    "mon_cluster_log_to_file",
-    "host",
-    "fsid",
+    "clog_to_monitors"s,
+    "clog_to_syslog"s,
+    "clog_to_syslog_facility"s,
+    "clog_to_syslog_level"s,
+    "clog_to_graylog"s,
+    "clog_to_graylog_host"s,
+    "clog_to_graylog_port"s,
+    "mon_cluster_log_to_file"s,
+    "host"s,
+    "fsid"s,
     // periodic health to clog
-    "mon_health_to_clog",
-    "mon_health_to_clog_interval",
-    "mon_health_to_clog_tick_interval",
+    "mon_health_to_clog"s,
+    "mon_health_to_clog_interval"s,
+    "mon_health_to_clog_tick_interval"s,
     // scrub interval
-    "mon_scrub_interval",
-    "mon_allow_pool_delete",
+    "mon_scrub_interval"s,
+    "mon_allow_pool_delete"s,
     // osdmap pruning - observed, not handled.
-    "mon_osdmap_full_prune_enabled",
-    "mon_osdmap_full_prune_min",
-    "mon_osdmap_full_prune_interval",
-    "mon_osdmap_full_prune_txsize",
+    "mon_osdmap_full_prune_enabled"s,
+    "mon_osdmap_full_prune_min"s,
+    "mon_osdmap_full_prune_interval"s,
+    "mon_osdmap_full_prune_txsize"s,
     // debug options - observed, not handled
-    "mon_debug_extra_checks",
-    "mon_debug_block_osdmap_trim",
-    NULL
+    "mon_debug_extra_checks"s,
+    "mon_debug_block_osdmap_trim"s
   };
-  return KEYS;
 }
 
 void Monitor::handle_conf_change(const ConfigProxy& conf,

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1054,7 +1054,7 @@ private:
   static int check_features(MonitorDBStore *store);
 
   // config observer
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string> &changed) override;
 

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -143,14 +143,6 @@ void NVMeofGwMon::tick()
   }
 }
 
-const char **NVMeofGwMon::get_tracked_conf_keys() const
-{
-  static const char* KEYS[] = {
-    NULL
-  };
-  return KEYS;
-}
-
 version_t NVMeofGwMon::get_trim_to() const
 {
   // we don't actually need *any* old states, but keep a few.

--- a/src/mon/NVMeofGwMon.h
+++ b/src/mon/NVMeofGwMon.h
@@ -49,7 +49,9 @@ public:
   ~NVMeofGwMon() override {}
 
   // config observer
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override {
+    return {};
+  }
   void handle_conf_change(
     const ConfigProxy& conf, const std::set<std::string> &changed) override {};
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -111,6 +111,7 @@ using ceph::ErasureCodeProfile;
 using ceph::Formatter;
 using ceph::JSONFormatter;
 using ceph::make_message;
+using namespace std::literals;
 
 #define dout_subsys ceph_subsys_mon
 static const string OSD_PG_CREATING_PREFIX("osd_pg_creating");
@@ -481,15 +482,13 @@ OSDMonitor::OSDMonitor(
   }
 }
 
-const char **OSDMonitor::get_tracked_conf_keys() const
+std::vector<std::string> OSDMonitor::get_tracked_keys() const noexcept
 {
-  static const char* KEYS[] = {
-    "mon_memory_target",
-    "mon_memory_autotune",
-    "rocksdb_cache_size",
-    NULL
+  return {
+    "mon_memory_target"s,
+    "mon_memory_autotune"s,
+    "rocksdb_cache_size"s
   };
-  return KEYS;
 }
 
 void OSDMonitor::handle_conf_change(const ConfigProxy& conf,

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -213,7 +213,7 @@ public:
   OSDMap osdmap;
 
   // config observer
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
     const std::set<std::string> &changed) override;
   // [leader]


### PR DESCRIPTION
.. with get_tracked_keys().

This PR is but one of a set. Following
https://github.com/ceph/ceph/pull/61394, all uses of
the deprecated interface will be updated, and that
old interface will be removed.
