### PR TITLE
mgr/dashboard: Smb enhancement

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolumegroup-form/cephfs-subvolumegroup-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolumegroup-form/cephfs-subvolumegroup-form.component.html
@@ -1,8 +1,8 @@
 <cds-modal size="lg"
            [open]="open"
            [hasScrollingContent]="true"
-           (overlaySelected)="closeModal()">
-  <cds-modal-header (closeSelect)="closeModal()">
+           (overlaySelected)="closeModal1()">
+  <cds-modal-header (closeSelect)="closeModal1()">
     <h3 cdsModalHeaderHeading
         i18n>{{ action | titlecase }} {{ resource | upperFirst }}</h3>
   </cds-modal-header>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.ts
@@ -201,7 +201,7 @@ export class SmbClusterFormComponent extends CdForm implements OnInit {
           })
         ]
       ],
-      count: [1],
+      count: [2],
       custom_dns: new FormArray([]),
       joinSources: new FormArray([]),
       clustering: new UntypedFormControl(
@@ -217,8 +217,8 @@ export class SmbClusterFormComponent extends CdForm implements OnInit {
   }
 
   multiSelector(event: any, field: 'label' | 'hosts') {
-    if (field === PLACEMENT.host) this.selectedLabels = event.map((label: any) => label.content);
-    else this.selectedHosts = event.map((host: any) => host.content);
+    if (field === PLACEMENT.host) this.selectedHosts = event.map((host: any) => host.content);
+    else this.selectedLabels = event.map((label: any) => label.content);
   }
 
   onAuthModeChange() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.html
@@ -9,7 +9,11 @@
            class="form-header">
         {{ action | titlecase }} {{ resource | upperFirst }}
       </div>
-
+      <legend>
+        <cd-help-text i18n>
+          An SMB share is a resource on a server that is made accessible to users over a network using the SMB protocol.
+        </cd-help-text>
+      </legend>
       <!-- Share Id -->
       <div class="form-item">
         <cds-text-label
@@ -75,7 +79,17 @@
           >
         </ng-template>
       </div>
+      <cd-alert-panel *ngIf="allFsNames?.length === 0"
+      type="info"
+      spacingClass="mb-3"
+      class="align-items-center"
+      actionName="Create"
+      i18n
+      (action)="goToCreateVolume()">
+      No volume found. Consider creating it first to proceed.
+      </cd-alert-panel>
 
+      <!-- Sub Volume Group -->
       <div class="form-item"
            *ngIf="smbShareForm.getValue('volume')">
         <cds-select
@@ -88,7 +102,12 @@
           <option *ngIf="allsubvolgrps === null"
                   value=""
                   i18n>Loading...</option>
-          <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length >= 0"
+          <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length === 0"
+                  value=""
+                  i18n>
+            -- No SMB subvolume group available --
+          </option>
+          <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length > 0"
                   value=""
                   i18n>
             -- Select the CephFS subvolume group --
@@ -103,7 +122,18 @@
           </option>
         </cds-select>
       </div>
+      <cd-alert-panel *ngIf="allsubvolgrps?.length === 0 && smbShareForm.getValue('volume')"
+      type="info"
+      spacingClass="mb-3"
+      class="align-items-center"
+      actionName="Create"
+      i18n
+      (action)="goToCreateSubVolumeGrp()"
+      >
+      No sub volume group found. Consider creating it first to proceed.
+      </cd-alert-panel>
 
+      <!-- Sub Volume -->
       <div class="form-group row"
            *ngIf="smbShareForm.getValue('volume')">
         <cds-select
@@ -136,51 +166,60 @@
           </option>
         </cds-select>
       </div>
+      <cd-alert-panel *ngIf="allsubvols?.length === 0 && smbShareForm.getValue('volume')"
+      type="info"
+      spacingClass="mb-3"
+      class="align-items-center"
+      actionName="Create"
+      i18n
+      (action)="goToCreateSubVolume()">
+      No sub volume found. Consider creating it first to proceed.
+      </cd-alert-panel>
 
-    <!-- Path -->
-    <div class="form-item form-item-append"
-         cdsRow>
-      <div cdsCol>
-        <cds-text-label labelInputID="prefixedPath"
-                        i18n
-                        helperText="A path is a relative path.">Prefixed Path
-          <input cdsText
-                 type="text"
-                 id="prefixedPath"
-                 formControlName="prefixedPath" />
-        </cds-text-label>
-      </div>
-      <div cdsCol>
-        <cds-text-label
-          labelInputID="inputPath"
-          i18n
-          [invalid]="
-            smbShareForm.controls.inputPath.invalid && smbShareForm.controls.inputPath.dirty
-          "
-          [invalidText]="pathError"
-          helperText="A relative path in a cephFS file system."
-          cdRequiredField="Path"
-          >Input Path
-          <input
-            cdsText
-            type="text"
-            id="inputPath"
-            formControlName="inputPath"
+      <!-- Path -->
+      <div class="form-item form-item-append"
+          cdsRow>
+        <div cdsCol>
+          <cds-text-label labelInputID="prefixedPath"
+                          i18n
+                          helperText="A path is a relative path.">Prefixed Path
+            <input cdsText
+                  type="text"
+                  id="prefixedPath"
+                  formControlName="prefixedPath" />
+          </cds-text-label>
+        </div>
+        <div cdsCol>
+          <cds-text-label
+            labelInputID="inputPath"
+            i18n
             [invalid]="
               smbShareForm.controls.inputPath.invalid && smbShareForm.controls.inputPath.dirty
             "
-          />
-        </cds-text-label>
-        <ng-template #pathError>
-          <span
-            class="invalid-feedback"
-            *ngIf="smbShareForm.showError('inputPath', formDir, 'required')"
-            i18n
-            >This field is required.</span
-          >
-        </ng-template>
+            [invalidText]="pathError"
+            helperText="A relative path in a cephFS file system."
+            cdRequiredField="Path"
+            >Input Path
+            <input
+              cdsText
+              type="text"
+              id="inputPath"
+              formControlName="inputPath"
+              [invalid]="
+                smbShareForm.controls.inputPath.invalid && smbShareForm.controls.inputPath.dirty
+              "
+            />
+          </cds-text-label>
+          <ng-template #pathError>
+            <span
+              class="invalid-feedback"
+              *ngIf="smbShareForm.showError('inputPath', formDir, 'required')"
+              i18n
+              >This field is required.</span
+            >
+          </ng-template>
+        </div>
       </div>
-    </div>
 
       <!-- Browseable -->
       <div class="form-item">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-list/smb-share-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-list/smb-share-list.component.ts
@@ -90,7 +90,7 @@ export class SmbShareListComponent implements OnInit {
     ];
     this.tableActions = [
       {
-        name: `${this.actionLabels.CREATE}`,
+        name: `${this.actionLabels.CREATE} share`,
         permission: 'create',
         icon: Icons.add,
         routerLink: () => ['/cephfs/smb/share/create', this.clusterId],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/smb.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/smb.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import {
   ClusterRequestModel,
@@ -19,11 +19,17 @@ export class SmbService {
   baseURL = 'api/smb';
   private modalDataSubject = new Subject<DomainSettings>();
   modalData$ = this.modalDataSubject.asObservable();
+  private poolDataSource = new BehaviorSubject<any>(null);
+  poolData$ = this.poolDataSource.asObservable();
 
   constructor(private http: HttpClient) {}
 
   passData(data: DomainSettings) {
     this.modalDataSubject.next(data);
+  }
+
+  passPoolData(data: any) {
+    this.poolDataSource.next(data);
   }
 
   listClusters(): Observable<SMBCluster[]> {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/70257

Signed-off-by: Dnyaneshwari Talwekar <dtalweka@redhat.com>

1. A link to Create Volume, subvolume group and subvolume from Create Share Page.
2. Fixed placement as host and label was not added in create request body.
3. "Count" default to 2 for Create Cluster Page.
4. Helper-text for Create Share Page.

https://github.com/user-attachments/assets/d1dd3380-f5fc-4734-ad38-ad70d5beafe5



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
