### PR TITLE
squid: qa: ignore variant of down fs

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -5,6 +5,7 @@ overrides:
       - FS_INLINE_DATA_DEPRECATED
       - FS_WITH_FAILED_MDS
       - MDS_ALL_DOWN
+      - is offline because no MDS
       - MDS_DAMAGE
       - MDS_DEGRADED
       - MDS_FAILED


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70156

---

backport of https://github.com/ceph/ceph/pull/61943
parent tracker: https://tracker.ceph.com/issues/70107

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh