### PR TITLE
reef: qa: ignore variant of down fs

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -7,6 +7,7 @@ overrides:
       - FS_WITH_FAILED_MDS
       - MDS_ALL_DOWN
       - filesystem is offline
+      - is offline because no MDS
       - MDS_DAMAGE
       - MDS_DEGRADED
       - MDS_FAILED


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70155

---

backport of https://github.com/ceph/ceph/pull/61943
parent tracker: https://tracker.ceph.com/issues/70107

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh