### PR TITLE
reef:  rgw/rados: enable object deletion at rados pool quota

### DIFF
--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -3,3 +3,9 @@ tasks:
     clients:
       client.0:
         - rgw/run-rados-pool-quota.sh
+
+overrides:
+  ceph:
+    log-ignorelist:
+      - reached quota
+      - POOL_FULL

--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rgw/run-rados-pool-quota.sh

--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -9,3 +9,4 @@ overrides:
     log-ignorelist:
       - reached quota
       - POOL_FULL
+      - pool(s) full

--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -9,4 +9,4 @@ overrides:
     log-ignorelist:
       - reached quota
       - POOL_FULL
-      - pool(s) full
+      - pool\(s\) full

--- a/qa/workunits/rgw/run-rados-pool-quota.sh
+++ b/qa/workunits/rgw/run-rados-pool-quota.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+
+# assume working ceph environment (radosgw-admin in path) and rgw on localhost:80
+# localhost::443 for ssl
+
+mydir=`dirname $0`
+
+python3 -m venv $mydir
+source $mydir/bin/activate
+pip install pip --upgrade
+pip install boto3
+
+## run test
+$mydir/bin/python3 $mydir/test_rgw_rados_pool_quota.py
+
+deactivate
+echo OK.
+

--- a/qa/workunits/rgw/test_rgw_rados_pool_quota.py
+++ b/qa/workunits/rgw/test_rgw_rados_pool_quota.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import logging as log
+import uuid
+import botocore
+import time
+from common import exec_cmd, create_user, boto_connect
+from botocore.config import Config
+
+"""
+Tests rgw behavior when backing rados pool is at quota
+"""
+# The test cases in this file have been annotated for inventory.
+# To extract the inventory (in csv format) use the command:
+#
+#   grep '^ *# TESTCASE' | sed 's/^ *# TESTCASE //'
+#
+#
+
+""" Constants """
+USER = 'quota-tester'
+DISPLAY_NAME = 'Quota Tester'
+ACCESS_KEY = 'LTA662PVVDTDWX6M2AB0'
+SECRET_KEY = 'pvtchqajgzqx5581t6qbddbkj0bgf3a69qdkjcea'
+BUCKET_NAME = 'quota-tester-bucket'
+DATA_POOL = 'default.rgw.buckets.data'
+
+def main():
+    """
+    execute quota tests
+    """
+    create_user(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY)
+
+    connection = boto_connect(ACCESS_KEY, SECRET_KEY, Config(retries = {
+        'total_max_attempts': 1,
+    }))
+
+    # pre-test cleanup
+    try:
+        exec_cmd(f"ceph osd pool set-quota {DATA_POOL} max_objects 0")
+    except:
+        pass
+
+    try:
+        bucket = connection.Bucket(BUCKET_NAME)
+        bucket.objects.all().delete()
+        bucket.delete()
+    except botocore.exceptions.ClientError as e:
+        if not e.response['Error']['Code'] == 'NoSuchBucket':
+            raise
+
+    bucket = connection.create_bucket(Bucket=BUCKET_NAME)
+
+    # reproducer for bug from https://tracker.ceph.com/issues/69723
+    # TESTCASE 'add objects to pool, set quota to small value, verify that we can delete objects'
+    log.debug('TEST: verify that objects can be deleted with rados pool at quota')
+    key = str(uuid.uuid4())
+
+    objects = [f"{key}.{i}" for i in range(10)]
+    for obj in objects:
+        bucket.put_object(Key=obj, Body=b"new data")
+
+    exec_cmd(f"ceph osd pool set-quota {DATA_POOL} max_objects 1")
+
+    log.debug('forcing quota to propagate')
+    # We need the monitor to notice the pool stats and set the pool flags
+    time.sleep(10)
+    # And then we need to make sure the map with the newly set pool flags
+    # has propagated to the OSDs.  rados ls should force every OSD with a
+    # pg for this pool to have the most recent map
+    exec_cmd(f'rados -p {DATA_POOL} ls')
+    log.debug('forced quota to propagate')
+
+    for obj in objects:
+        try:
+            bucket.Object(obj).delete()
+        except Exception as e:
+            log.debug(f"Got error {e} on delete of obj {obj}")
+            assert False, f'Failure to delete obj {obj} with error {e}'
+
+    (_out, ret) = exec_cmd(f'rados -p {DATA_POOL} ls | grep {key}', check_retcode=False)
+    assert ret != 0, f'some objects were not cleaned up: {_out.decode("utf-8")}'
+
+    # reset quota
+    exec_cmd(f"ceph osd pool set-quota {DATA_POOL} max_objects 0")
+
+main()
+log.info("Completed rados pool quota tests")

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -437,7 +437,7 @@ RGWRadosRemoveCR::RGWRadosRemoveCR(rgw::sal::RadosStore* store, const rgw_raw_ob
 int RGWRadosRemoveCR::send_request(const DoutPrefixProvider *dpp)
 {
   auto rados = store->getRados()->get_rados_handle();
-  int r = rados->ioctx_create(obj.pool.name.c_str(), ioctx);
+  int r = rgw_init_ioctx(dpp, rados, obj.pool, ioctx);
   if (r < 0) {
     lderr(cct) << "ERROR: failed to open pool (" << obj.pool.name << ") ret=" << r << dendl;
     return r;

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -673,6 +673,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
 	  }
 
 	  ctx->locator_set_key(obj.loc);
+	  ctx->set_pool_full_try(); // allow deletion at pool quota limit
 
 	  const string& oid = obj.key.name; /* just stored raw oid there */
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4650,6 +4650,7 @@ done_ret:
         continue;
       }
       auto& ref = obj.get_ref();
+      ref.pool.ioctx().set_pool_full_try();  // allow deletion at pool quota limit
 
       ObjectWriteOperation op;
       cls_refcount_put(op, ref_tag, true);
@@ -5066,6 +5067,7 @@ void RGWRados::delete_objs_inline(const DoutPrefixProvider *dpp, cls_rgw_obj_cha
         obj.pool << dendl;
         continue;
       }
+      ctx->set_pool_full_try();  // allow deletion at pool quota limit
       last_pool = obj.pool;
     }
     ctx->locator_set_key(obj.loc);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5535,6 +5535,7 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
   store->remove_rgw_head_obj(op);
 
   auto& ioctx = ref.pool.ioctx();
+  ioctx.set_pool_full_try(); // allow deletion at pool quota limit
   version_t epoch = 0;
   r = rgw_rados_operate(dpp, ioctx, ref.obj.oid, &op, y, 0, &epoch);
 

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -92,6 +92,8 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
   if (!pool.ns.empty()) {
     ioctx.set_namespace(pool.ns);
   }
+  // at pool quota, never block waiting for space - we want to error immediately
+  ioctx.set_pool_full_try();
   return 0;
 }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -132,6 +132,8 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_NO_SUCH_TAG_SET, {404, "NoSuchTagSet"}},
     { ERR_NO_SUCH_BUCKET_ENCRYPTION_CONFIGURATION, {404, "ServerSideEncryptionConfigurationNotFoundError"}},
     { ERR_NO_SUCH_PUBLIC_ACCESS_BLOCK_CONFIGURATION, {404, "NoSuchPublicAccessBlockConfiguration"}},
+    { EDQUOT, {507, "InsufficientCapacity"}},
+    { ENOSPC, {507, "InsufficientCapacity"}},
 });
 
 rgw_http_errors rgw_http_swift_errors({

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -82,6 +82,7 @@ const static struct rgw_http_status_code http_codes[] = {
   { 500, "Internal Server Error" },
   { 501, "Not Implemented" },
   { 503, "Slow Down"},
+  { 507, "Insufficient Storage"},
   { 0, NULL },
 };
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70265

---

backport of https://github.com/ceph/ceph/pull/61650
parent tracker: https://tracker.ceph.com/issues/69723

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh