### PR TITLE
mgr/dashboard: bucket lifecycle fixes after using xmltodict package

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-bucket-lifecycle.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-bucket-lifecycle.ts
@@ -1,0 +1,36 @@
+export interface Lifecycle {
+  LifecycleConfiguration: LifecycleConfiguration;
+}
+
+export interface LifecycleConfiguration {
+  Rule: Rule[];
+}
+
+export interface Rule {
+  ID: string;
+  Status: string;
+  Transition: Transition;
+  Prefix?: string;
+  Filter?: Filter;
+}
+
+export interface Filter {
+  And?: And;
+  Prefix?: string;
+  Tag?: Tag | Tag[];
+}
+
+export interface And {
+  Prefix: string;
+  Tag: Tag | Tag[];
+}
+
+export interface Tag {
+  Key: string;
+  Value: string;
+}
+
+export interface Transition {
+  Days: string;
+  StorageClass: string;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-lifecycle-list/rgw-bucket-lifecycle-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-lifecycle-list/rgw-bucket-lifecycle-list.component.ts
@@ -17,6 +17,7 @@ import { Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { Lifecycle, Rule } from '../models/rgw-bucket-lifecycle';
 
 @Component({
   selector: 'cd-rgw-bucket-lifecycle-list',
@@ -96,7 +97,7 @@ export class RgwBucketLifecycleListComponent implements OnInit {
     const allLifecycleRules$ = this.rgwBucketService
       .getLifecycle(this.bucket.bucket, this.bucket.owner)
       .pipe(
-        tap((lifecycle) => {
+        tap((lifecycle: Lifecycle) => {
           this.lifecycleRuleList = lifecycle;
         }),
         catchError(() => {
@@ -108,7 +109,7 @@ export class RgwBucketLifecycleListComponent implements OnInit {
     this.filteredLifecycleRules$ = allLifecycleRules$.pipe(
       map(
         (lifecycle: any) =>
-          lifecycle?.LifecycleConfiguration?.Rules?.filter((rule: object) =>
+          lifecycle?.LifecycleConfiguration?.Rule?.filter((rule: Rule) =>
             rule.hasOwnProperty('Transition')
           ) || []
       )
@@ -130,10 +131,10 @@ export class RgwBucketLifecycleListComponent implements OnInit {
 
   deleteAction() {
     const ruleNames = this.selection.selected.map((rule) => rule.ID);
-    const filteredRules = this.lifecycleRuleList.LifecycleConfiguration.Rules.filter(
-      (rule: any) => !ruleNames.includes(rule.ID)
+    const filteredRules = this.lifecycleRuleList.LifecycleConfiguration.Rule.filter(
+      (rule: Rule) => !ruleNames.includes(rule.ID)
     );
-    const rules = filteredRules.length > 0 ? { Rules: filteredRules } : {};
+    const rules = filteredRules.length > 0 ? { Rule: filteredRules } : {};
     this.modalRef = this.modalService.show(DeleteConfirmationModalComponent, {
       itemDescription: $localize`Rule`,
       itemNames: ruleNames,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.html
@@ -136,25 +136,35 @@
                  class="form-item form-item-append">
               <div cdsCol>
                 <cds-text-label labelInputID="Key"
+                                [invalid]="!tieringForm.controls['tags'].controls[i].controls['Key'].valid && tieringForm.controls['tags'].controls[i].controls['Key'].dirty"
+                                [invalidText]="tagKeyError"
                                 i18n>Name of the object key
                   <input cdsText
                          type="text"
                          placeholder="Enter name of the object key"
-                         id="Key"
                          formControlName="Key"
-                         i18n-placeholder/>
+                         i18n-placeholder
+                         [invalid]="tieringForm.controls['tags'].controls[i].controls['Key'].invalid && tieringForm.controls['tags'].controls[i].controls['Key'].dirty"/>
                 </cds-text-label>
+                <ng-template #tagKeyError>
+                  <ng-container i18n>This field is required.</ng-container>
+                </ng-template>
               </div>
               <div cdsCol>
                 <cds-text-label labelInputID="Value"
+                                [invalid]="!tieringForm.controls['tags'].controls[i].controls['Value'].valid && tieringForm.controls['tags'].controls[i].controls['Value'].dirty"
+                                [invalidText]="tagValueError"
                                 i18n>Value of the tag
                   <input cdsText
                          type="text"
                          placeholder="Enter value of the tag"
-                         id="Value"
                          formControlName="Value"
-                         i18n-placeholder/>
+                         i18n-placeholder
+                         [invalid]="tieringForm.controls['tags'].controls[i].controls['Value'].invalid && tieringForm.controls['tags'].controls[i].controls['Value'].dirty"/>
                 </cds-text-label>
+                <ng-template #tagValueError>
+                  <ng-container i18n>This field is required.</ng-container>
+                </ng-template>
               </div>
               <div cdsCol
                    [columnNumbers]="{ lg: 2, md: 2 }"


### PR DESCRIPTION
NOTE:
===
This PR is based on commits from this [PR](https://github.com/ceph/ceph/pull/61781/), after using xmltodict package, we can now edit/add tags in lifecycle rule.

Fixes: https://tracker.ceph.com/issues/70275


https://github.com/user-attachments/assets/d73497bd-0582-4b02-bd24-a3bd911ca217





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
