### PR TITLE
cls/cmpxattr: add cls to perform atomic cmp-exchange on a set of xattributes

### DIFF
--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -346,6 +346,7 @@ add_library(cls_2pc_queue_client STATIC ${cls_2pc_queue_client_srcs})
 
 
 add_subdirectory(cmpomap)
+add_subdirectory(cmpxattr)
 
 # cls_fifo
 set(cls_fifo_srcs fifo/cls_fifo.cc)

--- a/src/cls/cmpxattr/CMakeLists.txt
+++ b/src/cls/cmpxattr/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(cls_cmpxattr SHARED server.cc)
+set_target_properties(cls_cmpxattr PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH ""
+  CXX_VISIBILITY_PRESET hidden)
+install(TARGETS cls_cmpxattr DESTINATION ${cls_dir})
+
+add_library(cls_cmpxattr_client STATIC client.cc)

--- a/src/cls/cmpxattr/client.cc
+++ b/src/cls/cmpxattr/client.cc
@@ -1,0 +1,91 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IBM Corp.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "include/rados/librados.hpp"
+#include "client.h"
+#include "ops.h"
+#include "common/dout.h"
+#include "common/errno.h"
+
+namespace cls::cmpxattr {
+  //---------------------------------------------------------------------------
+  int cmp_vals_set_vals(librados::ObjectWriteOperation& op,
+			Mode mode, Op comparison,
+			const ComparisonMap&& cmp_pairs,
+			const std::map<std::string, bufferlist>&& set_pairs,
+			bufferlist *out)
+  {
+    // Limit the number of cmp/set pairs (currently set to 8)
+    if (unlikely(cmp_pairs.size() > max_keys || set_pairs.size() > max_keys)) {
+      return -E2BIG;
+    }
+
+    // Caller must supply non-empty cmp_pairs and set_pairs
+    // However, it is legal to pass an empty value bl for the key
+    //         this is used when try to set a new key/value atomically
+    if (unlikely(cmp_pairs.empty() || set_pairs.empty())) {
+      return -EINVAL;
+    }
+
+    cmp_vals_set_vals_op call;
+    call.mode = mode;
+    call.comparison = comparison;
+    call.cmp_pairs = std::move(cmp_pairs);
+    call.set_pairs = std::move(set_pairs);
+    // not sure what is it used for, so don't need to pass an argument for it
+    // in any case, keep a static place for an async reply
+    static int rval;
+    bufferlist in;
+    encode(call, in);
+    op.exec("cmpxattr", "cmp_vals_set_vals", in, out, &rval);
+    return 0;
+  }
+
+  //---------------------------------------------------------------------------
+  int report_cmp_set_error(const DoutPrefixProvider *dpp,
+			   int err_code,
+			   const bufferlist &err_bl,
+			   const char *caller)
+  {
+    int ret = err_code;
+    if (err_code != 0) {
+      ldpp_dout(dpp, 1) << caller << "::ERR: failed cmp_vals_set_vals::"
+			<< cpp_strerror(err_code)
+			<< ", err_code=" << err_code << dendl;
+    }
+    else if (err_bl.length() ) {
+      try {
+	std::string key;
+	std::string val;
+	auto bl_iter = err_bl.cbegin();
+	using ceph::decode;
+	decode(key, bl_iter);
+	decode(val, bl_iter);
+	ldpp_dout(dpp, 10) << caller << "::ERR: failed cmp_vals_set_vals for key: "
+			   << key << "::val=" << val << dendl;
+	// another thread set a new value causing CMP to fail
+	ret = -EBUSY;
+      } catch (buffer::error& err) {
+	ldpp_dout(dpp, 1) << caller << "::ERR: unable to decode err_bl" << dendl;
+	ret = -EINVAL;
+      }
+    }
+    else {
+      // Should only call this API to report error!
+      ldpp_dout(dpp, 10) << caller << "::success (should not be called)" << dendl;
+    }
+
+    return ret;
+  }
+} // namespace cls::cmpxattr

--- a/src/cls/cmpxattr/client.h
+++ b/src/cls/cmpxattr/client.h
@@ -1,0 +1,64 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IBM Corp.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <optional>
+#include "include/rados/librados_fwd.hpp"
+#include "types.h"
+#include "ops.h"
+#include "include/utime.h"
+#include "common/ceph_time.h"
+#include "common/dout.h"
+
+namespace cls::cmpxattr {
+  /// requests with too many key comparisons will be rejected with -E2BIG
+  static constexpr uint32_t max_keys = 8;
+
+  /// process each of the xattrs value comparisons according to the same rules as
+  /// cmpxattr(). IFF **all** key/value pairs in @cmp_pairs compare successfully
+  /// a set operation will be perfrom for **all** key/value pairs in @set_pairs.
+  /// Caller must supply non-empty cmp_pairs and set_pairs
+  /// However, it is legal to pass an empty value bl for any key
+  ///         An empty value will match key with an empty value or a non-existing key!
+  ///
+  /// for comparisons with Mode::U64, failure to decode an input value is
+  /// reported as -EINVAL.
+  /// a decode failure of a stored value is treated as an unsuccessful comparison
+  /// and is not reported as an error
+  [[nodiscard]] int cmp_vals_set_vals(librados::ObjectWriteOperation& writeop,
+				      Mode mode, Op comparison,
+				      const ComparisonMap&& cmp_pairs,
+				      const std::map<std::string, bufferlist>&& set_pairs,
+				      bufferlist *out);
+
+  int report_cmp_set_error(const DoutPrefixProvider *dpp,
+			   int err_code,
+			   const bufferlist &err_bl,
+			   const char *caller);
+
+  // bufferlist factories for comparison values
+  inline ceph::bufferlist string_buffer(const std::string_view& value) {
+    ceph::bufferlist bl;
+    bl.append(value);
+    return bl;
+  }
+  inline ceph::bufferlist u64_buffer(uint64_t value) {
+    ceph::bufferlist bl;
+    using ceph::encode;
+    encode(value, bl);
+    return bl;
+  }
+
+} // namespace cls::cmpxattr

--- a/src/cls/cmpxattr/ops.h
+++ b/src/cls/cmpxattr/ops.h
@@ -1,0 +1,50 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IBM Corp.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include "types.h"
+#include "include/encoding.h"
+#include <time.h>
+#include "include/utime.h"
+#include "common/ceph_time.h"
+
+namespace cls::cmpxattr {
+  struct cmp_vals_set_vals_op {
+    Mode mode;
+    Op comparison;
+    ComparisonMap cmp_pairs;
+    std::map<std::string, ceph::bufferlist> set_pairs;
+  };
+
+  inline void encode(const cmp_vals_set_vals_op& o, ceph::bufferlist& bl)
+  {
+    ENCODE_START(1, 1, bl);
+    encode(o.mode, bl);
+    encode(o.comparison, bl);
+    encode(o.cmp_pairs, bl);
+    encode(o.set_pairs, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  inline void decode(cmp_vals_set_vals_op& o, ceph::bufferlist::const_iterator& bl)
+  {
+    DECODE_START(1, bl);
+    decode(o.mode, bl);
+    decode(o.comparison, bl);
+    decode(o.cmp_pairs, bl);
+    decode(o.set_pairs, bl);
+    DECODE_FINISH(bl);
+  }
+} // namespace cls::cmpxattr

--- a/src/cls/cmpxattr/server.cc
+++ b/src/cls/cmpxattr/server.cc
@@ -1,0 +1,173 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IBM Corp.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "objclass/objclass.h"
+#include "ops.h"
+#include "common/errno.h"
+CLS_VER(1,0)
+CLS_NAME(cmpxattr)
+
+using namespace cls::cmpxattr;
+
+// returns negative error codes or 0/1 for failed/successful comparisons
+template <typename T>
+static int compare_values(Op op, const T& lhs, const T& rhs)
+{
+  switch (op) {
+  case Op::EQ:  return (lhs == rhs);
+  case Op::NE:  return (lhs != rhs);
+  case Op::GT:  return (lhs > rhs);
+  case Op::GTE: return (lhs >= rhs);
+  case Op::LT:  return (lhs < rhs);
+  case Op::LTE: return (lhs <= rhs);
+  default:      return -EINVAL;
+  }
+}
+
+static int compare_values_u64(Op op, uint64_t lhs, const bufferlist& value)
+{
+  // empty values compare as 0 for backward compat
+  uint64_t rhs = 0;
+  if (value.length()) {
+    try {
+      // decode existing value as rhs
+      auto p = value.cbegin();
+      using ceph::decode;
+      decode(rhs, p);
+    } catch (const buffer::error&) {
+      // failures to decode existing values are reported as EIO
+      return -EIO;
+    }
+  }
+  return compare_values(op, lhs, rhs);
+}
+
+static int compare_value(Mode mode, Op op, const bufferlist& input,
+			 const bufferlist& value)
+{
+  switch (mode) {
+  case Mode::String:
+    return compare_values(op, input, value);
+  case Mode::U64:
+    try {
+      // decode input value as lhs
+      uint64_t lhs;
+      auto p = input.cbegin();
+      using ceph::decode;
+      decode(lhs, p);
+      return compare_values_u64(op, lhs, value);
+    } catch (const buffer::error&) {
+      // failures to decode input values are reported as EINVAL
+      return -EINVAL;
+    }
+  default:
+    return -EINVAL;
+  }
+}
+
+//-------------------------------------------------------------------------------------
+static int cmp_vals_set_vals(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  cmp_vals_set_vals_op op;
+  try {
+    auto p = in->cbegin();
+    decode(op, p);
+  } catch (const buffer::error&) {
+    CLS_LOG(4, "ERROR: %s: failed to decode input", __func__);
+    return -EINVAL;
+  }
+
+  // read the values for each key to compare
+  std::map<std::string, bufferlist> cmp_values;
+  for (const auto& kv : op.cmp_pairs) {
+    const std::string &key = kv.first;
+    ceph::bufferlist bl;
+    int ret = cls_cxx_getxattr(hctx, key.c_str(), &bl);
+    if (ret < 0 && ret != -ENODATA) {
+      CLS_LOG(4, "ERROR: %s: cls_cxx_getxattr() for key=%s ret=%d",
+	      __func__, key.c_str(), ret);
+      return ret;
+    } else {
+      // ENODATA will generate an empty value bl
+      cmp_values[key] = bl;
+    }
+  }
+
+  auto v = cmp_values.begin();
+  for (const auto& [key, input] : op.cmp_pairs) {
+    auto k = cmp_values.end();
+    bufferlist value;
+    if (v != cmp_values.end() && v->first == key) {
+      value = std::move(v->second);
+      k = v++;
+      CLS_LOG(20, "%s::comparing key=%s mode=%d op=%d",
+	      __func__, key.c_str(), (int)op.mode, (int)op.comparison);
+    } else {
+      CLS_LOG(10, "%s:: missing key=%s, abort operation", __func__, key.c_str());
+      return -EINVAL;
+    }
+
+    int ret = 0;
+    // an empty input value will match an empty value or a non-existing key
+    if (input.length() == 0 && (op.comparison == Op::EQ)) {
+      if (value.length() == 0) {
+	ret = true;
+      }
+      else {
+	CLS_LOG(10, "%s:: key=%s exists!", __func__, key.c_str());
+	return -EEXIST;
+      }
+    }
+    else {
+      ret = compare_value(op.mode, op.comparison, input, value);
+    }
+    if (ret <= 0) {
+      // unsuccessful comparison
+      CLS_LOG(10, "%s:: failed compare key=%s ret=%d", __func__, key.c_str(), ret);
+      // set the failing key in the returned bl
+      encode(key, *out);
+      encode(value, *out);
+      return ret;
+    }
+
+    // successful comparison
+    CLS_LOG(20, "%s:: successful comparison key=%s", __func__, key.c_str());
+  }
+
+  // if arrived here all keys in the cmp_pairs passed check
+  // overwrite all key/values in the set_pairs
+  for (const auto& [key, value] : op.set_pairs) {
+    auto inbl = const_cast<ceph::bufferlist *>(&value);
+    int ret = cls_cxx_setxattr(hctx, key.c_str(), inbl);
+    if (ret == 0) {
+      CLS_LOG(20, "%s:: successful set xattr key=%s", __func__, key.c_str());
+    }
+    else {
+      CLS_LOG(4, "ERROR: %s failed to set xattr key=%s ret=%d", __func__, key.c_str(), ret);
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+CLS_INIT(cmpxattr)
+{
+  CLS_LOG(10, "Loaded cmpxattr class!");
+  cls_handle_t h_class;
+  cls_method_handle_t h_cmp_vals_set_vals;
+  cls_register("cmpxattr", &h_class);
+  cls_register_cxx_method(h_class, "cmp_vals_set_vals", CLS_METHOD_RD | CLS_METHOD_WR,
+			  cmp_vals_set_vals, &h_cmp_vals_set_vals);
+}

--- a/src/cls/cmpxattr/types.h
+++ b/src/cls/cmpxattr/types.h
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IBM Corp.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <string>
+#include <boost/container/flat_map.hpp>
+#include "include/rados.h" // CEPH_OSD_CMPXATTR_*
+#include "include/encoding.h"
+
+namespace cls::cmpxattr {
+
+  /// comparison operand type
+  enum class Mode : uint8_t {
+    String = CEPH_OSD_CMPXATTR_MODE_STRING,
+    U64    = CEPH_OSD_CMPXATTR_MODE_U64,
+  };
+
+  /// comparison operation, where the left-hand operand is the input value and
+  /// the right-hand operand is the stored value (or the optional default)
+  enum class Op : uint8_t {
+    EQ  = CEPH_OSD_CMPXATTR_OP_EQ,
+    NE  = CEPH_OSD_CMPXATTR_OP_NE,
+    GT  = CEPH_OSD_CMPXATTR_OP_GT,
+    GTE = CEPH_OSD_CMPXATTR_OP_GTE,
+    LT  = CEPH_OSD_CMPXATTR_OP_LT,
+    LTE = CEPH_OSD_CMPXATTR_OP_LTE,
+  };
+
+  /// mapping of xattr keys to value comparisons
+  using ComparisonMap = boost::container::flat_map<std::string, ceph::bufferlist>;
+
+} // namespace cls::cmpxattr

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -44,6 +44,7 @@ extern int cls_getxattr(cls_method_context_t hctx, const char *name,
                                  char **outdata, int *outdatalen);
 extern int cls_setxattr(cls_method_context_t hctx, const char *name,
                                  const char *value, int val_len);
+extern int cls_rmxattr(cls_method_context_t hctx, const char *name);
 /** This will fill in the passed origin pointer with the origin of the
  * request which activated your class call. */
 extern int cls_get_request_origin(cls_method_context_t hctx,

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -73,7 +73,8 @@ endif()
 
 # libcls_* are runtime dependencies
 add_dependencies(osd cls_journal cls_hello cls_lock cls_log cls_numops
-  cls_refcount cls_timeindex cls_user cls_version cls_cas cls_cmpomap)
+  cls_refcount cls_timeindex cls_user cls_version cls_cas cls_cmpomap cls_cmpxattr)
+
 if(WITH_CEPHFS)
   add_dependencies(osd cls_cephfs)
 endif()

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -102,6 +102,22 @@ int cls_setxattr(cls_method_context_t hctx, const char *name,
   return r;
 }
 
+int cls_rmxattr(cls_method_context_t hctx, const char *name)
+{
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
+  vector<OSDOp> nops(1);
+  OSDOp& op = nops[0];
+  int r;
+
+  op.op.op = CEPH_OSD_OP_RMXATTR;
+  op.op.xattr.name_len = strlen(name);
+  op.op.xattr.value_len = 0;
+  op.indata.append(name, op.op.xattr.name_len);
+  r = (*pctx)->pg->do_osd_ops(*pctx, nops);
+
+  return r;
+}
+
 int cls_read(cls_method_context_t hctx, int ofs, int len,
 	     char **outdata, int *outdatalen)
 {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -57,6 +57,7 @@ if(NOT WIN32)
   add_subdirectory(cls_queue)
   add_subdirectory(cls_2pc_queue)
   add_subdirectory(cls_cmpomap)
+  add_subdirectory(cls_cmpxattr)
   add_subdirectory(journal)
 
   add_subdirectory(erasure-code)

--- a/src/test/cls_cmpxattr/CMakeLists.txt
+++ b/src/test/cls_cmpxattr/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(ceph_test_cls_cmpxattr test_cls_cmpxattr.cc)
+target_link_libraries(ceph_test_cls_cmpxattr cls_cmpxattr_client librados radostest-cxx ${UNITTEST_LIBS})
+install(TARGETS ceph_test_cls_cmpxattr DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_cmpxattr/test_cls_cmpxattr.cc
+++ b/src/test/cls_cmpxattr/test_cls_cmpxattr.cc
@@ -1,0 +1,713 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat, Inc
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "cls/cmpxattr/client.h"
+#include "test/librados/test_cxx.h"
+#include "gtest/gtest.h"
+#include "common/errno.h"
+#include <optional>
+
+// create/destroy a pool that's shared by all tests in the process
+struct RadosEnv : public ::testing::Environment {
+  static std::optional<std::string> pool_name;
+public:
+  static librados::Rados rados;
+  static librados::IoCtx ioctx;
+
+  void SetUp() override {
+    // create pool
+    std::string name = get_temp_pool_name();
+    ASSERT_EQ("", create_one_pool_pp(name, rados));
+    pool_name = name;
+    ASSERT_EQ(rados.ioctx_create(name.c_str(), ioctx), 0);
+  }
+  void TearDown() override {
+    ioctx.close();
+    if (pool_name) {
+      ASSERT_EQ(destroy_one_pool_pp(*pool_name, rados), 0);
+    }
+  }
+};
+std::optional<std::string> RadosEnv::pool_name;
+librados::Rados RadosEnv::rados;
+librados::IoCtx RadosEnv::ioctx;
+
+auto *const rados_env = ::testing::AddGlobalTestEnvironment(new RadosEnv);
+
+namespace cls::cmpxattr {
+
+  // test fixture with helper functions
+  class CmpXattr : public ::testing::Test {
+  protected:
+    librados::IoCtx& ioctx = RadosEnv::ioctx;
+
+    //---------------------------------------------------------------------------
+    bool do_cmp_vals_set_vals(const std::string& oid,
+			      Mode mode,
+			      Op comparison,
+			      const ComparisonMap cmp_pairs,
+			      const std::map<std::string, bufferlist> set_pairs,
+			      int *p_ret = nullptr,
+			      std::string *p_key = nullptr)
+    {
+      bufferlist err_bl;
+      librados::ObjectWriteOperation op;
+      int ret = cmp_vals_set_vals(op, mode, comparison, std::move(cmp_pairs),
+				  std::move(set_pairs), &err_bl);
+      if (ret < 0) {
+	return ret;
+      }
+      ret = ioctx.operate(oid, &op, librados::OPERATION_RETURNVEC);
+      if (p_ret) {
+	*p_ret = ret;
+      }
+
+      if (ret == 0 && err_bl.length() && p_key) {
+	try {
+	  //std::string key;
+	  auto bl_iter = err_bl.cbegin();
+	  using ceph::decode;
+	  decode(*p_key, bl_iter);
+	} catch (buffer::error& err) {
+	  std::cerr << __func__ << "::ERROR: unable to decode err_bl" << std::endl;
+	}
+      }
+
+      return (ret == 0 && err_bl.length() == 0);
+    }
+
+  };
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_str_wrong_val_for_key)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const std::string key = "key_to_fail";
+    bufferlist val1 = string_buffer("val1");
+    bufferlist val2 = string_buffer("val2");
+
+    ASSERT_EQ(ioctx.setxattr(oid, key.c_str(), val1), 0);
+
+    std::string failed_key;
+    bool success = do_cmp_vals_set_vals(oid, Mode::String, Op::EQ, {{key, val2}}, {{key, val2}},
+					nullptr, &failed_key);
+    EXPECT_EQ(success, false);
+    EXPECT_EQ(key, failed_key);
+
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 1);
+      EXPECT_EQ(val1, vals[key]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_wrong_val_for_key)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const std::string key = "key_to_fail";
+    bufferlist val1 = u64_buffer(17);
+    bufferlist val2 = u64_buffer(29);
+
+    ASSERT_EQ(ioctx.setxattr(oid, key.c_str(), val1), 0);
+
+    std::string failed_key;
+    bool success = do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, {{key, val2}}, {{key, val2}},
+					nullptr, &failed_key);
+    EXPECT_EQ(success, false);
+    EXPECT_EQ(key, failed_key);
+
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 1);
+      EXPECT_EQ(val1, vals[key]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_str)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const bufferlist val1 = string_buffer("bbb");
+    const bufferlist val2 = string_buffer("ccc");
+    {
+      librados::ObjectWriteOperation op;
+      op.setxattr("eq",  val1);
+      op.setxattr("ne",  val1);
+      op.setxattr("gt",  val1);
+      op.setxattr("gte", val1);
+      op.setxattr("lt",  val1);
+      op.setxattr("lte", val1);
+      ASSERT_EQ(0, ioctx.operate(oid, &op));
+    }
+
+    Mode mode = Mode::String;
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::EQ,  {{"eq", val2}},  {{"eq", val2}}),  false);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::NE,  {{"ne", val2}},  {{"ne", val2}}),  true);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::GT,  {{"gt", val2}},  {{"gt", val2}}),  true);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::GTE, {{"gte", val2}}, {{"gte", val2}}), true);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::LT,  {{"lt", val2}},  {{"lt", val2}}),  false);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::LTE, {{"lte", val2}}, {{"lte", val2}}), false);
+
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 6);
+      EXPECT_EQ(val1, vals["eq"]);
+      EXPECT_EQ(val2, vals["ne"]);
+      EXPECT_EQ(val2, vals["gt"]);
+      EXPECT_EQ(val2, vals["gte"]);
+      EXPECT_EQ(val1, vals["lt"]);
+      EXPECT_EQ(val1, vals["lte"]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const bufferlist val1 = u64_buffer(17);
+    const bufferlist val2 = u64_buffer(41);
+    {
+      librados::ObjectWriteOperation op;
+      op.setxattr("eq",  val1);
+      op.setxattr("ne",  val1);
+      op.setxattr("gt",  val1);
+      op.setxattr("gte", val1);
+      op.setxattr("lt",  val1);
+      op.setxattr("lte", val1);
+      ASSERT_EQ(0, ioctx.operate(oid, &op));
+    }
+
+    Mode mode = Mode::U64;
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::EQ,  {{"eq", val2}},  {{"eq", val2}}),  false);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::NE,  {{"ne", val2}},  {{"ne", val2}}),  true);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::GT,  {{"gt", val2}},  {{"gt", val2}}),  true);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::GTE, {{"gte", val2}}, {{"gte", val2}}), true);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::LT,  {{"lt", val2}},  {{"lt", val2}}),  false);
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, mode, Op::LTE, {{"lte", val2}}, {{"lte", val2}}), false);
+
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 6);
+      EXPECT_EQ(val1, vals["eq"]);
+      EXPECT_EQ(val2, vals["ne"]);
+      EXPECT_EQ(val2, vals["gt"]);
+      EXPECT_EQ(val2, vals["gte"]);
+      EXPECT_EQ(val1, vals["lt"]);
+      EXPECT_EQ(val1, vals["lte"]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_single_set)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    ComparisonMap cmp_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    librados::ObjectWriteOperation op;
+    for (uint32_t i = 0; i < max_keys; i++) {
+      std::string key = std::to_string(i);
+      const bufferlist val1 = u64_buffer(i);
+      const bufferlist val2 = u64_buffer(i*2);
+      cmp_pairs.emplace(key, val1);
+      set_pairs.emplace(key, val2);
+      op.setxattr(key.c_str(), val1);
+    }
+    ASSERT_EQ(0, ioctx.operate(oid, &op));
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size());
+      for (uint32_t i = 0; i < cmp_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(cmp_pairs[key], vals[key]);
+      }
+    }
+
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, cmp_pairs, set_pairs), true);
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), set_pairs.size());
+      for (uint32_t i = 0; i < set_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(set_pairs[key], vals[key]);
+      }
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_existing_set_nonexisting_set)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    ComparisonMap cmp_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    librados::ObjectWriteOperation op;
+    for (uint32_t i = 0; i < max_keys; i++) {
+      std::string key1 = std::to_string(i);
+      std::string key2 = std::to_string(i+max_keys);
+      const bufferlist val1 = u64_buffer(i);
+      const bufferlist val2 = u64_buffer(i*5);
+      cmp_pairs.emplace(key1, val1);
+      set_pairs.emplace(key2, val2);
+      op.setxattr(key1.c_str(), val1);
+    }
+    ASSERT_EQ(0, ioctx.operate(oid, &op));
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size());
+      for (uint32_t i = 0; i < cmp_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(cmp_pairs[key], vals[key]);
+	EXPECT_EQ(set_pairs.contains(key), false);
+      }
+    }
+
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, cmp_pairs, set_pairs), true);
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size() + set_pairs.size());
+      for (uint32_t i = 0; i < set_pairs.size(); i++) {
+	std::string key1 = std::to_string(i);
+	std::string key2 = std::to_string(i+max_keys);
+	EXPECT_EQ(cmp_pairs[key1], vals[key1]);
+	EXPECT_EQ(set_pairs[key2], vals[key2]);
+      }
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_two_sets)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    ComparisonMap cmp_pairs;
+    std::map<std::string, bufferlist> old_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    librados::ObjectWriteOperation op;
+    for (uint32_t i = 0; i < max_keys; i++) {
+      std::string key1 = std::to_string(i);
+      std::string key2 = std::to_string(i+max_keys);
+      const bufferlist val1 = u64_buffer(i);
+      const bufferlist val2 = u64_buffer(i*5);
+      const bufferlist val3 = u64_buffer(i*7);
+      cmp_pairs.emplace(key1, val1);
+      old_pairs.emplace(key2, val2);
+      set_pairs.emplace(key2, val3);
+
+      op.setxattr(key1.c_str(), val1);
+      op.setxattr(key2.c_str(), val2);
+    }
+    ASSERT_EQ(0, ioctx.operate(oid, &op));
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size() + old_pairs.size());
+      for (uint32_t i = 0; i < cmp_pairs.size(); i++) {
+	std::string key1 = std::to_string(i);
+	std::string key2 = std::to_string(i+max_keys);
+	EXPECT_EQ(cmp_pairs[key1], vals[key1]);
+	EXPECT_EQ(old_pairs[key2], vals[key2]);
+      }
+    }
+
+    EXPECT_EQ(do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, cmp_pairs, set_pairs), true);
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size() + set_pairs.size());
+      for (uint32_t i = 0; i < set_pairs.size(); i++) {
+	std::string key1 = std::to_string(i);
+	std::string key2 = std::to_string(i+max_keys);
+	EXPECT_EQ(cmp_pairs[key1], vals[key1]);
+	EXPECT_EQ(set_pairs[key2], vals[key2]);
+      }
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_existing_set_nonexisting_set_fail)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    ComparisonMap cmp_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    librados::ObjectWriteOperation op;
+    for (uint32_t i = 0; i < max_keys; i++) {
+      std::string key1 = std::to_string(i);
+      std::string key2 = std::to_string(i+max_keys);
+      const bufferlist val1 = u64_buffer(i);
+      const bufferlist val2 = u64_buffer(i*5);
+      cmp_pairs.emplace(key1, val1);
+      set_pairs.emplace(key2, val2);
+      op.setxattr(key1.c_str(), val1);
+    }
+    ASSERT_EQ(0, ioctx.operate(oid, &op));
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size());
+      for (uint32_t i = 0; i < cmp_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(cmp_pairs[key], vals[key]);
+	EXPECT_EQ(set_pairs.contains(key), false);
+      }
+    }
+
+    // randomly select one key from the cmp_set and change it val to a different one
+    unsigned idx = std::rand() % cmp_pairs.size();
+    std::string key_to_fail = std::to_string(idx);
+    const bufferlist wrong_val = u64_buffer(idx+1);
+    cmp_pairs[key_to_fail] = wrong_val;
+
+    // the cmp will fail so no new values will; be set
+    ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, cmp_pairs, set_pairs), false);
+    // fix the cmp_pairs
+    cmp_pairs[key_to_fail] = u64_buffer(idx);
+
+    // make sure nothing was changed
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size());
+      for (uint32_t i = 0; i < cmp_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(cmp_pairs[key], vals[key]);
+	EXPECT_EQ(set_pairs.contains(key), false);
+      }
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_two_sets_fail)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    ComparisonMap cmp_pairs;
+    std::map<std::string, bufferlist> old_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    librados::ObjectWriteOperation op;
+    for (uint32_t i = 0; i < max_keys; i++) {
+      std::string key1 = std::to_string(i);
+      std::string key2 = std::to_string(i+max_keys);
+      const bufferlist val1 = u64_buffer(i);
+      const bufferlist val2 = u64_buffer(i*5);
+      const bufferlist val3 = u64_buffer(i*7);
+      cmp_pairs.emplace(key1, val1);
+      old_pairs.emplace(key2, val2);
+      set_pairs.emplace(key2, val3);
+
+      op.setxattr(key1.c_str(), val1);
+      op.setxattr(key2.c_str(), val2);
+    }
+    ASSERT_EQ(0, ioctx.operate(oid, &op));
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size() + old_pairs.size());
+      for (uint32_t i = 0; i < cmp_pairs.size(); i++) {
+	std::string key1 = std::to_string(i);
+	std::string key2 = std::to_string(i+max_keys);
+	EXPECT_EQ(cmp_pairs[key1], vals[key1]);
+	EXPECT_EQ(old_pairs[key2], vals[key2]);
+      }
+    }
+
+    // randomly select one key from the cmp_set and change it val to a different one
+    unsigned idx = std::rand() % cmp_pairs.size();
+    std::string key_to_fail = std::to_string(idx);
+    const bufferlist wrong_val = u64_buffer(idx+1);
+    cmp_pairs[key_to_fail] = wrong_val;
+
+    // the cmp will fail so no new values will; be set
+    ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, cmp_pairs, set_pairs), false);
+    // fix the cmp_pairs
+    cmp_pairs[key_to_fail] = u64_buffer(idx);
+
+    // make sure nothing was changed
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), cmp_pairs.size() + old_pairs.size());
+      for (uint32_t i = 0; i < cmp_pairs.size(); i++) {
+	std::string key1 = std::to_string(i);
+	std::string key2 = std::to_string(i+max_keys);
+	EXPECT_EQ(cmp_pairs[key1], vals[key1]);
+	EXPECT_EQ(old_pairs[key2], vals[key2]);
+      }
+    }
+
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_non_existing_vec)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    std::map<std::string, bufferlist> old_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    librados::ObjectWriteOperation op;
+    for (uint32_t i = 0; i < max_keys; i++) {
+      std::string key = std::to_string(i);
+      const bufferlist val1 = u64_buffer(i);
+      const bufferlist val2 = u64_buffer(i*5);
+      old_pairs.emplace(key, val1);
+      set_pairs.emplace(key, val2);
+      op.setxattr(key.c_str(), val1);
+    }
+    ASSERT_EQ(0, ioctx.operate(oid, &op));
+
+    bufferlist empty_bl;
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), old_pairs.size());
+
+      for (uint32_t i = 0; i < old_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(old_pairs[key], vals[key]);
+
+	// CMP_SET exiting key->val against an empty val should fail
+	ComparisonMap cmp_pairs = {{key, empty_bl}}; // -17
+	ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, cmp_pairs, set_pairs), false);
+      }
+    }
+
+    std::string new_key = std::to_string(0xFFFFFFFF);
+    ASSERT_EQ(old_pairs.contains(new_key), false);
+    ASSERT_EQ(set_pairs.contains(new_key), false);
+
+    {
+      // verify that nothing has changed because all cmp_set should have failed
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), old_pairs.size());
+      ASSERT_EQ(vals.contains(new_key), false);
+      for (uint32_t i = 0; i < old_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(old_pairs[key], vals[key]);
+      }
+    }
+
+    // TBD: fix U64 compare with an empty value
+    ComparisonMap cmp_pairs = {{new_key, empty_bl}};
+    ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, cmp_pairs, set_pairs), true);
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), set_pairs.size());
+      for (uint32_t i = 0; i < set_pairs.size(); i++) {
+	std::string key = std::to_string(i);
+	EXPECT_EQ(set_pairs[key], vals[key]);
+      }
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_str_non_existing_single)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    std::string key1 = "key1";
+    std::string key2 = "key2";
+    bufferlist val1 = string_buffer("val1");
+    bufferlist val2 = string_buffer("val2");
+    bufferlist val3 = string_buffer("val3");
+
+    {
+      // first set key1->val1
+      bufferlist bl;
+      ASSERT_EQ(ioctx.setxattr(oid, key1.c_str(), val1), 0);
+      ASSERT_EQ(ioctx.getxattr(oid, key1.c_str(), bl), val1.length());
+      ASSERT_EQ(bl, val1);
+    }
+
+    {
+      // comparing key1 with an empty val should fail
+      bufferlist empty_bl, bl;
+      ComparisonMap cmp_pairs = {{key1, empty_bl}};
+      std::map<std::string, bufferlist> set_pairs = {{key1, val2}}; // -17
+      ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::String, Op::EQ, cmp_pairs, set_pairs), false);
+      ASSERT_EQ(ioctx.getxattr(oid, key1.c_str(), bl), val1.length());
+      ASSERT_EQ(bl, val1);
+    }
+
+    {
+      // replace val1 with an empty val
+      bufferlist empty_bl, bl;
+      ComparisonMap cmp_pairs = {{key1, val1}};
+      std::map<std::string, bufferlist> set_pairs = {{key1, empty_bl}};
+      ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::String, Op::EQ, cmp_pairs, set_pairs), true);
+      EXPECT_EQ(ioctx.getxattr(oid, key1.c_str(), bl), empty_bl.length());
+      EXPECT_EQ(bl, empty_bl);
+    }
+
+    {
+      // now that key1 has an empty val compare against an empty val should succeed
+      bufferlist empty_bl, bl;
+      ComparisonMap cmp_pairs = {{key1, empty_bl}};
+      std::map<std::string, bufferlist> set_pairs = {{key1, val2}};
+      ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::String, Op::EQ, cmp_pairs, set_pairs), true);
+      ASSERT_EQ(ioctx.getxattr(oid, key1.c_str(), bl), val2.length());
+      ASSERT_EQ(bl, val2);
+    }
+
+    {
+      // compare non-existing key2 against an empty val should succeed
+      bufferlist empty_bl, bl;
+      ComparisonMap cmp_pairs = {{key2, empty_bl}};
+      std::map<std::string, bufferlist> set_pairs = {{key2, val3}};
+      ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::String, Op::EQ, cmp_pairs, set_pairs), true);
+
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 2);
+      EXPECT_EQ(val2, vals[key1]);
+      EXPECT_EQ(val3, vals[key2]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_str_einval)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const std::string key = "key";
+    bufferlist val1 = string_buffer("ccc");
+    bufferlist val2 = u64_buffer(17);
+
+    ASSERT_EQ(ioctx.setxattr(oid, key.c_str(), val1), 0);
+    ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::String, Op::EQ, {{key, val2}}, {{key, val2}}), false);
+
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 1);
+      EXPECT_EQ(val1, vals[key]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_str_eio)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const std::string key = "key";
+    bufferlist val1 = u64_buffer(17);
+    bufferlist val2 = string_buffer("ccc");
+
+    ASSERT_EQ(ioctx.setxattr(oid, key.c_str(), val1), 0);
+    ASSERT_EQ(do_cmp_vals_set_vals(oid, Mode::String, Op::EQ, {{key, val2}}, {{key, val2}}), false);
+
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 1);
+      EXPECT_EQ(val1, vals[key]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_einval)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const std::string key = "key";
+    bufferlist val1 = u64_buffer(17);
+    bufferlist val2 = string_buffer("ccc");
+
+    ASSERT_EQ(ioctx.setxattr(oid, key.c_str(), val1), 0);
+    int ret = 0;
+    bool success = do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, {{key, val2}}, {{key, val2}}, &ret);
+    ASSERT_EQ(success, false);
+    ASSERT_EQ(ret, -EINVAL);
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_u64_eio)
+  {
+    const std::string oid = __PRETTY_FUNCTION__;
+    const std::string key = "key";
+    bufferlist val1 = string_buffer("ccc");
+    bufferlist val2 = u64_buffer(17);
+
+    ASSERT_EQ(ioctx.setxattr(oid, key.c_str(), val1), 0);
+    int ret = 0;
+    bool success = do_cmp_vals_set_vals(oid, Mode::U64, Op::EQ, {{key, val2}}, {{key, val2}}, &ret);
+    ASSERT_EQ(success, false);
+    ASSERT_EQ(ret, -EIO);
+
+    {
+      std::map<std::string, bufferlist> vals;
+      ASSERT_EQ(0, ioctx.getxattrs(oid, vals));
+      ASSERT_EQ(vals.size(), 1);
+      EXPECT_EQ(val1, vals[key]);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_at_max_keys)
+  {
+    ComparisonMap cmp_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    const bufferlist value = u64_buffer(0);
+    for (uint32_t i = 0; i < max_keys; i++) {
+      cmp_pairs.emplace(std::to_string(i), value);
+      set_pairs.emplace(std::to_string(i), value);
+    }
+    bufferlist err_bl;
+    librados::ObjectWriteOperation op;
+    EXPECT_EQ(cmp_vals_set_vals(op, Mode::U64, Op::EQ, std::move(cmp_pairs),
+				std::move(set_pairs), &err_bl), 0);
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_over_max_keys)
+  {
+    ComparisonMap cmp_pairs;
+    std::map<std::string, bufferlist> set_pairs;
+    const bufferlist value = u64_buffer(0);
+    for (uint32_t i = 0; i < max_keys + 1; i++) {
+      cmp_pairs.emplace(std::to_string(i), value);
+      set_pairs.emplace(std::to_string(i), value);
+    }
+    bufferlist err_bl;
+    librados::ObjectWriteOperation op;
+    EXPECT_EQ(cmp_vals_set_vals(op, Mode::U64, Op::EQ, std::move(cmp_pairs),
+				std::move(set_pairs), &err_bl), -E2BIG);
+  }
+
+  //---------------------------------------------------------------------------
+  TEST_F(CmpXattr, cmp_set_vals_empty_pairs)
+  {
+    const std::string key = "key";
+    bufferlist val1 = string_buffer("val1");
+    bufferlist val2 = string_buffer("val2");
+
+    ComparisonMap empty_cmp_pairs;
+    ComparisonMap cmp_pairs = {{key, val1}};
+    std::map<std::string, bufferlist> empty_set_pairs;
+    std::map<std::string, bufferlist> set_pairs = {{key, val2}};
+
+    bufferlist err_bl;
+    librados::ObjectWriteOperation op;
+    EXPECT_EQ(cmp_vals_set_vals(op, Mode::String, Op::EQ, std::move(empty_cmp_pairs),
+				std::move(empty_set_pairs), &err_bl), -EINVAL);
+    EXPECT_EQ(cmp_vals_set_vals(op, Mode::String, Op::EQ, std::move(empty_cmp_pairs),
+				std::move(set_pairs), &err_bl), -EINVAL);
+    EXPECT_EQ(cmp_vals_set_vals(op, Mode::String, Op::EQ, std::move(cmp_pairs),
+				std::move(empty_set_pairs), &err_bl), -EINVAL);
+    EXPECT_EQ(cmp_vals_set_vals(op, Mode::String, Op::EQ, std::move(cmp_pairs),
+				std::move(set_pairs), &err_bl), 0);
+  }
+
+} // namespace cls::cmpxattr


### PR DESCRIPTION
The CLS accepts 2 sets of key/val pairs - the first set is used to compare against existing key/val while the second set holds key/value pairs to be set IFF all compare finish successfully.
The set pairs can hold existing and non-existing keys.
The set pair can be identical to the compare pair, but can also hold different values.
Last, there is a special case when passing an empty bl in the val for a given key which is allowed to compare against non-existing keys (the idea is to set the key IFF doesn't exist already)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
