### PR TITLE
squid: mgr/volumes: fix dangling symlink in clone index

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -9348,6 +9348,51 @@ class TestMisc(TestVolumesHelper):
         # remove group
         self._fs_cmd("subvolumegroup", "rm", self.volname, group)
 
+    def test_dangling_symlink(self):
+        """
+        test_dangling_symlink
+        Tests for the presence of any dangling symlink, if yes,
+        will remove it.
+        """
+        subvolume = self._gen_subvol_name()
+        snapshot = self._gen_subvol_snap_name()
+        clone = self._gen_subvol_clone_name()
+
+        self._fs_cmd("subvolume", "create", self.volname, subvolume)
+
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_delay', 60)
+
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', False)
+
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone)
+
+        result = json.loads(self._fs_cmd("subvolume", "snapshot", "info", self.volname, subvolume, snapshot))
+
+        # verify snapshot info
+        self.assertEqual(result['has_pending_clones'], "yes")
+
+        clone_path = f'./volumes/_nogroup/{clone}'
+        self.mount_a.run_shell(['sudo', 'rm', '-rf', clone_path], omit_sudo=False)
+
+        with safe_while(sleep=5, tries=6) as proceed:
+            while proceed():
+                try:
+                    result = json.loads(self._fs_cmd("subvolume", "snapshot", "info", self.volname, subvolume, snapshot))
+                    # verify snapshot info
+                    self.assertEqual(result['has_pending_clones'], "no")
+                    break
+                except AssertionError as e:
+                    log.debug(f'{e}, retrying')
+
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
+
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+
+        self._wait_for_trash_empty()
+
+
 class TestPerModuleFinsherThread(TestVolumesHelper):
     """
     Per module finisher thread tests related to mgr/volume cmds.

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -722,6 +722,20 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                 return False
             raise
 
+    def remove_non_existent_pending_clones(self, path, link_path, track_id):
+        try:
+            self.fs.lstat(link_path)
+        except cephfs.Error as e:
+            if e.args[0] == errno.ENOENT:
+                try:
+                    log.info(f"Cleaning up dangling symlink for the clone: {path}")
+                    self.fs.unlink(path)
+                    self._remove_snap_clone(track_id)
+                except (cephfs.Error, MetadataMgrException) as e:
+                    log.warning(f'Removing of dangling symlink for the clone {path}'
+                                f' failed with the exception:"{e}"')
+                    pass
+    
     def get_pending_clones(self, snapname):
         pending_clones_info: Dict[str, Any] = {"has_pending_clones": "no"}
         pending_track_id_list = []
@@ -747,7 +761,9 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
 
         for track_id in pending_track_id_list:
             try:
-                link_path = self.fs.readlink(os.path.join(index_path, track_id), 4096)
+                t_path = os.path.join(index_path, track_id)
+                link_path = self.fs.readlink(t_path, 4096)
+                self.remove_non_existent_pending_clones(t_path, link_path, track_id)
             except cephfs.Error as e:
                 if e.errno != errno.ENOENT:
                     raise VolumeException(-e.args[0], e.args[1])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70233

---

backport of https://github.com/ceph/ceph/pull/55838
parent tracker: https://tracker.ceph.com/issues/58090

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh