### PR TITLE
squid: qa: fix test_cephfs_mirror_stats failure

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -560,9 +560,10 @@ class TestMirroring(CephFSTestCase):
 
         # create a bunch of files in a directory to snap
         self.mount_a.run_shell(["mkdir", "d0"])
-        for i in range(100):
-            self.mount_a.write_n_mb(os.path.join('d0', f'file.{i}'), 1)
+        for i in range(10):
+            self.mount_a.write_n_mb(os.path.join('d0', f'file.{i}'), 1024)
 
+        time.sleep(60)
         self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
         self.add_directory(self.primary_fs_name, self.primary_fs_id, '/d0')
         self.peer_add(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph", self.secondary_fs_name)
@@ -574,7 +575,7 @@ class TestMirroring(CephFSTestCase):
         # take a snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap0"])
 
-        time.sleep(60)
+        time.sleep(500)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', 'snap0', 1)
         self.verify_snapshot('d0', 'snap0')
@@ -586,18 +587,18 @@ class TestMirroring(CephFSTestCase):
         self.assertGreater(second["counters"]["last_synced_start"], first["counters"]["last_synced_start"])
         self.assertGreater(second["counters"]["last_synced_end"], second["counters"]["last_synced_start"])
         self.assertGreater(second["counters"]["last_synced_duration"], 0)
-        self.assertEquals(second["counters"]["last_synced_bytes"], 104857600) # last_synced_bytes = 100 files of 1MB size each
+        self.assertEquals(second["counters"]["last_synced_bytes"], 10737418240) # last_synced_bytes = 10 files of 1024MB size each
 
         # some more IO
-        for i in range(150):
-            self.mount_a.write_n_mb(os.path.join('d0', f'more_file.{i}'), 1)
+        for i in range(10):
+            self.mount_a.write_n_mb(os.path.join('d0', f'more_file.{i}'), 1024)
 
         time.sleep(60)
 
         # take another snapshot
         self.mount_a.run_shell(["mkdir", "d0/.snap/snap1"])
 
-        time.sleep(120)
+        time.sleep(500)
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", '/d0', 'snap1', 2)
         self.verify_snapshot('d0', 'snap1')
@@ -609,7 +610,7 @@ class TestMirroring(CephFSTestCase):
         self.assertGreater(third["counters"]["last_synced_start"], second["counters"]["last_synced_end"])
         self.assertGreater(third["counters"]["last_synced_end"], third["counters"]["last_synced_start"])
         self.assertGreater(third["counters"]["last_synced_duration"], 0)
-        self.assertEquals(third["counters"]["last_synced_bytes"], 157286400) # last_synced_bytes = 150 files of 1MB size each
+        self.assertEquals(third["counters"]["last_synced_bytes"], 10737418240) # last_synced_bytes = 10 files of 1024MB size each
 
         # delete a snapshot
         self.mount_a.run_shell(["rmdir", "d0/.snap/snap0"])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70281

---

backport of https://github.com/ceph/ceph/pull/61076
parent tracker: https://tracker.ceph.com/issues/69232

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh