### PR TITLE
mgr/dashboard: NFS Rate Limit for enabling disabling QOS for Cluster and Export

### DIFF
--- a/src/cephadm/cephadmlib/container_engines.py
+++ b/src/cephadm/cephadmlib/container_engines.py
@@ -14,7 +14,7 @@ from .constants import (
     MIN_PODMAN_VERSION,
     PIDS_LIMIT_UNLIMITED_PODMAN_VERSION,
 )
-from .data_utils import with_units_to_int
+from ceph.utils import with_units_to_int
 from .exceptions import Error
 
 

--- a/src/cephadm/cephadmlib/data_utils.py
+++ b/src/cephadm/cephadmlib/data_utils.py
@@ -56,51 +56,6 @@ def dict_get_join(d: Dict[str, Any], key: str) -> Any:
     return value
 
 
-def bytes_to_human(num, mode='decimal'):
-    # type: (float, str) -> str
-    """Convert a bytes value into it's human-readable form.
-
-    :param num: number, in bytes, to convert
-    :param mode: Either decimal (default) or binary to determine divisor
-    :returns: string representing the bytes value in a more readable format
-    """
-    unit_list = ['', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
-    divisor = 1000.0
-    yotta = 'YB'
-
-    if mode == 'binary':
-        unit_list = ['', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
-        divisor = 1024.0
-        yotta = 'YiB'
-
-    for unit in unit_list:
-        if abs(num) < divisor:
-            return '%3.1f%s' % (num, unit)
-        num /= divisor
-    return '%.1f%s' % (num, yotta)
-
-
-def with_units_to_int(v: str) -> int:
-    if v.endswith('iB'):
-        v = v[:-2]
-    elif v.endswith('B'):
-        v = v[:-1]
-    mult = 1
-    if v[-1].upper() == 'K':
-        mult = 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'M':
-        mult = 1024 * 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'G':
-        mult = 1024 * 1024 * 1024
-        v = v[:-1]
-    elif v[-1].upper() == 'T':
-        mult = 1024 * 1024 * 1024 * 1024
-        v = v[:-1]
-    return int(float(v) * mult)
-
-
 def read_config(fn):
     # type: (Optional[str]) -> ConfigParser
     cp = ConfigParser()

--- a/src/cephadm/cephadmlib/host_facts.py
+++ b/src/cephadm/cephadmlib/host_facts.py
@@ -16,7 +16,7 @@ from typing import Any, cast, Dict, List, Optional, Set, Union
 
 from cephadmlib.call_wrappers import call, call_throws, CallVerbosity
 from cephadmlib.context import CephadmContext
-from cephadmlib.data_utils import bytes_to_human
+from ceph.utils import bytes_to_human
 from cephadmlib.exe_utils import find_executable
 from cephadmlib.file_utils import read_file
 from cephadmlib.net_utils import get_fqdn, get_ipv4_address, get_ipv6_address

--- a/src/cephadm/tests/test_agent.py
+++ b/src/cephadm/tests/test_agent.py
@@ -254,8 +254,8 @@ def test_agent_daemon_ls_subset(cephadm_fs, funkypatch):
         assert daemons['mgr.host1.pntmho']['container_id'] == mgr_cid
         assert daemons['crash.host1']['container_id'] == crash_cid
 
-        assert daemons['mgr.host1.pntmho']['memory_usage'] == 478570086  # 456.4 MB
-        assert daemons['crash.host1']['memory_usage'] == 7426015  # 7.082 MB
+        assert daemons['mgr.host1.pntmho']['memory_usage'] == 456400000  # 456.4 MB
+        assert daemons['crash.host1']['memory_usage'] == 7082000  # 7.082 MB
 
 
 @mock.patch("cephadm.list_daemons")

--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -16,7 +16,7 @@ from ..services.exception import DashboardException, handle_cephfs_error, \
     serialize_dashboard_exception
 from ..tools import str_to_bool
 from . import APIDoc, APIRouter, BaseController, Endpoint, EndpointDoc, \
-    ReadPermission, RESTController, Task, UIRouter
+    ReadPermission, RESTController, Task, UIRouter, UpdatePermission
 from ._version import APIVersion
 
 logger = logging.getLogger('controllers.nfs')
@@ -94,6 +94,67 @@ class NFSGaneshaCluster(RESTController):
                 {"name": key, **value} for key, value in mgr.remote('nfs', 'cluster_info').items()
             ]
         return mgr.remote('nfs', 'cluster_ls')
+
+    @Endpoint(method='GET', path='/qos')
+    @EndpointDoc("Get the cluster QoS configuration for bandwidth and iops")
+    @ReadPermission
+    def qos(self, cluster_id: str):
+        cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
+        return cluster_obj.get_cluster_qos(cluster_id, ret_bw_in_bytes=True)
+
+    @Endpoint(method='PATCH', path='/qos/bw')
+    @EndpointDoc("Enable/disable QoS configuration for bandwidth")
+    @UpdatePermission
+    def toggle_cluster_qos_bandwidth(self,
+                                     cluster_id: str,
+                                     qos_type: str = '',
+                                     max_export_write_bw: Optional[int] = None,
+                                     max_export_read_bw: Optional[int] = None,
+                                     max_client_write_bw: Optional[int] = None,
+                                     max_client_read_bw: Optional[int] = None,
+                                     max_export_combined_bw: Optional[int] = None,
+                                     max_client_combined_bw: Optional[int] = None,
+                                     disable_qos: bool = False):
+
+        if disable_qos:
+            cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
+            return cluster_obj.disable_cluster_qos_bw(cluster_id)
+        qos_obj = {}
+        if max_export_write_bw:
+            qos_obj['max_export_write_bw'] = str(max_export_write_bw)
+        if max_export_read_bw:
+            qos_obj['max_export_read_bw'] = str(max_export_read_bw)
+        if max_client_write_bw:
+            qos_obj['max_client_write_bw'] = str(max_client_write_bw)
+        if max_client_read_bw:
+            qos_obj['max_client_read_bw'] = str(max_client_read_bw)
+        if max_export_combined_bw:
+            qos_obj['max_export_combined_bw'] = str(max_export_combined_bw)
+        if max_client_combined_bw:
+            qos_obj['max_client_combined_bw'] = str(max_client_combined_bw)
+        # passing False for combined bandwidth, later can be changed to
+        # True when combined bandwidth functionality is added
+        return mgr.remote('nfs', 'enable_cluster_qos_bw', cluster_id, qos_type, False, **qos_obj)
+
+    @Endpoint(method='PATCH', path='/qos/ops')
+    @EndpointDoc("Enable/disable QoS configuration for NFS IOPs")
+    @UpdatePermission
+    def toggle_cluster_qos_operation(self,
+                                     cluster_id: str,
+                                     qos_type: str,
+                                     max_export_iops: int = 0,
+                                     max_client_iops: int = 0,
+                                     disable_Ops: bool = False):
+
+        if disable_Ops:
+            cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
+            return cluster_obj.disable_cluster_qos_ops(cluster_id)
+        obj = {}
+        if max_export_iops:
+            obj['max_export_iops'] = max_export_iops
+        if max_client_iops:
+            obj['max_client_iops'] = max_client_iops
+        return mgr.remote('nfs', 'enable_cluster_qos_ops', cluster_id, qos_type, **obj)
 
 
 @APIRouter('/nfs-ganesha/export', Scope.NFS_GANESHA)
@@ -225,6 +286,63 @@ class NFSGaneshaExports(RESTController):
                 msg=f'Export with id {export_id} not found.',
                 component='nfs')
         mgr.remote('nfs', 'export_rm', cluster_id, export['pseudo'])
+
+    @Endpoint(method='GET', path='/qos')
+    @EndpointDoc("Get the export QoS configuration for bandwidth and IOPS")
+    @ReadPermission
+    def qos(self, cluster_id: str, pseudo_path: str):
+        export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
+        return export_obj.get_export_qos(cluster_id, pseudo_path, ret_bw_in_bytes=True)
+
+    @Endpoint(method='PATCH', path='/qos')
+    @EndpointDoc("Enable/disable export QoS configuration for bandwidth")
+    @UpdatePermission
+    def toggle_export_qos_bandwidth(self,
+                                    cluster_id: str,
+                                    pseudo_path: str,
+                                    max_export_write_bw: Optional[int] = None,
+                                    max_export_read_bw: Optional[int] = None,
+                                    max_client_write_bw: Optional[int] = None,
+                                    max_client_read_bw: Optional[int] = None,
+                                    max_export_combined_bw: Optional[int] = None,
+                                    max_client_combined_bw: Optional[int] = None,
+                                    disable_qos: bool = False):
+        if disable_qos:
+            export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
+            return export_obj.disable_export_qos_bw(cluster_id, pseudo_path)
+        qos_obj = {}
+        if max_export_write_bw:
+            qos_obj['max_export_write_bw'] = str(max_export_write_bw)
+        if max_export_read_bw:
+            qos_obj['max_export_read_bw'] = str(max_export_read_bw)
+        if max_client_write_bw:
+            qos_obj['max_client_write_bw'] = str(max_client_write_bw)
+        if max_client_read_bw:
+            qos_obj['max_client_read_bw'] = str(max_client_read_bw)
+        if max_export_combined_bw:
+            qos_obj['max_export_combined_bw'] = str(max_export_combined_bw)
+        if max_client_combined_bw:
+            qos_obj['max_client_combined_bw'] = str(max_client_combined_bw)
+        return mgr.remote('nfs', 'enable_export_qos_bw', cluster_id, pseudo_path, False, **qos_obj)
+
+    @Endpoint(method='PATCH', path='/qos/ops')
+    @EndpointDoc("Enable/disable export QoS configuration for operations")
+    @UpdatePermission
+    def toggle_export_qos_operations(self,
+                                     cluster_id: str,
+                                     pseudo_path: str,
+                                     max_export_iops: Optional[int] = 0,
+                                     max_client_iops: Optional[int] = 0,
+                                     disable_qos_ops: bool = False):
+        if disable_qos_ops:
+            export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
+            return export_obj.disable_export_qos_ops(cluster_id, pseudo_path)
+        obj = {}
+        if max_export_iops:
+            obj['max_export_iops'] = max_export_iops
+        if max_client_iops:
+            obj['max_client_iops'] = max_client_iops
+        return mgr.remote('nfs', 'enable_export_qos_ops', cluster_id, pseudo_path, **obj)
 
 
 @UIRouter('/nfs-ganesha', Scope.NFS_GANESHA)

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -67,6 +67,7 @@ import { CephfsMirroringListComponent } from './ceph/cephfs/cephfs-mirroring-lis
 import { NotificationsPageComponent } from './core/navigation/notification-panel/notifications-page/notifications-page.component';
 import { CephfsMirroringWizardComponent } from './ceph/cephfs/cephfs-mirroring-wizard/cephfs-mirroring-wizard.component';
 import { CephfsMirroringErrorComponent } from './ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component';
+import { NfsClusterFormComponent } from './ceph/nfs/nfs-cluster-form/nfs-cluster-form.component';
 
 @Injectable()
 export class PerformanceCounterBreadcrumbsResolver extends BreadcrumbsResolver {
@@ -475,12 +476,17 @@ const routes: Routes = [
             children: [
               { path: '', component: NfsClusterComponent },
               {
+                path: `${URLVerbs.EDIT}/:cluster_id`,
+                component: NfsClusterFormComponent,
+                data: { breadcrumbs: ActionLabels.EDIT }
+              },
+              {
                 path: `${URLVerbs.CREATE}/:fs_name/:subvolume_group`,
                 component: NfsFormComponent,
                 data: { breadcrumbs: ActionLabels.CREATE }
               },
               {
-                path: `${URLVerbs.CREATE}`,
+                path: `${URLVerbs.CREATE}/:cluster_id`,
                 component: NfsFormComponent,
                 data: { breadcrumbs: ActionLabels.CREATE }
               },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
@@ -1,12 +1,44 @@
+export interface NFSCluster {
+  name: string;
+  virtual_ip: number;
+  port: number;
+  backend: NFSBackend[];
+}
 export interface NFSBackend {
   hostname: string;
   ip: string;
   port: number;
 }
 
-export interface NFSCluster {
-  name: string;
-  virtual_ip: number;
-  port: number;
-  backend: NFSBackend[];
+export interface NFSBwIopConfig {
+  cluster_id?: string;
+  qos_type?: string;
+  max_export_write_bw?: number;
+  max_export_read_bw?: number;
+  max_client_write_bw?: number;
+  max_client_read_bw?: number;
+  max_export_combined_bw?: number;
+  max_client_combined_bw?: number;
+  disable_qos?: boolean;
+  enable_qos?: boolean;
+  enable_bw_control?: boolean;
+  combined_rw_bw_control?: boolean;
+  pseudo_path?: string;
+}
+
+export enum QOSType {
+  PerShare = 'PerShare',
+  PerClient = 'PerClient',
+  PerSharePerClient = 'PerShare_PerClient'
+}
+
+export interface QOSTypeItem {
+  key: string;
+  value: string;
+  help: string;
+}
+
+export interface bwTypeItem {
+  value: string;
+  help: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
@@ -24,6 +24,12 @@ export interface NFSBwIopConfig {
   enable_bw_control?: boolean;
   combined_rw_bw_control?: boolean;
   pseudo_path?: string;
+  max_export_iops?: number;
+  max_client_iops?: number;
+  disable_Ops?: boolean;
+  enable_ops?: boolean;
+  disable_qos_ops?: boolean;
+  enable_iops_control?: boolean;
 }
 
 export enum QOSType {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
@@ -1,0 +1,40 @@
+
+  <div cdsCol
+       [columnNumbers]="{md: 4}">
+  <ng-container *cdFormLoading="loading">
+  <form name="nfsForm"
+        [formGroup]="nfsForm"
+        #formDir="ngForm"
+        novalidate>
+  <div i18n="form title"
+       class="form-header">
+  <span *ngIf="isEdit">
+          Set Cluster Quality of Service
+  </span>
+  <span *ngIf="!isEdit">
+       {{action | titlecase }} {{ resource | upperFirst }}
+  </span>
+  </div>
+
+  <div class="form-group row">
+  <cds-text-label for="cluster_id"
+                  i18n>Client ID
+  <input  cdsText
+          type="text"
+          id="cluster_id"
+          i18n-placeholder
+          formControlName="cluster_id">
+  </cds-text-label>
+  </div>
+  <cd-nfs-rate-limit-form [action]="action"
+                          [isEdit]="isEdit"
+                          [type]="'cluster'"
+                          (emitErrors)="childCompErrorHandler($event)"
+                          [clusterDataConfig]="nfsBwIopConfig"></cd-nfs-rate-limit-form>
+  <cd-form-button-panel (submitActionEvent)="submitAction()"
+                        [form]="nfsForm"
+                        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                        wrappingClass="text-right"></cd-form-button-panel>
+  </form>
+  </ng-container>
+  </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NfsClusterFormComponent } from './nfs-cluster-form.component';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { ReactiveFormsModule } from '@angular/forms';
+import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ToastrModule } from 'ngx-toastr';
+
+describe('NfsClusterFormComponent', () => {
+  let component: NfsClusterFormComponent;
+  let fixture: ComponentFixture<NfsClusterFormComponent>;
+  let notificationService: NotificationService;
+
+  configureTestBed({
+    imports: [
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      SharedModule,
+      ToastrModule.forRoot()
+    ],
+    declarations: [NfsClusterFormComponent, NfsRateLimitComponent]
+  });
+
+  beforeEach(async () => {
+    notificationService = TestBed.inject(NotificationService);
+    spyOn(notificationService, 'show').and.stub();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NfsClusterFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize form on ngOnInit', () => {
+    component.ngOnInit();
+    expect(component.nfsForm).toBeDefined();
+    expect(component.nfsForm.get('cluster_id')).toBeDefined();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import _ from 'lodash';
+import { UntypedFormControl } from '@angular/forms';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { getFsalFromRoute, getPathfromFsal } from '../utils';
+import { SUPPORTED_FSAL } from '../models/nfs.fsal';
+import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
+
+import { concat as observableConcat, Observable } from 'rxjs';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NFSBwIopConfig } from '../models/nfs-cluster-config';
+import { CdForm } from '~/app/shared/forms/cd-form';
+
+@Component({
+  selector: 'cd-nfs-cluster-form',
+  templateUrl: './nfs-cluster-form.component.html',
+  styleUrls: ['./nfs-cluster-form.component.scss']
+})
+export class NfsClusterFormComponent extends CdForm implements OnInit {
+  @ViewChild(NfsRateLimitComponent, { static: false })
+  nfsRateLimitComponent!: NfsRateLimitComponent;
+
+  action: string;
+  nfsForm: CdFormGroup;
+  resource: string;
+  isEdit = false;
+  fsal: SUPPORTED_FSAL;
+  id: string;
+  qosValue: string;
+  nfsBwIopConfig: NFSBwIopConfig;
+  submitObservables: Observable<Object>[] = [];
+
+  constructor(
+    public actionLabels: ActionLabelsI18n,
+    private route: ActivatedRoute,
+    private router: Router,
+    private nfsService: NfsService,
+    private notificationService: NotificationService
+  ) {
+    super();
+    this.resource = $localize`Cluster`;
+  }
+
+  ngOnInit(): void {
+    this.createClusterForm();
+    this.id = this.route.snapshot.paramMap.get('cluster_id');
+    this.fsal = getFsalFromRoute(this.router.url);
+    if (this.router.url.startsWith(`/${getPathfromFsal(this.fsal)}/nfs/edit`)) {
+      this.isEdit = true;
+    }
+    if (this.isEdit) {
+      this.action = this.actionLabels.EDIT;
+      this.nfsService.getClusterBandwidthOpsConfig(this.id).subscribe((data: NFSBwIopConfig) => {
+        this.nfsBwIopConfig = data;
+        this.nfsForm.get('cluster_id').setValue(this.id);
+      });
+      this.loadingReady();
+    } else {
+      this.action = this.actionLabels.CREATE;
+    }
+  }
+  childCompErrorHandler(event: Event) {
+    this.nfsForm.addControl('rateLimit', event);
+  }
+  createClusterForm() {
+    this.nfsForm = new CdFormGroup({
+      cluster_id: new UntypedFormControl({ value: '', disabled: true })
+    });
+  }
+  goToListView() {
+    this.router.navigate([`/${getPathfromFsal(this.fsal)}/nfs`]);
+  }
+  submitAction() {
+    let notificationTitle: string;
+    // Exit immediately if the form isn't dirty.
+    if (this.nfsForm.pristine && this.nfsRateLimitComponent.rateLimitForm.pristine) {
+      this.goToListView();
+      return;
+    }
+    let clusteFormrObj = this.nfsForm.getRawValue();
+    delete clusteFormrObj.rateLimit;
+    let ratelimitValue: NFSBwIopConfig = this.nfsRateLimitComponent.getRateLimitFormValue();
+    ratelimitValue = {
+      ...ratelimitValue,
+      ...clusteFormrObj,
+      disable_qos: !ratelimitValue.enable_qos
+    };
+    delete ratelimitValue.enable_qos;
+    this.submitObservables.push(this.nfsService.enableQosBandwidthForCLuster(ratelimitValue));
+    notificationTitle = $localize`Cluster QoS Type Configured for '${this.id}'`;
+
+    // Finally execute observables
+    observableConcat(...this.submitObservables).subscribe({
+      error: () => {
+        // Reset the 'Submit' button.
+        this.nfsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.notificationService.show(NotificationType.success, notificationTitle);
+        this.goToListView();
+      }
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.spec.ts
@@ -3,21 +3,74 @@ import { configureTestBed } from '~/testing/unit-test-helper';
 import { SharedModule } from '~/app/shared/shared.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NfsClusterComponent } from './nfs-cluster.component';
+import { of } from 'rxjs';
+import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('NfsClusterComponent', () => {
   let component: NfsClusterComponent;
   let fixture: ComponentFixture<NfsClusterComponent>;
+  let orchestratorService: OrchestratorService;
 
   configureTestBed({
     declarations: [NfsClusterComponent],
-    imports: [HttpClientTestingModule, SharedModule]
+    imports: [HttpClientTestingModule, SharedModule, RouterTestingModule],
+    providers: [
+      {
+        provide: OrchestratorService,
+        useValue: {
+          status: jest.fn().mockReturnValue(of({}))
+        }
+      },
+      {
+        provide: NfsService,
+        useValue: {
+          nfsClusterList: jest.fn().mockReturnValue(of([]))
+        }
+      },
+      {
+        provide: AuthStorageService,
+        useValue: {
+          getPermissions: jest.fn().mockReturnValue({ nfs: {} })
+        }
+      }
+    ]
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NfsClusterComponent);
     component = fixture.componentInstance;
+    orchestratorService = TestBed.inject(OrchestratorService);
+    fixture.detectChanges();
   });
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize orchestrator status on init', () => {
+    expect(orchestratorService.status).toHaveBeenCalled();
+  });
+
+  it('should initialize columns on init', () => {
+    expect(component.columns.length).toBeGreaterThan(0);
+  });
+
+  it('should load data on loadData call', () => {
+    const spy = jest.spyOn(component.subject, 'next');
+    component.loadData();
+    expect(spy).toHaveBeenCalledWith([]);
+  });
+
+  it('should update selection on updateSelection call', () => {
+    const selection = { first: jest.fn() } as any;
+    component.updateSelection(selection);
+    expect(component.selection).toBe(selection);
+  });
+
+  it('should set table actions on init', () => {
+    expect(component.tableActions.length).toBeGreaterThan(0);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.ts
@@ -11,6 +11,11 @@ import { URLBuilderService } from '~/app/shared/services/url-builder.service';
 import { NFSCluster } from '../models/nfs-cluster-config';
 import { OrchestratorStatus } from '~/app/shared/models/orchestrator.interface';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { SUPPORTED_FSAL } from '../models/nfs.fsal';
+import { getFsalFromRoute, getPathfromFsal } from '../utils';
+import { Router } from '@angular/router';
+import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 const BASE_URL = 'cephfs/nfs';
@@ -31,11 +36,16 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
   @ViewChild('virtualIpTpl', { static: true })
   virtualIpTpl: TemplateRef<any>;
 
+  @ViewChild('table', { static: true })
+  table: TableComponent;
+
   columns: CdTableColumn[] = [];
   selection: CdTableSelection = new CdTableSelection();
   tableActions: CdTableAction[] = [];
   permission: Permission;
   orchStatus: OrchestratorStatus;
+  fsal: SUPPORTED_FSAL;
+  viewCacheStatus: any;
   clusters$: Observable<NFSCluster[]>;
   subject = new BehaviorSubject<NFSCluster[]>([]);
 
@@ -44,7 +54,8 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
     protected ngZone: NgZone,
     private authStorageService: AuthStorageService,
     private nfsService: NfsService,
-    private orchService: OrchestratorService
+    private orchService: OrchestratorService,
+    private router: Router
   ) {
     super();
   }
@@ -53,6 +64,9 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
     this.orchService.status().subscribe((status: OrchestratorStatus) => {
       this.orchStatus = status;
     });
+    this.fsal = getFsalFromRoute(this.router.url);
+    const prefix = getPathfromFsal(this.fsal);
+    const getNfsUri = () => this.selection.first() && `${encodeURI(this.selection.first()?.name)}`;
     this.permission = this.authStorageService.getPermissions().nfs;
     this.clusters$ = this.subject.pipe(switchMap(() => this.nfsService.nfsClusterList()));
     this.columns = [
@@ -62,7 +76,7 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
         flexGrow: 1
       },
       {
-        name: $localize`Hostnames`,
+        name: $localize`Hostname`,
         prop: 'backend',
         flexGrow: 2,
         cellTemplate: this.hostnameTpl
@@ -80,12 +94,21 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
         cellTemplate: this.virtualIpTpl
       }
     ];
+
+    const editAction: CdTableAction = {
+      permission: 'update',
+      icon: Icons.edit,
+      routerLink: () => [`/${prefix}/nfs/edit/${getNfsUri()}`],
+      name: $localize`Set QOS`,
+      canBePrimary: () => true
+    };
+
+    this.tableActions = [editAction];
   }
 
   loadData() {
     this.subject.next([]);
   }
-
   updateSelection(selection: CdTableSelection) {
     this.selection = selection;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -16,6 +16,7 @@
                     label="Cluster"
                     cdRequiredField="Cluster"
                     id="cluster_id"
+                    (change)="registerClusterIdChange($event.target.value)"
                     [invalid]="nfsForm.controls.cluster_id.invalid && (nfsForm.controls.cluster_id.dirty)"
                     [invalidText]="clusterError"
                     [skeleton]="allClusters === null"
@@ -439,7 +440,14 @@
                 i18n>This field is required.</span>
         </ng-template>
       </div>
-
+      <!--Enable Disable Bandwidth -->
+        <cd-nfs-rate-limit-form [action]="action"
+                                [isEdit]="isEdit"
+                                [type]="'export'"
+                                (emitErrors)="childCompErrorHandler($event)"
+                                [clusterDataConfig]="clusterAllConfig"
+                                [exportDataConfig]="exportAllConfig"
+                                ></cd-nfs-rate-limit-form>
       <!-- Clients -->
       <cd-nfs-form-client [form]="nfsForm"
                           [clients]="clients"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -34,6 +34,10 @@ import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-g
 import { RgwUserService } from '~/app/shared/api/rgw-user.service';
 import { RgwExportType } from '../nfs-list/nfs-list.component';
 import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
+import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NFSBwIopConfig } from '../models/nfs-cluster-config';
 
 @Component({
   selector: 'cd-nfs-form',
@@ -45,6 +49,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   @ViewChild('nfsClients', { static: true })
   nfsClients: NfsFormClientComponent;
 
+  @ViewChild(NfsRateLimitComponent, { static: false })
+  nfsRateLimitComponent!: NfsRateLimitComponent;
   clients: any[] = [];
 
   permission: Permission;
@@ -70,7 +76,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
   action: string;
   resource: string;
-
+  bandwidthObj: NFSBwIopConfig;
   allsubvolgrps: any[] = [];
   allsubvols: any[] = [];
 
@@ -78,6 +84,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   selectedSubvolGroup: string = '';
   selectedSubvol: string = '';
   defaultSubVolGroup = DEFAULT_SUBVOLUME_GROUP;
+  exportAllConfig: NFSBwIopConfig;
+  clusterAllConfig: NFSBwIopConfig;
 
   pathDataSource = (text$: Observable<string>) => {
     return text$.pipe(
@@ -108,7 +116,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
     private rgwSiteService: RgwSiteService,
     private formBuilder: CdFormBuilder,
     private taskWrapper: TaskWrapperService,
-    public actionLabels: ActionLabelsI18n
+    public actionLabels: ActionLabelsI18n,
+    private notificationService: NotificationService
   ) {
     super();
     this.permission = this.authStorageService.getPermissions().pool;
@@ -147,6 +156,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
             }
           }
           promises.push(this.nfsService.get(this.cluster_id, this.export_id));
+          promises.push(this.nfsService.getClusterBandwidthOpsConfig(this.cluster_id));
           this.getData(promises);
         }
       );
@@ -156,18 +166,26 @@ export class NfsFormComponent extends CdForm implements OnInit {
     } else {
       this.action = this.actionLabels.CREATE;
       this.route.params.subscribe(
-        (params: { fs_name: string; subvolume_group: string; subvolume?: string }) => {
+        (params: {
+          fs_name: string;
+          subvolume_group: string;
+          cluster_id: string;
+          subvolume?: string;
+        }) => {
           this.selectedFsName = params.fs_name;
           this.selectedSubvolGroup = params.subvolume_group;
           if (params.subvolume) this.selectedSubvol = params.subvolume;
+          this.cluster_id = decodeURIComponent(params.cluster_id);
+          if (this.storageBackend === SUPPORTED_FSAL.RGW) {
+            this.nfsForm.get('rgw_export_type').setValue('bucket');
+            this.setBucket();
+          }
+          this.cluster_id
+            ? promises.push(this.nfsService.getClusterBandwidthOpsConfig(this.cluster_id))
+            : '';
+          this.getData(promises);
         }
       );
-
-      if (this.storageBackend === SUPPORTED_FSAL.RGW) {
-        this.nfsForm.get('rgw_export_type').setValue('bucket');
-        this.setBucket();
-      }
-      this.getData(promises);
     }
   }
 
@@ -175,11 +193,22 @@ export class NfsFormComponent extends CdForm implements OnInit {
     forkJoin(promises).subscribe((data: any[]) => {
       this.resolveClusters(data[0]);
       this.resolveFsals(data[1]);
-      if (data[2]) {
-        this.resolveModel(data[2]);
+      if (this.isEdit) {
+        data[2] ? this.resolveModel(data[2]) : '';
+        data[3] ? (this.clusterAllConfig = data[3]) : '';
+        this.getExportData(data[2].pseudo);
+      } else {
+        this.cluster_id ? (data[2] ? (this.clusterAllConfig = data[2]) : '') : '';
       }
       this.loadingReady();
     });
+  }
+  getExportData(pseudoPath: string) {
+    this.nfsService
+      .getexportBandwidthOpsConfig(this.cluster_id, pseudoPath)
+      .subscribe((obj: {}) => {
+        this.exportAllConfig = obj;
+      });
   }
 
   volumeChangeHandler() {
@@ -436,7 +465,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.allClusters.push({ cluster_id: cluster });
     }
     if (!this.isEdit && this.allClusters.length > 0) {
-      this.nfsForm.get('cluster_id').setValue(this.allClusters[0].cluster_id);
+      this.nfsForm.get('cluster_id').setValue(this.cluster_id);
     }
   }
 
@@ -467,7 +496,12 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.nfsForm.patchValue({
         subvolume_group: this.selectedSubvolGroup
       });
-      this.getSubVol();
+      (this.selectedSubvolGroup === this.defaultSubVolGroup
+        ? this.subvolService.get(this.selectedFsName)
+        : this.subvolService.get(this.selectedFsName, this.selectedSubvolGroup)
+      ).subscribe((data: any) => {
+        this.allsubvols = data;
+      });
     }
     if (!_.isEmpty(this.selectedSubvol)) {
       this.nfsForm.patchValue({
@@ -599,7 +633,9 @@ export class NfsFormComponent extends CdForm implements OnInit {
       return of([]);
     }
   }
-
+  childCompErrorHandler(event: Event) {
+    this.nfsForm.addControl('rateLimit', event);
+  }
   submitAction() {
     let action: Observable<any>;
     const requestModel = this.buildRequest();
@@ -626,10 +662,39 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
     action.subscribe({
       error: (errorResponse: CdHttpErrorResponse) => this.setFormErrors(errorResponse),
-      complete: () => this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`])
+      complete: () => {
+        this.bandwidthObj = this.nfsRateLimitComponent?.getRateLimitFormValue();
+        if (
+          !!this.bandwidthObj &&
+          this.clusterAllConfig?.enable_qos === this.bandwidthObj?.enable_qos
+        ) {
+          this.submitRateLimit();
+        }
+        this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`]);
+      }
     });
   }
-
+  submitRateLimit() {
+    let notificationTitle = $localize`Update Rate Limit For Export`;
+    let cluster_id = this.nfsForm.getValue('cluster_id');
+    this.bandwidthObj = {
+      ...this.bandwidthObj,
+      pseudo_path: this.nfsForm.getValue('pseudo'),
+      disable_qos: !this.bandwidthObj.enable_qos,
+      cluster_id
+    };
+    delete this.bandwidthObj.enable_qos;
+    delete this.bandwidthObj.qos_type;
+    this.nfsService.enableQosForExports(this.bandwidthObj).subscribe({
+      error: () => {
+        // Reset the 'Submit' button.
+        this.nfsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.notificationService.show(NotificationType.success, notificationTitle);
+      }
+    });
+  }
   private setFormErrors(errorResponse: CdHttpErrorResponse) {
     if (
       errorResponse.error.detail &&
@@ -688,7 +753,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       requestModel.transports.push('UDP');
     }
     delete requestModel.transportUDP;
-
+    delete requestModel.rateLimit;
     requestModel.clients.forEach((client: any) => {
       if (_.isString(client.addresses)) {
         client.addresses = _(client.addresses)
@@ -715,7 +780,6 @@ export class NfsFormComponent extends CdForm implements OnInit {
       requestModel.fsal.sec_label_xattr = requestModel.sec_label_xattr;
     }
     delete requestModel.sec_label_xattr;
-
     return requestModel;
   }
 
@@ -734,5 +798,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
         catchError(() => of({ pathNameNotAllowed: true }))
       );
     };
+  }
+  registerClusterIdChange(value: string) {
+    this.nfsService.getClusterBandwidthOpsConfig(value).subscribe((clusterData: NFSBwIopConfig) => {
+      this.clusterAllConfig = clusterData;
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -77,6 +77,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
   action: string;
   resource: string;
   bandwidthObj: NFSBwIopConfig;
+  bandwidthIopsObj: NFSBwIopConfig;
   allsubvolgrps: any[] = [];
   allsubvols: any[] = [];
 
@@ -636,10 +637,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
   childCompErrorHandler(event: Event) {
     this.nfsForm.addControl('rateLimit', event);
   }
+
   submitAction() {
     let action: Observable<any>;
     const requestModel = this.buildRequest();
-
     if (this.isEdit) {
       action = this.taskWrapper.wrapTaskAroundCall({
         task: new FinishedTask('nfs/edit', {
@@ -664,13 +665,24 @@ export class NfsFormComponent extends CdForm implements OnInit {
       error: (errorResponse: CdHttpErrorResponse) => this.setFormErrors(errorResponse),
       complete: () => {
         this.bandwidthObj = this.nfsRateLimitComponent?.getRateLimitFormValue();
-        if (
-          !!this.bandwidthObj &&
-          this.clusterAllConfig?.enable_qos === this.bandwidthObj?.enable_qos
-        ) {
-          this.submitRateLimit();
+        this.bandwidthIopsObj = this.nfsRateLimitComponent?.getRateLimitOpsFormValue();
+        if (this.bandwidthObj) {
+          if (
+            !!this.bandwidthObj &&
+            this.clusterAllConfig?.enable_qos === this.bandwidthObj?.enable_qos
+          ) {
+            this.submitRateLimit();
+          }
         }
-        this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`]);
+        if (this.bandwidthIopsObj) {
+          if (
+            !!this.bandwidthIopsObj &&
+            this.clusterAllConfig?.enable_ops === this.bandwidthIopsObj?.enable_ops
+          ) {
+            this.submitRateOPSLimit();
+          }
+          this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`]);
+        }
       }
     });
   }
@@ -695,6 +707,30 @@ export class NfsFormComponent extends CdForm implements OnInit {
       }
     });
   }
+
+  submitRateOPSLimit() {
+    let notificationTitle = $localize`Update Rate Limit For Export`;
+    let cluster_id = this.nfsForm.getValue('cluster_id');
+
+    this.bandwidthIopsObj = {
+      ...this.bandwidthIopsObj,
+      pseudo_path: this.nfsForm.getValue('pseudo'),
+      disable_qos_ops: !this.bandwidthIopsObj.enable_ops,
+      cluster_id
+    };
+    delete this.bandwidthIopsObj.enable_ops;
+    delete this.bandwidthIopsObj.qos_type;
+    this.nfsService.enableQosOpsForExports(this.bandwidthIopsObj).subscribe({
+      error: () => {
+        // Reset the 'Submit' button.
+        this.nfsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.notificationService.show(NotificationType.success, notificationTitle);
+      }
+    });
+  }
+
   private setFormErrors(errorResponse: CdHttpErrorResponse) {
     if (
       errorResponse.error.detail &&

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -101,7 +101,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
     const createAction: CdTableAction = {
       permission: 'create',
       icon: Icons.add,
-      routerLink: () => `/${prefix}/nfs/create`,
+      routerLink: () => `/${prefix}/nfs/create/${this.clusterId}`,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection,
       name: this.actionLabels.CREATE
     };
@@ -174,7 +174,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
         cellTemplate: this.protocolTpl
       },
       {
-        name: $localize`Transports`,
+        name: $localize`Transport Protocol`,
         prop: 'transports',
         flexGrow: 2,
         cellTemplate: this.transportTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
@@ -1,0 +1,338 @@
+<ng-container *ngIf="allowQoS">
+  <form name="rateLimitForm"
+        #formDir="ngForm"
+        [formGroup]="rateLimitForm"
+        novalidate>
+    <cd-alert-panel type="info"
+                    class="me-1"
+                    spacingClass="mt-1"
+                    *ngIf="clusterQoSDisabled"
+                    i18n>Cluster level QoS setting is disabled.
+    </cd-alert-panel>
+
+    <cd-alert-panel type="info"
+                    class="me-1"
+                    spacingClass="mt-1"
+                    *ngIf="showDisableWarning"
+                    i18n>Disable QoS will set QoS Bandwidth limit to Maximum.
+    </cd-alert-panel>
+
+    <cd-alert-panel type="info"
+                    class="me-1"
+                    spacingClass="mt-1"
+                    *ngIf="showQoStypeChangeNote"
+                    i18n>If changing from already set one then please make sure to update exports bandwidths according to QoS type.
+    </cd-alert-panel>
+    <!-- qos_type is perclient, then can't enable export level QoS -->
+    <div
+      class="form-item"
+      *ngIf="type === 'cluster' || (type === 'export' && nfsClusterData?.qos_type !== 'PerClient')"
+    >
+      <cds-checkbox
+        id="enable_qos"
+        type="checkbox"
+        (checkedChange)="showMaxBwNote()"
+        formControlName="enable_qos"
+        i18n
+        >Enable Bandwidth QoS
+      </cds-checkbox>
+    </div>
+    <span *ngIf="showMaxBw">Disable QoS will set QoS Bandwidth limit to Maximum.</span>
+
+    <div class="form-item"
+         *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
+      <cds-select
+        formControlName="bwType"
+        for="bwType"
+        label="Rate Limit"
+        id="bwType"
+        [helperText]="bwTypeHelper"
+        [skeleton]="bwTypeArr === null"
+      >
+        <option *ngIf="bwTypeArr === null"
+                [ngValue]="null">Loading...</option>
+        <option *ngIf="bwTypeArr !== null && bwTypeArr.length === 0"
+                i18n
+                [ngValue]="null">
+          -- No RateLimit type available --
+        </option>
+        <option *ngIf="bwTypeArr !== null && bwTypeArr.length > 0"
+                i18n
+                [ngValue]="null">
+          -- Select a RateLimit Type --
+        </option>
+        <option *ngFor="let type of bwTypeArr"
+                i18n
+                [value]="type.value">{{ type.value }}</option>
+      </cds-select>
+      <ng-template #bwTypeHelper>
+        <span *ngIf="rateLimitForm.getValue('bwType')">
+          {{ getbwTypeHelp(rateLimitForm.getValue('bwType')) }}
+        </span>
+      </ng-template>
+    </div>
+
+
+    <!-- qos type -->
+    <div class="form-item"
+         *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
+      <cds-select
+        formControlName="qos_type"
+        label="Bandwidth QOS Type"
+        id="qos_type"
+        [helperText]="qosTypeHelper"
+        [skeleton]="qosType === null"
+        (change)="registerQoSChange($event.target.value)"
+        i18n-label
+      >
+        <option *ngIf="qosType === null"
+                value="">Loading...</option>
+        <option *ngIf="qosType !== null && qosType.length === 0"
+                i18n
+                value="null">
+          -- No Bandwidth Qos type available --
+        </option>
+        <option *ngIf="qosType !== null && qosType?.length > 0"
+                value=""
+                i18n>
+          -- Select a Bandwidth QOS Type --
+        </option>
+        <option *ngFor="let type of qosType"
+                i18n
+                [value]="type.value">{{ type.key }}</option>
+      </cds-select>
+      <ng-template #qosTypeHelper>
+        <span *ngIf="rateLimitForm.getValue('qos_type')">
+          {{ getQoSTypeHelper(rateLimitForm.getValue('qos_type')) }}
+        </span>
+      </ng-template>
+    </div>
+
+    <ng-container
+      *ngIf="
+        rateLimitForm?.getValue('enable_qos') &&
+        (qosTypeVal === 'PerShare' || qosTypeVal === 'PerShare_PerClient')
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_export_read_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that can be used for export read per second"
+          cdRequiredField="Export read bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_export_read_bw.invalid &&
+            rateLimitForm.controls.max_export_read_bw.dirty
+          "
+          [invalidText]="Export_readbw_Error"
+          >Export Write Bandwidth
+          <input
+            cdsText
+            type="text"
+            placeholder="Export read bandwidth..."
+            i18n-placeholder
+            id="max_export_read_bw"
+            name="max_export_read_bw"
+            formControlName="max_export_read_bw"
+            [invalid]="
+              rateLimitForm.controls.max_export_read_bw.invalid &&
+              rateLimitForm.controls.max_export_read_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+        <ng-template #Export_readbw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_read_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_read_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_read_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+      <div class="form-group row">
+        <cds-text-label
+          for="max_export_write_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that can be used for export write per second"
+          cdRequiredField="Export write bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_export_write_bw.invalid &&
+            rateLimitForm.controls.max_export_write_bw.dirty
+          "
+          [invalidText]="Export_writebw_Error"
+          >Export Write Bandwidth
+          <input
+            cdsText
+            type="text"
+            placeholder="Export write bandwidth..."
+            i18n-placeholder
+            id="max_export_write_bw"
+            name="max_export_write_bw"
+            formControlName="max_export_write_bw"
+            [invalid]="
+              rateLimitForm.controls.max_export_write_bw.invalid &&
+              rateLimitForm.controls.max_export_write_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+
+        <ng-template #Export_writebw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_write_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_write_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_write_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+    </ng-container>
+
+    <ng-container
+      *ngIf="
+        rateLimitForm?.getValue('enable_qos') &&
+        ((this.type === 'cluster' &&
+          (this.qosTypeVal === 'PerClient' || this.qosTypeVal === 'PerShare_PerClient')) ||
+          (this.type === 'export' &&
+            this.qosTypeVal !== 'PerClient' &&
+            this.qosTypeVal !== 'PerShare'))
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_client_read_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that client can use for read per second"
+          cdRequiredField="Client read bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_client_read_bw.invalid &&
+            rateLimitForm.controls.max_client_read_bw.dirty
+          "
+          [invalidText]="client_read_bw_Error"
+          >Client Read Bandwidth
+          <input
+            cdsText
+            type="text"
+            id="max_client_read_bw"
+            name="max_client_read_bw"
+            formControlName="max_client_read_bw"
+            placeholder="Client read bandwidth..."
+            i18n-placeholder
+            [invalid]="
+              rateLimitForm.controls.max_client_read_bw.invalid &&
+              rateLimitForm.controls.max_client_read_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+
+        <ng-template #client_read_bw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_read_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_read_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_read_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+      <div class="form-group row">
+        <cds-text-label
+          for="max_client_write_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that client can use for write per second"
+          cdRequiredField="Client write bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_client_write_bw.invalid &&
+            rateLimitForm.controls.max_client_write_bw.dirty
+          "
+          [invalidText]="client_write_bw_Error"
+          >Client Write Bandwidth
+          <input
+            cdsText
+            type="text"
+            placeholder="Client write bandwidth..."
+            i18n-placeholder
+            id="max_client_write_bw"
+            name="max_client_write_bw"
+            formControlName="max_client_write_bw"
+            [invalid]="
+              rateLimitForm.controls.max_client_write_bw.invalid &&
+              rateLimitForm.controls.max_client_write_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+        <!-- [ngbTypeahead]="pathDataSource" -->
+        <ng-template #client_write_bw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_write_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_write_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_write_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+    </ng-container>
+  </form>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
@@ -1,32 +1,37 @@
-<ng-container *ngIf="allowQoS">
+<ng-container *ngIf="allowQoS || allowIops">
   <form name="rateLimitForm"
         #formDir="ngForm"
         [formGroup]="rateLimitForm"
         novalidate>
+    <!-- Cluster QoS Disabled Information -->
     <cd-alert-panel type="info"
                     class="me-1"
                     spacingClass="mt-1"
-                    *ngIf="clusterQoSDisabled"
-                    i18n>Cluster level QoS setting is disabled.
+                    *ngIf="clusterQosDisabled"
+                    i18n>Cluster level QOS setting is disabled.
     </cd-alert-panel>
 
     <cd-alert-panel type="info"
                     class="me-1"
                     spacingClass="mt-1"
                     *ngIf="showDisableWarning"
-                    i18n>Disable QoS will set QoS Bandwidth limit to Maximum.
+                    i18n>Disable Qos will set QOS Bandwidth limit to Maximum.
     </cd-alert-panel>
 
     <cd-alert-panel type="info"
                     class="me-1"
                     spacingClass="mt-1"
-                    *ngIf="showQoStypeChangeNote"
-                    i18n>If changing from already set one then please make sure to update exports bandwidths according to QoS type.
+                    *ngIf="showQostypeChangeNote"
+                    i18n>If changing from already set one then please make sure to update exports bandwidths according
+      to qos type.
     </cd-alert-panel>
-    <!-- qos_type is perclient, then can't enable export level QoS -->
+    <!-- qos_type is perclient, then can't enable export level qos -->
     <div
       class="form-item"
-      *ngIf="type === 'cluster' || (type === 'export' && nfsClusterData?.qos_type !== 'PerClient')"
+      *ngIf="
+        type === 'cluster' ||
+        (type === 'export' && nfsClusterData?.qos_type !== 'PerClient' && allowQoS)
+      "
     >
       <cds-checkbox
         id="enable_qos"
@@ -34,67 +39,32 @@
         (checkedChange)="showMaxBwNote()"
         formControlName="enable_qos"
         i18n
-        >Enable Bandwidth QoS
-      </cds-checkbox>
+        >Enable Bandwidth QOS</cds-checkbox>
     </div>
-    <span *ngIf="showMaxBw">Disable QoS will set QoS Bandwidth limit to Maximum.</span>
+    <span *ngIf="showMaxBw">Disable Qos will set QOS Bandwidth limit to Maximum.</span>
 
-    <div class="form-item"
-         *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
-      <cds-select
-        formControlName="bwType"
-        for="bwType"
-        label="Rate Limit"
-        id="bwType"
-        [helperText]="bwTypeHelper"
-        [skeleton]="bwTypeArr === null"
-      >
-        <option *ngIf="bwTypeArr === null"
-                [ngValue]="null">Loading...</option>
-        <option *ngIf="bwTypeArr !== null && bwTypeArr.length === 0"
-                i18n
-                [ngValue]="null">
-          -- No RateLimit type available --
-        </option>
-        <option *ngIf="bwTypeArr !== null && bwTypeArr.length > 0"
-                i18n
-                [ngValue]="null">
-          -- Select a RateLimit Type --
-        </option>
-        <option *ngFor="let type of bwTypeArr"
-                i18n
-                [value]="type.value">{{ type.value }}</option>
-      </cds-select>
-      <ng-template #bwTypeHelper>
-        <span *ngIf="rateLimitForm.getValue('bwType')">
-          {{ getbwTypeHelp(rateLimitForm.getValue('bwType')) }}
-        </span>
-      </ng-template>
-    </div>
-
-
-    <!-- qos type -->
+    <!-- QoS Type Selection -->
     <div class="form-item"
          *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
       <cds-select
         formControlName="qos_type"
+        for="qos_type"
         label="Bandwidth QOS Type"
         id="qos_type"
         [helperText]="qosTypeHelper"
         [skeleton]="qosType === null"
         (change)="registerQoSChange($event.target.value)"
-        i18n-label
       >
         <option *ngIf="qosType === null"
-                value="">Loading...</option>
+                [ngValue]="null">Loading...</option>
         <option *ngIf="qosType !== null && qosType.length === 0"
                 i18n
-                value="null">
-          -- No Bandwidth Qos type available --
+                [ngValue]="null">
+          -- No Bandwidth QOS type available --
         </option>
-        <option *ngIf="qosType !== null && qosType?.length > 0"
-                value=""
-                i18n>
+        <option *ngIf="qosType !== null && qosType.length > 0"
+                i18n
+                [ngValue]="null">
           -- Select a Bandwidth QOS Type --
         </option>
         <option *ngFor="let type of qosType"
@@ -108,6 +78,7 @@
       </ng-template>
     </div>
 
+    <!-- Export and Client Bandwidth Settings Based on QoS Type -->
     <ng-container
       *ngIf="
         rateLimitForm?.getValue('enable_qos') &&
@@ -331,6 +302,178 @@
             i18n
             >Enter a positive number.</span
           >
+        </ng-template>
+      </div>
+    </ng-container>
+
+    <!-- qos_type is perclient, then can't enable export level qos -->
+
+    <div
+      class="form-item"
+      *ngIf="
+        type === 'cluster' ||
+        (type === 'export' && nfsClusterData?.qos_type !== 'PerClient' && allowIops)
+      "
+    >
+      <cds-checkbox
+        id="enable_ops"
+        type="checkbox"
+        (checkedChange)="showMaxBwNote()"
+        formControlName="enable_ops"
+        i18n
+        >Enable IOPS QOS</cds-checkbox
+      >
+    </div>
+    <span *ngIf="showMaxBw">Disable Qos will set QOS Bandwidth limit to Maximum.</span>
+
+    <!-- IOPS Type Selection -->
+    <div class="form-item"
+         *ngIf="rateLimitForm.getValue('enable_ops') && type !== 'export'">
+      <cds-select
+        formControlName="qos_type_ops"
+        for="qos_type_ops"
+        label="IOPS QOS Type"
+        id="qos_type_ops"
+        [helperText]="qosiopsTypeHelper"
+        [skeleton]="qosType === null"
+        (change)="registerQoSIOPSChange($event.target.value)"
+      >
+        <option *ngIf="qosType === null"
+                [ngValue]="null">Loading...</option>
+        <option *ngIf="qosType !== null && qosType.length === 0"
+                i18n
+                [ngValue]="null">
+          -- No IOPS QOS type available --
+        </option>
+        <option *ngIf="qosType !== null && qosType.length > 0"
+                i18n
+                [ngValue]="null">
+          -- Select a IOPS QOS Type --
+        </option>
+        <option *ngFor="let type of qosType"
+                i18n
+                [value]="type.value">{{ type.key }}</option>
+      </cds-select>
+    </div>
+    <ng-template #qosiopsTypeHelper>
+      <span *ngIf="rateLimitForm.getValue('qos_type_ops')">
+        {{ getQoSTypeIOPSHelper(rateLimitForm.getValue('qos_type_ops')) }}
+      </span>
+    </ng-template>
+
+    <!-- Export and Client IOPS Settings Based on IOPS Type -->
+    <ng-container
+      *ngIf="
+        rateLimitForm?.getValue('enable_ops') &&
+        (qosTypeVal1 === 'PerShare' || qosTypeVal1 === 'PerShare_PerClient')
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_export_read_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that can be used for export read per second"
+          cdRequiredField="Export IOPS"
+          [invalid]="
+            rateLimitForm.controls.max_export_iops.invalid &&
+            rateLimitForm.controls.max_export_iops.dirty
+          "
+          [invalidText]="Export_iops_Error"
+          >Export IOPS
+          <input
+            cdsText
+            type="text"
+            placeholder="Export IOPS..."
+            i18n-placeholder
+            id="max_export_iops"
+            name="max_export_iops"
+            formControlName="max_export_iops"
+            [invalid]="
+              rateLimitForm.controls.max_export_iops.invalid &&
+              rateLimitForm.controls.max_export_iops.dirty
+            "
+            [invalidText]="Export_iops_Error"
+          />
+        </cds-text-label>
+        <ng-template #Export_iops_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_iops', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_export_iops').hasError('min')"
+            i18n
+            >Minimum value is 10 IOPS.
+          </span>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_export_iops').hasError('max')"
+            i18n
+            >Maximum value is 16384 IOPS.
+          </span>
+        </ng-template>
+      </div>
+    </ng-container>
+    <ng-container
+      *ngIf="
+        rateLimitForm?.getValue('enable_ops') &&
+        ((this.type === 'cluster' &&
+          (this.qosTypeVal1 === 'PerClient' || this.qosTypeVal1 === 'PerShare_PerClient')) ||
+          (this.type === 'export' &&
+            this.qosTypeVal1 !== 'PerClient' &&
+            this.qosTypeVal1 !== 'PerShare'))
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_client_iops"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that can be used for export write per second"
+          cdRequiredField="Client IOPS"
+          [invalid]="
+            rateLimitForm.controls.max_client_iops.invalid &&
+            rateLimitForm.controls.max_client_iops.dirty
+          "
+          [invalidText]="Client_iops_Error"
+        >
+          Client IOPS
+          <input
+            cdsText
+            type="text"
+            placeholder="Client IOPS..."
+            i18n-placeholder
+            name="max_client_iops"
+            formControlName="max_client_iops"
+            [invalid]="
+              rateLimitForm.controls.max_client_iops.invalid &&
+              rateLimitForm.controls.max_client_iops.dirty
+            "
+          />
+        </cds-text-label>
+        <ng-template #Client_iops_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_iops', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_client_iops').hasError('min')"
+            i18n
+            >Minimum value is 10 IOPS.
+          </span>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_client_iops').hasError('max')"
+            i18n
+            >Maximum value is 16384 IOPS.
+          </span>
         </ng-template>
       </div>
     </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
@@ -1,0 +1,423 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NfsRateLimitComponent } from './nfs-rate-limit.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '~/app/shared/shared.module';
+import { Validators } from '@angular/forms';
+import { FormatterService } from '~/app/shared/services/formatter.service';
+
+describe('NfsRateLimitComponent', () => {
+  let component: NfsRateLimitComponent;
+  let fixture: ComponentFixture<NfsRateLimitComponent>;
+
+  configureTestBed({
+    declarations: [NfsRateLimitComponent],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    providers: [FormatterService]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NfsRateLimitComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('loadConditionCheck', () => {
+    beforeEach(() => {
+      component.isEdit = true;
+    });
+
+    it('should handle type "cluster" with QoS enabled', () => {
+      component.type = 'cluster';
+      component.nfsClusterData = { enable_qos: true } as any;
+      spyOn(component, 'setFormData');
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).toBeTruthy();
+      expect(component.clusterQosDisabled).not.toBeTruthy();
+      expect(component.setFormData).toHaveBeenCalledWith(component.nfsClusterData);
+    });
+
+    it('should handle type "export" with cluster QoS enabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: true } as any;
+      spyOn(component, 'setFormData');
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).toBeTruthy();
+      expect(component.setFormData).toHaveBeenCalledWith(component.nfsExportdata);
+    });
+
+    it('should handle type "export" with export QoS enabled and cluster QoS disabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: false } as any;
+      component.nfsExportdata = { enable_qos: true } as any;
+      spyOn(component, 'registerQoSChange');
+      spyOn(component, 'setFormData');
+      spyOn(component, 'showDisabledField');
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).toBeTruthy();
+      expect(component.registerQoSChange).toHaveBeenCalledWith(component.nfsClusterData.qos_type);
+      expect(component.setFormData).toHaveBeenCalledWith(component.nfsExportdata);
+      expect(component.showDisabledField).toHaveBeenCalled();
+    });
+
+    it('should handle type "export" with both cluster and export QoS disabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: false } as any;
+      component.nfsExportdata = { enable_qos: false } as any;
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).not.toBeTruthy();
+    });
+  });
+  describe('setValidation', () => {
+    it('should set validators for PerShare QoS type', () => {
+      component.qosTypeVal = 'PerShare';
+      component.createForm();
+      jest.spyOn(component.rateLimitForm.controls['max_export_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_export_write_bw'], 'addValidators');
+
+      component.setValidation();
+
+      expect(
+        component.rateLimitForm.controls['max_export_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_export_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+
+    it('should set validators for PerClient QoS type', () => {
+      component.qosTypeVal = 'PerClient';
+      component.createForm();
+      jest.spyOn(component.rateLimitForm.controls['max_client_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_write_bw'], 'addValidators');
+
+      component.setValidation();
+
+      expect(
+        component.rateLimitForm.controls['max_client_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+
+    it('should set validators for PerSharePerClient QoS type', () => {
+      component.qosTypeVal = 'PerShare_PerClient';
+      component.createForm();
+      jest.spyOn(component.rateLimitForm.controls['max_export_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_export_write_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_write_bw'], 'addValidators');
+
+      component.setValidation();
+
+      expect(
+        component.rateLimitForm.controls['max_export_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_export_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+  });
+
+  describe('showMaxBwNote', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should add validators when QoS is enabled', () => {
+      jest.spyOn(component, 'setValidation');
+      component.showMaxBwNote(true);
+      expect(component.setValidation).toHaveBeenCalled();
+    });
+
+    it('should remove validators when QoS is disabled', () => {
+      jest.spyOn(component.rateLimitForm.controls['max_export_read_bw'], 'removeValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_export_write_bw'], 'removeValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_read_bw'], 'removeValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_write_bw'], 'removeValidators');
+
+      component.showMaxBwNote(false);
+
+      expect(
+        component.rateLimitForm.controls['max_export_read_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_export_write_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_read_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_write_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+  });
+
+  describe('registerQoSChange', () => {
+    it('should set validation and show note if QoS type is changed', () => {
+      component.isEdit = true;
+      component.nfsClusterData = { qos_type: 'oldType' } as any;
+      jest.spyOn(component, 'setValidation');
+
+      component.registerQoSChange('newType');
+
+      expect(component.setValidation).toHaveBeenCalled();
+      expect(component.showQostypeChangeNote).toBeTruthy();
+    });
+
+    it('should set validation and not show note if QoS type is not changed', () => {
+      component.isEdit = true;
+      component.nfsClusterData = { qos_type: 'sameType' } as any;
+      jest.spyOn(component, 'setValidation');
+
+      component.registerQoSChange('sameType');
+
+      expect(component.setValidation).toHaveBeenCalled();
+      expect(component.showQostypeChangeNote).toBeFalsy();
+    });
+  });
+
+  describe('showQOS', () => {
+    it('should allow QoS if type is export and cluster QoS is disabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: false } as any;
+
+      component.showQOS();
+
+      expect(component.allowQoS).toBeTruthy();
+    });
+
+    it('should not allow QoS if type is not export', () => {
+      component.type = 'cluster';
+      component.nfsClusterData = { enable_qos: false } as any;
+
+      component.showQOS();
+
+      expect(component.allowQoS).toBeFalsy();
+    });
+  });
+
+  describe('setFormData', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should set form data correctly', () => {
+      const data = {
+        enable_qos: true,
+        qos_type: 'PerShare',
+        max_export_read_bw: 100,
+        max_export_write_bw: 200,
+        max_client_read_bw: 300,
+        max_client_write_bw: 400
+      };
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      component.setFormData(data);
+
+      expect(component.rateLimitForm.get('enable_qos')?.value).toBe(data.enable_qos);
+      expect(component.rateLimitForm.get('qos_type')?.value).toBe(data.qos_type);
+      expect(component.rateLimitForm.get('max_export_read_bw')?.value).toBe(100);
+      expect(component.rateLimitForm.get('max_export_write_bw')?.value).toBe(100);
+      expect(component.rateLimitForm.get('max_client_read_bw')?.value).toBe(100);
+      expect(component.rateLimitForm.get('max_client_write_bw')?.value).toBe(100);
+    });
+  });
+
+  describe('getRateLimitFormValue', () => {
+    it('should return rate limit args if form is dirty', () => {
+      jest.spyOn(component, '_isRateLimitFormDirty').mockReturnValue(true);
+      const rateLimitArgs = { enable_qos: true } as any;
+      jest.spyOn(component, '_getRateLimitArgs').mockReturnValue(rateLimitArgs);
+
+      const result = component.getRateLimitFormValue();
+
+      expect(result).toBe(rateLimitArgs);
+    });
+
+    it('should return null if form is not dirty', () => {
+      jest.spyOn(component, '_isRateLimitFormDirty').mockReturnValue(false);
+
+      const result = component.getRateLimitFormValue();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('rateLimitBytesMaxSizeValidator', () => {
+    it('should return validation error for invalid input', () => {
+      const control = { value: 'invalid' } as any;
+      jest
+        .spyOn(FormatterService.prototype, 'performValidation')
+        .mockReturnValue({ rateByteMaxSize: true });
+
+      const result = component.rateLimitBytesMaxSizeValidator(control);
+
+      expect(result).toEqual({ rateByteMaxSize: true });
+    });
+
+    it('should return null for valid input', () => {
+      const control = { value: '100MB/s' } as any;
+      jest.spyOn(FormatterService.prototype, 'performValidation').mockReturnValue(null);
+
+      const result = component.rateLimitBytesMaxSizeValidator(control);
+
+      expect(result).toBeNull();
+    });
+  });
+  describe('createForm', () => {
+    it('should create the form with default values', () => {
+      component.createForm();
+
+      expect(component.rateLimitForm.get('enable_qos')?.value).toBe(false);
+      expect(component.rateLimitForm.get('qos_type')?.value).toBe('');
+      expect(component.rateLimitForm.get('bwType')?.value).toBe('Individual');
+      expect(component.rateLimitForm.get('max_export_read_bw')?.value).toBeNull();
+      expect(component.rateLimitForm.get('max_export_write_bw')?.value).toBeNull();
+      expect(component.rateLimitForm.get('max_client_read_bw')?.value).toBeNull();
+      expect(component.rateLimitForm.get('max_client_write_bw')?.value).toBeNull();
+    });
+  });
+
+  describe('getbwTypeHelp', () => {
+    it('should return the help text for the given bwType', () => {
+      component.bwTypeArr = [{ value: 'Individual', help: 'Individual help text' }];
+      const result = component.getbwTypeHelp('Individual');
+      expect(result).toBe('Individual help text');
+    });
+
+    it('should return an empty string if bwType is not found', () => {
+      component.bwTypeArr = [{ value: 'Combined', help: 'Combined help text' }];
+      const result = component.getbwTypeHelp('Individual');
+      expect(result).toBe('');
+    });
+  });
+
+  describe('getQoSTypeHelper', () => {
+    it('should return the help text for the given qosType', () => {
+      component.qosType = [{ value: 'PerShare', help: 'PerShare help text', key: 'PerShare' }];
+      const result = component.getQoSTypeHelper('PerShare');
+      expect(result).toBe('PerShare help text');
+    });
+
+    it('should return an empty string if qosType is not found', () => {
+      component.qosType = [{ value: 'PerClient', help: 'PerClient help text', key: 'PerClient' }];
+      const result = component.getQoSTypeHelper('PerShare');
+      expect(result).toBe('');
+    });
+  });
+
+  describe('showDisabledField', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should disable the appropriate fields', () => {
+      component.showDisabledField();
+
+      expect(component.rateLimitForm.get('enable_qos')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_export_read_bw')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_export_write_bw')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_client_read_bw')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_client_write_bw')?.disabled).toBeTruthy();
+    });
+  });
+
+  describe('_isRateLimitFormDirty', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should return true if any form control is dirty', () => {
+      component.rateLimitForm.get('enable_qos')?.markAsDirty();
+      const result = component._isRateLimitFormDirty();
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false if no form control is dirty', () => {
+      const result = component._isRateLimitFormDirty();
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('_getRateLimitArgs', () => {
+    beforeEach(() => {
+      component.createForm();
+      component.qosTypeVal = 'PerShare';
+    });
+
+    it('should return the correct rate limit args for PerShare', () => {
+      component.rateLimitForm.get('enable_qos')?.setValue(true);
+      component.rateLimitForm.get('qos_type')?.setValue('PerShare');
+      component.rateLimitForm.get('max_export_read_bw')?.setValue('100MB/s');
+      component.rateLimitForm.get('max_export_write_bw')?.setValue('200MB/s');
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      const result = component._getRateLimitArgs();
+
+      expect(result.enable_qos).toBe(true);
+      expect(result.qos_type).toBe('PerShare');
+      expect(result.max_export_read_bw).toBe(100);
+      expect(result.max_export_write_bw).toBe(100);
+    });
+
+    it('should return the correct rate limit args for PerClient', () => {
+      component.qosTypeVal = 'PerClient';
+      component.rateLimitForm.get('enable_qos')?.setValue(true);
+      component.rateLimitForm.get('qos_type')?.setValue('PerClient');
+      component.rateLimitForm.get('max_client_read_bw')?.setValue('300MB/s');
+      component.rateLimitForm.get('max_client_write_bw')?.setValue('400MB/s');
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      const result = component._getRateLimitArgs();
+
+      expect(result.enable_qos).toBe(true);
+      expect(result.qos_type).toBe('PerClient');
+      expect(result.max_client_read_bw).toBe(100);
+      expect(result.max_client_write_bw).toBe(100);
+    });
+
+    it('should return the correct rate limit args for PerSharePerClient', () => {
+      component.qosTypeVal = 'PerShare_PerClient';
+      component.rateLimitForm.get('enable_qos')?.setValue(true);
+      component.rateLimitForm.get('qos_type')?.setValue('PerShare_PerClient');
+      component.rateLimitForm.get('max_export_read_bw')?.setValue('100MB/s');
+      component.rateLimitForm.get('max_export_write_bw')?.setValue('200MB/s');
+      component.rateLimitForm.get('max_client_read_bw')?.setValue('300MB/s');
+      component.rateLimitForm.get('max_client_write_bw')?.setValue('400MB/s');
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      const result = component._getRateLimitArgs();
+
+      expect(result.enable_qos).toBe(true);
+      expect(result.qos_type).toBe('PerShare_PerClient');
+      expect(result.max_export_read_bw).toBe(100);
+      expect(result.max_export_write_bw).toBe(100);
+      expect(result.max_client_read_bw).toBe(100);
+      expect(result.max_client_write_bw).toBe(100);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
@@ -205,8 +205,6 @@ describe('NfsRateLimitComponent', () => {
       component.type = 'export';
       component.nfsClusterData = { enable_qos: false } as any;
 
-      component.showQOS();
-
       expect(component.allowQoS).toBeTruthy();
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
@@ -1,0 +1,298 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { AbstractControl, UntypedFormControl, ValidationErrors, Validators } from '@angular/forms';
+import _ from 'lodash';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { FormatterService } from '~/app/shared/services/formatter.service';
+import { bwTypeItem, NFSBwIopConfig, QOSType, QOSTypeItem } from '../models/nfs-cluster-config';
+import { CdValidators } from '~/app/shared/forms/cd-validators';
+
+@Component({
+  selector: 'cd-nfs-rate-limit-form',
+  templateUrl: './nfs-rate-limit.component.html',
+  styleUrls: ['./nfs-rate-limit.component.scss']
+})
+export class NfsRateLimitComponent implements OnInit {
+  @Input() action: string;
+  @Input() isEdit: boolean;
+  @Input() type: String;
+
+  @Input() set exportDataConfig(value: NFSBwIopConfig) {
+    if (value) {
+      this.nfsExportdata = value;
+      this.loadConditionCheck();
+    }
+  }
+  @Input() set clusterDataConfig(value: NFSBwIopConfig) {
+    if (value) {
+      this.nfsClusterData = value;
+      this.registerQoSChange(this.nfsClusterData.qos_type);
+      this.loadConditionCheck();
+    }
+  }
+
+  @Output()
+  emitErrors = new EventEmitter();
+
+  bwTypeArr: bwTypeItem[] = [];
+  nfsClusterData: NFSBwIopConfig = {};
+  qosTypeVal: string;
+  rateLimitForm: CdFormGroup;
+  qosType: QOSTypeItem[] = [];
+  clusterId: string;
+  allowQoS = false;
+  clusterQosDisabled = false;
+  showDisableWarning = false;
+  showQostypeChangeNote = false;
+  nfsExportdata: NFSBwIopConfig = {};
+
+  constructor(private nfsService: NfsService, private formatterService: FormatterService) {
+    this.bwTypeArr = this.nfsService.bwType;
+  }
+
+  ngOnInit(): void {
+    this.createForm();
+    this.qosType = this.nfsService.qosType;
+    this.loadConditionCheck();
+    this.rateLimitForm.controls['enable_qos'].valueChanges.subscribe((val) => {
+      this.showMaxBwNote(val);
+    });
+    this.emitErrors.emit(this.rateLimitForm);
+  }
+
+  setValidation() {
+    switch (this.qosTypeVal) {
+      case 'PerShare': {
+        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_write_bw'].removeValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_read_bw'].removeValidators(Validators.required);
+        break;
+      }
+      case 'PerClient': {
+        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_read_bw'].removeValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_write_bw'].removeValidators(Validators.required);
+        break;
+      }
+      case 'PerShare_PerClient': {
+        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+      }
+    }
+  }
+
+  showQOS() {
+    this.allowQoS = this.type === 'export' && !this.nfsClusterData?.enable_qos;
+  }
+
+  loadConditionCheck() {
+    this.showDisableWarning = false;
+
+    const isCLusterType = this.type === 'cluster';
+    const isExportType = this.type === 'export';
+    const clusterQOSEnabled = this.nfsClusterData?.enable_qos || false;
+    const exportQOSEnabled = this.nfsExportdata?.enable_qos || false;
+
+    this.allowQoS = true;
+
+    // Handle type 'cluster'
+    isCLusterType &&
+      clusterQOSEnabled &&
+      ((this.clusterQosDisabled = false), this.isEdit && this.setFormData(this.nfsClusterData));
+
+    // Handle type 'export'
+    isExportType &&
+      (clusterQOSEnabled && this.isEdit && this.setFormData(this.nfsExportdata),
+      !clusterQOSEnabled &&
+        exportQOSEnabled &&
+        (this.registerQoSChange(this.nfsClusterData?.qos_type),
+        this.setFormData(this.nfsExportdata),
+        this.showDisabledField()),
+      !clusterQOSEnabled && !exportQOSEnabled && (this.allowQoS = false));
+  }
+
+  createForm() {
+    this.rateLimitForm = new CdFormGroup({
+      enable_qos: new UntypedFormControl(false),
+      qos_type: new UntypedFormControl(''),
+      bwType: new UntypedFormControl('Individual'),
+      max_export_read_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ]),
+      max_export_write_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ]),
+      max_client_read_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ]),
+      max_client_write_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ])
+    });
+  }
+
+  showDisabledField() {
+    this.clusterQosDisabled = true;
+    this.qosTypeVal = 'PerShare_PerClient';
+    const fields = [
+      'enable_qos',
+      'max_export_read_bw',
+      'max_export_write_bw',
+      'max_client_read_bw',
+      'max_client_write_bw'
+    ];
+    fields.forEach((field) => {
+      this.rateLimitForm?.get(field)?.disable();
+    });
+  }
+
+  setFormData(data: NFSBwIopConfig) {
+    this.rateLimitForm?.get('enable_qos')?.setValue(data?.enable_qos);
+    this.rateLimitForm?.get('qos_type')?.setValue(data?.qos_type);
+    const fields = [
+      'max_export_read_bw',
+      'max_export_write_bw',
+      'max_client_read_bw',
+      'max_client_write_bw'
+    ];
+    fields.forEach((field) => {
+      this.rateLimitForm?.get(field)?.setValue(this.formatterService.toBytes(data?.[field]));
+    });
+  }
+
+  rateLimitBytesMaxSizeValidator(control: AbstractControl): ValidationErrors | null {
+    return new FormatterService().performValidation(
+      control,
+      '^(\\d+(\\.\\d+)?)\\s*(B/s|K(B|iB/s)?|M(B|iB/s)?|G(B|iB/s)?|T(B|iB/s)?|P(B|iB/s)?)?$',
+      { rateByteMaxSize: true },
+      'nfsRateLimit'
+    );
+  }
+
+  getbwTypeHelp(type: string) {
+    const bwTypeItem = this.bwTypeArr.find((item: bwTypeItem) => type === item.value);
+    return _.isObjectLike(bwTypeItem) ? bwTypeItem.help : '';
+  }
+
+  getRateLimitFormValue() {
+    if (this._isRateLimitFormDirty()) return this._getRateLimitArgs();
+    return null;
+  }
+
+  /**
+   * Check if the user rate limit has been modified.
+   * @return {Boolean} Returns TRUE if the user rate limit has been modified.
+   */
+  _isRateLimitFormDirty(): boolean {
+    return [
+      'bwType',
+      'enable_qos',
+      'qos_type',
+      'max_export_read_bw',
+      'max_export_write_bw',
+      'max_client_write_bw',
+      'max_client_read_bw'
+    ].some((path) => {
+      return this.rateLimitForm.get(path).dirty;
+    });
+  }
+
+  /**
+   * Helper function to get the arguments for the API request when the user
+   * rate limit configuration has been modified.
+   */
+  _getRateLimitArgs(): NFSBwIopConfig {
+    const formValues = {
+      enable_qos: this.rateLimitForm.getValue('enable_qos'),
+      qos_type: this.rateLimitForm.getValue('qos_type'),
+      max_export_write_bw: this.rateLimitForm.getValue('max_export_write_bw'),
+      max_export_read_bw: this.rateLimitForm.getValue('max_export_read_bw'),
+      max_client_write_bw: this.rateLimitForm.getValue('max_client_write_bw'),
+      max_client_read_bw: this.rateLimitForm.getValue('max_client_read_bw')
+    };
+
+    const result: NFSBwIopConfig = {
+      enable_qos: false,
+      qos_type: '',
+      max_export_write_bw: 0,
+      max_export_read_bw: 0,
+      max_client_write_bw: 0,
+      max_client_read_bw: 0,
+      max_export_combined_bw: 0,
+      max_client_combined_bw: 0
+    };
+
+    result['enable_qos'] = formValues.enable_qos;
+    result['qos_type'] = formValues.qos_type;
+
+    switch (this.qosTypeVal) {
+      case 'PerShare': {
+        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
+        result['max_export_write_bw'] = this.formatterService.toBytes(
+          formValues.max_export_write_bw
+        );
+        break;
+      }
+      case 'PerClient': {
+        result['max_client_write_bw'] = this.formatterService.toBytes(
+          formValues.max_client_write_bw
+        );
+        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
+        break;
+      }
+      case 'PerShare_PerClient': {
+        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
+        result['max_export_write_bw'] = this.formatterService.toBytes(
+          formValues.max_export_write_bw
+        );
+        result['max_client_write_bw'] = this.formatterService.toBytes(
+          formValues.max_client_write_bw
+        );
+        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
+      }
+    }
+    return result;
+  }
+
+  registerQoSChange(val: string) {
+    this.showQostypeChangeNote = false;
+    this.qosTypeVal = Object.values(QOSType).find((qos) => qos == val);
+
+    this.setValidation();
+    if (this.isEdit && this.nfsClusterData?.qos_type !== val) {
+      this.showQostypeChangeNote = true;
+    }
+  }
+
+  getQoSTypeHelper(qosType: string) {
+    const qosTypeItem = this.qosType.find(
+      (currentQosTypeItem: QOSTypeItem) => qosType === currentQosTypeItem.value
+    );
+    return _.isObjectLike(qosTypeItem) ? qosTypeItem.help : '';
+  }
+
+  showMaxBwNote(val: boolean) {
+    if (val) {
+      // adding required as per the qos type to handle parent component submit errors.
+      this.setValidation();
+    } else {
+      const fields = [
+        'max_export_read_bw',
+        'max_export_write_bw',
+        'max_client_read_bw',
+        'max_client_write_bw'
+      ];
+      fields.forEach((field) => {
+        this.rateLimitForm?.get(field)?.removeValidators(Validators.required);
+      });
+    }
+    this.showDisableWarning = false;
+    if (!val && this.isEdit == true && this.type == 'cluster' && !_.isEmpty(this.nfsClusterData)) {
+      this.showDisableWarning = true;
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { AbstractControl, UntypedFormControl, ValidationErrors, Validators } from '@angular/forms';
 import _ from 'lodash';
 import { NfsService } from '~/app/shared/api/nfs.service';
@@ -16,6 +16,7 @@ export class NfsRateLimitComponent implements OnInit {
   @Input() action: string;
   @Input() isEdit: boolean;
   @Input() type: String;
+  qosTypeVal1: string;
 
   @Input() set exportDataConfig(value: NFSBwIopConfig) {
     if (value) {
@@ -27,6 +28,7 @@ export class NfsRateLimitComponent implements OnInit {
     if (value) {
       this.nfsClusterData = value;
       this.registerQoSChange(this.nfsClusterData.qos_type);
+      this.registerQoSIOPSChange(this.nfsClusterData.qos_type);
       this.loadConditionCheck();
     }
   }
@@ -41,12 +43,18 @@ export class NfsRateLimitComponent implements OnInit {
   qosType: QOSTypeItem[] = [];
   clusterId: string;
   allowQoS = false;
+  allowIops = false;
   clusterQosDisabled = false;
+  clusterIopsDisabled = false;
   showDisableWarning = false;
   showQostypeChangeNote = false;
   nfsExportdata: NFSBwIopConfig = {};
 
-  constructor(private nfsService: NfsService, private formatterService: FormatterService) {
+  constructor(
+    private nfsService: NfsService,
+    private formatterService: FormatterService,
+    private chnageDetectorRef: ChangeDetectorRef
+  ) {
     this.bwTypeArr = this.nfsService.bwType;
   }
 
@@ -57,52 +65,81 @@ export class NfsRateLimitComponent implements OnInit {
     this.rateLimitForm.controls['enable_qos'].valueChanges.subscribe((val) => {
       this.showMaxBwNote(val);
     });
+    this.rateLimitForm.controls['enable_ops'].valueChanges.subscribe((val) => {
+      this.showMaxBwNote(val);
+    });
     this.emitErrors.emit(this.rateLimitForm);
   }
-
   setValidation() {
-    switch (this.qosTypeVal) {
-      case 'PerShare': {
-        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_write_bw'].removeValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_read_bw'].removeValidators(Validators.required);
-        break;
-      }
-      case 'PerClient': {
-        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_read_bw'].removeValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_write_bw'].removeValidators(Validators.required);
-        break;
-      }
-      case 'PerShare_PerClient': {
-        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+    if (this.rateLimitForm?.get('enable_qos').value) {
+      switch (this.qosTypeVal) {
+        case 'PerShare': {
+          this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_write_bw'].removeValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_read_bw'].removeValidators(Validators.required);
+          break;
+        }
+        case 'PerClient': {
+          this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_read_bw'].removeValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_write_bw'].removeValidators(Validators.required);
+          break;
+        }
+        case 'PerShare_PerClient': {
+          this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+        }
       }
     }
-  }
+    if (this.rateLimitForm?.get('enable_ops').value) {
+      switch (this.qosTypeVal) {
+        case 'PerShare': {
+          this.rateLimitForm?.controls['max_export_iops'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_iops'].removeValidators(Validators.required);
+          break;
+        }
+        case 'PerClient': {
+          this.rateLimitForm?.controls['max_client_iops'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_iops'].removeValidators(Validators.required);
+          break;
+        }
+        case 'PerShare_PerClient': {
+          this.rateLimitForm?.controls['max_export_iops'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_iops'].addValidators(Validators.required);
+        }
+      }
+    }
 
+    this.chnageDetectorRef.detectChanges();
+  }
   showQOS() {
-    this.allowQoS = this.type === 'export' && !this.nfsClusterData?.enable_qos;
+    this.allowQoS = this.type === 'export' && !this.nfsClusterData?.enable_bw_control;
   }
 
   loadConditionCheck() {
     this.showDisableWarning = false;
-
     const isCLusterType = this.type === 'cluster';
     const isExportType = this.type === 'export';
-    const clusterQOSEnabled = this.nfsClusterData?.enable_qos || false;
-    const exportQOSEnabled = this.nfsExportdata?.enable_qos || false;
+    const clusterQOSEnabled = this.nfsClusterData?.enable_bw_control || false;
+    const exportQOSEnabled = this.nfsExportdata?.enable_bw_control || false;
+
+    const clusterIopsEnabled = this.nfsClusterData?.enable_iops_control || false;
+    const exportIopsEnabled = this.nfsExportdata?.enable_iops_control || false;
 
     this.allowQoS = true;
-
+    this.allowIops = true;
     // Handle type 'cluster'
     isCLusterType &&
       clusterQOSEnabled &&
       ((this.clusterQosDisabled = false), this.isEdit && this.setFormData(this.nfsClusterData));
+
+    isCLusterType &&
+      clusterIopsEnabled &&
+      ((this.clusterIopsDisabled = false), this.isEdit && this.setFormData(this.nfsClusterData));
 
     // Handle type 'export'
     isExportType &&
@@ -113,13 +150,21 @@ export class NfsRateLimitComponent implements OnInit {
         this.setFormData(this.nfsExportdata),
         this.showDisabledField()),
       !clusterQOSEnabled && !exportQOSEnabled && (this.allowQoS = false));
+
+    isExportType &&
+      (clusterIopsEnabled && this.isEdit && this.setFormData(this.nfsExportdata),
+      !clusterIopsEnabled &&
+        exportIopsEnabled &&
+        (this.registerQoSIOPSChange(this.nfsClusterData?.qos_type),
+        this.setFormData(this.nfsExportdata),
+        this.showDisabledField()),
+      !clusterIopsEnabled && !exportIopsEnabled && (this.allowIops = false));
   }
 
   createForm() {
     this.rateLimitForm = new CdFormGroup({
       enable_qos: new UntypedFormControl(false),
       qos_type: new UntypedFormControl(''),
-      bwType: new UntypedFormControl('Individual'),
       max_export_read_bw: new UntypedFormControl(null, [
         CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
       ]),
@@ -131,7 +176,11 @@ export class NfsRateLimitComponent implements OnInit {
       ]),
       max_client_write_bw: new UntypedFormControl(null, [
         CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
-      ])
+      ]),
+      enable_ops: new UntypedFormControl(false),
+      qos_type_ops: new UntypedFormControl(''),
+      max_export_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(16384)]),
+      max_client_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(16384)])
     });
   }
 
@@ -148,16 +197,27 @@ export class NfsRateLimitComponent implements OnInit {
     fields.forEach((field) => {
       this.rateLimitForm?.get(field)?.disable();
     });
+
+    this.clusterIopsDisabled = true;
+    this.qosTypeVal1 = 'PerShare_PerClient';
+    const fields2 = ['enable_ops', 'max_client_iops', 'max_export_iops'];
+    fields2.forEach((field) => {
+      this.rateLimitForm?.get(field)?.disable();
+    });
   }
 
   setFormData(data: NFSBwIopConfig) {
-    this.rateLimitForm?.get('enable_qos')?.setValue(data?.enable_qos);
+    this.rateLimitForm?.get('enable_qos')?.setValue(data?.enable_bw_control);
+    this.rateLimitForm?.get('enable_ops')?.setValue(data?.enable_iops_control);
     this.rateLimitForm?.get('qos_type')?.setValue(data?.qos_type);
+    this.rateLimitForm?.get('qos_type_ops')?.setValue(data?.qos_type);
     const fields = [
       'max_export_read_bw',
       'max_export_write_bw',
       'max_client_read_bw',
-      'max_client_write_bw'
+      'max_client_write_bw',
+      'max_export_iops',
+      'max_client_iops'
     ];
     fields.forEach((field) => {
       this.rateLimitForm?.get(field)?.setValue(this.formatterService.toBytes(data?.[field]));
@@ -179,8 +239,11 @@ export class NfsRateLimitComponent implements OnInit {
   }
 
   getRateLimitFormValue() {
-    if (this._isRateLimitFormDirty()) return this._getRateLimitArgs();
-    return null;
+    return this._getRateLimitArgs();
+  }
+
+  getRateLimitOpsFormValue() {
+    return this._getRateLimitOpsArgs();
   }
 
   /**
@@ -201,18 +264,26 @@ export class NfsRateLimitComponent implements OnInit {
     });
   }
 
+  _isRateLimitOPSFormDirty(): boolean {
+    return ['bwType', 'enable_ops', 'qos_type_ops', 'max_export_iops', 'max_client_iops'].some(
+      (path) => {
+        return this.rateLimitForm.get(path).dirty;
+      }
+    );
+  }
+
   /**
    * Helper function to get the arguments for the API request when the user
    * rate limit configuration has been modified.
    */
   _getRateLimitArgs(): NFSBwIopConfig {
     const formValues = {
-      enable_qos: this.rateLimitForm.getValue('enable_qos'),
-      qos_type: this.rateLimitForm.getValue('qos_type'),
-      max_export_write_bw: this.rateLimitForm.getValue('max_export_write_bw'),
-      max_export_read_bw: this.rateLimitForm.getValue('max_export_read_bw'),
-      max_client_write_bw: this.rateLimitForm.getValue('max_client_write_bw'),
-      max_client_read_bw: this.rateLimitForm.getValue('max_client_read_bw')
+      enable_qos: this.rateLimitForm.get('enable_qos').value,
+      qos_type: this.rateLimitForm.get('qos_type').value,
+      max_export_write_bw: this.rateLimitForm.get('max_export_write_bw').value,
+      max_export_read_bw: this.rateLimitForm.get('max_export_read_bw').value,
+      max_client_write_bw: this.rateLimitForm.get('max_client_write_bw').value,
+      max_client_read_bw: this.rateLimitForm.get('max_client_read_bw').value
     };
 
     const result: NFSBwIopConfig = {
@@ -226,33 +297,83 @@ export class NfsRateLimitComponent implements OnInit {
       max_client_combined_bw: 0
     };
 
-    result['enable_qos'] = formValues.enable_qos;
-    result['qos_type'] = formValues.qos_type;
+    // If QoS is enabled, update the corresponding QoS values
+    if (formValues.enable_qos) {
+      result['enable_qos'] = formValues.enable_qos;
+      result['qos_type'] = formValues.qos_type;
 
-    switch (this.qosTypeVal) {
-      case 'PerShare': {
-        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
-        result['max_export_write_bw'] = this.formatterService.toBytes(
-          formValues.max_export_write_bw
-        );
-        break;
+      switch (this.qosTypeVal) {
+        case 'PerShare': {
+          result['max_export_read_bw'] = this.formatterService.toBytes(
+            formValues.max_export_read_bw
+          );
+          result['max_export_write_bw'] = this.formatterService.toBytes(
+            formValues.max_export_write_bw
+          );
+          break;
+        }
+        case 'PerClient': {
+          result['max_client_write_bw'] = this.formatterService.toBytes(
+            formValues.max_client_write_bw
+          );
+          result['max_client_read_bw'] = this.formatterService.toBytes(
+            formValues.max_client_read_bw
+          );
+          break;
+        }
+        case 'PerShare_PerClient': {
+          result['max_export_read_bw'] = this.formatterService.toBytes(
+            formValues.max_export_read_bw
+          );
+          result['max_export_write_bw'] = this.formatterService.toBytes(
+            formValues.max_export_write_bw
+          );
+          result['max_client_write_bw'] = this.formatterService.toBytes(
+            formValues.max_client_write_bw
+          );
+          result['max_client_read_bw'] = this.formatterService.toBytes(
+            formValues.max_client_read_bw
+          );
+          break;
+        }
       }
-      case 'PerClient': {
-        result['max_client_write_bw'] = this.formatterService.toBytes(
-          formValues.max_client_write_bw
-        );
-        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
-        break;
-      }
-      case 'PerShare_PerClient': {
-        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
-        result['max_export_write_bw'] = this.formatterService.toBytes(
-          formValues.max_export_write_bw
-        );
-        result['max_client_write_bw'] = this.formatterService.toBytes(
-          formValues.max_client_write_bw
-        );
-        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
+    }
+    return result;
+  }
+
+  _getRateLimitOpsArgs(): NFSBwIopConfig {
+    const formValues = {
+      enable_ops: this.rateLimitForm.get('enable_ops').value,
+      qos_type: this.rateLimitForm.get('qos_type_ops').value,
+      max_export_iops: this.rateLimitForm.get('max_export_iops').value,
+      max_client_iops: this.rateLimitForm.get('max_client_iops').value
+    };
+
+    const result: NFSBwIopConfig = {
+      enable_ops: false,
+      qos_type: '',
+      max_export_iops: 0,
+      max_client_iops: 0
+    };
+    // If Ops is enabled, update the corresponding Ops values
+    if (formValues.enable_ops) {
+      result['enable_ops'] = formValues.enable_ops;
+      result['qos_type'] = formValues.qos_type;
+
+      switch (this.qosTypeVal) {
+        case 'PerShare': {
+          result['max_export_iops'] = this.formatterService.toBytes(formValues.max_export_iops);
+          break;
+        }
+        case 'PerClient': {
+          result['max_client_iops'] = this.formatterService.toBytes(formValues.max_client_iops);
+          break;
+        }
+        case 'PerShare_PerClient': {
+          result['max_export_iops'] = this.formatterService.toBytes(formValues.max_export_iops);
+          result['max_client_iops'] = this.formatterService.toBytes(formValues.max_client_iops);
+          break;
+        }
       }
     }
     return result;
@@ -261,7 +382,14 @@ export class NfsRateLimitComponent implements OnInit {
   registerQoSChange(val: string) {
     this.showQostypeChangeNote = false;
     this.qosTypeVal = Object.values(QOSType).find((qos) => qos == val);
+    this.setValidation();
+    if (this.isEdit && this.nfsClusterData?.qos_type !== val) {
+      this.showQostypeChangeNote = true;
+    }
+  }
 
+  registerQoSIOPSChange(val: string) {
+    this.qosTypeVal1 = Object.values(QOSType).find((qos) => qos == val);
     this.setValidation();
     if (this.isEdit && this.nfsClusterData?.qos_type !== val) {
       this.showQostypeChangeNote = true;
@@ -269,6 +397,13 @@ export class NfsRateLimitComponent implements OnInit {
   }
 
   getQoSTypeHelper(qosType: string) {
+    const qosTypeItem = this.qosType.find(
+      (currentQosTypeItem: QOSTypeItem) => qosType === currentQosTypeItem.value
+    );
+    return _.isObjectLike(qosTypeItem) ? qosTypeItem.help : '';
+  }
+
+  getQoSTypeIOPSHelper(qosType: string) {
     const qosTypeItem = this.qosType.find(
       (currentQosTypeItem: QOSTypeItem) => qosType === currentQosTypeItem.value
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
@@ -27,6 +27,8 @@ import Close from '@carbon/icons/es/close/32';
 import { NfsClusterComponent } from './nfs-cluster/nfs-cluster.component';
 import { ClusterModule } from '../cluster/cluster.module';
 import { NfsClusterDetailsComponent } from './nfs-cluster-details/nfs-cluster-details.component';
+import { NfsClusterFormComponent } from './nfs-cluster-form/nfs-cluster-form.component';
+import { NfsRateLimitComponent } from './nfs-rate-limit/nfs-rate-limit.component';
 
 @NgModule({
   imports: [
@@ -48,14 +50,23 @@ import { NfsClusterDetailsComponent } from './nfs-cluster-details/nfs-cluster-de
     TabsModule,
     ClusterModule
   ],
-  exports: [NfsListComponent, NfsFormComponent, NfsDetailsComponent, NfsClusterComponent],
+  exports: [
+    NfsListComponent,
+    NfsFormComponent,
+    NfsDetailsComponent,
+    NfsClusterComponent,
+    NfsFormClientComponent,
+    NfsClusterDetailsComponent
+  ],
   declarations: [
     NfsListComponent,
     NfsDetailsComponent,
     NfsFormComponent,
     NfsFormClientComponent,
     NfsClusterComponent,
-    NfsClusterDetailsComponent
+    NfsClusterDetailsComponent,
+    NfsClusterFormComponent,
+    NfsRateLimitComponent
   ]
 })
 export class NfsModule {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -116,6 +116,7 @@ import { RgwTopicDetailsComponent } from './rgw-topic-details/rgw-topic-details.
 import { RgwTopicFormComponent } from './rgw-topic-form/rgw-topic-form.component';
 import { RgwBucketNotificationListComponent } from './rgw-bucket-notification-list/rgw-bucket-notification-list.component';
 import { RgwNotificationFormComponent } from './rgw-notification-form/rgw-notification-form.component';
+import { NfsClusterFormComponent } from '../nfs/nfs-cluster-form/nfs-cluster-form.component';
 
 @NgModule({
   imports: [
@@ -421,7 +422,12 @@ const routes: Routes = [
     children: [
       { path: '', component: NfsClusterComponent },
       {
-        path: URLVerbs.CREATE,
+        path: `${URLVerbs.EDIT}/:cluster_id`,
+        component: NfsClusterFormComponent,
+        data: { breadcrumbs: ActionLabels.EDIT }
+      },
+      {
+        path: `${URLVerbs.CREATE}/:cluster_id`,
         component: NfsFormComponent,
         data: { breadcrumbs: ActionLabels.CREATE }
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
@@ -160,9 +160,30 @@ export class NfsService extends ApiClient {
     });
   }
 
+  enableQosOpsForExports(exportObj: NFSBwIopConfig) {
+    return this.http.patch(`${this.apiPath}/export/qos/ops`, exportObj, {
+      headers: { Accept: this.getVersionHeaderValue(1, 0) },
+      observe: 'response'
+    });
+  }
+
   getexportBandwidthOpsConfig(clusterId: string, pseudoPath: string) {
     return this.http.get(
       `${this.apiPath}/export/qos/${clusterId}/${encodeURIComponent(pseudoPath)}`
     );
+  }
+
+  enableQosOpsForCLuster(obj: NFSBwIopConfig) {
+    return this.http.patch(`${this.apiPath}/cluster/qos/ops`, obj, {
+      headers: { Accept: this.getVersionHeaderValue(1, 0) },
+      observe: 'response'
+    });
+  }
+
+  enableOpsForExports(exportObj: NFSBwIopConfig) {
+    return this.http.patch(`${this.apiPath}/export/ops`, exportObj, {
+      headers: { Accept: this.getVersionHeaderValue(1, 0) },
+      observe: 'response'
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dimless-binary-per-second.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dimless-binary-per-second.directive.ts
@@ -65,6 +65,9 @@ export class DimlessBinaryPerSecondDirective implements OnInit {
   @Input()
   roundPower: number;
 
+  @Input()
+  defaultEmptyValue: boolean = false;
+
   /**
    * Default unit that should be used when user do not type a unit.
    * By default, "MiB" will be used.
@@ -95,6 +98,11 @@ export class DimlessBinaryPerSecondDirective implements OnInit {
   }
 
   setValue(value: string) {
+    if (value === '' && this.defaultEmptyValue) {
+      this.ngModelChange.emit(value);
+      this.control.control.setValue(value);
+      return;
+    }
     if (/^[\d.]+$/.test(value)) {
       value += this.defaultUnit || 'm';
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, ValidationErrors } from '@angular/forms';
+
 import _ from 'lodash';
 import { isEmptyInputValue } from '../forms/cd-validators';
 
@@ -90,7 +91,7 @@ export class FormatterService {
     const base = 1024;
     const units = ['b', 'k', 'm', 'g', 't', 'p', 'e', 'z', 'y'];
     const bytesRegexMatch = RegExp(
-      '^(\\d+(.\\d+)?) ?([' + units.join('') + ']?(b|ib|B/s|B/m|iB/m)?)?$',
+      '^(\\d+(.\\d+)?) ?([' + units.join('') + ']?(b|ib|B/s|B/m|iB/m|iB/s)?)?$',
       'i'
     ).exec(value);
     if (bytesRegexMatch === null) {
@@ -102,7 +103,6 @@ export class FormatterService {
     }
     return Math.round(bytes);
   }
-
   /**
    * Converts `x ms` to `x` (currently) or `0` if the conversion fails
    */
@@ -167,6 +167,11 @@ export class FormatterService {
     if (type == 'quota') {
       const bytes = new FormatterService().toBytes(control.value);
       return bytes < 1024 ? errorObject : null;
+    }
+    // For all bandwidth values:  minimum  1Mbps Maximum. 4Gbps
+    if (type == 'nfsRateLimit') {
+      const bytes = new FormatterService().toBytes(control.value);
+      return bytes < 1024 * 1024 || bytes > 4 * (1024 * 1024 * 1024) ? errorObject : null;
     }
     return null;
   }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -11581,6 +11581,130 @@ paths:
       - jwt: []
       tags:
       - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/bw:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos:
+                  default: false
+                  type: boolean
+                max_client_combined_bw:
+                  type: string
+                max_client_read_bw:
+                  type: string
+                max_client_write_bw:
+                  type: string
+                max_export_combined_bw:
+                  type: string
+                max_export_read_bw:
+                  type: string
+                max_export_write_bw:
+                  type: string
+                qos_type:
+                  default: ''
+                  type: string
+              required:
+              - cluster_id
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable QoS configuration for bandwidth
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/ops:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_Ops:
+                  default: false
+                  type: boolean
+                max_client_iops:
+                  default: 0
+                  type: integer
+                max_export_iops:
+                  default: 0
+                  type: integer
+                qos_type:
+                  type: string
+              required:
+              - cluster_id
+              - qos_type
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable QoS configuration for NFS IOPs
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/{cluster_id}:
+    get:
+      parameters:
+      - in: path
+        name: cluster_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get the cluster QoS configuration for bandwidth and iops
+      tags:
+      - NFS-Ganesha
   /api/nfs-ganesha/export:
     get:
       parameters:
@@ -12033,6 +12157,135 @@ paths:
       security:
       - jwt: []
       summary: Creates a new NFS-Ganesha export
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos:
+                  default: false
+                  type: boolean
+                max_client_combined_bw:
+                  type: string
+                max_client_read_bw:
+                  type: string
+                max_client_write_bw:
+                  type: string
+                max_export_combined_bw:
+                  type: string
+                max_export_read_bw:
+                  type: string
+                max_export_write_bw:
+                  type: string
+                pseudo_path:
+                  type: string
+              required:
+              - cluster_id
+              - pseudo_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable export QoS configuration for bandwidth
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos/ops:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos_ops:
+                  default: false
+                  type: boolean
+                max_client_iops:
+                  default: 0
+                  type: integer
+                max_export_iops:
+                  default: 0
+                  type: integer
+                pseudo_path:
+                  type: string
+              required:
+              - cluster_id
+              - pseudo_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable export QoS configuration for operations
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos/{cluster_id}/{pseudo_path}:
+    get:
+      parameters:
+      - in: path
+        name: cluster_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pseudo_path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get the export QoS configuration for bandwidth and IOPS
       tags:
       - NFS-Ganesha
   /api/nfs-ganesha/export/{cluster_id}/{export_id}:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -26,7 +26,8 @@ from .ganesha_conf import format_block, GaneshaConfParser
 from .qos_conf import (
     QOS,
     QOSType,
-    QOSBandwidthControl)
+    QOSBandwidthControl,
+    QOSOpsControl)
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -368,23 +369,27 @@ class NFSCluster:
             return qos_obj
         return None
 
-    def update_cluster_qos_bw(self,
-                              cluster_id: str,
-                              enable_qos: bool,
-                              bw_obj: QOSBandwidthControl,
-                              qos_type: Optional[QOSType] = None) -> None:
+    def update_cluster_qos_obj(self,
+                               cluster_id: str,
+                               qos_obj: Optional[QOS],
+                               enable_qos: bool,
+                               qos_type: Optional[QOSType] = None,
+                               bw_obj: Optional[QOSBandwidthControl] = None,
+                               ops_obj: Optional[QOSOpsControl] = None) -> None:
         """Update cluster QOS config"""
         qos_obj_exists = False
-        qos_obj = self.get_cluster_qos_config(cluster_id)
         if not qos_obj:
             log.debug(f"Creating new QOS block for cluster {cluster_id}")
-            qos_obj = QOS(True, enable_qos, qos_type, bw_obj)
+            qos_obj = QOS(True, enable_qos, qos_type, bw_obj, ops_obj)
         else:
             log.debug(f"Updating existing QOS block for cluster {cluster_id}")
             qos_obj_exists = True
             qos_obj.enable_qos = enable_qos
             qos_obj.qos_type = qos_type
-            qos_obj.bw_obj = bw_obj
+            if bw_obj:
+                qos_obj.bw_obj = bw_obj
+            if ops_obj:
+                qos_obj.ops_obj = ops_obj
 
         qos_config = format_block(qos_obj.to_qos_block())
         rados_obj = self._rados(cluster_id)
@@ -395,6 +400,53 @@ class NFSCluster:
             rados_obj.update_obj(qos_config, qos_conf_obj_name(cluster_id),
                                  conf_obj_name(cluster_id), should_notify=False)
         log.debug(f"Successfully saved {cluster_id}s QOS bandwidth control config: \n {qos_config}")
+
+    def update_cluster_qos(self,
+                           cluster_id: str,
+                           qos_obj: Optional[QOS],
+                           enable_qos: bool,
+                           qos_type: Optional[QOSType] = None,
+                           bw_obj: Optional[QOSBandwidthControl] = None,
+                           ops_obj: Optional[QOSOpsControl] = None) -> None:
+        try:
+            if cluster_id in available_clusters(self.mgr):
+                self.update_cluster_qos_obj(cluster_id, qos_obj, enable_qos, qos_type, bw_obj, ops_obj)
+                restart_nfs_service(self.mgr, cluster_id)
+                return
+            raise ClusterNotFound()
+        except NotImplementedError:
+            raise ManualRestartRequired(f"NFS-Ganesha QOS config added successfully for {cluster_id}")
+
+    def validate_qos_type(self,
+                          qos_obj: QOS,
+                          qos_type: QOSType,
+                          bw_obj: Optional[QOSBandwidthControl] = None,
+                          ops_obj: Optional[QOSOpsControl] = None) -> None:
+        if not qos_obj or not (bw_obj or ops_obj):
+            return
+        # if qos is not enabled then we can set new directly
+        if not (qos_obj.enable_qos and qos_obj.qos_type):
+            return
+
+        other_qos_obj: Any = None
+        if bw_obj:
+            other_qos_obj = qos_obj.ops_obj
+            is_other_enable = qos_obj.ops_obj.enable_iops_ctrl if qos_obj.ops_obj else False
+            is_this_enable = qos_obj.bw_obj.enable_bw_ctrl if qos_obj.bw_obj else False
+            ctrl_type = "IOPS"
+        else:
+            other_qos_obj = qos_obj.bw_obj
+            is_other_enable = qos_obj.bw_obj.enable_bw_ctrl if qos_obj.bw_obj else False
+            is_this_enable = qos_obj.ops_obj.enable_iops_ctrl if qos_obj.ops_obj else False
+            ctrl_type = "Bandwidth"
+
+        if other_qos_obj and is_other_enable:
+            # if earlier only other qos control is enabled
+            if not is_this_enable and qos_obj.qos_type != qos_type:
+                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} qos type, please update that qos type for {ctrl_type} first.")
+            # if both qos control are enabled, the user will need to disable one first to change qos type
+            elif is_this_enable and qos_obj.qos_type != qos_type:
+                raise Exception(f"{ctrl_type} control is using {qos_obj.qos_type.name} qos type, please disable {ctrl_type} control to update qos type and then enable {ctrl_type} control again with new qos type")
 
     def enable_cluster_qos_bw(self,
                               cluster_id: str,
@@ -414,17 +466,15 @@ class NFSCluster:
             c. If qos_type is pershare_perclient, then export_rw_bw and client_rw_bw parameters are compulsory
         """
         try:
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            if qos_obj:
+                self.validate_qos_type(qos_obj, qos_type, bw_obj=bw_obj)
             bw_obj.qos_bandwidth_checks(qos_type)
-            if cluster_id in available_clusters(self.mgr):
-                self.update_cluster_qos_bw(cluster_id, True, bw_obj, qos_type)
-                restart_nfs_service(self.mgr, cluster_id)
-                log.info(f"QOS bandwidth control has been successfully enabled for cluster {cluster_id}. "
-                         "If the qos_type is changed during this process, ensure that the bandwidth "
-                         "values for all exports are updated accordingly.")
-                return
-            raise ClusterNotFound()
-        except NotImplementedError:
-            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added Successfully for {cluster_id}")
+            self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, bw_obj=bw_obj)
+            log.info(f"QOS bandwidth control has been successfully enabled for cluster {cluster_id}. "
+                     "If the qos_type is changed during this process, ensure that the bandwidth "
+                     "values for all exports are updated accordingly.")
+            return
         except Exception as e:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
@@ -441,16 +491,51 @@ class NFSCluster:
 
     def disable_cluster_qos_bw(self, cluster_id: str) -> None:
         try:
-            if cluster_id in available_clusters(self.mgr):
-                self.update_cluster_qos_bw(cluster_id, False, QOSBandwidthControl())
-                restart_nfs_service(self.mgr, cluster_id)
-                log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
-                         f"cluster {cluster_id}. As a result, export-level bandwidth control will "
-                         "no longer have any effect, even if it's enabled.")
-                return
-            raise ClusterNotFound()
-        except NotImplementedError:
-            raise ManualRestartRequired(f"NFS-Ganesha QOS bandwidth control config added successfully for {cluster_id}")
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            status = False
+            qos_type = None
+            if qos_obj:
+                status = qos_obj.get_enable_qos_val(disable_bw=True)
+                if status:
+                    qos_type = qos_obj.qos_type
+            self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, bw_obj=QOSBandwidthControl())
+            log.info("Cluster-level QoS bandwidth control has been successfully disabled for "
+                     f"cluster {cluster_id}. As a result, export-level bandwidth control will "
+                     "no longer have any effect, even if it's enabled.")
+            return
         except Exception as e:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl) -> None:
+        try:
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            if qos_obj:
+                self.validate_qos_type(qos_obj, qos_type, ops_obj=ops_obj)
+            ops_obj.qos_ops_checks(qos_type)
+            self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, ops_obj=ops_obj)
+            log.info(f"QOS IOPS control has been successfully enabled for cluster {cluster_id}. "
+                     "If the qos_type is changed during this process, ensure that ops count "
+                     "values for all exports are updated accordingly.")
+            return
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS IOPS control config failed for {cluster_id}")
+            raise ErrorResponse.wrap(e)
+
+    def disable_cluster_qos_ops(self, cluster_id: str) -> None:
+        try:
+            qos_obj = self.get_cluster_qos_config(cluster_id)
+            status = False
+            qos_type = None
+            if qos_obj:
+                status = qos_obj.get_enable_qos_val(disable_ops=True)
+                if status:
+                    qos_type = qos_obj.qos_type
+            self.update_cluster_qos(cluster_id, qos_obj, status, qos_type, ops_obj=QOSOpsControl())
+            log.info("Cluster-level QoS IOPS control has been successfully disabled for "
+                     f"cluster {cluster_id}. As a result, export-level ops control will "
+                     "no longer have any effect, even if it's enabled.")
+            return
+        except Exception as e:
+            log.exception(f"Setting NFS-Ganesha QOS IOPS control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -479,11 +479,11 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def get_cluster_qos(self, cluster_id: str) -> Dict[str, Any]:
+    def get_cluster_qos(self, cluster_id: str, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         try:
             if cluster_id in available_clusters(self.mgr):
                 qos_obj = self.get_cluster_qos_config(cluster_id)
-                return qos_obj.to_dict() if qos_obj else {}
+                return qos_obj.to_dict(ret_bw_in_bytes) if qos_obj else {}
             raise ClusterNotFound()
         except Exception as e:
             log.exception(f"Fetching NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -451,7 +451,8 @@ class NFSCluster:
     def enable_cluster_qos_bw(self,
                               cluster_id: str,
                               qos_type: QOSType,
-                              bw_obj: QOSBandwidthControl
+                              bw_obj: QOSBandwidthControl,
+                              skip_qos_type_validation: bool = False
                               ) -> None:
         """
         There are 2 cases to consider:
@@ -467,7 +468,7 @@ class NFSCluster:
         """
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
-            if qos_obj:
+            if qos_obj and not skip_qos_type_validation:
                 self.validate_qos_type(qos_obj, qos_type, bw_obj=bw_obj)
             bw_obj.qos_bandwidth_checks(qos_type)
             self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, bw_obj=bw_obj)
@@ -507,10 +508,10 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl) -> None:
+    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl, skip_qos_type_validation: bool = False) -> None:
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
-            if qos_obj:
+            if qos_obj and not skip_qos_type_validation:
                 self.validate_qos_type(qos_obj, qos_type, ops_obj=ops_obj)
             ops_obj.qos_ops_checks(qos_type)
             self.update_cluster_qos(cluster_id, qos_obj, True, qos_type=qos_type, ops_obj=ops_obj)

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -915,10 +915,10 @@ class ExportMgr:
             log.exception(f"Setting NFS-Ganesha QOS bandwidth control failed for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def get_export_qos(self, cluster_id: str, pseudo_path: str) -> Dict[str, int]:
+    def get_export_qos(self, cluster_id: str, pseudo_path: str, ret_bw_in_bytes: bool = False) -> Dict[str, int]:
         try:
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
-            return export_obj.qos_block.to_dict() if export_obj.qos_block else {}
+            return export_obj.qos_block.to_dict(ret_bw_in_bytes) if export_obj.qos_block else {}
         except Exception as e:
             log.exception(f"Failed to get QOS configuration for {pseudo_path} of {cluster_id}")
             raise ErrorResponse.wrap(e)

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -842,7 +842,11 @@ class ExportMgr:
 
         # check QOS
         if new_export_dict.get('qos_block'):
-            export_dict_qos_bw_ops_checks(cluster_id, self.mgr, dict(new_export_dict.get('qos_block', {})))
+            old_qos = {}
+            if old_export.qos_block:
+                old_qos = old_export.qos_block.to_dict()
+            export_dict_qos_bw_ops_checks(cluster_id, self.mgr, dict(new_export_dict.get('qos_block', {})),
+                                          old_qos)
 
         self.exports[cluster_id].remove(old_export)
 

--- a/src/pybind/mgr/nfs/export_utils.py
+++ b/src/pybind/mgr/nfs/export_utils.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+from .cluster import NFSCluster
+from .qos_conf import QOSType, QOSParams, QOSBandwidthControl
+
+
+def export_dict_bw_checks(cluster_id: str,
+                          mgr_obj: Any,
+                          qos_enable: bool,
+                          qos_dict: dict) -> None:
+    enable_bw_ctrl = qos_dict.get('enable_bw_control')
+    combined_bw_ctrl = qos_dict.get('combined_rw_bw_control')
+    bandwith_param_exists = any(key.endswith('bw') for key in qos_dict)
+    if enable_bw_ctrl is None:
+        if combined_bw_ctrl and bandwith_param_exists:
+            raise Exception('Bandwidth control is not enabled but associated parameters exists')
+        return
+    if combined_bw_ctrl is None:
+        combined_bw_ctrl = False
+    if not qos_enable and enable_bw_ctrl:
+        raise Exception('To enable bandwidth control, qos_enable should be true.')
+    if not (isinstance(enable_bw_ctrl, bool) and isinstance(combined_bw_ctrl, bool)):
+        raise Exception('Invalid values for the enable_bw_ctrl and combined_bw_ctrl parameters.')
+    # if qos is disabled, then bandwidths should not be set and no need to bandwidth checks
+    if not enable_bw_ctrl:
+        if bandwith_param_exists:
+            raise Exception('Bandwidths should not be passed when enable_bw_control is false.')
+        return
+    if enable_bw_ctrl and not bandwith_param_exists:
+        raise Exception('Bandwidths should be set when enable_bw_control is true.')
+    bw_obj = QOSBandwidthControl(enable_bw_ctrl,
+                                 combined_bw_ctrl,
+                                 export_writebw=qos_dict.get(QOSParams.export_writebw.value, '0'),
+                                 export_readbw=qos_dict.get(QOSParams.export_readbw.value, '0'),
+                                 client_writebw=qos_dict.get(QOSParams.client_writebw.value, '0'),
+                                 client_readbw=qos_dict.get(QOSParams.client_readbw.value, '0'),
+                                 export_rw_bw=qos_dict.get(QOSParams.export_rw_bw.value, '0'),
+                                 client_rw_bw=qos_dict.get(QOSParams.client_rw_bw.value, '0'))
+    export_qos_bw_checks(cluster_id, mgr_obj, bw_obj)
+
+
+def export_dict_qos_checks(cluster_id: str,
+                           mgr_obj: Any,
+                           qos_dict: dict) -> None:
+    """Validate the qos block of dict passed to apply_export method"""
+    qos_enable = qos_dict.get('enable_qos')
+    if qos_enable is None:
+        raise Exception('The QOS block requires at least the enable_qos parameter')
+    if not isinstance(qos_enable, bool):
+        raise Exception('Invalid value for the enable_qos parameter')
+    export_dict_bw_checks(cluster_id, mgr_obj, qos_enable, qos_dict)
+
+
+def export_qos_bw_checks(cluster_id: str,
+                         mgr_obj: Any,
+                         bw_obj: QOSBandwidthControl,
+                         nfs_clust_obj: Any = None) -> None:
+    """check cluster level qos is enabled to enable export level qos and validate bandwidths"""
+    if not nfs_clust_obj:
+        nfs_clust_obj = NFSCluster(mgr_obj)
+    clust_qos_obj = nfs_clust_obj.get_cluster_qos_config(cluster_id)
+    if not clust_qos_obj or (clust_qos_obj and not (clust_qos_obj.enable_qos)):
+        raise Exception('To configure bandwidth control for export, you must first enable bandwidth control at the cluster level.')
+    if clust_qos_obj.qos_type:
+        if clust_qos_obj.qos_type == QOSType.PerClient:
+            raise Exception('Export-level QoS bandwidth control cannot be enabled if the QoS type at the cluster level is set to PerClient.')
+        bw_obj.qos_bandwidth_checks(clust_qos_obj.qos_type)

--- a/src/pybind/mgr/nfs/export_utils.py
+++ b/src/pybind/mgr/nfs/export_utils.py
@@ -1,7 +1,7 @@
-from typing import Any
+from typing import Any, Optional
 
 from .cluster import NFSCluster
-from .qos_conf import QOSType, QOSParams, QOSBandwidthControl, QOSOpsControl
+from .qos_conf import QOSType, QOSParams, QOSBandwidthControl, QOSOpsControl, QOS
 
 
 def export_dict_bw_checks(cluster_id: str,
@@ -109,3 +109,8 @@ def export_qos_ops_checks(cluster_id: str,
         if clust_qos_obj.qos_type == QOSType.PerClient:
             raise Exception(f'Export-level QoS IOPS control cannot be enabled if the QoS type at the cluster {cluster_id} level is set to PerClient.')
         ops_obj.qos_ops_checks(clust_qos_obj.qos_type)
+
+
+def get_cluster_qos_config(cluster_id: str, mgr_obj: Any) -> Optional[QOS]:
+    nfs_clust_obj = NFSCluster(mgr_obj)
+    return nfs_clust_obj.get_cluster_qos_config(cluster_id)

--- a/src/pybind/mgr/nfs/ganesha_conf.py
+++ b/src/pybind/mgr/nfs/ganesha_conf.py
@@ -5,6 +5,7 @@ from mgr_module import NFS_GANESHA_SUPPORTED_FSALS
 
 from .exception import NFSInvalidOperation, FSNotFound
 from .utils import check_fs
+from .qos_conf import QOS, RawBlock
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -51,27 +52,6 @@ def _validate_sec_type(sec_type: str) -> None:
     if not isinstance(sec_type, str) or sec_type not in valid_sec_types:
         raise NFSInvalidOperation(
             f"SecType {sec_type} invalid, valid types are {valid_sec_types}")
-
-
-class RawBlock():
-    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
-        if not values:  # workaround mutable default argument
-            values = {}
-        if not blocks:  # workaround mutable default argument
-            blocks = []
-        self.block_name = block_name
-        self.blocks = blocks
-        self.values = values
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, RawBlock):
-            return False
-        return self.block_name == other.block_name and \
-            self.blocks == other.blocks and \
-            self.values == other.values
-
-    def __repr__(self) -> str:
-        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'
 
 
 class GaneshaConfParser:
@@ -375,7 +355,8 @@ class Export:
             transports: List[str],
             fsal: FSAL,
             clients: Optional[List[Client]] = None,
-            sectype: Optional[List[str]] = None) -> None:
+            sectype: Optional[List[str]] = None,
+            qos_block: Optional[QOS] = None) -> None:
         self.export_id = export_id
         self.path = path
         self.fsal = fsal
@@ -389,6 +370,7 @@ class Export:
         self.transports = transports
         self.clients: List[Client] = clients or []
         self.sectype = sectype
+        self.qos_block = qos_block
 
     @classmethod
     def from_export_block(cls, export_block: RawBlock, cluster_id: str) -> 'Export':
@@ -397,6 +379,10 @@ class Export:
 
         client_blocks = [b for b in export_block.blocks
                          if b.block_name == "CLIENT"]
+
+        qos_block = [b for b in export_block.blocks
+                     if b.block_name == "qos_block"]
+        qos_block = QOS.from_qos_block(qos_block[0]) if qos_block else None
 
         protocols = export_block.values.get('protocols')
         if not isinstance(protocols, list):
@@ -430,7 +416,9 @@ class Export:
                    FSAL.from_fsal_block(fsal_blocks[0]),
                    [Client.from_client_block(client)
                     for client in client_blocks],
-                   sectype=sectype)
+                   sectype=sectype,
+                   qos_block=qos_block
+                   )
 
     def to_export_block(self) -> RawBlock:
         values = {
@@ -453,10 +441,16 @@ class Export:
             client.to_client_block()
             for client in self.clients
         ]
+        if self.qos_block:
+            result.blocks.append(self.qos_block.to_qos_block())
         return result
 
     @classmethod
     def from_dict(cls, export_id: int, ex_dict: Dict[str, Any]) -> 'Export':
+        if ex_dict.get('qos_block'):
+            qos_block = QOS.from_dict(ex_dict.get('qos_block', {}))
+        else:
+            qos_block = None
         return cls(export_id,
                    ex_dict.get('path', '/'),
                    ex_dict['cluster_id'],
@@ -468,7 +462,9 @@ class Export:
                    ex_dict.get('transports', ['TCP']),
                    FSAL.from_dict(ex_dict.get('fsal', {})),
                    [Client.from_dict(client) for client in ex_dict.get('clients', [])],
-                   sectype=ex_dict.get("sectype"))
+                   sectype=ex_dict.get("sectype"),
+                   qos_block=qos_block
+                   )
 
     def to_dict(self) -> Dict[str, Any]:
         values = {
@@ -486,6 +482,8 @@ class Export:
         }
         if self.sectype:
             values['sectype'] = self.sectype
+        if self.qos_block:
+            values['qos_block'] = self.qos_block.to_dict()
         return values
 
     def validate(self, mgr: 'Module') -> None:

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -384,7 +384,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             raise object_format.ErrorResponse.wrap(e)
         return self.nfs.enable_cluster_qos_bw(cluster_id=cluster_id,
                                               qos_type=QOSType[qos.value],
-                                              bw_obj=bw_obj)
+                                              bw_obj=bw_obj,
+                                              skip_qos_type_validation=True)
 
     def enable_export_qos_bw(self, cluster_id: str,
                              pseudo_path: str,
@@ -419,7 +420,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             raise object_format.ErrorResponse.wrap(e)
         return self.nfs.enable_cluster_qos_ops(cluster_id=cluster_id,
                                                qos_type=QOSType[qos.value],
-                                               ops_obj=ops_obj)
+                                               ops_obj=ops_obj,
+                                               skip_qos_type_validation=True)
 
     def enable_export_qos_ops(self, cluster_id: str,
                               pseudo_path: str,

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -14,6 +14,7 @@ from mgr_util import CephFSEarmarkResolver
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
 from .utils import available_clusters
+from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType
 
 log = logging.getLogger(__name__)
 
@@ -231,3 +232,84 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def fetch_nfs_cluster_obj(self) -> NFSCluster:
         return self.nfs
+
+    @CLICommand('nfs export qos enable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_bw_enable(self,
+                                  cluster_id: str,
+                                  pseudo_path: str,
+                                  combined_rw_bw_ctrl: bool = False,
+                                  max_export_write_bw: str = '0',
+                                  max_export_read_bw: str = '0',
+                                  max_client_write_bw: str = '0',
+                                  max_client_read_bw: str = '0',
+                                  max_export_combined_bw: str = '0',
+                                  max_client_combined_bw: str = '0'
+                                  ) -> None:
+        """enable QOS config for NFS export and set different bandwidth"""
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_rw_bw_ctrl,
+                                         export_writebw=max_export_write_bw,
+                                         export_readbw=max_export_read_bw,
+                                         client_writebw=max_client_write_bw,
+                                         client_readbw=max_client_read_bw,
+                                         export_rw_bw=max_export_combined_bw,
+                                         client_rw_bw=max_client_combined_bw)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_bw(cluster_id=cluster_id,
+                                                    pseudo_path=pseudo_path,
+                                                    bw_obj=bw_obj)
+
+    @CLICommand('nfs export qos get', perm='r')
+    @object_format.Responder()
+    def _cmd_export_qos_get(self, cluster_id: str, pseudo_path: str) -> Dict[str, int]:
+        """Get NFS export QOS config"""
+        return self.export_mgr.get_export_qos(cluster_id, pseudo_path)
+
+    @CLICommand('nfs export qos disable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_bw_disable(self, cluster_id: str, pseudo_path: str) -> None:
+        """Disable NFS export QOS config"""
+        return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
+
+    @CLICommand('nfs cluster qos enable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_bw_enable(self,
+                                   cluster_id: str,
+                                   qos_type: UserQoSType,
+                                   combined_rw_bw_ctrl: bool = False,
+                                   max_export_write_bw: str = '0',
+                                   max_export_read_bw: str = '0',
+                                   max_client_write_bw: str = '0',
+                                   max_client_read_bw: str = '0',
+                                   max_export_combined_bw: str = '0',
+                                   max_client_combined_bw: str = '0') -> None:
+        """Enable QOS ratelimiting for NFS cluster and set default export and client max bandwidth"""
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_rw_bw_ctrl,
+                                         export_writebw=max_export_write_bw,
+                                         export_readbw=max_export_read_bw,
+                                         client_writebw=max_client_write_bw,
+                                         client_readbw=max_client_read_bw,
+                                         export_rw_bw=max_export_combined_bw,
+                                         client_rw_bw=max_client_combined_bw)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_bw(cluster_id=cluster_id,
+                                              qos_type=QOSType[qos_type.value],
+                                              bw_obj=bw_obj)
+
+    @CLICommand('nfs cluster qos disable bandwidth_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_bw_disable(self, cluster_id: str) -> None:
+        """Disable QOS for NFS cluster"""
+        return self.nfs.disable_cluster_qos_bw(cluster_id)
+
+    @CLICommand('nfs cluster qos get', perm='r')
+    @object_format.Responder()
+    def _cmd_cluster_qos_get(self, cluster_id: str) -> Dict[str, Any]:
+        """Get QOS configuration of NFS cluster"""
+        return self.nfs.get_cluster_qos(cluster_id)

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -14,7 +14,7 @@ from mgr_util import CephFSEarmarkResolver
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
 from .utils import available_clusters
-from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType
+from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 
 log = logging.getLogger(__name__)
 
@@ -246,7 +246,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                   max_export_combined_bw: str = '0',
                                   max_client_combined_bw: str = '0'
                                   ) -> None:
-        """enable QOS config for NFS export and set different bandwidth"""
+        """enable QOS bandwidth control for NFS export and set different bandwidth"""
         try:
             bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
                                          combined_bw_ctrl=combined_rw_bw_ctrl,
@@ -271,7 +271,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @CLICommand('nfs export qos disable bandwidth_control', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_export_qos_bw_disable(self, cluster_id: str, pseudo_path: str) -> None:
-        """Disable NFS export QOS config"""
+        """Disable NFS export QOS bandwidth control"""
         return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
 
     @CLICommand('nfs cluster qos enable bandwidth_control', perm='rw')
@@ -286,7 +286,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                    max_client_read_bw: str = '0',
                                    max_export_combined_bw: str = '0',
                                    max_client_combined_bw: str = '0') -> None:
-        """Enable QOS ratelimiting for NFS cluster and set default export and client max bandwidth"""
+        """Enable QOS bandwidth control for NFS cluster and set default export and client max bandwidth"""
         try:
             bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
                                          combined_bw_ctrl=combined_rw_bw_ctrl,
@@ -305,7 +305,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @CLICommand('nfs cluster qos disable bandwidth_control', perm='rw')
     @object_format.EmptyResponder()
     def _cmd_cluster_qos_bw_disable(self, cluster_id: str) -> None:
-        """Disable QOS for NFS cluster"""
+        """Disable QOS bandwidth control for NFS cluster"""
         return self.nfs.disable_cluster_qos_bw(cluster_id)
 
     @CLICommand('nfs cluster qos get', perm='r')
@@ -313,3 +313,53 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_cluster_qos_get(self, cluster_id: str) -> Dict[str, Any]:
         """Get QOS configuration of NFS cluster"""
         return self.nfs.get_cluster_qos(cluster_id)
+
+    @CLICommand('nfs export qos enable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_ops_enable(self,
+                                   cluster_id: str,
+                                   pseudo_path: str,
+                                   max_export_iops: int = 0,
+                                   max_client_iops: int = 0,
+                                   ) -> None:
+        """enable QOS IOPS control for NFS export"""
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=max_export_iops,
+                                    max_client_iops=max_client_iops)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_ops(cluster_id=cluster_id,
+                                                     pseudo_path=pseudo_path,
+                                                     ops_obj=ops_obj)
+
+    @CLICommand('nfs export qos disable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_export_qos_ops_disable(self, cluster_id: str, pseudo_path: str) -> None:
+        """Disable NFS export QOS IOPS control"""
+        return self.export_mgr.disable_export_qos_ops(cluster_id, pseudo_path)
+
+    @CLICommand('nfs cluster qos enable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_ops_enable(self,
+                                    cluster_id: str,
+                                    qos_type: UserQoSType,
+                                    max_export_iops: int = 0,
+                                    max_client_iops: int = 0,
+                                    ) -> None:
+        """enable QOS IOPS control for NFS cluster"""
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=max_export_iops,
+                                    max_client_iops=max_client_iops)
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_ops(cluster_id=cluster_id,
+                                               qos_type=QOSType[qos_type.value],
+                                               ops_obj=ops_obj)
+
+    @CLICommand('nfs cluster qos disable ops_control', perm='rw')
+    @object_format.EmptyResponder()
+    def _cmd_cluster_qos_ops_disable(self, cluster_id: str) -> None:
+        """Disable NFS cluster QOS IOPS control"""
+        return self.nfs.disable_cluster_qos_ops(cluster_id)

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -363,3 +363,74 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_cluster_qos_ops_disable(self, cluster_id: str) -> None:
         """Disable NFS cluster QOS IOPS control"""
         return self.nfs.disable_cluster_qos_ops(cluster_id)
+
+    def enable_cluster_qos_bw(self, cluster_id: str,
+                              qos_type: str,
+                              combined_bw_ctrl: bool,
+                              **kwargs: Any
+                              ) -> None:
+        qos = UserQoSType(qos_type)
+        try:
+            # by default it will take 0 which is expected by this function
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_bw_ctrl,
+                                         export_writebw=kwargs.get('max_export_write_bw', '0'),
+                                         export_readbw=kwargs.get('max_export_read_bw', '0'),
+                                         client_writebw=kwargs.get('max_client_write_bw', '0'),
+                                         client_readbw=kwargs.get('max_client_read_bw', '0'),
+                                         export_rw_bw=kwargs.get('max_export_combined_bw', '0'),
+                                         client_rw_bw=kwargs.get('max_client_combined_bw', '0'))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_bw(cluster_id=cluster_id,
+                                              qos_type=QOSType[qos.value],
+                                              bw_obj=bw_obj)
+
+    def enable_export_qos_bw(self, cluster_id: str,
+                             pseudo_path: str,
+                             combined_bw_ctrl: bool,
+                             **kwargs: Any
+                             ) -> None:
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_bw_ctrl,
+                                         export_writebw=kwargs.get('max_export_write_bw', '0'),
+                                         export_readbw=kwargs.get('max_export_read_bw', '0'),
+                                         client_writebw=kwargs.get('max_client_write_bw', '0'),
+                                         client_readbw=kwargs.get('max_client_read_bw', '0'),
+                                         export_rw_bw=kwargs.get('max_export_combined_bw', '0'),
+                                         client_rw_bw=kwargs.get('max_client_combined_bw', '0'))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_bw(cluster_id=cluster_id,
+                                                    pseudo_path=pseudo_path,
+                                                    bw_obj=bw_obj)
+
+    def enable_cluster_qos_ops(self, cluster_id: str,
+                               qos_type: str,
+                               **kwargs: Any
+                               ) -> None:
+        qos = UserQoSType(qos_type)
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=kwargs.get('max_export_iops', 0),
+                                    max_client_iops=kwargs.get('max_client_iops', 0))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_ops(cluster_id=cluster_id,
+                                               qos_type=QOSType[qos.value],
+                                               ops_obj=ops_obj)
+
+    def enable_export_qos_ops(self, cluster_id: str,
+                              pseudo_path: str,
+                              **kwargs: Any
+                              ) -> None:
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=kwargs.get('max_export_iops', 0),
+                                    max_client_iops=kwargs.get('max_client_iops', 0))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_ops(cluster_id=cluster_id,
+                                                     pseudo_path=pseudo_path,
+                                                     ops_obj=ops_obj)

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -1,0 +1,247 @@
+from typing import List, Dict, Any, Optional
+from enum import Enum
+
+from ceph.utils import bytes_to_human, with_units_to_int
+
+
+class RawBlock():
+    def __init__(self, block_name: str, blocks: List['RawBlock'] = [], values: Dict[str, Any] = {}):
+        if not values:  # workaround mutable default argument
+            values = {}
+        if not blocks:  # workaround mutable default argument
+            blocks = []
+        self.block_name = block_name
+        self.blocks = blocks
+        self.values = values
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, RawBlock):
+            return False
+        return self.block_name == other.block_name and \
+            self.blocks == other.blocks and \
+            self.values == other.values
+
+    def __repr__(self) -> str:
+        return f'RawBlock({self.block_name!r}, {self.blocks!r}, {self.values!r})'
+
+
+class QOSParams(Enum):
+    clust_block = "QOS_DEFAULT_CONFIG"
+    export_block = "QOS_BLOCK"
+    enable_qos = "enable_qos"
+    enable_bw_ctrl = "enable_bw_control"
+    combined_bw_ctrl = "combined_rw_bw_control"
+    qos_type = "qos_type"
+    export_writebw = "max_export_write_bw"
+    export_readbw = "max_export_read_bw"
+    client_writebw = "max_client_write_bw"
+    client_readbw = "max_client_read_bw"
+    export_rw_bw = "max_export_combined_bw"
+    client_rw_bw = "max_client_combined_bw"
+
+
+class UserQoSType(Enum):
+    per_share = 'PerShare'
+    per_client = 'PerClient'
+    per_share_per_client = 'PerShare_PerClient'
+
+
+class QOSType(Enum):
+    PerShare = 1
+    PerClient = 2
+    PerShare_PerClient = 3
+
+
+def _validate_qos_bw(bandwidth: str) -> int:
+    min_bw = 1000000  # 1MB
+    max_bw = 2000000000  # 2GB
+    bw_bytes = with_units_to_int(bandwidth)
+    if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
+        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (2GB) bytes")
+    return bw_bytes
+
+
+QOS_REQ_PARAMS = {
+    'combined_bw_disabled': {
+        'PerShare': ['max_export_write_bw', 'max_export_read_bw'],
+        'PerClient': ['max_client_write_bw', 'max_client_read_bw'],
+        'PerShare_PerClient': ['max_export_write_bw', 'max_export_read_bw', 'max_client_write_bw', 'max_client_read_bw']
+    },
+    'combined_bw_enabled': {
+        'PerShare': ['max_export_combined_bw'],
+        'PerClient': ['max_client_combined_bw'],
+        'PerShare_PerClient': ['max_export_combined_bw', 'max_client_combined_bw'],
+    }
+}
+
+
+class QOSBandwidthControl(object):
+    def __init__(self,
+                 enable_bw_ctrl: bool = False,
+                 combined_bw_ctrl: bool = False,
+                 export_writebw: str = '0',
+                 export_readbw: str = '0',
+                 client_writebw: str = '0',
+                 client_readbw: str = '0',
+                 export_rw_bw: str = '0',
+                 client_rw_bw: str = '0'
+                 ) -> None:
+        self.enable_bw_ctrl = enable_bw_ctrl
+        self.combined_bw_ctrl = combined_bw_ctrl
+        try:
+            self.export_writebw: int = _validate_qos_bw(export_writebw)
+            self.export_readbw: int = _validate_qos_bw(export_readbw)
+            self.client_writebw: int = _validate_qos_bw(client_writebw)
+            self.client_readbw: int = _validate_qos_bw(client_readbw)
+            self.export_rw_bw: int = _validate_qos_bw(export_rw_bw)
+            self.client_rw_bw: int = _validate_qos_bw(client_rw_bw)
+        except Exception as e:
+            raise Exception(f"Invalid bandwidth value. {e}")
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSBandwidthControl':
+        # json has bandwidths in human readable format(str)
+        bw_kwargs = {
+            'enable_bw_ctrl': qos_dict.get(QOSParams.enable_bw_ctrl.value, False),
+            'combined_bw_ctrl': qos_dict.get(QOSParams.combined_bw_ctrl.value, False),
+            'export_writebw': qos_dict.get(QOSParams.export_writebw.value, '0'),
+            'export_readbw': qos_dict.get(QOSParams.export_readbw.value, '0'),
+            'client_writebw': qos_dict.get(QOSParams.client_writebw.value, '0'),
+            'client_readbw': qos_dict.get(QOSParams.client_readbw.value, '0'),
+            'export_rw_bw': qos_dict.get(QOSParams.export_rw_bw.value, '0'),
+            'client_rw_bw': qos_dict.get(QOSParams.client_rw_bw.value, '0')
+        }
+        return cls(**bw_kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock) -> 'QOSBandwidthControl':
+        # block has bandwidths in bytes(int)
+        bw_kwargs = {
+            'enable_bw_ctrl': qos_block.values.get(QOSParams.enable_bw_ctrl.value, False),
+            'combined_bw_ctrl': qos_block.values.get(QOSParams.combined_bw_ctrl.value, False),
+            'export_writebw': str(qos_block.values.get(QOSParams.export_writebw.value, 0)),
+            'export_readbw': str(qos_block.values.get(QOSParams.export_readbw.value, 0)),
+            'client_writebw': str(qos_block.values.get(QOSParams.client_writebw.value, 0)),
+            'client_readbw': str(qos_block.values.get(QOSParams.client_readbw.value, 0)),
+            'export_rw_bw': str(qos_block.values.get(QOSParams.export_rw_bw.value, 0)),
+            'client_rw_bw': str(qos_block.values.get(QOSParams.client_rw_bw.value, 0))
+        }
+        return cls(**bw_kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        result = RawBlock('qos_bandwidths_control')
+        result.values[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
+        result.values[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
+        if self.export_writebw:
+            result.values[QOSParams.export_writebw.value] = self.export_writebw
+        if self.export_readbw:
+            result.values[QOSParams.export_readbw.value] = self.export_readbw
+        if self.client_writebw:
+            result.values[QOSParams.client_writebw.value] = self.client_writebw
+        if self.client_readbw:
+            result.values[QOSParams.client_readbw.value] = self.client_readbw
+        if self.export_rw_bw:
+            result.values[QOSParams.export_rw_bw.value] = self.export_rw_bw
+        if self.client_rw_bw:
+            result.values[QOSParams.client_rw_bw.value] = self.client_rw_bw
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: dict[str, Any] = {}
+        r[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
+        r[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
+        if self.export_writebw:
+            r[QOSParams.export_writebw.value] = bytes_to_human(self.export_writebw)
+        if self.export_readbw:
+            r[QOSParams.export_readbw.value] = bytes_to_human(self.export_readbw)
+        if self.client_writebw:
+            r[QOSParams.client_writebw.value] = bytes_to_human(self.client_writebw)
+        if self.client_readbw:
+            r[QOSParams.client_readbw.value] = bytes_to_human(self.client_readbw)
+        if self.export_rw_bw:
+            r[QOSParams.export_rw_bw.value] = bytes_to_human(self.export_rw_bw)
+        if self.client_rw_bw:
+            r[QOSParams.client_rw_bw.value] = bytes_to_human(self.client_rw_bw)
+        return r
+
+    def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
+        """Checks for enabling qos"""
+        params = {}
+        d = vars(self)
+        for key in d:
+            if key.endswith('bw'):
+                params[QOSParams[key].value] = d[key]
+        if not self.combined_bw_ctrl:
+            req_params = QOS_REQ_PARAMS['combined_bw_disabled'][qos_type.name]
+        else:
+            req_params = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+        allowed_params = []
+        not_allowed_params = []
+        for key in params:
+            if key in req_params and params[key] == 0:
+                allowed_params.append(key)
+            elif key not in req_params and params[key] != 0:
+                not_allowed_params.append(key)
+        if allowed_params or not_allowed_params:
+            raise Exception(f"When combined_rw_bw is {'enabled' if self.combined_bw_ctrl else 'disabled'} "
+                            f"and qos_type is {qos_type.name}, "
+                            f"{'attributes ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                            f"{'attributes ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+
+
+class QOS(object):
+    def __init__(self,
+                 cluster_op: bool = False,
+                 enable_qos: bool = False,
+                 qos_type: Optional[QOSType] = None,
+                 bw_obj: Optional[QOSBandwidthControl] = None
+                 ) -> None:
+        self.cluster_op = cluster_op
+        self.enable_qos = enable_qos
+        self.qos_type = qos_type
+        self.bw_obj = bw_obj
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any], cluster_op: bool = False) -> 'QOS':
+        kwargs: dict[str, Any] = {}
+        # qos dict will have qos type as enum name
+        if cluster_op:
+            qos_type = qos_dict.get(QOSParams.qos_type.value)
+            if qos_type:
+                kwargs['qos_type'] = QOSType[qos_type]
+        kwargs['enable_qos'] = qos_dict.get(QOSParams.enable_qos.value)
+        kwargs['bw_obj'] = QOSBandwidthControl.from_dict(qos_dict)
+        return cls(cluster_op, **kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock, cluster_op: bool = False) -> 'QOS':
+        kwargs: dict[str, Any] = {}
+        # qos block will have qos type as enum value
+        if cluster_op:
+            qos_type = qos_block.values.get(QOSParams.qos_type.value)
+            if qos_type:
+                kwargs['qos_type'] = QOSType(qos_type)
+        kwargs['enable_qos'] = qos_block.values.get(QOSParams.enable_qos.value)
+        kwargs['bw_obj'] = QOSBandwidthControl.from_qos_block(qos_block)
+        return cls(cluster_op, **kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        if self.cluster_op:
+            result = RawBlock(QOSParams.clust_block.value)
+        else:
+            result = RawBlock(QOSParams.export_block.value)
+        result.values[QOSParams.enable_qos.value] = self.enable_qos
+        if self.cluster_op and self.qos_type:
+            result.values[QOSParams.qos_type.value] = self.qos_type.value
+        if self.bw_obj and (res := self.bw_obj.to_qos_block()):
+            result.values.update(res.values)
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: Dict[str, Any] = {}
+        r[QOSParams.enable_qos.value] = self.enable_qos
+        if self.cluster_op and self.qos_type:
+            r[QOSParams.qos_type.value] = self.qos_type.name
+        if self.bw_obj and (res := self.bw_obj.to_dict()):
+            r.update(res)
+        return r

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -29,15 +29,20 @@ class QOSParams(Enum):
     clust_block = "QOS_DEFAULT_CONFIG"
     export_block = "QOS_BLOCK"
     enable_qos = "enable_qos"
+    qos_type = "qos_type"
+    # bandwidth control
     enable_bw_ctrl = "enable_bw_control"
     combined_bw_ctrl = "combined_rw_bw_control"
-    qos_type = "qos_type"
     export_writebw = "max_export_write_bw"
     export_readbw = "max_export_read_bw"
     client_writebw = "max_client_write_bw"
     client_readbw = "max_client_read_bw"
     export_rw_bw = "max_export_combined_bw"
     client_rw_bw = "max_client_combined_bw"
+    # ops control
+    enable_iops_ctrl = "enable_iops_control"
+    max_export_iops = "max_export_iops"
+    max_client_iops = "max_client_iops"
 
 
 class UserQoSType(Enum):
@@ -61,7 +66,15 @@ def _validate_qos_bw(bandwidth: str) -> int:
     return bw_bytes
 
 
-QOS_REQ_PARAMS = {
+def _validate_qos_ops(count: int) -> int:
+    min_cnt = 1000  # 1K
+    max_cnt = 500000  # 5L
+    if count != 0 and (count < min_cnt or count > max_cnt):
+        raise Exception(f"Provided IOS count value is not in range, Please enter a value between {min_cnt} (1K) and {max_cnt} (5L) bytes")
+    return count
+
+
+QOS_REQ_BW_PARAMS = {
     'combined_bw_disabled': {
         'PerShare': ['max_export_write_bw', 'max_export_read_bw'],
         'PerClient': ['max_client_write_bw', 'max_client_read_bw'],
@@ -72,6 +85,12 @@ QOS_REQ_PARAMS = {
         'PerClient': ['max_client_combined_bw'],
         'PerShare_PerClient': ['max_export_combined_bw', 'max_client_combined_bw'],
     }
+}
+
+QOS_REQ_OPS_PARAMS = {
+    'PerShare': ['max_export_iops'],
+    'PerClient': ['max_client_iops'],
+    'PerShare_PerClient': ['max_export_iops', 'max_client_iops']
 }
 
 
@@ -100,7 +119,7 @@ class QOSBandwidthControl(object):
 
     @classmethod
     def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSBandwidthControl':
-        # json has bandwidths in human readable format(str)
+        # qos dict has bandwidths in human readable format(str)
         bw_kwargs = {
             'enable_bw_ctrl': qos_dict.get(QOSParams.enable_bw_ctrl.value, False),
             'combined_bw_ctrl': qos_dict.get(QOSParams.combined_bw_ctrl.value, False),
@@ -115,7 +134,7 @@ class QOSBandwidthControl(object):
 
     @classmethod
     def from_qos_block(cls, qos_block: RawBlock) -> 'QOSBandwidthControl':
-        # block has bandwidths in bytes(int)
+        # qos block has bandwidths in bytes(int)
         bw_kwargs = {
             'enable_bw_ctrl': qos_block.values.get(QOSParams.enable_bw_ctrl.value, False),
             'combined_bw_ctrl': qos_block.values.get(QOSParams.combined_bw_ctrl.value, False),
@@ -165,16 +184,16 @@ class QOSBandwidthControl(object):
         return r
 
     def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
-        """Checks for enabling qos"""
+        """Checks for enabling qos bandwidth control"""
         params = {}
         d = vars(self)
         for key in d:
             if key.endswith('bw'):
                 params[QOSParams[key].value] = d[key]
         if not self.combined_bw_ctrl:
-            req_params = QOS_REQ_PARAMS['combined_bw_disabled'][qos_type.name]
+            req_params = QOS_REQ_BW_PARAMS['combined_bw_disabled'][qos_type.name]
         else:
-            req_params = QOS_REQ_PARAMS['combined_bw_enabled'][qos_type.name]
+            req_params = QOS_REQ_BW_PARAMS['combined_bw_enabled'][qos_type.name]
         allowed_params = []
         not_allowed_params = []
         for key in params:
@@ -185,8 +204,73 @@ class QOSBandwidthControl(object):
         if allowed_params or not_allowed_params:
             raise Exception(f"When combined_rw_bw is {'enabled' if self.combined_bw_ctrl else 'disabled'} "
                             f"and qos_type is {qos_type.name}, "
-                            f"{'attributes ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
-                            f"{'attributes ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+                            f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                            f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
+
+
+class QOSOpsControl(object):
+    def __init__(self,
+                 enable_iops_ctrl: bool = False,
+                 max_export_iops: int = 0,
+                 max_client_iops: int = 0
+                 ) -> None:
+        self.enable_iops_ctrl = enable_iops_ctrl
+        self.max_export_iops = _validate_qos_ops(max_export_iops)
+        self.max_client_iops = _validate_qos_ops(max_client_iops)
+
+    @classmethod
+    def from_dict(cls, qos_dict: Dict[str, Any]) -> 'QOSOpsControl':
+        kwargs: dict[str, Any] = {}
+        kwargs['enable_iops_ctrl'] = qos_dict.get(QOSParams.enable_iops_ctrl.value, False)
+        kwargs['max_export_iops'] = qos_dict.get(QOSParams.max_export_iops.value, 0)
+        kwargs['max_client_iops'] = qos_dict.get(QOSParams.max_client_iops.value, 0)
+        return cls(**kwargs)
+
+    @classmethod
+    def from_qos_block(cls, qos_block: RawBlock) -> 'QOSOpsControl':
+        kwargs: dict[str, Any] = {}
+        kwargs['enable_iops_ctrl'] = qos_block.values.get(QOSParams.enable_iops_ctrl.value, False)
+        kwargs['max_export_iops'] = qos_block.values.get(QOSParams.max_export_iops.value, 0)
+        kwargs['max_client_iops'] = qos_block.values.get(QOSParams.max_client_iops.value, 0)
+        return cls(**kwargs)
+
+    def to_qos_block(self) -> RawBlock:
+        result = RawBlock('qos_ops_control')
+        result.values[QOSParams.enable_iops_ctrl.value] = self.enable_iops_ctrl
+        if self.max_export_iops:
+            result.values[QOSParams.max_export_iops.value] = self.max_export_iops
+        if self.max_client_iops:
+            result.values[QOSParams.max_client_iops.value] = self.max_client_iops
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        r: dict[str, Any] = {}
+        r[QOSParams.enable_iops_ctrl.value] = self.enable_iops_ctrl
+        if self.max_export_iops:
+            r[QOSParams.max_export_iops.value] = self.max_export_iops
+        if self.max_client_iops:
+            r[QOSParams.max_client_iops.value] = self.max_client_iops
+        return r
+
+    def qos_ops_checks(self, qos_type: QOSType) -> None:
+        """Checks for enabling qos IOPS control"""
+        params = {}
+        d = vars(self)
+        for key in d:
+            if key.endswith('iops'):
+                params[QOSParams[key].value] = d[key]
+        req_params = QOS_REQ_OPS_PARAMS[qos_type.name]
+        allowed_params = []
+        not_allowed_params = []
+        for key in params:
+            if key in req_params and params[key] == 0:
+                allowed_params.append(key)
+            elif key not in req_params and params[key] != 0:
+                not_allowed_params.append(key)
+        if allowed_params or not_allowed_params:
+            raise Exception(f"When qos_type is {qos_type.name}, "
+                            f"{'attribute ' + ', '.join(allowed_params) + ' required' if allowed_params else ''} "
+                            f"{'attribute ' + ', '.join(not_allowed_params) + ' are not allowed' if not_allowed_params else ''}.")
 
 
 class QOS(object):
@@ -194,12 +278,14 @@ class QOS(object):
                  cluster_op: bool = False,
                  enable_qos: bool = False,
                  qos_type: Optional[QOSType] = None,
-                 bw_obj: Optional[QOSBandwidthControl] = None
+                 bw_obj: Optional[QOSBandwidthControl] = None,
+                 ops_obj: Optional[QOSOpsControl] = None
                  ) -> None:
         self.cluster_op = cluster_op
         self.enable_qos = enable_qos
         self.qos_type = qos_type
         self.bw_obj = bw_obj
+        self.ops_obj = ops_obj
 
     @classmethod
     def from_dict(cls, qos_dict: Dict[str, Any], cluster_op: bool = False) -> 'QOS':
@@ -211,6 +297,7 @@ class QOS(object):
                 kwargs['qos_type'] = QOSType[qos_type]
         kwargs['enable_qos'] = qos_dict.get(QOSParams.enable_qos.value)
         kwargs['bw_obj'] = QOSBandwidthControl.from_dict(qos_dict)
+        kwargs['ops_obj'] = QOSOpsControl.from_dict(qos_dict)
         return cls(cluster_op, **kwargs)
 
     @classmethod
@@ -223,6 +310,7 @@ class QOS(object):
                 kwargs['qos_type'] = QOSType(qos_type)
         kwargs['enable_qos'] = qos_block.values.get(QOSParams.enable_qos.value)
         kwargs['bw_obj'] = QOSBandwidthControl.from_qos_block(qos_block)
+        kwargs['ops_obj'] = QOSOpsControl.from_qos_block(qos_block)
         return cls(cluster_op, **kwargs)
 
     def to_qos_block(self) -> RawBlock:
@@ -235,6 +323,8 @@ class QOS(object):
             result.values[QOSParams.qos_type.value] = self.qos_type.value
         if self.bw_obj and (res := self.bw_obj.to_qos_block()):
             result.values.update(res.values)
+        if self.ops_obj and (res := self.ops_obj.to_qos_block()):
+            result.values.update(res.values)
         return result
 
     def to_dict(self) -> Dict[str, Any]:
@@ -244,4 +334,17 @@ class QOS(object):
             r[QOSParams.qos_type.value] = self.qos_type.name
         if self.bw_obj and (res := self.bw_obj.to_dict()):
             r.update(res)
+        if self.ops_obj and (res := self.ops_obj.to_dict()):
+            r.update(res)
         return r
+
+    def get_enable_qos_val(self, disable_bw: bool = False, disable_ops: bool = False) -> bool:
+        if not (self.enable_qos) or not (disable_bw or disable_ops):
+            return False
+        # check if ops control is enabled
+        if disable_bw and self.ops_obj and self.ops_obj.enable_iops_ctrl:
+            return True
+        # check if bandwidth control is enabled
+        if disable_ops and self.bw_obj and self.bw_obj.enable_bw_ctrl:
+            return True
+        return False

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -59,18 +59,18 @@ class QOSType(Enum):
 
 def _validate_qos_bw(bandwidth: str) -> int:
     min_bw = 1000000  # 1MB
-    max_bw = 2000000000  # 2GB
+    max_bw = 4000000000  # 4GB
     bw_bytes = with_units_to_int(bandwidth)
     if bw_bytes != 0 and (bw_bytes < min_bw or bw_bytes > max_bw):
-        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (2GB) bytes")
+        raise Exception(f"Provided bandwidth value is not in range, Please enter a value between {min_bw} (1MB) and {max_bw} (4GB) bytes per second.")
     return bw_bytes
 
 
 def _validate_qos_ops(count: int) -> int:
-    min_cnt = 1000  # 1K
-    max_cnt = 500000  # 5L
+    min_cnt = 10
+    max_cnt = 16384
     if count != 0 and (count < min_cnt or count > max_cnt):
-        raise Exception(f"Provided IOS count value is not in range, Please enter a value between {min_cnt} (1K) and {max_cnt} (5L) bytes")
+        raise Exception(f"Provided IOS count value is not in range, Please enter a value between {min_cnt} and {max_cnt} bytes per second.")
     return count
 
 

--- a/src/pybind/mgr/nfs/qos_conf.py
+++ b/src/pybind/mgr/nfs/qos_conf.py
@@ -165,22 +165,26 @@ class QOSBandwidthControl(object):
             result.values[QOSParams.client_rw_bw.value] = self.client_rw_bw
         return result
 
-    def to_dict(self) -> Dict[str, Any]:
+    @staticmethod
+    def bw_for_to_dict(bandwidth: int, ret_bw_in_bytes: bool = False) -> str:
+        return bytes_to_human(bandwidth) if not ret_bw_in_bytes else str(bandwidth)
+
+    def to_dict(self, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         r: dict[str, Any] = {}
         r[QOSParams.enable_bw_ctrl.value] = self.enable_bw_ctrl
         r[QOSParams.combined_bw_ctrl.value] = self.combined_bw_ctrl
         if self.export_writebw:
-            r[QOSParams.export_writebw.value] = bytes_to_human(self.export_writebw)
+            r[QOSParams.export_writebw.value] = self.bw_for_to_dict(self.export_writebw, ret_bw_in_bytes)
         if self.export_readbw:
-            r[QOSParams.export_readbw.value] = bytes_to_human(self.export_readbw)
+            r[QOSParams.export_readbw.value] = self.bw_for_to_dict(self.export_readbw, ret_bw_in_bytes)
         if self.client_writebw:
-            r[QOSParams.client_writebw.value] = bytes_to_human(self.client_writebw)
+            r[QOSParams.client_writebw.value] = self.bw_for_to_dict(self.client_writebw, ret_bw_in_bytes)
         if self.client_readbw:
-            r[QOSParams.client_readbw.value] = bytes_to_human(self.client_readbw)
+            r[QOSParams.client_readbw.value] = self.bw_for_to_dict(self.client_readbw, ret_bw_in_bytes)
         if self.export_rw_bw:
-            r[QOSParams.export_rw_bw.value] = bytes_to_human(self.export_rw_bw)
+            r[QOSParams.export_rw_bw.value] = self.bw_for_to_dict(self.export_rw_bw, ret_bw_in_bytes)
         if self.client_rw_bw:
-            r[QOSParams.client_rw_bw.value] = bytes_to_human(self.client_rw_bw)
+            r[QOSParams.client_rw_bw.value] = self.bw_for_to_dict(self.client_rw_bw, ret_bw_in_bytes)
         return r
 
     def qos_bandwidth_checks(self, qos_type: QOSType) -> None:
@@ -327,12 +331,12 @@ class QOS(object):
             result.values.update(res.values)
         return result
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
         r: Dict[str, Any] = {}
         r[QOSParams.enable_qos.value] = self.enable_qos
         if self.cluster_op and self.qos_type:
             r[QOSParams.qos_type.value] = self.qos_type.name
-        if self.bw_obj and (res := self.bw_obj.to_dict()):
+        if self.bw_obj and (res := self.bw_obj.to_dict(ret_bw_in_bytes)):
             r.update(res)
         if self.ops_obj and (res := self.ops_obj.to_dict()):
             r.update(res)

--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Optional, Any
+
+from rados import TimedOut, ObjectNotFound, Rados
+from mgr_module import NFS_POOL_NAME as POOL_NAME
+from .ganesha_conf import RawBlock, format_block
+from .utils import USER_CONF_PREFIX
+
+log = logging.getLogger(__name__)
+
+
+def _check_rados_notify(ioctx: Any, obj: str) -> None:
+    try:
+        ioctx.notify(obj)
+    except TimedOut:
+        log.exception("Ganesha timed out")
+
+
+class NFSRados:
+    def __init__(self, rados: 'Rados', namespace: str) -> None:
+        self.rados = rados
+        self.pool = POOL_NAME
+        self.namespace = namespace
+
+    def _make_rados_url(self, obj: str) -> str:
+        return "rados://{}/{}/{}".format(self.pool, self.namespace, obj)
+
+    def _create_url_block(self, obj_name: str) -> RawBlock:
+        return RawBlock('%url', values={'value': self._make_rados_url(obj_name)})
+
+    def write_obj(self, conf_block: str, obj: str, config_obj: str = '') -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            ioctx.write_full(obj, conf_block.encode('utf-8'))
+            if not config_obj:
+                # Return after creating empty common config object
+                return
+            log.debug("write configuration into rados object %s/%s/%s",
+                      self.pool, self.namespace, obj)
+
+            # Add created obj url to common config obj
+            ioctx.append(config_obj, format_block(
+                         self._create_url_block(obj)).encode('utf-8'))
+            _check_rados_notify(ioctx, config_obj)
+            log.debug("Added %s url to %s", obj, config_obj)
+
+    def read_obj(self, obj: str) -> Optional[str]:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            try:
+                return ioctx.read(obj, 1048576).decode()
+            except ObjectNotFound:
+                return None
+
+    def update_obj(self, conf_block: str, obj: str, config_obj: str,
+                   should_notify: Optional[bool] = True) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            ioctx.write_full(obj, conf_block.encode('utf-8'))
+            log.debug("write configuration into rados object %s/%s/%s",
+                      self.pool, self.namespace, obj)
+            if should_notify:
+                _check_rados_notify(ioctx, config_obj)
+            log.debug("Update export %s in %s", obj, config_obj)
+
+    def remove_obj(self, obj: str, config_obj: str) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            export_urls = ioctx.read(config_obj)
+            url = '%url "{}"\n\n'.format(self._make_rados_url(obj))
+            export_urls = export_urls.replace(url.encode('utf-8'), b'')
+            ioctx.remove_object(obj)
+            ioctx.write_full(config_obj, export_urls)
+            _check_rados_notify(ioctx, config_obj)
+            log.debug("Object deleted: %s", url)
+
+    def remove_all_obj(self) -> None:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            for obj in ioctx.list_objects():
+                obj.remove()
+
+    def check_config(self, config: str = USER_CONF_PREFIX) -> bool:
+        with self.rados.open_ioctx(self.pool) as ioctx:
+            ioctx.set_namespace(self.namespace)
+            for obj in ioctx.list_objects():
+                if obj.key.startswith(config):
+                    return True
+        return False

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -1486,14 +1486,14 @@ NFS_CORE_PARAM {
 
     @pytest.mark.parametrize("qos_type, params, positive_tc", [
         (QOSType['PerShare'], {'max_export_iops': 10000}, True),
-        (QOSType['PerClient'], {'max_client_iops': 20000}, True),
-        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000}, True),
+        (QOSType['PerClient'], {'max_client_iops': 15000}, True),
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 14000}, True),
         # negative testing
         (QOSType['PerShare_PerClient'], {'max_export_iops': 1000}, False),
         (QOSType['PerShare'], {'max_client_iops': 10000}, False),
         (QOSType['PerShare'], {}, False),
         (QOSType['PerClient'], {'max_export_iops': 2000, 'max_client_iops': 1000}, False),
-        (QOSType['PerShare_PerClient'], {'max_export_iops': 10}, False)
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 9}, False)
         ])
     def test_cluster_qos_ops(self, qos_type, params, positive_tc):
         self._do_mock_test(self._do_test_cluster_qos_ops, qos_type, params, positive_tc)
@@ -1532,13 +1532,13 @@ NFS_CORE_PARAM {
 
     @pytest.mark.parametrize("qos_type, clust_params", [
         (QOSType['PerShare'], {'max_export_iops': 10000}),
-        (QOSType['PerClient'], {'max_client_iops': 20000}),
-        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000})
+        (QOSType['PerClient'], {'max_client_iops': 2000}),
+        (QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 4000})
         ])
     @pytest.mark.parametrize("export_params", [
         ({'max_export_iops': 10000}),
-        ({'max_client_iops': 20000}),
-        ({'max_export_iops': 3000, 'max_client_iops': 40000})
+        ({'max_client_iops': 2000}),
+        ({'max_export_iops': 3000, 'max_client_iops': 4000})
         ])
     def test_export_qos_ops(self, qos_type, clust_params, export_params):
         self._do_mock_test(self._do_test_export_qos_ops, qos_type, clust_params, export_params)
@@ -1582,10 +1582,10 @@ NFS_CORE_PARAM {
         (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, 
          QOSType['PerShare'], {'max_export_iops': 10000}, True),
         (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'},
-         QOSType['PerClient'], {'max_client_iops': 20000}, True),
+         QOSType['PerClient'], {'max_client_iops': 2000}, True),
         (QOSType['PerShare_PerClient'],
          {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'},
-         QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 40000}, True),
+         QOSType['PerShare_PerClient'], {'max_export_iops': 3000, 'max_client_iops': 4000}, True),
         # negative TCs
         (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, QOSType['PerClient'], {}, False),
         (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, QOSType['PerShare'], {}, False),
@@ -1656,14 +1656,14 @@ NFS_CORE_PARAM {
     @pytest.mark.parametrize("qos_type, clust_bw_params, clust_ops_params", [
         # positive TCs
         (QOSType['PerShare'], {'export_writebw': '100MB', 'export_readbw': '200MB'}, {'max_export_iops': 10000}),
-        (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 20000}),
+        (QOSType['PerClient'], {'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 2000}),
         (QOSType['PerShare_PerClient'],
-         {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 40000})
+         {'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 4000})
     ])
     @pytest.mark.parametrize("export_bw_params, export_ops_params", [
         ({'export_writebw': '100MB', 'export_readbw': '200MB'}, {'max_export_iops': 10000}),
-        ({'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 20000}),
-        ({'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 40000})
+        ({'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_client_iops': 12000}),
+        ({'export_writebw': '100MB', 'export_readbw': '200MB', 'client_writebw': '300MB', 'client_readbw': '400MB'}, {'max_export_iops': 3000, 'max_client_iops': 4000})
         ])
     def test_export_qos_bw_ops(self, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params):
         self._do_mock_test(self._do_test_export_qos_bw_ops, qos_type, clust_bw_params, clust_ops_params, export_bw_params, export_ops_params)

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -186,6 +186,18 @@ QOS_BLOCK {
         "enable_iops_control": False
     }
 
+    qos_cluster_dict_bw_in_bytes = {
+        "enable_bw_control": True,
+        "enable_qos": True,
+        "combined_rw_bw_control": False,
+        "max_client_read_bw": "4000000",
+        "max_client_write_bw": "3000000",
+        "max_export_read_bw": "2000000",
+        "max_export_write_bw": "1000000",
+        "qos_type": "PerShare_PerClient",
+        "enable_iops_control": False
+    }
+
     qos_export_dict = {
         "enable_bw_control": True,
         "enable_qos": True,
@@ -194,6 +206,16 @@ QOS_BLOCK {
         "max_client_write_bw": "3.0MB",
         "max_export_read_bw": "2.0MB",
         "max_export_write_bw": "1.0MB",
+        "enable_iops_control": False
+    }
+    qos_export_dict_bw_in_bytes = {
+        "enable_bw_control": True,
+        "enable_qos": True,
+        "combined_rw_bw_control": False,
+        "max_client_read_bw": "4000000",
+        "max_client_write_bw": "3000000",
+        "max_export_read_bw": "2000000",
+        "max_export_write_bw": "1000000",
         "enable_iops_control": False
     }
 
@@ -1354,16 +1376,17 @@ NFS_CORE_PARAM {
         assert qos.bw_obj.client_writebw == 3000000
         assert qos.bw_obj.client_readbw == 4000000
 
-    @pytest.mark.parametrize("qos_block, qos_dict", [
-        (qos_cluster_block, qos_cluster_dict),
-        (qos_export_block, qos_export_dict)
+    @pytest.mark.parametrize("qos_block, qos_dict, qos_dict_bw_in_bytes", [
+        (qos_cluster_block, qos_cluster_dict, qos_cluster_dict_bw_in_bytes),
+        (qos_export_block, qos_export_dict, qos_export_dict_bw_in_bytes)
         ])
-    def test_qos_from_block(self, qos_block, qos_dict):
+    def test_qos_from_block(self, qos_block, qos_dict, qos_dict_bw_in_bytes):
         blocks = GaneshaConfParser(qos_block).parse()
         assert isinstance(blocks, list)
         assert len(blocks) == 1
         qos = QOS.from_qos_block(blocks[0], True)
         assert qos.to_dict() == qos_dict
+        assert qos.to_dict(ret_bw_in_bytes=True) == qos_dict_bw_in_bytes
 
     def _do_test_cluster_qos_bw(self, qos_type, combined_bw_ctrl, params, positive_tc):
         nfs_mod = Module('nfs', '', '')

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 EXPORT_PREFIX: str = "export-"
 CONF_PREFIX: str = "conf-nfs."
 USER_CONF_PREFIX: str = "userconf-nfs."
+QOS_CONF_PREFIX: str = "qosconf-nfs."
 
 log = logging.getLogger(__name__)
 
@@ -57,8 +58,13 @@ def conf_obj_name(cluster_id: str) -> str:
 
 
 def user_conf_obj_name(cluster_id: str) -> str:
-    """Returna a rados object name for the user config."""
+    """Return a rados object name for the user config."""
     return f"{USER_CONF_PREFIX}{cluster_id}"
+
+
+def qos_conf_obj_name(cluster_id: str) -> str:
+    """Return a rados object name for the qos config."""
+    return f"{QOS_CONF_PREFIX}{cluster_id}"
 
 
 def available_clusters(mgr: 'Module') -> List[str]:

--- a/src/python-common/ceph/utils.py
+++ b/src/python-common/ceph/utils.py
@@ -189,3 +189,51 @@ def strtobool(value: str) -> bool:
     if value.lower() in _FALSE_VALS:
         return False
     raise ValueError(f'invalid truth value {value!r}')
+
+
+def bytes_to_human(num: float, mode: str = 'decimal') -> str:
+    """Convert a bytes value into it's human-readable form.
+
+    :param num: number, in bytes, to convert
+    :param mode: Either decimal (default) or binary to determine divisor
+    :returns: string representing the bytes value in a more readable format
+    """
+    unit_list = ['', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB']
+    divisor = 1000.0
+    yotta = 'YB'
+
+    if mode == 'binary':
+        unit_list = ['', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB']
+        divisor = 1024.0
+        yotta = 'YiB'
+
+    for unit in unit_list:
+        if abs(num) < divisor:
+            return '%3.1f%s' % (num, unit)
+        num /= divisor
+    return '%.1f%s' % (num, yotta)
+
+
+def with_units_to_int(v: str) -> int:
+    if not v:
+        return 0
+    if v.endswith('iB'):
+        v = v[:-2]
+        bytes_mult = 1024
+    elif v.endswith('B'):
+        v = v[:-1]
+        bytes_mult = 1000
+    mult = 1
+    if v[-1].upper() == 'K':
+        mult = bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'M':
+        mult = bytes_mult * bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'G':
+        mult = bytes_mult * bytes_mult * bytes_mult
+        v = v[:-1]
+    elif v[-1].upper() == 'T':
+        mult = bytes_mult * bytes_mult * bytes_mult * bytes_mult
+        v = v[:-1]
+    return int(float(v) * mult)


### PR DESCRIPTION
This PR is based on https://github.com/ceph/ceph/pull/61283

Fixes: https://tracker.ceph.com/issues/69839

Signed-off-by: Achint Kaur    <ackaur@redhat.com>

https://github.com/user-attachments/assets/4bf8b9f0-5e61-4e06-92e3-856ea85fd63a

Screenshare NFS Export Listing PR merged -

https://github.com/user-attachments/assets/18641e98-9299-4368-bda4-b26f85051a21


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
