### PR TITLE
reef: librbd: fix a deadlock on image_lock caused by Mirror::image_disable()

### DIFF
--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -572,9 +572,8 @@ int Mirror<I>::image_disable(I *ictx, bool force) {
     }
   };
 
-  std::unique_lock image_locker{ictx->image_lock};
-  std::map<librados::snap_t, SnapInfo> snap_info = ictx->snap_info;
-  for (auto &info : snap_info) {
+  std::shared_lock image_locker{ictx->image_lock};
+  for (const auto& info : ictx->snap_info) {
     cls::rbd::ParentImageSpec parent_spec{ictx->md_ctx.get_id(),
                                           ictx->md_ctx.get_namespace(),
                                           ictx->id, info.first};


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70302

---

backport of https://github.com/ceph/ceph/pull/62072
parent tracker: https://tracker.ceph.com/issues/70190