### PR TITLE
tests: replace obsolete get_tracked_conf_keys()

### DIFF
--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -32,17 +32,9 @@ static int get_concurrency() {
 }
 
 using namespace std::placeholders;
+using namespace std::literals;
 
 namespace librados {
-
-namespace {
-
-const char *config_keys[] = {
-  "librados_thread_count",
-  NULL
-};
-
-} // anonymous namespace
 
 static void finish_aio_completion(AioCompletionImpl *c, int r) {
   c->lock.lock();
@@ -142,8 +134,12 @@ boost::asio::io_context& TestRadosClient::get_io_context() {
   return m_io_context_pool->get_io_context();
 }
 
-const char** TestRadosClient::get_tracked_conf_keys() const {
-  return config_keys;
+std::vector<std::string>TestRadosClient::get_tracked_keys()
+    const noexcept
+{
+  return {
+    "librados_thread_count"s
+  };
 }
 
 void TestRadosClient::handle_conf_change(

--- a/src/test/librados_test_stub/TestRadosClient.h
+++ b/src/test/librados_test_stub/TestRadosClient.h
@@ -136,7 +136,7 @@ protected:
   virtual void transaction_finish(const std::string& nspace,
                                   const std::string &oid) = 0;
 
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string> &changed) override;
 

--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -31,26 +31,16 @@
 #include "msg/async/Stack.h"
 
 using namespace std;
+using namespace std::literals;
 
 class NoopConfigObserver : public md_config_obs_t {
-  std::list<std::string> options;
-  const char **ptrs = 0;
+  std::vector<std::string> options;
 
 public:
-  NoopConfigObserver(std::list<std::string> l) : options(l) {
-    ptrs = new const char*[options.size() + 1];
-    unsigned j = 0;
-    for (auto& i : options) {
-      ptrs[j++] = i.c_str();
-    }
-    ptrs[j] = 0;
-  }
-  ~NoopConfigObserver() {
-    delete[] ptrs;
-  }
-
-  const char** get_tracked_conf_keys() const override {
-    return ptrs;
+  NoopConfigObserver(std::vector<std::string> l) : options(l) {}
+  ~NoopConfigObserver() = default;
+  std::vector<std::string> get_tracked_keys() const noexcept override {
+    return options;
   }
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set <std::string> &changed) override {


### PR DESCRIPTION
.. with get_tracked_keys().

Following https://github.com/ceph/ceph/pull/61394, all uses of the deprecated interface
will be updated, and that old interface will be removed.

