### PR TITLE
squid: rgw/log: Fix crash during shutdown with ops-log enable.

### DIFF
--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -407,7 +407,7 @@ void rgw::AppMain::init_opslog()
     olog_manifold->add_sink(ops_log_file);
   }
   olog_manifold->add_sink(new OpsLogRados(env.driver));
-  olog = olog_manifold;
+  env.olog.reset(olog_manifold);
 } /* init_opslog */
 
 int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
@@ -449,7 +449,6 @@ int rgw::AppMain::init_frontends2(RGWLib* rgwlib)
 
   // initialize RGWProcessEnv
   env.rest = &rest;
-  env.olog = olog;
   env.auth_registry = rgw::auth::StrategyRegistry::create(
       dpp->get_cct(), *implicit_tenant_context, env.driver);
   env.ratelimiting = ratelimiter.get();
@@ -592,8 +591,6 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
 
   ldh.reset(nullptr); // deletes ldap helper if it was created
   rgw_log_usage_finalize();
-
-  delete olog;
 
   if (lua_background) {
     lua_background->shutdown();

--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -316,7 +316,7 @@ namespace rgw {
               << e.what() << dendl;
     }
     if (should_log) {
-      rgw_log_op(nullptr /* !rest */, s, op, env.olog);
+      rgw_log_op(nullptr /* !rest */, s, op, env.olog.get());
     }
 
     int http_ret = s->err.http_ret;

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -67,7 +67,6 @@ class AppMain {
   std::vector<RGWFrontendConfig*> fe_configs;
   std::multimap<string, RGWFrontendConfig*> fe_map;
   std::unique_ptr<rgw::LDAPHelper> ldh;
-  OpsLogSink* olog = nullptr;
   RGWREST rest;
   std::unique_ptr<rgw::lua::Background> lua_background;
   std::unique_ptr<rgw::auth::ImplicitTenants> implicit_tenant_context;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -335,7 +335,7 @@ int process_request(const RGWProcessEnv& penv,
     } else if (rc < 0) {
       ldpp_dout(op, 5) << "WARNING: failed to read pre request script. error: " << rc << dendl;
     } else {
-      rc = rgw::lua::request::execute(driver, rest, penv.olog, s, op, script);
+      rc = rgw::lua::request::execute(driver, rest, penv.olog.get(), s, op, script);
       if (rc < 0) {
         ldpp_dout(op, 5) << "WARNING: failed to execute pre request script. error: " << rc << dendl;
       }
@@ -425,7 +425,7 @@ done:
     } else if (rc < 0) {
       ldpp_dout(op, 5) << "WARNING: failed to read post request script. error: " << rc << dendl;
     } else {
-      rc = rgw::lua::request::execute(driver, rest, penv.olog, s, op, script);
+      rc = rgw::lua::request::execute(driver, rest, penv.olog.get(), s, op, script);
       if (rc < 0) {
         ldpp_dout(op, 5) << "WARNING: failed to execute post request script. error: " << rc << dendl;
       }
@@ -441,7 +441,7 @@ done:
     perfcounter->inc(l_rgw_qactive, -1);
   }
   if (should_log) {
-    rgw_log_op(rest, s, op, penv.olog);
+    rgw_log_op(rest, s, op, penv.olog.get());
   }
 
   if (http_ret != nullptr) {

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -42,7 +42,7 @@ struct RGWProcessEnv {
   rgw::sal::Driver* driver = nullptr;
   rgw::SiteConfig* site = nullptr;
   RGWREST *rest = nullptr;
-  OpsLogSink *olog = nullptr;
+  std::unique_ptr<OpsLogSink> olog;
   std::unique_ptr<rgw::auth::StrategyRegistry> auth_registry;
   ActiveRateLimiter* ratelimiting = nullptr;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70311

---

backport of https://github.com/ceph/ceph/pull/61944
parent tracker: https://tracker.ceph.com/issues/70104

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh