### PR TITLE
rgw/logging: prevent commiting log objects with open transactions

### DIFF
--- a/src/cls/refcount/cls_refcount.cc
+++ b/src/cls/refcount/cls_refcount.cc
@@ -71,7 +71,7 @@ static int cls_rc_refcount_get(cls_method_context_t hctx, bufferlist *in, buffer
 
   obj_refcount objr;
   int ret = read_refcount(hctx, op.implicit_ref, &objr);
-  if (ret < 0)
+  if ((ret < 0 && ret != -ENOENT) || (op.must_exist && ret == -ENOENT))
     return ret;
 
   CLS_LOG(10, "cls_rc_refcount_get() tag=%s\n", op.tag.c_str());

--- a/src/cls/refcount/cls_refcount_client.cc
+++ b/src/cls/refcount/cls_refcount_client.cc
@@ -12,12 +12,13 @@ using std::string;
 
 using ceph::bufferlist;
 
-void cls_refcount_get(librados::ObjectWriteOperation& op, const string& tag, bool implicit_ref)
+void cls_refcount_get(librados::ObjectWriteOperation& op, const string& tag, bool implicit_ref, bool must_exist)
 {
   bufferlist in;
   cls_refcount_get_op call;
   call.tag = tag;
   call.implicit_ref = implicit_ref;
+  call.must_exist = must_exist;
   encode(call, in);
   op.exec("refcount", "get", in);
 }

--- a/src/cls/refcount/cls_refcount_client.cc
+++ b/src/cls/refcount/cls_refcount_client.cc
@@ -42,7 +42,7 @@ void cls_refcount_set(librados::ObjectWriteOperation& op, list<string>& refs)
   op.exec("refcount", "set", in);
 }
 
-int cls_refcount_read(librados::IoCtx& io_ctx, string& oid, list<string> *refs, bool implicit_ref)
+int cls_refcount_read(librados::IoCtx& io_ctx, const std::string& oid, list<string> *refs, bool implicit_ref)
 {
   bufferlist in, out;
   cls_refcount_read_op call;

--- a/src/cls/refcount/cls_refcount_client.h
+++ b/src/cls/refcount/cls_refcount_client.h
@@ -27,9 +27,12 @@
  * we don't have a tag for this refcount, we consider this tag as a wildcard. So if the refcount
  * is being decreased by an unknown tag and we still have one wildcard tag, we'll accept it
  * as the relevant tag, and the refcount will be decreased.
+ *
+ * If must_exist is set to "false", the object will be created if it doesn't exist when increasing
+ * the refcount. This is useful for cases where we want the object to be created with a refcount.
  */
 
-void cls_refcount_get(librados::ObjectWriteOperation& op, const std::string& tag, bool implicit_ref = false);
+void cls_refcount_get(librados::ObjectWriteOperation& op, const std::string& tag, bool implicit_ref = false, bool must_exist = true);
 void cls_refcount_put(librados::ObjectWriteOperation& op, const std::string& tag, bool implicit_ref = false);
 void cls_refcount_set(librados::ObjectWriteOperation& op, std::list<std::string>& refs);
 // these overloads which call io_ctx.operate() or io_ctx.exec() should not be called in the rgw.

--- a/src/cls/refcount/cls_refcount_client.h
+++ b/src/cls/refcount/cls_refcount_client.h
@@ -38,7 +38,7 @@ void cls_refcount_set(librados::ObjectWriteOperation& op, std::list<std::string>
 // these overloads which call io_ctx.operate() or io_ctx.exec() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()/exec()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_refcount_read(librados::IoCtx& io_ctx, std::string& oid, std::list<std::string> *refs, bool implicit_ref = false);
+int cls_refcount_read(librados::IoCtx& io_ctx, const std::string& oid, std::list<std::string> *refs, bool implicit_ref = false);
 #endif
 
 #endif

--- a/src/cls/refcount/cls_refcount_ops.cc
+++ b/src/cls/refcount/cls_refcount_ops.cc
@@ -11,6 +11,7 @@ void cls_refcount_get_op::dump(ceph::Formatter *f) const
 {
   f->dump_string("tag", tag);
   f->dump_int("implicit_ref", (int)implicit_ref);
+  f->dump_int("must_exist", (int)must_exist);
 }
 
 void cls_refcount_get_op::generate_test_instances(list<cls_refcount_get_op*>& ls)
@@ -19,6 +20,7 @@ void cls_refcount_get_op::generate_test_instances(list<cls_refcount_get_op*>& ls
   ls.push_back(new cls_refcount_get_op);
   ls.back()->tag = "foo";
   ls.back()->implicit_ref = true;
+  ls.back()->must_exist = true;
 }
 
 

--- a/src/cls/refcount/cls_refcount_ops.h
+++ b/src/cls/refcount/cls_refcount_ops.h
@@ -10,20 +10,25 @@
 struct cls_refcount_get_op {
   std::string tag;
   bool implicit_ref;
+  bool must_exist;
 
-  cls_refcount_get_op() : implicit_ref(false) {}
+  cls_refcount_get_op() : implicit_ref(false), must_exist(true) {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(tag, bl);
     encode(implicit_ref, bl);
+    encode(must_exist, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(tag, bl);
     decode(implicit_ref, bl);
+    if (struct_v >= 2) {
+      decode(must_exist, bl);
+    }
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -799,7 +799,9 @@ class RadosBucket : public StoreBucket {
         RGWObjVersionTracker* objv_tracker) override;
     int commit_logging_object(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp) override;
     int remove_logging_object(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp) override;
-    int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp, bool async_completion) override;
+    int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp,
+        bool async_completion, boost::optional<const std::string&> transaction_id = boost::none) override;
+    int complete_logging_object_write(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp, const std::string& transaction_id) override;
 
   private:
     int link(const DoutPrefixProvider* dpp, const rgw_owner& new_owner, optional_yield y, bool update_entrypoint = true, RGWObjVersionTracker* objv = nullptr);

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1034,7 +1034,11 @@ class Bucket {
     //** Remove the pending bucket logging object */
     virtual int remove_logging_object(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp) = 0;
     /** Write a record to the pending bucket logging object */
-    virtual int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp, bool async_completion) = 0;
+    virtual int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp, 
+        bool async_completion,
+        boost::optional<const std::string&> transaction_id = boost::none) = 0;
+    /** mark a transaction that was previously written to the pending bucket logging object as complete */
+    virtual int complete_logging_object_write(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp, const std::string& transaction_id) = 0;
 
     /* dang - This is temporary, until the API is completed */
     virtual rgw_bucket& get_key() = 0;

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -694,8 +694,12 @@ public:
   int remove_logging_object(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp) override {
     return next->remove_logging_object(obj_name, y, dpp);
   }
-  int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp, bool async_completion) override {
-    return next->write_logging_object(obj_name, record, y, dpp, async_completion);
+  int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp,
+      bool async_completion, boost::optional<const std::string&> transaction_id = boost::none) override {
+    return next->write_logging_object(obj_name, record, y, dpp, async_completion, transaction_id);
+  }
+  int complete_logging_object_write(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp, const std::string& transaction_id) override {
+    return next->complete_logging_object_write(obj_name, y, dpp, transaction_id);
   }
 
   virtual rgw_bucket& get_key() override { return next->get_key(); }

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -270,7 +270,11 @@ class StoreBucket : public Bucket {
         RGWObjVersionTracker* objv_tracker) override { return 0; }
     int commit_logging_object(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp) override { return 0; }
     int remove_logging_object(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp) override { return 0; }
-    int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp, bool async_completion) override {
+    int write_logging_object(const std::string& obj_name, const std::string& record, optional_yield y, const DoutPrefixProvider *dpp,
+        bool async_completion, boost::optional<const std::string&> transaction_id = boost::none) override {
+      return 0;
+    }
+    int complete_logging_object_write(const std::string& obj_name, optional_yield y, const DoutPrefixProvider *dpp, const std::string& transaction_id) override {
       return 0;
     }
 


### PR DESCRIPTION
in journal mode, we log the record before the operation is completed.
therefore, before commiting and makign the log object available in
the log bucket, we have to wait for all open transactions to be
completed.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
