### PR TITLE
rgw: report failed replication status caused by user errors

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2745,6 +2745,7 @@ static int rgw_obj_check_mtime(cls_method_context_t hctx, bufferlist *in, buffer
   }
   if (ret == -ENOENT) {
     CLS_LOG(10, "object does not exist, skipping check");
+    return 0;
   }
 
   ceph_timespec obj_ts = ceph::real_clock::to_ceph_timespec(obj_ut);

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -111,7 +111,8 @@ int D4NFilterBucket::create(const DoutPrefixProvider* dpp,
 }
 
 int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-                            Attrs* delattrs, optional_yield y, uint32_t flags)
+                            Attrs* delattrs, optional_yield y, uint32_t flags,
+                            ceph::real_time unmod_since)
 {
   if (setattrs != NULL) {
     /* Ensure setattrs and delattrs do not overlap */
@@ -142,7 +143,7 @@ int D4NFilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattr
       ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): CacheDriver delete_attrs method failed." << dendl;
   }
 
-  return next->set_obj_attrs(dpp, setattrs, delattrs, y, flags);
+  return next->set_obj_attrs(dpp, setattrs, delattrs, y, flags, unmod_since);
 }
 
 int D4NFilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -179,7 +179,8 @@ class D4NFilterObject : public FilterObject {
 
     virtual const std::string &get_name() const override { return next->get_name(); }
     virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-                            Attrs* delattrs, optional_yield y, uint32_t flags) override;
+                            Attrs* delattrs, optional_yield y, uint32_t flags,
+                            ceph::real_time unmod_since = ceph::real_clock::zero()) override;
     virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
                             rgw_obj* target_obj = NULL) override;
     virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val,

--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -896,7 +896,8 @@ int DaosObject::load_obj_state(const DoutPrefixProvider* dpp,
 DaosObject::~DaosObject() { close(nullptr); }
 
 int DaosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-                              Attrs* delattrs, optional_yield y, uint32_t flags) {
+                              Attrs* delattrs, optional_yield y, uint32_t flags,
+                              ceph::real_time unmod_since) {
   ldpp_dout(dpp, 20) << "DEBUG: DaosObject::set_obj_attrs()" << dendl;
   // TODO handle target_obj
   // Get object's metadata (those stored in rgw_bucket_dir_entry)

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -620,7 +620,8 @@ class DaosObject : public StoreObject {
   virtual int load_obj_state(const DoutPrefixProvider *dpp, optional_yield y,
                              bool follow_olh = true) override;
   virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-                            Attrs* delattrs, optional_yield y, uint32_t flags) override;
+                            Attrs* delattrs, optional_yield y, uint32_t flags,
+                            ceph::real_time unmod_since = ceph::real_clock::zero()) override;
   virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
                             rgw_obj* target_obj = NULL) override;
   virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val,

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -1177,7 +1177,7 @@ MotrObject::~MotrObject() {
 //    return read_op.prepare(dpp);
 //  }
 
-int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags)
+int MotrObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags, ceph::real_time unmod_since)
 {
   // TODO: implement
   ldpp_dout(dpp, 20) <<__func__<< ": MotrObject::set_obj_attrs()" << dendl;

--- a/src/rgw/driver/motr/rgw_sal_motr.h
+++ b/src/rgw/driver/motr/rgw_sal_motr.h
@@ -678,7 +678,7 @@ class MotrObject : public StoreObject {
     virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
     virtual int set_acl(const RGWAccessControlPolicy& acl) override { acls = acl; return 0; }
     virtual int load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh = true) override;
-    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags) override;
+    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags, ceph::real_time unmod_since = ceph::real_clock::zero()) override;
     virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) override;
     virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp,
                                  uint32_t flags = rgw::sal::FLAG_LOG_OP) override;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2918,7 +2918,8 @@ int POSIXObject::load_obj_state(const DoutPrefixProvider* dpp, optional_yield y,
 }
 
 int POSIXObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-                            Attrs* delattrs, optional_yield y, uint32_t flags)
+                            Attrs* delattrs, optional_yield y, uint32_t flags,
+                            ceph::real_time unmod_since)
 {
   if (delattrs) {
     for (auto& it : *delattrs) {

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -664,7 +664,8 @@ public:
 
   virtual int load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh = true) override;
   virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-			    Attrs* delattrs, optional_yield y, uint32_t flags) override;
+			    Attrs* delattrs, optional_yield y, uint32_t flags,
+                            ceph::real_time unmod_since = ceph::real_clock::zero()) override;
   virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
 			    rgw_obj* target_obj = NULL) override;
   virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val,

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4604,6 +4604,15 @@ public:
 		       bs.bucket.name, key, zone_name);
           set_status("Skipping object sync: precondition failed (object contains newer change or policy doesn't allow sync)");
           tn->log(0, "Skipping object sync: precondition failed (object contains newer change or policy doesn't allow sync)");
+
+          if (retcode == -EPERM || retcode == -EACCES) {
+            // update src object with failed status
+            call(data_sync_module->fail_object_replication_status(dpp, sc, sync_pipe, key));
+            if (retcode < 0) {
+              tn->log(0, SSTR("ERROR: failed to update object replication status: " << cpp_strerror(-retcode)));
+            }
+          }
+
           retcode = 0;
         }
       } while (marker_tracker->need_retry(key));

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1300,22 +1300,13 @@ int restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
   int delete_obj_index(const rgw_obj& obj, ceph::real_time mtime,
 		       const DoutPrefixProvider *dpp, optional_yield y);
 
-  /**
-   * Set an attr on an object.
-   * bucket: name of the bucket holding the object
-   * obj: name of the object to set the attr on
-   * name: the attr to set
-   * bl: the contents of the attr
-   * Returns: 0 on success, -ERR# otherwise.
-   */
-  int set_attr(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, const char *name, bufferlist& bl, optional_yield y);
-
   int set_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                         std::map<std::string, bufferlist>& attrs,
                         std::map<std::string, bufferlist>* rmattrs,
                         optional_yield y,
                         bool log_op,
-                        ceph::real_time set_mtime = ceph::real_clock::zero());
+                        ceph::real_time set_mtime = ceph::real_clock::zero(),
+                        ceph::real_time unmod_since = ceph::real_clock::zero());
 
   int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx,
                     RGWBucketInfo& bucket_info, const rgw_obj& obj,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2676,7 +2676,7 @@ int RadosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, A
 			get_obj(),
 			setattrs ? *setattrs : empty,
 			delattrs,
-			y, log_op, mtime);
+			y, log_op, mtime, unmod_since);
 }
 
 int RadosObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj)

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2675,7 +2675,7 @@ int RadosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, A
 			bucket->get_info(),
 			get_obj(),
 			setattrs ? *setattrs : empty,
-			delattrs ? delattrs : nullptr,
+			delattrs,
 			y, log_op, mtime);
 }
 

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2664,7 +2664,7 @@ int RadosObject::read_attrs(const DoutPrefixProvider* dpp, RGWRados::Object::Rea
   return read_op.prepare(y, dpp);
 }
 
-int RadosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags)
+int RadosObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags, ceph::real_time unmod_since)
 {
   Attrs empty;
   const bool log_op = flags & rgw::sal::FLAG_LOG_OP;

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -605,7 +605,7 @@ class RadosObject : public StoreObject {
 			   bool* truncated, list_parts_each_t each_func,
 			   optional_yield y) override;
 
-    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags) override;
+    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags, ceph::real_time unmod_since = ceph::real_clock::zero()) override;
     virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) override;
     virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp,
                                  uint32_t flags = rgw::sal::FLAG_LOG_OP) override;

--- a/src/rgw/driver/rados/rgw_sync_module.h
+++ b/src/rgw/driver/rados/rgw_sync_module.h
@@ -39,6 +39,8 @@ public:
                                       bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) = 0;
   virtual RGWCoroutine *create_delete_marker(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& bucket_info, rgw_obj_key& key, real_time& mtime,
                                              rgw_bucket_entry_owner& owner, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) = 0;
+  virtual RGWCoroutine *fail_object_replication_status(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc,
+                                                       rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key) { return NULL; }
 };
 
 class RGWRESTMgr;

--- a/src/rgw/driver/rados/rgw_sync_module.h
+++ b/src/rgw/driver/rados/rgw_sync_module.h
@@ -40,7 +40,7 @@ public:
   virtual RGWCoroutine *create_delete_marker(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc, rgw_bucket_sync_pipe& bucket_info, rgw_obj_key& key, real_time& mtime,
                                              rgw_bucket_entry_owner& owner, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) = 0;
   virtual RGWCoroutine *fail_object_replication_status(const DoutPrefixProvider *dpp, RGWDataSyncCtx *sc,
-                                                       rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key) { return NULL; }
+                                                       rgw_bucket_sync_pipe& sync_pipe, rgw_obj_key& key, real_time& timestamp) { return NULL; }
 };
 
 class RGWRESTMgr;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -526,6 +526,7 @@ enum http_op {
   OP_POST,
   OP_COPY,
   OP_OPTIONS,
+  OP_PATCH,
   OP_UNKNOWN,
 };
 

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -154,7 +154,6 @@ class RGWSendRawRESTResourceCR: public RGWSimpleCoroutine {
   std::string path;
   param_vec_t params;
   param_vec_t headers;
-  std::map<std::string, std::string> *attrs;
   T *result;
   E *err_result;
   bufferlist input_bl;
@@ -172,7 +171,7 @@ class RGWSendRawRESTResourceCR: public RGWSimpleCoroutine {
                           E *_err_result = nullptr)
    : RGWSimpleCoroutine(_cct, NUM_ENPOINT_IOERROR_RETRIES), conn(_conn), http_manager(_http_manager),
      method(_method), path(_path), params(make_param_list(_params)),
-     headers(make_param_list(_attrs)), attrs(_attrs),
+     headers(make_param_list(_attrs)),
      result(_result), err_result(_err_result),
      input_bl(_input), send_content_length(_send_content_length) {}
 
@@ -182,7 +181,7 @@ class RGWSendRawRESTResourceCR: public RGWSimpleCoroutine {
                           rgw_http_param_pair *_params, std::map<std::string, std::string> *_attrs,
                           T *_result, E *_err_result = nullptr)
    : RGWSimpleCoroutine(_cct, NUM_ENPOINT_IOERROR_RETRIES), conn(_conn), http_manager(_http_manager),
-    method(_method), path(_path), params(make_param_list(_params)), headers(make_param_list(_attrs)), attrs(_attrs), result(_result),
+    method(_method), path(_path), params(make_param_list(_params)), headers(make_param_list(_attrs)), result(_result),
     err_result(_err_result) {}
 
   ~RGWSendRawRESTResourceCR() override {

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -189,6 +189,10 @@ class RGWSendRawRESTResourceCR: public RGWSimpleCoroutine {
   }
 
   int send_request(const DoutPrefixProvider *dpp) override {
+    if (send_content_length) {
+      headers.push_back(param_pair_t("Content-Length", std::to_string(input_bl.length())));
+    }
+
     auto op = boost::intrusive_ptr<RGWRESTSendResource>(
         new RGWRESTSendResource(conn, method, path, params, &headers, http_manager));
 

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -327,6 +327,21 @@ public:
 
 };
 
+template <class T, class E = int>
+class RGWPatchRawRESTResourceCR: public RGWSendRawRESTResourceCR <T, E> {
+ public:
+ RGWPatchRawRESTResourceCR(CephContext *_cct, RGWRESTConn *_conn,
+                           RGWHTTPManager *_http_manager,
+                           const std::string& _path,
+                           rgw_http_param_pair *_params,
+                           std::map<std::string, std::string> * _attrs,
+                           bufferlist& _input,
+                           T *_result, E *_err_result = nullptr)
+    : RGWSendRawRESTResourceCR<T, E>(_cct, _conn, _http_manager, "PATCH", _path,
+                                  _params, _attrs, _input, _result, true, _err_result) {}
+
+};
+
 class RGWDeleteRESTResourceCR : public RGWSimpleCoroutine {
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
 

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -527,7 +527,7 @@ static curl_slist *headers_to_slist(param_vec_t& headers)
 
 static bool is_upload_request(const string& method)
 {
-  return method == "POST" || method == "PUT";
+  return method == "POST" || method == "PUT" || method == "PATCH";
 }
 
 /*

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8317,7 +8317,7 @@ void RGWSetAttrs::execute(optional_yield y)
 
   if (!rgw::sal::Object::empty(s->object.get())) {
     rgw::sal::Attrs a(attrs);
-    op_ret = s->object->set_obj_attrs(this, &a, nullptr, y, set_attrs_flags);
+    op_ret = s->object->set_obj_attrs(this, &a, nullptr, y, set_attrs_flags, unmod_since);
   } else {
     op_ret = s->bucket->merge_and_store_attrs(this, attrs, y);
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8317,7 +8317,7 @@ void RGWSetAttrs::execute(optional_yield y)
 
   if (!rgw::sal::Object::empty(s->object.get())) {
     rgw::sal::Attrs a(attrs);
-    op_ret = s->object->set_obj_attrs(this, &a, nullptr, y, rgw::sal::FLAG_LOG_OP);
+    op_ret = s->object->set_obj_attrs(this, &a, nullptr, y, set_attrs_flags);
   } else {
     op_ret = s->bucket->merge_and_store_attrs(this, attrs, y);
   }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2368,6 +2368,7 @@ protected:
   std::map<std::string, buffer::list> attrs;
   uint32_t set_attrs_flags{rgw::sal::FLAG_LOG_OP};
   ceph::real_time unmod_since; /* if unmodified since */
+  bool no_precondition_error{false};
 
 public:
   RGWSetAttrs() {}

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2367,6 +2367,7 @@ class RGWSetAttrs : public RGWOp {
 protected:
   std::map<std::string, buffer::list> attrs;
   uint32_t set_attrs_flags{rgw::sal::FLAG_LOG_OP};
+  ceph::real_time unmod_since; /* if unmodified since */
 
 public:
   RGWSetAttrs() {}

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2366,6 +2366,7 @@ public:
 class RGWSetAttrs : public RGWOp {
 protected:
   std::map<std::string, buffer::list> attrs;
+  uint32_t set_attrs_flags{rgw::sal::FLAG_LOG_OP};
 
 public:
   RGWSetAttrs() {}

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1715,6 +1715,9 @@ RGWOp* RGWHandler_REST::get_op(void)
    case OP_OPTIONS:
      op = op_options();
      break;
+    case OP_PATCH:
+      op = op_patch();
+      break;
    default:
      return NULL;
   }
@@ -1877,6 +1880,8 @@ static http_op op_from_method(const char *method)
     return OP_COPY;
   if (strcmp(method, "OPTIONS") == 0)
     return OP_OPTIONS;
+  if (strcmp(method, "PATCH") == 0)
+    return OP_PATCH;
 
   return OP_UNKNOWN;
 }
@@ -1925,6 +1930,9 @@ int RGWHandler_REST::read_permissions(RGWOp* op_obj, optional_yield y)
     break;
   case OP_OPTIONS:
     only_bucket = true;
+    break;
+  case OP_PATCH:
+    only_bucket = false;
     break;
   default:
     return -EINVAL;

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -403,6 +403,12 @@ public:
   virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
 };
 
+class RGWSetObjAttrs_ObjStore : public RGWSetAttrs {
+public:
+  RGWSetObjAttrs_ObjStore() {}
+  ~RGWSetObjAttrs_ObjStore() override {}
+};
+
 class RGWGetObjAttrs_ObjStore : public RGWGetObjAttrs {
 public:
   RGWGetObjAttrs_ObjStore() {}

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -629,6 +629,7 @@ protected:
   virtual RGWOp *op_post() { return NULL; }
   virtual RGWOp *op_copy() { return NULL; }
   virtual RGWOp *op_options() { return NULL; }
+  virtual RGWOp *op_patch() { return NULL; }
 
 public:
   static int allocate_formatter(req_state *s, RGWFormat default_formatter,

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -272,21 +272,6 @@ int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
   return ret;
 }
 
-static void set_date_header(const real_time *t, map<string, string>& headers, bool high_precision_time, const string& header_name)
-{
-  if (!t) {
-    return;
-  }
-  stringstream s;
-  utime_t tm = utime_t(*t);
-  if (high_precision_time) {
-    tm.gmtime_nsec(s);
-  } else {
-    tm.gmtime(s);
-  }
-  headers[header_name] = s.str();
-}
-
 template <class T>
 static void set_header(T val, map<string, string>& headers, const string& header_name)
 {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -640,10 +640,7 @@ void RGWRESTSendResource::init_common(param_vec_t *extra_headers)
 
 int RGWRESTSendResource::send(const DoutPrefixProvider *dpp, bufferlist& outbl, optional_yield y)
 {
-  req.set_send_length(outbl.length());
-  req.set_outbl(outbl);
-
-  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr);
+  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr, &outbl);
   if (ret < 0) {
     ldpp_dout(dpp, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -660,10 +657,7 @@ int RGWRESTSendResource::send(const DoutPrefixProvider *dpp, bufferlist& outbl, 
 
 int RGWRESTSendResource::aio_send(const DoutPrefixProvider *dpp, bufferlist& outbl)
 {
-  req.set_send_length(outbl.length());
-  req.set_outbl(outbl);
-
-  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr);
+  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr, &outbl);
   if (ret < 0) {
     ldpp_dout(dpp, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -65,6 +65,21 @@ inline param_vec_t make_param_list(const std::map<std::string, std::string> *pp)
   return params;
 }
 
+inline void set_date_header(const ceph::real_time *t, std::map<std::string, std::string>& headers, bool high_precision_time, const std::string& header_name)
+{
+  if (!t) {
+    return;
+  }
+  std::stringstream s;
+  utime_t tm = utime_t(*t);
+  if (high_precision_time) {
+    tm.gmtime_nsec(s);
+  } else {
+    tm.gmtime(s);
+  }
+  headers[header_name] = s.str();
+}
+
 class RGWRESTConn
 {
   /* the endpoint is not able to connect if the timestamp is not real_clock::zero */

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1339,6 +1339,28 @@ struct ReplicationConfiguration {
       }
       pipe->dest.bucket.emplace(dest_bk);
 
+      std::unique_ptr<rgw::sal::Bucket> dest_bucket;
+      if (r = driver->load_bucket(s, *pipe->dest.bucket, &dest_bucket, s->yield); r < 0) {
+        if (r == -ENOENT) {
+          s->err.message = "Destination bucket must exist.";
+          return -EINVAL;
+        }
+
+        ldpp_dout(s, 0) << "ERROR: failed to load bucket info for bucket=" << *pipe.dest.bucket << " r=" << r << dendl;
+        return r;
+      }
+
+      // check versioning identicality
+      if (dest_bucket->get_info().versioned() != s->bucket->get_info().versioned()) {
+        s->err.message = "Versioning must be identical in source and destination buckets.";
+        return -EINVAL;
+      }
+      // check object lock identicality
+      if (dest_bucket->get_info().obj_lock_enabled() != s->bucket->get_info().obj_lock_enabled()) {
+        s->err.message = "Object lock must be identical in source and destination buckets.";
+        return -EINVAL;
+      }
+
       if (filter) {
         int r = filter->to_sync_pipe_filter(s->cct, &pipe->params.source.filter);
         if (r < 0) {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -374,6 +374,16 @@ public:
   int get_params(optional_yield y) override;
 };
 
+class RGWSetObjAttrs_ObjStore_S3 : public RGWSetObjAttrs_ObjStore {
+public:
+  RGWSetObjAttrs_ObjStore_S3() {}
+  ~RGWSetObjAttrs_ObjStore_S3() override {}
+
+  int get_params(optional_yield y) override;
+  int verify_permission(optional_yield y) override;
+  void send_response() override;
+};
+
 class RGWGetObjAttrs_ObjStore_S3 : public RGWGetObjAttrs_ObjStore {
 public:
   RGWGetObjAttrs_ObjStore_S3() {}
@@ -802,6 +812,7 @@ protected:
   RGWOp *op_delete() override;
   RGWOp *op_post() override;
   RGWOp *op_options() override;
+  RGWOp *op_patch() override;
 public:
   using RGWHandler_REST_S3::RGWHandler_REST_S3;
   ~RGWHandler_REST_Obj_S3() override = default;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1219,7 +1219,7 @@ class Object {
     virtual int load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh = true) = 0;
     /** Set attributes for this object from the backing store.  Attrs can be set or
      * deleted.  @note the attribute APIs may be revisited in the future. */
-    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags) = 0;
+    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags, ceph::real_time unmod_since = ceph::real_clock::zero()) = 0;
     /** Get attributes for this object */
     virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) = 0;
     /** Modify attributes for this object. */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -528,7 +528,7 @@ namespace rgw::sal {
     return read_op.prepare(dpp);
   }
 
-  int DBObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags)
+  int DBObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags, ceph::real_time unmod_since)
   {
     Attrs empty;
     DB::Object op_target(store->getDB(),

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -553,7 +553,7 @@ protected:
       virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
       virtual int set_acl(const RGWAccessControlPolicy& acl) override { acls = acl; return 0; }
 
-      virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags) override;
+      virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs, Attrs* delattrs, optional_yield y, uint32_t flags, ceph::real_time unmod_since = ceph::real_clock::zero()) override;
 
       /** If multipart, enumerate (a range [marker..marker+[min(max_parts, parts_count-1)] of) parts of the object */
       virtual int list_parts(const DoutPrefixProvider* dpp, CephContext* cct,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -1068,9 +1068,10 @@ int FilterObject::load_obj_state(const DoutPrefixProvider *dpp,
 }
 
 int FilterObject::set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-				Attrs* delattrs, optional_yield y, uint32_t flags)
+				Attrs* delattrs, optional_yield y, uint32_t flags,
+                                ceph::real_time unmod_since)
 {
-  return next->set_obj_attrs(dpp, setattrs, delattrs, y, flags);
+  return next->set_obj_attrs(dpp, setattrs, delattrs, y, flags, unmod_since);
 }
 
 int FilterObject::get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -797,7 +797,8 @@ public:
   virtual int load_obj_state(const DoutPrefixProvider *dpp, optional_yield y,
                              bool follow_olh = true) override;
   virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
-			    Attrs* delattrs, optional_yield y, uint32_t flags) override;
+			    Attrs* delattrs, optional_yield y, uint32_t flags,
+                            ceph::real_time unmod_since = ceph::real_clock::zero()) override;
   virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp,
 			    rgw_obj* target_obj = NULL) override;
   virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val,


### PR DESCRIPTION
Report errors caused by user configuration during replication to the source zone to update the object's replication status attr.

Fixes: https://tracker.ceph.com/issues/70326
Require:
- [x] https://github.com/ceph/ceph/pull/61828
- [x] https://github.com/ceph/ceph/pull/61962
- [ ] https://github.com/ceph/ceph/pull/62642
- [x] ~https://github.com/ceph/ceph/pull/62323~