### PR TITLE
mgr/dashboard: fix access control permissions for roles

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-pie/dashboard-pie.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-pie/dashboard-pie.component.ts
@@ -15,9 +15,9 @@ export class DashboardPieComponent implements OnChanges, OnInit {
   @Input()
   data: any;
   @Input()
-  highThreshold: number;
+  highThreshold = 0;
   @Input()
-  lowThreshold: number;
+  lowThreshold = 0;
 
   color: string;
 
@@ -162,15 +162,15 @@ export class DashboardPieComponent implements OnChanges, OnInit {
     const percentAvailable = this.calcPercentage(max - current, max);
     const percentUsed = this.calcPercentage(current, max);
 
-    if (fullRatioPercent >= 0 && percentUsed >= fullRatioPercent) {
+    if (fullRatioPercent > 0 && percentUsed >= fullRatioPercent) {
       this.color = 'chart-color-red';
-    } else if (nearFullRatioPercent >= 0 && percentUsed >= nearFullRatioPercent) {
+    } else if (nearFullRatioPercent > 0 && percentUsed >= nearFullRatioPercent) {
       this.color = 'chart-color-yellow';
     } else {
       this.color = 'chart-color-blue';
     }
 
-    if (fullRatioPercent >= 0 && nearFullRatioPercent >= 0) {
+    if (fullRatioPercent > 0 && nearFullRatioPercent > 0) {
       chart.dataset[0].data = [
         Math.round(nearFullRatioPercent),
         Math.round(Math.abs(nearFullRatioPercent - fullRatioPercent)),

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
@@ -227,7 +227,7 @@
                    [fullHeight]="true"
                    aria-label="Capacity card">
             <ng-container class="ms-4 me-4"
-                          *ngIf="capacity && osdSettings">
+                          *ngIf="capacity">
               <cd-dashboard-pie [data]="{max: capacity.total_bytes, current: capacity.total_used_raw_bytes}"
                                 [lowThreshold]="osdSettings.nearfull_ratio"
                                 [highThreshold]="osdSettings.full_ratio">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
@@ -26,6 +26,7 @@ import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { AlertClass } from '~/app/shared/enum/health-icon.enum';
 import { HardwareService } from '~/app/shared/api/hardware.service';
 import { SettingsService } from '~/app/shared/api/settings.service';
+import { OsdSettings } from '~/app/shared/models/osd-settings';
 
 @Component({
   selector: 'cd-dashboard-v3',
@@ -35,7 +36,7 @@ import { SettingsService } from '~/app/shared/api/settings.service';
 export class DashboardV3Component extends PrometheusListHelper implements OnInit, OnDestroy {
   detailsCardData: DashboardDetails = {};
   osdSettingsService: any;
-  osdSettings: any;
+  osdSettings = new OsdSettings();
   interval = new Subscription();
   permissions: Permissions;
   enabledFeature$: FeatureTogglesMap$;
@@ -117,7 +118,8 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
     }
     this.interval = this.refreshIntervalService.intervalData$.subscribe(() => {
       this.getHealth();
-      this.getCapacityCardData();
+      this.getCapacity();
+      if (this.permissions.configOpt.read) this.getOsdSettings();
       if (this.hardwareEnabled) this.hardwareSubject.next([]);
     });
     this.getPrometheusData(this.prometheusService.lastHourDateObject);
@@ -165,16 +167,19 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
     );
   }
 
-  getCapacityCardData() {
-    this.osdSettingsService = this.osdService
-      .getOsdSettings()
-      .pipe(take(1))
-      .subscribe((data: any) => {
-        this.osdSettings = data;
-      });
+  private getCapacity() {
     this.capacityService = this.healthService.getClusterCapacity().subscribe((data: any) => {
       this.capacity = data;
     });
+  }
+
+  private getOsdSettings() {
+    this.osdSettingsService = this.osdService
+      .getOsdSettings()
+      .pipe(take(1))
+      .subscribe((data: OsdSettings) => {
+        this.osdSettings = data;
+      });
   }
 
   public getPrometheusData(selectedTime: any) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.html
@@ -1,6 +1,7 @@
 <cd-rgw-multisite-tabs></cd-rgw-multisite-tabs>
 <div>
-  <cd-alert-panel *ngIf="!rgwModuleStatus"
+  <!-- Show the alert only when the user has the permission to configure -->
+  <cd-alert-panel *ngIf="permissions.configOpt.create && !rgwModuleStatus"
                   type="info"
                   spacingClass="mb-3"
                   class="d-flex align-items-center"
@@ -18,32 +19,32 @@
        Cluster->Services</a>
   </cd-alert-panel>
   <cd-table-actions class="btn-group mb-4 me-2"
-                    [permission]="permission"
+                    [permission]="permissions.rgw"
                     [selection]="selection"
                     [tableActions]="multisiteReplicationActions">
   </cd-table-actions>
   <cd-table-actions *ngIf="showMigrateAndReplicationActions"
                     class="btn-group mb-4 me-2 secondary"
-                    [permission]="permission"
+                    [permission]="permissions.rgw"
                     [btnColor]="'light'"
                     [selection]="selection"
                     [tableActions]="migrateTableAction">
   </cd-table-actions>
   <cd-table-actions *ngIf="!showMigrateAndReplicationActions"
                     class="btn-group mb-4 me-2"
-                    [permission]="permission"
+                    [permission]="permissions.rgw"
                     [selection]="selection"
                     [tableActions]="createTableActions"
                     [primaryDropDown]="true">
   </cd-table-actions>
   <cd-table-actions class="btn-group mb-4 me-2"
-                    [permission]="permission"
+                    [permission]="permissions.rgw"
                     [btnColor]="'light'"
                     [selection]="selection"
                     [tableActions]="importAction">
   </cd-table-actions>
   <cd-table-actions class="btn-group mb-4 me-2"
-                    [permission]="permission"
+                    [permission]="permissions.rgw"
                     [btnColor]="'light'"
                     [selection]="selection"
                     [tableActions]="exportAction">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
@@ -21,7 +21,7 @@ import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdTableAction } from '~/app/shared/models/cd-table-action';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
-import { Permission } from '~/app/shared/models/permissions';
+import { Permissions } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -68,7 +68,7 @@ export class RgwMultisiteDetailsComponent implements OnDestroy, OnInit {
   blockUI: NgBlockUI;
 
   icons = Icons;
-  permission: Permission;
+  permissions: Permissions;
   selection = new CdTableSelection();
   createTableActions: CdTableAction[];
   migrateTableAction: CdTableAction[];
@@ -144,7 +144,7 @@ export class RgwMultisiteDetailsComponent implements OnDestroy, OnInit {
     private rgwMultisiteService: RgwMultisiteService,
     private changeDetectionRef: ChangeDetectorRef
   ) {
-    this.permission = this.authStorageService.getPermissions().rgw;
+    this.permissions = this.authStorageService.getPermissions();
   }
 
   openModal(entity: any | string, edit = false) {
@@ -305,22 +305,17 @@ export class RgwMultisiteDetailsComponent implements OnDestroy, OnInit {
         },
         (_error) => {}
       );
-    this.mgrModuleService.list().subscribe((moduleData: any) => {
-      this.rgwModuleData = moduleData.filter((module: object) => module['name'] === 'rgw');
-      if (this.rgwModuleData.length > 0) {
-        this.rgwModuleStatus = this.rgwModuleData[0].enabled;
-      }
-    });
+
+    // Only get the module status if you can read from configOpt
+    if (this.permissions.configOpt.read) {
+      this.mgrModuleService.list().subscribe((moduleData: any) => {
+        this.rgwModuleData = moduleData.filter((module: object) => module['name'] === 'rgw');
+        if (this.rgwModuleData.length > 0) {
+          this.rgwModuleStatus = this.rgwModuleData[0].enabled;
+        }
+      });
+    }
   }
-  /* setConfigValues() {
-    this.rgwDaemonService
-      .setMultisiteConfig(
-        this.defaultsInfo['defaultRealmName'],
-        this.defaultsInfo['defaultZonegroupName'],
-        this.defaultsInfo['defaultZoneName']
-      )
-      .subscribe(() => {});
-  }*/
 
   ngOnDestroy() {
     this.sub.unsubscribe();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts
@@ -43,6 +43,8 @@ import { RgwMultisiteWizardComponent } from '../rgw-multisite-wizard/rgw-multisi
 import { RgwMultisiteSyncPolicyComponent } from '../rgw-multisite-sync-policy/rgw-multisite-sync-policy.component';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { RgwMultisiteService } from '~/app/shared/api/rgw-multisite.service';
+import { MgrModuleInfo } from '~/app/shared/models/mgr-modules.interface';
+import { RGW } from '../utils/constants';
 
 const BASE_URL = 'rgw/multisite/configuration';
 
@@ -307,18 +309,20 @@ export class RgwMultisiteDetailsComponent implements OnDestroy, OnInit {
       );
 
     // Only get the module status if you can read from configOpt
-    if (this.permissions.configOpt.read) {
-      this.mgrModuleService.list().subscribe((moduleData: any) => {
-        this.rgwModuleData = moduleData.filter((module: object) => module['name'] === 'rgw');
-        if (this.rgwModuleData.length > 0) {
-          this.rgwModuleStatus = this.rgwModuleData[0].enabled;
-        }
-      });
-    }
+    if (this.permissions.configOpt.read) this.getRgwModuleStatus();
   }
 
   ngOnDestroy() {
     this.sub.unsubscribe();
+  }
+
+  private getRgwModuleStatus() {
+    this.mgrModuleService.list().subscribe((moduleData: MgrModuleInfo[]) => {
+      this.rgwModuleData = moduleData.filter((module: MgrModuleInfo) => module.name === RGW);
+      if (this.rgwModuleData.length > 0) {
+        this.rgwModuleStatus = this.rgwModuleData[0].enabled;
+      }
+    });
   }
 
   private abstractTreeData(multisiteInfo: [object, object, object]): any[] {
@@ -632,7 +636,7 @@ export class RgwMultisiteDetailsComponent implements OnDestroy, OnInit {
     };
 
     if (!this.rgwModuleStatus) {
-      $obs = this.mgrModuleService.enable('rgw');
+      $obs = this.mgrModuleService.enable(RGW);
     }
     $obs.subscribe(
       () => undefined,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/constants.ts
@@ -1,0 +1,1 @@
+export const RGW = 'rgw';

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/administration/administration.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/administration/administration.component.html
@@ -1,7 +1,6 @@
 <cds-overflow-menu [customTrigger]="customTrigger"
                    [flip]="true">
-  <li class="cds--overflow-menu-options__option mb-2"
-      *ngIf="userPermission.read">
+  <li class="cds--overflow-menu-options__option mb-2">
     <button routerLink="/user-management"
             class="cds--overflow-menu-options__btn"
             i18n>User management</button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -39,7 +39,8 @@
       <div class="cds--btn cds--btn--icon-only cds--header__action">
         <cd-dashboard-help></cd-dashboard-help>
       </div>
-      <div class="cds--btn cds--btn--icon-only cds--header__action">
+      <div class="cds--btn cds--btn--icon-only cds--header__action"
+           *ngIf="permissions.user.read">
         <cd-administration></cd-administration>
       </div>
       <div class="cds--btn cds--btn--icon-only cds--header__action">
@@ -93,6 +94,7 @@
         </cds-sidenav-item>
         <!-- Multi-cluster Dashboard -->
         <cds-sidenav-menu title="Multi-Cluster"
+                          *ngIf="permissions.configOpt.read"
                           i18n-title>
           <svg cdsIcon="edge-cluster"
                icon

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
@@ -6,6 +6,7 @@ import { Observable, timer as observableTimer } from 'rxjs';
 import { NotificationService } from '../services/notification.service';
 import { TableComponent } from '../datatable/table/table.component';
 import { Router } from '@angular/router';
+import { MgrModuleInfo } from '../models/mgr-modules.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -28,8 +29,8 @@ export class MgrModuleService {
    * Get the list of Ceph Mgr modules and their state (enabled/disabled).
    * @return {Observable<Object[]>}
    */
-  list(): Observable<Object[]> {
-    return this.http.get<Object[]>(`${this.url}`);
+  list(): Observable<MgrModuleInfo[]> {
+    return this.http.get<MgrModuleInfo[]>(`${this.url}`);
   }
 
   /**

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/mgr-modules.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/mgr-modules.interface.ts
@@ -1,0 +1,21 @@
+export interface MgrModuleInfo {
+  name: string;
+  enabled: boolean;
+  always_on: boolean;
+  options: Record<string, MgrModuleOption>;
+}
+
+interface MgrModuleOption {
+  name: string;
+  type: string;
+  level: string;
+  flags: number;
+  default_value: number;
+  min: string;
+  max: string;
+  enum_allowed: string[];
+  desc: string;
+  long_desc: string;
+  tags: string[];
+  see_also: string[];
+}

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -232,6 +232,7 @@ BLOCK_MGR_ROLE = Role(
         Scope.RBD_MIRRORING: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
         Scope.NVME_OF: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+        Scope.PROMETHEUS: [_P.READ]
     })
 
 
@@ -240,6 +241,7 @@ RGW_MGR_ROLE = Role(
     'rgw-manager', 'allows full permissions for the rgw scope', {
         Scope.RGW: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
+        Scope.PROMETHEUS: [_P.READ]
     })
 
 
@@ -263,6 +265,7 @@ POOL_MGR_ROLE = Role(
     'pool-manager', 'allows full permissions for the pool scope', {
         Scope.POOL: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
+        Scope.PROMETHEUS: [_P.READ]
     })
 
 # CephFS manager role provides all permissions for CephFS related scopes
@@ -270,6 +273,7 @@ CEPHFS_MGR_ROLE = Role(
     'cephfs-manager', 'allows full permissions for the cephfs scope', {
         Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
+        Scope.PROMETHEUS: [_P.READ]
     })
 
 GANESHA_MGR_ROLE = Role(
@@ -278,7 +282,8 @@ GANESHA_MGR_ROLE = Role(
         Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.RGW: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
-        Scope.SMB: [_P.READ]
+        Scope.SMB: [_P.READ],
+        Scope.PROMETHEUS: [_P.READ]
     })
 
 SMB_MGR_ROLE = Role(
@@ -287,7 +292,8 @@ SMB_MGR_ROLE = Role(
         Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.RGW: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
-        Scope.NFS_GANESHA: [_P.READ]
+        Scope.NFS_GANESHA: [_P.READ],
+        Scope.PROMETHEUS: [_P.READ]
     })
 
 


### PR DESCRIPTION
**AFTER**
![image](https://github.com/user-attachments/assets/a5fa35ab-1af2-49fa-bd82-e75ba52c7d7e)


**BEFORE**
![Screenshot From 2025-03-06 10-45-18](https://github.com/user-attachments/assets/c3ec99dc-db84-4f3b-85f1-b09eeb7104f6)


Since prometheus is being used in the dashboard page we need to make sure every role has prometheus read only access so that the dashboard page can load the utilization metrics.

I also saw permission issue with the osd settings endpoint when its trying to get the nearfull/full ratio. so instead of failing the entire page i am proceeding with a chart that doesn't have those details when the user doesn't have permission to access the config opt.

Multisite page was not accessible in the case of rgw-manager or read-only user because its trying to show the status of rgw module. This si also now gracefully handled to show the alert only when the user has sufficient permission.

Fixes: https://tracker.ceph.com/issues/70331





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
