### PR TITLE
reef: blk/kerneldevice: notify_all only required when discard_drain wait for condition

### DIFF
--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -53,6 +53,7 @@ private:
   void *discard_callback_priv;
   bool aio_stop;
   bool discard_stop;
+  bool need_notify = false;
 
   ceph::mutex discard_lock = ceph::make_mutex("KernelDevice::discard_lock");
   ceph::condition_variable discard_cond;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70147

---

backport of https://github.com/ceph/ceph/pull/59529
parent tracker: https://tracker.ceph.com/issues/67835

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh