### PR TITLE
rgw: add coroutine wait for auth cache

### DIFF
--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -114,6 +114,12 @@ add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
 add_ceph_unittest(unittest_rgw_reshard_wait)
 target_link_libraries(unittest_rgw_reshard_wait ${rgw_libs})
 
+# unittest_rgw_auth_keystone
+add_executable(unittest_rgw_auth_keystone test_rgw_auth_keystone.cc)
+add_ceph_unittest(unittest_rgw_auth_keystone)
+find_package(Boost REQUIRED COMPONENTS coroutine)
+target_link_libraries(unittest_rgw_auth_keystone ${rgw_libs} Boost::coroutine)
+
 set(test_rgw_a_src test_rgw_common.cc)
 add_library(test_rgw_a STATIC ${test_rgw_a_src})
 target_link_libraries(test_rgw_a ${rgw_libs})

--- a/src/test/rgw/test_rgw_auth_keystone.cc
+++ b/src/test/rgw/test_rgw_auth_keystone.cc
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+#include <boost/asio.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/optional.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <thread>
+#include <vector>
+#include "rgw_auth_keystone.h"
+
+using namespace boost::asio;
+
+class SecretCacheTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+	cct.reset(new CephContext(CEPH_ENTITY_TYPE_CLIENT));
+        // Initialize the cache with a valid token
+        cache.add("valid_token", token, "valid_secret");
+    }
+
+    void TearDown() override {
+        // Clear the cache after each test
+        cache.clear();
+    }
+
+    boost::intrusive_ptr<CephContext> cct;
+    rgw::auth::keystone::SecretCache cache(cct);
+    rgw::keystone::TokenEnvelope token;
+};
+
+TEST_F(SecretCacheTest, TokenFoundInCache) {
+    optional_yield y{null_yield}; // No yield context for synchronous test
+
+    auto result = cache.find("valid_token", y);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result->get<1>(), "valid_secret");
+}
+
+TEST_F(SecretCacheTest, TokenNotFoundInCache) {
+    optional_yield y{null_yield}; // No yield context for synchronous test
+
+    auto result = cache.find("invalid_token", y);
+    ASSERT_FALSE(result);
+}
+
+TEST_F(SecretCacheTest, TokenLookupWithWaiting) {
+    io_context io_ctx;
+
+    // Spawn a coroutine to simulate an asynchronous lookup
+    spawn(io_ctx, [&](yield_context yield) {
+        optional_yield y{yield};
+
+        // Attempt to find the token (should wait)
+        auto result = cache.find("valid_token", y);
+        ASSERT_TRUE(result); // Token should be found after waiting
+        EXPECT_EQ(result->get<1>(), "valid_secret");
+    });
+
+    io_ctx.run();
+}
+
+TEST_F(SecretCacheTest, ConcurrentAccess) {
+    const int num_threads = 10;
+    std::vector<std::thread> threads;
+    std::vector<bool> results(num_threads, false);
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&, i]() {
+            io_context io_ctx;
+
+            spawn(io_ctx, [&](yield_context yield) {
+                optional_yield y{yield};
+
+                // Attempt to find the token
+                auto result = cache.find("valid_token", y);
+                results[i] = (result && result->get<1>() == "valid_secret");
+            });
+
+            io_ctx.run();
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify that all threads found the token
+    for (bool result : results) {
+        EXPECT_TRUE(result);
+    }
+}
+
+TEST_F(SecretCacheTest, TokenLookupWithAuthRequestCacheWait) {
+    io_context io_ctx;
+
+    // Spawn a coroutine to simulate an asynchronous lookup
+    spawn(io_ctx, [&](yield_context yield) {
+        optional_yield y{yield};
+
+        // Remove the token from the cache to simulate a cache miss
+        cache.clear();
+
+        // Attempt to find the token (should wait)
+        auto result = cache.find("valid_token", y);
+        ASSERT_TRUE(result);
+        EXPECT_EQ(result->get<1>(), "valid_secret");
+    });
+
+    // Add the token to the cache after a short delay
+    std::thread([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        cache.add("valid_token", token, "valid_secret");
+    }).detach();
+
+    io_ctx.run();
+}


### PR DESCRIPTION
fixes: https://tracker.ceph.com/issues/67793





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
