### PR TITLE
squid: rgw: use object ARN for InitMultipart permissions

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6204,7 +6204,8 @@ int RGWInitMultipart::verify_permission(optional_yield y)
   // add server-side encryption headers
   rgw_iam_add_crypt_attrs(s->env, s->info.crypt_attribute_map);
 
-  if (!verify_bucket_permission(this, s, rgw::IAM::s3PutObject)) {
+  if (!verify_bucket_permission(this, s, ARN(s->object->get_obj()),
+                                rgw::IAM::s3PutObject)) {
     return -EACCES;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70340

---

backport of https://github.com/ceph/ceph/pull/62020
parent tracker: https://tracker.ceph.com/issues/70191

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh