### PR TITLE
squid: radosgw-admin: lower default thread pool size

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3355,7 +3355,12 @@ int main(int argc, const char **argv)
     exit(0);
   }
 
-  auto cct = rgw_global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+  // alternative defaults for radosgw-admin
+  map<std::string,std::string> defaults = {
+    { "rgw_thread_pool_size", "8" },
+  };
+
+  auto cct = rgw_global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			     CODE_ENVIRONMENT_UTILITY, 0);
   ceph::async::io_context_pool context_pool(cct->_conf->rgw_thread_pool_size);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70343

---

backport of https://github.com/ceph/ceph/pull/62018
parent tracker: https://tracker.ceph.com/issues/70219

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh