### PR TITLE
qa/rgw: use storage classes for rgw/crypt

### DIFF
--- a/qa/suites/rgw/bucket-logging/overrides.yaml
+++ b/qa/suites/rgw/bucket-logging/overrides.yaml
@@ -7,7 +7,9 @@ overrides:
         debug rgw: 20
         rgw bucket logging obj roll time: 5
   rgw:
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      FROZEN:
   s3tests:
     accounts:
       iam root: RGW88888888888888888

--- a/qa/suites/rgw/cloud-transition/overrides.yaml
+++ b/qa/suites/rgw/cloud-transition/overrides.yaml
@@ -13,9 +13,12 @@ overrides:
         rgw lc debug interval: 10
         rgw_restore_debug_interval: 20
   rgw:
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      FROZEN:
     frontend: beast
   s3tests:
+    storage classes: LUKEWARM, FROZEN
     accounts:
       iam root: RGW88888888888888888
       iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/cloud-transition/tasks/restore/cloud_restore_s3tests.yaml
+++ b/qa/suites/rgw/cloud-transition/tasks/restore/cloud_restore_s3tests.yaml
@@ -2,7 +2,6 @@ tasks:
 - install:
 - ceph:
 - rgw:
-    storage classes: LUKEWARM, FROZEN
     client.0:
       port: 8000
     client.1:
@@ -25,7 +24,6 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      storage classes: LUKEWARM, FROZEN
       extra_attrs: ["cloud_restore"]
       lc_debug_interval: 10
       rgw_restore_debug_interval: 20

--- a/qa/suites/rgw/cloud-transition/tasks/transition/cloud_transition_s3tests.yaml
+++ b/qa/suites/rgw/cloud-transition/tasks/transition/cloud_transition_s3tests.yaml
@@ -2,7 +2,6 @@ tasks:
 - install:
 - ceph:
 - rgw:
-    storage classes: LUKEWARM, FROZEN
     client.0:
       port: 8000
     client.1:
@@ -49,7 +48,6 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      storage classes: LUKEWARM, FROZEN
       extra_attrs: ["cloud_transition"]
       lc_debug_interval: 10
       lifecycle_tests: True
@@ -57,7 +55,6 @@ tasks:
     #client.2:
       #force-branch: ceph-master
       #rgw_server: client.2
-      #storage classes: LUKEWARM, FROZEN
       #extra_attrs: ["cloud_transition"]
       #lc_debug_interval: 10
       #cloudtier_tests: True

--- a/qa/suites/rgw/crypt/overrides.yaml
+++ b/qa/suites/rgw/crypt/overrides.yaml
@@ -1,5 +1,11 @@
 overrides:
+  rgw:
+    compression type: random
+    storage classes:
+      LUKEWARM: [--compression, zlib]
+      FROZEN:
   s3tests:
+    storage classes: LUKEWARM, FROZEN
     accounts:
       iam root: RGW88888888888888888
       iam alt root: RGW99999999999999999

--- a/qa/suites/rgw/lifecycle/overrides.yaml
+++ b/qa/suites/rgw/lifecycle/overrides.yaml
@@ -12,7 +12,9 @@ overrides:
         rgw s3 auth use sts: true
         rgw lc debug interval: 10
   rgw:
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      FROZEN:
   s3tests:
     accounts:
       iam root: RGW88888888888888888

--- a/qa/suites/rgw/lua/overrides.yaml
+++ b/qa/suites/rgw/lua/overrides.yaml
@@ -6,4 +6,6 @@ overrides:
         setgroup: ceph
         debug rgw: 20
   rgw:
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      FROZEN:

--- a/qa/suites/rgw/multifs/overrides.yaml
+++ b/qa/suites/rgw/multifs/overrides.yaml
@@ -11,7 +11,13 @@ overrides:
         rgw sts key: abcdefghijklmnop
         rgw s3 auth use sts: true
   rgw:
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      - --data-pool
+      - default.rgw.buckets.data.lukewarm
+      FROZEN:
+      - --data-pool
+      - default.rgw.buckets.data.frozen
   s3tests:
     storage classes: LUKEWARM, FROZEN
     accounts:

--- a/qa/suites/rgw/notifications/overrides.yaml
+++ b/qa/suites/rgw/notifications/overrides.yaml
@@ -14,4 +14,6 @@ overrides:
     realm: MyRealm
     zonegroup: MyZoneGroup
     zone: MyZone
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      FROZEN:

--- a/qa/suites/rgw/sts/overrides.yaml
+++ b/qa/suites/rgw/sts/overrides.yaml
@@ -15,7 +15,9 @@ overrides:
         rgw sts key: abcdefghijklmnop
         rgw s3 auth use sts: true
   rgw:
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      FROZEN:
   s3tests:
     storage classes: LUKEWARM, FROZEN
     accounts:

--- a/qa/suites/rgw/verify/overrides.yaml
+++ b/qa/suites/rgw/verify/overrides.yaml
@@ -17,7 +17,9 @@ overrides:
         rgw reshard progress judge interval: 10
   rgw:
     compression type: random
-    storage classes: LUKEWARM, FROZEN
+    storage classes:
+      LUKEWARM:
+      FROZEN:
   s3tests:
     storage classes: LUKEWARM, FROZEN
     accounts:


### PR DESCRIPTION
adjust the rgw task's yaml format for "storage classes" so that the rgw/crypt suite can enable compression

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
