### PR TITLE
mgr/smb: Add ceph_snapshots vfs module to share definition

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
@@ -43,7 +43,7 @@ tasks:
             globals = ["default", "domain"]
             instance_name = "SAMBA"
             [shares.share1.options]
-            "vfs objects" = "acl_xattr ceph"
+            "vfs objects" = "acl_xattr ceph_snapshots ceph"
             path = "/"
             "acl_xattr:security_acl_name" = "user.NTACL"
             "ceph:config_file" = "/etc/ceph/ceph.conf"

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
@@ -42,7 +42,7 @@ tasks:
           globals = ["default", "domain"]
           instance_name = "SAMBA"
           [shares.share1.options]
-          "vfs objects" = "acl_xattr ceph"
+          "vfs objects" = "acl_xattr ceph_snapshots ceph"
           path = "/"
           "acl_xattr:security_acl_name" = "user.NTACL"
           "ceph:config_file" = "/etc/ceph/ceph.conf"

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1187,7 +1187,7 @@ def _generate_share(
         # smb.conf options
         'options': {
             'path': path,
-            "vfs objects": f"acl_xattr {ceph_vfs}",
+            "vfs objects": f"acl_xattr ceph_snapshots {ceph_vfs}",
             'acl_xattr:security_acl_name': 'user.NTACL',
             f'{ceph_vfs}:config_file': '/etc/ceph/ceph.conf',
             f'{ceph_vfs}:filesystem': cephfs.volume,


### PR DESCRIPTION
In order to expose and manage snapshots as previous versions from Windows we make use of the existing _ceph_snapshots_ vfs module from Samba. _vfs_ceph_snapshots_ by default assumes the snap directory to be named "_.snap_" with an option to configure a different name to match the value for '_client_snapdir_' parameter for CephFS client. We follow the default behaviour to avoid further complications on a live running cluster and thereby recommend to keep the default for '_client_snapdir_'. This limitation may slightly change in future to dynamically detect the current snap directory name while shares are created and not afterwards.

ref: https://www.samba.org/samba/docs/current/man-html/vfs_ceph_snapshots.8.html