### PR TITLE
mgr/vol: allow passing multiple data pools and creating pools for "volume create" cmd

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -215,6 +215,10 @@
 
 * RGW: Add support for the `RestrictPublicBuckets` property of the S3 `PublicAccessBlock`
   configuration.
+* CephFS: The "ceph fs volume create" command now allows users to pass a list of
+  data pool names instead of a single data pool name, and the command adds all
+  of these data pools to the created volume right after its creation.
+
 
 * RBD: Moving an image that is a member of a group to trash is no longer
   allowed.  `rbd trash mv` command now behaves the same way as `rbd rm` in this

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -219,6 +219,12 @@
   data pool names instead of a single data pool name, and the command adds all
   of these data pools to the created volume right after its creation.
 
+* CephFS: The "ceph fs volume create" command now creates pools if the pool
+  names passed to the command are non-existent. If the list of pool names
+  passed is a mix of existing and unexisting pools, the command will create
+  the ones that are unexisting and then will add all pools to the created
+  volume.
+
 
 * RBD: Moving an image that is a member of a group to trash is no longer
   allowed.  `rbd trash mv` command now behaves the same way as `rbd rm` in this

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -58,6 +58,10 @@ optional string that specifies the :ref:`orchestrator-cli-placement-spec` for
 the MDS. See also :ref:`orchestrator-cli-cephfs` for more examples on
 placement.
 
+This command can also accept a comma-separated list of data pools names::
+
+    ceph fs volume create <vol_name> --data-pool <data-pool-1>,<data-pool-2>,<data-pool-3>
+
 .. note:: Specifying placement via a YAML file is not supported through the
           volume interface.
 

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -62,6 +62,8 @@ This command can also accept a comma-separated list of data pools names::
 
     ceph fs volume create <vol_name> --data-pool <data-pool-1>,<data-pool-2>,<data-pool-3>
 
+.. note:: If a specified pool does not exist, it will be created.
+
 .. note:: Specifying placement via a YAML file is not supported through the
           volume interface.
 

--- a/doc/cephfs/multifs.rst
+++ b/doc/cephfs/multifs.rst
@@ -38,6 +38,8 @@ Multiple data pools can be specified with a comma-spearated list::
 
     ceph fs volume create <vol-name> --meta-pool <meta-pool-name> --data-pool <data-pool-1>,<data-pool-2>,<data-pool-3>
 
+If any specified pool does not exist, it will be created.
+
 
 Securing access
 ---------------

--- a/doc/cephfs/multifs.rst
+++ b/doc/cephfs/multifs.rst
@@ -34,6 +34,9 @@ these pool(s) can be passed as follows::
 
     ceph fs volume create <vol-name> --meta-pool <meta-pool-name> --data-pool <data-pool-name>
 
+Multiple data pools can be specified with a comma-spearated list::
+
+    ceph fs volume create <vol-name> --meta-pool <meta-pool-name> --data-pool <data-pool-1>,<data-pool-2>,<data-pool-3>
 
 
 Securing access

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -995,6 +995,46 @@ class TestVolumeCreate(TestVolumesHelper):
         for i in data.split(','):
             self.assertIn(f'{i}', output)
 
+    def test_passing_list_of_unexisting_data_pool(self):
+        v = self._gen_vol_name()
+
+        meta = f'ceph.{v}.meta'
+        self.run_ceph_cmd(f'osd pool create {meta}')
+
+        data = f'ceph.{v}.data1,ceph.{v}.data2,ceph.{v}.data3'
+
+        self.run_ceph_cmd(f'fs volume create {v} --meta-pool {meta} --data-pool {data}')
+
+        # ensure that the volume was created by above "fs volume create"
+        output = self.get_ceph_cmd_stdout('fs ls')
+        self.assertIn(f'name: {v}', output)
+
+        # ensure that all data pools were created by above "fs volume create"
+        # command.
+        for i in data.split(','):
+            self.assertIn(f'{i}', output)
+
+    def test_mix_of_existing_and_unexisting_data_pool_names(self):
+        v = self._gen_vol_name()
+
+        meta = f'ceph.{v}.meta'
+        self.run_ceph_cmd(f'osd pool create {meta}')
+
+        data = f'ceph.{v}.data1,ceph.{v}.data2,ceph.{v}.data3'
+        for i in data.split(',')[:-1]:
+            self.run_ceph_cmd(f'osd pool create {i}')
+
+        self.run_ceph_cmd(f'fs volume create {v} --meta-pool {meta} --data-pool {data}')
+
+        # ensure that the volume was created by above "fs volume create"
+        output = self.get_ceph_cmd_stdout('fs ls')
+        self.assertIn(f'name: {v}', output)
+
+        # ensure that all the data pools were created by above "fs volume
+        # create" command.
+        for i in data.split(','):
+            self.assertIn(f'{i}', output)
+
 
 class TestRenameCmd(TestVolumesHelper):
 

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -975,6 +975,27 @@ class TestVolumeCreate(TestVolumesHelper):
         self.assertIn(data_pool, o)
         self.assertNotIn(non_existent_meta_pool, o)
 
+    def test_passing_list_of_multiple_data_pools(self):
+        v = self._gen_vol_name()
+
+        meta = f'ceph.{v}.meta'
+        self.run_ceph_cmd(f'osd pool create {meta}')
+
+        data = f'ceph.{v}.data1,ceph.{v}.data2,ceph.{v}.data3'
+        for i in data.split(','):
+            self.run_ceph_cmd(f'osd pool create {i}')
+
+        self.run_ceph_cmd(f'fs volume create {v} --meta-pool {meta} --data-pool {data}')
+
+        # ensure that the volume was created by above "fs volume create"
+        output = self.get_ceph_cmd_stdout('fs ls')
+        self.assertIn(f'name: {v}', output)
+
+        # ensure that all data pools are used by the volume created above
+        for i in data.split(','):
+            self.assertIn(f'{i}', output)
+
+
 class TestRenameCmd(TestVolumesHelper):
 
     def test_volume_rename(self):

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -27,6 +27,11 @@ def rename_pool(mgr, pool_name, new_pool_name):
                'destpool': new_pool_name}
     return mgr.mon_command(command)
 
+def add_data_pool_to_fs(mgr, fs_name, data_pool):
+    command = {'prefix': 'fs add_data_pool', 'fs_name': fs_name,
+               'pool': data_pool}
+    return mgr.mon_command(command)
+
 def create_filesystem(mgr, fs_name, metadata_pool, data_pool):
     command = {'prefix': 'fs new', 'fs_name': fs_name, 'metadata': metadata_pool,
                'data': data_pool}

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -54,7 +54,17 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    f'name=name,type=CephString,goodchars={goodchars} '
                    'name=placement,type=CephString,req=false '
                   f'name=meta_pool,type=CephString,goodchars={goodchars},req=false '
-                  f'name=data_pool,type=CephString,goodchars={goodchars},req=false ',
+                  # XXX goodchars here is not being passed deliberately since
+                  # --data-pool can receive a list of data pool names separated
+                  # by commas and that is a problem. If goodchars variable
+                  # declared in this module is passed as it is(that is without
+                  # adding comma to it), arg parser would reject comma separated
+                  # data pool names. And if comma is added to goodchars and then
+                  # passed below, arg parser misinterprets it since comma has a
+                  # special # meaning for it. So the best option is to not
+                  # restrict data pool names to goodchars and do that
+                  # restriction elsewhere.
+                  f'name=data_pool,type=CephString,req=false ',
             'desc': "Create a CephFS volume",
             'perm': 'rw'
         },


### PR DESCRIPTION
1. Allow passing multiple data pool names to "ceph fs volume create" command. Fixes: https://tracker.ceph.com/issues/70357

2. If pool names passed to "ceph fs volume create" command are non-existent, create them before creating data pool name. Fixes: https://tracker.ceph.com/issues/70358







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>