### PR TITLE
cephfs,mon: disallow non-empty data pool for "fs new" and "fs add_data_pool" cmd

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -499,6 +499,76 @@ class TestFsNew(TestAdminCommands):
     """
     MDSS_REQUIRED = 3
 
+    def test_that_nonempty_metadata_pool_isnt_allowed_by_default(self):
+        '''
+        Test that "ceph fs new" command fails when non-empty metadata pool is
+        passed (without passing --force).
+        '''
+        fs = 'somefs'
+        meta = f'cephfs.{fs}.meta'
+        data = f'cephfs.{fs}.data'
+
+        self.run_ceph_cmd(f'osd pool create {meta}')
+        self.run_ceph_cmd(f'osd pool create {data}')
+        self.mon_manager.controller.run(args='echo somedata > file1')
+        self.mon_manager.do_rados(['put', 'obj1', 'file1', '--pool', meta])
+        # XXX some time is required for stats to be generated so that "fs new"
+        # command, which is called by "fs volume create" command, can detect
+        # that the meta pool is not empty and therefore abort with an error.
+        sleep(5)
+
+        try:
+            # actual test...
+            self.negtest_ceph_cmd(f'fs new {fs} {meta} {data}',
+                                  retval=errno.EINVAL,
+                                  errmsgs=('already contains some objects. use '
+                                           'an empty pool instead'))
+
+            # being extra sure that volume wasn't created
+            output = self.get_ceph_cmd_stdout('fs ls').lower()
+            self.assertNotIn(fs, output)
+        # regardless of how this test goes, ensure that these leftover pools
+        # are deleted. else, they might mess up the teardown or setup code
+        # somehow.
+        finally:
+            self.run_ceph_cmd(f'osd pool rm {meta} {meta} '
+                               '--yes-i-really-really-mean-it')
+            self.run_ceph_cmd(f'osd pool rm {data} {data} '
+                               '--yes-i-really-really-mean-it')
+
+    def test_that_nonempty_metadata_pool_is_allowed_with_force(self):
+        '''
+        Test that "ceph fs new" command passes when non-empty metadata pool is
+        passed along with --force.
+        '''
+        fs = 'somefs'
+        meta = f'cephfs.{fs}.meta'
+        data = f'cephfs.{fs}.data'
+
+        self.run_ceph_cmd(f'osd pool create {meta}')
+        self.run_ceph_cmd(f'osd pool create {data}')
+        self.mon_manager.controller.run(args='echo somedata > file1')
+        self.mon_manager.do_rados(['put', 'obj1', 'file1', '--pool', meta])
+        # XXX some time is required for stats to be generated so that "fs new"
+        # command, which is called by "fs volume create" command, can detect
+        # that the meta pool is not empty and therefore abort with an error.
+        sleep(5)
+
+        try:
+            # actual test...
+            self.run_ceph_cmd(f'fs new {fs} {meta} {data} --force')
+
+            # being extra sure that volume wasn't created
+            output = self.get_ceph_cmd_stdout('fs ls').lower()
+            self.assertNotIn(fs, output)
+        # regardless of how this test goes, ensure that these leftover pools
+        # are deleted. else, they might mess up the teardown or setup code
+        # somehow.
+        finally:
+            self.run_ceph_cmd(f'osd pool rm {meta} {meta} '
+                               '--yes-i-really-really-mean-it')
+            self.run_ceph_cmd(f'osd pool rm {data} {data} ')
+
     def test_fsnames_can_only_by_goodchars(self):
         n = 'test_fsnames_can_only_by_goodchars'
         metapoolname, datapoolname = n+'-testmetapool', n+'-testdatapool'

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -569,6 +569,77 @@ class TestFsNew(TestAdminCommands):
                                '--yes-i-really-really-mean-it')
             self.run_ceph_cmd(f'osd pool rm {data} {data} ')
 
+    def test_that_nonempty_data_pool_isnt_allowed_by_default(self):
+        '''
+        Test that "ceph fs new" command fails when non-empty data pool is
+        passed (without passing --force).
+        '''
+        fs = 'somefs'
+        meta = f'cephfs.{fs}.meta'
+        data = f'cephfs.{fs}.data'
+
+        self.run_ceph_cmd(f'osd pool create {meta}')
+        self.run_ceph_cmd(f'osd pool create {data}')
+        self.mon_manager.controller.run(args='echo somedata > file1')
+        self.mon_manager.do_rados(['put', 'obj1', 'file1', '--pool', data])
+        # XXX some time is required for stats to be generated so that "fs new"
+        # command, which is called by "fs volume create" command, can detect
+        # that the meta pool is not empty and therefore abort with an error.
+        sleep(5)
+
+        try:
+            # actual test...
+            self.negtest_ceph_cmd(f'fs new {fs} {meta} {data}',
+                                  retval=errno.EINVAL,
+                                  errmsgs=('already contains some objects. use '
+                                           'an empty pool instead'))
+
+            # being extra sure that volume wasn't created
+            output = self.get_ceph_cmd_stdout('fs ls').lower()
+            self.assertNotIn(fs, output)
+        # regardless of how this test goes, ensure that these leftover pools
+        # are deleted. else, they might mess up the teardown or setup code
+        # somehow.
+        finally:
+            self.run_ceph_cmd(f'osd pool rm {meta} {meta} '
+                               '--yes-i-really-really-mean-it')
+            self.run_ceph_cmd(f'osd pool rm {data} {data} '
+                               '--yes-i-really-really-mean-it')
+
+    def test_that_nonempty_data_pool_is_allowed_with_force(self):
+        '''
+        Test that "ceph fs new" command passes when non-empty adata pool is
+        passed along with --force.
+        '''
+        fs = 'somefs'
+        meta = f'cephfs.{fs}.meta'
+        data = f'cephfs.{fs}.data'
+
+        self.run_ceph_cmd(f'osd pool create {meta}')
+        self.run_ceph_cmd(f'osd pool create {data}')
+        self.mon_manager.controller.run(args='echo somedata > file1')
+        self.mon_manager.do_rados(['put', 'obj1', 'file1', '--pool', data])
+        # XXX some time is required for stats to be generated so that "fs new"
+        # command, which is called by "fs volume create" command, can detect
+        # that the meta pool is not empty and therefore abort with an error.
+        sleep(5)
+
+        try:
+            # actual test...
+            self.run_ceph_cmd(f'fs new {fs} {meta} {data} --force')
+
+            # being extra sure that volume wasn't created
+            output = self.get_ceph_cmd_stdout('fs ls').lower()
+            self.assertIn(fs, output)
+        # regardless of how this test goes, ensure that these leftover pools
+        # are deleted. else, they might mess up the teardown or setup code
+        # somehow.
+        finally:
+            self.run_ceph_cmd(f'osd pool rm {meta} {meta} '
+                               '--yes-i-really-really-mean-it')
+            self.run_ceph_cmd(f'osd pool rm {data} {data} '
+                               '--yes-i-really-really-mean-it')
+
     def test_fsnames_can_only_by_goodchars(self):
         n = 'test_fsnames_can_only_by_goodchars'
         metapoolname, datapoolname = n+'-testmetapool', n+'-testdatapool'

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -975,6 +975,93 @@ class TestVolumeCreate(TestVolumesHelper):
         self.assertIn(data_pool, o)
         self.assertNotIn(non_existent_meta_pool, o)
 
+    def test_with_nonempty_data_pool_name(self):
+        '''
+        Test that when data pool name passed to the command "ceph fs volume
+        create" is an non-empty of pool, the command aborts with an appropriate
+        error number and error message.
+        '''
+        v = self._gen_vol_name()
+        meta = f'cephfs.{v}.meta'
+        data = f'cephfs.{v}.data'
+
+        self.run_ceph_cmd(f'osd pool create {meta}')
+        self.run_ceph_cmd(f'osd pool create {data}')
+        self.mon_manager.controller.run(args='echo somedata > file1')
+        self.mon_manager.do_rados(['put', 'obj1', 'file1', '--pool', data])
+        # XXX some time is required for stats to be generated so that "fs new"
+        # command, which is called by "fs volume create" command, can detect
+        # that the meta pool is not empty and therefore abort with an error.
+        time.sleep(5)
+
+        try:
+            # actual test...
+            self.negtest_ceph_cmd(f'fs volume create {v} --meta-pool {meta} '
+                                  f'--data-pool {data}',
+                                  retval=errno.EINVAL,
+                                  errmsgs=('already contains some objects. use '
+                                           'an empty pool instead'))
+
+            # being extra sure that volume wasn't created
+            output = self.get_ceph_cmd_stdout('fs ls').lower()
+            self.assertNotIn(v, output)
+        # regardless of how this test goes, ensure that these leftover pools
+        # are deleted. else, they might mess up the teardown or setup code
+        # somehow.
+        finally:
+            self.run_ceph_cmd(f'osd pool rm {meta} {meta} '
+                               '--yes-i-really-really-mean-it')
+            self.run_ceph_cmd(f'osd pool rm {data} {data} '
+                               '--yes-i-really-really-mean-it')
+
+    def test_mix_of_empty_and_nonempty_data_pool_names(self):
+        '''
+        Test that "ceph fs volume create" command fail with appropriate error
+        code and error message when a list of empty and non-empty data pool
+        names are passed to it.
+        '''
+        v = self._gen_vol_name()
+
+        meta = f'ceph.{v}.meta'
+        self.run_ceph_cmd(f'osd pool create {meta}')
+
+        data = f'ceph.{v}.data1,ceph.{v}.data2,ceph.{v}.data3'
+        for i in data.split(','):
+            self.run_ceph_cmd(f'osd pool create {i}')
+
+        # add some object to the last pool
+        obj_name = 'obj1'
+        file_name = 'file1'
+        last_data_pool_name = data.split(',')[-1]
+        self.mon_manager.controller.run(args=f'echo somedata > {file_name}')
+        self.mon_manager.do_rados(['put', obj_name, file_name, '--pool',
+                                  last_data_pool_name])
+
+        try:
+            self.negtest_ceph_cmd(f'fs volume create {v} --meta-pool {meta} '
+                                  f'--data-pool {data}',
+                                  retval=errno.EINVAL,
+                                  errmsgs=('already contains some objects. use '
+                                           'an empty pool instead'))
+        except:
+            # ensure that the volume was created by above "fs volume create"
+            output = self.get_ceph_cmd_stdout('fs ls')
+            self.assertIn(f'name: {v}', output)
+
+            # ensure that all the data pools except the last one are part of the
+            # volume that was created by above
+            for i in data.split(',')[:-1]:
+                self.assertIn(f'{i}', output)
+
+            # test that last pool name is not in the output since it was not empty.
+            self.assertNotIn(last_data_pool_name, output)
+
+            # remove this data pool so that it won't somehow mess up teardown
+            # or setup code.
+            self.run_ceph_cmd(f'osd pool rm {data} {data} '
+                               '--yes-i-really-really-mean-it')
+
+
 class TestRenameCmd(TestVolumesHelper):
 
     def test_volume_rename(self):

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -975,6 +975,41 @@ class TestVolumeCreate(TestVolumesHelper):
         self.assertIn(data_pool, o)
         self.assertNotIn(non_existent_meta_pool, o)
 
+    def test_with_nonempty_meta_pool_name_and_force(self):
+        '''
+        Test that when --force is passed along with non-empty metadata pool to
+        the command "ceph fs volume create", the command run successfully.
+        '''
+        v = self._gen_vol_name()
+        meta = f'cephfs.{v}.meta'
+        data = f'cephfs.{v}.data'
+
+        self.run_ceph_cmd(f'osd pool create {meta}')
+        self.run_ceph_cmd(f'osd pool create {data}')
+        self.mon_manager.controller.run(args='echo somedata > file1')
+        self.mon_manager.do_rados(['put', 'obj1', 'file1', '--pool', meta])
+        # XXX some time is required for stats to be generated so that "fs new"
+        # command, which is called by "fs volume create" command, can detect
+        # that the meta pool is not empty and therefore abort with an error.
+        time.sleep(5)
+
+        try:
+            # actual test...
+            self.run_ceph_cmd(f'fs volume create {v} --meta-pool {meta} '
+                              f'--data-pool {data} --force')
+
+            # being extra sure that volume wasn't created
+            output = self.get_ceph_cmd_stdout('fs ls').lower()
+            self.assertNotIn(v, output)
+        # regardless of how this test goes, ensure that these leftover pools
+        # are deleted. else, they might mess up the teardown or setup code
+        # somehow.
+        finally:
+            self.run_ceph_cmd(f'osd pool rm {meta} {meta} '
+                               '--yes-i-really-really-mean-it')
+            self.run_ceph_cmd(f'osd pool rm {data} {data} '
+                               '--yes-i-really-really-mean-it')
+
     def test_with_nonempty_data_pool_name(self):
         '''
         Test that when data pool name passed to the command "ceph fs volume
@@ -1001,6 +1036,42 @@ class TestVolumeCreate(TestVolumesHelper):
                                   retval=errno.EINVAL,
                                   errmsgs=('already contains some objects. use '
                                            'an empty pool instead'))
+
+            # being extra sure that volume wasn't created
+            output = self.get_ceph_cmd_stdout('fs ls').lower()
+            self.assertNotIn(v, output)
+        # regardless of how this test goes, ensure that these leftover pools
+        # are deleted. else, they might mess up the teardown or setup code
+        # somehow.
+        finally:
+            self.run_ceph_cmd(f'osd pool rm {meta} {meta} '
+                               '--yes-i-really-really-mean-it')
+            self.run_ceph_cmd(f'osd pool rm {data} {data} '
+                               '--yes-i-really-really-mean-it')
+
+    def test_with_nonempty_data_pool_name_and_force(self):
+        '''
+        Test that when --force is passed along with non-empty data pool to the
+        command "ceph fs volume create", the command run successfully.
+        '''
+        v = self._gen_vol_name()
+        meta = f'cephfs.{v}.meta'
+        data = f'cephfs.{v}.data'
+
+        self.run_ceph_cmd(f'osd pool create {meta}')
+        self.run_ceph_cmd(f'osd pool create {data}')
+        self.mon_manager.controller.run(args='echo somedata > file1')
+        self.mon_manager.do_rados(['put', 'obj1', 'file1', '--pool', data])
+        # XXX some time is required for stats to be generated so that "fs new"
+        # command, which is called by "fs volume create" command, can detect
+        # that the meta pool is not empty and therefore abort with an error.
+        time.sleep(5)
+
+        try:
+            # actual test...
+            self.run_ceph_cmd(f'fs volume create {v} --meta-pool {meta} '
+                              f'--data-pool {data} --force',
+                              retval=errno.EINVAL)
 
             # being extra sure that volume wasn't created
             output = self.get_ceph_cmd_stdout('fs ls').lower()

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -213,8 +213,9 @@ class FsNewHandler : public FileSystemCommandHandler
       if (stat) {
 	int64_t metadata_num_objects = stat->stats.sum.num_objects;
 	if (metadata_num_objects > 0) {
-	  ss << "pool '" << metadata_name
-	     << "' already contains some objects. Use an empty pool instead.";
+	  ss << "pool '" << metadata_name << "' already contains some objects. "
+	        "Use an empty pool instead. Pass --force if you are sure that "
+		"you wish to continue";
 	  return -EINVAL;
 	}
       }

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1098,6 +1098,9 @@ class AddDataPoolHandler : public FileSystemCommandHandler
     string poolname;
     cmd_getval(cmdmap, "pool", poolname);
 
+    bool force = false;
+    cmd_getval(cmdmap, "force", force);
+
     string fs_name;
     if (!cmd_getval(cmdmap, "fs_name", fs_name)
         || fs_name.empty()) {
@@ -1124,6 +1127,19 @@ class AddDataPoolHandler : public FileSystemCommandHandler
     if (fsp == nullptr) {
         ss << "filesystem '" << fs_name << "' does not exist";
         return -ENOENT;
+    }
+
+    if (!force) {
+      const pool_stat_t *pool_stat = mon->mgrstatmon()->get_pool_stat(poolid);
+      if (pool_stat) {
+	int64_t data_num_objects = pool_stat->stats.sum.num_objects;
+	if (data_num_objects > 0) {
+	  ss << "pool '" << poolname  << "' already contains some objects. Use "
+		"an empty pool instead. Pass --force if you are sure that you "
+		"wish to continue";
+	  return -EINVAL;
+	}
+      }
     }
 
     // no-op when the data_pool already on fs

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -219,6 +219,17 @@ class FsNewHandler : public FileSystemCommandHandler
 	  return -EINVAL;
 	}
       }
+
+      const pool_stat_t *data_pool_stat = mon->mgrstatmon()->get_pool_stat(data);
+      if (data_pool_stat) {
+	int64_t data_num_objects = data_pool_stat->stats.sum.num_objects;
+	if (!force && data_num_objects > 0) {
+	  ss << "pool '" << data_name << "' already contains some objects. Use "
+		"an empty pool instead. Pass --force if you are sure that you "
+		" wish to continue";
+	  return -EINVAL;
+	}
+      }
     }
 
     if (fsmap.filesystem_count() > 0

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -208,13 +208,15 @@ class FsNewHandler : public FileSystemCommandHandler
     bool force = false;
     cmd_getval(cmdmap, "force", force);
 
-    const pool_stat_t *stat = mon->mgrstatmon()->get_pool_stat(metadata);
-    if (stat) {
-      int64_t metadata_num_objects = stat->stats.sum.num_objects;
-      if (!force && metadata_num_objects > 0) {
-	ss << "pool '" << metadata_name
-	   << "' already contains some objects. Use an empty pool instead.";
-	return -EINVAL;
+    if (!force) {
+      const pool_stat_t *stat = mon->mgrstatmon()->get_pool_stat(metadata);
+      if (stat) {
+	int64_t metadata_num_objects = stat->stats.sum.num_objects;
+	if (metadata_num_objects > 0) {
+	  ss << "pool '" << metadata_name
+	     << "' already contains some objects. Use an empty pool instead.";
+	  return -EINVAL;
+	}
       }
     }
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -442,7 +442,8 @@ COMMAND("fs required_client_features "
         "add/remove required features of clients", "mds", "rw")
 
 COMMAND("fs add_data_pool name=fs_name,type=CephString "
-	"name=pool,type=CephString",
+	"name=pool,type=CephString "
+	"name=force,type=CephBool,req=false",
 	"add data pool <pool>", "mds", "rw")
 COMMAND("fs rm_data_pool name=fs_name,type=CephString "
 	"name=pool,type=CephString",

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -11,10 +11,11 @@ from .exception import VolumeException
 
 log = logging.getLogger(__name__)
 
-def create_pool(mgr, pool_name, **extra_args):
+def create_pool(mgr, pool_name, force, **extra_args):
     # create the given pool
     command = extra_args
-    command.update({'prefix': 'osd pool create', 'pool': pool_name})
+    command.update({'prefix': 'osd pool create', 'pool': pool_name,
+                    'force': force})
     return mgr.mon_command(command)
 
 def remove_pool(mgr, pool_name):

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -72,7 +72,7 @@ def get_pool_ids(mgr, volname):
         return None, None
     return metadata_pool_id, data_pool_ids
 
-def create_fs_pools(mgr, volname, data_pool, metadata_pool):
+def create_fs_pools(mgr, volname, data_pool, metadata_pool, force):
     '''
     Generate names of metadata pool and data pool and create these pools.
 
@@ -83,14 +83,14 @@ def create_fs_pools(mgr, volname, data_pool, metadata_pool):
 
     metadata_pool, data_pool = gen_pool_names(volname)
 
-    r, outb, outs = create_pool(mgr, metadata_pool)
+    r, outb, outs = create_pool(mgr, metadata_pool, force)
     if r != 0:
         return [False, r, outb, outs]
 
     # default to a bulk pool for data. In case autoscaling has been disabled
     # for the cluster with `ceph osd pool set noautoscale`, this will have
     # no effect.
-    r, outb, outs = create_pool(mgr, data_pool, bulk=True)
+    r, outb, outs = create_pool(mgr, data_pool, force, bulk=True)
     # cleanup
     if r != 0:
         remove_pool(mgr, metadata_pool)
@@ -98,7 +98,7 @@ def create_fs_pools(mgr, volname, data_pool, metadata_pool):
 
     return [True, data_pool, metadata_pool]
 
-def create_volume(mgr, volname, placement, data_pool, metadata_pool):
+def create_volume(mgr, volname, placement, data_pool, metadata_pool, force):
     """
     Create volume, create pools if pool names are not passed and create MDS
     based on placement passed.

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -121,8 +121,8 @@ class VolumeClient(CephfsClient["Module"]):
 
     ### volume operations -- create, rm, ls
 
-    def create_fs_volume(self, volname, placement, data_pool, meta_pool):
-        return create_volume(self.mgr, volname, placement, data_pool, meta_pool)
+    def create_fs_volume(self, volname, placement, data_pool, meta_pool, force):
+        return create_volume(self.mgr, volname, placement, data_pool, meta_pool, force)
 
     def delete_fs_volume(self, volname, confirm):
         if confirm != "--yes-i-really-mean-it":

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -54,7 +54,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    f'name=name,type=CephString,goodchars={goodchars} '
                    'name=placement,type=CephString,req=false '
                   f'name=meta_pool,type=CephString,goodchars={goodchars},req=false '
-                  f'name=data_pool,type=CephString,goodchars={goodchars},req=false ',
+                  f'name=data_pool,type=CephString,goodchars={goodchars},req=false '
+                  f'name=force,type=CephBool,req=false',
             'desc': "Create a CephFS volume",
             'perm': 'rw'
         },
@@ -744,7 +745,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         placement = cmd.get('placement', '')
         data_pool = cmd.get('data_pool', None)
         meta_pool = cmd.get('meta_pool', None)
-        return self.vc.create_fs_volume(vol_id, placement, data_pool, meta_pool)
+        force = cmd.get('force', '')
+        return self.vc.create_fs_volume(vol_id, placement, data_pool,
+                                        meta_pool, force)
 
     @mgr_cmd_wrap
     def _cmd_fs_volume_rm(self, inbuf, cmd):


### PR DESCRIPTION
Instead of accepting non-empty data pool names exit with error code EINVAL and an appropriate error message.

Fixes: https://tracker.ceph.com/issues/70361
Fixes: https://tracker.ceph.com/issues/70362






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>