### PR TITLE
os/bluestore: use block size (4K) as minimal allocation unit for dedicated DB/WAL volumes

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -614,8 +614,7 @@ uint64_t BlueFS::get_used(unsigned id)
 uint64_t BlueFS::_get_total(unsigned id) const
 {
   ceph_assert(id < bdev.size());
-  ceph_assert(id < block_reserved.size());
-  return get_block_device_size(id) - block_reserved[id];
+  return get_block_device_size(id);
 }
 
 uint64_t BlueFS::get_total(unsigned id)
@@ -642,7 +641,7 @@ void BlueFS::dump_block_extents(ostream& out)
     if (!bdev[i] || !alloc[i]) {
       continue;
     }
-    auto total = get_total(i) + block_reserved[i];
+    auto total = get_total(i);
     auto free = get_free(i);
 
     out << i << " : device size 0x" << std::hex << total
@@ -841,9 +840,8 @@ void BlueFS::_init_alloc()
 				    bdev[id]->get_size(),
 				    super.bluefs_max_alloc_size[id],
 				    name);
-      alloc[id]->init_add_free(
-        block_reserved[id],
-        _get_total(id));
+      auto reserved = block_reserved[id];
+      alloc[id]->init_add_free(reserved, _get_total(id) - reserved);
     }
   }
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1861,6 +1861,26 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   return 0;
 }
 
+int BlueFS::super_dump()
+{
+  // only dump superblock's content
+  _init_logger();
+  int r = _open_super();
+  if (r < 0) {
+    derr << __func__ << " failed to open super: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ceph::JSONFormatter f(true);
+  f.open_object_section("superblock");
+  super.dump(&f);
+  f.close_section();
+  f.flush(std::cout);
+
+  _shutdown_logger();
+  super = bluefs_super_t();
+  return r;
+}
+
 int BlueFS::log_dump()
 {
   // only dump log file's content

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -201,9 +201,9 @@ BlueFS::BlueFS(CephContext* cct)
   : cct(cct),
     bdev(MAX_BDEV),
     ioc(MAX_BDEV),
-    block_reserved(MAX_BDEV),
     alloc(MAX_BDEV),
-    alloc_size(MAX_BDEV, 0)
+    alloc_size(MAX_BDEV, 0),
+    locked_alloc(MAX_BDEV)
 {
   dirty.pending_release.resize(MAX_BDEV);
   discard_cb[BDEV_WAL] = wal_discard_cb;
@@ -496,33 +496,28 @@ void BlueFS::_update_logger_stats()
 int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
                              bluefs_shared_alloc_context_t* _shared_alloc)
 {
-  uint64_t reserved;
   string dev_name;
   switch(id) {
     case BDEV_WAL:
     case BDEV_NEWWAL:
-      reserved = BDEV_LABEL_BLOCK_SIZE;
       dev_name = "wal";
       break;
     case BDEV_DB:
     case BDEV_NEWDB:
-      reserved = SUPER_RESERVED;
       dev_name = "db";
       break;
     case BDEV_SLOW:
-      reserved = 0;
       dev_name = "slow";
       break;
     default:
       ceph_assert(false);
   }
   dout(10) << __func__ << " bdev " << id << " path " << path << " "
-           << " reserved " << reserved << dendl;
+           << dendl;
   ceph_assert(id < bdev.size());
   ceph_assert(bdev[id] == NULL);
   BlockDevice *b = BlockDevice::create(cct, path, NULL, NULL,
 				       discard_cb[id], static_cast<void*>(this), dev_name.c_str());
-  block_reserved[id] = reserved;
   if (_shared_alloc) {
     b->set_no_exclusive_lock();
   }
@@ -628,6 +623,35 @@ uint64_t BlueFS::get_free(unsigned id)
   return alloc[id]->get_free();
 }
 
+uint64_t BlueFS::_get_minimal_reserved(unsigned id) const
+{
+  uint64_t reserved = 0;
+  switch(id) {
+    case BDEV_WAL:
+    case BDEV_NEWWAL:
+      reserved = BDEV_LABEL_BLOCK_SIZE;
+      break;
+    case BDEV_DB:
+    case BDEV_NEWDB:
+      reserved = SUPER_RESERVED;
+      break;
+    case BDEV_SLOW:
+      reserved = 0;
+      break;
+    default:
+      ceph_assert(false);
+  }
+  return reserved;
+}
+
+uint64_t BlueFS::get_full_reserved(unsigned id)
+{
+  if (!is_shared_alloc(id)) {
+    return locked_alloc[id].length + _get_minimal_reserved(id);
+  }
+  return 0;
+}
+
 void BlueFS::dump_perf_counters(Formatter *f)
 {
   f->open_object_section("bluefs_perf_counters");
@@ -684,13 +708,13 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   }
 
   _init_logger();
-  _init_alloc();
 
   super.version = 0;
   super.block_size = bdev[BDEV_DB]->get_block_size();
   super.osd_uuid = osd_uuid;
   super.uuid.generate_random();
-  dout(1) << __func__ << " uuid " << super.uuid << dendl;
+
+  _init_alloc();
 
   // init log
   FileRef log_file = ceph::make_ref<File>();
@@ -715,6 +739,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   super.log_fnode = log_file->fnode;
   super.memorized_layout = layout;
   _write_super(BDEV_DB);
+  dout(1) << __func__ << " super " << super << dendl;
   _flush_bdev();
 
   // clean up
@@ -737,27 +762,10 @@ void BlueFS::_init_alloc()
 {
   dout(20) << __func__ << dendl;
 
-  // 'changed' should keep its previous value if no actual modification occurred
-  auto change_alloc_size = [this](uint64_t& max_alloc_size,
-                                  uint64_t new_alloc, bool& changed) {
-    if (max_alloc_size == 0 ||
-        (max_alloc_size > new_alloc && ((new_alloc & (new_alloc -1)) == 0))) {
-      max_alloc_size = new_alloc;
-      changed = true;
-      dout(5) << " changed alloc_size to 0x" << std::hex << new_alloc << dendl;
-    } else if (max_alloc_size != new_alloc) {
-      derr << " can not change current alloc_size 0x" << std::hex
-           << max_alloc_size << " to new alloc_size 0x" << new_alloc << dendl;
-    }
-  };
-
-  bool alloc_size_changed = false;
   size_t wal_alloc_size = 0;
   if (bdev[BDEV_WAL]) {
     wal_alloc_size = cct->_conf->bluefs_alloc_size;
     alloc_size[BDEV_WAL] = wal_alloc_size;
-    change_alloc_size(super.bluefs_max_alloc_size[BDEV_WAL],
-                      wal_alloc_size, alloc_size_changed);
   }
   logger->set(l_bluefs_wal_alloc_unit, wal_alloc_size);
 
@@ -773,38 +781,18 @@ void BlueFS::_init_alloc()
   if (bdev[BDEV_SLOW]) {
     alloc_size[BDEV_DB] = cct->_conf->bluefs_alloc_size;
     alloc_size[BDEV_SLOW] = shared_alloc_size;
-    change_alloc_size(super.bluefs_max_alloc_size[BDEV_DB],
-                      cct->_conf->bluefs_alloc_size, alloc_size_changed);
-    change_alloc_size(super.bluefs_max_alloc_size[BDEV_SLOW],
-                      shared_alloc_size, alloc_size_changed);
   } else {
     alloc_size[BDEV_DB] = shared_alloc_size;
     alloc_size[BDEV_SLOW] = 0;
-    change_alloc_size(super.bluefs_max_alloc_size[BDEV_DB],
-                      shared_alloc_size, alloc_size_changed);
   }
   logger->set(l_bluefs_db_alloc_unit, alloc_size[BDEV_DB]);
   logger->set(l_bluefs_slow_alloc_unit, alloc_size[BDEV_SLOW]);
   // new wal and db devices are never shared
   if (bdev[BDEV_NEWWAL]) {
     alloc_size[BDEV_NEWWAL] = cct->_conf->bluefs_alloc_size;
-    change_alloc_size(super.bluefs_max_alloc_size[BDEV_NEWWAL],
-                      cct->_conf->bluefs_alloc_size, alloc_size_changed);
   }
-  if (alloc_size_changed) {
-    dout(1) << __func__ << " alloc_size changed, the new super is:" << super << dendl;
-    _write_super(BDEV_DB);
-  }
-
-  alloc_size_changed = false;
   if (bdev[BDEV_NEWDB]) {
     alloc_size[BDEV_NEWDB] = cct->_conf->bluefs_alloc_size;
-    change_alloc_size(super.bluefs_max_alloc_size[BDEV_NEWDB],
-                      cct->_conf->bluefs_alloc_size, alloc_size_changed);
-  }
-  if (alloc_size_changed) {
-    dout(1) << __func__ << " alloc_size changed, the new super is:" << super << dendl;
-    _write_super(BDEV_NEWDB);
   }
 
   for (unsigned id = 0; id < bdev.size(); ++id) {
@@ -812,7 +800,8 @@ void BlueFS::_init_alloc()
       continue;
     }
     ceph_assert(bdev[id]->get_size());
-    ceph_assert(super.bluefs_max_alloc_size[id]);
+    locked_alloc[id] = bluefs_extent_t();
+
     if (is_shared_alloc(id)) {
       dout(1) << __func__ << " shared, id " << id << std::hex
               << ", capacity 0x" << bdev[id]->get_size()
@@ -826,22 +815,39 @@ void BlueFS::_init_alloc()
         name += devnames[id];
       else
         name += to_string(uintptr_t(this));
-      string alloc_type = cct->_conf->bluefs_allocator;
 
+      auto reserved = _get_minimal_reserved(id);
+      uint64_t locked_offs = 0;
+      {
+        // Try to lock tailing space at device if allocator controlled space
+        // isn't aligned with recommended alloc unit.
+        // Final decision whether locked tail to be maintained is made after
+        // BlueFS replay depending on existing allocations.
+        uint64_t size0 = _get_total(id);
+        uint64_t size = size0 - reserved;
+        size = p2align(size, alloc_size[id]) + reserved;
+        if (size < size0) {
+          locked_offs = size;
+          locked_alloc[id] = bluefs_extent_t(id, locked_offs, uint32_t(size0 - size));
+        }
+      }
+      string alloc_type = cct->_conf->bluefs_allocator;
       dout(1) << __func__ << " new, id " << id << std::hex
               << ", allocator name " << name
               << ", allocator type " << alloc_type
               << ", capacity 0x" << bdev[id]->get_size()
-              << ", reserved 0x" << block_reserved[id]
-              << ", block size 0x" << alloc_size[id]
-              << ", max alloc size 0x" << super.bluefs_max_alloc_size[id]
+              << ", reserved 0x" << reserved
+              << ", locked 0x" << locked_alloc[id].offset
+              << "~" << locked_alloc[id].length
+              << ", block size 0x" << bdev[id]->get_block_size()
+              << ", alloc unit 0x" << alloc_size[id]
               << std::dec << dendl;
       alloc[id] = Allocator::create(cct, alloc_type,
 				    bdev[id]->get_size(),
-				    super.bluefs_max_alloc_size[id],
+				    bdev[id]->get_block_size(),
 				    name);
-      auto reserved = block_reserved[id];
-      alloc[id]->init_add_free(reserved, _get_total(id) - reserved);
+      uint64_t free_len = locked_offs ? locked_offs : _get_total(id) - reserved;
+      alloc[id]->init_add_free(reserved, free_len);
     }
   }
 }
@@ -1045,6 +1051,7 @@ int BlueFS::mount()
     derr << __func__ << " failed to open super: " << cpp_strerror(r) << dendl;
     goto out;
   }
+  dout(5) << __func__ << " super: " << super << dendl;
 
   // set volume selector if not provided before/outside
   if (vselector == nullptr) {
@@ -1057,7 +1064,6 @@ int BlueFS::mount()
 
   _init_alloc();
 
-  dout(5) << __func__ << " super: " << super << dendl;
   r = _replay(false, false);
   if (r < 0) {
     derr << __func__ << " failed to replay log: " << cpp_strerror(r) << dendl;
@@ -1075,6 +1081,20 @@ int BlueFS::mount()
         shared_alloc->bluefs_used += q.length;
         alloc[q.bdev]->init_rm_free(q.offset, q.length);
       } else if (!is_shared) {
+        if (locked_alloc[q.bdev].length) {
+          auto locked_offs = locked_alloc[q.bdev].offset;
+          if (q.offset + q.length > locked_offs) {
+            // we already have allocated extents in locked range,
+            // do not enforce this lock then.
+            bluefs_extent_t dummy;
+            std::swap(locked_alloc[q.bdev], dummy);
+            alloc[q.bdev]->init_add_free(dummy.offset, dummy.length);
+            dout(1) << __func__ << std::hex
+                    << " unlocked at " << q.bdev
+                    << " 0x" << dummy.offset << "~" << dummy.length
+                    << std::dec << dendl;
+          }
+        }
         alloc[q.bdev]->init_rm_free(q.offset, q.length);
       }
     }
@@ -1337,9 +1357,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   bool seen_recs = false;
 
   boost::dynamic_bitset<uint64_t> used_blocks[MAX_BDEV];
+  bool check_allocations = cct->_conf->bluefs_log_replay_check_allocations;
 
   if (!noop) {
-    if (cct->_conf->bluefs_log_replay_check_allocations) {
+    if (check_allocations) {
       for (size_t i = 0; i < MAX_BDEV; ++i) {
 	if (bdev[i] != nullptr) {
           // let's use minimal allocation unit we can have
@@ -1671,7 +1692,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
           }
           if (!noop) {
 	    FileRef f = _get_file(fnode.ino);
-	    if (cct->_conf->bluefs_log_replay_check_allocations) {
+	    if (check_allocations) {
               int r = _check_allocations(f->fnode,
 		used_blocks, false, "OP_FILE_UPDATE");
               if (r < 0) {
@@ -1687,7 +1708,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	    if (fnode.ino > ino_last) {
 	      ino_last = fnode.ino;
 	    }
-            if (cct->_conf->bluefs_log_replay_check_allocations) {
+            if (check_allocations) {
               int r = _check_allocations(f->fnode,
 		used_blocks, true, "OP_FILE_UPDATE");
               if (r < 0) {
@@ -1721,7 +1742,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	      // be leanient, if there is no extents just produce error message
 	      ceph_assert(delta.offset == fnode.allocated || delta.extents.empty());
 	    }
-	    if (cct->_conf->bluefs_log_replay_check_allocations) {
+	    if (check_allocations) {
               int r = _check_allocations(fnode,
 		used_blocks, false, "OP_FILE_UPDATE_INC");
               if (r < 0) {
@@ -1746,7 +1767,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	    if (fnode.ino > ino_last) {
 	      ino_last = fnode.ino;
 	    }
-	    if (cct->_conf->bluefs_log_replay_check_allocations) {
+	    if (check_allocations) {
               int r = _check_allocations(f->fnode,
 		used_blocks, true, "OP_FILE_UPDATE_INC");
               if (r < 0) {
@@ -1780,7 +1801,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
             auto p = nodes.file_map.find(ino);
             ceph_assert(p != nodes.file_map.end());
             vselector->sub_usage(p->second->vselector_hint, p->second->fnode);
-            if (cct->_conf->bluefs_log_replay_check_allocations) {
+            if (check_allocations) {
 	      int r = _check_allocations(p->second->fnode,
 		used_blocks, false, "OP_FILE_REMOVE");
               if (r < 0) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -552,13 +552,6 @@ bool BlueFS::bdev_support_label(unsigned id)
   return bdev[id]->supported_bdev_label();
 }
 
-uint64_t BlueFS::get_block_device_size(unsigned id) const
-{
-  if (id < bdev.size() && bdev[id])
-    return bdev[id]->get_size();
-  return 0;
-}
-
 BlockDevice* BlueFS::get_block_device(unsigned id) const
 {
   if (id < bdev.size() && bdev[id])
@@ -609,7 +602,7 @@ uint64_t BlueFS::get_used(unsigned id)
 uint64_t BlueFS::_get_total(unsigned id) const
 {
   ceph_assert(id < bdev.size());
-  return get_block_device_size(id);
+  return bdev[id] ? bdev[id]->get_size() : 0;
 }
 
 uint64_t BlueFS::get_total(unsigned id)
@@ -702,9 +695,9 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   if (vselector == nullptr) {
     vselector.reset(
       new OriginalVolumeSelector(
-        get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100));
+        _get_total(BlueFS::BDEV_WAL) * 95 / 100,
+        _get_total(BlueFS::BDEV_DB) * 95 / 100,
+        _get_total(BlueFS::BDEV_SLOW) * 95 / 100));
   }
 
   _init_logger();
@@ -1057,9 +1050,9 @@ int BlueFS::mount()
   if (vselector == nullptr) {
     vselector.reset(
       new OriginalVolumeSelector(
-        get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100));
+        _get_total(BlueFS::BDEV_WAL) * 95 / 100,
+        _get_total(BlueFS::BDEV_DB) * 95 / 100,
+        _get_total(BlueFS::BDEV_SLOW) * 95 / 100));
   }
 
   _init_alloc();

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -827,15 +827,17 @@ void BlueFS::_init_alloc()
         name += devnames[id];
       else
         name += to_string(uintptr_t(this));
+      string alloc_type = cct->_conf->bluefs_allocator;
+
       dout(1) << __func__ << " new, id " << id << std::hex
               << ", allocator name " << name
-              << ", allocator type " << cct->_conf->bluefs_allocator
+              << ", allocator type " << alloc_type
               << ", capacity 0x" << bdev[id]->get_size()
               << ", reserved 0x" << block_reserved[id]
               << ", block size 0x" << alloc_size[id]
               << ", max alloc size 0x" << super.bluefs_max_alloc_size[id]
               << std::dec << dendl;
-      alloc[id] = Allocator::create(cct, cct->_conf->bluefs_allocator,
+      alloc[id] = Allocator::create(cct, alloc_type,
 				    bdev[id]->get_size(),
 				    super.bluefs_max_alloc_size[id],
 				    name);
@@ -1174,10 +1176,14 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
 
 void BlueFS::collect_metadata(map<string,string> *pm, unsigned skip_bdev_id)
 {
-  if (skip_bdev_id != BDEV_DB && bdev[BDEV_DB])
+  if (skip_bdev_id != BDEV_DB && bdev[BDEV_DB]) {
     bdev[BDEV_DB]->collect_metadata("bluefs_db_", pm);
-  if (bdev[BDEV_WAL])
+    (*pm)["bluefs_db_allocator"]= alloc[BDEV_DB] ? alloc[BDEV_DB]->get_type(): "null";
+  }
+  if (bdev[BDEV_WAL]) {
     bdev[BDEV_WAL]->collect_metadata("bluefs_wal_", pm);
+    (*pm)["bluefs_wal_allocator"]= alloc[BDEV_WAL] ? alloc[BDEV_WAL]->get_type(): "null";
+  }
 }
 
 void BlueFS::get_devices(set<string> *ls)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -702,7 +702,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   _init_logger();
 
-  super.version = 0;
+  super.seq = 0;
   super.block_size = bdev[BDEV_DB]->get_block_size();
   super.osd_uuid = osd_uuid;
   super.uuid.generate_random();
@@ -1215,20 +1215,20 @@ int BlueFS::fsck()
 
 int BlueFS::_write_super(int dev)
 {
-  ++super.version;
+  ++super.seq;
   // build superblock
   bufferlist bl;
   encode(super, bl);
   uint32_t crc = bl.crc32c(-1);
   encode(crc, bl);
   dout(10) << __func__ << " super block length(encoded): " << bl.length() << dendl;
-  dout(10) << __func__ << " superblock " << super.version << dendl;
+  dout(10) << __func__ << " superblock " << super.seq << dendl;
   dout(10) << __func__ << " log_fnode " << super.log_fnode << dendl;
   ceph_assert_always(bl.length() <= get_super_length());
   bl.append_zero(get_super_length() - bl.length());
 
   bdev[dev]->write(get_super_offset(), bl, false, WRITE_LIFE_SHORT);
-  dout(20) << __func__ << " v " << super.version
+  dout(20) << __func__ << " seq " << super.seq
            << " crc 0x" << std::hex << crc
            << " offset 0x" << get_super_offset() << std::dec
            << dendl;
@@ -1263,7 +1263,7 @@ int BlueFS::_open_super()
          << dendl;
     return -EIO;
   }
-  dout(10) << __func__ << " superblock " << super.version << dendl;
+  dout(10) << __func__ << " superblock " << super.seq << dendl;
   dout(10) << __func__ << " log_fnode " << super.log_fnode << dendl;
   return 0;
 }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -520,9 +520,12 @@ private:
    */
   std::vector<BlockDevice*> bdev;                  ///< block devices we can use
   std::vector<IOContext*> ioc;                     ///< IOContexts for bdevs
-  std::vector<uint64_t> block_reserved;            ///< starting reserve extent per device
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
+  std::vector<bluefs_extent_t> locked_alloc;       ///< candidate extents for locked alocations,
+                                                   ///< no alloc/release reqs matching these space
+                                                   ///< to be issued to allocator.
+
 
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;
 
@@ -554,7 +557,7 @@ private:
 
   uint64_t _get_used(unsigned id) const;
   uint64_t _get_total(unsigned id) const;
-
+  uint64_t _get_minimal_reserved(unsigned id) const;
 
   FileRef _get_file(uint64_t ino);
   void _drop_link_D(FileRef f);
@@ -707,6 +710,7 @@ public:
   uint64_t get_total(unsigned id);
   uint64_t get_free(unsigned id);
   uint64_t get_used(unsigned id);
+  uint64_t get_full_reserved(unsigned id);
   void dump_perf_counters(ceph::Formatter *f);
 
   void dump_block_extents(std::ostream& out);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -556,7 +556,7 @@ private:
   void _pad_bl(ceph::buffer::list& bl, uint64_t pad_size = 0);
 
   uint64_t _get_used(unsigned id) const;
-  uint64_t _get_total(unsigned id) const;
+  uint64_t _get_block_device_size(unsigned id) const;
   uint64_t _get_minimal_reserved(unsigned id) const;
 
   FileRef _get_file(uint64_t ino);
@@ -708,7 +708,7 @@ public:
     const bluefs_layout_t& layout);
 
   uint64_t get_used();
-  uint64_t get_total(unsigned id);
+  uint64_t get_block_device_size(unsigned id);
   uint64_t get_free(unsigned id);
   uint64_t get_used(unsigned id);
   uint64_t get_full_reserved(unsigned id);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -687,6 +687,7 @@ public:
   int prepare_new_device(int id, const bluefs_layout_t& layout);
   
   int log_dump();
+  int super_dump();
 
   void collect_metadata(std::map<std::string,std::string> *pm, unsigned skip_bdev_id);
   void get_devices(std::set<std::string> *ls);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -773,7 +773,6 @@ public:
   int add_block_device(unsigned bdev, const std::string& path, bool trim,
                        bluefs_shared_alloc_context_t* _shared_alloc = nullptr);
   bool bdev_support_label(unsigned id);
-  uint64_t get_block_device_size(unsigned bdev) const;
   BlockDevice* get_block_device(unsigned bdev) const;
 
   // handler for discard event

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -522,9 +522,11 @@ private:
   std::vector<IOContext*> ioc;                     ///< IOContexts for bdevs
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
-  std::vector<bluefs_extent_t> locked_alloc;       ///< candidate extents for locked alocations,
-                                                   ///< no alloc/release reqs matching these space
-                                                   ///< to be issued to allocator.
+  std::vector<bluefs_locked_extents_t> locked_alloc;  ///< candidate extents
+                                                      ///< at both dev's head and tail
+                                                      ///< locked for allocations,
+                                                      ///< no alloc/release reqs matching
+                                                      ///< these space to be issued to allocator.
 
 
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7698,16 +7698,16 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
     }
     if (cct->_conf->bluestore_volume_selection_policy == "fit_to_fast") {
       vselector = new FitToFastVolumeSelector(
-        bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-        bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-        bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100);
+        bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
+        bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
+        bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100);
     } else {
       double reserved_factor = cct->_conf->bluestore_volume_selection_reserved_factor;
       vselector =
         new RocksDBBlueFSVolumeSelector(
-          bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-          bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-          bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100,
+          bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
+          bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
+          bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100,
 	  rocks_opts.write_buffer_size * rocks_opts.max_write_buffer_number,
           rocks_opts.max_bytes_for_level_base,
           rocks_opts.max_bytes_for_level_multiplier,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12009,6 +12009,7 @@ void BlueStore::collect_metadata(map<string,string> *pm)
   }
   (*pm)["bluestore_min_alloc_size"] = stringify(min_alloc_size);
   (*pm)["bluestore_allocation_from_file"] = stringify(fm && fm->is_null_manager());
+  (*pm)["bluestore_allocator"] = alloc ? alloc->get_type() : "null";
 }
 
 int BlueStore::get_numa_node(

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7698,16 +7698,16 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
     }
     if (cct->_conf->bluestore_volume_selection_policy == "fit_to_fast") {
       vselector = new FitToFastVolumeSelector(
-        bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
-        bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
-        bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100);
+        bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
+        bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
+        bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100);
     } else {
       double reserved_factor = cct->_conf->bluestore_volume_selection_reserved_factor;
       vselector =
         new RocksDBBlueFSVolumeSelector(
-          bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
-          bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
-          bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100,
 	  rocks_opts.write_buffer_size * rocks_opts.max_write_buffer_number,
           rocks_opts.max_bytes_for_level_base,
           rocks_opts.max_bytes_for_level_multiplier,
@@ -12120,7 +12120,7 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
     buf->internally_reserved = 0;
     // include dedicated db, too, if that isn't the shared device.
     if (bluefs_layout.shared_bdev != BlueFS::BDEV_DB) {
-      buf->total += bluefs->get_total(BlueFS::BDEV_DB);
+      buf->total += bluefs->get_block_device_size(BlueFS::BDEV_DB);
     }
     // call any non-omap bluefs space "internal metadata"
     buf->internal_metadata =
@@ -19138,7 +19138,7 @@ void BlueStore::_log_alerts(osd_alert_list_t& alerts)
     bluefs->get_used(BlueFS::BDEV_SLOW) : 0;
   if (used > 0) {
       auto db_used = bluefs->get_used(BlueFS::BDEV_DB);
-      auto db_total = bluefs->get_total(BlueFS::BDEV_DB);
+      auto db_total = bluefs->get_block_device_size(BlueFS::BDEV_DB);
       ostringstream ss;
       ss << "spilled over " << byte_u_t(used)
          << " metadata from 'db' device (" << byte_u_t(db_used)

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -75,7 +75,7 @@ void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
 }
 
 // bluefs_super_t
-bluefs_super_t::bluefs_super_t() : version(0), block_size(4096) {
+bluefs_super_t::bluefs_super_t() : seq(0), block_size(4096) {
 }
 
 void bluefs_super_t::encode(bufferlist& bl) const
@@ -83,7 +83,7 @@ void bluefs_super_t::encode(bufferlist& bl) const
   ENCODE_START(2, 1, bl);
   encode(uuid, bl);
   encode(osd_uuid, bl);
-  encode(version, bl);
+  encode(seq, bl);
   encode(block_size, bl);
   encode(log_fnode, bl);
   encode(memorized_layout, bl);
@@ -95,7 +95,7 @@ void bluefs_super_t::decode(bufferlist::const_iterator& p)
   DECODE_START(2, p);
   decode(uuid, p);
   decode(osd_uuid, p);
-  decode(version, p);
+  decode(seq, p);
   decode(block_size, p);
   decode(log_fnode, p);
   if (struct_v >= 2) {
@@ -108,7 +108,7 @@ void bluefs_super_t::dump(Formatter *f) const
 {
   f->dump_stream("uuid") << uuid;
   f->dump_stream("osd_uuid") << osd_uuid;
-  f->dump_unsigned("version", version);
+  f->dump_unsigned("seq", seq);
   f->dump_unsigned("block_size", block_size);
   f->dump_object("log_fnode", log_fnode);
 }
@@ -117,7 +117,7 @@ void bluefs_super_t::generate_test_instances(list<bluefs_super_t*>& ls)
 {
   ls.push_back(new bluefs_super_t);
   ls.push_back(new bluefs_super_t);
-  ls.back()->version = 1;
+  ls.back()->seq = 1;
   ls.back()->block_size = 4096;
 }
 
@@ -125,7 +125,7 @@ ostream& operator<<(ostream& out, const bluefs_super_t& s)
 {
   return out << "super(uuid " << s.uuid
 	     << " osd " << s.osd_uuid
-	     << " v " << s.version
+	     << " seq " << s.seq
 	     << " block_size 0x" << std::hex << s.block_size
 	     << " log_fnode 0x" << s.log_fnode
 	     << std::dec << ")";

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -76,25 +76,23 @@ void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
 
 // bluefs_super_t
 bluefs_super_t::bluefs_super_t() : version(0), block_size(4096) {
-  bluefs_max_alloc_size.resize(BlueFS::MAX_BDEV, 0);
 }
 
 void bluefs_super_t::encode(bufferlist& bl) const
 {
-  ENCODE_START(3, 1, bl);
+  ENCODE_START(2, 1, bl);
   encode(uuid, bl);
   encode(osd_uuid, bl);
   encode(version, bl);
   encode(block_size, bl);
   encode(log_fnode, bl);
   encode(memorized_layout, bl);
-  encode(bluefs_max_alloc_size, bl);
   ENCODE_FINISH(bl);
 }
 
 void bluefs_super_t::decode(bufferlist::const_iterator& p)
 {
-  DECODE_START(3, p);
+  DECODE_START(2, p);
   decode(uuid, p);
   decode(osd_uuid, p);
   decode(version, p);
@@ -102,11 +100,6 @@ void bluefs_super_t::decode(bufferlist::const_iterator& p)
   decode(log_fnode, p);
   if (struct_v >= 2) {
     decode(memorized_layout, p);
-  }
-  if (struct_v >= 3) {
-    decode(bluefs_max_alloc_size, p);
-  } else {
-    std::fill(bluefs_max_alloc_size.begin(), bluefs_max_alloc_size.end(), 0);
   }
   DECODE_FINISH(p);
 }
@@ -118,8 +111,6 @@ void bluefs_super_t::dump(Formatter *f) const
   f->dump_unsigned("version", version);
   f->dump_unsigned("block_size", block_size);
   f->dump_object("log_fnode", log_fnode);
-  for (auto& p : bluefs_max_alloc_size)
-    f->dump_unsigned("max_alloc_size", p);
 }
 
 void bluefs_super_t::generate_test_instances(list<bluefs_super_t*>& ls)
@@ -137,7 +128,6 @@ ostream& operator<<(ostream& out, const bluefs_super_t& s)
 	     << " v " << s.version
 	     << " block_size 0x" << std::hex << s.block_size
 	     << " log_fnode 0x" << s.log_fnode
-	     << " max_alloc_size " << s.bluefs_max_alloc_size
 	     << std::dec << ")";
 }
 

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -35,6 +35,37 @@ WRITE_CLASS_DENC(bluefs_extent_t)
 
 std::ostream& operator<<(std::ostream& out, const bluefs_extent_t& e);
 
+struct bluefs_locked_extents_t {
+  uint64_t head_offset = 0;
+  uint32_t head_length = 0;
+
+  uint64_t gray_tail_offset = 0;
+  uint32_t gray_tail_length = 0;
+
+  uint64_t tail_offset = 0;
+  uint32_t tail_length = 0;
+
+  bluefs_locked_extents_t() {}
+  bluefs_locked_extents_t(uint64_t head_reserved, uint64_t full_size, uint64_t alloc_size);
+
+  void reset() {
+    *this = bluefs_locked_extents_t();
+  }
+  uint64_t head_end() const { return head_offset + head_length; }
+  uint64_t gray_tail_end() const { return gray_tail_offset + gray_tail_length; }
+  uint64_t tail_end() const { return tail_offset + tail_length; }
+
+  void reset_intersected(const bluefs_extent_t& e);
+
+  // returns extents in a form where tails are merged
+  bluefs_locked_extents_t get_merged() const;
+
+  // returns final locked extents where head/tail are present only
+  bluefs_locked_extents_t finalize() const;
+};
+
+std::ostream& operator<<(std::ostream& out, const bluefs_locked_extents_t& e);
+
 struct bluefs_fnode_delta_t {
   uint64_t ino;
   uint64_t size;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -213,7 +213,7 @@ WRITE_CLASS_ENCODER(bluefs_layout_t)
 struct bluefs_super_t {
   uuid_d uuid;      ///< unique to this bluefs instance
   uuid_d osd_uuid;  ///< matches the osd that owns us
-  uint64_t version;
+  uint64_t version; ///< In fact that's update counter
   uint32_t block_size;
 
   bluefs_fnode_t log_fnode;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -213,7 +213,7 @@ WRITE_CLASS_ENCODER(bluefs_layout_t)
 struct bluefs_super_t {
   uuid_d uuid;      ///< unique to this bluefs instance
   uuid_d osd_uuid;  ///< matches the osd that owns us
-  uint64_t version; ///< In fact that's update counter
+  uint64_t seq;     ///< sequence counter
   uint32_t block_size;
 
   bluefs_fnode_t log_fnode;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -220,8 +220,6 @@ struct bluefs_super_t {
 
   std::optional<bluefs_layout_t> memorized_layout;
 
-  std::vector<uint64_t> bluefs_max_alloc_size;
-
   bluefs_super_t();
 
   uint64_t block_mask() const {

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -214,6 +214,25 @@ void log_dump(
   delete fs;
 }
 
+void super_dump(
+  CephContext *cct,
+  const string& path,
+  const vector<string>& devs)
+{
+  validate_path(cct, path, true);
+  BlueFS *fs = new BlueFS(cct);
+
+  add_devices(fs, cct, devs);
+  int r = fs->super_dump();
+  if (r < 0) {
+    cerr << "super_dump failed" << ": "
+         << cpp_strerror(r) << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  delete fs;
+}
+
 void inferring_bluefs_devices(vector<string>& devs, std::string& path)
 {
   cout << "inferring bluefs devices from bluestore path" << std::endl;
@@ -340,6 +359,7 @@ int main(int argc, char **argv)
         "set-label-key, "
         "rm-label-key, "
         "prime-osd-dir, "
+        "bluefs-super-dump, "
         "bluefs-log-dump, "
         "free-dump, "
         "free-score, "
@@ -513,6 +533,7 @@ int main(int argc, char **argv)
   }
   if (action == "bluefs-export" || 
       action == "bluefs-import" || 
+      action == "bluefs-super-dump" ||
       action == "bluefs-log-dump") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
@@ -1001,6 +1022,8 @@ int main(int argc, char **argv)
     delete fs;
   } else if (action == "bluefs-log-dump") {
     log_dump(cct.get(), path, devs);
+  } else if (action == "bluefs-super-dump") {
+    super_dump(cct.get(), path, devs);
   } else if (action == "bluefs-bdev-new-db" || action == "bluefs-bdev-new-wal") {
     map<string, int> cur_devs_map;
     bool need_db = action == "bluefs-bdev-new-db";

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11993,7 +11993,7 @@ TEST_P(StoreTestSpecificAUSize, BlueFSReservedTest) {
             g_conf()->bluefs_alloc_size);
 
   ASSERT_EQ(fs->get_full_reserved(BlueFS::BDEV_WAL),
-            wal_extra);
+            g_conf()->bluefs_alloc_size + wal_extra);
 }
 
 #endif  // WITH_BLUESTORE

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -112,7 +112,7 @@ TEST(BlueFS, mkfs_mount) {
   ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
-  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size);
+  ASSERT_EQ(fs.get_block_device_size(BlueFS::BDEV_DB), size);
   ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size);
   fs.umount();
 }

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -112,8 +112,8 @@ TEST(BlueFS, mkfs_mount) {
   ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
-  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - SUPER_RESERVED);
-  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - SUPER_RESERVED);
+  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size);
+  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size);
   fs.umount();
 }
 


### PR DESCRIPTION
Effective allocation unit is still bluefs_alloc_size to avoid performance penalties.
Unaligned tailing part of device's space  is marked as non-free if no allocations exist in this ares. This allows to maintain relevant allocation map unfragmented if all allocation requests are aligned with use bluefs_alloc_size.

Plus some cleanup.
Plus some helpers.

Fixes: https://tracker.ceph.com/issues/68772

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
