### PR TITLE
reef: rbd-nbd: use netlink interface by default

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,10 @@
+>=18.2.5
+--------
+
+* RBD: The ``try-netlink`` mapping option for rbd-nbd has become the default
+  and is now deprecated. If the NBD netlink interface is not supported by the
+  kernel, then the mapping is retried using the legacy ioctl interface.
+
 >=18.2.4
 --------
 

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -205,6 +205,7 @@ used=`rbd -p ${POOL} --format xml du ${IMAGE} |
 unmap_device ${DEV} ${PID}
 
 # resize test
+# also test that try-netlink option is accepted for compatibility
 DEV=`_sudo rbd device -t nbd -o try-netlink map ${POOL}/${IMAGE}`
 get_pid ${POOL}
 devname=$(basename ${DEV})
@@ -391,7 +392,7 @@ cat ${LOG_FILE}
 expect_false grep 'quiesce failed' ${LOG_FILE}
 
 # test detach/attach
-OUT=`_sudo rbd device --device-type nbd --options try-netlink,show-cookie map ${POOL}/${IMAGE}`
+OUT=`_sudo rbd device --device-type nbd --show-cookie map ${POOL}/${IMAGE}`
 read DEV COOKIE <<< "${OUT}"
 get_pid ${POOL}
 _sudo mount ${DEV} ${TEMPDIR}/mnt
@@ -419,7 +420,7 @@ _sudo umount ${TEMPDIR}/mnt
 unmap_device ${DEV} ${PID}
 # if kernel supports cookies
 if [ -n "${COOKIE}" ]; then
-    OUT=`_sudo rbd device --device-type nbd --show-cookie --cookie "abc de" --options try-netlink map ${POOL}/${IMAGE}`
+    OUT=`_sudo rbd device --device-type nbd --show-cookie --cookie "abc de" map ${POOL}/${IMAGE}`
     read DEV ANOTHER_COOKIE <<< "${OUT}"
     get_pid ${POOL}
     test "${ANOTHER_COOKIE}" = "abc de"
@@ -429,7 +430,7 @@ DEV=
 
 # test detach/attach with --snap-id
 SNAPID=`rbd snap ls ${POOL}/${IMAGE} | awk '$2 == "snap" {print $1}'`
-OUT=`_sudo rbd device --device-type nbd --options try-netlink,show-cookie map --snap-id ${SNAPID} ${POOL}/${IMAGE}`
+OUT=`_sudo rbd device --device-type nbd --show-cookie map --snap-id ${SNAPID} ${POOL}/${IMAGE}`
 read DEV COOKIE <<< "${OUT}"
 get_pid ${POOL}
 _sudo rbd device detach ${POOL}/${IMAGE} --snap-id ${SNAPID} --device-type nbd

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -1254,7 +1254,6 @@ nbd_open(const char *name, struct rbd_ctx *ctx)
 			   SubProcess::KEEP);
 	process.add_cmd_arg("map");
 	process.add_cmd_arg("--io-timeout=600");
-	process.add_cmd_arg("--try-netlink");
 	std::string img;
 	img.append(pool);
 	img.append("/");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70364

---

backport of https://github.com/ceph/ceph/pull/55234
parent tracker: https://tracker.ceph.com/issues/64063