### PR TITLE
squid: ceph-volume: allow zapping partitions on multipath devices

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -398,7 +398,7 @@ class Zap:
         devices = self.args.devices
         for device in devices:
             mlogger.info("Zapping: %s", device.path)
-            if device.is_mapper and not device.is_mpath:
+            if device.is_mapper and not device.is_mpath and not device.is_partition:
                 terminal.error("Refusing to zap the mapper device: {}".format(device))
                 raise SystemExit(1)
             if device.is_lvm_member:

--- a/src/ceph-volume/ceph_volume/tests/devices/test_zap.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/test_zap.py
@@ -30,7 +30,8 @@ class TestZap(object):
             exists=True,
             has_partitions=False,
             has_gpt_headers=False,
-            has_fs=False
+            has_fs=False,
+            is_partition=False
         )
         with pytest.raises(SystemExit):
             lvm.zap.Zap(argv=[device_name]).main()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70367

---

backport of https://github.com/ceph/ceph/pull/62173
parent tracker: https://tracker.ceph.com/issues/70363

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh