### PR TITLE
osd: Improve logging using pg_vector_string

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -445,7 +445,7 @@ void PeeringState::advance_map(
 {
   ceph_assert(lastmap == osdmap_ref);
   psdout(10) << "handle_advance_map "
-	    << newup << "/" << newacting
+	    << pg_vector_string(newup) << "/" << pg_vector_string(newacting)
 	    << " -- " << up_primary << "/" << acting_primary
 	    << dendl;
 
@@ -550,8 +550,8 @@ bool PeeringState::should_restart_peering(
 	osdmap.get(),
 	lastmap.get(),
 	info.pgid.pgid)) {
-    psdout(20) << "new interval newup " << newup
-	       << " newacting " << newacting << dendl;
+    psdout(20) << "new interval newup " << pg_vector_string(newup)
+	       << " newacting " << pg_vector_string(newacting) << dendl;
     return true;
   }
   if (!lastmap->is_up(pg_whoami.osd) && osdmap->is_up(pg_whoami.osd)) {
@@ -676,8 +676,8 @@ void PeeringState::start_peering_interval(
 
   on_new_interval();
 
-  psdout(1) << "up " << oldup << " -> " << up
-	    << ", acting " << oldacting << " -> " << acting
+  psdout(1) << "up " << pg_vector_string(oldup) << " -> " << pg_vector_string(up)
+	    << ", acting " << pg_vector_string(oldacting) << " -> " << pg_vector_string(acting)
 	    << ", acting_primary " << old_acting_primary << " -> "
 	    << new_acting_primary
 	    << ", up_primary " << old_up_primary << " -> " << new_up_primary
@@ -725,7 +725,8 @@ void PeeringState::start_peering_interval(
     // no role change.
     // did primary change?
     if (get_primary() != old_acting_primary) {
-      psdout(10) << oldacting << " -> " << acting
+      psdout(10) << pg_vector_string(oldacting) << " -> "
+	       << pg_vector_string(acting)
 	       << ", acting primary "
 	       << old_acting_primary << " -> " << get_primary()
 	       << dendl;
@@ -735,7 +736,8 @@ void PeeringState::start_peering_interval(
 	// i am (still) primary. but my replica set changed.
 	state_clear(PG_STATE_CLEAN);
 
-	psdout(10) << oldacting << " -> " << acting
+	psdout(10) << pg_vector_string(oldacting) << " -> "
+		 << pg_vector_string(acting)
 		 << ", replicas changed" << dendl;
       }
     }
@@ -770,7 +772,8 @@ void PeeringState::on_new_interval()
   }
   psdout(20) << "upacting_features 0x" << std::hex
 	     << upacting_features << std::dec
-	     << " from " << acting << "+" << up << dendl;
+	     << " from " << pg_vector_string(acting)
+	     << "+" << pg_vector_string(up) << dendl;
 
   psdout(20) << "checking missing set deletes flag. missing = "
 	     << get_pg_log().get_missing() << dendl;
@@ -2235,7 +2238,7 @@ void PeeringState::choose_async_recovery_ec(
       async_recovery->insert(cur_shard);
     }
   }
-  psdout(20) << "result want=" << *want
+  psdout(20) << "result want=" << pg_vector_string(*want)
 	     << " async_recovery=" << *async_recovery << dendl;
 }
 
@@ -2442,7 +2445,8 @@ bool PeeringState::choose_acting(pg_shard_t &auth_log_shard_id,
     want.pop_back();
   }
   if (want != acting) {
-    psdout(10) << "want " << want << " != acting " << acting
+    psdout(10) << "want " << pg_vector_string(want)
+	       << " != acting " << pg_vector_string(acting)
 	       << ", requesting pg_temp change" << dendl;
     want_acting = want;
 
@@ -2485,9 +2489,9 @@ bool PeeringState::choose_acting(pg_shard_t &auth_log_shard_id,
   for (auto i = want_backfill.begin(); i != want_backfill.end(); ++i) {
     ceph_assert(stray_set.find(*i) == stray_set.end());
   }
-  psdout(10) << "choose_acting want=" << want << " backfill_targets="
-           << want_backfill << " async_recovery_targets="
-           << async_recovery_targets << dendl;
+  psdout(10) << "choose_acting want=" << pg_vector_string(want)
+	     << " backfill_targets=" << want_backfill
+	     << " async_recovery_targets=" << async_recovery_targets << dendl;
   return true;
 }
 
@@ -3979,8 +3983,9 @@ void PeeringState::init(
   const PastIntervals& pi,
   ObjectStore::Transaction &t)
 {
-  psdout(10) << "init role " << role << " up "
-	     << newup << " acting " << newacting
+  psdout(10) << "init role " << role
+	     << " up " << pg_vector_string(newup)
+	     << " acting " << pg_vector_string(newacting)
 	     << " history " << history
 	     << " past_intervals " << pi
 	     << dendl;
@@ -7120,7 +7125,9 @@ boost::statechart::result PeeringState::WaitActingChange::react(const AdvMap& ad
   DECLARE_LOCALS;
   OSDMapRef osdmap = advmap.osdmap;
 
-  psdout(10) << "verifying no want_acting " << ps->want_acting << " targets didn't go down" << dendl;
+  psdout(10) << "verifying no want_acting "
+	     << pg_vector_string(ps->want_acting)
+	     << " targets didn't go down" << dendl;
   for (auto p = ps->want_acting.begin(); p != ps->want_acting.end(); ++p) {
     if (!osdmap->is_up(*p)) {
       psdout(10) << " want_acting target osd." << *p << " went down, resetting" << dendl;

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1476,7 +1476,7 @@ void PeeringState::reject_reservation()
  * find_best_info
  *
  * Returns an iterator to the best info in infos sorted by:
- *  1) Prefer newer last_update
+ *  1) Prefer newer (oldest for ec_pool) last_update
  *  2) Prefer longer tail if it brings another info into contiguity
  *  3) Prefer current primary
  */
@@ -2457,8 +2457,9 @@ bool PeeringState::choose_acting(pg_shard_t &auth_log_shard_id,
 	ceph_assert(want_backfill.empty());
 	vector<int> empty;
 	pl->queue_want_pg_temp(empty);
-      } else
+      } else {
 	pl->queue_want_pg_temp(want);
+      }
     }
     return false;
   }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3834,8 +3834,10 @@ ostream& operator<<(ostream& out, const PastIntervals::pg_interval_t& i)
 std::string PastIntervals::pg_interval_t::fmt_print() const
 {
   return fmt::format(
-      "interval({}-{} up {}({}) acting {}({}){})", first, last, up, up_primary,
-      acting, primary, maybe_went_rw ? " maybe_went_rw" : "");
+      "interval({}-{} up {}({}) acting {}({}){})", first, last,
+      pg_vector_string(up), up_primary,
+      pg_vector_string(acting), primary,
+      maybe_went_rw ? " maybe_went_rw" : "");
 }
 
 void PastIntervals::pg_interval_t::generate_test_instances(list<pg_interval_t*>& o)


### PR DESCRIPTION
Improve the logging of up set/acting set in peering logs by making more use of the existing function pg_vector_string to convert a vector of ints into a string modifying 2147483647 (MaxInt) which represents an absent osd to NONE.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [X] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
