### PR TITLE
mds,nvmeof,rbd: replace obsolete get_tracked_conf_keys()

### DIFF
--- a/src/librbd/ConfigWatcher.cc
+++ b/src/librbd/ConfigWatcher.cc
@@ -26,36 +26,28 @@ template <typename I>
 struct ConfigWatcher<I>::Observer : public md_config_obs_t {
   ConfigWatcher<I>* m_config_watcher;
 
-  std::deque<std::string> m_config_key_strs;
-  mutable std::vector<const char*> m_config_keys;
+  std::vector<std::string> m_config_key_strs;
 
   Observer(CephContext* cct, ConfigWatcher<I>* config_watcher)
     : m_config_watcher(config_watcher) {
-    const std::string rbd_key_prefix("rbd_");
+    static const std::string rbd_key_prefix("rbd_");
     auto& schema = cct->_conf.get_schema();
     for (auto& pair : schema) {
       // watch all "rbd_" keys for simplicity
-      if (!boost::starts_with(pair.first, rbd_key_prefix)) {
+      if (!pair.first.starts_with(rbd_key_prefix)) {
         continue;
       }
 
       m_config_key_strs.emplace_back(pair.first);
     }
-
-    m_config_keys.reserve(m_config_key_strs.size());
-    for (auto& key : m_config_key_strs) {
-      m_config_keys.emplace_back(key.c_str());
-    }
-    m_config_keys.emplace_back(nullptr);
   }
 
-  const char** get_tracked_conf_keys() const override {
-    ceph_assert(!m_config_keys.empty());
-    return &m_config_keys[0];
+  std::vector<std::string> get_tracked_keys() const noexcept {
+    return m_config_key_strs;
   }
 
   void handle_conf_change(const ConfigProxy& conf,
-                          const std::set <std::string> &changed) override {
+                          const std::set<std::string> &changed) override {
     m_config_watcher->handle_global_config_change(changed);
   }
 };

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -4026,112 +4026,103 @@ void MDSRank::command_cache_drop(uint64_t timeout, Formatter *f, Context *on_fin
 
 epoch_t MDSRank::get_osd_epoch() const
 {
-  return objecter->with_osdmap(std::mem_fn(&OSDMap::get_epoch));  
+  return objecter->with_osdmap(std::mem_fn(&OSDMap::get_epoch));
 }
 
-const char** MDSRankDispatcher::get_tracked_conf_keys() const
+std::vector<std::string> MDSRankDispatcher::get_tracked_keys()
+    const noexcept
 {
-#define KEYS \
-    "clog_to_graylog", \
-    "clog_to_graylog_host", \
-    "clog_to_graylog_port", \
-    "clog_to_monitors", \
-    "clog_to_syslog", \
-    "clog_to_syslog_facility", \
-    "clog_to_syslog_level", \
-    "fsid", \
-    "host", \
-    "mds_allow_async_dirops", \
-    "mds_alternate_name_max", \
-    "mds_bal_export_pin", \
-    "mds_bal_fragment_dirs", \
-    "mds_bal_fragment_fast_factor", \
-    "mds_bal_fragment_interval", \
-    "mds_bal_fragment_size_max", \
-    "mds_bal_interval", \
-    "mds_bal_max", \
-    "mds_bal_max_until", \
-    "mds_bal_merge_size", \
-    "mds_bal_mode", \
-    "mds_bal_replicate_threshold", \
-    "mds_bal_sample_interval", \
-    "mds_bal_split_bits", \
-    "mds_bal_split_rd", \
-    "mds_bal_split_size", \
-    "mds_bal_split_wr", \
-    "mds_bal_unreplicate_threshold", \
-    "mds_cache_memory_limit", \
-    "mds_cache_mid", \
-    "mds_cache_quiesce_decay_rate", \
-    "mds_cache_quiesce_sleep", \
-    "mds_cache_quiesce_threshold", \
-    "mds_cache_reservation", \
-    "mds_cache_trim_decay_rate", \
-    "mds_cap_acquisition_throttle_retry_request_time", \
-    "mds_cap_revoke_eviction_timeout", \
-    "mds_debug_subtrees", \
-    "mds_dir_max_entries", \
-    "mds_dump_cache_threshold_file", \
-    "mds_dump_cache_threshold_formatter", \
-    "mds_enable_op_tracker", \
-    "mds_export_ephemeral_distributed", \
-    "mds_export_ephemeral_random", \
-    "mds_export_ephemeral_random_max", \
-    "mds_extraordinary_events_dump_interval", \
-    "mds_forward_all_requests_to_auth", \
-    "mds_health_cache_threshold", \
-    "mds_heartbeat_grace", \
-    "mds_heartbeat_reset_grace", \
-    "mds_inject_journal_corrupt_dentry_first", \
-    "mds_inject_migrator_session_race", \
-    "mds_inject_rename_corrupt_dentry_first", \
-    "mds_kill_dirfrag_at", \
-    "mds_kill_shutdown_at", \
-    "mds_log_event_large_threshold", \
-    "mds_log_events_per_segment", \
-    "mds_log_major_segment_event_ratio", \
-    "mds_log_max_events", \
-    "mds_log_max_segments", \
-    "mds_log_pause", \
-    "mds_log_skip_corrupt_events", \
-    "mds_log_skip_unbounded_events", \
-    "mds_log_trim_decay_rate", \
-    "mds_log_trim_threshold", \
-    "mds_max_caps_per_client", \
-    "mds_max_export_size", \
-    "mds_max_purge_files", \
-    "mds_max_purge_ops", \
-    "mds_max_purge_ops_per_pg", \
-    "mds_max_snaps_per_dir", \
-    "mds_op_complaint_time", \
-    "mds_op_history_duration", \
-    "mds_op_history_size", \
-    "mds_op_log_threshold", \
-    "mds_recall_max_decay_rate", \
-    "mds_recall_warning_decay_rate", \
-    "mds_request_load_average_decay_rate", \
-    "mds_server_dispatch_client_request_delay", \
-    "mds_server_dispatch_killpoint_random", \
-    "mds_session_cache_liveness_decay_rate", \
-    "mds_session_cap_acquisition_decay_rate", \
-    "mds_session_cap_acquisition_throttle", \
-    "mds_session_max_caps_throttle_ratio", \
-    "mds_session_metadata_threshold", \
+  static constexpr auto as_sv = std::to_array<std::string_view>({
+    "clog_to_graylog",
+    "clog_to_graylog_host",
+    "clog_to_graylog_port",
+    "clog_to_monitors",
+    "clog_to_syslog",
+    "clog_to_syslog_facility",
+    "clog_to_syslog_level",
+    "fsid",
+    "host",
+    "mds_allow_async_dirops",
+    "mds_alternate_name_max",
+    "mds_bal_export_pin",
+    "mds_bal_fragment_dirs",
+    "mds_bal_fragment_fast_factor",
+    "mds_bal_fragment_interval",
+    "mds_bal_fragment_size_max",
+    "mds_bal_interval",
+    "mds_bal_max",
+    "mds_bal_max_until",
+    "mds_bal_merge_size",
+    "mds_bal_mode",
+    "mds_bal_replicate_threshold",
+    "mds_bal_sample_interval",
+    "mds_bal_split_bits",
+    "mds_bal_split_rd",
+    "mds_bal_split_size",
+    "mds_bal_split_wr",
+    "mds_bal_unreplicate_threshold",
+    "mds_cache_memory_limit",
+    "mds_cache_mid",
+    "mds_cache_quiesce_decay_rate",
+    "mds_cache_quiesce_sleep",
+    "mds_cache_quiesce_threshold",
+    "mds_cache_reservation",
+    "mds_cache_trim_decay_rate",
+    "mds_cap_acquisition_throttle_retry_request_time",
+    "mds_cap_revoke_eviction_timeout",
+    "mds_debug_subtrees",
+    "mds_dir_max_entries",
+    "mds_dump_cache_threshold_file",
+    "mds_dump_cache_threshold_formatter",
+    "mds_enable_op_tracker",
+    "mds_export_ephemeral_distributed",
+    "mds_export_ephemeral_random",
+    "mds_export_ephemeral_random_max",
+    "mds_extraordinary_events_dump_interval",
+    "mds_forward_all_requests_to_auth",
+    "mds_health_cache_threshold",
+    "mds_heartbeat_grace",
+    "mds_heartbeat_reset_grace",
+    "mds_inject_journal_corrupt_dentry_first",
+    "mds_inject_migrator_session_race",
+    "mds_inject_rename_corrupt_dentry_first",
+    "mds_kill_dirfrag_at",
+    "mds_kill_shutdown_at",
+    "mds_log_event_large_threshold",
+    "mds_log_events_per_segment",
+    "mds_log_major_segment_event_ratio",
+    "mds_log_max_events",
+    "mds_log_max_segments",
+    "mds_log_pause",
+    "mds_log_skip_corrupt_events",
+    "mds_log_skip_unbounded_events",
+    "mds_log_trim_decay_rate",
+    "mds_log_trim_threshold",
+    "mds_max_caps_per_client",
+    "mds_max_export_size",
+    "mds_max_purge_files",
+    "mds_max_purge_ops",
+    "mds_max_purge_ops_per_pg",
+    "mds_max_snaps_per_dir",
+    "mds_op_complaint_time",
+    "mds_op_history_duration",
+    "mds_op_history_size",
+    "mds_op_log_threshold",
+    "mds_recall_max_decay_rate",
+    "mds_recall_warning_decay_rate",
+    "mds_request_load_average_decay_rate",
+    "mds_server_dispatch_client_request_delay",
+    "mds_server_dispatch_killpoint_random",
+    "mds_session_cache_liveness_decay_rate",
+    "mds_session_cap_acquisition_decay_rate",
+    "mds_session_cap_acquisition_throttle",
+    "mds_session_max_caps_throttle_ratio",
+    "mds_session_metadata_threshold",
     "mds_symlink_recovery"
-
-  constexpr bool is_sorted = [] () constexpr {
-    constexpr auto arr = std::to_array<std::string_view>({KEYS});
-    for (unsigned long i = 0; i < arr.size()-1; ++i) {
-      if (arr[i] > arr[i+1]) {
-        return false;
-      }
-    }
-    return true;
-  }();
-  static_assert(is_sorted, "keys are not sorted!");
-
-  static char const* keys[] = {KEYS, nullptr};
-  return keys;
+  });
+  static_assert(std::is_sorted(as_sv.begin(), as_sv.end()),
+                "keys are not sorted!");
+  return {as_sv.begin(), as_sv.end()};
 }
 
 void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed)

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -736,7 +736,7 @@ public:
   void handle_osd_map();
   void update_log_config();
 
-  const char** get_tracked_conf_keys() const override final;
+  std::vector<std::string> get_tracked_keys() const noexcept final;
   void handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed) override;
 
   void dump_sessions(const SessionFilter &filter, Formatter *f, bool cap_dump=false) const;

--- a/src/nvmeof/NVMeofGwMonitorClient.cc
+++ b/src/nvmeof/NVMeofGwMonitorClient.cc
@@ -50,14 +50,6 @@ NVMeofGwMonitorClient::NVMeofGwMonitorClient(int argc, const char **argv) :
 
 NVMeofGwMonitorClient::~NVMeofGwMonitorClient() = default;
 
-const char** NVMeofGwMonitorClient::get_tracked_conf_keys() const
-{
-  static const char* KEYS[] = {
-    NULL
-  };
-  return KEYS;
-}
-
 std::string read_file(const std::string& filename) {
     std::ifstream file(filename);
     std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());

--- a/src/nvmeof/NVMeofGwMonitorClient.h
+++ b/src/nvmeof/NVMeofGwMonitorClient.h
@@ -80,9 +80,11 @@ public:
   bool ms_handle_refused(Connection *con) override { return false; };
 
   // config observer bits
-  const char** get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override {
+    return {};
+  }
   void handle_conf_change(const ConfigProxy& conf,
-			  const std::set <std::string> &changed) override {};
+			  const std::set<std::string> &changed) override {};
 
   int init();
   void shutdown();

--- a/src/tools/rbd_mirror/Throttler.cc
+++ b/src/tools/rbd_mirror/Throttler.cc
@@ -30,7 +30,6 @@ namespace mirror {
 template <typename I>
 Throttler<I>::Throttler(CephContext *cct, const std::string &config_key)
   : m_cct(cct), m_config_key(config_key),
-    m_config_keys{m_config_key.c_str(), nullptr},
     m_lock(ceph::make_mutex(
       librbd::util::unique_lock_name("rbd::mirror::Throttler", this))),
     m_max_concurrent_ops(cct->_conf.get_val<uint64_t>(m_config_key)) {
@@ -219,11 +218,6 @@ void Throttler<I>::print_status(ceph::Formatter *f) {
   f->dump_int("max_parallel_requests", m_max_concurrent_ops);
   f->dump_int("running_requests", m_inflight_ops.size());
   f->dump_int("waiting_requests", m_queue.size());
-}
-
-template <typename I>
-const char** Throttler<I>::get_tracked_conf_keys() const {  
-  return m_config_keys;
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/Throttler.h
+++ b/src/tools/rbd_mirror/Throttler.h
@@ -53,7 +53,6 @@ private:
 
   CephContext *m_cct;
   const std::string m_config_key;
-  mutable const char* m_config_keys[2];
 
   ceph::mutex m_lock;
   uint32_t m_max_concurrent_ops;
@@ -61,7 +60,9 @@ private:
   std::map<Id, Context *> m_queued_ops;
   std::set<Id> m_inflight_ops;
 
-  const char **get_tracked_conf_keys() const override;
+  std::vector<std::string> get_tracked_keys() const noexcept override {
+    return std::vector<std::string>{m_config_key};
+  }
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string> &changed) override;
 };


### PR DESCRIPTION
.. with get_tracked_keys().

This PR is but one of a set. Following
https://github.com/ceph/ceph/pull/61394, all uses of
the deprecated interface will be updated, and that
old interface will be removed.
