### PR TITLE
rgw/auth: Remove legacy Keystone admin token

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -637,40 +637,6 @@ options:
   services:
   - rgw
   with_legacy: true
-- name: rgw_keystone_admin_token
-  type: str
-  level: advanced
-  desc: 'DEPRECATED: The admin token (shared secret) that is used for the Keystone
-    requests.'
-  fmt_desc: The Keystone admin token (shared secret). In Ceph RGW
-    authentication with the admin token has priority over
-    authentication with the admin credentials
-    (``rgw_keystone_admin_user``, ``rgw_keystone_admin_password``,
-    ``rgw_keystone_admin_tenant``, ``rgw_keystone_admin_project``,
-    ``rgw_keystone_admin_domain``). The Keystone admin token
-    has been deprecated, but can be used to integrate with
-    older environments.  It is preferred to instead configure
-    ``rgw_keystone_admin_token_path`` to avoid exposing the token.
-  services:
-  - rgw
-  with_legacy: true
-- name: rgw_keystone_admin_token_path
-  type: str
-  level: advanced
-  desc: Path to a file containing the admin token (shared secret) that is used for
-    the Keystone requests.
-  fmt_desc: Path to a file containing the Keystone admin token
-    (shared secret).  In Ceph RadosGW authentication with
-    the admin token has priority over authentication with
-    the admin credentials
-    (``rgw_keystone_admin_user``, ``rgw_keystone_admin_password``,
-    ``rgw_keystone_admin_tenant``, ``rgw_keystone_admin_project``,
-    ``rgw_keystone_admin_domain``).
-    The Keystone admin token has been deprecated, but can be
-    used to integrate with older environments.
-  services:
-  - rgw
-  with_legacy: true
 - name: rgw_keystone_admin_user
   type: str
   level: advanced

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -287,14 +287,11 @@ void rgw::AppMain::cond_init_apis()
     }
 
     /* warn about insecure keystone secret config options */
-    if (!(g_ceph_context->_conf->rgw_keystone_admin_token.empty() ||
-          g_ceph_context->_conf->rgw_keystone_admin_password.empty())) {
+    if (!g_ceph_context->_conf->rgw_keystone_admin_password.empty()) {
       dout(0)
-          << "WARNING: rgw_keystone_admin_token and "
-             "rgw_keystone_admin_password should be avoided as they can "
-             "expose secrets.  Prefer the new rgw_keystone_admin_token_path "
-             "and rgw_keystone_admin_password_path options, which read their "
-             "secrets from files."
+          << "WARNING: rgw_keystone_admin_password should be avoided as "
+             "it can expose the password. Prefer the rgw_keystone_admin_password_path "
+	     "option which read the password from a file."
           << dendl;
     }
 

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -95,20 +95,6 @@ static inline std::string read_secret(const std::string& file_path)
   return s;
 }
 
-std::string CephCtxConfig::get_admin_token() const noexcept
-{
-  auto& atv = g_ceph_context->_conf->rgw_keystone_admin_token_path;
-  if (!atv.empty()) {
-    return read_secret(atv);
-  } else {
-    auto& atv = g_ceph_context->_conf->rgw_keystone_admin_token;
-    if (!atv.empty()) {
-      return atv;
-    }
-  }
-  return empty;
-}
-
 std::string CephCtxConfig::get_admin_password() const noexcept  {
   auto& apv = g_ceph_context->_conf->rgw_keystone_admin_password_path;
   if (!apv.empty()) {
@@ -129,14 +115,6 @@ int Service::get_admin_token(const DoutPrefixProvider *dpp,
                              std::string& token,
                              bool& token_cached)
 {
-  /* Let's check whether someone uses the deprecated "admin token" feature
-   * based on a shared secret from keystone.conf file. */
-  const auto& admin_token = config.get_admin_token();
-  if (! admin_token.empty()) {
-    token = std::string(admin_token.data(), admin_token.length());
-    return 0;
-  }
-
   TokenEnvelope t;
 
   /* Try cache first before calling Keystone for a new admin token. */

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -37,7 +37,6 @@ protected:
 public:
   virtual std::string get_endpoint_url() const noexcept = 0;
 
-  virtual std::string get_admin_token() const noexcept = 0;
   virtual std::string_view get_admin_user() const noexcept = 0;
   virtual std::string get_admin_password() const noexcept = 0;
   virtual std::string_view get_admin_tenant() const noexcept = 0;
@@ -59,8 +58,6 @@ public:
   }
 
   std::string get_endpoint_url() const noexcept override;
-
-  std::string get_admin_token() const noexcept override;
 
   std::string_view get_admin_user() const noexcept override {
     return g_ceph_context->_conf->rgw_keystone_admin_user;


### PR DESCRIPTION
The legacy hardcoded admin token in the Keystone
configuration is removed since several years and
is not possible or supported anymore.

The only supported way is to authenticate with a
username and password to retrieve a token that is
valid for a specified amount of time.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
