### PR TITLE
nvmeofgw* :do not allow failover for gws during redeploy (fast-reboot)

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -77,7 +77,14 @@ options:
   level: advanced
   desc: Period in seconds from last beacon to monitor marking a  NVMeoF gateway as
     failed
-  default: 10
+  default: 15
+  services:
+  - mon
+- name: mon_nvmeofgw_skip_failovers_interval
+  type: secs
+  level: advanced
+  desc: Period in seconds in which no failovers are performed in GW's pool-group
+  default: 12
   services:
   - mon
 - name: mon_nvmeofgw_set_group_id_retry

--- a/src/mon/NVMeofGwMap.h
+++ b/src/mon/NVMeofGwMap.h
@@ -87,6 +87,7 @@ public:
        const NvmeGroupKey& group_key, bool &map_modified);
   void gw_performed_startup(const NvmeGwId &gw_id,
        const NvmeGroupKey& group_key, bool &propose_pending);
+  void skip_failovers_for_group(const NvmeGroupKey& group_key);
 private:
   int  do_delete_gw(const NvmeGwId &gw_id, const NvmeGroupKey& group_key);
   int  do_erase_gw_id(const NvmeGwId &gw_id,

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -153,9 +153,35 @@ version_t NVMeofGwMon::get_trim_to() const
   return 0;
 }
 
+/**
+ * restore_pending_map_info
+ * function called during new paxos epochs
+ * function called to restore in pending map all data that is not serialized
+ * to paxos peons. Othervise it would be overriden in "pending_map = map"
+ * currently  just "allow_failovers_ts" variable is restored
+ */
+void NVMeofGwMon::restore_pending_map_info(NVMeofGwMap & tmp_map) {
+  std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+  for (auto& created_map_pair: tmp_map.created_gws) {
+    auto group_key = created_map_pair.first;
+    NvmeGwMonStates& gw_created_map = created_map_pair.second;
+    for (auto& gw_created_pair: gw_created_map) {
+      auto gw_id = gw_created_pair.first;
+      if (gw_created_pair.second.allow_failovers_ts > now) {
+        // restore not persistent information upon new epochs
+        dout(10) << " restore skip-failovers timeout for gw  " << gw_id  << dendl;
+        pending_map.created_gws[group_key][gw_id].allow_failovers_ts =
+          gw_created_pair.second.allow_failovers_ts;
+      }
+    }
+  }
+}
+
 void NVMeofGwMon::create_pending()
 {
+  NVMeofGwMap tmp_map = pending_map;
   pending_map = map;// deep copy of the object
+  restore_pending_map_info(tmp_map);
   pending_map.epoch++;
   dout(10) << " pending " << pending_map  << dendl;
 }
@@ -641,11 +667,12 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
       if (pending_map.created_gws[group_key][gw_id].availability ==
 	  gw_availability_t::GW_AVAILABLE) {
 	dout(1) << " Warning :GW marked as Available in the NVmeofGwMon "
-		<< "database, performed full startup - Apply GW!"
+		<< "database, performed full startup - Apply it but don't allow failover!"
 		<< gw_id << dendl;
 	 process_gw_down(gw_id, group_key, gw_propose, avail);
-	 LastBeacon lb = {gw_id, group_key};
-	 last_beacon[lb] = now; //Update last beacon
+	 pending_map.skip_failovers_for_group(group_key);
+	 dout(4) << "set skip-failovers for gw's group " << gw_id << " group "
+	 << group_key << dendl;
       } else if (
 	pending_map.created_gws[group_key][gw_id].performed_full_startup ==
 	false) {
@@ -654,6 +681,8 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
 	pending_map.created_gws[group_key][gw_id].addr_vect =
 	    entity_addrvec_t(con->get_peer_addr());
       }
+      LastBeacon lb = {gw_id, group_key};
+      last_beacon[lb] = now; //Update last beacon
       goto set_propose;
     }
   // gw already created
@@ -774,15 +803,19 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
           % beacons_till_ack) == 0))|| (!apply_ack_logic) ) {
     send_ack = true;
     if (apply_ack_logic) {
-      dout(10) << "ack sent: beacon index "
+      dout(20) << "ack sent: beacon index "
        << pending_map.created_gws[group_key][gw_id].beacon_index
        << " gw " << gw_id <<dendl;
     }
   }
   if (send_ack && ((!gw_propose && epoch_filter_enabled) ||
-                    (propose && !epoch_filter_enabled)) ) {
-          // if epoch-filter-bit: send ack to beacon in case no propose
-          //or if changed something not relevant to gw-epoch
+                    (propose && !epoch_filter_enabled) ||
+                    (avail == gw_availability_t::GW_CREATED)) ) {
+          /* always send beacon ack to gw in Created state,
+           * it should be temporary state
+           * if epoch-filter-bit: send ack to beacon in case no propose
+           * or if changed something not relevant to gw-epoch
+          */
     if (gw_created) {
       // respond with a map slice correspondent to the same GW
       ack_map.created_gws[group_key][gw_id] = map.created_gws[group_key][gw_id];

--- a/src/mon/NVMeofGwMon.h
+++ b/src/mon/NVMeofGwMon.h
@@ -98,6 +98,7 @@ private:
        NvmeGwId &gw_id, NvmeGroupKey& group_key);
   epoch_t get_ack_map_epoch(bool gw_created, const NvmeGroupKey& group_key);
   void recreate_gw_epoch();
+  void restore_pending_map_info(NVMeofGwMap & tmp_map);
 };
 
 #endif /* MON_NVMEGWMONITOR_H_ */

--- a/src/mon/NVMeofGwTypes.h
+++ b/src/mon/NVMeofGwTypes.h
@@ -131,6 +131,28 @@ struct NvmeGwMonState {
   //ceph entity address allocated for the GW-client that represents this GW-id
   entity_addrvec_t addr_vect;
   uint16_t beacon_index = 0;
+  /**
+   * during redeploy action and maybe other emergency use-cases gw performs scenario
+   * that we call fast-reboot. It quickly reboots(due to redeploy f.e) and sends the
+   * first beacon to monitor in "Created" state while according to monitor FSM it
+   * still appears "Available".
+   * This lost of synchronizarion with GW is detected by monitor. After fast reboot, the monitor
+   * still considers this GW as not eligible for owning any ANA group until it becomes
+   * in Available state (sends the next beacon that includes the subsystems information).
+   * In this specific fast-reboot case, we prefer to avoid failing over the ANA groups
+   * that were owned by this GW for a short time frame, assuming that this GW will be
+   * in Available State in few seconds. Doing too many failovers and failbacks
+   * in a very short times frame, on many GWs, is causing a lot of pain to the
+   * initiators, up to the point that they might stuck.
+   *
+   * So was decided to set to GW new timeout varible "allow_failovers_ts" - no failovers
+   * are performed to GW's pool-group during 12 seconds from the time it is set.
+   * this variable is not persistent - not serialized to peers, so need to prevent
+   * it from being overriden by new epochs in monitor's function create_pending -
+   * function restore_pending_map_info is called for this purpose
+  */
+  std::chrono::system_clock::time_point allow_failovers_ts =
+             std::chrono::system_clock::now();
   NvmeGwMonState(): ana_grp_id(REDUNDANT_GW_ANA_GROUP_ID) {}
 
   NvmeGwMonState(NvmeAnaGrpId id)


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
