### PR TITLE
reef: LogMonitor: set no_reply for forward MLog commands

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -711,11 +711,9 @@ bool LogMonitor::preprocess_log(MonOpRequestRef op)
     goto done;
   }
 
-  return false;
-
- done:
-  mon.no_reply(op);
-  return true;
+  done:
+    mon.no_reply(op);
+    return (!num_new);
 }
 
 struct LogMonitor::C_Log : public C_MonOp {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70379

---

backport of https://github.com/ceph/ceph/pull/61933
parent tracker: https://tracker.ceph.com/issues/54489

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh