### PR TITLE
os/bluestore: Fast WAL for RocksDB

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -34,7 +34,7 @@ Synopsis
 | **ceph-bluestore-tool** show-sharding --path *osd path*
 | **ceph-bluestore-tool** trim --path *osd path*
 | **ceph-bluestore-tool** zap-device --dev *dev path*
-| **ceph-bluestore-tool** downgrade-wal-to-v1 --path *osd path*
+| **ceph-bluestore-tool** revert-wal-to-plain --path *osd path*
 
 
 Description
@@ -166,10 +166,10 @@ Commands
 
    Zeros all device label locations. This effectively makes device appear empty.
 
-:command: `downgrade-wal-to-v1` --path *osd path*
+:command: `revert-wal-to-plain` --path *osd path*
 
-   Changes WAL disk format from the new version to the legacy one. Useful for downgrades, or if you
-   might want to disable this new feature (bluefs_wal_v2).
+   Changes WAL files from envelope mode to the legacy plain mode.
+   Useful for downgrades, or if you might want to disable this new feature (bluefs_wal_envelope_mode).
 
 Options
 =======

--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -34,6 +34,7 @@ Synopsis
 | **ceph-bluestore-tool** show-sharding --path *osd path*
 | **ceph-bluestore-tool** trim --path *osd path*
 | **ceph-bluestore-tool** zap-device --dev *dev path*
+| **ceph-bluestore-tool** downgrade-wal-to-v1 --path *osd path*
 
 
 Description
@@ -164,6 +165,11 @@ Commands
 :command: `zap-device` --dev *dev path*
 
    Zeros all device label locations. This effectively makes device appear empty.
+
+:command: `downgrade-wal-to-v1` --path *osd path*
+
+   Changes WAL disk format from the new version to the legacy one. Useful for downgrades, or if you
+   might want to disable this new feature (bluefs_wal_v2).
 
 Options
 =======

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6718,3 +6718,12 @@ options:
   desc: Enables exception throwing instead of process abort on transaction submission error.
   default: false
   with_legacy: false
+- name: bluefs_wal_v2
+  type: bool
+  level: advanced
+  desc: Enables a faster backend in BlueFS for WAL writes.
+  long_desc: Enabling this feature will reduce ~50% the amount of fdatasync syscalls issued by WAL writes. This happens because we embed metadata
+    with the data itself. Downgrading from a version that uses v2 to v1 will require running `ceph-bluestore-tool --command downgrade-wal-to-v1`
+    to move wal files to previous format.
+  default: true
+  with_legacy: false

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4248,6 +4248,15 @@ options:
   level: advanced
   default: false
   with_legacy: true
+- name: bluefs_wal_envelope_mode
+  type: bool
+  level: advanced
+  desc: Enables a faster backend in BlueFS for WAL writes.
+  long_desc: In envelope mode BlueFS files do not need to update metadata. When applied to RocksDB WAL files,
+    it reduces by ~50% the amount of fdatasync syscalls.
+    Downgrading from an envelope mode to legacy mode requires `ceph-bluestore-tool --command downgrade-wal-to-v1`.
+  default: true
+  with_legacy: false
 - name: bluefs_allocator
   type: str
   level: dev
@@ -6717,13 +6726,4 @@ options:
   level: dev
   desc: Enables exception throwing instead of process abort on transaction submission error.
   default: false
-  with_legacy: false
-- name: bluefs_wal_envelope_mode
-  type: bool
-  level: advanced
-  desc: Enables a faster backend in BlueFS for WAL writes.
-  long_desc: In envelope mode BlueFS files do not need to update metadata. When applied to RocksDB WAL files,
-    it reduces by ~50% the amount of fdatasync syscalls.
-    Downgrading from an envelope mode to legacy mode requires `ceph-bluestore-tool --command downgrade-wal-to-v1`.
-  default: true
   with_legacy: false

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6718,12 +6718,12 @@ options:
   desc: Enables exception throwing instead of process abort on transaction submission error.
   default: false
   with_legacy: false
-- name: bluefs_wal_v2
+- name: bluefs_wal_envelope_mode
   type: bool
   level: advanced
   desc: Enables a faster backend in BlueFS for WAL writes.
-  long_desc: Enabling this feature will reduce ~50% the amount of fdatasync syscalls issued by WAL writes. This happens because we embed metadata
-    with the data itself. Downgrading from a version that uses v2 to v1 will require running `ceph-bluestore-tool --command downgrade-wal-to-v1`
-    to move wal files to previous format.
+  long_desc: In envelope mode BlueFS files do not need to update metadata. When applied to RocksDB WAL files,
+    it reduces by ~50% the amount of fdatasync syscalls.
+    Downgrading from an envelope mode to legacy mode requires `ceph-bluestore-tool --command downgrade-wal-to-v1`.
   default: true
   with_legacy: false

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -834,6 +834,7 @@ struct error_code;
       contiguous_filler(char* const pos) : pos(pos) {}
 
     public:
+      contiguous_filler() : pos(nullptr) {}
       void advance(const unsigned len) {
 	pos += len;
       }

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1912,6 +1912,16 @@ struct StructVChecker
   _denc_start(p, &struct_v.v, &struct_compat, &_denc_pchar, &_denc_u32);	\
   do {
 
+// This variant is unsafe, because older versions will not even catch incompatibility.
+// The ability to decode must be verified by other means,
+#define DENC_START_UNSAFE(v, compat, p)				\
+  __u8 struct_v = v;							\
+  __u8 struct_compat = compat;						\
+  char *_denc_pchar;							\
+  uint32_t _denc_u32;							\
+  _denc_start(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);	\
+  do {
+
 // For osd_reqid_t which cannot be upgraded at all.
 // We used it to communicate with clients and now we cannot safely upgrade.
 #define DENC_START_OSD_REQID(_v, compat, p)				\

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1835,8 +1835,6 @@ struct StructVChecker
     p += 2 + 4;								\
   }									\
   static void _denc_finish(size_t& p,					\
-			   __u8 *struct_v,				\
-			   __u8 *struct_compat,				\
 			   char **, uint32_t *) { }			\
   /* encode */								\
   static void _denc_start(::ceph::buffer::list::contiguous_appender& p,	\
@@ -1850,8 +1848,6 @@ struct StructVChecker
     *start_oob_off = p.get_out_of_band_offset();			\
   }									\
   static void _denc_finish(::ceph::buffer::list::contiguous_appender& p, \
-			   __u8 *struct_v,				\
-			   __u8 *struct_compat,				\
 			   char **len_pos,				\
 			   uint32_t *start_oob_off) {			\
     *(ceph_le32*)*len_pos = p.get_pos() - *len_pos - sizeof(uint32_t) +	\
@@ -1872,7 +1868,6 @@ struct StructVChecker
     *start_pos = const_cast<char*>(p.get_pos());			\
   }									\
   static void _denc_finish(::ceph::buffer::ptr::const_iterator& p,	\
-			   __u8 *struct_v, __u8 *struct_compat,		\
 			   char **start_pos,				\
 			   uint32_t *struct_len) {			\
     const char *pos = p.get_pos();					\
@@ -1900,6 +1895,16 @@ struct StructVChecker
   uint32_t _denc_u32;							\
   static_assert(CEPH_RELEASE >= (CEPH_RELEASE_SQUID /*19*/ + 2) || compat == 1);	\
   _denc_start(p, &struct_v.v, &struct_compat, &_denc_pchar, &_denc_u32);	\
+  do {
+
+// the variant for seldom-used cases when we manually select encoding version
+#define DENC_START_UNCHECKED(_v, compat, p)				\
+  __u8 struct_v = _v; 							\
+  __u8 struct_compat = compat;						\
+  char *_denc_pchar;							\
+  uint32_t _denc_u32;							\
+  static_assert(CEPH_RELEASE >= (CEPH_RELEASE_SQUID /*19*/ + 2) || compat == 1);	\
+  _denc_start(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);	\
   do {
 
 // For the only type that is with compat 2: unittest.
@@ -1935,8 +1940,7 @@ struct StructVChecker
 
 #define DENC_FINISH(p)							\
   } while (false);							\
-  _denc_finish(p, &struct_v.v, &struct_compat, &_denc_pchar, &_denc_u32);
-
+  _denc_finish(p, &_denc_pchar, &_denc_u32);
 
 // ----------------------------------------------------------------------
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1447,21 +1447,6 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   using ::ceph::encode;					     \
   do {
 
-#define ENCODE_START_FILLER(v, compat, filler_in)			     \
-  __u8 struct_v = v;                                         \
-  __u8 struct_compat = compat;		                     \
-  ceph_le32 struct_len;				             \
-  auto& filler = filler_in;	     \
-  filler.copy_in(sizeof(struct_v), (char *)&struct_v);       \
-  filler.copy_in(sizeof(struct_compat),			     \
-    (char *)&struct_compat);				     \
-  char* struct_len_ptr = filler.c_str(); \
-  filler.advance(sizeof(struct_len)); \
-  const auto starting_bl_len = filler.c_str();		     \
-  using ::ceph::encode;					     \
-  do {
-
-
 /**
  * finish encoding block
  *
@@ -1478,18 +1463,6 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   filler.copy_in(sizeof(struct_compat),			     \
     (char *)&struct_compat);				     \
   filler.copy_in(sizeof(struct_len), (char *)&struct_len);
-
-
-/**
-  * finish encoding block with filler
-  *
-  * @param bl bufferlist we were encoding to
-  * @param new_struct_compat struct-compat value to use
-  */
-#define ENCODE_FINISH_FILLER()      \
-  } while (false);                                           \
-  struct_len = filler.c_str() - starting_bl_len;              \
-  *((ceph_le32*)struct_len_ptr) = struct_len;
 
 #define ENCODE_FINISH(bl) ENCODE_FINISH_NEW_COMPAT(bl, 0)
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1447,6 +1447,21 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   using ::ceph::encode;					     \
   do {
 
+#define ENCODE_START_FILLER(v, compat, filler_in)			     \
+  __u8 struct_v = v;                                         \
+  __u8 struct_compat = compat;		                     \
+  ceph_le32 struct_len;				             \
+  auto& filler = filler_in;	     \
+  filler.copy_in(sizeof(struct_v), (char *)&struct_v);       \
+  filler.copy_in(sizeof(struct_compat),			     \
+    (char *)&struct_compat);				     \
+  char* struct_len_ptr = filler.c_str(); \
+  filler.advance(sizeof(struct_len)); \
+  const auto starting_bl_len = filler.c_str();		     \
+  using ::ceph::encode;					     \
+  do {
+
+
 /**
  * finish encoding block
  *
@@ -1463,6 +1478,18 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   filler.copy_in(sizeof(struct_compat),			     \
     (char *)&struct_compat);				     \
   filler.copy_in(sizeof(struct_len), (char *)&struct_len);
+
+
+/**
+  * finish encoding block with filler
+  *
+  * @param bl bufferlist we were encoding to
+  * @param new_struct_compat struct-compat value to use
+  */
+#define ENCODE_FINISH_FILLER()      \
+  } while (false);                                           \
+  struct_len = filler.c_str() - starting_bl_len;              \
+  *((ceph_le32*)struct_len_ptr) = struct_len;
 
 #define ENCODE_FINISH(bl) ENCODE_FINISH_NEW_COMPAT(bl, 0)
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2214,6 +2214,137 @@ int BlueFS::device_migrate_to_new(
   return 0;
 }
 
+int BlueFS::downgrade_wal_to_v1() {
+  _init_logger();
+  string wal_dir("db.wal");
+  auto dir_it = nodes.dir_map.find(wal_dir);
+  if (dir_it == nodes.dir_map.end()) {
+    dout(5) << fmt::format("{} No files needed to move", __func__) << dendl;
+    return 0;
+  }
+
+  DirRef dir = dir_it->second;
+
+  size_t wal_v2_aggregated_size = 0;
+  std::vector<std::pair<string, FileRef>> files_to_migrate;
+  files_to_migrate.reserve(dir->file_map.size());
+
+  // get info about wal files
+  for (const auto& [file_name, file] : dir->file_map) {
+    if(file->is_new_wal()) {
+      wal_v2_aggregated_size += file->fnode.wal_size;
+      files_to_migrate.push_back({ file_name, file });
+    }
+  }
+
+  // check free space
+  uint8_t prefer_bdev = vselector->select_prefer_bdev(vselector->get_hint_by_dir(wal_dir));
+  uint64_t free_space = alloc[prefer_bdev]->get_free();
+  if (free_space < wal_v2_aggregated_size) {
+    dout(1) << fmt::format("{} Error trying to migrate new WAL V2 to V1. Aggregated size of WAL files is {}, free space is {}", __func__, wal_v2_aggregated_size, free_space) << dendl;
+    return -ENOSPC;
+  }
+
+  // do migration
+  size_t file_migrated_count = 0;
+  string tmp_name_prefix("__tmp_name_");
+  uint64_t buffer_size = 1024*1024*50; // 50 MiB?
+  bool failure_while_migrating = false;
+  for (auto &[name, file] : files_to_migrate) {
+    FileWriter *writer;
+    string new_file_temp_name = fmt::format("{}{}", tmp_name_prefix, file_migrated_count);
+    int r = open_for_write(wal_dir, new_file_temp_name, &writer, false);
+    ceph_assert(r == 0);
+    auto close_writer_path = make_scope_guard([&] {
+      close_writer(writer);
+    });
+
+    // use normal v1 write path by marking node type to legacy
+    writer->file->fnode.type = bluefs_node_type::REGULAR;
+
+    FileReader* previous_reader;
+    r = open_for_read(wal_dir, name, &previous_reader);
+    auto read_writer_path = make_scope_guard([&] {
+      delete previous_reader;
+    });
+    ceph_assert(r == 0);
+
+    // move contents from previous to new file
+    uint64_t previous_size = previous_reader->file->fnode.wal_size;
+    uint64_t left_to_read = previous_size;
+    bufferlist read_buffer;
+    uint64_t read_offset = 0;
+    while(left_to_read > 0) {
+      // read from prevoius file
+      read_buffer.clear();
+      uint64_t to_read = std::min(buffer_size, left_to_read);
+      int r = _read_wal(previous_reader, read_offset, to_read, &read_buffer, nullptr);
+      ceph_assert(r >= 0);
+      if (uint64_t(r) < to_read) {
+        dout(5) << fmt::format("{} read less than expect while migrating file {} to wal v1", __func__, name) << dendl;
+        failure_while_migrating = true;
+        break;
+      }
+
+      // add to new file
+      append_try_flush(writer, read_buffer.c_str(), read_buffer.length());
+
+      // update state
+      read_offset += to_read;
+      left_to_read -= to_read;
+    }
+    if (failure_while_migrating) {
+      break;
+    }
+    // todo things left to read, do cleanup
+
+    int fsync_ret = fsync(writer);
+    if (fsync_ret != 0) {
+      derr << fmt::format("{} fsync error {} while moving data for file {} ", __func__, fsync_ret, name) << dendl;
+      failure_while_migrating = true;
+      break;
+    }
+
+    file_migrated_count++;
+  }
+
+  if (failure_while_migrating) {
+    derr << fmt::format("{} couldn't properly move data from v2 to v1, unlinking temp files...", __func__) << dendl;
+    size_t file_migrated_count = 0;
+    for (size_t i = 0; i < files_to_migrate.size(); i++) {
+      string new_file_temp_name = fmt::format("{}{}", tmp_name_prefix, file_migrated_count);
+      derr << fmt::format("{} unlinking {}", __func__, new_file_temp_name) << dendl;
+      int unlink_ret = unlink(wal_dir, new_file_temp_name);
+      ceph_assert(unlink_ret == 0);
+      file_migrated_count++;
+    }
+    return -EIO;
+  }
+
+  // everything went okay, rename files
+  file_migrated_count = 0;
+  for (auto &[name, file] : files_to_migrate) {
+    
+    dout(5) << fmt::format("{} unlinking {}", __func__, name) << dendl;
+    int unlink_ret = unlink(wal_dir, name);
+    ceph_assert(unlink_ret == 0);
+    
+    string new_file_temp_name = fmt::format("{}{}", tmp_name_prefix, file_migrated_count);
+    dout(5) << fmt::format("{} renaming {} to {}", __func__, tmp_name_prefix, name) << dendl;
+    int rename_ret = rename(wal_dir, new_file_temp_name, wal_dir, name);
+    ceph_assert(rename_ret == 0);
+    file_migrated_count++;
+  }
+
+  // Ensure no dangling wal v2 files are inside transactions.
+  _compact_log_sync_LNF_LD();
+
+  _write_super(BDEV_DB, 1);
+
+  dout(5) << fmt::format("{} success moving data", __func__) << dendl;
+
+  return 0;
+}
 
 BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
 {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
+#include <asm-generic/errno-base.h>
 #include <chrono>
+#include <fmt/compile.h>
 #include "boost/algorithm/string.hpp" 
 #include "bluestore_common.h"
 #include "BlueFS.h"
@@ -10,8 +12,10 @@
 #include "common/errno.h"
 #include "common/perf_counters.h"
 #include "Allocator.h"
+#include "include/buffer_fwd.h"
 #include "include/ceph_assert.h"
 #include "common/admin_socket.h"
+#include "os/bluestore/bluefs_types.h"
 
 #ifdef WITH_SEASTAR
 #include "crimson/common/perf_counters_collection.h"
@@ -1228,9 +1232,15 @@ int BlueFS::fsck()
   return 0;
 }
 
-int BlueFS::_write_super(int dev)
+int BlueFS::_write_super(int dev, uint8_t wal_version)
 {
   ++super.seq;
+  if (wal_version > 0) {
+    super.wal_version = wal_version;
+  } else {
+    bool use_wal_v2 = cct->_conf.get_val<bool>("bluefs_wal_v2");
+    super.wal_version = use_wal_v2 ? 2 : 1;
+  }
   // build superblock
   bufferlist bl;
   encode(super, bl);
@@ -1617,6 +1627,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
               vselector->get_hint_by_dir(dirname);
             vselector->add_usage(file->vselector_hint, file->fnode);
 
+
 	    q->second->file_map[filename] = file;
 	    ++file->refs;
 	  }
@@ -1642,8 +1653,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	    ceph_assert(q != nodes.dir_map.end());
 	    map<string,FileRef>::iterator r = q->second->file_map.find(filename);
 	    ceph_assert(r != q->second->file_map.end());
-            ceph_assert(r->second->refs > 0); 
-	    --r->second->refs;
+
+            FileRef file = r->second;
+            ceph_assert(file->refs > 0);
+            --file->refs;
 	    q->second->file_map.erase(r);
 	  }
 	}
@@ -1692,6 +1705,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
         {
 	  bluefs_fnode_t fnode;
 	  decode(fnode, p);
+          ceph_assert(fnode.type == bluefs_node_type::REGULAR || fnode.type == bluefs_node_type::WAL_V2);
 	  dout(20) << __func__ << " 0x" << std::hex << pos << std::dec
                    << ":  op_file_update " << " " << fnode << " " << dendl;
           if (unlikely(to_stdout)) {
@@ -1763,8 +1777,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	    if (fnode.ino != 1) {
 	      vselector->sub_usage(f->vselector_hint, fnode);
 	    }
-	    fnode.size = delta.size;
 	    fnode.claim_extents(delta.extents);
+      fnode.size = delta.size;
+      fnode.wal_limit = delta.wal_limit;
+      fnode.wal_size = delta.wal_size;
 	    dout(20) << __func__ << " 0x" << std::hex << pos << std::dec
 		     << ":  op_file_update_inc produced " << " " << fnode << " " << dendl;
 
@@ -1840,7 +1856,18 @@ int BlueFS::_replay(bool noop, bool to_stdout)
     dirty.seq_live = log_seq + 1;
     log.t.seq = log.seq_live;
     dirty.seq_stable = log_seq;
+
+    for (const auto &[filename, file] : nodes.file_map) {
+      if (file->is_new_wal()) {
+          dout(5) << __func__ << " " << file << " " << file->refs << dendl;
+          if (file->refs == 0) {
+            continue;
+          }
+          _wal_update_size(file, file->fnode.size);
+      }
+    }
   }
+
 
   dout(10) << __func__ << " log file size was 0x"
            << std::hex << log_file->fnode.size << std::dec << dendl;
@@ -2186,6 +2213,7 @@ int BlueFS::device_migrate_to_new(
   return 0;
 }
 
+
 BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
 {
   auto p = nodes.file_map.find(ino);
@@ -2346,6 +2374,185 @@ int64_t BlueFS::_read_random(
            << std::dec  << dendl;
   --h->file->num_reading;
   logger->tinc(l_bluefs_read_random_lat, mono_clock::now() - t0);
+  return ret;
+}
+
+void BlueFS::_wal_update_size(FileRef file, uint64_t increment) {
+  using WALLength = File::WALFlush::WALLength;
+
+  file->is_wal_read_loaded = true;
+  file->wal_flushes.clear();
+
+  uint64_t flush_offset = 0;
+  dout(20)
+      << fmt::format(
+        "{} updating WAL file {} for range {:#x}~{:#x} limit is {:#x}",
+        __func__, file->fnode.ino, flush_offset, increment, file->fnode.wal_limit)
+      << dendl;
+  ceph_assert(file->wal_flushes.empty());
+
+  FileReader *h = new FileReader(file, cct->_conf->bluefs_max_prefetch, false, true);
+
+  size_t header_size = File::WALFlush::header_size();
+
+  uint64_t flush_end = flush_offset + increment;
+  while (flush_offset < file->fnode.wal_limit) {
+    // read first part of wal flush
+    bufferlist bl;
+    bluefs_wal_header_t header;
+
+    uint64_t read_result = (uint64_t)_read(h, flush_offset, header_size, &bl, nullptr);
+    if (read_result < header_size) {
+      dout(20) << fmt::format("{} cannot read wal header, most likely we are out of bounds. flush_offset={:#X}", __func__, flush_offset) << dendl;
+      break;
+    }
+
+    dout(30) << __func__ << " result \n";
+    bl.hexdump(*_dout);
+    *_dout << dendl;
+    auto buffer_iterator = bl.cbegin();
+    try {
+      decode(header, buffer_iterator);
+    } catch(ceph::buffer::error& e) {
+      // EOF or corruption
+      dout(30) << fmt::format("couldn't decode wal flush header at offset {:#x}: {}", flush_offset, e.what()) << dendl;
+      break;
+    }
+
+    WALLength flush_length = header.flush_length;
+    dout(20) << __func__ << " flush_length " << flush_length << dendl;
+    File::WALFlush new_flush(flush_offset, flush_length);
+
+    // read marker
+    bl.clear();
+    uint64_t marker_offset = new_flush.get_marker_offset();
+    read_result = _read(h, marker_offset, new_flush.tail_size(), &bl, nullptr);
+    if (read_result < new_flush.tail_size()) {
+      dout(20) << fmt::format("{} cannot read marker, most likely we are out of bounds. flush_offset={:#X}, marker_offset={:#X}", __func__, flush_offset, marker_offset) << dendl;
+      break;
+    }
+    uint64_t marker;
+    buffer_iterator = bl.cbegin();
+    decode(marker, buffer_iterator);
+    if (marker != File::WALFlush::generate_hashed_marker(super.osd_uuid, file->fnode.ino)) {
+      // EOF or corruption
+      dout(30) << fmt::format("reached eof or marker corruption {:#x}", flush_offset) << dendl;
+      break;
+    }
+
+    uint64_t increase = new_flush.end_offset() - new_flush.offset;
+    dout(20) << fmt::format("{} adding flush {:#x}~{:#x}", __func__, flush_offset, new_flush.length) << dendl;
+    file->wal_flushes.push_back(new_flush);
+    if (flush_offset >= flush_end) {
+      dout(20) << fmt::format("{} recovering flush {:#x}~{:#x}", __func__, flush_offset, new_flush.length) << dendl;
+      file->fnode.wal_size += new_flush.length;
+      file->fnode.size += increase;
+      vselector->add_usage(file->vselector_hint, increase);
+    }
+
+    flush_offset += increase;
+  }
+
+  // if we read less it might mean corruption
+  if (flush_offset < flush_end) {
+    dout(20) << fmt::format("{} read less than expected {:#x} bytes", __func__, flush_offset) << dendl;
+  }
+  ceph_assert(flush_offset >= flush_end);
+
+  delete h;
+}
+
+int64_t BlueFS::_read_wal(
+  FileReader *h,         ///< [in] read from here
+  uint64_t off,          ///< [in] offset
+  size_t len,            ///< [in] this many bytes
+  bufferlist *outbl,     ///< [out] optional: reference the result here
+  char *out)             ///< [out] optional: or copy it here
+{
+  ceph_assert(h->file->is_wal_read_loaded);
+  dout(20) << __func__ << " h " << h << " offset: 0x"
+    << off << std::hex << "~" << len << std::hex << dendl;
+  if (outbl) {
+    outbl->clear();
+  }
+
+  int64_t ret = 0;
+
+  // WAL data is wrapped in an envelope that has a format of [length of flush, payload, file ino]
+  // wal_data_logical_offset points to the offset of the payload we are currently in.
+  uint64_t wal_data_logical_offset = 0;
+
+
+  // save previous position as buffer pos is treated difffernt on regular files
+  uint64_t previous_pos = h->buf.pos;
+
+  uint64_t remaining_len = len;
+  auto flush_iterator = h->file->wal_flushes.begin();
+  while (remaining_len > 0 && flush_iterator != h->file->wal_flushes.end()) {
+    uint64_t flush_offset = flush_iterator->offset;
+    uint64_t flush_length = flush_iterator->length;
+    dout(25) << fmt::format("{} flush_offset={:#x} flush_length={:#x}", __func__, flush_offset, flush_length) << dendl;
+
+    if (flush_length == 0) {
+      if (remaining_len > 0) {
+        dout(5) << __func__ << " flush_length 0: reading less then required "
+          << ret << "<" << len - ret << dendl;
+      }
+      break;
+    }
+    // if we won't find offset here, go ahead
+    bool in_range = wal_data_logical_offset < off + len && wal_data_logical_offset + flush_length > off;
+    ceph_assert(wal_data_logical_offset < off+len);
+    if (!in_range) {
+      if (off >= wal_data_logical_offset + flush_length) {
+        // move to next flush
+        // TODO(pere): do we check "ino" here too?
+        wal_data_logical_offset += flush_length;
+        flush_iterator++;
+        continue;
+      }
+    }
+
+    uint64_t payload_offset = flush_iterator->get_payload_offset();
+
+    uint64_t skip_front = 0;
+    if(wal_data_logical_offset < off) {
+      // offset is in this flush chunk so if we are before we move forward
+      skip_front = off - wal_data_logical_offset;
+    }
+    payload_offset += skip_front;
+    wal_data_logical_offset += skip_front;
+
+    dout(20) << fmt::format("{} payload_offset is {:#X} after skipping {:#X} bytes", __func__, payload_offset, skip_front) << dendl;
+
+    uint64_t data_to_read_from_flush = std::min(flush_length-skip_front, remaining_len);
+    bufferlist payload;
+    dout(25) << fmt::format("{} data to read from flush = {:#X}", __func__, data_to_read_from_flush) << dendl;
+    _read(h, payload_offset, data_to_read_from_flush, &payload, nullptr);
+
+    if (out) {
+      auto p = payload.begin();
+      p.copy(data_to_read_from_flush, out);
+      out += data_to_read_from_flush;
+    }
+    if (outbl) {
+      outbl->claim_append(payload);
+    }
+    flush_iterator++;
+
+    remaining_len -= data_to_read_from_flush;
+    wal_data_logical_offset += data_to_read_from_flush;
+    ret += data_to_read_from_flush;
+  }
+  if (remaining_len > 0) {
+    dout(20) << __func__ << " reading less than required, missing: " << remaining_len <<  dendl;
+  }
+
+  dout(20) << __func__ << std::hex
+           << " got 0x" << ret
+           << std::dec  << dendl;
+  ceph_assert(!outbl || (int)outbl->length() == ret);
+  h->buf.pos = previous_pos + ret;
   return ret;
 }
 
@@ -3478,14 +3685,19 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   if (partial) {
     tail_block.splice(0, tail_block.length(), &bl);
   }
+  dout(20) << __func__ << " tail is" << std::hex << bl.length() << dendl;
+  ceph_assert(length >= bl.length());
   const auto remaining_len = length - bl.length();
   buffer.splice(0, remaining_len, &bl);
   if (buffer.length()) {
     dout(20) << " leaving 0x" << std::hex << buffer.length() << std::dec
              << " unflushed" << dendl;
   }
-  if (const unsigned tail = bl.length() & ~super.block_mask(); tail) {
-    const auto padding_len = super.block_size - tail;
+  unsigned padding_len = 0;
+  // Append padding to fill block
+  const unsigned tail = bl.length() & ~super.block_mask();
+  if (tail) {
+    padding_len = super.block_size - tail;
     dout(20) << __func__ << " caching tail of 0x"
              << std::hex << tail
              << " and padding block with 0x" << padding_len
@@ -3496,6 +3708,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
     // Otherwise a costly rebuild could happen in e.g. `KernelDevice`.
     buffer_appender.append_zero(padding_len);
     buffer.splice(buffer.length() - padding_len, padding_len, &bl);
+
     // Deep copy the tail here. This allows to avoid costlier copy on
     // bufferlist rebuild in e.g. `KernelDevice` and minimizes number
     // of memory allocations.
@@ -3507,6 +3720,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   } else {
     tail_block.clear();
   }
+
   return bl;
 }
 
@@ -3558,6 +3772,13 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
   ceph_assert(h->file->num_readers.load() == 0);
   ceph_assert(h->file->fnode.ino > 1);
 
+  if (h->file->is_new_wal()) {
+    // WALFlush::WALLength is already appended at the start of first append_try_flush
+    // update length, offset is already updated with correct position
+    length += File::WALFlush::tail_size();
+  }
+  uint64_t end = offset + length;
+
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
 	   << " 0x" << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode
@@ -3570,9 +3791,11 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 
   bool buffered = cct->_conf->bluefs_buffered_io;
 
-  if (offset + length <= h->pos)
+  if (end <= h->pos)
     return 0;
   if (offset < h->pos) {
+    // NOTE: let's assume that we do not overwrite wal
+    ceph_assert(!h->file->is_new_wal());
     length -= h->pos - offset;
     offset = h->pos;
     dout(10) << " still need 0x"
@@ -3585,11 +3808,11 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
   uint64_t allocated = h->file->fnode.get_allocated();
   // do not bother to dirty the file if we are overwriting
   // previously allocated extents.
-  if (allocated < offset + length) {
+  if (allocated < end) {
     // we should never run out of log space here; see the min runway check
     // in _flush_and_sync_log.
     int r = _allocate(vselector->select_prefer_bdev(h->file->vselector_hint),
-		      offset + length - allocated,
+		      end - allocated,
                       0,
 		      &h->file->fnode,
 		      [&](const bluefs_extent_t& e) {
@@ -3604,11 +3827,27 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
     }
     h->file->is_dirty = true;
   }
-  if (h->file->fnode.size < offset + length) {
-    vselector->add_usage(h->file->vselector_hint, offset + length - h->file->fnode.size);
-    h->file->fnode.size = offset + length;
-    h->file->is_dirty = true;
+  if (h->file->fnode.size < end) {
+    vselector->add_usage(h->file->vselector_hint, end - h->file->fnode.size);
+    h->file->fnode.size = end;
+    // Don't mark regular appends as dirty on WAL_V2. Note that allocations are marked as dirty.
+    if (!h->file->is_new_wal()) {
+      h->file->is_dirty = true;
+    }
   }
+
+  if (h->file->is_new_wal()) {
+    // create WAL flush envelope
+    uint64_t flush_size = length - File::WALFlush::extra_envelope_size_on_front_and_tail();
+    ceph_assert(h->get_wal_header_filler() != nullptr);
+    bluefs_wal_header_t(flush_size).encode(*h->get_wal_header_filler());
+    h->set_wal_header_filler(nullptr);
+
+    h->append(h->file->wal_marker);
+    h->file->fnode.wal_size += flush_size;
+    h->file->fnode.wal_limit = h->file->fnode.get_allocated();
+  }
+
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
   int res = _flush_data(h, offset, length, buffered);
   logger->tinc(l_bluefs_flush_lat, mono_clock::now() - t0);
@@ -3698,6 +3937,7 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
       }
     }
   }
+
   dout(20) << __func__ << " h " << h << " pos now 0x"
            << std::hex << h->pos << std::dec << dendl;
   return 0;
@@ -3738,6 +3978,14 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)/*_WF_L
   bool flushed_sum = false;
   {
     std::unique_lock hl(h->lock);
+
+    if (h->file->is_new_wal() && h->get_buffer_length() == 0) {
+      size_t size = 0;
+      bluefs_wal_header_t().bound_encode(size);
+      bufferlist::contiguous_filler filler = h->append_hole(size);
+      h->set_wal_header_filler(std::make_unique<bufferlist::contiguous_filler>(bufferlist::contiguous_filler(filler)));
+    }
+
     size_t max_size = 1ull << 30; // cap to 1GB
     while (len > 0) {
       bool need_flush = true;
@@ -3866,6 +4114,16 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)/*_WF_L*/
   {
     std::lock_guard ll(log.lock);
     std::lock_guard dl(dirty.lock);
+    if (h->file->is_new_wal()) {
+      // This assumption comes from reading logs of rocksdb+bluefs where a WAL file follows this pattern:
+      // 1. create wal
+      // 2. open_for_write
+      // 3. close_writer
+      // 4. truncate -> fnode.size
+      // 5. unlink
+      ceph_assert(h->file->fnode.size == offset || offset == 0);
+      h->file->fnode.wal_limit = offset;
+    }
     bool changed_extents = false;
     vselector->sub_usage(h->file->vselector_hint, fnode);
     uint64_t x_off = 0;
@@ -3913,7 +4171,7 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)/*_WF_L*/
   return 0;
 }
 
-int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
+int BlueFS::fsync(FileWriter *h, bool force_dirty)/*_WF_WD_WLD_WLNF_WNF*/
 {
   auto t0 = mono_clock::now();
   _maybe_check_vselector_LNF();
@@ -3926,7 +4184,7 @@ int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
     if (r < 0)
       return r;
     _flush_bdev(h);
-    if (h->file->is_dirty) {
+    if (h->file->is_dirty || force_dirty) {
       _signal_dirty_to_log_D(h);
       h->file->is_dirty = false;
     }
@@ -4184,8 +4442,11 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)/*_LF*/
       });
     if (r < 0)
       return r;
-
+    if (f->is_new_wal()) {
+      f->fnode.wal_limit = f->fnode.get_allocated();
+    }
     log.t.op_file_update_inc(f->fnode);
+    f->is_dirty = true;
   }
   return 0;
 }
@@ -4297,18 +4558,15 @@ int BlueFS::open_for_write(
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
 
-  log.t.op_file_update(file->fnode);
-  if (create)
-    log.t.op_dir_link(dirname, filename, file->fnode.ino);
+	*h = _create_writer(file);
 
-  std::lock_guard dl(dirty.lock);
-  for (auto& p : pending_release_extents) {
-    dirty.pending_release[p.bdev].insert(p.offset, p.length);
-  }
-  }
-  *h = _create_writer(file);
-
-  if (boost::algorithm::ends_with(filename, ".log")) {
+	if (boost::algorithm::ends_with(filename, ".log")) {
+	  bool use_wal_v2 = cct->_conf.get_val<bool>("bluefs_wal_v2");
+    if (use_wal_v2) {
+      file->fnode.type = WAL_V2;
+      file->is_wal_read_loaded = false;
+      file->wal_marker = File::WALFlush::generate_hashed_marker(super.osd_uuid, file->fnode.ino);
+    }
     (*h)->writer_type = BlueFS::WRITER_WAL;
     if (logger && !overwrite) {
       logger->inc(l_bluefs_files_written_wal);
@@ -4319,6 +4577,18 @@ int BlueFS::open_for_write(
       logger->inc(l_bluefs_files_written_sst);
     }
   }
+
+  log.t.op_file_update(file->fnode);
+  if (create) {
+    log.t.op_dir_link(dirname, filename, file->fnode.ino);
+  }
+
+  std::lock_guard dl(dirty.lock);
+  for (auto& p : pending_release_extents) {
+    dirty.pending_release[p.bdev].insert(p.offset, p.length);
+  }
+  }
+
 
   dout(10) << __func__ << " h " << *h << " on " << file->fnode << dendl;
   return 0;
@@ -4360,6 +4630,11 @@ void BlueFS::_close_writer(FileWriter *h)
 }
 void BlueFS::close_writer(FileWriter *h)
 {
+  if (h->file->is_new_wal()) {
+    // we force fsync by forcing dirty flag
+    fsync(h, true);
+  }
+
   {
     std::lock_guard l(h->lock);
     _drain_writer(h);
@@ -4535,8 +4810,15 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
   File *file = q->second.get();
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << " " << file->fnode << dendl;
-  if (size)
-    *size = file->fnode.size;
+
+  if (size) {
+    if (file->is_new_wal()) {
+      *size = file->fnode.wal_size;
+    } else {
+      *size = file->fnode.size;
+    }
+  }
+
   if (mtime)
     *mtime = file->fnode.mtime;
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1165,7 +1165,11 @@ void BlueFS::umount(bool avoid_compact)
   _close_writer(log.writer);
   log.writer = NULL;
   log.t.clear();
-
+  // if we umount with pending release, we can possibly mount again
+  // with pending release, and will release something that is not allocated
+  for (auto& d: dirty.pending_release) {
+    d.clear();
+  }
   vselector.reset(nullptr);
   _stop_alloc();
   nodes.file_map.clear();

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1369,7 +1369,6 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 
   FileReader *log_reader = new FileReader(
     log_file, cct->_conf->bluefs_max_prefetch,
-    false,  // !random
     true);  // ignore eof
 
   bool seen_recs = false;
@@ -2402,7 +2401,7 @@ void BlueFS::_wal_index_file(
   File::wal_flush_t flush;
   bool envelope_good;
   uint64_t file_size = file->fnode.size;
-  FileReader *h = new FileReader(file, 4096, false, true);
+  FileReader *h = new FileReader(file, 4096, true);
   ceph_assert(h);
   while(scan_ofs < file->fnode.allocated) {
     envelope_good = _read_wal_flush(h, scan_ofs, wal_ofs, &flush);
@@ -4698,7 +4697,7 @@ int BlueFS::open_for_read(
     _wal_index_file(file);
   }
   *h = new FileReader(file, random ? 4096 : cct->_conf->bluefs_max_prefetch,
-		      random, file->is_new_wal());
+                      file->is_new_wal());
   dout(10) << __func__ << " h " << *h << " on " << file->fnode << dendl;
   return 0;
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2214,8 +2214,43 @@ int BlueFS::device_migrate_to_new(
   return 0;
 }
 
-int BlueFS::downgrade_wal_to_v1() {
-  _init_logger();
+int BlueFS::downgrade_wal_to_v1(
+    const std::string& dir,
+    const std::string& name)
+{
+  int r;
+  string tmp_name("__tmp_name__.log");
+  FileWriter* writer = nullptr;
+  FileReader* reader = nullptr;
+  // we use dir for wals and name like wal; should get proper hint
+  r = open_for_write(dir, tmp_name, &writer, false);
+  // use normal v1 write path by marking node type to legacy
+  writer->file->fnode.type = bluefs_node_type::REGULAR;
+  ceph_assert(r == 0);
+  r = open_for_read(dir, name, &reader);
+  ceph_assert(r == 0);
+  uint64_t offset = 0;
+  uint64_t len = 1024 * 1024;
+  bufferlist bl;
+  while (true) {
+    r = read(reader, offset, len, &bl, nullptr);
+    if (r <= 0) break;
+    append_try_flush(writer, bl.c_str(), bl.length());
+    offset += r;
+  }
+  if (r == 0) {
+    r = fsync(writer);
+    ceph_assert(r == 0);
+  }
+  delete reader;
+  close_writer(writer);
+  r = rename(dir, tmp_name, dir, name);
+  ceph_assert(r == 0);
+  return 0;
+}
+
+int BlueFS::downgrade_wal_to_v1()
+{
   string wal_dir("db.wal");
   auto dir_it = nodes.dir_map.find(wal_dir);
   if (dir_it == nodes.dir_map.end()) {
@@ -2223,122 +2258,21 @@ int BlueFS::downgrade_wal_to_v1() {
     return 0;
   }
 
-  DirRef dir = dir_it->second;
-
-  size_t wal_v2_aggregated_size = 0;
-  std::vector<std::pair<string, FileRef>> files_to_migrate;
-  files_to_migrate.reserve(dir->file_map.size());
-
-  // get info about wal files
-  for (const auto& [file_name, file] : dir->file_map) {
+  // copy, so it does not change
+  auto dir_copy = dir_it->second->file_map;
+  for (const auto& [file_name, file] : dir_copy) {
     if(file->is_new_wal()) {
-      wal_v2_aggregated_size += file->fnode.wal_size;
-      files_to_migrate.push_back({ file_name, file });
+      downgrade_wal_to_v1(wal_dir, file_name);
+      sync_metadata(true);
+      dout(10) << __func__ << fmt::format(" {} v2=>v1", file_name) << dendl;
+    } else {
+      dout(10) << __func__ << fmt::format(" {} in v1", file_name) << dendl;
     }
-  }
-
-  // check free space
-  uint8_t prefer_bdev = vselector->select_prefer_bdev(vselector->get_hint_by_dir(wal_dir));
-  uint64_t free_space = alloc[prefer_bdev]->get_free();
-  if (free_space < wal_v2_aggregated_size) {
-    dout(1) << fmt::format("{} Error trying to migrate new WAL V2 to V1. Aggregated size of WAL files is {}, free space is {}", __func__, wal_v2_aggregated_size, free_space) << dendl;
-    return -ENOSPC;
-  }
-
-  // do migration
-  size_t file_migrated_count = 0;
-  string tmp_name_prefix("__tmp_name_");
-  uint64_t buffer_size = 1024*1024*50; // 50 MiB?
-  bool failure_while_migrating = false;
-  for (auto &[name, file] : files_to_migrate) {
-    FileWriter *writer;
-    string new_file_temp_name = fmt::format("{}{}", tmp_name_prefix, file_migrated_count);
-    int r = open_for_write(wal_dir, new_file_temp_name, &writer, false);
-    ceph_assert(r == 0);
-    auto close_writer_path = make_scope_guard([&] {
-      close_writer(writer);
-    });
-
-    // use normal v1 write path by marking node type to legacy
-    writer->file->fnode.type = bluefs_node_type::REGULAR;
-
-    FileReader* previous_reader;
-    r = open_for_read(wal_dir, name, &previous_reader);
-    auto read_writer_path = make_scope_guard([&] {
-      delete previous_reader;
-    });
-    ceph_assert(r == 0);
-
-    // move contents from previous to new file
-    uint64_t previous_size = previous_reader->file->fnode.wal_size;
-    uint64_t left_to_read = previous_size;
-    bufferlist read_buffer;
-    uint64_t read_offset = 0;
-    while(left_to_read > 0) {
-      // read from prevoius file
-      read_buffer.clear();
-      uint64_t to_read = std::min(buffer_size, left_to_read);
-      int r = _read_wal(previous_reader, read_offset, to_read, &read_buffer, nullptr);
-      ceph_assert(r >= 0);
-      if (uint64_t(r) < to_read) {
-        dout(5) << fmt::format("{} read less than expect while migrating file {} to wal v1", __func__, name) << dendl;
-        failure_while_migrating = true;
-        break;
-      }
-
-      // add to new file
-      append_try_flush(writer, read_buffer.c_str(), read_buffer.length());
-
-      // update state
-      read_offset += to_read;
-      left_to_read -= to_read;
-    }
-    if (failure_while_migrating) {
-      break;
-    }
-    // todo things left to read, do cleanup
-
-    int fsync_ret = fsync(writer);
-    if (fsync_ret != 0) {
-      derr << fmt::format("{} fsync error {} while moving data for file {} ", __func__, fsync_ret, name) << dendl;
-      failure_while_migrating = true;
-      break;
-    }
-
-    file_migrated_count++;
-  }
-
-  if (failure_while_migrating) {
-    derr << fmt::format("{} couldn't properly move data from v2 to v1, unlinking temp files...", __func__) << dendl;
-    size_t file_migrated_count = 0;
-    for (size_t i = 0; i < files_to_migrate.size(); i++) {
-      string new_file_temp_name = fmt::format("{}{}", tmp_name_prefix, file_migrated_count);
-      derr << fmt::format("{} unlinking {}", __func__, new_file_temp_name) << dendl;
-      int unlink_ret = unlink(wal_dir, new_file_temp_name);
-      ceph_assert(unlink_ret == 0);
-      file_migrated_count++;
-    }
-    return -EIO;
-  }
-
-  // everything went okay, rename files
-  file_migrated_count = 0;
-  for (auto &[name, file] : files_to_migrate) {
-    
-    dout(5) << fmt::format("{} unlinking {}", __func__, name) << dendl;
-    int unlink_ret = unlink(wal_dir, name);
-    ceph_assert(unlink_ret == 0);
-    
-    string new_file_temp_name = fmt::format("{}{}", tmp_name_prefix, file_migrated_count);
-    dout(5) << fmt::format("{} renaming {} to {}", __func__, tmp_name_prefix, name) << dendl;
-    int rename_ret = rename(wal_dir, new_file_temp_name, wal_dir, name);
-    ceph_assert(rename_ret == 0);
-    file_migrated_count++;
   }
 
   // Ensure no dangling wal v2 files are inside transactions.
   _compact_log_sync_LNF_LD();
-
+  // TODO assert on presence of wal_v2
   _write_super(BDEV_DB, 1);
 
   dout(5) << fmt::format("{} success moving data", __func__) << dendl;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <mutex>
 #include <limits>
+#include <uuid/uuid.h>
 
 #include "bluefs_types.h"
 #include "blk/BlockDevice.h"
@@ -13,10 +14,13 @@
 #include "common/RefCountedObj.h"
 #include "common/ceph_context.h"
 #include "global/global_context.h"
+#include "include/byteorder.h"
+#include "include/ceph_hash.h"
 #include "include/common_fwd.h"
 
 #include "boost/intrusive/list.hpp"
 #include "boost/dynamic_bitset.hpp"
+#include "include/hash.h"
 
 class Allocator;
 
@@ -265,6 +269,65 @@ public:
   struct File : public RefCountedObject {
     MEMPOOL_CLASS_HELPERS();
 
+    /*
+     * WAL files in bluefs have a different format from normal ones. In order to not flush metadata 
+     * for every write we make to data extents, we create a package/envelope around the real data 
+     * that includes Length of the data we want to flush and a marker that identifies the flush.
+     *
+     * The format on disk will look something like:
+     * legend = l = length of flush, d = data, m = marker, x=unused/used bvy other file, each character will be a byte
+     *
+     * flush 0 l==24                                                  flush 1 l==4                 flush 2 l==12
+     * v                                                               v                             v
+     * llll llll dddd dddd dddd dddd dddd dddd mmmm mmmm xxxx xxx xxxx llll llll dddd mmmm mmmm xxxx llll llll  dddd dddd dddd mmmm mmmm
+     *
+     */
+    struct WALFlush {
+      typedef uint64_t WALMarker;
+      typedef uint64_t WALLength;
+
+      uint64_t offset = 0; // offset of start of flush, it should be length offset
+      uint64_t length = 0;
+
+      WALFlush(uint64_t offset, uint64_t length) : offset(offset), length(length) {}
+
+
+      static constexpr size_t header_size() {
+        return bluefs_wal_header_t::size();
+      }
+
+      static constexpr size_t tail_size() {
+        return sizeof(WALMarker);
+      }
+
+      uint64_t end_offset() {
+        return get_marker_offset() + tail_size();
+      }
+
+      uint64_t get_payload_offset() {
+        return offset + header_size();
+      }
+
+      uint64_t get_marker_offset() {
+        return get_payload_offset() + length;
+      }
+
+      static constexpr uint64_t extra_envelope_size_on_front_and_tail() {
+        return header_size() + tail_size();
+      }
+
+      static uint64_t generate_hashed_marker(uuid_d uuid, uint64_t ino) {
+        char uuid_copy[16];
+        memcpy(uuid_copy, uuid.bytes(), 16);
+        uint64_t* blocks_of_64 = (uint64_t*)&uuid_copy[0];
+        for (size_t i = 0; i < (sizeof(uuid_copy) / sizeof(uint64_t)); i++) {
+          blocks_of_64[i] ^= ino;
+        }
+        return ceph_str_hash(CEPH_STR_HASH_RJENKINS, &uuid_copy[0], sizeof(uuid_copy));
+      }
+    };
+
+
     bluefs_fnode_t fnode;
     int refs;
     uint64_t dirty_seq;
@@ -283,6 +346,13 @@ public:
        _replay, device_migrate_to_existing, device_migrate_to_new */
     ceph::mutex lock = ceph::make_mutex("BlueFS::File::lock");
 
+    bool is_wal_read_loaded; // mark whether the WAL file is ready to be read as wal_update_size was called 
+    std::vector<WALFlush> wal_flushes; // to keep track of the amount of flushes we performed on a WAL file
+                                       // so that we can easily recalculate real data offsets.
+                                       // On "replay" this should be refilled in order to append data
+                                       // correctly. Nevertheless, replayed wal file most probably won't be reused
+    uint64_t wal_marker;
+
   private:
     FRIEND_MAKE_REF(File);
     File()
@@ -295,7 +365,8 @@ public:
 	num_readers(0),
 	num_writers(0),
 	num_reading(0),
-        vselector_hint(nullptr)
+        vselector_hint(nullptr),
+        is_wal_read_loaded(false)
       {}
     ~File() override {
       ceph_assert(num_readers.load() == 0);
@@ -303,6 +374,12 @@ public:
       ceph_assert(num_reading.load() == 0);
       ceph_assert(!locked);
     }
+
+  public:
+    bool is_new_wal() {
+      return fnode.type == WAL_V2;
+    }
+
   };
   using FileRef = ceph::ref_t<File>;
 
@@ -329,8 +406,8 @@ public:
 
     FileRef file;
     uint64_t pos = 0;       ///< start offset for buffer
-  private:
     ceph::buffer::list buffer;      ///< new data to write (at end of file)
+  private:
     ceph::buffer::list tail_block;  ///< existing partial block at end of file, if any
   public:
     unsigned get_buffer_length() const {
@@ -342,6 +419,7 @@ public:
       const unsigned length,
       const bluefs_super_t& super);
     ceph::buffer::list::page_aligned_appender buffer_appender;  //< for const char* only
+    std::unique_ptr<bufferlist::contiguous_filler> wal_header_filler; // To encode bluefs_wal_header_t we need to save the location of the header we want to fill
   public:
     int writer_type = 0;    ///< WRITER_*
     int write_hint = WRITE_LIFE_NOT_SET;
@@ -353,7 +431,7 @@ public:
     FileWriter(FileRef f)
       : file(std::move(f)),
        buffer_appender(buffer.get_page_aligned_appender(
-                         g_conf()->bluefs_alloc_size / CEPH_PAGE_SIZE)) {
+                         g_conf()->bluefs_alloc_size / CEPH_PAGE_SIZE)), wal_header_filler(nullptr) {
       ++file->num_writers;
       iocv.fill(nullptr);
       dirty_devs.fill(false);
@@ -393,9 +471,30 @@ public:
       buffer_appender.append_zero(len);
     }
 
+    void append(uint64_t value) {
+      uint64_t l0 = get_buffer_length();
+      ceph_assert(l0 + sizeof(value) <= std::numeric_limits<uint32_t>::max());
+      bufferlist encoded;
+      encode(value, encoded);
+      buffer_appender.append(encoded);
+    }
+
+    bufferlist::contiguous_filler append_hole(uint64_t len) {
+      return buffer.append_hole(len);
+    }
+
+    void set_wal_header_filler(std::unique_ptr<bufferlist::contiguous_filler> filler) {
+      wal_header_filler.swap(filler);
+    }
+
+    bufferlist::contiguous_filler* get_wal_header_filler() {
+      return wal_header_filler.get();
+    }
+
     uint64_t get_effective_write_pos() {
       return pos + buffer.length();
     }
+
   };
 
   struct FileReaderBuffer {
@@ -636,6 +735,14 @@ private:
   void _flush_bdev();  // this is safe to call without a lock
   void _flush_bdev(std::array<bool, MAX_BDEV>& dirty_bdevs);  // this is safe to call without a lock
 
+  void _wal_update_size(FileRef file, uint64_t increment);
+
+  int64_t _read_wal(
+    FileReader *h,   ///< [in] read from here
+    uint64_t offset, ///< [in] offset
+    size_t len,      ///< [in] this many bytes
+    ceph::buffer::list *outbl,   ///< [out] optional: reference the result here
+    char *out);      ///< [out] optional: or copy it here
   int64_t _read(
     FileReader *h,   ///< [in] read from here
     uint64_t offset, ///< [in] offset
@@ -649,7 +756,7 @@ private:
     char *out);      ///< [out] optional: or copy it here
 
   int _open_super();
-  int _write_super(int dev);
+  int _write_super(int dev, uint8_t wal_version = 1);
   int _check_allocations(const bluefs_fnode_t& fnode,
     boost::dynamic_bitset<uint64_t>* used_blocks,
     bool is_alloc, //true when allocating, false when deallocating
@@ -677,6 +784,7 @@ private:
       _check_vselector_LNF();
     }
   }
+
 public:
   BlueFS(CephContext* cct);
   ~BlueFS();
@@ -784,12 +892,15 @@ public:
 
   void append_try_flush(FileWriter *h, const char* buf, size_t len);
   void flush_range(FileWriter *h, uint64_t offset, uint64_t length);
-  int fsync(FileWriter *h);
+  int fsync(FileWriter *h, bool force_dirty = false);
   int64_t read(FileReader *h, uint64_t offset, size_t len,
 	   ceph::buffer::list *outbl, char *out) {
     // no need to hold the global lock here; we only touch h and
     // h->file, and read vs write or delete is already protected (via
     // atomics and asserts).
+    if (h->file->is_new_wal()) {
+      return _read_wal(h, offset, len, outbl, out);
+    }
     return _read(h, offset, len, outbl, out);
   }
   int64_t read_random(FileReader *h, uint64_t offset, size_t len,

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -944,6 +944,10 @@ private:
 			       size_t read_len,
 			       bufferlist* bl);
   void _check_vselector_LNF();
+  int downgrade_wal_to_v1(
+    const std::string& dir,
+    const std::string& name
+  );
 };
 
 class OriginalVolumeSelector : public BlueFSVolumeSelector {

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -527,18 +527,15 @@ public:
 
     FileRef file;
     FileReaderBuffer buf;
-    bool random;
     bool ignore_eof;        ///< used when reading our log file
-
     ceph::shared_mutex lock {
      ceph::make_shared_mutex(std::string(), false, false, false)
     };
 
 
-    FileReader(FileRef f, uint64_t mpf, bool rand, bool ie)
+    FileReader(FileRef f, uint64_t mpf, bool ie)
       : file(f),
 	buf(mpf),
-	random(rand),
 	ignore_eof(ie) {
       ++file->num_readers;
     }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -801,7 +801,7 @@ public:
     const std::set<int>& devs_source,
     int dev_target,
     const bluefs_layout_t& layout);
-  int downgrade_wal_to_v1();
+  int revert_wal_to_plain();
 
   uint64_t get_used();
   uint64_t get_block_device_size(unsigned id);
@@ -930,7 +930,7 @@ private:
 			       size_t read_len,
 			       bufferlist* bl);
   void _check_vselector_LNF();
-  int downgrade_wal_to_v1(
+  int revert_wal_to_plain(
     const std::string& dir,
     const std::string& name
   );

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -815,6 +815,7 @@ public:
     const std::set<int>& devs_source,
     int dev_target,
     const bluefs_layout_t& layout);
+  int downgrade_wal_to_v1();
 
   uint64_t get_used();
   uint64_t get_block_device_size(unsigned id);

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -213,19 +213,14 @@ class BlueRocksWritableFile : public rocksdb::WritableFile {
   // size due to whole pages writes. The behavior is undefined if called
   // with other writes to follow.
   rocksdb::Status Truncate(uint64_t size) override {
-    // we mirror the posix env, which does nothing here; instead, it
-    // truncates to the final size on close.  whatever!
-    return rocksdb::Status::OK();
-    //int r = fs->truncate(h, size);
-    //  return err_to_status(r);
-  }
-
-  rocksdb::Status Close() override {
-
-    int r = fs->truncate(h, h->pos);
+    int r = fs->truncate(h, size);
     if (r < 0) {
       return err_to_status(r);
     }
+    return rocksdb::Status::OK();
+  }
+
+  rocksdb::Status Close() override {
     fs->fsync(h);
     return rocksdb::Status::OK();
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10836,6 +10836,33 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair)
   return _fsck_on_open(depth, repair);
 }
 
+int BlueStore::downgrade_wal_to_v1() {
+  int r = _mount_readonly();
+  if (r < 0) {
+    goto out;
+  }
+
+  if (int r = _open_fm(nullptr, false, false); r < 0) {
+    goto close_readonly;
+  }
+
+  if (int r = _init_alloc(); r < 0) {
+    goto close_fm;
+  }
+  r = bluefs->downgrade_wal_to_v1();
+
+  _close_alloc();
+
+  close_fm:
+  _close_fm();
+
+  close_readonly:
+  _umount_readonly();
+
+  out:
+  return r;
+}
+
 int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 {
   uint64_t sb_hash_size = uint64_t(

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10836,13 +10836,13 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair)
   return _fsck_on_open(depth, repair);
 }
 
-int BlueStore::downgrade_wal_to_v1() {
+int BlueStore::revert_wal_to_plain() {
   int r = cold_open();
   if (r != 0) {
     dout(1) << __func__ << "failed to open db / allocator" << dendl;
     goto out;
   }
-  bluefs->downgrade_wal_to_v1();
+  bluefs->revert_wal_to_plain();
   cold_close();
   out:
   return r;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3177,6 +3177,7 @@ public:
   int repair(bool deep) override {
     return _fsck(deep ? FSCK_DEEP : FSCK_REGULAR, true);
   }
+  int downgrade_wal_to_v1();
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3177,7 +3177,7 @@ public:
   int repair(bool deep) override {
     return _fsck(deep ? FSCK_DEEP : FSCK_REGULAR, true);
   }
-  int downgrade_wal_to_v1();
+  int revert_wal_to_plain();
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -5,7 +5,9 @@
 #include "bluefs_types.h"
 #include "BlueFS.h"
 #include "common/Formatter.h"
+#include "include/byteorder.h"
 #include "include/denc.h"
+#include "include/encoding.h"
 #include "include/uuid.h"
 #include "include/stringify.h"
 
@@ -171,24 +173,34 @@ void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
 }
 
 // bluefs_super_t
-bluefs_super_t::bluefs_super_t() : seq(0), block_size(4096) {
+bluefs_super_t::bluefs_super_t() : seq(0), block_size(4096), wal_version(1) {
 }
 
 void bluefs_super_t::encode(bufferlist& bl) const
 {
-  ENCODE_START(2, 1, bl);
+  __u8 _version = 2;
+  __u8 _compat = 1;
+  if (wal_version >= 2) {
+    _version = 3;
+    _compat = 3;
+  }
+  ENCODE_START(_version, _compat, bl);
   encode(uuid, bl);
   encode(osd_uuid, bl);
   encode(seq, bl);
   encode(block_size, bl);
   encode(log_fnode, bl);
   encode(memorized_layout, bl);
+  if (_version >= 3) {
+    encode(wal_version, bl);
+  }
   ENCODE_FINISH(bl);
 }
 
 void bluefs_super_t::decode(bufferlist::const_iterator& p)
 {
-  DECODE_START(2, p);
+
+  DECODE_START(3, p);
   decode(uuid, p);
   decode(osd_uuid, p);
   decode(seq, p);
@@ -196,6 +208,9 @@ void bluefs_super_t::decode(bufferlist::const_iterator& p)
   decode(log_fnode, p);
   if (struct_v >= 2) {
     decode(memorized_layout, p);
+  }
+  if (struct_v >= 3) {
+    decode(wal_version, p);
   }
   DECODE_FINISH(p);
 }
@@ -265,6 +280,10 @@ bluefs_fnode_delta_t* bluefs_fnode_t::make_delta(bluefs_fnode_delta_t* delta) {
   delta->mtime = mtime;
   delta->offset = allocated_commited;
   delta->extents.clear();
+
+  delta->type = type;
+  delta->wal_limit = wal_limit;
+  delta->wal_size = wal_size;
   if (allocated_commited < allocated) {
     uint64_t x_off = 0;
     auto p = seek(allocated_commited, &x_off);
@@ -302,17 +321,24 @@ void bluefs_fnode_t::generate_test_instances(list<bluefs_fnode_t*>& ls)
   ls.back()->mtime = utime_t(123,45);
   ls.back()->extents.push_back(bluefs_extent_t(0, 1048576, 4096));
   ls.back()->__unused__ = 1;
+  ls.back()->type = 0;
 }
 
 ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
 {
-  return out << "file(ino " << file.ino
+  out << "file(ino " << file.ino
 	     << " size 0x" << std::hex << file.size << std::dec
 	     << " mtime " << file.mtime
 	     << " allocated " << std::hex << file.allocated << std::dec
 	     << " alloc_commit " << std::hex << file.allocated_commited << std::dec
-	     << " extents " << file.extents
-	     << ")";
+	     << " extents " << file.extents;
+  if (file.type == WAL_V2) {
+    out << " wal_limit " << file.wal_limit << std::hex;
+    out << " wal_size " << file.wal_size << std::hex;
+    out << " type WAL_V2 " << std::dec;
+  }
+  out << ")";
+  return out;
 }
 
 // bluefs_fnode_delta_t
@@ -405,3 +431,29 @@ ostream& operator<<(ostream& out, const bluefs_transaction_t& t)
 	     << std::dec << ")";
 }
 
+void bluefs_wal_header_t::bound_encode(size_t &s) const {
+  s += 1; // version
+  s += 1; // compat
+  s += 4; // size
+  denc(flush_length, s);
+}
+
+void bluefs_wal_header_t::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  encode(flush_length, bl);
+  ENCODE_FINISH(bl);
+}
+
+void bluefs_wal_header_t::encode(bufferlist::contiguous_filler& filler_in) const {
+  ENCODE_START_FILLER(1, 1, filler_in);
+  ceph_le64 flush_length_le(flush_length);
+  filler_in.copy_in(sizeof(flush_length_le), (char*)&flush_length_le);
+  ENCODE_FINISH_FILLER();
+}
+
+void bluefs_wal_header_t::decode(bufferlist::const_iterator& p)
+{
+  DECODE_START(1, p);
+  decode(flush_length, p);
+  DECODE_FINISH(p);
+}

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -4,6 +4,7 @@
 #define CEPH_OS_BLUESTORE_BLUEFS_TYPES_H
 
 #include <optional>
+#include <ostream>
 
 #include "bluestore_types.h"
 #include "include/utime.h"
@@ -32,6 +33,12 @@ public:
   static void generate_test_instances(std::list<bluefs_extent_t*>&);
 };
 WRITE_CLASS_DENC(bluefs_extent_t)
+
+enum bluefs_node_type {
+  REGULAR = 0,
+  WAL_V2 = 1,
+  NODE_TYPE_END = 0x100,
+};
 
 std::ostream& operator<<(std::ostream& out, const bluefs_extent_t& e);
 
@@ -73,16 +80,65 @@ struct bluefs_fnode_delta_t {
   uint64_t offset; // Contains offset in file of extents.
                    // Equal to 'allocated' when created.
                    // Used for consistency checking.
+
+  // only relevant in case of wal node
+  uint64_t wal_limit;
+  uint64_t wal_size;
+  uint8_t type = REGULAR;
+
+
   mempool::bluefs::vector<bluefs_extent_t> extents;
 
-  DENC(bluefs_fnode_delta_t, v, p) {
-    DENC_START(1, 1, p);
+  DENC_HELPERS
+
+  void bound_encode(size_t& p) const {
+    _denc_friend(*this, p);
+  }
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
+    DENC_DUMP_PRE(bluefs_fnode_t);
+    _denc_friend(*this, p);
+  }
+  void decode(ceph::buffer::ptr::const_iterator& p) {
+    DENC_START_UNSAFE(2, 2, p);
+    denc_varint(ino, p);
+    denc_varint(size, p);
+    denc(mtime, p);
+    denc(offset, p);
+    denc(extents, p);
+
+    if (struct_v >= 2) {
+      denc(type, p);
+      denc(wal_limit, p);
+      denc(wal_size, p);
+    }
+    DENC_FINISH(p);
+
+  }
+
+  template<typename T, typename P>
+  friend std::enable_if_t<std::is_same_v<bluefs_fnode_delta_t, std::remove_const_t<T>>>
+  _denc_friend(T& v, P& p) {
+    uint8_t version = 1, compat = 1;
+    if (v.type == WAL_V2) {
+      version = 2;
+      compat = 2;
+    }
+    DENC_START_UNSAFE(version, compat, p);
+
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);
     denc(v.offset, p);
     denc(v.extents, p);
+
+    if (struct_v >= 2) {
+      denc(v.type, p);
+      denc(v.wal_limit, p);
+      denc(v.wal_size, p);
+    }
+
     DENC_FINISH(p);
+
   }
 };
 WRITE_CLASS_DENC(bluefs_fnode_delta_t)
@@ -102,14 +158,19 @@ struct bluefs_fnode_t {
 
   uint64_t allocated;
   uint64_t allocated_commited;
+  uint8_t type = REGULAR;
+  uint64_t wal_limit; // EOF of wal, this limit represents upper limit of fnode.size, not upper limit of wal_size
+  uint64_t wal_size; // Amount of payload bytes in WAL(not including envelope data), there could be more on power off instances, in range of wal_size~wal_limit
 
-  bluefs_fnode_t() : ino(0), size(0), allocated(0), allocated_commited(0) {}
+  bluefs_fnode_t() : ino(0), size(0), allocated(0), allocated_commited(0), wal_limit(0), wal_size(0) {}
   bluefs_fnode_t(uint64_t _ino, uint64_t _size, utime_t _mtime) :
-    ino(_ino), size(_size), mtime(_mtime), allocated(0), allocated_commited(0) {}
+    ino(_ino), size(_size), mtime(_mtime), allocated(0), allocated_commited(0), wal_limit(0), wal_size(0) {}
   bluefs_fnode_t(const bluefs_fnode_t& other) :
     ino(other.ino), size(other.size), mtime(other.mtime),
     allocated(other.allocated),
-    allocated_commited(other.allocated_commited) {
+    allocated_commited(other.allocated_commited),
+    wal_limit(other.wal_limit),
+    wal_size(other.wal_size) {
     clone_extents(other);
   }
 
@@ -136,19 +197,46 @@ struct bluefs_fnode_t {
     DENC_DUMP_PRE(bluefs_fnode_t);
     _denc_friend(*this, p);
   }
+
   void decode(ceph::buffer::ptr::const_iterator& p) {
-    _denc_friend(*this, p);
+    DENC_START_COMPAT_2(2, 2, p);
+    denc_varint(ino, p);
+    denc_varint(size, p);
+    denc(mtime, p);
+    denc(__unused__, p);
+    denc(extents, p);
+    if (struct_v >= 2) {
+      denc(type, p);
+      denc(wal_limit, p);
+      denc(wal_size, p);
+    }
+    if (struct_v == 1) {
+      type = REGULAR;
+    }
+    DENC_FINISH(p);
     recalc_allocated();
   }
+
   template<typename T, typename P>
   friend std::enable_if_t<std::is_same_v<bluefs_fnode_t, std::remove_const_t<T>>>
   _denc_friend(T& v, P& p) {
-    DENC_START(1, 1, p);
+
+    uint8_t version = 1, compat = 1;
+    if (v.type == WAL_V2) {
+      version = 2;
+      compat = 2;
+    }
+    DENC_START_UNSAFE(version, compat, p);
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);
     denc(v.__unused__, p);
     denc(v.extents, p);
+    if (struct_v >= 2) {
+      denc(v.type, p);
+      denc(v.wal_limit, p);
+      denc(v.wal_size, p);
+    }
     DENC_FINISH(p);
   }
   void reset_delta() {
@@ -251,6 +339,8 @@ struct bluefs_super_t {
 
   std::optional<bluefs_layout_t> memorized_layout;
 
+  uint8_t wal_version;
+
   bluefs_super_t();
 
   uint64_t block_mask() const {
@@ -287,7 +377,6 @@ struct bluefs_transaction_t {
   uuid_d uuid;          ///< fs uuid
   uint64_t seq;         ///< sequence number
   ceph::buffer::list op_bl;     ///< encoded transaction ops
-
   bluefs_transaction_t() : seq(0) {}
 
   void clear() {
@@ -369,4 +458,20 @@ struct bluefs_transaction_t {
 WRITE_CLASS_ENCODER(bluefs_transaction_t)
 
 std::ostream& operator<<(std::ostream& out, const bluefs_transaction_t& t);
+
+
+
+struct bluefs_wal_header_t {
+  uint64_t flush_length;
+
+  bluefs_wal_header_t() : flush_length(0) {}
+  bluefs_wal_header_t(uint64_t flush_length) : flush_length(flush_length) {}
+  static constexpr size_t size() { return (sizeof(__u8)*2) + sizeof(uint32_t) + sizeof(uint64_t); }
+  void bound_encode(size_t &s) const;
+  void encode(ceph::buffer::list& bl) const;
+  void encode(ceph::buffer::list::contiguous_filler& filler_in) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+};
+WRITE_CLASS_ENCODER(bluefs_wal_header_t)
+
 #endif

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -36,7 +36,8 @@ WRITE_CLASS_DENC(bluefs_extent_t)
 
 enum bluefs_node_type {
   REGULAR = 0,
-  WAL_V2 = 1,
+  WAL_V2 = 1,     // WAL_V2 that is open for write
+  WAL_V2_FIN = 2, // WAL_V2 that we are done writing to; there is no data in [onode.size ... allocated)
   NODE_TYPE_END = 0x100,
 };
 
@@ -82,63 +83,52 @@ struct bluefs_fnode_delta_t {
                    // Used for consistency checking.
 
   // only relevant in case of wal node
-  uint64_t wal_limit;
-  uint64_t wal_size;
   uint8_t type = REGULAR;
-
+  uint64_t wal_size; // The size of payload in the file; size = wal_size + n * envelope_size
 
   mempool::bluefs::vector<bluefs_extent_t> extents;
 
   DENC_HELPERS
 
   void bound_encode(size_t& p) const {
-    _denc_friend(*this, p);
-  }
-  void encode(ceph::buffer::list::contiguous_appender& p) const {
-    DENC_DUMP_PRE(bluefs_fnode_t);
-    _denc_friend(*this, p);
-  }
-  void decode(ceph::buffer::ptr::const_iterator& p) {
-    DENC_START_UNSAFE(2, 2, p);
-    denc_varint(ino, p);
-    denc_varint(size, p);
-    denc(mtime, p);
-    denc(offset, p);
-    denc(extents, p);
-
-    if (struct_v >= 2) {
-      denc(type, p);
-      denc(wal_limit, p);
-      denc(wal_size, p);
-    }
-    DENC_FINISH(p);
-
-  }
-
-  template<typename T, typename P>
-  friend std::enable_if_t<std::is_same_v<bluefs_fnode_delta_t, std::remove_const_t<T>>>
-  _denc_friend(T& v, P& p) {
     uint8_t version = 1, compat = 1;
-    if (v.type == WAL_V2) {
+    if (type == WAL_V2  || type == WAL_V2_FIN) {
       version = 2;
       compat = 2;
     }
     DENC_START_UNSAFE(version, compat, p);
+    _denc_friend(*this, p, version);
+    DENC_FINISH(p);
+  }
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
+    DENC_DUMP_PRE(bluefs_fnode_t);
+    uint8_t version = 1, compat = 1;
+    if (type == WAL_V2  || type == WAL_V2_FIN) {
+      version = 2;
+      compat = 2;
+    }
+    DENC_START_UNSAFE(version, compat, p);
+    _denc_friend(*this, p, version);
+    DENC_FINISH(p);
+  }
+  void decode(ceph::buffer::ptr::const_iterator& p) {
+    DENC_START_UNSAFE(2, !"value unused in decode", p);
+    _denc_friend(*this, p, struct_v);
+    DENC_FINISH(p);
+  }
 
+  template<typename T, typename P>
+  friend std::enable_if_t<std::is_same_v<bluefs_fnode_delta_t, std::remove_const_t<T>>>
+  _denc_friend(T& v, P& p, __u8& struct_v) {
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);
     denc(v.offset, p);
     denc(v.extents, p);
-
     if (struct_v >= 2) {
-      denc(v.type, p);
-      denc(v.wal_limit, p);
-      denc(v.wal_size, p);
+      denc_varint(v.type, p);
+      denc_varint(v.wal_size, p);
     }
-
-    DENC_FINISH(p);
-
   }
 };
 WRITE_CLASS_DENC(bluefs_fnode_delta_t)
@@ -159,17 +149,16 @@ struct bluefs_fnode_t {
   uint64_t allocated;
   uint64_t allocated_commited;
   uint8_t type = REGULAR;
-  uint64_t wal_limit; // EOF of wal, this limit represents upper limit of fnode.size, not upper limit of wal_size
-  uint64_t wal_size; // Amount of payload bytes in WAL(not including envelope data), there could be more on power off instances, in range of wal_size~wal_limit
+  uint64_t wal_size; // Amount of payload bytes in WAL(not including envelope data), there could be more on power off instances, in range of fnode.size~wal_limit
 
-  bluefs_fnode_t() : ino(0), size(0), allocated(0), allocated_commited(0), wal_limit(0), wal_size(0) {}
+  bluefs_fnode_t() : ino(0), size(0), allocated(0), allocated_commited(0), wal_size(0) {}
   bluefs_fnode_t(uint64_t _ino, uint64_t _size, utime_t _mtime) :
-    ino(_ino), size(_size), mtime(_mtime), allocated(0), allocated_commited(0), wal_limit(0), wal_size(0) {}
+    ino(_ino), size(_size), mtime(_mtime), allocated(0), allocated_commited(0), wal_size(0) {}
   bluefs_fnode_t(const bluefs_fnode_t& other) :
     ino(other.ino), size(other.size), mtime(other.mtime),
     allocated(other.allocated),
     allocated_commited(other.allocated_commited),
-    wal_limit(other.wal_limit),
+    type(other.type),
     wal_size(other.wal_size) {
     clone_extents(other);
   }
@@ -191,53 +180,46 @@ struct bluefs_fnode_t {
 
   DENC_HELPERS
   void bound_encode(size_t& p) const {
-    _denc_friend(*this, p);
+    uint8_t version = 1, compat = 1;
+    if (type == WAL_V2 || type == WAL_V2_FIN) {
+      version = 2;
+      compat = 2;
+    }
+    DENC_START_UNSAFE(version, compat, p);
+    _denc_friend(*this, p, version);
+    DENC_FINISH(p);
   }
   void encode(ceph::buffer::list::contiguous_appender& p) const {
     DENC_DUMP_PRE(bluefs_fnode_t);
-    _denc_friend(*this, p);
+    uint8_t version = 1, compat = 1;
+    if (type == WAL_V2 || type == WAL_V2_FIN) {
+      version = 2;
+      compat = 2;
+    }
+    DENC_START_UNSAFE(version, compat, p);
+    _denc_friend(*this, p, version);
+    DENC_FINISH(p);
   }
 
   void decode(ceph::buffer::ptr::const_iterator& p) {
-    DENC_START_COMPAT_2(2, 2, p);
-    denc_varint(ino, p);
-    denc_varint(size, p);
-    denc(mtime, p);
-    denc(__unused__, p);
-    denc(extents, p);
-    if (struct_v >= 2) {
-      denc(type, p);
-      denc(wal_limit, p);
-      denc(wal_size, p);
-    }
-    if (struct_v == 1) {
-      type = REGULAR;
-    }
+    DENC_START_UNSAFE(2, !"value unused in decode", p);
+    _denc_friend(*this, p, struct_v);
     DENC_FINISH(p);
     recalc_allocated();
   }
 
   template<typename T, typename P>
   friend std::enable_if_t<std::is_same_v<bluefs_fnode_t, std::remove_const_t<T>>>
-  _denc_friend(T& v, P& p) {
-
-    uint8_t version = 1, compat = 1;
-    if (v.type == WAL_V2) {
-      version = 2;
-      compat = 2;
-    }
-    DENC_START_UNSAFE(version, compat, p);
+  _denc_friend(T& v, P& p, __u8& struct_v) {
     denc_varint(v.ino, p);
     denc_varint(v.size, p);
     denc(v.mtime, p);
     denc(v.__unused__, p);
     denc(v.extents, p);
     if (struct_v >= 2) {
-      denc(v.type, p);
-      denc(v.wal_limit, p);
-      denc(v.wal_size, p);
+      denc_varint(v.type, p);
+      denc_varint(v.wal_size, p);
     }
-    DENC_FINISH(p);
   }
   void reset_delta() {
     allocated_commited = allocated;
@@ -458,20 +440,5 @@ struct bluefs_transaction_t {
 WRITE_CLASS_ENCODER(bluefs_transaction_t)
 
 std::ostream& operator<<(std::ostream& out, const bluefs_transaction_t& t);
-
-
-
-struct bluefs_wal_header_t {
-  uint64_t flush_length;
-
-  bluefs_wal_header_t() : flush_length(0) {}
-  bluefs_wal_header_t(uint64_t flush_length) : flush_length(flush_length) {}
-  static constexpr size_t size() { return (sizeof(__u8)*2) + sizeof(uint32_t) + sizeof(uint64_t); }
-  void bound_encode(size_t &s) const;
-  void encode(ceph::buffer::list& bl) const;
-  void encode(ceph::buffer::list::contiguous_filler& filler_in) const;
-  void decode(ceph::buffer::list::const_iterator& p);
-};
-WRITE_CLASS_ENCODER(bluefs_wal_header_t)
 
 #endif

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -367,10 +367,10 @@ int main(int argc, char **argv)
         "bluefs-stats, "
         "reshard, "
         "show-sharding, "
-	"trim, "
-        "zap-device"
-)
-    ;
+        "trim, "
+        "zap-device, "
+        "downgrade-wal-to-v1"
+    );
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
 
@@ -486,7 +486,7 @@ int main(int argc, char **argv)
     }
   }
 
-  if (action == "fsck" || action == "repair" || action == "quick-fix" || action == "allocmap" || action == "qfsck" || action == "restore_cfb") {
+  if (action == "fsck" || action == "repair" || action == "quick-fix" || action == "allocmap" || action == "qfsck" || action == "restore_cfb" || action == "migrate-wal-to-v1") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -701,7 +701,8 @@ int main(int argc, char **argv)
   }
   else if (action == "fsck" ||
       action == "repair" ||
-      action == "quick-fix") {
+      action == "quick-fix" ||
+      action == "downgrade-wal-to-v1") {
     validate_path(cct.get(), path, false);
     BlueStore bluestore(cct.get(), path);
     int r;
@@ -709,6 +710,8 @@ int main(int argc, char **argv)
       r = bluestore.fsck(fsck_deep);
     } else if (action == "repair") {
       r = bluestore.repair(fsck_deep);
+    } else if (action == "downgrade-wal-to-v1") {
+      r = bluestore.downgrade_wal_to_v1();
     } else {
       r = bluestore.quick_fix();
     }

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
         "show-sharding, "
         "trim, "
         "zap-device, "
-        "downgrade-wal-to-v1"
+        "revert-wal-to-plain"
     );
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -486,7 +486,10 @@ int main(int argc, char **argv)
     }
   }
 
-  if (action == "fsck" || action == "repair" || action == "quick-fix" || action == "allocmap" || action == "qfsck" || action == "restore_cfb" || action == "migrate-wal-to-v1") {
+  if (action == "fsck" || action == "repair" ||
+      action == "quick-fix" || action == "allocmap" ||
+      action == "qfsck" || action == "restore_cfb" ||
+      action == "revert-wal-to-plain") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -702,7 +705,7 @@ int main(int argc, char **argv)
   else if (action == "fsck" ||
       action == "repair" ||
       action == "quick-fix" ||
-      action == "downgrade-wal-to-v1") {
+      action == "revert-wal-to-plain") {
     validate_path(cct.get(), path, false);
     BlueStore bluestore(cct.get(), path);
     int r;
@@ -710,8 +713,8 @@ int main(int argc, char **argv)
       r = bluestore.fsck(fsck_deep);
     } else if (action == "repair") {
       r = bluestore.repair(fsck_deep);
-    } else if (action == "downgrade-wal-to-v1") {
-      r = bluestore.downgrade_wal_to_v1();
+    } else if (action == "revert-wal-to-plain") {
+      r = bluestore.revert_wal_to_plain();
     } else {
       r = bluestore.quick_fix();
     }

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -11,6 +11,8 @@
 #include <thread>
 #include <stack>
 #include <gtest/gtest.h>
+#include "common/dout.h"
+#include "common/debug.h"
 #include "global/global_init.h"
 #include "common/ceph_argparse.h"
 #include "include/stringify.h"
@@ -18,6 +20,7 @@
 #include "common/errno.h"
 
 #include "os/bluestore/Allocator.h"
+#include "os/bluestore/bluefs_types.h"
 #include "os/bluestore/bluestore_common.h"
 #include "os/bluestore/BlueFS.h"
 
@@ -888,6 +891,658 @@ TEST(BlueFS, test_tracker_50965) {
   fs.close_writer(h_slow);
   fs.close_writer(h_db);
 
+  fs.umount();
+}
+
+// borrowed from store_test
+static bool bl_eq(bufferlist& expected, bufferlist& actual) {
+  if (expected.contents_equal(actual))
+    return true;
+
+  unsigned first = 0;
+  if(expected.length() != actual.length()) {
+    cout << "--- buffer lengths mismatch " << std::hex
+         << "expected 0x" << expected.length() << " != actual 0x"
+         << actual.length() << std::dec << std::endl;
+  }
+  auto len = std::min(expected.length(), actual.length());
+  while ( first<len && expected[first] == actual[first])
+    ++first;
+  unsigned last = len;
+  while (last > 0 && expected[last-1] == actual[last-1])
+    --last;
+  if(len > 0) {
+    cout << "--- buffer mismatch between offset 0x" << std::hex << first
+         << " and 0x" << last << ", total 0x" << len << std::dec
+         << std::endl;
+    cout << "--- expected:\n";
+    expected.hexdump(cout);
+    cout << "--- actual:\n";
+    actual.hexdump(cout);
+  }
+  return false;
+}
+
+TEST(BlueFS, test_wal_write) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  bufferlist bl1;
+  auto gen_debugable = [](size_t amount, bufferlist& bl) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append('a');
+    }
+  };
+  gen_debugable(70000, bl1);
+  fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  fs.fsync(writer);
+
+  // WAL files don't update internal extents while writing to save memory, only on _replay
+  fs.umount();
+  fs.mount();
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  bufferlist read_bl;
+  fs.read(reader, 0, 70000, &read_bl, NULL);
+  ASSERT_TRUE(bl_eq(bl1, read_bl));
+  delete reader;
+  fs.umount();
+
+}
+
+TEST(BlueFS, test_wal_write_multiple) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  auto gen_debugable = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c);
+    }
+  };
+  size_t buffer_size = 70000;
+  for (int i = 0; i < 10; i++) {
+    bufferlist bl1;
+    gen_debugable(buffer_size, bl1, 'a' + i);
+    fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+    fs.fsync(writer);
+
+    // WAL files don't update internal extents while writing to save memory
+    fs.umount();
+    fs.mount();
+
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    bufferlist read_bl;
+    fs.read(reader, i * buffer_size, buffer_size, &read_bl, NULL);
+    ASSERT_TRUE(bl_eq(bl1, read_bl));
+    delete reader;
+  }
+  fs.umount();
+}
+
+TEST(BlueFS, test_wal_write_multiple_recover) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  auto gen_debugable = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c);
+    }
+  };
+  size_t buffer_size = 70000;
+  uint64_t flush_count = 10;
+  for (int i = 0; i < 10; i++) {
+    bufferlist bl1;
+    gen_debugable(buffer_size, bl1, 'a' + i);
+    fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+    fs.fsync(writer);
+  }
+  fs.close_writer(writer);
+
+  fs.umount();
+  fs.mount();
+
+  uint64_t size = 0;
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  fs.stat(dir_db, wal_file, &size, nullptr);
+  ASSERT_EQ(reader->file->wal_flushes.size(), flush_count);
+  ASSERT_EQ(size, 70000  * flush_count);
+  delete reader;
+}
+
+TEST(BlueFS, test_wal_write_multiple_recover_fsync_end) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "524288");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  auto gen_debugable = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c);
+    }
+  };
+  size_t buffer_size = 8;
+  uint64_t flush_count = 1;
+  for (int i = 0; i < 10; i++) {
+    bufferlist bl1;
+    gen_debugable(buffer_size, bl1, 'a' + i);
+    fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  }
+  fs.fsync(writer);
+  fs.close_writer(writer);
+
+  fs.umount();
+  fs.mount();
+
+  uint64_t size = 0;
+
+  { // test size
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    fs.stat(dir_db, wal_file, &size, nullptr);
+    ASSERT_EQ(reader->file->wal_flushes.size(), flush_count);
+    ASSERT_EQ(size, buffer_size * 10);
+    delete reader;
+  }
+
+  // test contents
+  for (int i = 0; i < 10; i++) {
+    bufferlist bl1;
+    gen_debugable(buffer_size, bl1, 'a' + i);
+
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    bufferlist read_bl;
+    fs.read(reader, i * buffer_size, buffer_size, &read_bl, NULL);
+    ASSERT_TRUE(bl_eq(bl1, read_bl));
+    delete reader;
+  }
+}
+
+TEST(BlueFS, test_wal_read_2_partial) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+
+  auto gen_debugable_alternating = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c + (rand() % 10));
+    }
+  };
+  uint64_t flush_count = 2;
+  uint64_t flush_size = 65536;
+  uint64_t total_size = flush_count * flush_size;
+
+  vector<uint64_t> chunk_sizes = {total_size / 32, total_size / 64};
+
+  uint64_t chunk_size = flush_size;
+  bufferlist contents;
+  ASSERT_TRUE((total_size)%chunk_size == 0);
+
+  string wal_file("wal1.log");
+
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+  //
+  uint64_t remaining = total_size;
+  while(remaining > 0) {
+    bufferlist bl1;
+    gen_debugable_alternating(chunk_size, bl1, 'a'+ (remaining % 10));
+    fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+    contents.append(bl1);
+    remaining -= chunk_size;
+  }
+  fs.fsync(writer);
+  fs.close_writer(writer);
+
+  fs.umount();
+  fs.mount();
+
+  uint64_t size = 0;
+
+
+  { // test size
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    fs.stat(dir_db, wal_file, &size, nullptr);
+    ASSERT_EQ(reader->file->wal_flushes.size(), flush_count);
+    ASSERT_EQ(size, total_size);
+    delete reader;
+  }
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  bufferlist read_bl;
+  uint64_t offset = chunk_size / 2;
+  uint64_t length = chunk_size;
+  fs.read(reader, offset, length, &read_bl, NULL);
+  bufferlist chunk_contents;
+  chunk_contents.substr_of(contents, offset, length);
+  ASSERT_TRUE(bl_eq(chunk_contents, read_bl));
+  delete reader;
+}
+
+TEST(BlueFS, test_wal_read_2_partial_compact) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+
+  auto gen_debugable_alternating = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c + (rand() % 10));
+    }
+  };
+  uint64_t flush_count = 2;
+  uint64_t flush_size = 65536;
+  uint64_t total_size = flush_count * flush_size;
+
+  vector<uint64_t> chunk_sizes = {total_size / 32, total_size / 64};
+
+  uint64_t chunk_size = flush_size;
+  bufferlist contents;
+  ASSERT_TRUE((total_size)%chunk_size == 0);
+
+  string wal_file("wal1.log");
+
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+  //
+  uint64_t remaining = total_size;
+  while(remaining > 0) {
+    bufferlist bl1;
+    gen_debugable_alternating(chunk_size, bl1, 'a'+ (remaining % 10));
+    fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+    contents.append(bl1);
+    remaining -= chunk_size;
+  }
+  fs.fsync(writer);
+  fs.close_writer(writer);
+
+  fs.compact_log();
+  fs.umount();
+  fs.mount();
+
+  uint64_t size = 0;
+
+
+  { // test size
+    BlueFS::FileReader *reader;
+    ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+    fs.stat(dir_db, wal_file, &size, nullptr);
+    ASSERT_EQ(reader->file->wal_flushes.size(), flush_count);
+    ASSERT_EQ(size, total_size);
+    delete reader;
+  }
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  bufferlist read_bl;
+  uint64_t offset = chunk_size / 2;
+  uint64_t length = chunk_size;
+  fs.read(reader, offset, length, &read_bl, NULL);
+  bufferlist chunk_contents;
+  chunk_contents.substr_of(contents, offset, length);
+  ASSERT_TRUE(bl_eq(chunk_contents, read_bl));
+  delete reader;
+}
+
+TEST(BlueFS, test_wal_write_multiple_recover_partial_reads) {
+  // read from the middle of one flush and end somewhere in between other flush
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "524288");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+
+  auto gen_debugable_alternating = [](size_t amount, bufferlist& bl, char c) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append(c + (i % 10));
+    }
+  };
+  uint64_t flush_count = 2;
+  uint64_t flush_size = 524288;
+  uint64_t total_size = flush_count * flush_size;
+
+  vector<uint64_t> chunk_sizes = {total_size / 32, total_size / 64};
+
+  uint64_t fileid = 0;
+  for (auto chunk_size : chunk_sizes) {
+    bufferlist contents;
+    fileid++;
+    ASSERT_TRUE((total_size)%chunk_size == 0);
+
+    string wal_file("wal");
+    wal_file += to_string(fileid);
+    wal_file += ".log";
+
+    BlueFS::FileWriter *writer;
+    ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+    ASSERT_NE(nullptr, writer);
+    //
+    uint64_t remaining = total_size;
+    while(remaining > 0) {
+      bufferlist bl1;
+      gen_debugable_alternating(chunk_size, bl1, 'a'+ (remaining % 10));
+      fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+      contents.append(bl1);
+      remaining -= chunk_size;
+    }
+    fs.fsync(writer);
+    fs.close_writer(writer);
+
+    fs.umount();
+    fs.mount();
+
+    uint64_t size = 0;
+
+
+    { // test size
+      BlueFS::FileReader *reader;
+      ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+      fs.stat(dir_db, wal_file, &size, nullptr);
+      ASSERT_EQ(reader->file->wal_flushes.size(), flush_count);
+      ASSERT_EQ(size, total_size);
+      delete reader;
+    }
+
+    uint64_t read_chunks =  size / chunk_size; // WAL default chunk size is 32k
+    for (uint64_t chunk = 0; chunk < read_chunks; chunk++) {
+      BlueFS::FileReader *reader;
+      ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+      bufferlist read_bl;
+      uint64_t offset = chunk * chunk_size;
+      uint64_t length = chunk_size;
+      fs.read(reader, offset, length, &read_bl, NULL);
+      bufferlist chunk_contents;
+      chunk_contents.substr_of(contents, offset, length);
+      ASSERT_TRUE(bl_eq(chunk_contents, read_bl));
+      delete reader;
+    }
+
+  }
+}
+
+
+TEST(BlueFS, test_wal_write_truncate) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  bufferlist bl1;
+  auto gen_debugable = [](size_t amount, bufferlist& bl) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append('a');
+    }
+  };
+  gen_debugable(70000, bl1);
+  fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  fs.fsync(writer);
+  fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  fs.fsync(writer);
+  fs.truncate(writer, 70000+BlueFS::File::WALFlush::extra_envelope_size_on_front_and_tail());
+  fs.fsync(writer);
+
+  fs.umount();
+  fs.mount();
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  ASSERT_EQ(reader->file->fnode.wal_limit, 70000+BlueFS::File::WALFlush::extra_envelope_size_on_front_and_tail());
+  ASSERT_EQ(reader->file->wal_flushes.size(), 1);
+  bufferlist read_bl;
+  fs.read(reader, 0, 70000, &read_bl, NULL);
+  ASSERT_TRUE(bl_eq(bl1, read_bl));
+  delete reader;
+  fs.umount();
+
+}
+
+TEST(BlueFS, test_wal_read_after_rollback_to_v1) {
+  // test whether we still read with v2 version even though new files will be v1
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.SetVal("bluefs_wal_v2", "true");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_EQ(writer->file->fnode.type, WAL_V2);
+  ASSERT_NE(nullptr, writer);
+
+  bufferlist bl1;
+  auto gen_debugable = [](size_t amount, bufferlist& bl) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append('a');
+    }
+  };
+  gen_debugable(70000, bl1);
+  fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  fs.fsync(writer);
+
+  g_ceph_context->_conf.set_val("bluefs_wal_v2", "false");
+  fs.umount();
+  fs.mount();
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  bufferlist read_bl;
+  fs.read(reader, 0, 70000, &read_bl, NULL);
+  ASSERT_TRUE(bl_eq(bl1, read_bl));
+  delete reader;
+
+  {
+    // open another file to ensure v1 is set correctly
+    string wal_file = "wal2.log";
+    BlueFS::FileWriter *writer;
+    ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+    ASSERT_NE(nullptr, writer);
+    ASSERT_EQ(writer->file->fnode.type, REGULAR);
+  }
   fs.umount();
 }
 

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1099,6 +1099,61 @@ public:
   }
 };
 
+TEST(BlueFS, test_wal_migrate) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  bufferlist bl1;
+  auto gen_debugable = [](size_t amount, bufferlist& bl) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append('a');
+    }
+  };
+  gen_debugable(70000, bl1);
+  fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  fs.fsync(writer);
+
+  // WAL files don't update internal extents while writing to save memory, only on _replay
+  fs.umount();
+  fs.mount();
+  fs.downgrade_wal_to_v1();
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  ASSERT_EQ(reader->file->fnode.type, bluefs_node_type::REGULAR);
+  ASSERT_EQ(reader->file->is_new_wal(), false);
+
+  bufferlist read_bl;
+  fs.read(reader, 0, 70000, &read_bl, NULL);
+  ASSERT_TRUE(bl_eq(bl1, read_bl));
+  delete reader;
+  fs.umount();
+}
 
 
 TEST_F(BlueFS_wal, wal_v2_check)

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1141,7 +1141,7 @@ TEST(BlueFS, test_wal_migrate) {
   // WAL files don't update internal extents while writing to save memory, only on _replay
   fs.umount();
   fs.mount();
-  fs.downgrade_wal_to_v1();
+  fs.revert_wal_to_plain();
 
   BlueFS::FileReader *reader;
   ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1178,6 +1178,7 @@ TEST_F(BlueFS_wal, wal_v2_check)
 
 TEST_F(BlueFS_wal, wal_v2_check_feature)
 {
+  SKIP_JENKINS();
   ConfSaver conf(g_ceph_context->_conf);
   conf.SetVal("bluefs_min_flush_size", "65536");
   conf.SetVal("bluefs_wal_v2", "true");

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1948,9 +1948,10 @@ TEST(BlueFS, truncate_drops_allocations) {
     uint64_t shared_alloc_unit = s.slow_alloc_size;
     shared_alloc.set(
       Allocator::create(g_ceph_context, g_ceph_context->_conf->bluefs_allocator,
-                        s.slow_size, shared_alloc_unit, "test shared allocator"),
+                        s.slow_size ? s.slow_size : s.db_size,
+                        shared_alloc_unit, "test shared allocator"),
       shared_alloc_unit);
-    shared_alloc.a->init_add_free(0, s.slow_size);
+    shared_alloc.a->init_add_free(0, s.slow_size ? s.slow_size : s.db_size);
 
     BlueFS fs(g_ceph_context);
     if (s.db_size != 0) {
@@ -1979,6 +1980,7 @@ TEST(BlueFS, truncate_drops_allocations) {
     EXPECT_EQ(pre, post - s.allocated_after_truncate);
 
     fs.umount();
+    delete shared_alloc.a;
   }
 }
 


### PR DESCRIPTION
The work here is based on #56927.
It implements the design principles showed there, but with a bit different implementation details.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
