### PR TITLE
common: fmt support for bitset_set & mini_flat_map

### DIFF
--- a/src/common/bitset_set.h
+++ b/src/common/bitset_set.h
@@ -14,7 +14,9 @@
 
 #pragma once
 #include <cstdint>
+#include <fmt/ranges.h>
 
+#include "common/fmt_common.h"
 #include "include/buffer.h"
 
 template<typename KeyT, typename IntT>
@@ -409,6 +411,20 @@ class bitset_set {
     return lhs;
   }
 
+  std::string fmt_print() const
+  requires has_formatter<KeyT> {
+    std::string s = "{";
+    int c = (int)size();
+    for (auto k : *this) {
+      s += fmt::format("{}", k);
+      if (--c > 0) {
+	s += ",";
+      }
+    }
+    s += "}";
+    return s;
+  }
+
   /** returns a bitset_set with the elements from lhs which are not found in rhs
    *
    * Useful to replace calls to std::difference which looked at the complete
@@ -447,3 +463,8 @@ class bitset_set {
     return std::strong_ordering::equal;
   }
 };
+
+// make sure fmt::range would not try (and fail) to treat bitset_set as a range
+template<size_t NumBitsV, typename KeyT>
+struct fmt::is_range<bitset_set<NumBitsV, KeyT>, char> : std::false_type {};
+

--- a/src/common/mini_flat_map.h
+++ b/src/common/mini_flat_map.h
@@ -3,11 +3,14 @@
 
 #pragma once
 
-#include <common/bitset_set.h>
-#include <include/ceph_assert.h>
 #include <cstddef>
+#include <fmt/ranges.h>
 #include <memory>
 #include <vector>
+
+#include "common/bitset_set.h"
+#include "common/fmt_common.h"
+#include "include/ceph_assert.h"
 
 
 /* This class struct provides an API similar to std::map, but with the
@@ -490,4 +493,23 @@ class mini_flat_map {
     lhs << "}";
     return lhs;
   }
+
+  std::string fmt_print() const
+  requires has_formatter<KeyT> && has_formatter<ValueT> {
+    int c = (int)_size;
+    std::string s = "{";
+    for (auto&& [k, v] : *this) {
+      s += fmt::format("{}:{}", k, v);
+      if (--c > 0) {
+	s += ",";
+      }
+    }
+    s += "}";
+    return s;
+  }
 };
+
+// make sure fmt::range does not apply to mini_flat_map
+template<typename KeyT, typename ValueT>
+struct fmt::is_range<mini_flat_map<KeyT, ValueT>, char> : std::false_type {};
+


### PR DESCRIPTION
Note: both classes have begin()/end() methods, which
required an explicit opt-out of fmt/range default handling.
