### PR TITLE
common, osd: add cmd_getval_cast_or()

### DIFF
--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -102,11 +102,34 @@ T cmd_getval_or(const cmdmap_t& cmdmap, std::string_view k,
 		const V& defval)
 {
   auto found = cmdmap.find(k);
-  if (found == cmdmap.end()) {
+  if (found == cmdmap.cend()) {
     return T(defval);
   }
   try {
-    return boost::get<T>(cmdmap.find(k)->second);
+    return boost::get<T>(found->second);
+  } catch (boost::bad_get&) {
+    throw bad_cmd_get(k, cmdmap);
+  }
+}
+
+/**
+ * with default, to be used when the parameter type (which matches the type of the
+ * 'default' object) is not one of the limited set of parameters type.
+ * Added to support "safe types" - typed wrappers "around" simple types (e.g.
+ * shard_id_t which is a structure holding one int8_t), without requiring the
+ * user to specify the default in the 'internal type'.
+ *
+ * Throws if the key is found, but the type is not the expected one.
+ */
+template <typename CMD_TYPE, typename T>
+T cmd_getval_cast_or(const cmdmap_t& cmdmap, std::string_view k, T defval)
+{
+  auto found = cmdmap.find(k);
+  if (found == cmdmap.cend()) {
+    return defval;
+  }
+  try {
+    return T(boost::get<CMD_TYPE>(found->second));
   } catch (boost::bad_get&) {
     throw bad_cmd_get(k, cmdmap);
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -193,6 +193,7 @@ using ceph::make_mutex;
 using namespace ceph::osd::scheduler;
 using TOPNSPC::common::cmd_getval;
 using TOPNSPC::common::cmd_getval_or;
+using TOPNSPC::common::cmd_getval_cast_or;
 using namespace std::literals;
 
 static ostream& _prefix(std::ostream* _dout, int whoami, epoch_t epoch) {
@@ -6582,10 +6583,10 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       return;
     }
 
-    int64_t shardid64 = cmd_getval_or<int64_t>(cmdmap, "shardid", static_cast<int64_t>(shard_id_t::NO_SHARD));
-    shard_id_t shardid = shard_id_t(static_cast<int8_t>(shardid64));
-
-    hobject_t obj(object_t(objname), string(""), CEPH_NOSNAP, rawpg.ps(), pool, nspace);
+    shard_id_t shardid =
+	cmd_getval_cast_or<int64_t>(cmdmap, "shardid", shard_id_t::NO_SHARD);
+    hobject_t obj(
+	object_t(objname), ""s, CEPH_NOSNAP, rawpg.ps(), pool, nspace);
     ghobject_t gobj(obj, ghobject_t::NO_GEN, shardid);
     spg_t pgid(curmap->raw_pg_to_pg(rawpg), shardid);
     if (curmap->pg_is_ec(rawpg)) {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -16,6 +16,7 @@
 #include "os/bluestore/Writer.h"
 #include "common/pretty_binary.h"
 
+#include <bitset>
 #include <sstream>
 
 #define _STR(x) #x


### PR DESCRIPTION
This slight variation of cmd_getval_or() can be used where
the object type is different from the configuration item
type (as when the object is a wrapper around an integer).
It allows specifying the 'default' value in the object type.

A first use of cmd_getval_cast_or() was added in OSD.cc,
which was the trigger for this PR.