### PR TITLE
qa: update 'minval' based on the default counter values in perf stats output

### DIFF
--- a/qa/tasks/check_counter.py
+++ b/qa/tasks/check_counter.py
@@ -79,12 +79,10 @@ class CheckCounter(Task):
 
             for daemon_id, daemon in daemons.items():
                 if not daemon.running():
-                    log.info("Ignoring daemon {0}, it isn't running".format(daemon_id))
+                    log.info(f"Ignoring daemon {daemon_type}.{daemon_id}, it isn't running")
                     continue
                 elif daemon_type == 'mgr' and daemon_id != active_mgr:
                     continue
-                else:
-                    log.debug("Getting stats from {0}".format(daemon_id))
 
                 if daemon_type == 'mds':
                     mds_info = status.get_mds(daemon_id)
@@ -104,13 +102,14 @@ class CheckCounter(Task):
                             log.debug(f"Failed to do 'perf dump' on {mds}")
                         continue
                 else:
+                    log.debug(f"Getting stats from {daemon_type}.{daemon_id}")
                     manager = self.ctx.managers[cluster_name]
                     proc = manager.admin_socket(daemon_type, daemon_id, ["perf", "dump"])
                     response_data = proc.stdout.getvalue().strip()
                 if response_data:
                     perf_dump = json.loads(response_data)
                 else:
-                    log.warning("No response from {0}, skipping".format(daemon_id))
+                    log.warning(f"No response from {daemon_type}.{daemon_id}, skipping")
                     continue
 
                 minval = ''
@@ -137,18 +136,17 @@ class CheckCounter(Task):
                         val = val[key]
 
                     if val is not None:
-                        log.info(f"Daemon {daemon_type}.{daemon_id} {name}={val}")
-                        if isinstance(minval, int) and val >= minval:
-                            seen.add(name)
-                        elif isinstance(expected_val, int) and val == expected_val:
+                        if (isinstance(minval, int) and val >= minval) or \
+                           (isinstance(expected_val, int) and val == expected_val):
+                            log.info(f"Found daemon: {daemon_type}.{daemon_id}, "
+                                     f"counter: {name}={val} in perf dump")
                             seen.add(name)
 
             if not dry_run:
                 unseen = set(expected) - set(seen)
                 if unseen:
                     raise RuntimeError("The following counters failed to be set "
-                                       "on {0} daemons: {1}".format(
-                        daemon_type, unseen
-                    ))
+                                       f"on {daemon_type} daemon: {unseen}")
+                log.info(f"Expected counters {expected} to be set on {daemon_type}")
 
 task = CheckCounter

--- a/qa/tasks/check_counter.py
+++ b/qa/tasks/check_counter.py
@@ -124,7 +124,7 @@ class CheckCounter(Task):
                             expected_val = counter['expected_val']
                     else:
                         name = counter
-                        minval = 1
+                        minval = 0
                     expected.add(name)
 
                     val = perf_dump


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/65770
Fixes: https://tracker.ceph.com/issues/69665
Fixes: https://tracker.ceph.com/issues/70441

Updating the `minval` default value fixes the check counters failure, as `mds.imported` and `mds.exported` is now `seen` by check_counter.py. They were present in the `perf stats` o/p but not seen by check_counter.py.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
