### PR TITLE
Reverting to previous of offset allocation for power

### DIFF
--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -39,7 +39,12 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
   uint64_t search_bytes = 0;
   auto rs_start = range_tree.lower_bound(range_t{*cursor, size}, compare);
   for (auto rs = rs_start; rs != range_tree.end(); ++rs) {
-    uint64_t offset = rs->start;
+    uint64_t offset;
+    #ifdef HAVE_POWER8
+      offset = p2roundup(rs->start, align);
+    #else
+      offset = rs->start;
+    #endif
     *cursor = offset + size;
     if (offset + size <= rs->end) {
       return offset;
@@ -59,7 +64,12 @@ uint64_t AvlAllocator::_pick_block_after(uint64_t *cursor,
   }
   // If we reached end, start from beginning till cursor.
   for (auto rs = range_tree.begin(); rs != rs_start; ++rs) {
-    uint64_t offset = rs->start;
+    uint64_t offset;
+    #ifdef HAVE_POWER8
+      offset = p2roundup(rs->start, align);
+    #else
+      offset = rs->start;
+    #endif
     *cursor = offset + size;
     if (offset + size <= rs->end) {
       return offset;
@@ -82,7 +92,12 @@ uint64_t AvlAllocator::_pick_block_fits(uint64_t size,
   const auto compare = range_size_tree.key_comp();
   auto rs_start = range_size_tree.lower_bound(range_t{0, size}, compare);
   for (auto rs = rs_start; rs != range_size_tree.end(); ++rs) {
-    uint64_t offset = rs->start;
+    uint64_t offset;
+    #ifdef HAVE_POWER8
+      offset = p2roundup(rs->start, align);
+    #else
+      offset = rs->start;
+    #endif
     if (offset + size <= rs->end) {
       return offset;
     }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -46,6 +46,7 @@ enum {
   l_bluefs_slow_alloc_unit,
   l_bluefs_db_alloc_unit,
   l_bluefs_wal_alloc_unit,
+  l_bluefs_main_alloc_unit,
   l_bluefs_read_random_lat,
   l_bluefs_read_random_count,
   l_bluefs_read_random_bytes,

--- a/src/os/bluestore/BtreeAllocator.cc
+++ b/src/os/bluestore/BtreeAllocator.cc
@@ -25,7 +25,12 @@ uint64_t BtreeAllocator::_pick_block_after(uint64_t *cursor,
 {
   auto rs_start = range_tree.lower_bound(*cursor);
   for (auto rs = rs_start; rs != range_tree.end(); ++rs) {
-    uint64_t offset = rs->first;
+    uint64_t offset;
+    #ifdef HAVE_POWER8
+      offset = p2roundup(rs->first, align);
+    #else
+      offset = rs->first;
+    #endif
     if (offset + size <= rs->second) {
       *cursor = offset + size;
       return offset;
@@ -37,7 +42,12 @@ uint64_t BtreeAllocator::_pick_block_after(uint64_t *cursor,
   }
   // If we reached end, start from beginning till cursor.
   for (auto rs = range_tree.begin(); rs != rs_start; ++rs) {
-    uint64_t offset = rs->first;
+    uint64_t offset;
+    #ifdef HAVE_POWER8
+      offset = p2roundup(rs->first, align);
+    #else
+      offset = rs->first;
+    #endif
     if (offset + size <= rs->second) {
       *cursor = offset + size;
       return offset;
@@ -53,7 +63,12 @@ uint64_t BtreeAllocator::_pick_block_fits(uint64_t size,
   // the needs
   auto rs_start = range_size_tree.lower_bound(range_value_t{0,size});
   for (auto rs = rs_start; rs != range_size_tree.end(); ++rs) {
-    uint64_t offset = rs->start;
+    uint64_t offset;
+    #ifdef HAVE_POWER8
+      offset = p2roundup(rs->start, align);
+    #else
+      offset = rs->start;
+    #endif
     if (offset + size <= rs->start + rs->size) {
       return offset;
     }

--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -17,6 +17,21 @@ uint64_t AllocatorLevel::l2_allocs = 0;
 
 inline interval_t _align2units(uint64_t offset, uint64_t len, uint64_t min_length)
 {
+  #ifdef HAVE_POWER8
+    interval_t res;
+    if (len >= min_length) {
+      res.offset = p2roundup(offset, min_length);
+      auto delta_off = res.offset - offset;
+      if (len > delta_off) {
+        res.length = len - delta_off;
+        res.length = p2align<uint64_t>(res.length, min_length);
+        if (res.length) {
+	        return res;
+        }
+      }
+    }
+    return interval_t();
+  #endif
   return len >= min_length ?
     interval_t(offset, p2align<uint64_t>(len, min_length)) :
     interval_t();


### PR DESCRIPTION
The following issue is seen on POWER when a stress test (writing many files parallely on the mounted path)
```
2025-02-28T05:13:56.449-0500 7fff7adec0c0 -1 bluestore(/var/lib/ceph/osd/ceph-2) _verify_csum bad crc32c/0x1000 checksum at blob offset 0x2000, got 0x6706be76, expected 0x4373e7be, device location [0x1f5321000~1000], logical extent 0x212000~1000, object #4:a6f051b6:::200.00000174:head#
2025-02-28T05:13:56.459-0500 7fff7adec0c0 -1 bluestore(/var/lib/ceph/osd/ceph-2) _verify_csum bad crc32c/0x1000 checksum at blob offset 0x2000, got 0x6706be76, expected 0x4373e7be, device location [0x1f5321000~1000], logical extent 0x212000~1000, object #4:a6f051b6:::200.00000174:head#
```

Stress test reference: https://github.com/hasan4791/ceph-setup/blob/chasan-working/multiple_files.sh
This is observed since the following commit is introduced.
https://github.com/ceph/ceph/pull/53483/files#diff-5eb5704e3a1c0c9d042492c4e87d8c864ad9cb96afa1249f9ec294acc2fba977

Hence, reverting the same and running many tests, the above mentioned checksum issue isn't observed, hence reverting the same only for power. 