### PR TITLE
reef: mgr/dashboard: pin lxml to fix run-dashboard-tox-make-check failure

### DIFF
--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -11,3 +11,4 @@ pyyaml
 natsort
 setuptools
 jsonpatch
+lxml==4.8.0  # to fix https://github.com/xmlsec/python-xmlsec/issues/320


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70424

---

backport of https://github.com/ceph/ceph/pull/62242
parent tracker: https://tracker.ceph.com/issues/70411

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh