### PR TITLE
qa/tasks/cephfs/mount: use 'ip route' instead 'route'

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -296,12 +296,11 @@ class CephFSMountBase(object):
         self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         
         # Setup the NAT
-        p = self.client_remote.run(args=['route'], stderr=StringIO(),
-                                   stdout=StringIO(), timeout=(5*60))
-        p = re.findall(r'default .*', p.stdout.getvalue())
-        if p == False:
+        routes = self.client_remote.sh('ip r', timeout=(5*60))
+        defaults = re.findall(r'^default .*', routes)
+        if defaults == False:
             raise RuntimeError("No default gw found")
-        gw = p[0].split()[7]
+        gw = defaults[0].split()[4]
 
         self.run_shell_payload(f"""
             set -e
@@ -441,12 +440,12 @@ class CephFSMountBase(object):
         ip = IP(self.ceph_brx_net)[-2]
         mask = self.ceph_brx_net.split('/')[1]
 
-        p = self.client_remote.run(args=['route'], stderr=StringIO(),
-                                   stdout=StringIO(), timeout=(5*60))
-        p = re.findall(r'default .*', p.stdout.getvalue())
-        if p == False:
+        routes = self.client_remote.sh('ip r', timeout=(5*60))
+        defaults = re.findall(r'^default .*', routes)
+        if defaults == False:
             raise RuntimeError("No default gw found")
-        gw = p[0].split()[7]
+        gw = defaults[0].split()[4]
+
         self.run_shell_payload(f"""
             set -e
             sudo iptables -D FORWARD -o {gw} -i ceph-brx -j ACCEPT

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -264,6 +264,13 @@ class CephFSMountBase(object):
             if 'permission denied' in stderr.getvalue().lower():
                 pass
 
+    def _default_gateway(self):
+        routes = self.client_remote.sh('ip r', timeout=(5*60))
+        defaults = re.findall(r'^default .*', routes)
+        if defaults == False:
+            raise RuntimeError("No default gw found")
+        return defaults[0].split()[4]
+
     def _setup_brx_and_nat(self):
         # The ip for ceph-brx should be
         ip = IP(self.ceph_brx_net)[-2]
@@ -296,11 +303,7 @@ class CephFSMountBase(object):
         self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         
         # Setup the NAT
-        routes = self.client_remote.sh('ip r', timeout=(5*60))
-        defaults = re.findall(r'^default .*', routes)
-        if defaults == False:
-            raise RuntimeError("No default gw found")
-        gw = defaults[0].split()[4]
+        gw = self._default_gateway()
 
         self.run_shell_payload(f"""
             set -e
@@ -440,11 +443,7 @@ class CephFSMountBase(object):
         ip = IP(self.ceph_brx_net)[-2]
         mask = self.ceph_brx_net.split('/')[1]
 
-        routes = self.client_remote.sh('ip r', timeout=(5*60))
-        defaults = re.findall(r'^default .*', routes)
-        if defaults == False:
-            raise RuntimeError("No default gw found")
-        gw = defaults[0].split()[4]
+        gw = self._default_gateway()
 
         self.run_shell_payload(f"""
             set -e


### PR DESCRIPTION
Instead of satisfying another dependency like 'net-tools' in order to use 'route' command, just use 'ip route' to find out which is the default gateway.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
