### PR TITLE
quincy: doc/rados/configuration/bluestore-config-ref: Fix lowcase typo

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -358,7 +358,7 @@ OSD and run the following command:
 
        ceph-bluestore-tool \
         --path <data path> \
-        --sharding="m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} l p" \
+        --sharding="m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} L P" \
         reshard
 
 .. confval:: bluestore_rocksdb_cf

--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -507,7 +507,7 @@ examine the presence and value of ``/sys/block/<drive>/queue/optimal_io_size``.
 .. note:: When running Reef or a later Ceph release, the ``min_alloc_size``
    baked into each OSD is conveniently reported by ``ceph osd metadata``.
 
-To inspect a specific OSD, run the following command:
+To inspect a specific OSD, run a command of the following form:
 
 .. prompt:: bash #
 


### PR DESCRIPTION
Letters "L P" got lowcased to "l p".
Reverted that.

Signed-off-by: Adam Kupczyk <akupczyk@ibm.com>
(cherry picked from commit 59a7f01b5c3cc48aa1e15ee44204d3552ffd593a)

Fixes: https://tracker.ceph.com/issues/70185

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
