### PR TITLE
mgr/dashboard:fixed issue with notification icon

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -33,8 +33,9 @@
       <cds-header-navigation>
         <cd-language-selector class="d-flex"></cd-language-selector>
       </cds-header-navigation>
-      <div class="cds--btn cds--btn--icon-only cds--header__action">
-        <cd-notifications (click)="toggleRightSidebar()"></cd-notifications>
+      <div class="cds--btn cds--btn--icon-only cds--header__action"
+           (click)="toggleSidebar()">
+        <cd-notifications></cd-notifications>
       </div>
       <div class="cds--btn cds--btn--icon-only cds--header__action">
         <cd-dashboard-help></cd-dashboard-help>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -14,6 +14,7 @@ import {
   FeatureTogglesMap$,
   FeatureTogglesService
 } from '~/app/shared/services/feature-toggles.service';
+import { NotificationService } from '~/app/shared/services/notification.service';
 import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
 import { SummaryService } from '~/app/shared/services/summary.service';
 
@@ -49,6 +50,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
   currentClusterName: string;
 
   constructor(
+    public notificationService: NotificationService,
     private authStorageService: AuthStorageService,
     private multiClusterService: MultiClusterService,
     private router: Router,
@@ -189,7 +191,9 @@ export class NavigationComponent implements OnInit, OnDestroy {
       }
     );
   }
-
+  toggleSidebar() {
+    this.notificationService.toggleSidebar();
+  }
   trackByFn(item: any) {
     return item;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.html
@@ -1,7 +1,7 @@
 <a i18n-title
    title="Tasks and Notifications"
    [ngClass]="{ 'running': hasRunningTasks }"
-   (click)="toggleSidebar()">
+   >
   <svg cdsIcon="notification"
        size="20"
        title="notification"></svg>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
@@ -40,8 +40,4 @@ export class NotificationsComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.subs.unsubscribe();
   }
-
-  toggleSidebar() {
-    this.notificationService.toggleSidebar();
-  }
 }


### PR DESCRIPTION
mgr/dashboard: Fix issue with notification icon click area

Previously, users had to click precisely on the bell icon to open the notification drawer.
This commit expands the clickable area, allowing users to open the notification drawer by clicking anywhere within the container.

Fixes: https://tracker.ceph.com/issues/70253
 Signed-off-by: Ankit Kumar <51ankitkp@gmail.com>
Reference Video: [fixVideo.webm](https://github.com/user-attachments/assets/ac6964e8-4abe-4091-bda0-aa224b6eeb7d)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

