### PR TITLE
rbd: print the return codes on error for mirror pool commands

### DIFF
--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -775,7 +775,8 @@ public:
     librbd::RBD rbd;
     int r = rbd.list2(m_io_ctx, &m_images);
     if (r < 0 && r != -ENOENT) {
-      std::cerr << "rbd: failed to list images within pool" << std::endl;
+      std::cerr << "rbd: failed to list images within pool: "
+                << cpp_strerror(r) << std::endl;
       return r;
     }
 
@@ -929,7 +930,8 @@ int execute_peer_bootstrap_import(
     fd = open(token_path.c_str(), O_RDONLY|O_BINARY);
     if (fd < 0) {
       r = -errno;
-      std::cerr << "rbd: error opening " << token_path << std::endl;
+      std::cerr << "rbd: error opening " << token_path << ": "
+                << cpp_strerror(r) << std::endl;
       return r;
     }
   }
@@ -967,7 +969,8 @@ int execute_peer_bootstrap_import(
     std::cerr << "rbd: mirroring is not enabled on remote peer" << std::endl;
     return r;
   } else if (r < 0) {
-    std::cerr << "rbd: failed to import peer bootstrap token" << std::endl;
+    std::cerr << "rbd: failed to import peer bootstrap token: "
+              << cpp_strerror(r) << std::endl;
     return r;
   }
 
@@ -1027,7 +1030,8 @@ int execute_peer_add(const po::variables_map &vm,
   std::vector<librbd::mirror_peer_site_t> mirror_peers;
   r = rbd.mirror_peer_site_list(io_ctx, &mirror_peers);
   if (r < 0) {
-    std::cerr << "rbd: failed to list mirror peers" << std::endl;
+    std::cerr << "rbd: failed to list mirror peers: "
+              << cpp_strerror(r) << std::endl;
     return r;
   }
 
@@ -1059,7 +1063,8 @@ int execute_peer_add(const po::variables_map &vm,
     std::cerr << "rbd: mirror peer already exists" << std::endl;
     return r;
   } else if (r < 0) {
-    std::cerr << "rbd: error adding mirror peer" << std::endl;
+    std::cerr << "rbd: error adding mirror peer: "
+              << cpp_strerror(r) << std::endl;
     return r;
   }
 
@@ -1111,7 +1116,8 @@ int execute_peer_remove(const po::variables_map &vm,
   librbd::RBD rbd;
   r = rbd.mirror_peer_site_remove(io_ctx, uuid);
   if (r < 0) {
-    std::cerr << "rbd: error removing mirror peer" << std::endl;
+    std::cerr << "rbd: error removing mirror peer: "
+              << cpp_strerror(r) << std::endl;
     return r;
   }
   return 0;
@@ -1208,7 +1214,8 @@ int execute_peer_set(const po::variables_map &vm,
       std::vector<librbd::mirror_peer_site_t> mirror_peers;
       r = rbd.mirror_peer_site_list(io_ctx, &mirror_peers);
       if (r < 0) {
-        std::cerr << "rbd: failed to list mirror peers" << std::endl;
+        std::cerr << "rbd: failed to list mirror peers: "
+                  << cpp_strerror(r) << std::endl;
         return r;
       }
 
@@ -1375,16 +1382,16 @@ int execute_enable(const po::variables_map &vm,
     std::string original_remote_namespace;
     r = rbd.mirror_remote_namespace_get(io_ctx, &original_remote_namespace);
     if (r < 0) {
-      std::cerr << "rbd: failed to get the current remote namespace."
-	        << std::endl;
+      std::cerr << "rbd: failed to get the current remote namespace: "
+	        << cpp_strerror(r) << std::endl;
       return r;
     }
 
     if (original_remote_namespace != remote_namespace) {
       r = rbd.mirror_remote_namespace_set(io_ctx, remote_namespace);
       if (r < 0) {
-        std::cerr << "rbd: failed to set the remote namespace."
-                  << std::endl;
+        std::cerr << "rbd: failed to set the remote namespace: "
+                  << cpp_strerror(r) << std::endl;
 	return r;
       }
     }


### PR DESCRIPTION
The api calls in the mirror pool cli do not always print the error code. Doing so no to make debugging easier.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
