### PR TITLE
squid: debian: add ceph-exporter package

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2090,6 +2090,7 @@ fi
 
 %files -n ceph-exporter
 %{_bindir}/ceph-exporter
+%{_unitdir}/ceph-exporter.service
 
 %files -n rbd-fuse
 %{_bindir}/rbd-fuse

--- a/debian/ceph-exporter.install
+++ b/debian/ceph-exporter.install
@@ -1,1 +1,2 @@
+lib/systemd/system/ceph-exporter*
 usr/bin/ceph-exporter

--- a/debian/ceph-exporter.install
+++ b/debian/ceph-exporter.install
@@ -1,0 +1,1 @@
+usr/bin/ceph-exporter

--- a/debian/control
+++ b/debian/control
@@ -355,6 +355,30 @@ Description: debugging symbols for ceph-mgr
  .
  This package contains the debugging symbols for ceph-mgr.
 
+Package: ceph-exporter
+Architecture: linux-any
+Depends: ceph-base (= ${binary:Version}),
+Description: metrics exporter for the ceph distributed storage system
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains the metrics exporter daemon, which is used to expose
+ the performance metrics.
+
+Package: ceph-exporter-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: ceph-exporter (= ${binary:Version}),
+         ${misc:Depends},
+Description: debugging symbols for ceph-exporter
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains the debugging symbols for ceph-exporter.
+
 Package: ceph-mon
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),

--- a/debian/rules
+++ b/debian/rules
@@ -106,6 +106,7 @@ override_dh_strip:
 	dh_strip -pceph-mds --dbg-package=ceph-mds-dbg
 	dh_strip -pceph-fuse --dbg-package=ceph-fuse-dbg
 	dh_strip -pceph-mgr --dbg-package=ceph-mgr-dbg
+	dh_strip -pceph-exporter --dbg-package=ceph-exporter-dbg
 	dh_strip -pceph-mon --dbg-package=ceph-mon-dbg
 	dh_strip -pceph-osd --dbg-package=ceph-osd-dbg
 	dh_strip -pceph-base --dbg-package=ceph-base-dbg

--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CEPH_SYSTEMD_ENV_DIR "/etc/sysconfig"
 set(SYSTEMD_ENV_FILE "${CEPH_SYSTEMD_ENV_DIR}/ceph")
 foreach(service
     ceph-crash
+    ceph-exporter
     ceph-fuse@
     ceph-mds@
     ceph-mgr@

--- a/systemd/ceph-exporter.service.in
+++ b/systemd/ceph-exporter.service.in
@@ -1,0 +1,29 @@
+[Unit]
+Description=Ceph cluster exporter daemon
+PartOf=ceph.target
+After=network-online.target local-fs.target
+Before=ceph.target
+Wants=network-online.target local-fs.target ceph.target ceph-mon.target
+
+[Service]
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/ceph-exporter -f --id %i --setuser ceph --setgroup ceph
+LockPersonality=true
+NoNewPrivileges=true
+PrivateDevices=yes
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=full
+Restart=on-failure
+RestartSec=10
+RestrictSUIDSGID=true
+StartLimitBurst=3
+StartLimitInterval=30min
+
+[Install]
+WantedBy=multi-user.target ceph.target


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70445

---

backport of https://github.com/ceph/ceph/pull/55409
parent tracker: https://tracker.ceph.com/issues/64095

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh