### PR TITLE
rgw: fetch_remote_obj() need to re-encrypt sse-s3 encrypted objects

### DIFF
--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -360,6 +360,10 @@ int rgw_cloud_tier_get_object(RGWLCCloudTierCtx& tier_ctx, bool head,
       return ret;
     }
 
+    if (req_params.cb) {
+      req_params.cb->set_in_stream_req(in_req);
+    }
+
     /* fetch headers */
     // accounted_size in complete_request() reads from RGWX_OBJECT_SIZE which is set
     // only for internal ops/sync. So instead read from headers[CONTENT_LEN].

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -927,10 +927,10 @@ struct CryptAttributes {
   }
 };
 
-std::string fetch_bucket_key_id(req_state *s)
+std::string fetch_bucket_key_id(const rgw::sal::Attrs& bucket_attrs)
 {
-  auto kek_iter = s->bucket_attrs.find(RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID);
-  if (kek_iter == s->bucket_attrs.end())
+  auto kek_iter = bucket_attrs.find(RGW_ATTR_BUCKET_ENCRYPTION_KEY_ID);
+  if (kek_iter == bucket_attrs.end())
     return std::string();
   std::string a_key { kek_iter->second.to_str() };
   // early code appends a nul; pretend that didn't happen
@@ -998,7 +998,7 @@ static int get_sse_s3_bucket_key(req_state *s, optional_yield y,
     return -EINVAL;
   }
 
-  saved_key = fetch_bucket_key_id(s);
+  saved_key = fetch_bucket_key_id(s->bucket->get_attrs());
   if (saved_key != "") {
     ldpp_dout(s, 5) << "Found KEK ID: " << key_id << dendl;
   }
@@ -1518,7 +1518,7 @@ int rgw_remove_sse_s3_bucket_key(req_state *s, optional_yield y)
 {
   int res;
   auto key_id { expand_key_name(s, s->cct->_conf->rgw_crypt_sse_s3_key_template) };
-  auto saved_key { fetch_bucket_key_id(s) };
+  auto saved_key { fetch_bucket_key_id(s->bucket_attrs) };
   size_t i;
 
   if (key_id == cant_expand_key) {

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -209,14 +209,6 @@ add_object_to_context(rgw_obj &obj, rapidjson::Document &d)
     return true;
 }
 
-static inline const std::string &
-get_tenant_or_id(req_state *s)
-{
-    const std::string &tenant{ s->user->get_tenant() };
-    if (!tenant.empty()) return tenant;
-    return s->user->get_id().id;
-}
-
 int
 make_canonical_context(req_state *s,
     std::string_view &context,
@@ -231,7 +223,7 @@ mec_option::empty };
     std::ostringstream oss;
     canonical_char_sorter<MyMember> ccs{s, s->cct};
 
-    obj.bucket.tenant = get_tenant_or_id(s);
+    obj.bucket.tenant = s->bucket->get_tenant();
     obj.bucket.name = s->bucket->get_name();
     obj.key.name = s->object->get_name();
     std::string iline;

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -179,3 +179,13 @@ static inline std::string get_str_attribute(const std::map<std::string, bufferli
 }
 
 int rgw_remove_sse_s3_bucket_key(req_state *s, optional_yield y);
+
+int handle_sse_s3_encryption(const DoutPrefixProvider *dpp,
+  CephContext *cct,
+  optional_yield y,
+  rgw::sal::Bucket* bucket,
+  const rgw_obj_key& object,
+  std::string* err_msg,
+  std::map<std::string, ceph::bufferlist>& attrs,
+  std::unique_ptr<BlockCrypt>* block_crypt,
+  std::map<std::string, std::string>* crypt_http_responses);

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -72,7 +72,7 @@ protected:
 
   int init_request(rgw_http_req_data *req_data);
 
-  virtual int receive_header(void *ptr, size_t len) {
+  virtual int receive_header(void *ptr, size_t len, bool *pause) {
     return 0;
   }
   virtual int receive_data(void *ptr, size_t len, bool *pause) {
@@ -228,7 +228,7 @@ public:
   }
 
 protected:
-  int receive_header(void *ptr, size_t len) override;
+  int receive_header(void *ptr, size_t len, bool *pause) override;
 
 private:
   const std::set<header_name_t, ltstr_nocase> relevant_headers;

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -1029,6 +1029,11 @@ int RGWHTTPStreamRWRequest::handle_header(const string& name, const string& val,
 
     cb->set_extra_data_len(len);
   }
+
+  if (name == "X_AMZ_SERVER_SIDE_ENCRYPTION" && val == "AES256") {
+    cb->make_sse_s3_key(pause);
+  }
+
   return 0;
 }
 

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -26,7 +26,7 @@ int RGWHTTPSimpleRequest::get_status()
   return status;
 }
 
-int RGWHTTPSimpleRequest::handle_header(const string& name, const string& val) 
+int RGWHTTPSimpleRequest::handle_header(const string& name, const string& val, bool *pause)
 {
   if (name == "CONTENT_LENGTH") {
     string err;
@@ -42,7 +42,7 @@ int RGWHTTPSimpleRequest::handle_header(const string& name, const string& val)
   return 0;
 }
 
-int RGWHTTPSimpleRequest::receive_header(void *ptr, size_t len)
+int RGWHTTPSimpleRequest::receive_header(void *ptr, size_t len, bool *pause)
 {
   unique_lock guard(out_headers_lock);
 
@@ -92,7 +92,7 @@ int RGWHTTPSimpleRequest::receive_header(void *ptr, size_t len)
           }
           buf[i] = '\0';
           out_headers[buf] = l;
-          int r = handle_header(buf, l);
+          int r = handle_header(buf, l, pause);
           if (r < 0)
             return r;
         }
@@ -1017,7 +1017,7 @@ int RGWHTTPStreamRWRequest::handle_headers(const map<string, string>& headers, i
   return 0;
 }
 
-int RGWHTTPStreamRWRequest::handle_header(const string& name, const string& val)
+int RGWHTTPStreamRWRequest::handle_header(const string& name, const string& val, bool *pause)
 {
   if (name == "RGWX_EMBEDDED_METADATA_LEN") {
     string err;

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -104,6 +104,8 @@ public:
   const std::string& get_url() { return url; }
 };
 
+class RGWRESTStreamRWRequest;
+
 class RGWHTTPStreamRWRequest : public RGWHTTPSimpleRequest {
 public:
     class ReceiveCB;
@@ -143,6 +145,8 @@ public:
       virtual void set_extra_data_len(uint64_t len) {
         extra_data_len = len;
       }
+      virtual void set_in_stream_req(RGWRESTStreamRWRequest *req) {}
+      virtual void make_sse_s3_key(bool *pause) {}
   };
 
   RGWHTTPStreamRWRequest(CephContext *_cct, const std::string& _method, const std::string& _url,

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -24,7 +24,7 @@ protected:
   size_t max_response; /* we need this as we don't stream out response */
   bufferlist response;
 
-  virtual int handle_header(const std::string& name, const std::string& val);
+  virtual int handle_header(const std::string& name, const std::string& val, bool *pause);
   virtual int handle_headers(const std::map<std::string, std::string>& headers, int http_status) { return 0; }
   void get_params_str(std::map<std::string, std::string>& extra_args, std::string& dest);
 
@@ -48,7 +48,7 @@ public:
       params = *_params;
   }
 
-  int receive_header(void *ptr, size_t len) override;
+  int receive_header(void *ptr, size_t len, bool *pause) override;
   int receive_data(void *ptr, size_t len, bool *pause) override;
   int send_data(void *ptr, size_t len, bool* pause=nullptr) override;
 
@@ -126,7 +126,7 @@ private:
 protected:
   bufferlist outbl;
 
-  int handle_header(const std::string& name, const std::string& val) override;
+  int handle_header(const std::string& name, const std::string& val, bool *pause) override;
   int handle_headers(const std::map<std::string, std::string>& headers, int http_status) override;
 public:
   int send_data(void *ptr, size_t len, bool *pause) override;

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -296,7 +296,7 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_owner *uid,
                          const real_time *mod_ptr, const real_time *unmod_ptr,
                          uint32_t mod_zone_id, uint64_t mod_pg_ver,
                          bool prepend_metadata, bool get_op, bool rgwx_stat,
-                         bool sync_manifest, bool skip_decrypt,
+                         bool sync_manifest, const string& decrypt_mode,
                          rgw_zone_set_entry *dst_zone_trace, bool sync_cloudtiered,
                          bool send, RGWHTTPStreamRWRequest::ReceiveCB *cb, RGWRESTStreamRWRequest **req)
 {
@@ -310,7 +310,7 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_owner *uid,
   params.get_op = get_op;
   params.rgwx_stat = rgwx_stat;
   params.sync_manifest = sync_manifest;
-  params.skip_decrypt = skip_decrypt;
+  params.decrypt_mode = decrypt_mode;
   params.sync_cloudtiered = sync_cloudtiered;
   params.dst_zone_trace = dst_zone_trace;
   params.cb = cb;
@@ -341,8 +341,8 @@ int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_obj& obj, cons
   if (in_params.sync_cloudtiered) {
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "sync-cloudtiered", ""));
   }
-  if (in_params.skip_decrypt) {
-    params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "skip-decrypt", ""));
+  if (!in_params.decrypt_mode.empty()) {
+    params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "decrypt-mode", in_params.decrypt_mode));
   }
   if (in_params.dst_zone_trace) {
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "if-not-replicated-to", in_params.dst_zone_trace->to_str()));

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -168,7 +168,7 @@ public:
     bool sync_manifest{false};
     bool sync_cloudtiered{false};
 
-    bool skip_decrypt{true};
+    std::string decrypt_mode;
     RGWHTTPStreamRWRequest::ReceiveCB *cb{nullptr};
 
     bool range_is_set{false};
@@ -185,7 +185,7 @@ public:
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
               bool prepend_metadata, bool get_op, bool rgwx_stat, bool sync_manifest,
-              bool skip_decrypt, rgw_zone_set_entry *dst_zone_trace, bool sync_cloudtiered,
+              const std::string& decrypt_mode, rgw_zone_set_entry *dst_zone_trace, bool sync_cloudtiered,
               bool send, RGWHTTPStreamRWRequest::ReceiveCB *cb, RGWRESTStreamRWRequest **req);
   int complete_request(const DoutPrefixProvider* dpp,
                        RGWRESTStreamRWRequest *req,

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -44,6 +44,7 @@ protected:
   int custom_http_ret = 0;
   bool checksum_mode{false};
   std::map<std::string, std::string> crypt_http_responses;
+  std::string decrypt_mode;
   int override_range_hdr(const rgw::auth::StrategyRegistry& auth_registry, optional_yield y);
 public:
   RGWGetObj_ObjStore_S3() {}


### PR DESCRIPTION
As SSE-S3 encrypted objects are tied to the source bucket's encryption key, they must be re-encrypted using the destination bucket's key to eliminate any dependencies on the source bucket's key.
The same principle applies to replication.

Fixes: https://tracker.ceph.com/issues/70446