### PR TITLE
crimson/osd/pg: Logically ignore older repops replies

### DIFF
--- a/qa/suites/crimson-rados/thrash/workloads/radosbench-even-higher-concurrency.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/radosbench-even-higher-concurrency.yaml
@@ -1,0 +1,49 @@
+overrides:
+  ceph:
+    conf:
+      client.0:
+        debug ms: 1
+        debug objecter: 20
+        debug rados: 20
+tasks:
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180

--- a/qa/suites/crimson-rados/thrash_simple/workloads/radosbench-even-higher-concurrency.yaml
+++ b/qa/suites/crimson-rados/thrash_simple/workloads/radosbench-even-higher-concurrency.yaml
@@ -1,0 +1,49 @@
+overrides:
+  ceph:
+    conf:
+      client.0:
+        debug ms: 1
+        debug objecter: 20
+        debug rados: 20
+tasks:
+- full_sequential:
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180
+  - radosbench:
+      clients: [client.0]
+      concurrency: 256
+      size: 8192
+      time: 180

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -181,12 +181,18 @@ public:
   }
 
   void complete_write(eversion_t v, eversion_t lc) {
+    LOG_PREFIX(PG::complete_write);
+    SUBDEBUGDPP(osd, "updating pct to: {} updating lcod to: {}",
+                *this, v, lc);
     peering_state.complete_write(v, lc);
   }
 
   void update_peer_last_complete_ondisk(
     pg_shard_t fromosd,
     eversion_t lcod) {
+    LOG_PREFIX(PG::update_peer_last_complete_ondisk);
+    SUBDEBUGDPP(osd, "updating my peer {} lcod to: {}",
+               *this, fromosd, lcod);
     peering_state.update_peer_last_complete_ondisk(fromosd, lcod);
   }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -187,6 +187,17 @@ public:
     peering_state.complete_write(v, lc);
   }
 
+  void try_complete_write(eversion_t v, eversion_t lc) {
+    LOG_PREFIX(PG::try_complete_write);
+    SUBWARNDPP(osd, "pct is: {} version got {} (lc: {})",
+                *this, get_pg_committed_to(), v, lc);
+    // when completing a write both pct and lcod are updated.
+    // For this reason, checking only one of them (pct) is enough.
+    if (v < get_pg_committed_to()) {
+      complete_write(v, lc);
+    }
+  }
+
   void update_peer_last_complete_ondisk(
     pg_shard_t fromosd,
     eversion_t lcod) {

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -167,6 +167,7 @@ ReplicatedBackend::submit_transaction(
     }
     if (--peers->pending == 0) {
       // no peers other than me, replication size is 1
+      WARNDPP("no peers other than me, completing write", dpp);
       pg.complete_write(peers->at_version, peers->last_complete);
       peers->all_committed.set_value();
       peers->all_committed = {};
@@ -209,6 +210,7 @@ void ReplicatedBackend::on_actingset_changed(bool same_primary)
 void ReplicatedBackend::got_rep_op_reply(const MOSDRepOpReply& reply)
 {
   LOG_PREFIX(ReplicatedBackend::got_rep_op_reply);
+  DEBUGDPP("got reply from {} - {}",dpp, reply.from, reply);
   auto found = pending_trans.find(reply.get_tid());
   if (found == pending_trans.end()) {
     WARNDPP("cannot find rep op for message {}", dpp, reply);
@@ -221,6 +223,7 @@ void ReplicatedBackend::got_rep_op_reply(const MOSDRepOpReply& reply)
       pg.update_peer_last_complete_ondisk(
 	peer.shard, peer.last_complete_ondisk);
       if (--peers.pending == 0) {
+        DEBUGDPP("all peers have acked, completing write", dpp);
         pg.complete_write(peers.at_version, peers.last_complete);
         peers.all_committed.set_value();
         peers.all_committed = {};


### PR DESCRIPTION
```
When recieving a reply from peers we:
1) Update our local peer (from pending_trans) last_complete_ondisk
2) Update PeeringState::peer_last_complete_ondisk
3) If all peers replied:
     complete_write- upate PeertingState::pg_committed_to/last_complete_ondisk

In Crimson, we seperate between the handling of each write to the
peer replies awaiting. That means that the following scenario is
possible:

1) Handle write to obj a version 1'1
2) Append write 1'1 to pglog
3) Share write (1'1) with replicas
4) Write to obj a version 1'2
5) Append write 1'2 to pglog
6) Share write (1'2) with replicas
7) Peer replies from write (1'2) recieved.
8) Peer replies from write (1'1) recieved.

In this case, it's safe to ignore the peer replies
from write (1'1) when updating our peer lcod and this pg
pct and lcod (since we already have a later version commited).

With this fix, we check if the reply recieved can be ignored
before updating this pg peer and state.

Fixes: https://tracker.ceph.com/issues/69439
```

debugging: https://tracker.ceph.com/issues/69439
draft for now. to be tested w/ #62276.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
