### PR TITLE
crimson: take read lock on replica during final push commit

### DIFF
--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -107,12 +107,22 @@ public:
     ceph_assert(is_head());
     obs = std::move(_obs);
     ssc = std::move(_ssc);
+    // ObjectContextLoader::load_and_lock* rely on this to determine whether to
+    // start loading from disk.  As this method fills in the metadata, such
+    // loading will not be necessary in the future. loading_started will already
+    // be set if this is invoked from ObjectContextLoader::load_and_lock*
+    loading_started = true;
     fully_loaded = true;
   }
 
   void set_clone_state(ObjectState &&_obs) {
     ceph_assert(!is_head());
     obs = std::move(_obs);
+    // ObjectContextLoader::load_and_lock* rely on this to determine whether to
+    // start loading from disk.  As this method fills in the metadata, such
+    // loading will not be necessary in the future. loading_started will already
+    // be set if this is invoked from ObjectContextLoader::load_and_lock*
+    loading_started = true;
     fully_loaded = true;
   }
 

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -114,6 +114,12 @@ ObjectContextLoader::load_and_lock_clone(
 
     if (manager.target_state.obc->loading_started) {
       co_await manager.target_state.lock_to(RWState::RWREAD);
+      if (!manager.target_state.obc->ssc) {
+	// A cached clone obc may have a null ssc if created via
+	// create_cached_obc_from_push_data.  This interface
+	// is responsible for fixing that if found.
+	manager.target_state.obc->ssc = manager.head_state.obc->ssc;
+      }
     } else {
       manager.target_state.lock_excl_sync();
       manager.target_state.obc->loading_started = true;
@@ -123,6 +129,8 @@ ObjectContextLoader::load_and_lock_clone(
     }
   }
 
+  ceph_assert(manager.target_state.obc->ssc);
+  ceph_assert(manager.head_state.obc->ssc);
   releaser.cancel();
 }
 

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -22,8 +22,9 @@ ObjectContextLoader::load_and_lock_head(Manager &manager, RWState::State lock_ty
     auto [obc, _] = obc_registry.get_cached_obc(manager.target);
     manager.set_state_obc(manager.head_state, obc);
   }
-  ceph_assert(manager.target_state.is_empty());
-  manager.set_state_obc(manager.target_state, manager.head_state.obc);
+  if (manager.target_state.is_empty()) {
+    manager.set_state_obc(manager.target_state, manager.head_state.obc);
+  }
 
   if (manager.target_state.obc->loading_started) {
     co_await manager.target_state.lock_to(lock_type);
@@ -45,7 +46,6 @@ ObjectContextLoader::load_and_lock_clone(
   auto releaser = manager.get_releaser();
 
   ceph_assert(!manager.target.is_head());
-  ceph_assert(manager.target_state.is_empty());
 
   if (manager.head_state.is_empty()) {
     auto [obc, _] = obc_registry.get_cached_obc(manager.target.get_head());
@@ -65,6 +65,9 @@ ObjectContextLoader::load_and_lock_clone(
   }
 
   if (manager.options.resolve_clone) {
+    // target_state must be empty because we won't know which object to load
+    // until now
+    ceph_assert(manager.target_state.is_empty());
     auto resolved_oid = resolve_oid(
       manager.head_state.obc->get_head_ss(),
       manager.target);
@@ -91,6 +94,8 @@ ObjectContextLoader::load_and_lock_clone(
      * actually can mutate a clone do not set resolve_clone, so target will not
      * become head here.
      */
+    ceph_assert(manager.options.resolve_clone);
+    ceph_assert(manager.target_state.is_empty());
     manager.set_state_obc(manager.target_state, manager.head_state.obc);
     if (lock_type != manager.head_state.state) {
       // This case isn't actually possible at the moment for the above reason.
@@ -101,8 +106,11 @@ ObjectContextLoader::load_and_lock_clone(
       manager.head_state.state = RWState::RWNONE;
     }
   } else {
-    auto [obc, _] = obc_registry.get_cached_obc(manager.target);
-    manager.set_state_obc(manager.target_state, obc);
+    // caller may have already populated this if !resolve_clone
+    if (manager.target_state.is_empty()) {
+      auto [obc, _] = obc_registry.get_cached_obc(manager.target);
+      manager.set_state_obc(manager.target_state, obc);
+    }
 
     if (manager.target_state.obc->loading_started) {
       co_await manager.target_state.lock_to(RWState::RWREAD);

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -136,6 +136,7 @@ public:
     friend ObjectContextLoader;
 
     void set_state_obc(state_t &s, ObjectContextRef _obc) {
+      ceph_assert(s.is_empty());
       s.obc = std::move(_obc);
       s.obc->append_to(loader.obc_set_accessing);
     }

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1315,9 +1315,10 @@ void PG::log_operation(
 void PG::replica_clear_repop_obc(
   const std::vector<pg_log_entry_t> &logv) {
   LOG_PREFIX(PG::replica_clear_repop_obc);
-  DEBUGDPP("clearing obc for {} log entries", logv.size());
+  DEBUGDPP("clearing obc for {} log entries", *this, logv.size());
   for (auto &&e: logv) {
     DEBUGDPP("clearing entry for {} from: {} to: {}",
+	     *this,
 	     e.soid,
 	     e.soid.get_object_boundary(),
 	     e.soid.get_head());

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -50,6 +50,8 @@ void RecoveryBackend::clean_up(ceph::os::Transaction& t,
   });
   clear_temp_objs();
 
+  replica_push_targets.clear();
+
   for (auto& [soid, recovery_waiter] : recovering) {
     if ((recovery_waiter->pull_info
          && recovery_waiter->pull_info->is_complete())

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -272,6 +272,14 @@ protected:
   virtual interruptible_future<> handle_backfill_op(
     Ref<MOSDFastDispatchOp> m,
     crimson::net::ConnectionXcoreRef conn);
+
+  /**
+   * replica_push_targets
+   *
+   * Holds obc on replica for in-progress pushes, see
+   * ReplicatedRecoveryBackend::handle_push
+   */
+  std::map<hobject_t, crimson::osd::ObjectContextRef> replica_push_targets;
 private:
   void handle_backfill_finish(
     MOSDPGBackfill& m,

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -863,8 +863,6 @@ ReplicatedRecoveryBackend::_handle_pull_response(
         WARNDPP("unable to decode SnapSet", pg);
         throw crimson::osd::invalid_argument();
       }
-      assert(!pull_info.obc->ssc->exists ||
-             obc->ssc->snapset.seq == pull_info.obc->ssc->snapset.seq);
     }
     pull_info.recovery_info.oi = obc->obs.oi;
     if (pull_info.recovery_info.soid.snap &&

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -1028,9 +1028,11 @@ ReplicatedRecoveryBackend::handle_push(
   co_await interruptor::make_interruptible(
     shard_services.get_store().do_transaction(coll, std::move(t)));
 
-  //TODO: this should be grouped with pg.on_local_recover somehow.
-  pg.get_recovery_handler()->_committed_pushed_object(
-    epoch_frozen, pg.get_info().last_complete);
+  if (complete) {
+    //TODO: this should be grouped with pg.on_local_recover somehow.
+    pg.get_recovery_handler()->_committed_pushed_object(
+      epoch_frozen, pg.get_info().last_complete);
+  }
 
   auto reply = crimson::make_message<MOSDPGPushReply>();
   reply->from = pg.get_pg_whoami();

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -175,4 +175,7 @@ private:
     bufferlist omap_header);
   using interruptor = crimson::interruptible::interruptor<
     crimson::osd::IOInterruptCondition>;
+
+  std::pair<object_info_t, crimson::osd::SnapSetContextRef>
+  get_md_from_push_op(PushOp &push_op);
 };

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -102,11 +102,6 @@ protected:
   void submit_push_complete(
     const ObjectRecoveryInfo &recovery_info,
     ObjectStore::Transaction *t);
-  interruptible_future<> _handle_push(
-    pg_shard_t from,
-    PushOp& push_op,
-    PushReplyOp *response,
-    ceph::os::Transaction *t);
   interruptible_future<std::optional<PushOp>> _handle_push_reply(
     pg_shard_t peer,
     const PushReplyOp &op);


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
