### PR TITLE
common, *: make the abort() in ceph_assert() bypassable

### DIFF
--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -43,6 +43,12 @@ namespace ceph {
   {
     ceph_assert(!g_assert_context);
     g_assert_context = cct;
+    const auto supressions = get_str_list(
+      g_assert_context->_conf.get_val<std::string>("ceph_assert_supresssions"));
+    if (!supressions.empty()) {
+      lderr(g_assert_context) << "WARNING: supressions for ceph_assert present: "
+			      << supressions << dendl;
+    }
   }
 
   [[gnu::cold]] void __ceph_assert_fail(const char *assertion,

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -17,6 +17,7 @@
 #include <sstream>
 
 #include "include/compat.h"
+#include "include/str_list.h"
 #include "common/BackTrace.h"
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/debug.h"
@@ -70,6 +71,7 @@ namespace ceph {
     oss << ClibBackTrace(1);
     dout_emergency(oss.str());
 
+    bool should_abort = true;
     if (g_assert_context) {
       lderr(g_assert_context) << g_assert_msg << std::endl;
       *_dout << oss.str() << dendl;
@@ -78,9 +80,22 @@ namespace ceph {
       if (!g_assert_context->_conf->fatal_signal_handlers) {
 	g_assert_context->_log->dump_recent();
       }
-    }
 
-    abort();
+      // bypass the abort?
+      const auto supressions = get_str_list(
+	g_assert_context->_conf.get_val<std::string>("ceph_assert_supresssions"));
+      should_abort = std::none_of(
+	std::begin(supressions), std::end(supressions),
+	[file, line](const auto& supression) {
+	  return supression == fmt::format("{}:{}", file, line);
+        });
+    }
+    if (should_abort) {
+      abort();
+    } else {
+      dout_emergency("WARNING: ceph_assert() does NOT abort() due "
+		     "to ceph_assert_supresssions");
+    }
   }
 
   [[gnu::cold]] void __ceph_assert_fail(const assert_data &ctx)
@@ -151,6 +166,7 @@ namespace ceph {
     oss << *bt;
     dout_emergency(oss.str());
 
+    bool should_abort = true;
     if (g_assert_context) {
       lderr(g_assert_context) << g_assert_msg << std::endl;
       *_dout << oss.str() << dendl;
@@ -159,9 +175,22 @@ namespace ceph {
       if (!g_assert_context->_conf->fatal_signal_handlers) {
 	g_assert_context->_log->dump_recent();
       }
-    }
 
-    abort();
+      // bypass the abort?
+      const auto supressions = get_str_list(
+	g_assert_context->_conf.get_val<std::string>("ceph_assert_supresssions"));
+      should_abort = std::none_of(
+	std::begin(supressions), std::end(supressions),
+	[file, line](const auto& supression) {
+	  return supression == fmt::format("{}:{}", file, line);
+        });
+    }
+    if (should_abort) {
+      abort();
+    } else {
+      dout_emergency("WARNING: ceph_assertf() does NOT abort() due to"
+		     "to ceph_assert_supresssions");
+    }
   }
 
   [[gnu::cold]] void __ceph_abort(const char *file, int line,

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6718,3 +6718,10 @@ options:
   desc: Enables exception throwing instead of process abort on transaction submission error.
   default: false
   with_legacy: false
+- name: ceph_assert_supresssions
+  type: str
+  desc: Suppress specific ceph_assert instances to let the execution continue with unknown, potentially DESTRUCTIVE consequences.
+  fmt_desc: Comma-separated list of locations of ceph_assert in the source code.
+    The format is ``{file}:{line} [, {file}:{line}]``
+  level: dev
+  with_legacy: false

--- a/src/common/perf_histogram.cc
+++ b/src/common/perf_histogram.cc
@@ -33,7 +33,7 @@ void PerfHistogramCommon::dump_formatted_axis(
       f->dump_string("scale_type", "log2");
       break;
     default:
-      ceph_assert(false && "Invalid scale type");
+      ceph_abort_msg("Invalid scale type");
   }
 
   {
@@ -63,7 +63,7 @@ int64_t get_quants(int64_t i, PerfHistogramCommon::scale_type_d st) {
     case PerfHistogramCommon::SCALE_LOG2:
       return int64_t(1) << (i - 1);
   }
-  ceph_assert(false && "Invalid scale type");
+  ceph_abort_msg("Invalid scale type");
 }
 
 int64_t PerfHistogramCommon::get_bucket_for_axis(
@@ -87,7 +87,7 @@ int64_t PerfHistogramCommon::get_bucket_for_axis(
       }
       return ac.m_buckets - 1;
   }
-  ceph_assert(false && "Invalid scale type");
+  ceph_abort_msg("Invalid scale type");
 }
 
 std::vector<std::pair<int64_t, int64_t>>

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -638,7 +638,7 @@ auto AlienStore::omap_get_header(CollectionRef ch,
         return crimson::ct_error::enoent::make();
       } else if (r < 0) {
         logger().error("omap_get_header: {}", r);
-        ceph_assert(0 == "impossible");
+        ceph_abort_msg("impossible");
       } else {
         return get_attr_errorator::make_ready_future<ceph::bufferlist>(
 	  std::move(bl));

--- a/src/crimson/osd/scheduler/mclock_scheduler.cc
+++ b/src/crimson/osd/scheduler/mclock_scheduler.cc
@@ -123,12 +123,12 @@ item_t mClockScheduler::dequeue()
   } else {
     mclock_queue_t::PullReq result = scheduler.pull_request();
     if (result.is_future()) {
-      ceph_assert(
-	0 == "Not implemented, user would have to be able to be woken up");
+      ceph_abort_msg(
+	"Not implemented, user would have to be able to be woken up");
       return std::move(*(item_t*)nullptr);
     } else if (result.is_none()) {
-      ceph_assert(
-	0 == "Impossible, must have checked empty() first");
+      ceph_abort_msg(
+	"Impossible, must have checked empty() first");
       return std::move(*(item_t*)nullptr);
     } else {
       ceph_assert(result.is_retn());

--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -52,6 +52,10 @@ struct assert_data {
 
 extern void __ceph_assert_fail(const char *assertion, const char *file, int line, const char *function);
 extern void __ceph_assert_fail(const assert_data &ctx);
+template <const assert_data* AssertCtxV>
+[[gnu::noinline, gnu::cold]] static void __ceph_assert_fail()  {
+  __ceph_assert_fail(*AssertCtxV);
+}
 
 extern void __ceph_assertf_fail(const char *assertion, const char *file, int line, const char *function, const char* msg, ...);
 extern void __ceph_assert_warn(const char *assertion, const char *file, int line, const char *function);
@@ -98,11 +102,14 @@ using namespace ceph;
   } while (false)
 #else
 #define ceph_assert(expr)							\
-  do { static const ceph::assert_data assert_data_ctx = \
-   {__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION}; \
-   ((expr) \
-   ? _CEPH_ASSERT_VOID_CAST (0) \
-    : ::ceph::__ceph_assert_fail(assert_data_ctx)); } while(false)
+  do { \
+    static const auto func_name = __CEPH_ASSERT_FUNCTION; \
+    [] (const bool eval) { \
+    static const ceph::assert_data assert_data_ctx = \
+    {__STRING(expr), __FILE__, __LINE__, func_name}; \
+    ((eval) \
+    ? _CEPH_ASSERT_VOID_CAST (0) \
+    : ::ceph::__ceph_assert_fail<&assert_data_ctx>()); }((bool)(expr)); } while(false)
 #endif
 
 // this variant will *never* get compiled out to NDEBUG in the future.
@@ -116,11 +123,14 @@ using namespace ceph;
   } while(false)
 #else
 #define ceph_assert_always(expr)							\
-  do { static const ceph::assert_data assert_data_ctx = \
-   {__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION}; \
-   ((expr) \
-   ? _CEPH_ASSERT_VOID_CAST (0) \
-    : ::ceph::__ceph_assert_fail(assert_data_ctx)); } while(false)
+  do { \
+    static const auto func_name = __CEPH_ASSERT_FUNCTION; \
+    [] (const bool eval) { \
+    static const ceph::assert_data assert_data_ctx = \
+    {__STRING(expr), __FILE__, __LINE__, func_name}; \
+    ((eval) \
+    ? _CEPH_ASSERT_VOID_CAST (0) \
+    : ::ceph::__ceph_assert_fail<&assert_data_ctx>()); }((bool)(expr)); } while(false)
 #endif
 
 // Named by analogy with printf.  Along with an expression, takes a format

--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -50,13 +50,10 @@ struct assert_data {
   const char *function;
 };
 
-extern void __ceph_assert_fail(const char *assertion, const char *file, int line, const char *function)
-  __attribute__ ((__noreturn__));
-extern void __ceph_assert_fail(const assert_data &ctx)
-  __attribute__ ((__noreturn__));
+extern void __ceph_assert_fail(const char *assertion, const char *file, int line, const char *function);
+extern void __ceph_assert_fail(const assert_data &ctx);
 
-extern void __ceph_assertf_fail(const char *assertion, const char *file, int line, const char *function, const char* msg, ...)
-  __attribute__ ((__noreturn__));
+extern void __ceph_assertf_fail(const char *assertion, const char *file, int line, const char *function, const char* msg, ...);
 extern void __ceph_assert_warn(const char *assertion, const char *file, int line, const char *function);
 
 [[noreturn]] void __ceph_abort(const char *file, int line, const char *func,

--- a/src/librbd/crypto/CryptoContextPool.h
+++ b/src/librbd/crypto/CryptoContextPool.h
@@ -57,7 +57,7 @@ private:
         case CIPHER_MODE_DEC:
           return m_decrypt_contexts;
         default:
-          ceph_assert(false);
+          ceph_abort();
       }
     }
 };

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4156,10 +4156,10 @@ struct AnonConnection : public Connection {
   entity_addr_t socket_addr;
 
   int send_message(Message *m) override {
-    ceph_assert(!"send_message on anonymous connection");
+    ceph_abort_msg("send_message on anonymous connection");
   }
   void send_keepalive() override {
-    ceph_assert(!"send_keepalive on anonymous connection");
+    ceph_abort_msg("send_keepalive on anonymous connection");
   }
   void mark_down() override {
     // silently ignore

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10143,7 +10143,7 @@ public:
     }
     /// Check whether there is anything to do.
     bool _empty() override {
-      ceph_assert(false);
+      ceph_abort();
     }
 
     /// Get the next work item to process.
@@ -10210,7 +10210,7 @@ public:
      * so at most one copy will execute simultaneously for a given thread pool.
      * It can be used for non-thread-safe finalization. */
     void _void_process_finish(void*) override {
-      ceph_assert(false);
+      ceph_abort();
     }
 
     bool queue(

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -998,7 +998,7 @@ public:
       }
       loc -= e.length;
     }
-    ceph_assert(false);
+    ceph_abort();
   };
 
   /// updates blob's pextents container and return unused pextents eligible

--- a/src/osd/scheduler/OpScheduler.cc
+++ b/src/osd/scheduler/OpScheduler.cc
@@ -43,7 +43,7 @@ OpSchedulerRef make_scheduler(
       mClockScheduler>(cct, whoami, num_shards, shard_id, is_rotational,
         op_queue_cut_off, monc);
   } else {
-    ceph_assert("Invalid choice of wq" == 0);
+    ceph_abort_msg("Invalid choice of wq");
   }
 }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1023,3 +1023,11 @@ add_executable(test_nvmeof_mon_encoding
 target_link_libraries(test_nvmeof_mon_encoding
   mon ceph-common global-static
   )
+
+if(NOT WIN32)
+# unittest_ceph_assert
+add_executable(unittest_ceph_assert
+  ceph_assert.cc)
+add_ceph_unittest(unittest_ceph_assert)
+target_link_libraries(unittest_ceph_assert ceph-common global)
+endif()

--- a/src/test/ceph_assert.cc
+++ b/src/test/ceph_assert.cc
@@ -1,0 +1,51 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <fmt/format.h>
+
+#include "common/ceph_argparse.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+
+#include "include/ceph_assert.h"
+
+#include "gtest/gtest.h"
+
+static void non_supressed_assert_line16() {
+  ceph_assert(42 == 41); // LINE16
+}
+static void supressed_assert_line19() {
+  ceph_assert(42 == 40); // LINE19
+}
+static void supressed_assertf_line22() {
+  ceph_assertf(42 == 39, "FAILED ceph_assertf"); // LINE22
+}
+static void non_supressed_assertf_line25() {
+  ceph_assertf(42 == 38, "FAILED ceph_assertf"); // LINE25
+}
+
+TEST(CephAssertDeathTest, ceph_assert_supresssions) {
+  ASSERT_DEATH(non_supressed_assert_line16(), "FAILED ceph_assert");
+  supressed_assert_line19();
+  supressed_assertf_line22();
+  ASSERT_DEATH(non_supressed_assertf_line25(), "FAILED ceph_assertf");
+}
+
+int main(int argc, char **argv) {
+
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(
+    nullptr,
+    args,
+    CEPH_ENTITY_TYPE_CLIENT,
+    CODE_ENVIRONMENT_UTILITY,
+    CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  g_ceph_context->_conf.set_val(
+    "ceph_assert_supresssions",
+    fmt::format(
+      "{}:{}, {}:{}", __FILE__, /* LINE19 */19, __FILE__, /* LINE22 */22));
+  common_init_finish(g_ceph_context);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/crimson/seastore/test_extent_allocator.cc
+++ b/src/test/crimson/seastore/test_extent_allocator.cc
@@ -38,7 +38,7 @@ struct allocator_test_t :
       allocator.reset(new AvlAllocator(false));
       return seastar::now();
     } 
-    ceph_assert(0 == "no support");
+    ceph_abort("no support");
   }
   seastar::future<> tear_down_fut() final {
     if (allocator) {

--- a/src/tools/immutable_object_cache/ObjectCacheStore.cc
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.cc
@@ -276,7 +276,7 @@ int ObjectCacheStore::lookup_object(std::string pool_nspace, uint64_t pool_id,
       return ret;
     default:
       lderr(m_cct) << "unrecognized object cache status" << dendl;
-      ceph_assert(0);
+      ceph_abort();
   }
 }
 


### PR DESCRIPTION
## On the performance
The worry I had was about that the cold handlers of `ceph_assert` cannot be marked as `noreturn`.
As bypassing the `abort()` within them requires the ability to resume execution after the assert is hit, compilers are
not allowed anymore to optimize these returns out.

To estimate the impact on performance, let's analyze a snippet and the differences in the correpsonding machine codes.

### The subject
```cpp
void PeeringState::clear_blocked_outgoing() {
  ceph_assert(orig_ctx);
  ceph_assert(rctx);
  messages_pending_flush = std::optional<BufferedRecoveryMessages>();
}
```

### The hot, assert-free paths before the change
```
0000000000e3cf90 <PeeringState::clear_blocked_outgoing()>:
  e3cf90:       48 83 ec 08             sub    $0x8,%rsp
  e3cf94:       48 83 bf e0 00 00 00    cmpq   $0x0,0xe0(%rdi)
  e3cf9b:       00
  e3cf9c:       74 3d                   je     e3cfdb
<PeeringState::clear_blocked_outgoing()+0x4b>
  e3cf9e:       80 bf 40 01 00 00 00    cmpb   $0x0,0x140(%rdi)
  e3cfa5:       74 28                   je     e3cfcf
<PeeringState::clear_blocked_outgoing()+0x3f>
  e3cfa7:       80 bf 18 01 00 00 00    cmpb   $0x0,0x118(%rdi)
  e3cfae:       75 08                   jne    e3cfb8
<PeeringState::clear_blocked_outgoing()+0x28>
  e3cfb0:       48 83 c4 08             add    $0x8,%rsp
  e3cfb4:       c3                      retq
...
  e3cfb8:       c6 87 18 01 00 00 00    movb   $0x0,0x118(%rdi)
  e3cfbf:       48 8b bf f8 00 00 00    mov    0xf8(%rdi),%rdi
  e3cfc6:       48 83 c4 08             add    $0x8,%rsp
  e3cfca:       e9 01 bd ff ff          jmpq   e38cd0 <std::_Rb_tree<int, std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > >, std::_Select1st<std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > > >, std::less<int>, std::allocator<std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > > >*) [clone .isra.0]>
```

### The hot, assert-free paths after the change
```
0000000000e424e0 <PeeringState::clear_blocked_outgoing()>:
  e424e0:       53                      push   %rbx
  e424e1:       48 83 bf e0 00 00 00    cmpq   $0x0,0xe0(%rdi)
  e424e8:       00
  e424e9:       48 89 fb                mov    %rdi,%rbx
  e424ec:       74 4a                   je     e42538 <PeeringState::clear_blocked_outgoing()+0x58>
  e424ee:       80 bb 40 01 00 00 00    cmpb   $0x0,0x140(%rbx)
  e424f5:       74 11                   je     e42508 <PeeringState::clear_blocked_outgoing()+0x28>
  e424f7:       80 bb 18 01 00 00 00    cmpb   $0x0,0x118(%rbx)
  e424fe:       75 1d                   jne    e4251d <PeeringState::clear_blocked_outgoing()+0x3d>
  e42500:       5b                      pop    %rbx
  e42501:       c3                      retq
...
  e4251d:       c6 83 18 01 00 00 00    movb   $0x0,0x118(%rbx)
  e42524:       48 8b bb f8 00 00 00    mov    0xf8(%rbx),%rdi
  e4252b:       5b                      pop    %rbx
  e4252c:       e9 9f bc ff ff          jmpq   e3e1d0 <std::_Rb_tree<int, std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > >, std::_Select1st<std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > > >, std::less<int>, std::allocator<std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::vector<boost::intrusive_ptr<Message>, std::allocator<boost::intrusive_ptr<Message> > > > >*) [clone .isra.0]>
```

The difference is the compiler replaced the `sub $0x8,%rsp` and `add $0x8,%rsp` instructions with `push %rbx` and `pop %rbx`, which in addition to managing the stack pointer, also store the register's value.
The rationale is the cold, `unlikely` path of the `ceph_assert` macro prepares the `assert_data_ctx` which is then passed via `%rdi` to the `__ceph_assert_fail(ceph::assert_data const&)`. As this cold handler may return now, the original value of the register cannot be thrashed.

On the `unlikely` paths this is visible as the extra `jmp`:

```
  e42538:       48 8d 3d e1 32 29 01    lea    0x12932e1(%rip),%rdi        # 20d5820 <PeeringState::clear_blocked_outgoing()::assert_data_ctx>
  e4253f:       e8 26 83 b6 ff          callq  9aa86a <ceph::__ceph_assert_fail(ceph::assert_data const&)>
  e42544:       eb a8                   jmp    e424ee <PeeringState::clear_blocked_outgoing()+0xe>
```

~~In short: on the hot paths the cost is just the burden to not thrash the register for passing the argument to the cold `__ceph_assert_fail`.~~

### UPDATE
The penalty described above has been eliminated by ensuring the entire assert handling (even the `%rdi` loading for the sake of passing the context to `__ceph_assert_fail()`) has been put on into cold sections. See: https://github.com/ceph/ceph/pull/62294#issuecomment-2723118828.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
