### PR TITLE
reef: mds: set alternate_name for new fullbit dentries

### DIFF
--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1316,6 +1316,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, int type, MDPeerUpdate 
 	dn->set_version(fb.dnv);
 	if (fb.is_dirty()) dn->_mark_dirty(logseg);
 	dout(10) << "EMetaBlob.replay added (full) " << *dn << dendl;
+        dn->set_alternate_name(mempool::mds_co::string(fb.alternate_name));
       } else {
 	dn->set_version(fb.dnv);
 	if (fb.is_dirty()) dn->_mark_dirty(logseg);
@@ -1323,6 +1324,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, int type, MDPeerUpdate 
 	dn->first = fb.dnfirst;
 	ceph_assert(dn->last == fb.dnlast);
       }
+      ceph_assert(dn->get_alternate_name() == fb.alternate_name);
       if (lump.is_importing())
 	dn->mark_auth();
 
@@ -1431,6 +1433,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, int type, MDPeerUpdate 
 	dn->first = rb.dnfirst;
 	ceph_assert(dn->last == rb.dnlast);
       }
+      ceph_assert(dn->get_alternate_name() == rb.alternate_name);
       if (lump.is_importing())
 	dn->mark_auth();
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70483

---

backport of https://github.com/ceph/ceph/pull/62231
parent tracker: https://tracker.ceph.com/issues/70409

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh