### PR TITLE
squid: OSDMonitor: exclude destroyed OSDs from "ceph node ls" output

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2205,6 +2205,9 @@ void OSDMonitor::print_nodes(Formatter *f)
       // not likely though
       continue;
     }
+    if (osdmap.is_destroyed(osd)) {
+      continue;
+    }
     osds[hostname->second].push_back(osd);
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70496

---

backport of https://github.com/ceph/ceph/pull/62243
parent tracker: https://tracker.ceph.com/issues/70400

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh