### PR TITLE
common: md_config_obs_impl: remove deprecated get_tracked_conf_keys()

### DIFF
--- a/src/common/config_cacher.h
+++ b/src/common/config_cacher.h
@@ -20,13 +20,12 @@
 
 /**
  * A simple class to cache a single configuration value.
- * Points to note:
- * - as get_tracked_conf_keys() must return a pointer to a null-terminated
- *   array of C-strings, 'keys' - an array - is used to hold the sole key
- *   that this observer is interested in.
- * - the const cast should be removed once we change the
- *   get_tracked_conf_keys() to return const char* const * (or something
- *   similar).
+ *
+ * The md_config_cacher_t object registers itself to receive
+ * notifications of changes to the specified single configuration
+ * option.  When the option changes, the new value is stored
+ * in an atomic variable.  The value can be accessed using
+ * the dereference operator.
  */
 template <typename ValueT>
 class md_config_cacher_t : public md_config_obs_t {

--- a/src/common/config_obs.h
+++ b/src/common/config_obs.h
@@ -33,27 +33,16 @@ class md_config_obs_impl {
 public:
   virtual ~md_config_obs_impl() {}
 
-  /** @brief Get a table of strings specifying the configuration keys in which the object is interested.
-   * This is called when the object is subscribed to configuration changes with add_observer().
-   * The returned table should not be freed until the observer is removed with remove_observer().
-   * Note that it is not possible to change the set of tracked keys without re-subscribing.
-   *
-   * DEPRECATED! Use get_tracked_keys() instead.
-   */
-  virtual const char** get_tracked_conf_keys() const {
-    return nullptr;
-  }
-
   /**
    * Returns a vector of strings specifying the configuration keys in which
-   * the object is interested.
+   * the object is interested. This is called when the object is subscribed to
+   * configuration changes with add_observer().
+   *
    * Note - the strings in the returned vector are 'moveable'. The caller
    * (ostensibly the observer manager) is expected to move them into its
    * map.
    */
-  virtual std::vector<std::string> get_tracked_keys() const noexcept {
-    return {};
-  }
+  virtual std::vector<std::string> get_tracked_keys() const noexcept = 0;
 
   /// React to a configuration change.
   virtual void handle_conf_change(const ConfigProxy& conf,

--- a/src/common/config_obs_mgr.h
+++ b/src/common/config_obs_mgr.h
@@ -65,13 +65,6 @@ void ObserverMgr<ConfigObs>::add_observer(ConfigObs* observer)
   for (auto&& k : observer->get_tracked_keys()) {
     observers.emplace(std::move(k), ptr);
   }
-
-  // legacy observer interface:
-  if (const char** keys = observer->get_tracked_conf_keys(); keys) {
-    for (const char** k = keys; *k; ++k) {
-      observers.emplace(*k, ptr);
-    }
-  }
 }
 
 template<class ConfigObs>


### PR DESCRIPTION
This is the last step in a set of PRs that replaced the deprecated get_tracked_conf_keys()
with the new get_tracked_keys().
Now that no clients of the old interface remain, it is removed from md_config_obs_impl
(which means: removed from md_config_obs_t)

