### PR TITLE
librbd: migrate from boost::variant to std::variant 

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -59,10 +59,10 @@
 #include "journal/Journaler.h"
 
 #include <boost/scope_exit.hpp>
-#include <boost/variant.hpp>
 #include "include/ceph_assert.h"
 
 #include <shared_mutex> // for std::shared_lock
+#include <variant>
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -275,7 +275,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     return io_ctx.tmap_update(RBD_DIRECTORY, cmdbl);
   }
 
-  typedef boost::variant<std::string,uint64_t> image_option_value_t;
+  typedef std::variant<std::string, uint64_t> image_option_value_t;
   typedef std::map<int,image_option_value_t> image_options_t;
   typedef std::shared_ptr<image_options_t> image_options_ref;
 
@@ -433,7 +433,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       return -ENOENT;
     }
 
-    *optval = boost::get<std::string>(j->second);
+    *optval = std::get<std::string>(j->second);
     return 0;
   }
 
@@ -454,7 +454,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       return -ENOENT;
     }
 
-    *optval = boost::get<uint64_t>(j->second);
+    *optval = std::get<uint64_t>(j->second);
     return 0;
   }
 

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -11,8 +11,8 @@
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/Types.h"
 #include "librbd/io/ReadResult.h"
-#include <boost/variant/variant.hpp>
 #include <atomic>
+#include <variant>
 
 namespace librbd {
 
@@ -99,13 +99,13 @@ public:
     }
   };
 
-  typedef boost::variant<Read,
-                         Discard,
-                         Write,
-                         WriteSame,
-                         CompareAndWrite,
-                         Flush,
-                         ListSnaps> Request;
+  typedef std::variant<Read,
+                       Discard,
+                       Write,
+                       WriteSame,
+                       CompareAndWrite,
+                       Flush,
+                       ListSnaps> Request;
 
   C_Dispatcher dispatcher_ctx;
 

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -14,7 +14,6 @@
 #include "librbd/io/RefreshImageDispatch.h"
 #include "librbd/io/Utils.h"
 #include "librbd/io/WriteBlockImageDispatch.h"
-#include <boost/variant.hpp>
 
 #include <shared_mutex> // for std::shared_lock
 
@@ -280,7 +279,7 @@ bool ImageDispatcher<I>::send_dispatch(
     }
   }
 
-  return boost::apply_visitor(
+  return std::visit(
     SendVisitor{image_dispatch, image_dispatch_spec},
     image_dispatch_spec->request);
 }
@@ -288,7 +287,7 @@ bool ImageDispatcher<I>::send_dispatch(
 template <typename I>
 bool ImageDispatcher<I>::preprocess(
     ImageDispatchSpec* image_dispatch_spec) {
-  return boost::apply_visitor(
+  return std::visit(
     PreprocessVisitor{this, image_dispatch_spec},
     image_dispatch_spec->request);
 }

--- a/src/test/librbd/crypto/luks/test_mock_FlattenRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_FlattenRequest.cc
@@ -96,7 +96,7 @@ struct TestMockCryptoLuksFlattenRequest : public TestMockFixture {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_))
             .WillOnce(Invoke([this, offset,
                               length](io::ImageDispatchSpec* spec) {
-                auto* read = boost::get<io::ImageDispatchSpec::Read>(
+                auto* read = std::get_if<io::ImageDispatchSpec::Read>(
                         &spec->request);
                 ASSERT_TRUE(read != nullptr);
 
@@ -122,7 +122,7 @@ struct TestMockCryptoLuksFlattenRequest : public TestMockFixture {
   void expect_image_write() {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_))
             .WillOnce(Invoke([this](io::ImageDispatchSpec* spec) {
-                auto* write = boost::get<io::ImageDispatchSpec::Write>(
+                auto* write = std::get_if<io::ImageDispatchSpec::Write>(
                         &spec->request);
                 ASSERT_TRUE(write != nullptr);
 
@@ -145,7 +145,7 @@ struct TestMockCryptoLuksFlattenRequest : public TestMockFixture {
   void expect_image_flush(int r) {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_)).WillOnce(
             Invoke([r](io::ImageDispatchSpec* spec) {
-              ASSERT_TRUE(boost::get<io::ImageDispatchSpec::Flush>(
+              ASSERT_TRUE(std::get_if<io::ImageDispatchSpec::Flush>(
                       &spec->request) != nullptr);
               spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
               spec->aio_comp->set_request_count(1);

--- a/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_FormatRequest.cc
@@ -66,7 +66,7 @@ struct TestMockCryptoLuksFormatRequest : public TestMockFixture {
   void expect_image_write() {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_))
             .WillOnce(Invoke([this](io::ImageDispatchSpec* spec) {
-                auto* write = boost::get<io::ImageDispatchSpec::Write>(
+                auto* write = std::get_if<io::ImageDispatchSpec::Write>(
                         &spec->request);
                 ASSERT_TRUE(write != nullptr);
 

--- a/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
@@ -81,7 +81,7 @@ struct TestMockCryptoLuksLoadRequest : public TestMockFixture {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_))
             .WillOnce(Invoke([this, offset,
                               length](io::ImageDispatchSpec* spec) {
-                auto* read = boost::get<io::ImageDispatchSpec::Read>(
+                auto* read = std::get_if<io::ImageDispatchSpec::Read>(
                         &spec->request);
                 ASSERT_TRUE(read != nullptr);
 

--- a/src/test/librbd/crypto/test_mock_FormatRequest.cc
+++ b/src/test/librbd/crypto/test_mock_FormatRequest.cc
@@ -135,7 +135,7 @@ struct TestMockCryptoFormatRequest : public TestMockFixture {
   void expect_image_flush(int r) {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_)).WillOnce(
             Invoke([r](io::ImageDispatchSpec* spec) {
-              ASSERT_TRUE(boost::get<io::ImageDispatchSpec::Flush>(
+              ASSERT_TRUE(std::get_if<io::ImageDispatchSpec::Flush>(
                       &spec->request) != nullptr);
               spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
               spec->aio_comp->set_request_count(1);

--- a/src/test/librbd/crypto/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/test_mock_LoadRequest.cc
@@ -119,7 +119,7 @@ struct TestMockCryptoLoadRequest : public TestMockFixture {
   void expect_image_flush(int r = 0) {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_)).WillOnce(
             Invoke([r](io::ImageDispatchSpec* spec) {
-              ASSERT_TRUE(boost::get<io::ImageDispatchSpec::Flush>(
+              ASSERT_TRUE(std::get_if<io::ImageDispatchSpec::Flush>(
                       &spec->request) != nullptr);
               spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
               spec->aio_comp->set_request_count(1);

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -119,12 +119,12 @@ void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size,
 
 
 MATCHER(IsListSnaps, "") {
-  auto req = boost::get<io::ImageDispatchSpec::ListSnaps>(&arg->request);
+  auto req = std::get_if<io::ImageDispatchSpec::ListSnaps>(&arg->request);
   return (req != nullptr);
 }
 
 MATCHER_P2(IsRead, snap_id, image_interval, "") {
-  auto req = boost::get<io::ImageDispatchSpec::Read>(&arg->request);
+  auto req = std::get_if<io::ImageDispatchSpec::Read>(&arg->request);
   if (req == nullptr ||
       arg->io_context->get_read_snap() != snap_id) {
     return false;

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -168,7 +168,7 @@ public:
   void expect_flush_io(MockTestImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(*mock_image_ctx.io_image_dispatcher, send(_))
       .WillOnce(Invoke([&mock_image_ctx, r](io::ImageDispatchSpec* spec) {
-                  ASSERT_TRUE(boost::get<io::ImageDispatchSpec::Flush>(
+                  ASSERT_TRUE(std::get_if<io::ImageDispatchSpec::Flush>(
                     &spec->request) != nullptr);
                   spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
                   auto aio_comp = spec->aio_comp;

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -513,7 +513,7 @@ public:
   void expect_image_flush(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(*mock_image_ctx.io_image_dispatcher, send(_))
       .WillOnce(Invoke([r](io::ImageDispatchSpec* spec) {
-                  ASSERT_TRUE(boost::get<io::ImageDispatchSpec::Flush>(
+                  ASSERT_TRUE(std::get_if<io::ImageDispatchSpec::Flush>(
                     &spec->request) != nullptr);
                   spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
                   spec->aio_comp->set_request_count(1);

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -138,7 +138,7 @@ static bool operator==(const SnapContext& rhs, const SnapContext& lhs) {
 #include "librbd/io/CopyupRequest.cc"
 
 MATCHER_P(IsRead, image_extents, "") {
-  auto req = boost::get<librbd::io::ImageDispatchSpec::Read>(&arg->request);
+  auto req = std::get_if<librbd::io::ImageDispatchSpec::Read>(&arg->request);
   return (req != nullptr && image_extents == arg->image_extents);
 }
 
@@ -210,7 +210,7 @@ struct TestMockIoCopyupRequest : public TestMockFixture {
                 send(IsRead(image_extents)))
       .WillOnce(Invoke(
         [&mock_image_ctx, image_extents, data, r](io::ImageDispatchSpec* spec) {
-          auto req = boost::get<librbd::io::ImageDispatchSpec::Read>(
+          auto req = std::get_if<librbd::io::ImageDispatchSpec::Read>(
             &spec->request);
           ASSERT_TRUE(req != nullptr);
 

--- a/src/test/librbd/operation/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/operation/test_mock_ResizeRequest.cc
@@ -129,7 +129,7 @@ public:
   void expect_flush_cache(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(*mock_image_ctx.io_image_dispatcher, send(_))
       .WillOnce(Invoke([&mock_image_ctx, r](io::ImageDispatchSpec* spec) {
-                  ASSERT_TRUE(boost::get<io::ImageDispatchSpec::Flush>(
+                  ASSERT_TRUE(std::get_if<io::ImageDispatchSpec::Flush>(
                     &spec->request) != nullptr);
                   spec->dispatch_result = io::DISPATCH_RESULT_COMPLETE;
                   auto aio_comp = spec->aio_comp;


### PR DESCRIPTION
This change is part of a broader effort to reduce dependencies on third-party libraries by leveraging C++ standard library alternatives.

Migrating from boost::variant to std::variant improves code readability and maintainability while reducing external dependencies.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
