### PR TITLE
reef: build-with-container: two small fixes

### DIFF
--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -569,7 +569,7 @@ def bc_run_tests(ctx):
         [
             "bash",
             "-c",
-            f"cd {ctx.cli.homedir} && source ./run-make-check.sh && build && run",
+            f"cd {ctx.cli.homedir} && source ./run-make-check.sh && build tests && run",
         ],
     )
     with ctx.user_command():

--- a/src/script/buildcontainer-setup.sh
+++ b/src/script/buildcontainer-setup.sh
@@ -28,18 +28,18 @@ fi
 # packages etc.
 case "${CEPH_BASE_BRANCH}~${DISTRO_KIND}" in
     *~*centos*8)
-        dnf install -y java-1.8.0-openjdk-headless /usr/bin/rpmbuild wget
+        dnf install -y java-1.8.0-openjdk-headless /usr/bin/rpmbuild wget curl
         install_container_deps
         dnf_clean
     ;;
     *~*centos*9|*~*centos*10*|*~fedora*)
-        dnf install -y /usr/bin/rpmbuild wget
+        dnf install -y /usr/bin/rpmbuild wget curl
         install_container_deps
         dnf_clean
     ;;
     *~*ubuntu*)
         apt-get update
-        apt-get install -y wget reprepro
+        apt-get install -y wget reprepro curl
         install_container_deps
     ;;
     *)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70506

---

backport of https://github.com/ceph/ceph/pull/62274
parent tracker: https://tracker.ceph.com/issues/70451

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh