### PR TITLE
squid: rgw: sync fairness watcher reconnects on any error

### DIFF
--- a/src/rgw/driver/rados/sync_fairness.cc
+++ b/src/rgw/driver/rados/sync_fairness.cc
@@ -219,10 +219,9 @@ class Watcher : public librados::WatchCtx2 {
     if (cookie != handle) {
       return;
     }
-    if (err == -ENOTCONN) {
-      ldpp_dout(dpp, 4) << "Disconnected watch on " << ref.obj << dendl;
-      restart();
-    }
+    ldpp_dout(dpp, 4) << "Disconnected watch on " << ref.obj
+        << " err=" << err << dendl;
+    restart();
   }
 }; // Watcher
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70528

---

backport of https://github.com/ceph/ceph/pull/62156
parent tracker: https://tracker.ceph.com/issues/70270

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh