### PR TITLE
rgw/lua: Replace background map mutex with Intel TBB concurrent map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,7 @@ option(WITH_RADOSGW_POSIX "POSIX backend for Rados Gateway" ON)
 option(WITH_RADOSGW_SELECT_PARQUET "Support for s3 select on parquet objects" ON)
 option(WITH_RADOSGW_ARROW_FLIGHT "Build arrow flight when not using system-provided arrow" OFF)
 option(WITH_RADOSGW_BACKTRACE_LOGGING "Enable backtraces in rgw logs" OFF)
+option(WITH_RADOSGW_INTEL_TBB "Build RadosGW with Intel TBB support" OFF)
 
 option(WITH_SYSTEM_ARROW "Use system-provided arrow" OFF)
 option(WITH_SYSTEM_UTF8PROC "Use system-provided utf8proc" OFF)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -338,6 +338,9 @@ BuildRequires:  librdkafka-devel
 Requires:  lua-devel
 Requires:  %{luarocks_package_name}
 %endif
+%if 0%{with intel_tbb}
+BuildRequires:  intel-oneapi-tbb-devel
+%endif
 %if 0%{with make_check}
 BuildRequires:  hostname
 BuildRequires:  jq
@@ -1509,6 +1512,11 @@ cmake .. \
 %endif
 %if 0%{without lua_packages}
     -DWITH_RADOSGW_LUA_PACKAGES:BOOL=OFF \
+%endif
+%if 0%{with intel_tbb}
+    -DWITH_RADOSGW_INTEL_TBB:BOOL=ON \
+%else
+    -DWITH_RADOSGW_INTEL_TBB:BOOL=OFF \
 %endif
 %if 0%{with cmake_verbose_logging}
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \

--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -1,0 +1,46 @@
+# Find Intel Threading Building Blocks (TBB) library
+#
+# This module defines:
+# TBB_FOUND - True if TBB is found
+# TBB_INCLUDE_DIRS - TBB include directories
+# TBB_LIBRARIES - TBB libraries to link against
+
+if(NOT TBB_ROOT_DIR)
+  set(TBB_ROOT_DIR $ENV{TBB_ROOT_DIR})
+endif()
+
+find_path(TBB_INCLUDE_DIR
+  NAMES tbb/concurrent_hash_map.h
+  PATHS ${TBB_ROOT_DIR}/include
+        /usr/include
+        /usr/local/include
+)
+
+find_library(TBB_LIBRARY
+  NAMES tbb
+  PATHS ${TBB_ROOT_DIR}/lib
+        ${TBB_ROOT_DIR}/lib64
+        /usr/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/local/lib64
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TBB
+  REQUIRED_VARS TBB_LIBRARY TBB_INCLUDE_DIR
+)
+
+if(TBB_FOUND)
+  set(TBB_INCLUDE_DIRS ${TBB_INCLUDE_DIR})
+  set(TBB_LIBRARIES ${TBB_LIBRARY})
+  if(NOT TARGET TBB::tbb)
+    add_library(TBB::tbb INTERFACE IMPORTED)
+    set_target_properties(TBB::tbb PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${TBB_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${TBB_INCLUDE_DIRS}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(TBB_INCLUDE_DIR TBB_LIBRARY)

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -335,6 +335,7 @@ if [ x$(uname)x = xFreeBSDx ]; then
         devel/libedit \
         devel/libtool \
         devel/google-perftools \
+        devel/onetbb \
         lang/cython \
         net/openldap24-client \
         archivers/snappy \
@@ -393,6 +394,8 @@ else
                 $SUDO apt-get install -y $INSTALL_EXTRA_PACKAGES
             fi
         fi
+        # TBB package
+        $SUDO apt-get install -y libtbb-dev
         $SUDO apt-get install -y devscripts equivs
         $SUDO apt-get install -y dpkg-dev
         ensure_python3_sphinx_on_ubuntu

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -351,6 +351,9 @@
 /* Defined if lua packages can be installed by radosgw */
 #cmakedefine WITH_RADOSGW_LUA_PACKAGES
 
+/* Defined if intel tbb is available for radosgw */
+#cmakedefine WITH_RADOSGW_INTEL_TBB
+
 /* Backend dbstore for Rados Gateway */
 #cmakedefine WITH_RADOSGW_DBSTORE
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -596,6 +596,15 @@ if(WITH_RADOSGW_KAFKA_ENDPOINT)
   target_link_libraries(rgw PRIVATE RDKafka::RDKafka)
 endif()
 
+if(WITH_RADOSGW_INTEL_TBB)
+  find_package(TBB REQUIRED CONFIG)
+  target_link_libraries(rgw_common
+    PRIVATE
+      TBB::tbb
+      TBB::tbbmalloc
+      TBB::tbbmalloc_proxy)
+endif()
+
 set_target_properties(rgw PROPERTIES OUTPUT_NAME rgw VERSION 2.0.0
   SOVERSION 2)
 install(TARGETS rgw DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
This commit introduces a configurable concurrent map implementation for the Lua background table in RADOS Gateway. Users can now choose between Intel's TBB `tbb::concurrent_hash_map` or `std::unordered_map` based on build-time configuration.

Changes:
- Created a new `ProtectedMap` class that abstracts the map implementation.
- Introduced `WITH_RADOSGW_INTEL_TBB` CMake flag to enable TBB support.
- Implemented `ProtectedMap` with two variants:
  - **TBB mode** (`WITH_RADOSGW_INTEL_TBB=ON`): Uses `tbb::concurrent_hash_map` for lock-free concurrent access.
  - **Standard mode** (`WITH_RADOSGW_INTEL_TBB=OFF`): Falls back to `std::unordered_map` with a mutex for thread safety.
- Updated `rgw_lua_background.h` and related files to use `ProtectedMap` instead of `std::unordered_map`.
- Ensured compatibility with existing APIs, including `increment_by` and `pairs` iteration.

Build system updates:
- Updated `install-deps.sh` to include the Intel TBB package when enabled.
- Modified `ceph.spec.in` to include `intel-oneapi-tbb-devel`.
- Added a CMake option `WITH_RADOSGW_INTEL_TBB` to allow optional TBB dependency.

This change improves flexibility, allowing users to choose between performance (TBB) and simplicity (`std::unordered_map`).

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
