### PR TITLE
mgr/smb: additional input and output controls

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -55,7 +55,7 @@ Create Cluster
 
 .. code:: bash
 
-    $ ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>] [--clustering=<clustering>]
+    $ ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>] [--clustering=<clustering>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>]
 
 Create a new logical cluster, identified by the cluster id value. The cluster
 create command must specify the authentication mode the cluster will use. This
@@ -101,15 +101,39 @@ public_addrs
     Supported only when using Samba's clustering. Assign "virtual" IP
     addresses that will be managed by the clustering subsystem and may automatically
     move between nodes running Samba containers.
+password_filter
+    One of ``none`` or ``base64``. If the filter is ``none`` the password
+    values on the command line are assumed to be plain text. If the filter is
+    ``base64`` the password values are assumed to be obscured with
+    base64 encoding the string. If ``--password-filter-out`` is not specified
+    this filter will also be applied to the output.
+password_filter_out
+    One of ``none``, ``base64``, or ``hidden``. If the filter is ``none`` the
+    password fields in the output are emitted as plain text. If the filter is
+    ``base64`` password fields will be obscured by base64 encoding the
+    string.  If the filter is ``hidden`` the password values will be replaced
+    by a invalid generic replacement string containing only asterisks.
 
 Remove Cluster
 ++++++++++++++
 
 .. code:: bash
 
-    $ ceph smb cluster rm <cluster_id>
+    $ ceph smb cluster rm <cluster_id> [--password-filter=<password_filter>]
 
 Remove a logical SMB cluster from the Ceph cluster.
+
+Options:
+
+cluster_id
+    A ``cluster_id`` value identifying a cluster resource.
+password_filter
+    One of ``none``, ``base64``, or ``hidden``. If the filter is ``none`` the
+    password fields in the output are emitted as plain text. If the filter is
+    ``base64`` password fields will be obscured by base64 encoding the
+    string.  If the filter is ``hidden`` the password values will be replaced
+    by a invalid generic replacement string containing only asterisks.
+
 
 List Clusters
 ++++++++++++++
@@ -190,15 +214,68 @@ command, for example:
 
     $ ceph smb apply -i /path/to/resources.yaml
 
+In addition to the resource specification the ``apply`` sub-command accepts
+options that control how the input and output of the command behave:
+
+.. code:: bash
+
+    $ ceph smb apply [--format=<format>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>] -i <input>
+
+Options:
+
+format
+    One of ``json`` (the default) or ``yaml``. Output format can be
+    selected independent of the input format.
+password_filter
+    One of ``none`` or ``base64``. If the filter is ``none`` the password
+    fields in the input are assumed to be plain text. If the filter is
+    ``base64`` the password fields are assumed to be obscured with
+    base64 encoding the string. If ``--password-filter-out`` is not specified
+    this filter will also be applied to the output.
+password_filter_out
+    One of ``none``, ``base64``, or ``hidden``. If the filter is ``none`` the
+    password fields in the output are emitted as plain text. If the filter is
+    ``base64`` password fields will be obscured by base64 encoding the
+    string.  If the filter is ``hidden`` the password values will be replaced
+    by a invalid generic replacement string containing only asterisks.
+input
+    A file name or ``-`` to use stdin.
+
+
 Resources that have already been applied to the Ceph cluster configuration can
 be viewed using the ``ceph smb show`` command. For example:
 
 .. code:: bash
 
-    $ ceph smb show [<resource_name>...]
+    $ ceph smb show ceph.smb.cluster.cluster1
 
-The ``show`` command can show all resources of a given type or specific
-resources by id. ``resource_name`` arguments can take the following forms:
+The ``show`` command can show all resources, resources of a given type, or specific
+resource items. Options can be provided that control the output of the command.
+
+.. code:: bash
+
+    $ ceph smb show [resource_name...] [--format=<format>] [--results=<results>] [--password-filter=<password_filter>]
+
+Options:
+
+resource_name
+    One or more strings specifying a resource or resource type. See description below.
+format
+    One of ``json`` (the default) or ``yaml``.
+results
+    One of ``collapsed`` (the default) or ``full``. When set to ``collapsed``
+    the output of the command will show only the resource JSON/YAML of
+    a single item if a single item is found. When set to ``full`` even if a
+    single item is found the output will always include a wrapper object like
+    (in pseudo-JSON): ``{"resources": [...Resource objects...]}``.
+password_filter
+    One of ``none``, ``base64``, or ``hidden``. If the filter is ``none`` the
+    password fields in the output are emitted as plain text. If the filter is
+    ``base64`` password fields will be obscured by base64 encoding the
+    string.  If the filter is ``hidden`` the password values will be replaced
+    by a invalid generic replacement string containing only asterisks.
+
+``resource_name`` arguments can take the following forms:
 
 - ``ceph.smb.cluster``: show all cluster resources
 - ``ceph.smb.cluster.<cluster_id>``: show specific cluster with given cluster id

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -107,3 +107,11 @@ class SMBClustering(_StrEnum):
 class ShowResults(_StrEnum):
     FULL = 'full'
     COLLAPSED = 'collapsed'
+
+
+class PasswordFilter(_StrEnum):
+    """Filter type for password values."""
+
+    NONE = 'none'
+    BASE64 = 'base64'
+    HIDDEN = 'hidden'

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -102,3 +102,8 @@ class SMBClustering(_StrEnum):
     DEFAULT = 'default'
     ALWAYS = 'always'
     NEVER = 'never'
+
+
+class ShowResults(_StrEnum):
+    FULL = 'full'
+    COLLAPSED = 'collapsed'

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -115,3 +115,17 @@ class PasswordFilter(_StrEnum):
     NONE = 'none'
     BASE64 = 'base64'
     HIDDEN = 'hidden'
+
+
+class InputPasswordFilter(_StrEnum):
+    """Filter type for input password values."""
+
+    NONE = 'none'
+    BASE64 = 'base64'
+
+    def to_password_filter(self) -> PasswordFilter:
+        """Convert input password filter to password filter type."""
+        # This is because python doesn't allow extending enums (with values)
+        # but we want a InputPasswordFilter to be a strict subset of the
+        # password filter enum.
+        return PasswordFilter(self.value)

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -21,6 +21,7 @@ from . import (
 from .enums import (
     AuthMode,
     JoinSourceType,
+    ShowResults,
     SMBClustering,
     UserGroupSourceType,
 )
@@ -334,8 +335,12 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         )
         return self._handler.apply([share]).one()
 
-    @cli.SMBCommand('show', perm='r')
-    def show(self, resource_names: Optional[List[str]] = None) -> Simplified:
+    @cli.SMBCommand("show", perm="r")
+    def show(
+        self,
+        resource_names: Optional[List[str]] = None,
+        results: ShowResults = ShowResults.COLLAPSED,
+    ) -> Simplified:
         """Show resources fetched from the local config store based on resource
         type or resource type and id(s).
         """
@@ -346,9 +351,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                 resources = self._handler.matching_resources(resource_names)
             except handler.InvalidResourceMatch as err:
                 raise cli.InvalidInputValue(str(err)) from err
-        if len(resources) == 1:
+        if len(resources) == 1 and results is ShowResults.COLLAPSED:
             return resources[0].to_simplified()
-        return {'resources': [r.to_simplified() for r in resources]}
+        return {"resources": [r.to_simplified() for r in resources]}
 
     def submit_smb_spec(self, spec: SMBSpec) -> None:
         """Submit a new or updated smb spec object to ceph orchestration."""

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -21,6 +21,7 @@ from . import (
 from .enums import (
     AuthMode,
     JoinSourceType,
+    PasswordFilter,
     ShowResults,
     SMBClustering,
     UserGroupSourceType,
@@ -340,6 +341,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         self,
         resource_names: Optional[List[str]] = None,
         results: ShowResults = ShowResults.COLLAPSED,
+        password_filter: PasswordFilter = PasswordFilter.NONE,
     ) -> Simplified:
         """Show resources fetched from the local config store based on resource
         type or resource type and id(s).
@@ -351,6 +353,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                 resources = self._handler.matching_resources(resource_names)
             except handler.InvalidResourceMatch as err:
                 raise cli.InvalidInputValue(str(err)) from err
+        if password_filter is not PasswordFilter.NONE:
+            op = (PasswordFilter.NONE, password_filter)
+            log.debug('Password filtering for smb show: %r', op)
+            resources = [r.convert(op) for r in resources]
         if len(resources) == 1 and results is ShowResults.COLLAPSED:
             return resources[0].to_simplified()
         return {"resources": [r.to_simplified() for r in resources]}

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -280,6 +280,20 @@ class UserGroupSettings(_RBase):
     users: List[Dict[str, str]]
     groups: List[Dict[str, str]]
 
+    def convert(self, operation: ConversionOp) -> Self:
+        def _convert_pw_key(dct: Dict[str, str]) -> Dict[str, str]:
+            pw = dct.get('password', None)
+            if pw is not None:
+                data = dict(dct)
+                data["password"] = _password_convert(pw, operation)
+                return data
+            return dct
+
+        return self.__class__(
+            users=[_convert_pw_key(u) for u in self.users],
+            groups=self.groups,
+        )
+
 
 @resourcelib.component()
 class UserGroupSource(_RBase):
@@ -516,6 +530,15 @@ class UsersAndGroups(_RBase):
         rc.linked_to_cluster.quiet = True
         rc.on_construction_error(InvalidResourceError.wrap)
         return rc
+
+    def convert(self, operation: ConversionOp) -> Self:
+        values = None if not self.values else self.values.convert(operation)
+        return self.__class__(
+            users_groups_id=self.users_groups_id,
+            intent=self.intent,
+            values=values,
+            linked_to_cluster=self.linked_to_cluster,
+        )
 
 
 # SMBResource is a union of all valid top-level smb resource types.

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -748,3 +748,83 @@ def test_show_password_filter_b64(tmodule):
     join_auth = ja[0]
     assert join_auth['auth']['username'] == 'testadmin'
     assert join_auth['auth']['password'] == 'UGFzc3cwcmQ='
+
+
+def test_apply_password_filter(tmodule):
+    _example_cfg_1(tmodule)
+
+    txt = json.dumps(
+        {
+            'resource_type': 'ceph.smb.usersgroups',
+            'users_groups_id': 'ug1',
+            'intent': 'present',
+            'values': {
+                'users': [
+                    {'username': 'foo', 'password': 'YWJyYWNhZGFicmE='},
+                    {'username': 'bar', 'password': 'eHl6enk='},
+                ],
+                'groups': [],
+            },
+        }
+    )
+
+    rg = tmodule.apply_resources(
+        txt, password_filter=smb.enums.InputPasswordFilter.BASE64
+    )
+    assert rg.success, rg.to_simplified()
+    ts = rg.to_simplified()
+    assert len(ts['results']) == 1
+    r = ts['results'][0]['resource']
+    assert r['resource_type'] == 'ceph.smb.usersgroups'
+    assert len(r['values']['users']) == 2
+    # filtered passwords of command output should match input by default
+    assert r['values']['users'][0]['password'] == 'YWJyYWNhZGFicmE='
+    assert r['values']['users'][1]['password'] == 'eHl6enk='
+
+    # get unfiltered object
+    out = tmodule.show(['ceph.smb.usersgroups.ug1'])
+    assert out['resource_type'] == 'ceph.smb.usersgroups'
+    assert len(out['values']['users']) == 2
+    assert out['values']['users'][0]['password'] == 'abracadabra'
+    assert out['values']['users'][1]['password'] == 'xyzzy'
+
+
+def test_apply_password_filter_in_out(tmodule):
+    _example_cfg_1(tmodule)
+
+    txt = json.dumps(
+        {
+            'resource_type': 'ceph.smb.usersgroups',
+            'users_groups_id': 'ug1',
+            'intent': 'present',
+            'values': {
+                'users': [
+                    {'username': 'foo', 'password': 'YWJyYWNhZGFicmE='},
+                    {'username': 'bar', 'password': 'eHl6enk='},
+                ],
+                'groups': [],
+            },
+        }
+    )
+
+    rg = tmodule.apply_resources(
+        txt,
+        password_filter=smb.enums.InputPasswordFilter.BASE64,
+        password_filter_out=smb.enums.PasswordFilter.HIDDEN,
+    )
+    assert rg.success, rg.to_simplified()
+    ts = rg.to_simplified()
+    assert len(ts['results']) == 1
+    r = ts['results'][0]['resource']
+    assert r['resource_type'] == 'ceph.smb.usersgroups'
+    assert len(r['values']['users']) == 2
+    # filtered passwords of command output should match input by default
+    assert r['values']['users'][0]['password'] == '****************'
+    assert r['values']['users'][1]['password'] == '****************'
+
+    # get unfiltered object
+    out = tmodule.show(['ceph.smb.usersgroups.ug1'])
+    assert out['resource_type'] == 'ceph.smb.usersgroups'
+    assert len(out['values']['users']) == 2
+    assert out['values']['users'][0]['password'] == 'abracadabra'
+    assert out['values']['users'][1]['password'] == 'xyzzy'

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -722,3 +722,29 @@ def test_show_cluster_without_shares(tmodule):
 }
     """.strip()
     )
+
+
+def test_show_password_filter_hidden(tmodule):
+    _example_cfg_1(tmodule)
+    out = tmodule.show(password_filter=smb.enums.PasswordFilter.HIDDEN)
+    assert 'resources' in out
+    res = out['resources']
+    assert len(res) == 4
+    ja = [r for r in res if r['resource_type'] == 'ceph.smb.join.auth']
+    assert ja
+    join_auth = ja[0]
+    assert join_auth['auth']['username'] == 'testadmin'
+    assert join_auth['auth']['password'] == '****************'
+
+
+def test_show_password_filter_b64(tmodule):
+    _example_cfg_1(tmodule)
+    out = tmodule.show(password_filter=smb.enums.PasswordFilter.BASE64)
+    assert 'resources' in out
+    res = out['resources']
+    assert len(res) == 4
+    ja = [r for r in res if r['resource_type'] == 'ceph.smb.join.auth']
+    assert ja
+    join_auth = ja[0]
+    assert join_auth['auth']['username'] == 'testadmin'
+    assert join_auth['auth']['password'] == 'UGFzc3cwcmQ='


### PR DESCRIPTION
Add a `--results=[collapsed|full]` option to the `ceph smb show` command. This can be used to request/prevent the show command from collapsing a single valued list result to just the resource in the list.

Add `--password-filter=[none|base64|hidden]` to the `ceph smb show` command as well as `--password-filter` and `--password-filter-out` options to `ceph smb apply`, `ceph smb cluster create` and a few other related commands. The password filter is not a security mechanism - but can be used to obscure passwords and prevent casual shoulder surfers from seeing password values. Note that `hidden` intentionally loses information - replacing the password with a fixed number of asterisks. This filter mode is _not_ supported for --password-filter for input values but will be supported by --password-filter-out on commands that have that 2nd option.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
