### PR TITLE
squid: qa/rgw: fix user cleanup in s3tests task

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -229,7 +229,7 @@ def create_users(ctx, config, s3tests_conf):
         for client in config.keys():
             for section, user in users.items():
                 # don't need to delete keystone users
-                if not user in keystone_users:
+                if section in keystone_users:
                     continue
                 uid = '{user}.{client}'.format(user=user, client=client)
                 cluster_name, daemon_type, client_id = teuthology.split_role(client)

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -259,6 +259,7 @@ def create_users(ctx, config, s3tests_conf):
                             '--cluster', cluster_name,
                             'account', 'rm',
                             '--account-id', account_id,
+                            '--purge-data',
                             ])
 
 

--- a/src/rgw/rgw_account.h
+++ b/src/rgw/rgw_account.h
@@ -53,6 +53,7 @@ struct AdminOpState {
   std::optional<int64_t> quota_max_size;
   std::optional<int64_t> quota_max_objects;
   std::optional<bool> quota_enabled;
+  bool purge_data = false;
 };
 
 /// create an account

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -11523,6 +11523,7 @@ next:
       .max_groups = max_groups,
       .max_access_keys = max_access_keys,
       .max_buckets = max_buckets,
+      .purge_data = static_cast<bool>(purge_data),
     };
 
     std::string err_msg;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70538

---

backport of https://github.com/ceph/ceph/pull/61596
parent tracker: https://tracker.ceph.com/issues/69741

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh