### PR TITLE
dmclock: migrate from boost::variant to std::variant

### DIFF
--- a/src/dmclock/sim/src/ssched/ssched_server.h
+++ b/src/dmclock/sim/src/ssched/ssched_server.h
@@ -19,8 +19,7 @@
 #include <mutex>
 #include <deque>
 #include <functional>
-
-#include "boost/variant.hpp"
+#include <variant>
 
 #include "ssched_recs.h"
 
@@ -56,7 +55,7 @@ namespace crimson {
 	};
 
 	Type                 type;
-	boost::variant<Retn> data;
+	std::variant<Retn> data;
       };
 
     protected:

--- a/src/dmclock/src/dmclock_recs.h
+++ b/src/dmclock/src/dmclock_recs.h
@@ -16,6 +16,7 @@
 #pragma once
 
 
+#include <cstdint>
 #include <ostream>
 #include <assert.h>
 

--- a/src/dmclock/src/dmclock_server.h
+++ b/src/dmclock/src/dmclock_server.h
@@ -40,8 +40,7 @@
 #include <iostream>
 #include <sstream>
 #include <limits>
-
-#include <boost/variant.hpp>
+#include <variant>
 
 #include "indirect_intrusive_heap.h"
 #include "../support/src/run_every.h"
@@ -92,7 +91,7 @@ namespace crimson {
 
     // the AtLimit constructor parameter can either accept AtLimit or a value
     // for RejectThreshold (which implies AtLimit::Reject)
-    using AtLimitParam = boost::variant<AtLimit, RejectThreshold>;
+    using AtLimitParam = std::variant<AtLimit, RejectThreshold>;
 
     struct ClientInfo {
       double reservation;  // minimum
@@ -837,7 +836,7 @@ namespace crimson {
       // given type T, or a default value of T otherwise
       template <typename T, typename Variant>
       static T get_or_default(const Variant& param, T default_value) {
-	const T *p = boost::get<T>(&param);
+	const T *p = std::get_if<T>(&param);
 	return p ? *p : default_value;
       }
 
@@ -1302,17 +1301,17 @@ namespace crimson {
 	};
 
 	typename super::NextReqType   type;
-	boost::variant<Retn,Time>     data;
+	std::variant<Retn,Time>     data;
 
 	bool is_none() const { return type == super::NextReqType::none; }
 
 	bool is_retn() const { return type == super::NextReqType::returning; }
 	Retn& get_retn() {
-	  return boost::get<Retn>(data);
+	  return std::get<Retn>(data);
 	}
 
 	bool is_future() const { return type == super::NextReqType::future; }
-	Time getTime() const { return boost::get<Time>(data); }
+	Time getTime() const { return std::get<Time>(data); }
       };
 
 
@@ -1483,7 +1482,7 @@ namespace crimson {
 	    auto tag = super::pop_process_request(this->ready_heap,
 				     process_f(result, PhaseType::priority));
 	    // need to use retn temporarily
-	    auto& retn = boost::get<typename PullReq::Retn>(result.data);
+	    auto& retn = std::get<typename PullReq::Retn>(result.data);
 	    super::reduce_reservation_tags(retn.client, tag);
 	  }
 	  ++this->prop_sched_count;

--- a/src/dmclock/test/test_dmclock_server.cc
+++ b/src/dmclock/test/test_dmclock_server.cc
@@ -912,7 +912,7 @@ namespace crimson {
       for (int i = 0; i < 6; ++i) {
 	Queue::PullReq pr = pq->pull_request();
 	EXPECT_EQ(Queue::NextReqType::returning, pr.type);
-	auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+	auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
 
 	if (client1 == retn.client) ++c1_count;
 	else if (client2 == retn.client) ++c2_count;
@@ -967,7 +967,7 @@ namespace crimson {
       for (int i = 0; i < 6; ++i) {
 	Queue::PullReq pr = pq->pull_request();
 	EXPECT_EQ(Queue::NextReqType::returning, pr.type);
-	auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+	auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
 
 	if (client1 == retn.client) ++c1_count;
 	else if (client2 == retn.client) ++c2_count;
@@ -1022,7 +1022,7 @@ namespace crimson {
       for (int i = 0; i < 10; ++i) {
 	Queue::PullReq pr = pq->pull_request();
 	EXPECT_EQ(Queue::NextReqType::returning, pr.type);
-	auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+	auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
 
 	if (i > 5) continue;
 	if (client1 == retn.client) ++c1_count;
@@ -1056,7 +1056,7 @@ namespace crimson {
       for (int i = 0; i < 6; ++i) {
 	Queue::PullReq pr = pq->pull_request();
 	EXPECT_EQ(Queue::NextReqType::returning, pr.type);
-	auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+	auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
 
 	if (client1 == retn.client) ++c1_count;
 	else if (client2 == retn.client) ++c2_count;
@@ -1123,7 +1123,7 @@ namespace crimson {
 	  if (i < num_requests * lower_bound || i > num_requests * upper_bound) {
 	    continue;
 	  }
-	  auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+	  auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
 	  if (client1 == retn.client) {
 	    ++c1_count;
 	  } else if (client2 == retn.client) {
@@ -1279,7 +1279,7 @@ namespace crimson {
 
       EXPECT_EQ(Queue::NextReqType::future, pr.type);
 
-      Time when = boost::get<Time>(pr.data);
+      Time when = std::get<Time>(pr.data);
       EXPECT_EQ(now + 100, when);
     }
 
@@ -1310,7 +1310,7 @@ namespace crimson {
 
       EXPECT_EQ(Queue::NextReqType::returning, pr.type);
 
-      auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+      auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
       EXPECT_EQ(client1, retn.client);
     }
 
@@ -1341,7 +1341,7 @@ namespace crimson {
 
       EXPECT_EQ(Queue::NextReqType::returning, pr.type);
 
-      auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+      auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
       EXPECT_EQ(client1, retn.client);
     }
 
@@ -1456,7 +1456,7 @@ namespace crimson {
       for (int i = 0; i < 2; ++i) {
         Queue::PullReq pr = pq->pull_request();
         EXPECT_EQ(Queue::NextReqType::returning, pr.type);
-        auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+        auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
 
         if (client1 == retn.client) {
           ++c1_count;
@@ -1483,7 +1483,7 @@ namespace crimson {
       for (int i = 0; i < 50; ++i) {
         Queue::PullReq pr = pq->pull_request();
         EXPECT_EQ(Queue::NextReqType::returning, pr.type);
-        auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+        auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
 
         if (client1 == retn.client) {
           ++c1_count;
@@ -1513,7 +1513,7 @@ namespace crimson {
       // Trying to pull a request after restoring the limit should succeed.
       pr = pq->pull_request(old_time + 2.0);
       EXPECT_EQ(Queue::NextReqType::returning, pr.type);
-      auto& retn = boost::get<Queue::PullReq::Retn>(pr.data);
+      auto& retn = std::get<Queue::PullReq::Retn>(pr.data);
       EXPECT_EQ(retn.client, client2);
       EXPECT_EQ(47u, pq->request_count());
     } // dmclock_server_pull.pull_wait_at_limit


### PR DESCRIPTION
This change is part of a broader effort to reduce dependencies on third-party libraries by leveraging C++ standard library alternatives.

Migrating from boost::variant to std::variant improves code readability and maintainability while reducing external dependencies.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
