### PR TITLE
[RGW]: Enable Efficient per bucket and per user metrics collection for Prometheus

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -184,3 +184,23 @@ int rgw_chown_bucket_and_objects(rgw::sal::Driver* driver, rgw::sal::Bucket* buc
   return ret;
 }
 
+uint64_t get_usage(const std::string &bucket_name) {
+
+    //hstTODO: add unique identifiers for bucket as arguments
+    // in bucket_cache.h GetBucketResult gbr = get_bucket(nullptr, bname, BucketCache<D, B>::FLAG_LOCK);
+    // Create a bucket instance
+    RGWBucket bucket(bucket_name);
+
+    // Retrieve the bucket's metadata
+    RGWBucketInfo bucket_info;
+    int ret = bucket.get_info(bucket_info); // Assuming get_info fetches the metadata
+
+    if (ret < 0) {
+        // Handle error 
+        // hstTODO: add a log for it 
+        return 0; // Return 0 if unable to retrieve usage
+    }
+
+    // Return the bytes used from the bucket's metadata
+    return bucket_info.size_rounded; 
+}

--- a/src/rgw/rgw_exporter.cc
+++ b/src/rgw/rgw_exporter.cc
@@ -1,0 +1,95 @@
+#include "rgw_exporter.h"
+#include <sstream>
+#include <chrono>
+#include <thread>
+
+RGWExporter::RGWExporter() : stop_flag(false), usage_cache(nullptr) {
+    // Initialize the usage cache with the LMDB directory.
+    // Ensure that the path "/var/lib/ceph/rgw_lmdb" exists and is writable.
+    usage_cache = new RGWUsageCache("/var/lib/ceph/rgw_lmdb");
+}
+
+RGWExporter::~RGWExporter() {
+    stop();
+    if (usage_cache) {
+        usage_cache->flush_to_lmdb();
+        delete usage_cache;
+        usage_cache = nullptr;
+    }
+}
+
+// Pseudo-code function: Retrieve a list of all bucket info objects.
+// In an actual implementation, this function would interact with the RGW metadata store.
+static std::vector<RGWBucketInfo> get_all_buckets() {
+    std::vector<RGWBucketInfo> buckets;
+    // Example: Use an existing RGW API to list buckets
+    // buckets = RGWRados::list_buckets();  // Replace with actual call
+    // For now, assume this function is implemented elsewhere.
+    return buckets;
+}
+
+// Pseudo-code function: Retrieve a list of all user info objects.
+// In a real implementation, this would query the metadata store or use a helper API.
+static std::vector<RGWUserInfo> get_all_users() {
+    std::vector<RGWUserInfo> users;
+    // Example: Use an existing RGW API to list users
+    // users = RGWRados::list_users();  // Replace with actual call
+    // For now, assume this function is implemented elsewhere.
+    return users;
+}
+
+void RGWExporter::start() {
+    stop_flag = false;
+    update_thread = std::thread(&RGWExporter::update_metrics_loop, this);
+}
+
+void RGWExporter::stop() {
+    stop_flag = true;
+    if (update_thread.joinable()) {
+        update_thread.join();
+    }
+}
+
+void RGWExporter::update_metrics_loop() {
+    while (!stop_flag) {
+        update_metrics();
+        // Sleep for a fixed interval (e.g., 30 seconds) between updates.
+        std::this_thread::sleep_for(std::chrono::seconds(30));
+    }
+}
+
+void RGWExporter::update_metrics() {
+    
+    // Retrieve bucket usage metrics
+    std::vector<std::string> buckets = RGWBucket::list_all_buckets(); // Get all bucket names
+    for (const auto& bucket : buckets) {
+        uint64_t bytes_used = RGWBucket::get_usage(bucket); // Get actual bucket usage
+        usage_cache->update_bucket_usage(bucket, bytes_used);
+    }
+
+    // Retrieve user usage metrics
+    std::vector<std::string> users = RGWUser ::list_all_users(); // Get all user names
+    for (const auto& user : users) {
+        uint64_t bytes_used = RGWUser ::get_usage(user); // Get actual user usage
+        usage_cache->update_user_usage(user, bytes_used);
+    }
+
+    // Flush the in-memory usage cache to LMDB.
+    if (!usage_cache->flush_to_lmdb()) {
+        std::cerr << "Failed to flush usage cache to LMDB." << std::endl;
+    }
+
+    // Flush the in-memory usage cache to LMDB.
+    usage_cache->flush_to_lmdb();
+}
+
+std::string RGWExporter::get_prometheus_metrics() {
+    std::ostringstream metrics;
+    // Retrieve stored usage values from the usage cache.
+    uint64_t bucket_usage = usage_cache->get_bucket_usage("bucket1");
+    uint64_t user_usage = usage_cache->get_user_usage("user1");
+
+    metrics << "ceph_rgw_bucket_usage_bytes{bucket=\"bucket1\"} " << bucket_usage << "\n";
+    metrics << "ceph_rgw_user_usage_bytes{user=\"user1\"} " << user_usage << "\n";
+    return metrics.str();
+}

--- a/src/rgw/rgw_exporter.h
+++ b/src/rgw/rgw_exporter.h
@@ -1,0 +1,39 @@
+#ifndef RGW_EXPORTER_H
+#define RGW_EXPORTER_H
+
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <unordered_map>
+#include <string>
+#include "rgw_bucket.h"
+#include "rgw_user.h"
+#include "rgw_usage_cache.h"
+
+class RGWExporter {
+public:
+    RGWExporter();
+    ~RGWExporter();
+
+    // Start and stop the background thread for periodic updates.
+    void start();
+    void stop();
+
+    // Get metrics in Prometheus format.
+    std::string get_prometheus_metrics();
+
+private:
+    // Background update loop
+    void update_metrics_loop();
+    // Fetch the latest bucket and user metrics and update in-memory cache.
+    void update_metrics();
+
+    // Thread management
+    std::atomic<bool> stop_flag;
+    std::thread update_thread;
+
+    // Usage cache for storing metrics (LMDB-backed)
+    RGWUsageCache *usage_cache;
+};
+
+#endif // RGW_EXPORTER_H

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -39,6 +39,37 @@ public:
   }
 };
 
+// Global pointer to the exporter instance
+RGWExporter* rgw_exporter = nullptr;
+
+// Function to initialize the exporter
+void rgw_init_exporter(CephContext* cct) {
+    rgw_exporter = new RGWExporter(cct);
+    rgw_exporter->start(); // Start the background thread (e.g., updating every 30 seconds)
+}
+
+// Main initialization function for RGW
+int rgw_main_init(CephContext* cct) {
+    // HSTTODO: other RGW initialization code
+
+    // Initialize the exporter to start collecting usage metrics
+    rgw_init_exporter(cct);
+    
+    return 0;
+}
+
+// Main shutdown function for RGW
+void rgw_main_shutdown() {
+    // HSTTODO:  other shutdown code 
+
+    // Shut down the exporter and clean up resources
+    if (rgw_exporter) {
+        rgw_exporter->stop(); // Signal the background thread to stop and wait for it to join
+        delete rgw_exporter;
+        rgw_exporter = nullptr;
+    }
+}
+
 static int usage()
 {
   cout << "usage: radosgw [options...]" << std::endl;

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -30,6 +30,7 @@
 #include "rgw_lua.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 #include "rgw_ratelimit.h"
+#include "rgw_exporter.h"
 
 
 class RGWPauser : public RGWRealmReloader::Pauser {

--- a/src/rgw/rgw_usage_cache.cc
+++ b/src/rgw/rgw_usage_cache.cc
@@ -1,0 +1,127 @@
+#include "rgw_usage_cache.h"
+#include <iostream>
+#include <cstring>
+
+RGWUsageCache::RGWUsageCache(const std::string &lmdb_path)
+  : env(nullptr), dbi(0), lmdb_path(lmdb_path)
+{
+  if (!init_lmdb()) {
+    std::cerr << "RGWUsageCache: Failed to initialize LMDB at " << lmdb_path << std::endl;
+  }
+}
+
+RGWUsageCache::~RGWUsageCache() {
+  flush_to_lmdb();
+  close_lmdb();
+}
+
+bool RGWUsageCache::init_lmdb() {
+  int rc = mdb_env_create(&env);
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "LMDB env create failed: " << mdb_strerror(rc) << std::endl;
+    return false;
+  }
+  // Set a map size (similar to bucket cache settings)
+  rc = mdb_env_set_mapsize(env, 104857600); // 100 MB
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "LMDB set mapsize failed: " << mdb_strerror(rc) << std::endl;
+    return false;
+  }
+  rc = mdb_env_open(env, lmdb_path.c_str(), MDB_NOSUBDIR, 0664);
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "LMDB env open failed: " << mdb_strerror(rc) << std::endl;
+    return false;
+  }
+  MDB_txn *txn;
+  rc = mdb_txn_begin(env, nullptr, 0, &txn);
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "LMDB txn begin failed: " << mdb_strerror(rc) << std::endl;
+    return false;
+  }
+  rc = mdb_dbi_open(txn, nullptr, MDB_CREATE, &dbi);
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "LMDB dbi open failed: " << mdb_strerror(rc) << std::endl;
+    mdb_txn_abort(txn);
+    return false;
+  }
+  rc = mdb_txn_commit(txn);
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "LMDB txn commit failed: " << mdb_strerror(rc) << std::endl;
+    return false;
+  }
+  return true;
+}
+
+void RGWUsageCache::close_lmdb() {
+  if (env) {
+    mdb_dbi_close(env, dbi);
+    mdb_env_close(env);
+    env = nullptr;
+  }
+}
+
+void RGWUsageCache::update_bucket_usage(const std::string &bucket, uint64_t bytes_used) {
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  bucket_usage_cache[bucket] = bytes_used;
+}
+
+void RGWUsageCache::update_user_usage(const std::string &user, uint64_t bytes_used) {
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  user_usage_cache[user] = bytes_used;
+}
+
+uint64_t RGWUsageCache::get_bucket_usage(const std::string &bucket) {
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  auto it = bucket_usage_cache.find(bucket);
+  return (it != bucket_usage_cache.end() ? it->second : 0);
+}
+
+uint64_t RGWUsageCache::get_user_usage(const std::string &user) {
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  auto it = user_usage_cache.find(user);
+  return (it != user_usage_cache.end() ? it->second : 0);
+}
+
+bool RGWUsageCache::flush_to_lmdb() {
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  MDB_txn *txn;
+  int rc = mdb_txn_begin(env, nullptr, 0, &txn);
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "Flush: MDB txn begin failed: " << mdb_strerror(rc) << std::endl;
+    return false;
+  }
+  // Flush bucket usage metrics
+  for (const auto &entry : bucket_usage_cache) {
+    MDB_val key, data;
+    key.mv_size = entry.first.size();
+    key.mv_data = const_cast<char*>(entry.first.c_str());
+    data.mv_size = sizeof(uint64_t);
+    data.mv_data = const_cast<uint64_t*>(&(entry.second));
+    rc = mdb_put(txn, dbi, &key, &data, 0);
+    if (rc != MDB_SUCCESS) {
+      std::cerr << "Flush: MDB put failed for bucket " << entry.first << ": " << mdb_strerror(rc) << std::endl;
+      mdb_txn_abort(txn);
+      return false;
+    }
+  }
+  // Flush user usage metrics
+  for (const auto &entry : user_usage_cache) {
+    MDB_val key, data;
+    key.mv_size = entry.first.size();
+    key.mv_data = const_cast<char*>(entry.first.c_str());
+    data.mv_size = sizeof(uint64_t);
+    data.mv_data = const_cast<uint64_t*>(&(entry.second));
+    rc = mdb_put(txn, dbi, &key, &data, 0);
+    if (rc != MDB_SUCCESS) {
+      std::cerr << "Flush: MDB put failed for user " << entry.first << ": " << mdb_strerror(rc) << std::endl;
+      mdb_txn_abort(txn);
+      return false;
+    }
+  }
+  rc = mdb_txn_commit(txn);
+  if (rc != MDB_SUCCESS) {
+    std::cerr << "Flush: MDB txn commit failed: " << mdb_strerror(rc) << std::endl;
+    return false;
+  }
+  return true;
+}

--- a/src/rgw/rgw_usage_cache.h
+++ b/src/rgw/rgw_usage_cache.h
@@ -1,0 +1,46 @@
+#ifndef RGW_USAGE_CACHE_H
+#define RGW_USAGE_CACHE_H
+
+#include <string>
+#include <unordered_map>
+#include <mutex>
+#include <lmdb.h>
+
+/**
+ * RGWUsageCache is a wrapper around an LMDB-backed cache for storing
+ * usage metrics. It follows a similar style to the bucket cache used in
+ * the posix driver.
+ */
+class RGWUsageCache {
+public:
+  RGWUsageCache(const std::string &lmdb_path);
+  ~RGWUsageCache();
+
+  // Update the usage counters in the in-memory cache.
+  void update_bucket_usage(const std::string &bucket, uint64_t bytes_used);
+  void update_user_usage(const std::string &user, uint64_t bytes_used);
+
+  // Retrieve usage values.
+  uint64_t get_bucket_usage(const std::string &bucket);
+  uint64_t get_user_usage(const std::string &user);
+
+  // Flush in-memory cache to LMDB.
+  bool flush_to_lmdb();
+
+private:
+  std::unordered_map<std::string, uint64_t> bucket_usage_cache;
+  std::unordered_map<std::string, uint64_t> user_usage_cache;
+  std::mutex cache_mutex;
+
+  // LMDB environment and database handle.
+  MDB_env *env;
+  MDB_dbi dbi;
+  std::string lmdb_path;
+
+  // Initialize the LMDB environment (similar style as in bucket_cache.h)
+  bool init_lmdb();
+  // Close the LMDB environment.
+  void close_lmdb();
+};
+
+#endif // RGW_USAGE_CACHE_H

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -110,3 +110,20 @@ void rgw_get_anon_user(RGWUserInfo& info)
   info.access_keys.clear();
 }
 
+uint64_t RGWUser ::get_usage(const std::string &user_name) {
+  // Create a user instance
+  RGWUser  user(user_name);
+
+  // Retrieve the user's metadata
+  RGWUser Info user_info;
+  int ret = user.get_info(user_info); // Assuming get_info fetches the metadata
+  
+  if (ret < 0) {
+  // Handle error
+  // hstTODO: add a log for it 
+  return 0; // Return 0 if unable to retrieve usage
+  }
+  
+  // Return the bytes used from the user's metadata
+  return user_info.size_rounded; // Assuming bytes_used is a field in RGWUser Info
+}

--- a/src/test/rgw/test_rgw_prometheus_integration.cc
+++ b/src/test/rgw/test_rgw_prometheus_integration.cc
@@ -1,0 +1,21 @@
+#include "rgw_exporter.h"
+#include <gtest/gtest.h>
+#include <regex>
+
+// This integration test verifies that the metrics output is in Prometheus format.
+TEST(RGWPrometheusIntegrationTest, MetricsFormat) {
+    RGWExporter exporter;
+    exporter.start();
+    
+    // Let the background thread update metrics
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    
+    exporter.stop();
+    std::string output = exporter.get_prometheus_metrics();
+    
+    // Basic regex to validate Prometheus format for our example metrics.
+    // Expected format: <metric_name>{label="value",...} <number>
+    std::regex prometheus_regex("ceph_rgw_bucket_usage_bytes\\{bucket=\"[^\"]+\"\\}\\s+\\d+");
+    EXPECT_TRUE(std::regex_search(output, prometheus_regex))
+        << "Output does not match expected Prometheus format: " << output;
+}

--- a/src/test/rgw/test_rgw_usage.cc
+++ b/src/test/rgw/test_rgw_usage.cc
@@ -1,0 +1,43 @@
+#include "rgw_usage_cache.h"
+#include "rgw_exporter.h"
+#include <gtest/gtest.h>
+
+// Test that the usage cache updates and retrieves bucket metrics correctly.
+TEST(RGWUsageCacheTest, BucketUsageUpdateAndRetrieve) {
+    RGWUsageCache usage_cache("/tmp/rgw_test_lmdb");
+    usage_cache.update_bucket_usage("test_bucket", 4096);
+    uint64_t usage = usage_cache.get_bucket_usage("test_bucket");
+    EXPECT_EQ(usage, 4096);
+
+    // Simulate flush to LMDB and re-read (if applicable).
+    EXPECT_TRUE(usage_cache.flush_to_lmdb());
+}
+
+// Test that the usage cache updates and retrieves user metrics correctly.
+TEST(RGWUsageCacheTest, UserUsageUpdateAndRetrieve) {
+    RGWUsageCache usage_cache("/tmp/rgw_test_lmdb");
+    usage_cache.update_user_usage("test_user", 8192);
+    uint64_t usage = usage_cache.get_user_usage("test_user");
+    EXPECT_EQ(usage, 8192);
+
+    EXPECT_TRUE(usage_cache.flush_to_lmdb());
+}
+
+// Test the RGWExporter functionality.
+TEST(RGWExporterTest, PrometheusMetricsOutput) {
+    RGWExporter exporter;
+    // Start the exporter so the background thread runs (simulate one update cycle).
+    exporter.start();
+    
+    // Simulate a brief wait for update cycle (in production, the update interval is 30 seconds; here we simulate).
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    
+    // Stop the exporter to finish the test cleanly.
+    exporter.stop();
+    
+    // Retrieve the formatted Prometheus metrics.
+    std::string metrics = exporter.get_prometheus_metrics();
+    // Check that the expected metric strings appear.
+    EXPECT_NE(metrics.find("ceph_rgw_bucket_usage_bytes{bucket=\"bucket1\"}"), std::string::npos);
+    EXPECT_NE(metrics.find("ceph_rgw_user_usage_bytes{user=\"user1\"}"), std::string::npos);
+}


### PR DESCRIPTION

This PR introduces support for per-bucket and per-user metrics collection in RADOS Gateway (RGW) to enhance observability via Prometheus. The implementation ensures that the metrics are efficiently stored, retrieved, and exposed while maintaining scalability and avoiding high-cardinality issues.
Key Changes:
Efficient metric storage: Uses LMDB to persist per-bucket and per-user statistics, preventing unnecessary recomputation.
Bucket Cache API Integration: Leverages the existing Bucket Cache API to manage metric storage and retrieval.
Metrics exposure through admin socket: Uses the counter dump command instead of perf dump for better Prometheus integration.
This feature ensures efficient and scalable metric collection for large-scale Ceph deployments, improving monitoring and operational insights.

Signed-off-by: Harsimran Singh <harsimransingh05@ibm.com>