### PR TITLE
client: pass feature bits to be negated by the client

### DIFF
--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/1-client.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/1-client.yaml
@@ -1,9 +1,9 @@
 tasks:
 - ceph-fuse:
     client.0:
-      client_feature_range: "[0-13],[15-21]"
+      client_feature_range: "14,22"
     client.1:
-      client_feature_range: "[0-13],[15-21]"
+      client_feature_range: "14,22"
 - print: "**** done client"
 - workunit:
     clients:

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/1-client.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/1-client.yaml
@@ -4,7 +4,7 @@ overrides:
 tasks:
 - ceph-fuse:
     client.1:
-      client_feature_range: "[0-13],[15-21]"
+      client_feature_range: "14,22"
 - print: "**** done client"
 - workunit:
     clients:

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1747,7 +1747,7 @@ class TestFsAuthorize(CephFSTestCase):
 
         CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK = 21
         # all but CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK
-        features = ",".join([str(i) for i in range(CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK)])
+        features = f"{CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK}"
         mntargs = [f"--client_debug_inject_features={features}"]
 
         # should succeed
@@ -1776,7 +1776,7 @@ class TestFsAuthorize(CephFSTestCase):
 
         CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK = 21
         # all but CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK
-        features = ",".join([str(i) for i in range(CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK)])
+        features = f"{CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK}"
         mntargs = [f"--client_debug_inject_features={features}"]
 
         # should succeed
@@ -1806,7 +1806,7 @@ class TestFsAuthorize(CephFSTestCase):
 
         CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK = 21
         # all but CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK
-        features = ",".join([str(i) for i in range(CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK)])
+        features = f"{CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK}"
         mntargs = [f"--client_debug_inject_features={features}"]
 
         # should succeed

--- a/qa/tasks/cephfs/test_dir_charmap.py
+++ b/qa/tasks/cephfs/test_dir_charmap.py
@@ -191,7 +191,7 @@ class TestCharMapVxattr(CephFSTestCase, CharMapMixin):
 
         CEPHFS_FEATURE_CHARMAP = 22
         # all but CEPHFS_FEATURE_CHARMAP
-        features = ",".join([str(i) for i in range(CEPHFS_FEATURE_CHARMAP)])
+        features = f"{CEPHFS_FEATURE_CHARMAP}"
         mntargs = [f"--client_debug_inject_features={features}"]
 
         self.mount_a.remount(mntargs=mntargs)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -380,6 +380,27 @@ vinodeno_t Client::map_faked_ino(ino_t ino)
   return _map_faked_ino(ino);
 }
 
+std::string Client::remove_feature_bits(const std::string& input) {
+  std::vector<int> feature_bits_list = CEPHFS_FEATURES_CLIENT_SUPPORTED;
+  std::string lis;
+  std::stringstream css(input);
+
+  while(getline(css, lis, ',')) {
+    int feature = std::stoi(lis);
+    feature_bits_list.erase(remove(feature_bits_list.begin(), feature_bits_list.end(), feature), feature_bits_list.end());
+  }
+
+  std::stringstream res;
+  for (size_t i = 0; i < final_features_bits_list.size(); ++i) {
+    res << final_features_bits_list[i];
+    if (i != final_features_bits_list.size() - 1) {
+      res << ",";
+    }
+  }
+  return res.str();
+}
+
+
 // cons/des
 
 Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
@@ -428,7 +449,7 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     acl_type = POSIX_ACL;
 
   if (auto str = cct->_conf->client_debug_inject_features; !str.empty()) {
-    myfeatures = feature_bitset_t(str);
+    myfeatures = feature_bitset_t(remove_feature_bits(str));
   } else {
     myfeatures = feature_bitset_t(CEPHFS_FEATURES_CLIENT_SUPPORTED);
   }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -858,6 +858,7 @@ public:
 
   bool use_faked_inos() { return _use_faked_inos; }
   vinodeno_t map_faked_ino(ino_t ino);
+  std::string remove_feature_bits(const std::string& input);
 
   //notify the mds to flush the mdlog
   void flush_mdlog_sync(Inode *in);

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -258,6 +258,7 @@ options:
   - mds_client
   flags:
   - startup
+  fmt_desc: Set the feature bits that needs to be excluded
   with_legacy: true
 - name: client_max_inline_size
   type: size


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/66494
Signed-off-by: Neeraj Pratap Singh<neesingh@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
