### PR TITLE
squid: cephfs-shell: add option to remove xattr

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -980,6 +980,13 @@ class TestXattr(TestCephFSShell):
             cmd=['getxattr', self.dir_name, input_val[0]])
         self.negtest_cephfs_shell_cmd(cmd=['listxattr', self.dir_name])
 
+    def test_remove_xattr(self):
+        self.test_set()
+        self.get_cephfs_shell_cmd_output(
+            ['removexattr', self.dir_name, 'user.key'])
+        self.negtest_cephfs_shell_cmd(
+            cmd=['getxattr', self.dir_name, 'user.key'])
+
 
 class TestLS(TestCephFSShell):
     dir_name = 'test_dir'

--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -1664,6 +1664,22 @@ class CephFSShell(Cmd):
         except libcephfs.Error as e:
             set_exit_code_msg(msg=e)
 
+    removexattr_parser = argparse.ArgumentParser(
+        description='Remove extended attribute set for a file')
+    removexattr_parser.add_argument('path', type=str, action=path_to_bytes,
+                                    help='Name of the file')
+    removexattr_parser.add_argument('name', type=str, help='Extended attribute name')
+
+    @with_argparser(removexattr_parser)
+    def do_removexattr(self, args):
+        """
+        Remove extended attribute for a file
+        """
+        try:
+            poutput('{}'.format(cephfs.removexattr(args.path, to_bytes(args.name))))
+        except libcephfs.Error as e:
+            set_exit_code_msg(msg=e)
+
 
 #######################################################
 #


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70416

---

backport of https://github.com/ceph/ceph/pull/62136
parent tracker: https://tracker.ceph.com/issues/69274

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh