### PR TITLE
squid: rados/test_crash.sh: add PG_DEGRADED to ignorelist

### DIFF
--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -11,6 +11,7 @@ tasks:
         - OSD_.*DOWN
         - \(RECENT_CRASH\)
         - \(POOL_APP_NOT_ENABLED\)
+        - \(PG_DEGRADED\)
   - workunit:
       clients:
          client.0:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70135

---

backport of https://github.com/ceph/ceph/pull/60934
parent tracker: https://tracker.ceph.com/issues/69010

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh