### PR TITLE
mgr/dashboard: use existing pools for cephfs vol creation 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
@@ -10,6 +10,14 @@ And('enter {string} {string}', (field: string, value: string) => {
 });
 
 /**
+ * Ticks a checkbox in the form
+ * @param field name of the field that needs to be filled out.
+ */
+And('checks {string}', (field: string) => {
+  cy.get('cds-checkbox span').contains(field).click();
+});
+
+/**
  * Fills in the given field using the value provided
  * @param field ID of the field that needs to be filled out.
  * @param value Value that should be filled in the field.
@@ -95,6 +103,6 @@ Then('I should see an error in {string} field', (field: string) => {
 });
 
 And('select {string} {string}', (selectionName: string, option: string) => {
-  cy.get(`select[name=${selectionName}]`).select(option);
-  cy.get(`select[name=${selectionName}] option:checked`).contains(option);
+  cy.get(`select[id=${selectionName}]`).select(option);
+  cy.get(`select[id=${selectionName}] option:checked`).contains(option);
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/urls.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/urls.po.ts
@@ -43,6 +43,10 @@ export class UrlsCollection extends PageHelper {
 
     // CephFS
     cephfs: { url: '#/cephfs/fs', id: 'cd-cephfs-list' },
-    'create cephfs': { url: '#/cephfs/fs/create', id: 'cd-cephfs-form' }
+    'create cephfs': { url: '#/cephfs/fs/create', id: 'cd-cephfs-form' },
+
+    // Pools
+    pools: { url: '/#pool', id: 'cd-pool-list' },
+    'create pool': { url: '#/pool/create', id: 'cd-pool-form' }
   };
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/filesystems.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/filesystems.e2e-spec.feature
@@ -29,3 +29,47 @@ Feature: CephFS Management
         And I confirm the resource "test_cephfs"
         And I click on "Remove File System" button
         Then I should not see a row with "test_cephfs"
+
+    Scenario Outline: Create two cephfs pools for attaching to a volume
+        Given I am on the "create pool" page
+        And enter "name" "<pool_name>"
+        And select "poolType" "<type>"
+        And select options "<application>"
+        And I click on "Create Pool" button
+        Then I should see a row with "<pool_name>"
+
+        Examples:
+            | pool_name | type | application |
+            | e2e_cephfs_data | replicated | cephfs |
+            | e2e_cephfs_meta | replicated | cephfs |
+
+    Scenario Outline: Create a CephFS Volume with pre-created pools
+        Given I am on the "create cephfs" page
+        And enter "name" "<fs_name>"
+        And checks "Use existing pools"
+        And select "dataPool" "<data_pool>"
+        And select "metadataPool" "<metadata_pool>"
+        And I click on "Create File System" button
+        Then I should see a row with "<fs_name>"
+
+        Examples:
+            | fs_name | data_pool | metadata_pool |
+            | e2e_custom_pool_cephfs | e2e_cephfs_data | e2e_cephfs_meta |
+
+    Scenario Outline: Remove CephFS Volume that has pre-created pools
+        Given I am on the "cephfs" page
+        And I select a row "<fs_name>"
+        And I click on "Remove" button from the table actions
+        Then I should see the carbon modal
+        And I confirm the resource "<fs_name>"
+        And I click on "Remove File System" button
+        Then I should not see a row with "<fs_name>"
+
+        # verify pools associated with the volume is removed
+        Given I am on the "pools" page
+        Then I should not see a row with "<data_pool>"
+        And I should not see a row with "<metadata_pool>"
+
+        Examples:
+            | fs_name | data_pool | metadata_pool |
+            | e2e_custom_pool_cephfs | e2e_cephfs_data | e2e_cephfs_meta |

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
@@ -53,6 +53,107 @@
           </ng-template>
         </div>
 
+        <div class="form-item"
+             *ngIf="!editing">
+          <cds-checkbox id="customPools"
+                        name="customPools"
+                        formControlName="customPools"
+                        i18n>Use existing pools
+            <cd-help-text>Allows you to use replicated pools with 'cephfs' application tag that are already created.</cd-help-text>
+          </cds-checkbox>
+
+          <cd-alert-panel *ngIf="pools.length < 2"
+                          type="info"
+                          spacingClass="mt-1"
+                          i18n>
+            You need to have atleast 2 pools that are empty, applied with cephfs label and not erasure-coded.
+          </cd-alert-panel>
+        </div>
+
+        <!-- Data pool -->
+        <div class="form-item"
+             *ngIf="form.get('customPools')?.value || editing">
+          <cds-text-label for="dataPool"
+                          i18n
+                          *ngIf="editing">Data pool
+            <input cdsText
+                   type="text"
+                   placeholder="Pool name..."
+                   id="dataPool"
+                   name="dataPool"
+                   formControlName="dataPool">
+          </cds-text-label>
+          <cds-select label="Data pool"
+                      for="dataPool"
+                      name="dataPool"
+                      id="dataPool"
+                      formControlName="dataPool"
+                      (valueChange)="onPoolChange($event)"
+                      cdRequiredField="Data pool"
+                      [invalid]="!form.controls.dataPool.valid && form.controls.dataPool.dirty"
+                      [invalidText]="dataPoolError"
+                      *ngIf="!editing">
+            <option *ngIf="dataPools === null"
+                    [ngValue]="null"
+                    i18n>Loading...</option>
+            <option *ngIf="dataPools !== null && dataPools?.length === 0"
+                    [ngValue]="null"
+                    i18n>-- No cephfs pools available --</option>
+            <option *ngIf="dataPools !== null && dataPools?.length > 0"
+                    [ngValue]="null"
+                    i18n>-- Select a pool --</option>
+            <option *ngFor="let pool of dataPools"
+                    [value]="pool?.pool_name">{{ pool?.pool_name }}</option>
+          </cds-select>
+          <ng-template #dataPoolError>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('dataPool', formDir, 'required')"
+                  i18n>This field is required!</span>
+          </ng-template>
+        </div>
+
+        <!-- Metadata pool -->
+        <div class="form-item"
+             *ngIf="form.get('customPools')?.value || editing">
+          <cds-text-label for="metadataPool"
+                          i18n
+                          *ngIf="editing">Metadata pool
+            <input cdsText
+                   type="text"
+                   placeholder="Pool name..."
+                   id="metadataPool"
+                   name="metadataPool"
+                   formControlName="metadataPool">
+          </cds-text-label>
+          <cds-select label="Metadata pool"
+                      for="metadataPool"
+                      name="metadataPool"
+                      id="metadataPool"
+                      formControlName="metadataPool"
+                      cdRequiredField="Metadata pool"
+                      [invalid]="!form.controls.metadataPool.valid && form.controls.metadataPool.dirty"
+                      [invalidText]="metadataPoolError"
+                      (valueChange)="onPoolChange($event, true)"
+                      *ngIf="!editing">
+            <option *ngIf="metadatPools === null"
+                    [ngValue]="null"
+                    i18n>Loading...</option>
+            <option *ngIf="metadatPools !== null && metadatPools?.length === 0"
+                    [ngValue]="null"
+                    i18n>-- No cephfs pools available --</option>
+            <option *ngIf="metadatPools !== null && metadatPools?.length > 0"
+                    [ngValue]="null"
+                    i18n>-- Select a pool --</option>
+            <option *ngFor="let pool of metadatPools"
+                    [value]="pool?.pool_name">{{ pool?.pool_name }}</option>
+          </cds-select>
+          <ng-template #metadataPoolError>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('metadataPool', formDir, 'required')"
+                  i18n>This field is required!</span>
+          </ng-template>
+        </div>
+
         <ng-container *ngIf="orchStatus.available">
           <!-- Placement -->
           <div class="form-item"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.spec.ts
@@ -10,7 +10,13 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
 import { of } from 'rxjs';
-import { ComboBoxModule, GridModule, InputModule, SelectModule } from 'carbon-components-angular';
+import {
+  CheckboxModule,
+  ComboBoxModule,
+  GridModule,
+  InputModule,
+  SelectModule
+} from 'carbon-components-angular';
 
 describe('CephfsVolumeFormComponent', () => {
   let component: CephfsVolumeFormComponent;
@@ -29,7 +35,8 @@ describe('CephfsVolumeFormComponent', () => {
       GridModule,
       InputModule,
       SelectModule,
-      ComboBoxModule
+      ComboBoxModule,
+      CheckboxModule
     ],
     declarations: [CephfsVolumeFormComponent]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
@@ -20,3 +20,10 @@
     </cd-table-actions>
   </div>
 </cd-table>
+
+<ng-template #deleteTpl>
+  <cd-alert-panel type="danger"
+                  i18n>
+    This will remove its data and metadata pools. It'll also remove the MDS daemon associated with the volume.
+  </cd-alert-panel>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { Permissions } from '~/app/shared/models/permissions';
 import { Router } from '@angular/router';
 
@@ -37,6 +37,9 @@ const BASE_URL = 'cephfs/fs';
   providers: [{ provide: URLBuilderService, useValue: new URLBuilderService(BASE_URL) }]
 })
 export class CephfsListComponent extends ListWithDetails implements OnInit {
+  @ViewChild('deleteTpl', { static: true })
+  deleteTpl: TemplateRef<any>;
+
   columns: CdTableColumn[];
   filesystems: any = [];
   selection = new CdTableSelection();
@@ -178,6 +181,7 @@ export class CephfsListComponent extends ListWithDetails implements OnInit {
       itemDescription: 'File System',
       itemNames: [volName],
       actionDescription: 'remove',
+      bodyTemplate: this.deleteTpl,
       submitActionObservable: () =>
         this.taskWrapper.wrapTaskAroundCall({
           task: new FinishedTask('cephfs/remove', { volumeName: volName }),

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.ts
@@ -79,10 +79,15 @@ export class CephfsService {
     });
   }
 
-  create(name: string, serviceSpec: object) {
+  create(name: string, serviceSpec: object, dataPool = '', metadataPool = '') {
     return this.http.post(
       this.baseURL,
-      { name: name, service_spec: serviceSpec },
+      {
+        name: name,
+        service_spec: serviceSpec,
+        data_pool: dataPool,
+        metadata_pool: metadataPool
+      },
       {
         observe: 'response'
       }
@@ -116,5 +121,9 @@ export class CephfsService {
       caps: caps,
       root_squash: rootSquash
     });
+  }
+
+  getUsedPools(): Observable<number[]> {
+    return this.http.get<number[]>(`${this.baseUiURL}/used-pools`);
   }
 }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -1692,6 +1692,10 @@ paths:
           application/json:
             schema:
               properties:
+                data_pool:
+                  type: string
+                metadata_pool:
+                  type: string
                 name:
                   type: string
                 service_spec:

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -14,8 +14,11 @@ logger = logging.getLogger('cephfs')
 
 class CephFS(object):
     @classmethod
-    def list_filesystems(cls):
+    def list_filesystems(cls, all_info=False):
         fsmap = mgr.get("fs_map")
+
+        if all_info:
+            return fsmap['filesystems']
         return [{'id': fs['id'], 'name': fs['mdsmap']['fs_name']}
                 for fs in fsmap['filesystems']]
 


### PR DESCRIPTION
We can use the newly introduced data and metadata params to create a vol
with those pools.
    
UI is being intelligent by filtering out the used pools and only uses
the pools that are labeled by cephfs and also not in use. To figure out
a pool is in use or not, we are fetching the pool stats and checking its
used_bytes.

Note: Using ec pools for data pool layout is something discouraged
according to offical doc: https://docs.ceph.com/en/latest/cephfs/createfs/#creating-a-file-system
We can force it but for now I have disabled it entirely in the dashboard
unless people say its okay to do it.

One more extra thing I am doing here is to add a note on deleting a
filesystem that the underlying pools and mds daemons will be removed.

Fixes: https://tracker.ceph.com/issues/70600




https://github.com/user-attachments/assets/dbdc17c8-b389-4bea-84fa-edfd6ff9cd8a


and if there aren't any more pools to use
![image](https://github.com/user-attachments/assets/09c8ee9a-bfd2-41e7-878c-7544e08183fd)


Removing a volume
![image](https://github.com/user-attachments/assets/7bbb307f-3b3e-4a5d-933f-4008e159e9dc)


<!--



  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
