### PR TITLE
mgr/dashboard: tenanted bucket lifecycle management fix

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -726,13 +726,18 @@ class RgwBucket(RgwRESTController):
     @RESTController.Collection(method='PUT', path='/lifecycle')
     @allow_empty_body
     def set_lifecycle_policy(self, bucket_name: str = '', lifecycle: str = '', daemon_name=None,
-                             owner=None):
+                             owner=None, tenant=None):
+        owner = self._get_owner(owner)
+        bucket_name = RgwBucket.get_s3_bucket_name(bucket_name, tenant)
         if lifecycle == '{}':
             return self._delete_lifecycle(bucket_name, daemon_name, owner)
         return self._set_lifecycle(bucket_name, lifecycle, daemon_name, owner)
 
     @RESTController.Collection(method='GET', path='/lifecycle')
-    def get_lifecycle_policy(self, bucket_name: str = '', daemon_name=None, owner=None):
+    def get_lifecycle_policy(self, bucket_name: str = '', daemon_name=None, owner=None,
+                             tenant=None):
+        owner = self._get_owner(owner)
+        bucket_name = RgwBucket.get_s3_bucket_name(bucket_name, tenant)
         return self._get_lifecycle(bucket_name, daemon_name, owner)
 
     @Endpoint(method='GET', path='/ratelimit')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-lifecycle-list/rgw-bucket-lifecycle-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-lifecycle-list/rgw-bucket-lifecycle-list.component.ts
@@ -95,7 +95,7 @@ export class RgwBucketLifecycleListComponent implements OnInit {
 
   loadLifecyclePolicies(context: CdTableFetchDataContext) {
     const allLifecycleRules$ = this.rgwBucketService
-      .getLifecycle(this.bucket.bucket, this.bucket.owner)
+      .getLifecycle(this.bucket.bucket, this.bucket.owner, this.bucket.tenant)
       .pipe(
         tap((lifecycle: Lifecycle) => {
           this.lifecycleRuleList = lifecycle;
@@ -145,7 +145,12 @@ export class RgwBucketLifecycleListComponent implements OnInit {
 
   submitLifecycleConfig(rules: any) {
     this.rgwBucketService
-      .setLifecycle(this.bucket.bucket, JSON.stringify(rules), this.bucket.owner)
+      .setLifecycle(
+        this.bucket.bucket,
+        JSON.stringify(rules),
+        this.bucket.owner,
+        this.bucket.tenant
+      )
       .subscribe({
         next: () => {
           this.notificationService.show(

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.spec.ts
@@ -62,6 +62,7 @@ describe('RgwBucketTieringFormComponent', () => {
 
   it('should call setLifecyclePolicy function', () => {
     component.ngOnInit();
+    component.bucket.tenant = '';
     component.tieringForm.setValue({
       name: 'test',
       storageClass: 'CLOUD',
@@ -80,7 +81,8 @@ describe('RgwBucketTieringFormComponent', () => {
     expect(setLifecycleSpy).toHaveBeenCalledWith(
       'bucket1',
       JSON.stringify(component.configuredLifecycle.LifecycleConfiguration),
-      'dashboard'
+      'dashboard',
+      component.bucket.tenant
     );
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.ts
@@ -56,7 +56,7 @@ export class RgwBucketTieringFormComponent extends CdForm implements OnInit {
 
   ngOnInit() {
     this.rgwBucketService
-      .getLifecycle(this.bucket.bucket, this.bucket.owner)
+      .getLifecycle(this.bucket.bucket, this.bucket.owner, this.bucket.tenant)
       .subscribe((lifecycle: Lifecycle) => {
         if (lifecycle === null) {
           lifecycle = { LifecycleConfiguration: { Rule: [] } };
@@ -235,7 +235,8 @@ export class RgwBucketTieringFormComponent extends CdForm implements OnInit {
         .setLifecycle(
           this.bucket.bucket,
           JSON.stringify(this.configuredLifecycle.LifecycleConfiguration),
-          this.bucket.owner
+          this.bucket.owner,
+          this.bucket.tenant
         )
         .subscribe({
           next: () => {
@@ -262,7 +263,8 @@ export class RgwBucketTieringFormComponent extends CdForm implements OnInit {
         .setLifecycle(
           this.bucket.bucket,
           JSON.stringify(this.configuredLifecycle.LifecycleConfiguration),
-          this.bucket.owner
+          this.bucket.owner,
+          this.bucket.tenant
         )
         .subscribe({
           next: () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -250,22 +250,24 @@ export class RgwBucketService extends ApiClient {
     });
   }
 
-  setLifecycle(bucket_name: string, lifecycle: string, owner: string) {
+  setLifecycle(bucket_name: string, lifecycle: string, owner: string, tenant: string) {
     return this.rgwDaemonService.request((params: HttpParams) => {
       params = params.appendAll({
         bucket_name: bucket_name,
         lifecycle: lifecycle,
-        owner: owner
+        owner: owner,
+        tenant: tenant
       });
       return this.http.put(`${this.url}/lifecycle`, null, { params: params });
     });
   }
 
-  getLifecycle(bucket_name: string, owner: string) {
+  getLifecycle(bucket_name: string, owner: string, tenant: string) {
     return this.rgwDaemonService.request((params: HttpParams) => {
       params = params.appendAll({
         bucket_name: bucket_name,
-        owner: owner
+        owner: owner,
+        tenant: tenant
       });
       return this.http.get(`${this.url}/lifecycle`, { params: params });
     });

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -11607,6 +11607,11 @@ paths:
         name: owner
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: tenant
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -11642,6 +11647,8 @@ paths:
                   default: ''
                   type: string
                 owner:
+                  type: string
+                tenant:
                   type: string
               type: object
       responses:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/70588

Signed-off-by: Naman Munet <naman.munet@ibm.com>

Before:
===
As the tenant was not passed in lifecycle calls made through bucket details > tiering tab, & also account_id was not resolved to the user of the bucket, hence not able to manage the Tiering configuration lifecycle changes

After:
=== 
Account_id is resolved to user_id and tenant is additionally passed to the lifecycle API so as to handle the tenanted bucket scenario


https://github.com/user-attachments/assets/036bd024-d3aa-4874-836c-3b6e0324c38d





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
