### PR TITLE
crimson/os/seastore: misc cleanups

### DIFF
--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -182,7 +182,7 @@ public:
       assert(extent.is_pending_in_trans(t.get_trans_id()));
       return false;
     }
-    auto &pendings = extent.mutation_pendings;
+    auto &pendings = extent.mutation_pending_extents;
     auto trans_id = t.get_trans_id();
     bool unviewable = (pendings.find(trans_id, trans_spec_view_t::cmp_t()) !=
 		       pendings.end());

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -919,14 +919,14 @@ void Cache::invalidate_extent(
     CachedExtent& extent)
 {
   if (!extent.may_conflict()) {
-    assert(extent.transactions.empty());
+    assert(extent.read_transactions.empty());
     extent.set_invalid(t);
     return;
   }
 
   LOG_PREFIX(Cache::invalidate_extent);
   bool do_conflict_log = true;
-  for (auto &&i: extent.transactions) {
+  for (auto &&i: extent.read_transactions) {
     if (!i.t->conflicted) {
       if (do_conflict_log) {
         SUBDEBUGT(seastore_t, "conflict begin -- {}", t, extent);
@@ -1181,7 +1181,7 @@ CachedExtentRef Cache::duplicate_for_write(
   ret->prior_instance = i;
   // duplicate_for_write won't occur after ool write finished
   assert(!i->prior_poffset);
-  auto [iter, inserted] = i->mutation_pendings.insert(*ret);
+  auto [iter, inserted] = i->mutation_pending_extents.insert(*ret);
   ceph_assert(inserted);
   t.add_mutated_extent(ret);
   if (is_root_type(ret->get_type())) {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -62,7 +62,7 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
   auto result = t.get_extent(addr, &ext);
   if (result == Transaction::get_extent_ret::PRESENT) {
     DEBUGT("retire {}~0x{:x} on t -- {}", t, addr, length, *ext);
-    t.add_to_retired_set(CachedExtentRef(&*ext));
+    t.add_present_to_retired_set(CachedExtentRef(&*ext));
     return retire_extent_iertr::now();
   } else if (result == Transaction::get_extent_ret::RETIRED) {
     ERRORT("retire {}~0x{:x} failed, already retired -- {}", t, addr, length, *ext);
@@ -90,8 +90,7 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
            t, addr, length, *ext);
     add_extent(ext);
   }
-  t.add_to_read_set(ext);
-  t.add_to_retired_set(ext);
+  t.add_absent_to_retired_set(ext);
   return retire_extent_iertr::now();
 }
 
@@ -117,8 +116,7 @@ void Cache::retire_absent_extent_addr(
   DEBUGT("retire {}~0x{:x} as placeholder, add extent -- {}",
 	 t, addr, length, *ext);
   add_extent(ext);
-  t.add_to_read_set(ext);
-  t.add_to_retired_set(ext);
+  t.add_absent_to_retired_set(ext);
 }
 
 void Cache::dump_contents()

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -665,9 +665,10 @@ private:
           "{} {}~0x{:x} is absent, add extent and reading range 0x{:x}~0x{:x} ... -- {}",
           T::TYPE, offset, length, partial_off, partial_len, *ret);
       add_extent(ret);
-      // touch_extent() should be included in on_cache
-      on_cache(*ret);
       extent_init_func(*ret);
+      // touch_extent() should be included in on_cache,
+      // required by add_extent()
+      on_cache(*ret);
       return read_extent<T>(
 	std::move(ret), partial_off, partial_len, p_src);
     }
@@ -685,7 +686,6 @@ private:
           "{} {}~0x{:x} is absent(placeholder), add extent and reading range 0x{:x}~0x{:x} ... -- {}",
           T::TYPE, offset, length, partial_off, partial_len, *ret);
       extents_index.replace(*ret, *cached);
-      on_cache(*ret);
 
       // replace placeholder in transactions
       while (!cached->read_transactions.empty()) {
@@ -695,6 +695,7 @@ private:
 
       cached->state = CachedExtent::extent_state_t::INVALID;
       extent_init_func(*ret);
+      on_cache(*ret);
       return read_extent<T>(
 	std::move(ret), partial_off, partial_len, p_src);
     }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -688,8 +688,8 @@ private:
       on_cache(*ret);
 
       // replace placeholder in transactions
-      while (!cached->transactions.empty()) {
-        auto t = cached->transactions.begin()->t;
+      while (!cached->read_transactions.empty()) {
+        auto t = cached->read_transactions.begin()->t;
         t->replace_placeholder(*cached, *ret);
       }
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -153,7 +153,7 @@ public:
   void retire_extent(Transaction &t, CachedExtentRef ref) {
     LOG_PREFIX(Cache::retire_extent);
     SUBDEBUGT(seastore_cache, "retire extent -- {}", t, *ref);
-    t.add_to_retired_set(ref);
+    t.add_present_to_retired_set(ref);
   }
 
   /// Declare paddr retired in t

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -81,8 +81,8 @@ CachedExtent* CachedExtent::get_transactional_view(Transaction &t) {
 }
 
 CachedExtent* CachedExtent::get_transactional_view(transaction_id_t tid) {
-  auto it = mutation_pendings.find(tid, trans_spec_view_t::cmp_t());
-  if (it != mutation_pendings.end()) {
+  auto it = mutation_pending_extents.find(tid, trans_spec_view_t::cmp_t());
+  if (it != mutation_pending_extents.end()) {
     return (CachedExtent*)&(*it);
   } else {
     return this;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -403,6 +403,8 @@ public:
   virtual extent_types_t get_type() const = 0;
 
   virtual bool is_logical() const {
+    assert(!is_logical_type(get_type()));
+    assert(is_physical_type(get_type()));
     return false;
   }
 
@@ -1349,10 +1351,6 @@ public:
     ceph_assert(0 == "Should never happen for a placeholder");
   }
 
-  bool is_logical() const final {
-    return false;
-  }
-
   void on_rewrite(Transaction &, CachedExtent&, extent_len_t) final {}
 
   std::ostream &print_detail(std::ostream &out) const final {
@@ -1406,6 +1404,8 @@ public:
   }
 
   bool is_logical() const final {
+    assert(is_logical_type(get_type()));
+    assert(!is_physical_type(get_type()));
     return true;
   }
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -51,17 +51,6 @@ public:
     laddr_t offset, extent_len_t length) = 0;
 
   /**
-   * Fetches mappings for a list of laddr_t in range [offset, offset + len)
-   *
-   * Future will not resolve until all pins have resolved (set_paddr called)
-   * For indirect lba mappings, get_mappings will always retrieve the original
-   * lba value.
-   */
-  virtual get_mappings_ret get_mappings(
-    Transaction &t,
-    laddr_list_t &&extent_lisk) = 0;
-
-  /**
    * Fetches the mapping for laddr_t
    *
    * Future will not resolve until the pin has resolved (set_paddr called)

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -120,20 +120,11 @@ public:
   using ref_ret = ref_iertr::future<ref_update_result_t>;
 
   /**
-   * Decrements ref count on extent
+   * Removes a mapping and deal with indirection
    *
    * @return returns resulting refcount
    */
-  virtual ref_ret decref_extent(
-    Transaction &t,
-    laddr_t addr) = 0;
-
-  /**
-   * Increments ref count on extent
-   *
-   * @return returns resulting refcount
-   */
-  virtual ref_ret incref_extent(
+  virtual ref_ret remove_mapping(
     Transaction &t,
     laddr_t addr) = 0;
 

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -242,31 +242,6 @@ BtreeLBAManager::_get_original_mappings(
   });
 }
 
-
-BtreeLBAManager::get_mappings_ret
-BtreeLBAManager::get_mappings(
-  Transaction &t,
-  laddr_list_t &&list)
-{
-  LOG_PREFIX(BtreeLBAManager::get_mappings);
-  TRACET("{}", t, list);
-  auto l = std::make_unique<laddr_list_t>(std::move(list));
-  auto retptr = std::make_unique<lba_pin_list_t>();
-  auto &ret = *retptr;
-  return trans_intr::do_for_each(
-    l->begin(),
-    l->end(),
-    [this, &t, &ret](const auto &p) {
-      return this->get_mappings(t, p.first, p.second).si_then(
-	[&ret](auto res) {
-	  ret.splice(ret.end(), res, res.begin(), res.end());
-	  return get_mappings_iertr::now();
-	});
-    }).si_then([l=std::move(l), retptr=std::move(retptr)]() mutable {
-      return std::move(*retptr);
-    });
-}
-
 BtreeLBAManager::get_mapping_ret
 BtreeLBAManager::get_mapping(
   Transaction &t,

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -269,14 +269,9 @@ public:
     Transaction &t,
     laddr_t offset, extent_len_t length) final;
 
-  get_mappings_ret get_mappings(
-    Transaction &t,
-    laddr_list_t &&list) final;
-
   get_mapping_ret get_mapping(
     Transaction &t,
     laddr_t offset) final;
-
 
   struct alloc_mapping_info_t {
     laddr_t key = L_ADDR_NULL; // once assigned, the allocation to

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -430,19 +430,10 @@ public:
     });
   }
 
-  ref_ret decref_extent(
+  ref_ret remove_mapping(
     Transaction &t,
     laddr_t addr) final {
     return update_refcount(t, addr, -1, true
-    ).si_then([](auto res) {
-      return std::move(res.ref_update_res);
-    });
-  }
-
-  ref_ret incref_extent(
-    Transaction &t,
-    laddr_t addr) final {
-    return update_refcount(t, addr, 1, false
     ).si_then([](auto res) {
       return std::move(res.ref_update_res);
     });

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -302,9 +302,9 @@ public:
   TCachedExtentRef<T> find_pending_version(Transaction &t, node_key_t key) {
     auto &me = down_cast();
     assert(me.is_stable());
-    auto mut_iter = me.mutation_pendings.find(
+    auto mut_iter = me.mutation_pending_extents.find(
       t.get_trans_id(), trans_spec_view_t::cmp_t());
-    if (mut_iter != me.mutation_pendings.end()) {
+    if (mut_iter != me.mutation_pending_extents.end()) {
       assert(copy_dests_by_trans.find(t.get_trans_id()) ==
 	copy_dests_by_trans.end());
       return static_cast<T*>(&(*mut_iter));

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -171,15 +171,15 @@ public:
 
     assert(ref->is_valid());
 
-    auto it = ref->transactions.lower_bound(
+    auto it = ref->read_transactions.lower_bound(
       this, read_set_item_t<Transaction>::trans_cmp_t());
-    if (it != ref->transactions.end() && it->t == this) {
+    if (it != ref->read_transactions.end() && it->t == this) {
       return false;
     }
 
     auto [iter, inserted] = read_set.emplace(this, ref);
     ceph_assert(inserted);
-    ref->transactions.insert_before(
+    ref->read_transactions.insert_before(
       it, const_cast<read_set_item_t<Transaction>&>(*iter));
     return true;
   }
@@ -191,13 +191,13 @@ public:
 
     assert(ref->is_valid());
 
-    auto it = ref->transactions.lower_bound(
+    auto it = ref->read_transactions.lower_bound(
       this, read_set_item_t<Transaction>::trans_cmp_t());
-    assert(it == ref->transactions.end() || it->t != this);
+    assert(it == ref->read_transactions.end() || it->t != this);
 
     auto [iter, inserted] = read_set.emplace(this, ref);
     ceph_assert(inserted);
-    ref->transactions.insert_before(
+    ref->read_transactions.insert_before(
       it, const_cast<read_set_item_t<Transaction>&>(*iter));
   }
 
@@ -306,7 +306,7 @@ public:
       assert(where->ref.get() == &placeholder);
       where = read_set.erase(where);
       auto it = read_set.emplace_hint(where, this, &extent);
-      extent.transactions.insert(const_cast<read_set_item_t<Transaction>&>(*it));
+      extent.read_transactions.insert(const_cast<read_set_item_t<Transaction>&>(*it));
     }
     {
       auto where = retired_set.find(&placeholder);
@@ -610,7 +610,7 @@ private:
    * Submitting a transaction mutating any contained extent/addr will
    * invalidate *this.
    */
-  read_set_t<Transaction> read_set; ///< set of extents read by paddr
+  read_extent_set_t<Transaction> read_set; ///< set of extents read by paddr
 
   uint64_t fresh_backref_extents = 0; // counter of new backref extents
 
@@ -663,7 +663,7 @@ private:
    *
    * Set of extents retired by *this.
    */
-  pextent_set_t retired_set;
+  retired_extent_set_t retired_set;
 
   /// stats to collect when commit or invalidate
   tree_stats_t onode_tree_stats;

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -339,18 +339,6 @@ public:
   using ref_iertr = LBAManager::ref_iertr;
   using ref_ret = ref_iertr::future<extent_ref_count_t>;
 
-#ifdef UNIT_TESTS_BUILT
-  /// Add refcount for ref
-  ref_ret inc_ref(
-    Transaction &t,
-    LogicalChildNodeRef &ref);
-
-  /// Add refcount for offset
-  ref_ret inc_ref(
-    Transaction &t,
-    laddr_t offset);
-#endif
-
   /** 
    * remove
    *

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -322,18 +322,7 @@ public:
 
   /// Obtain mutable copy of extent
   LogicalChildNodeRef get_mutable_extent(Transaction &t, LogicalChildNodeRef ref) {
-    LOG_PREFIX(TransactionManager::get_mutable_extent);
-    auto ret = cache->duplicate_for_write(
-      t,
-      ref)->cast<LogicalChildNode>();
-    if (!ret->has_laddr()) {
-      SUBDEBUGT(seastore_tm, "duplicate from {}", t, *ref);
-      ret->set_laddr(ref->get_laddr());
-    } else {
-      assert(ref->is_mutable());
-      assert(&*ref == &*ret);
-    }
-    return ret;
+    return cache->duplicate_for_write(t, ref)->cast<LogicalChildNode>();
   }
 
   using ref_iertr = LBAManager::ref_iertr;

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1043,6 +1043,7 @@ private:
       partial_len,
       [&pref]
       (T &extent) mutable {
+	assert(extent.is_logical());
 	assert(!extent.has_laddr());
 	assert(!extent.has_been_invalidated());
 	assert(!pref.has_been_invalidated());
@@ -1118,6 +1119,7 @@ private:
       direct_key,
       direct_length,
       [&pref](CachedExtent &extent) mutable {
+	assert(extent.is_logical());
 	auto &lextent = static_cast<LogicalChildNode&>(extent);
 	assert(!lextent.has_laddr());
 	assert(!lextent.has_been_invalidated());


### PR DESCRIPTION
Cleanups related to cache, extent and transaction, should be straightforward.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
