### PR TITLE
monitoring: Add script to automate conversion of json to libsonnet

### DIFF
--- a/monitoring/ceph-mixin/README.md
+++ b/monitoring/ceph-mixin/README.md
@@ -67,11 +67,29 @@ alert rules file, developers should include any necessary changes to the MIB.
       `golang-github-google-jsonnet` in fedora
 - Install [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler)
 
-To rebuild all the generated files, you can run `tox -egrafonnet-fix`.
+To rebuild all the generated files, you can run `tox -e jsonnet-fix`.
 
 The jsonnet code located in this directory depends on some Jsonnet third party
 libraries. To update those libraries you can run `jb update` and then update
-the generated files using `tox -egrafonnet-fix`.
+the generated files using `tox -e jsonnet-fix`.
+
+### Building libsonnet from json 
+
+If a new grafana dashboard (or changes in existing one) is added from UI, 
+we need to convert JSON from grafana UI to libsonnet in 
+`monitoring/ceph-mixin/dashboards/`. 
+
+To automatically convert JSON to libsonnet, run this command 
+from `monitoring/ceph-mixin` directory: 
+
+```
+tox -e jsonnet-generate -- dashboards_out/new.json -v
+``` 
+To see all possible functions, run:
+```
+tox -e jsonnet-generate -- --help
+``` 
+
 
 ### Building alerts from `prometheus_alerts.libsonnet`
 

--- a/monitoring/ceph-mixin/grafana-json-to-libsonnet.py
+++ b/monitoring/ceph-mixin/grafana-json-to-libsonnet.py
@@ -1,0 +1,65 @@
+import argparse, textwrap
+from pathlib import Path
+import json
+import sys
+import logging
+from jinja2 import Environment, FileSystemLoader
+
+GRAFANA_TEMPLATE = "grafana-template.libsonnet.j2"
+
+logging.basicConfig(
+    level=logging.INFO, format="%(levelname)s: %(message)s", stream=sys.stdout
+)
+logger = logging.getLogger(__name__)
+
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter, 
+    description=textwrap.dedent("""Tool to convert grafana JSON to libsonnet.
+Example: python3 grafana-libsonnet-to-json.py dashboards_out/test.json --debug
+Example: python3 grafana-libsonnet-to-json.py dashboards_out/test.json -o dashboards/output.libsonnet """),
+)
+parser.add_argument("json_path")
+parser.add_argument("-o", "--output")
+parser.add_argument("-v", "--verbose", action="store_true")
+
+
+def read_json(path):
+    with open(str(path), "r") as f:
+        json_data = json.load(f)
+    return json_data
+
+def write_output(path, data):
+    with open(str(path), "w") as f:
+        f.write(data)
+
+def convert(json_data, json_file_name):
+    env = Environment(loader=FileSystemLoader("."))
+    template = env.get_template(GRAFANA_TEMPLATE)
+    libsonnet_data = template.render(json_data, logger=logger, json_file=json_file_name)
+    return libsonnet_data
+
+def main():
+    cli = parser.parse_args()
+
+    if cli.verbose: 
+            logger.setLevel(logging.DEBUG)
+
+    input_path = cli.json_path 
+    input_path = Path(input_path)
+    if not input_path.exists():
+        raise Exception(f'Cannot find input JSON file at: {input_path}')
+
+    output_path = cli.output
+    if not output_path:
+        output_path = input_path.with_suffix(".libsonnet")
+
+
+    json_data = read_json(str(input_path))
+    libsonnet_data = convert(json_data, input_path.name)
+    write_output(str(output_path), libsonnet_data)
+
+    print(f"Successfully converted! Find output libsonnet at: '{output_path}'.")
+
+main() 
+

--- a/monitoring/ceph-mixin/grafana-template.libsonnet.j2
+++ b/monitoring/ceph-mixin/grafana-template.libsonnet.j2
@@ -1,0 +1,270 @@
+local g = import 'grafonnet/grafana.libsonnet';
+
+
+(import 'utils.libsonnet') {
+  '{{json_file}}': $.dashboardSchema(
+    '{{ title }}',
+    '{{ description }}',
+    "{{ uid }}",
+    "{{ time.from }}",
+    "{{ refresh }}", 
+    "{{ schemaVersion }}",
+    $._config.dashboardTags,
+    ''
+  )
+  {{ logger.debug("Processing annotations...") or "" }}
+{%- for annotate in annotations.get('list') -%}
+  .addAnnotation(
+      $.addAnnotationSchema(
+        {{ annotate.builtIn }},
+        {{ annotate.datasource }},
+        {{ annotate.enable }},
+        {{ annotate.hide }},
+        '{{ annotate.iconColor }}',
+        '{{ annotate.name }}',
+        '{{ annotate.type }}'
+      )
+  )
+{%- endfor -%}
+  {{ logger.debug("Processing links...") or "" }}
+{%- for link in links -%}
+  .addLink(
+      $.addLinkSchema(
+        asDropdown={{ link.get('asDropdown', true) | tojson }},
+        icon='{{ link.get('icon', '') }}',
+        includeVars={{ link.get(includeVars, true) | tojson }},
+        keepTime={{ link.get('keepTime', true) | tojson }},
+        tags={{ link.get('tags', []) }},
+        targetBlank={{ link.get('targetBlank', false) | tojson }},
+        title='{{ link.get('title', '') }}',
+        tooltip='{{ link.get('tooltip', '') }}',
+        type='{{ link.get('type', '') }}',
+        url='{{ link.get('url', '') }}'
+      ),
+  )
+{%- endfor -%}
+{{ logger.debug("Processing templates...") or "" }}
+{%- for template in templating.list -%}
+  {%- if template.type == "datasource" -%}  
+  .addTemplate(
+    g.template.datasource('datasource', 'prometheus', 'default', label='Data Source')
+  )
+  {%- elif template.type == "query" -%}
+  .addTemplate(
+    $.addTemplateSchema(
+      name='{{ template.name }}',
+      datasource='$datasource',
+      query="{{ template.get('query', '') }}",
+      refresh={{ template.refresh }},
+      includeAll={{ template.get('includeAll', true) | tojson }},
+      sort={{ template.sort }},
+      label='{{ template.label }}',
+      regex='{{ template.regex }}',
+      multi={{ template.multi | tojson }},
+      current={{ template.get('current', none) | tojson }}
+    )
+  )
+  {%- endif -%}
+{%- endfor -%}
+
+{{ logger.debug("Processing panels...") or "" }}
+  .addPanels([
+{%- for panel in panels -%}
+{{ logger.debug("Processing " ~ panel.type ~ " panel '" ~ panel.title ~ "'...") or "" }}
+  {%- if panel.type == "row" %}  
+      $.addRowSchema(collapse={{ panel.collapsed | tojson }}, showTitle=true, title='{{ panel.title }}') + { gridPos: { x: {{ panel.gridPos.x }}, y: {{ panel.gridPos.y }}, w: {{ panel.gridPos.w }}, h: {{ panel.gridPos.h }} } }
+  {%- else -%}
+    {% if panel.type == "stat" %}
+      $.addStatPanel(
+        title='{{ panel.title }}',
+        description='{{ panel.description }}',
+        unit='{{ panel.get('options', {}).get('fieldOptions', {}).get('defaults', {}).get('unit', '') | default("", true) }}',
+        datasource='$datasource',
+        gridPosition={ x: {{ panel.gridPos.x }}, y: {{ panel.gridPos.y }}, w: {{ panel.gridPos.w }}, h: {{ panel.gridPos.h }} },
+        colorMode="{{ panel.options.colorMode }}",
+        graphMode="{{ panel.options.graphMode }}",
+        justifyMode="{{ panel.options.justifyMode }}",
+        orientation="{{ panel.options.orientation }}",
+        textMode="{{ panel.options.textMode }}",
+        interval='1m',
+        color={ mode: 'thresholds' },
+        thresholdsMode='{{ panel.get('options', {}).get('fieldOptions', {}).get('defaults', {}).get('thresholds', {}).get('mode', '') }}',
+        noValue={{ panel.fieldConfig.defaults.get('noValue', none) | tojson }},
+      )
+    {%- elif panel.type == "bargauge" %}
+      $.addBarGaugePanel(
+        title='{{ panel.title }}',
+        description='{{ panel.description }}',
+        datasource='${datasource}',
+        gridPosition={ x: {{ panel.gridPos.x }}, y: {{ panel.gridPos.y }}, w: {{ panel.gridPos.w }}, h: {{ panel.gridPos.h }} },
+        unit='{{ panel.get('fieldConfig', {}).get('defaults', {}).get('unit', '') | default("", true) }}',
+        {%- if panel.get('fieldConfig', {}).get('defaults', {}).get('thresholds', {}) %}
+        thresholds={ 
+          mode: '{{ panel.get('fieldConfig', {}).get('defaults', {}).get('thresholds', {}).get('mode', '') }}',
+          steps: [
+          {%- for step in panel.fieldConfig.defaults.thresholds.steps  %}
+            { color: '{{ step.color }}', value: {{ step.get('value', none) | tojson }} },
+          {%- endfor %}
+          ]
+        },
+        {%- endif %}
+      )
+    {%- elif panel.type == "timeseries" %}
+      $.timeSeriesPanel( 
+        title='{{ panel.title }}',
+        description='{{ panel.description }}',
+        gridPosition={ x: {{ panel.gridPos.x }}, y: {{ panel.gridPos.y }}, w: {{ panel.gridPos.w }}, h: {{ panel.gridPos.h }} },
+        lineInterpolation='{{ panel.fieldConfig.defaults.custom.lineInterpolation }}',
+        lineWidth={{ panel.fieldConfig.defaults.custom.lineWidth }},
+        drawStyle='{{ panel.fieldConfig.defaults.custom.drawStyle }}',
+        axisPlacement='{{ panel.fieldConfig.defaults.custom.axisPlacement }}',
+        datasource='$datasource',
+        fillOpacity={{ panel.fieldConfig.defaults.custom.fillOpacity }},
+        pointSize={{ panel.fieldConfig.defaults.custom.pointSize }},
+        showPoints='{{ panel.fieldConfig.defaults.custom.showPoints }}',
+        unit='{{ panel.fieldConfig.defaults.unit }}',
+        displayMode='{{ panel.options.legend.displayMode }}',
+        showLegend={{ panel.options.legend.showLegend | tojson }},
+        placement='{{ panel.options.legend.placement }}',
+        tooltip={{ panel.options.tooltip }},
+        stackingMode='{{ panel.fieldConfig.defaults.custom.get('stacking', {}).get('mode', '') }}',
+        spanNulls={{ panel.fieldConfig.defaults.custom.spanNulls | tojson }},
+        decimals={{ panel.fieldConfig.defaults.get('decimals', none) | tojson  }},
+        thresholdsMode='{{ panel.fieldConfig.defaults.thresholds.mode }}',
+        noValue={{ panel.fieldConfig.defaults.get('noValue', none) | tojson }},
+      )
+    {%- elif panel.type == "table" %}
+      $.addTableExtended(
+        title='{{ panel.title }}',
+        datasource='$datasource',
+        gridPosition={ x: {{ panel.gridPos.x }}, y: {{ panel.gridPos.y }}, w: {{ panel.gridPos.w }}, h: {{ panel.gridPos.h }} },
+        color={{ panel.fieldConfig.defaults.color }},
+        options={{ panel.options | tojson }},
+        custom={{ panel.fieldConfig.defaults.custom | tojson }},
+        thresholds={{ panel.fieldConfig.defaults.thresholds | tojson }},
+        overrides={{ panel.fieldConfig.get('overrides', {}) | tojson }},
+      )
+    {%- elif panel.type == "piechart" %}
+      $.pieChartPanel(
+        title='{{ panel.title }}',
+        description='{{ panel.description }}',
+        datasource='$datasource',
+        gridPos={ x: {{ panel.gridPos.x }}, y: {{ panel.gridPos.y }}, w: {{ panel.gridPos.w }}, h: {{ panel.gridPos.h }} },
+        displayMode='{{ panel.options.legend.displayMode }}',
+        placement='{{ panel.options.legend.placement }}',
+        showLegend={{ panel.options.legend.showLegend | tojson }},
+        displayLabels={{ panel.options.displayLabels }},
+        tooltip={{ panel.options.tooltip }}, 
+        pieType='{{ panel.options.pieType }}',
+        values={{ panel.options.legend.get('values', []) }},
+        colorMode='{{ panel.fieldConfig.defaults.get('color', {}).get('mode', '') }}',
+        overrides={{ panel.fieldConfig.overrides }},
+        reduceOptions={{ panel.options.reduceOptions | tojson }}
+      )
+    {%- elif panel.type == "alertlist" %}
+      $.addAlertListPanel(
+        title='{{ panel.title }}',
+        datasource={
+          type: 'datasource',
+          uid: 'grafana',
+        },
+        gridPosition={ x: {{ panel.gridPos.x }}, y: {{ panel.gridPos.y }}, w: {{ panel.gridPos.w }}, h: {{ panel.gridPos.h }} },
+        alertInstanceLabelFilter='{{ panel.alertInstanceLabelFilter }}',
+        alertName='{{ panel.options.get('alertName', '') }}',
+        dashboardAlerts={{ panel.options.get('dashboardAlerts', false) | tojson }},
+        groupBy={{ panel.options.get('groupBy', '') }},
+        groupMode='{{ panel.options.get('groupMode', '') }}',
+        maxItems={{ panel.options.get('maxItems', '') }},
+        sortOrder={{ panel.options.get('sortOrder', '') }},
+        stateFilter={{ panel.options.get('stateFilter', {}) | tojson }},
+      )
+    {%- else %}
+{{ logger.warning("ALERT!! grafana-template.libsonnet.j2 is missing support for " ~ panel.type ~ " type panel!") or "" }}
+TODO: {{ panel.type }}
+    {%- endif %}
+      {%- if panel.type not in ["bargauge", "table"] and panel.get('fieldConfig', {}).get('defaults', {}).get('thresholds', {}).get('steps', []) -%}
+      .addThresholds([
+      {%- for threshold in panel.get('fieldConfig', {}).get('defaults', {}).get('thresholds', {}).get('steps', []) %}
+        { color: '{{ threshold.color }}', value: {{ threshold.get('value', none) | tojson }} },
+      {%- endfor %}
+      ])
+      {%- endif -%}
+      {%- if panel.get('options', {}).get('fieldOptions', {}).get('defaults', {}).get('mappings', []) -%}
+      .addMappings([
+      {%- for mapping in panel.get('options', {}).get('fieldOptions', {}).get('defaults', {}).get('mappings', []) %}
+        { 
+          options: { 
+            match: null, 
+            result: { 
+              index: {{ mapping.options.result.index }}, 
+              text: '{{ mapping.options.result.text }}',
+              {%- if mapping.options.result.get('color', '') %}
+              color: '{{ mapping.options.result.color }}',
+              {%- endif %}
+            } 
+          }, 
+          type: '{{ mapping.type }}' 
+        },
+      {%- endfor %}
+      ])
+      {%- endif -%}
+      {%- for target in panel.get('targets', []) %}
+      .addTarget(
+        $.addTargetSchema(
+          expr="{{ target.get('expr', '') }}",
+          format='{{ target.get('format', '') }}',
+          instant={{ target.get('instant', none) | tojson }},
+          legendFormat="{{ target.get('legendFormat', '') | tojson }}",
+          range={{ target.get('range', true) | tojson }},
+          datasource='$datasource',
+        )
+      )
+      {%- endfor %}
+      {%- if panel.get('transformations', []) and panel.type == "table" -%}
+      .addTransformations(
+        {{ panel.transformations | tojson }}
+      )
+      {%- endif -%}
+      {%- if panel.get('fieldConfig', {}).get('overrides', {}) and panel.type not in ["bargauge", "table"] %}
+      .addOverrides([
+      {%- for override in panel.get('fieldConfig', {}).get('overrides', {}) %}
+        {
+          matcher: { id: '{{ override.matcher.id }}', options: '{{ override.matcher.options }}' },
+          properties: [
+          {%- for props in override.properties %}
+            {
+              id: '{{ props.id }}',
+              {%- if props.id == 'color' %}
+              value: { 
+                fixedColor: '{{ props.value.fixedColor }}', 
+                mode: '{{ props.value.mode }}' 
+              },
+              {%- elif props.id == 'links' %}
+              value: [
+                {%- for v in props.value %}
+                {
+                  title: {{ v.get('title', '') | tojson }},
+                  url: '{{ v.url }}'
+                },
+                {%- endfor %}
+              ], 
+              {%- else %}
+              value: {{ props.value | tojson }}
+              {%- endif %}
+            },
+          {%- endfor %}
+          ],
+        },
+      {%- endfor %}
+      ])
+      {%- endif %}
+      {%- if panel.type == "bargauge" %}
+      + { fieldConfig: {{ panel.fieldConfig | tojson }}, options: {{ panel.options | tojson }} }
+      {%- endif %}
+  {%- endif -%}
+  ,
+{% endfor %}
+  ])
+
+{{ logger.debug("Processed all.") or "" }}
+}

--- a/monitoring/ceph-mixin/requirements-grafonnet.txt
+++ b/monitoring/ceph-mixin/requirements-grafonnet.txt
@@ -1,1 +1,2 @@
 jsondiff
+jinja2

--- a/monitoring/ceph-mixin/tox.ini
+++ b/monitoring/ceph-mixin/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    jsonnet-{check,lint,fix},
+    jsonnet-{check,lint,fix-generate},
     jsonnet-bundler-{install,update},
     promql-query-{test,lint},
     alerts-{fix,check,lint,test}
@@ -18,7 +18,7 @@ commands =
     install: jb install
     update: jb update
 
-[testenv:jsonnet-{check,fix,lint}]
+[testenv:jsonnet-{check,fix,lint,generate}]
 basepython = python3
 allowlist_externals =
     find
@@ -31,6 +31,7 @@ description =
     check: Ensure that auto-generated files matches the current version
     fix: Update generated files from jsonnet file with latest changes
     lint: Test if jsonnet files are linted (without any update)
+    generate: Convert grafana JSON to jsonnet 
 deps =
     -rrequirements-grafonnet.txt
 depends = jsonnet-bundler-install
@@ -38,6 +39,7 @@ commands =
     check: sh test-jsonnet.sh
     lint: ./lint-jsonnet.sh --test
     fix: jsonnet -J vendor -m dashboards_out dashboards.jsonnet
+    generate: python3 grafana-json-to-libsonnet.py {posargs} 
 
 [testenv:lint]
 description =


### PR DESCRIPTION
Add template to convert json to libsonnet:
grafana-template.libsonnet.j2

Add python script which uses this template:
grafana-json-to-libsonnet.py





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
