### PR TITLE
reef: rgw/iam: add policy evaluation for Arn-based Conditions

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -19,6 +19,8 @@
   Related trackers:
    - https://tracker.ceph.com/issues/67179
    - https://tracker.ceph.com/issues/66867
+* RGW: IAM policy evaluation now supports conditions ArnEquals and ArnLike, along
+  with their Not and IfExists variants.
 
 >=18.2.4
 --------

--- a/src/rgw/rgw_arn.cc
+++ b/src/rgw/rgw_arn.cc
@@ -328,15 +328,15 @@ bool ARN::match(const ARN& candidate) const {
     return false;
   }
 
-  if (!match_policy(region, candidate.region, MATCH_POLICY_ARN)) {
+  if (!match_wildcards(region, candidate.region, MATCH_CASE_INSENSITIVE)) {
     return false;
   }
 
-  if (!match_policy(account, candidate.account, MATCH_POLICY_ARN)) {
+  if (!match_wildcards(account, candidate.account, MATCH_CASE_INSENSITIVE)) {
     return false;
   }
 
-  if (!match_policy(resource, candidate.resource, MATCH_POLICY_RESOURCE)) {
+  if (!match_wildcards(resource, candidate.resource, 0)) {
     return false;
   }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2156,7 +2156,7 @@ int rgw_parse_op_type_list(const string& str, uint32_t *perm)
 bool match_policy(const std::string& pattern, const std::string& input,
                   uint32_t flag)
 {
-  const uint32_t flag2 = flag & (MATCH_POLICY_ACTION|MATCH_POLICY_ARN) ?
+  const uint32_t flag2 = (flag & MATCH_POLICY_ACTION) ?
       MATCH_CASE_INSENSITIVE : 0;
 
   std::string_view::size_type last_pos_input = 0, last_pos_pattern = 0;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2158,15 +2158,11 @@ bool match_policy(const std::string& pattern, const std::string& input,
 {
   const uint32_t flag2 = flag & (MATCH_POLICY_ACTION|MATCH_POLICY_ARN) ?
       MATCH_CASE_INSENSITIVE : 0;
-  const bool colonblocks = !(flag & (MATCH_POLICY_RESOURCE |
-				     MATCH_POLICY_STRING));
 
-  const auto npos = std::string_view::npos;
   std::string_view::size_type last_pos_input = 0, last_pos_pattern = 0;
   while (true) {
-    auto cur_pos_input = colonblocks ? input.find(":", last_pos_input) : npos;
-    auto cur_pos_pattern =
-      colonblocks ? pattern.find(":", last_pos_pattern) : npos;
+    auto cur_pos_input = input.find(":", last_pos_input);
+    auto cur_pos_pattern = pattern.find(":", last_pos_pattern);
 
     auto substr_input = input.substr(last_pos_input, cur_pos_input);
     auto substr_pattern = pattern.substr(last_pos_pattern, cur_pos_pattern);
@@ -2174,9 +2170,9 @@ bool match_policy(const std::string& pattern, const std::string& input,
     if (!match_wildcards(substr_pattern, substr_input, flag2))
       return false;
 
-    if (cur_pos_pattern == npos)
-      return cur_pos_input == npos;
-    if (cur_pos_input == npos)
+    if (cur_pos_pattern == pattern.npos)
+      return cur_pos_input == input.npos;
+    if (cur_pos_input == input.npos)
       return false;
 
     last_pos_pattern = cur_pos_pattern + 1;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1753,9 +1753,7 @@ extern std::string calc_hash_sha256_restart_stream(ceph::crypto::SHA256** phash)
 extern int rgw_parse_op_type_list(const std::string& str, uint32_t *perm);
 
 static constexpr uint32_t MATCH_POLICY_ACTION = 0x01;
-static constexpr uint32_t MATCH_POLICY_RESOURCE = 0x02;
-static constexpr uint32_t MATCH_POLICY_ARN = 0x04;
-static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
+static constexpr uint32_t MATCH_POLICY_ARN = 0x02;
 
 extern bool match_policy(const std::string& pattern, const std::string& input,
                          uint32_t flag);

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -1271,15 +1271,6 @@ TEST(MatchPolicy, Action)
   EXPECT_FALSE(match_policy("a:*", "a:b:c", flag)); // cannot span segments
 }
 
-TEST(MatchPolicy, Resource)
-{
-  constexpr auto flag = MATCH_POLICY_RESOURCE;
-  EXPECT_TRUE(match_policy("a:b:c", "a:b:c", flag));
-  EXPECT_FALSE(match_policy("a:b:c", "A:B:C", flag)); // case sensitive
-  EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
-  EXPECT_TRUE(match_policy("a:*", "a:b:c", flag)); // can span segments
-}
-
 TEST(MatchPolicy, ARN)
 {
   constexpr auto flag = MATCH_POLICY_ARN;
@@ -1287,15 +1278,6 @@ TEST(MatchPolicy, ARN)
   EXPECT_TRUE(match_policy("a:b:c", "A:B:C", flag)); // case insensitive
   EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
   EXPECT_FALSE(match_policy("a:*", "a:b:c", flag)); // cannot span segments
-}
-
-TEST(MatchPolicy, String)
-{
-  constexpr auto flag = MATCH_POLICY_STRING;
-  EXPECT_TRUE(match_policy("a:b:c", "a:b:c", flag));
-  EXPECT_FALSE(match_policy("a:b:c", "A:B:C", flag)); // case sensitive
-  EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
-  EXPECT_TRUE(match_policy("a:*", "a:b:c", flag)); // can span segments
 }
 
 Action_t set_range_bits(std::uint64_t start, std::uint64_t end)

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -1275,7 +1275,7 @@ TEST(MatchPolicy, ARN)
 {
   constexpr auto flag = MATCH_POLICY_ARN;
   EXPECT_TRUE(match_policy("a:b:c", "a:b:c", flag));
-  EXPECT_TRUE(match_policy("a:b:c", "A:B:C", flag)); // case insensitive
+  EXPECT_FALSE(match_policy("a:b:c", "A:B:C", flag)); // case sensitive
   EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
   EXPECT_FALSE(match_policy("a:*", "a:b:c", flag)); // cannot span segments
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70595

---

backport of https://github.com/ceph/ceph/pull/62285
parent tracker: https://tracker.ceph.com/issues/70481

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh