### PR TITLE
librbd: migrate from boost::variant to std::variant

### DIFF
--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -205,7 +205,7 @@ struct GetTagsRequest {
     }
 
     journal::ImageClientMeta *image_client_meta =
-      boost::get<journal::ImageClientMeta>(&client_data.client_meta);
+      std::get_if<journal::ImageClientMeta>(&client_data.client_meta);
     if (image_client_meta == nullptr) {
       lderr(cct) << this << " OpenJournalerRequest::" << __func__ << ": "
                  << "failed to get client meta" << dendl;
@@ -1768,7 +1768,7 @@ int Journal<I>::check_resync_requested(bool *do_resync) {
   }
 
   journal::ImageClientMeta *image_client_meta =
-    boost::get<journal::ImageClientMeta>(&client_data.client_meta);
+    std::get_if<journal::ImageClientMeta>(&client_data.client_meta);
   if (image_client_meta == nullptr) {
     lderr(cct) << this << " " << __func__ << ": "
                << "failed to access image client meta struct" << dendl;

--- a/src/librbd/journal/OpenRequest.cc
+++ b/src/librbd/journal/OpenRequest.cc
@@ -83,7 +83,7 @@ void OpenRequest<I>::handle_init(int r) {
   }
 
   journal::ImageClientMeta *image_client_meta =
-    boost::get<journal::ImageClientMeta>(&client_data.client_meta);
+    std::get_if<journal::ImageClientMeta>(&client_data.client_meta);
   if (image_client_meta == nullptr) {
     lderr(cct) << this << " " << __func__ << ": "
                << "failed to extract client meta data" << dendl;

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -220,8 +220,8 @@ void Replay<I>::process(const EventEntry &event_entry,
     return;
   }
 
-  boost::apply_visitor(EventVisitor(this, on_ready, on_safe),
-                       event_entry.event);
+  std::visit(EventVisitor(this, on_ready, on_safe),
+             event_entry.event);
 }
 
 template <typename I>

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -16,7 +16,7 @@ using ceph::decode;
 namespace {
 
 template <typename E>
-class GetTypeVisitor : public boost::static_visitor<E> {
+class GetTypeVisitor {
 public:
   template <typename T>
   inline E operator()(const T&) const {
@@ -24,7 +24,7 @@ public:
   }
 };
 
-class EncodeVisitor : public boost::static_visitor<void> {
+class EncodeVisitor {
 public:
   explicit EncodeVisitor(bufferlist &bl) : m_bl(bl) {
   }
@@ -38,7 +38,7 @@ private:
   bufferlist &m_bl;
 };
 
-class DecodeVisitor : public boost::static_visitor<void> {
+class DecodeVisitor {
 public:
   DecodeVisitor(__u8 version, bufferlist::const_iterator &iter)
     : m_version(version), m_iter(iter) {
@@ -53,7 +53,7 @@ private:
   bufferlist::const_iterator &m_iter;
 };
 
-class DumpVisitor : public boost::static_visitor<void> {
+class DumpVisitor {
 public:
   explicit DumpVisitor(Formatter *formatter, const std::string &key)
     : m_formatter(formatter), m_key(key) {}
@@ -411,12 +411,12 @@ void UnknownEvent::dump(Formatter *f) const {
 }
 
 EventType EventEntry::get_event_type() const {
-  return boost::apply_visitor(GetTypeVisitor<EventType>(), event);
+  return std::visit(GetTypeVisitor<EventType>(), event);
 }
 
 void EventEntry::encode(bufferlist& bl) const {
   ENCODE_START(5, 1, bl);
-  boost::apply_visitor(EncodeVisitor(bl), event);
+  std::visit(EncodeVisitor(bl), event);
   ENCODE_FINISH(bl);
   encode_metadata(bl);
 }
@@ -494,7 +494,7 @@ void EventEntry::decode(bufferlist::const_iterator& it) {
     break;
   }
 
-  boost::apply_visitor(DecodeVisitor(struct_v, it), event);
+  std::visit(DecodeVisitor(struct_v, it), event);
   DECODE_FINISH(it);
   if (struct_v >= 4) {
     decode_metadata(it);
@@ -502,7 +502,7 @@ void EventEntry::decode(bufferlist::const_iterator& it) {
 }
 
 void EventEntry::dump(Formatter *f) const {
-  boost::apply_visitor(DumpVisitor(f, "event_type"), event);
+  std::visit(DumpVisitor(f, "event_type"), event);
   f->dump_stream("timestamp") << timestamp;
 }
 
@@ -689,12 +689,12 @@ void UnknownClientMeta::dump(Formatter *f) const {
 }
 
 ClientMetaType ClientData::get_client_meta_type() const {
-  return boost::apply_visitor(GetTypeVisitor<ClientMetaType>(), client_meta);
+  return std::visit(GetTypeVisitor<ClientMetaType>(), client_meta);
 }
 
 void ClientData::encode(bufferlist& bl) const {
   ENCODE_START(2, 1, bl);
-  boost::apply_visitor(EncodeVisitor(bl), client_meta);
+  std::visit(EncodeVisitor(bl), client_meta);
   ENCODE_FINISH(bl);
 }
 
@@ -720,12 +720,12 @@ void ClientData::decode(bufferlist::const_iterator& it) {
     break;
   }
 
-  boost::apply_visitor(DecodeVisitor(struct_v, it), client_meta);
+  std::visit(DecodeVisitor(struct_v, it), client_meta);
   DECODE_FINISH(it);
 }
 
 void ClientData::dump(Formatter *f) const {
-  boost::apply_visitor(DumpVisitor(f, "client_meta_type"), client_meta);
+  std::visit(DumpVisitor(f, "client_meta_type"), client_meta);
 }
 
 void ClientData::generate_test_instances(std::list<ClientData *> &o) {

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -13,9 +13,9 @@
 #include "librbd/Types.h"
 #include <iosfwd>
 #include <list>
+#include <variant>
 #include <boost/none.hpp>
 #include <boost/optional.hpp>
-#include <boost/variant.hpp>
 #include <boost/mpl/vector.hpp>
 
 namespace ceph {
@@ -410,7 +410,7 @@ struct UnknownEvent {
   void dump(Formatter *f) const;
 };
 
-typedef boost::mpl::vector<AioDiscardEvent,
+using Event = std::variant<AioDiscardEvent,
                            AioWriteEvent,
                            AioFlushEvent,
                            OpFinishEvent,
@@ -430,8 +430,7 @@ typedef boost::mpl::vector<AioDiscardEvent,
                            MetadataRemoveEvent,
                            AioWriteSameEvent,
                            AioCompareAndWriteEvent,
-                           UnknownEvent> EventVector;
-typedef boost::make_variant_over<EventVector>::type Event;
+                           UnknownEvent>;
 
 struct EventEntry {
   static uint32_t get_fixed_size() {
@@ -575,10 +574,10 @@ struct UnknownClientMeta {
   void dump(Formatter *f) const;
 };
 
-typedef boost::variant<ImageClientMeta,
-                       MirrorPeerClientMeta,
-                       CliClientMeta,
-                       UnknownClientMeta> ClientMeta;
+using ClientMeta = std::variant<ImageClientMeta,
+                                MirrorPeerClientMeta,
+                                CliClientMeta,
+                                UnknownClientMeta>;
 
 struct ClientData {
   ClientData() {

--- a/src/librbd/mirror/DisableRequest.cc
+++ b/src/librbd/mirror/DisableRequest.cc
@@ -258,7 +258,7 @@ Context *DisableRequest<I>::handle_get_clients(int *result) {
     m_ret[client.id] = 0;
 
     journal::MirrorPeerClientMeta client_meta =
-      boost::get<journal::MirrorPeerClientMeta>(client_data.client_meta);
+      std::get<journal::MirrorPeerClientMeta>(client_data.client_meta);
 
     for (const auto& sync : client_meta.sync_points) {
       send_remove_snap(client.id, sync.snap_namespace, sync.snap_name);

--- a/src/test/librbd/journal/test_Entries.cc
+++ b/src/test/librbd/journal/test_Entries.cc
@@ -13,7 +13,6 @@
 #include "journal/ReplayHandler.h"
 #include "journal/Settings.h"
 #include <list>
-#include <boost/variant.hpp>
 
 void register_test_journal_entries() {
 }
@@ -147,7 +146,7 @@ TEST_F(TestJournalEntries, AioWrite) {
             event_entry.get_event_type());
 
   librbd::journal::AioWriteEvent aio_write_event =
-    boost::get<librbd::journal::AioWriteEvent>(event_entry.event);
+    std::get<librbd::journal::AioWriteEvent>(event_entry.event);
   ASSERT_EQ(123U, aio_write_event.offset);
   ASSERT_EQ(buffer.size(), aio_write_event.length);
 
@@ -191,7 +190,7 @@ TEST_F(TestJournalEntries, AioDiscard) {
             event_entry.get_event_type());
 
   librbd::journal::AioDiscardEvent aio_discard_event =
-    boost::get<librbd::journal::AioDiscardEvent>(event_entry.event);
+    std::get<librbd::journal::AioDiscardEvent>(event_entry.event);
   ASSERT_EQ(123U, aio_discard_event.offset);
   ASSERT_EQ(234U, aio_discard_event.length);
 }
@@ -251,7 +250,7 @@ TEST_F(TestJournalEntries, AioDiscardWithPrune) {
               event_entry.get_event_type());
 
     librbd::journal::AioDiscardEvent aio_discard_event =
-      boost::get<librbd::journal::AioDiscardEvent>(event_entry.event);
+      std::get<librbd::journal::AioDiscardEvent>(event_entry.event);
     ASSERT_EQ(offset, aio_discard_event.offset);
     ASSERT_EQ(size, aio_discard_event.length);
 

--- a/src/test/rbd_mirror/image_replayer/journal/test_mock_EventPreprocessor.cc
+++ b/src/test/rbd_mirror/image_replayer/journal/test_mock_EventPreprocessor.cc
@@ -163,7 +163,7 @@ TEST_F(TestMockImageReplayerJournalEventPreprocessor, PreprocessSnapRename) {
   ASSERT_EQ(expected_snap_seqs, m_client_meta.snap_seqs);
 
   librbd::journal::SnapRenameEvent *event =
-    boost::get<librbd::journal::SnapRenameEvent>(&event_entry.event);
+    std::get_if<librbd::journal::SnapRenameEvent>(&event_entry.event);
   ASSERT_EQ(6U, event->snap_id);
 }
 
@@ -186,7 +186,7 @@ TEST_F(TestMockImageReplayerJournalEventPreprocessor, PreprocessSnapRenameMissin
   ASSERT_EQ(-ENOENT, ctx.wait());
 
   librbd::journal::SnapRenameEvent *event =
-    boost::get<librbd::journal::SnapRenameEvent>(&event_entry.event);
+    std::get_if<librbd::journal::SnapRenameEvent>(&event_entry.event);
   ASSERT_EQ(CEPH_NOSNAP, event->snap_id);
 }
 
@@ -215,7 +215,7 @@ TEST_F(TestMockImageReplayerJournalEventPreprocessor, PreprocessSnapRenameKnown)
   ASSERT_EQ(expected_snap_seqs, m_client_meta.snap_seqs);
 
   librbd::journal::SnapRenameEvent *event =
-    boost::get<librbd::journal::SnapRenameEvent>(&event_entry.event);
+    std::get_if<librbd::journal::SnapRenameEvent>(&event_entry.event);
   ASSERT_EQ(6U, event->snap_id);
 }
 

--- a/src/tools/rbd_mirror/image_replayer/Utils.cc
+++ b/src/tools/rbd_mirror/image_replayer/Utils.cc
@@ -42,7 +42,7 @@ bool decode_client_meta(const cls::journal::Client& client,
     return false;
   }
 
-  auto local_client_meta = boost::get<librbd::journal::MirrorPeerClientMeta>(
+  auto local_client_meta = std::get_if<librbd::journal::MirrorPeerClientMeta>(
     &client_data.client_meta);
   if (local_client_meta == nullptr) {
     derr << "unknown peer registration" << dendl;

--- a/src/tools/rbd_mirror/image_replayer/journal/EventPreprocessor.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/EventPreprocessor.cc
@@ -11,7 +11,6 @@
 #include "librbd/Utils.h"
 #include "librbd/asio/ContextWQ.h"
 #include "librbd/journal/Types.h"
-#include <boost/variant.hpp>
 
 #include <shared_mutex> // for std::shared_lock
 
@@ -95,8 +94,8 @@ void EventPreprocessor<I>::preprocess_event() {
   m_snap_seqs = m_client_meta->snap_seqs;
   m_snap_seqs_updated = prune_snap_map(&m_snap_seqs);
 
-  int r = boost::apply_visitor(PreprocessEventVisitor(this),
-                               m_event_entry->event);
+  int r = std::visit(PreprocessEventVisitor(this),
+                     m_event_entry->event);
   if (r < 0) {
     finish(r);
     return;

--- a/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/PrepareReplayRequest.cc
@@ -162,7 +162,7 @@ void PrepareReplayRequest<I>::handle_get_remote_tag_class(int r) {
   }
 
   librbd::journal::ImageClientMeta *client_meta =
-    boost::get<librbd::journal::ImageClientMeta>(&client_data.client_meta);
+    std::get_if<librbd::journal::ImageClientMeta>(&client_data.client_meta);
   if (client_meta == nullptr) {
     derr << "unknown remote client registration" << dendl;
     finish(-EINVAL);


### PR DESCRIPTION
migrate from boost::variant to std::variant

Complete migration started in commit 017f3339c, replacing boost::variant with std::variant throughout the librbd codebase. This change is part of our ongoing effort to reduce third-party dependencies by leveraging C++ standard library alternatives where possible.

Benefits include:
- Improved code readability and maintainability
- Reduced external dependency surface
- More consistent API usage with other components





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
