### PR TITLE
mgr/dashboard: upgrading nvmeof doesn't update configuration

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -171,7 +171,7 @@ class NvmeofService(CephService):
                         'prefix': 'dashboard nvmeof-gateway-add',
                         'inbuf': service_url,
                         'name': service_name,
-                        'group': spec.group,
+                        'group': spec.group if spec.group else '',
                         'daemon_name': dd.name()
                     })
             return cmd_dicts

--- a/src/pybind/mgr/dashboard/services/nvmeof_conf.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_conf.py
@@ -55,13 +55,19 @@ class NvmeofGatewaysConfig(object):
         config = cls.get_gateways_config()
 
         if name in config.get('gateways', {}):
-            existing_gateways = config['gateways'][name]
-            for gateway in existing_gateways:
-                if 'daemon_name' not in gateway:
-                    gateway['daemon_name'] = daemon_name
-                    break
-                if gateway['service_url'] == service_url:
-                    return
+            # the nvmeof dashboard config used in v19.2.0 saves the below
+            # to a dict. Converting that to a list so that the upgrade
+            # properly migrate it to the newer format, and also keep it empty.
+            if isinstance(config['gateways'][name], dict):
+                config['gateways'][name] = []
+            else:
+                existing_gateways = config['gateways'][name]
+                for gateway in existing_gateways:
+                    if 'daemon_name' not in gateway:
+                        gateway['daemon_name'] = daemon_name
+                        break
+                    if gateway['service_url'] == service_url:
+                        return
 
         new_gateway = {
             'service_url': service_url,

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -73,6 +73,10 @@ class KVStoreMockMixin(object):
     def get_key(cls, key):
         return cls.CONFIG_KEY_DICT.get(key, None)
 
+    @classmethod
+    def set_key(cls, key, value):
+        cls.CONFIG_KEY_DICT[key] = value
+
 
 # pylint: disable=protected-access
 class CLICommandTestMixin(KVStoreMockMixin):

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_cli.py
@@ -1,10 +1,13 @@
 import errno
+import json
+import unittest
 from unittest.mock import MagicMock
 
 import pytest
 from mgr_module import CLICommand, HandleCommandResult
 
 from ..services.nvmeof_cli import NvmeofCLICommand
+from ..tests import CLICommandTestMixin
 
 
 @pytest.fixture(scope="class", name="sample_command")
@@ -85,3 +88,176 @@ class TestNvmeofCLICommand:
         assert result.stdout == ''
         assert result.stderr == ''
         base_call_return_none_mock.assert_called_once()
+
+
+class TestNVMeoFConfCLI(unittest.TestCase, CLICommandTestMixin):
+    def setUp(self):
+        self.mock_kv_store()
+
+    def test_cli_add_gateway(self):
+
+        self.exec_cmd(
+            'nvmeof-gateway-add',
+            name='nvmeof.pool.group',
+            inbuf='http://nvmf:port',
+            daemon_name='nvmeof_daemon',
+            group='group'
+        )
+
+        config = json.loads(self.get_key('_nvmeof_config'))
+        self.assertEqual(
+            config['gateways'], {
+                'nvmeof.pool.group': [{
+                    'group': 'group',
+                    'daemon_name': 'nvmeof_daemon',
+                    'service_url': 'http://nvmf:port'
+                }]
+            }
+        )
+
+    def test_cli_migration_from_legacy_config(self):
+        legacy_config = json.dumps({
+            'gateways': {
+                'nvmeof.pool': {
+                    'service_url': 'http://nvmf:port'
+                }
+            }
+        })
+        self.set_key('_nvmeof_config', legacy_config)
+
+        self.exec_cmd(
+            'nvmeof-gateway-add',
+            name='nvmeof.pool',
+            inbuf='http://nvmf:port',
+            daemon_name='nvmeof_daemon',
+            group=''
+        )
+
+        config = json.loads(self.get_key('_nvmeof_config'))
+        self.assertEqual(
+            config['gateways'], {
+                'nvmeof.pool': [{
+                    'daemon_name': 'nvmeof_daemon',
+                    'group': '',
+                    'service_url': 'http://nvmf:port'
+                }]
+            }
+        )
+
+    def test_cli_add_gw_to_existing(self):
+        # add first gw
+        self.exec_cmd(
+            'nvmeof-gateway-add',
+            name='nvmeof.pool',
+            inbuf='http://nvmf:port',
+            daemon_name='nvmeof_daemon',
+            group=''
+        )
+
+        # add another daemon to the first gateway
+        self.exec_cmd(
+            'nvmeof-gateway-add',
+            name='nvmeof.pool',
+            inbuf='http://nvmf-2:port',
+            daemon_name='nvmeof_daemon_2',
+            group=''
+        )
+
+        config = json.loads(self.get_key('_nvmeof_config'))
+
+        # make sure its appended to the existing gateway
+        self.assertEqual(
+            config['gateways'], {
+                'nvmeof.pool': [{
+                    'daemon_name': 'nvmeof_daemon',
+                    'group': '',
+                    'service_url': 'http://nvmf:port'
+                }, {
+                    'daemon_name': 'nvmeof_daemon_2',
+                    'group': '',
+                    'service_url': 'http://nvmf-2:port'
+                }]
+            }
+        )
+
+    def test_cli_add_new_gw(self):
+        # add first config
+        self.exec_cmd(
+            'nvmeof-gateway-add',
+            name='nvmeof.pool',
+            inbuf='http://nvmf:port',
+            daemon_name='nvmeof_daemon',
+            group=''
+        )
+
+        # add another gateway
+        self.exec_cmd(
+            'nvmeof-gateway-add',
+            name='nvmeof2.pool.group',
+            inbuf='http://nvmf-2:port',
+            daemon_name='nvmeof_daemon_2',
+            group='group'
+        )
+
+        config = json.loads(self.get_key('_nvmeof_config'))
+
+        # make sure its added as a new entry
+        self.assertEqual(
+            config['gateways'], {
+                'nvmeof.pool': [{
+                    'daemon_name': 'nvmeof_daemon',
+                    'group': '',
+                    'service_url': 'http://nvmf:port'
+                }],
+                'nvmeof2.pool.group': [{
+                    'daemon_name': 'nvmeof_daemon_2',
+                    'group': 'group',
+                    'service_url': 'http://nvmf-2:port'
+                }]
+            }
+        )
+
+    def test_cli_rm_gateway(self):
+        self.test_cli_add_gateway()
+        self.exec_cmd('nvmeof-gateway-rm', name='nvmeof.pool.group')
+
+        config = json.loads(self.get_key('_nvmeof_config'))
+        self.assertEqual(
+            config['gateways'], {}
+        )
+
+    def test_cli_rm_daemon_from_gateway(self):
+        self.test_cli_add_gw_to_existing()
+        self.exec_cmd(
+            'nvmeof-gateway-rm',
+            name='nvmeof.pool',
+            daemon_name='nvmeof_daemon'
+        )
+
+        config = json.loads(self.get_key('_nvmeof_config'))
+        self.assertEqual(
+            config['gateways'], {
+                'nvmeof.pool': [{
+                    'daemon_name': 'nvmeof_daemon_2',
+                    'group': '',
+                    'service_url': 'http://nvmf-2:port'
+                }]
+            }
+        )
+
+    def test_cli_legacy_config_rm(self):
+        legacy_config = json.dumps({
+            'gateways': {
+                'nvmeof.pool': {
+                    'service_url': 'http://nvmf:port'
+                }
+            }
+        })
+        self.set_key('_nvmeof_config', legacy_config)
+
+        self.exec_cmd('nvmeof-gateway-rm', name='nvmeof.pool')
+
+        config = json.loads(self.get_key('_nvmeof_config'))
+        self.assertEqual(
+            config['gateways'], {}
+        )


### PR DESCRIPTION
Happens from 19.2.0 to any of the latest upgrade

During upgrade I get
```
Failed to set Dashboard config for nvmeof: dashboard nvmeof-gateway-add failed: JSON array/object not allowed {"prefix": "dashboard nvmeof-gateway-add", "name": "nvmeof.rbd", "group": null, "daemon_name": "nvmeof.rbd.ceph-node-01.irpssg"} retval: -22
```

which is fixed by handling the group_name when its not there in spec.

And the other error was
```
Failed to set Dashboard config for nvmeof: dashboard nvmeof-gateway-add failed: Traceback (most recent call last): File "/usr/share/ceph/mgr/mgr_module.py", line 1864, in _handle_command return CLICommand.COMMANDS[cmd['prefix']].call(self, cmd, inbuf) File "/usr/share/ceph/mgr/mgr_module.py", line 499, in call return self.func(mgr, **kwargs) File "/usr/share/ceph/mgr/mgr_module.py", line 535, in check return func(*args, **kwargs) File "/usr/share/ceph/mgr/dashboard/services/nvmeof_cli.py", line 28, in add_nvmeof_gateway NvmeofGatewaysConfig.add_gateway(name, service_url, group, daemon_name) File "/usr/share/ceph/mgr/dashboard/services/nvmeof_conf.py", line 61, in add_gateway gateway['daemon_name'] = daemon_name TypeError: 'str' object does not support item assignment retval: -22
```

which is fixed by properly updating the config to the newer format that is available in newer version

Fixes: https://tracker.ceph.com/issues/70629





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
