### PR TITLE
erasure-code: use new/delete to alloc/free coefficients array

### DIFF
--- a/src/erasure-code/isa/ErasureCodeIsaTableCache.cc
+++ b/src/erasure-code/isa/ErasureCodeIsaTableCache.cc
@@ -192,7 +192,7 @@ ErasureCodeIsaTableCache::setEncodingTable(int matrix, int k, int m, unsigned ch
   if (*ec_out_table) {
     // somebody might have deposited this table in the meanwhile, so clean
     // the input table and return the stored one
-    free (ec_in_table);
+    delete[] ec_in_table;
     return *ec_out_table;
   } else {
     // we store the provided input table and return this one


### PR DESCRIPTION
before this change, we allocate coefficients table with malloc() in ErasureCodeIsaDefault::prepare(), but free them using delete.

so, in this change, we use new [] and delete [] to allocate and free them, to be more consistent, and to silence this warning.

this issue was identified by AddressSanitizer:

```
2025-03-22T04:27:58.210 INFO:tasks.ceph.osd.3.smithi102.stderr:==42899==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs free) on 0x611000570d40
2025-03-22T04:27:58.253 DEBUG:teuthology.orchestra.run.smithi102:> sudo adjust-ulimits ceph-coverage /home/ubuntu/cephtest/archive/coverage timeout 120 env ASAN_OPTIONS=detect_leaks=0,detect_odr_violation=0,alloc_dealloc_mismatch=0 LD_PRELOAD=/lib64/libasan.so.6 ceph --cluster ceph osd pool set cephfs_data_ec allow_ec_overwrites true
2025-03-22T04:27:58.442 INFO:tasks.ceph.osd.3.smithi102.stderr:    #0 0x7efdc30b46b7 in free (/lib64/libasan.so.6+0xb46b7)
2025-03-22T04:27:58.442 INFO:tasks.ceph.osd.3.smithi102.stderr:    #1 0x7efd9e2e5f26 in ErasureCodeIsaTableCache::setEncodingTable(int, int, int, unsigned char*) (/usr/lib64/ceph/erasure-code/libec_isa.so+0x3bf26)
2025-03-22T04:27:58.442 INFO:tasks.ceph.osd.3.smithi102.stderr:    #2 0x7efd9e2f0fae in ErasureCodeIsaDefault::prepare() (/usr/lib64/ceph/erasure-code/libec_isa.so+0x46fae)
2025-03-22T04:27:58.442 INFO:tasks.ceph.osd.3.smithi102.stderr:    #3 0x7efd9e2bfa3e in ErasureCodeIsa::init(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&, std::ostream*) (/usr/lib64/ceph/erasure-code/libec_isa.so+0x15a3e)
2025-03-22T04:27:58.442 INFO:tasks.ceph.osd.3.smithi102.stderr:    #4 0x7efd9e2ff510 in ErasureCodePluginIsa::factory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&, std::shared_ptr<ceph::ErasureCodeInterface>*, std::ostream*) (/usr/lib64/ceph/erasure-code/libec_isa.so+0x55510)
2025-03-22T04:27:58.442 INFO:tasks.ceph.osd.3.smithi102.stderr:    #5 0x55a7ef19b395 in ceph::ErasureCodePluginRegistry::factory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&, std::shared_ptr<ceph::ErasureCodeInterface>*, std::ostream*) (/usr/bin/ceph-osd+0x4dcb395)
2025-03-22T04:27:58.442 INFO:tasks.ceph.osd.3.smithi102.stderr:    #6 0x55a7eb9089d8 in PGBackend::build_pg_backend(pg_pool_t const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, PGBackend::Listener*, coll_t, boost::intrusive_ptr<ObjectStore::CollectionImpl>&, ObjectStore*, ceph::common::CephContext*) (/usr/bin/ceph-osd+0x15389d8)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #7 0x55a7eb4b63ec in PrimaryLogPG::PrimaryLogPG(OSDService*, std::shared_ptr<OSDMap const>, PGPool const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, spg_t) (/usr/bin/ceph-osd+0x10e63ec)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #8 0x55a7eaef1cc7 in OSD::_make_pg(std::shared_ptr<OSDMap const>, spg_t) (/usr/bin/ceph-osd+0xb21cc7)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #9 0x55a7eaef8d69 in OSD::handle_pg_create_info(std::shared_ptr<OSDMap const> const&, PGCreateInfo const*) (/usr/bin/ceph-osd+0xb28d69)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #10 0x55a7eafeb9ed in OSD::ShardedOpWQ::_process(unsigned int, ceph::heartbeat_handle_d*) (/usr/bin/ceph-osd+0xc1b9ed)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #11 0x55a7ed04c9aa in ShardedThreadPool::shardedthreadpool_worker(unsigned int) (/usr/bin/ceph-osd+0x2c7c9aa)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #12 0x55a7ed04d338 in ShardedThreadPool::WorkThreadSharded::entry() (/usr/bin/ceph-osd+0x2c7d338)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #13 0x55a7ecf92b46 in Thread::entry_wrapper() (/usr/bin/ceph-osd+0x2bc2b46)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #14 0x55a7ecf92b82 in Thread::_entry_func(void*) (/usr/bin/ceph-osd+0x2bc2b82)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #15 0x7efdc1e8a3b1 in start_thread (/lib64/libc.so.6+0x8a3b1)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:    #16 0x7efdc1f0f42f in __GI___clone3 (/lib64/libc.so.6+0x10f42f)
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:
2025-03-22T04:27:58.443 INFO:tasks.ceph.osd.3.smithi102.stderr:0x611000570d40 is located 0 bytes inside of 256-byte region [0x611000570d40,0x611000570e40)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:allocated by thread T817 here:
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #0 0x7efdc30b64d7 in operator new[](unsigned long) (/lib64/libasan.so.6+0xb64d7)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #1 0x7efd9e2f0e32 in ErasureCodeIsaDefault::prepare() (/usr/lib64/ceph/erasure-code/libec_isa.so+0x46e32)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #2 0x7efd9e2bfa3e in ErasureCodeIsa::init(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&, std::ostream*) (/usr/lib64/ceph/erasure-code/libec_isa.so+0x15a3e)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #3 0x7efd9e2ff510 in ErasureCodePluginIsa::factory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&, std::shared_ptr<ceph::ErasureCodeInterface>*, std::ostream*) (/usr/lib64/ceph/erasure-code/libec_isa.so+0x55510)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #4 0x55a7ef19b395 in ceph::ErasureCodePluginRegistry::factory(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&, std::shared_ptr<ceph::ErasureCodeInterface>*, std::ostream*) (/usr/bin/ceph-osd+0x4dcb395)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #5 0x55a7eb9089d8 in PGBackend::build_pg_backend(pg_pool_t const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, PGBackend::Listener*, coll_t, boost::intrusive_ptr<ObjectStore::CollectionImpl>&, ObjectStore*, ceph::common::CephContext*) (/usr/bin/ceph-osd+0x15389d8)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #6 0x55a7eb4b63ec in PrimaryLogPG::PrimaryLogPG(OSDService*, std::shared_ptr<OSDMap const>, PGPool const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, spg_t) (/usr/bin/ceph-osd+0x10e63ec)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #7 0x55a7eaef1cc7 in OSD::_make_pg(std::shared_ptr<OSDMap const>, spg_t) (/usr/bin/ceph-osd+0xb21cc7)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #8 0x55a7eaef8d69 in OSD::handle_pg_create_info(std::shared_ptr<OSDMap const> const&, PGCreateInfo const*) (/usr/bin/ceph-osd+0xb28d69)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #9 0x55a7eafeb9ed in OSD::ShardedOpWQ::_process(unsigned int, ceph::heartbeat_handle_d*) (/usr/bin/ceph-osd+0xc1b9ed)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #10 0x55a7ed04c9aa in ShardedThreadPool::shardedthreadpool_worker(unsigned int) (/usr/bin/ceph-osd+0x2c7c9aa)
2025-03-22T04:27:58.444 INFO:tasks.ceph.osd.3.smithi102.stderr:    #11 0x55a7ed04d338 in ShardedThreadPool::WorkThreadSharded::entry() (/usr/bin/ceph-osd+0x2c7d338)
2025-03-22T04:27:58.445 INFO:tasks.ceph.osd.3.smithi102.stderr:    #12 0x55a7ecf92b46 in Thread::entry_wrapper() (/usr/bin/ceph-osd+0x2bc2b46)
2025-03-22T04:27:58.445 INFO:tasks.ceph.osd.3.smithi102.stderr:    #13 0x55a7ecf92b82 in Thread::_entry_func(void*) (/usr/bin/ceph-osd+0x2bc2b82)
2025-03-22T04:27:58.445 INFO:tasks.ceph.osd.3.smithi102.stderr:    #14 0x7efdc1e8a3b1 in start_thread (/lib64/libc.so.6+0x8a3b1)
2025-03-22T04:27:58.445 INFO:tasks.ceph.osd.3.smithi102.stderr:
```
Fixes: https://tracker.ceph.com/issues/70619
Signed-off-by: Kefu Chai <tchaikov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
