### PR TITLE
squid: rgw/notification: For kafka include user-id & password as part of the key along with endpoint for connection pooling.

### DIFF
--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -13,6 +13,7 @@
 #include <thread>
 #include <atomic>
 #include <mutex>
+#include <boost/functional/hash.hpp>
 #include <boost/lockfree/queue.hpp>
 #include "common/dout.h"
 
@@ -63,6 +64,47 @@ inline std::string status_to_string(int s) {
     default:
       return std::string(rd_kafka_err2str(static_cast<rd_kafka_resp_err_t>(s)));
   }
+}
+
+connection_id_t::connection_id_t(
+    const std::string& _broker,
+    const std::string& _user,
+    const std::string& _password,
+    const boost::optional<const std::string&>& _ca_location,
+    const boost::optional<const std::string&>& _mechanism,
+    bool _ssl)
+    : broker(_broker), user(_user), password(_password), ssl(_ssl) {
+  if (_ca_location.has_value()) {
+    ca_location = _ca_location.get();
+  }
+  if (_mechanism.has_value()) {
+    mechanism = _mechanism.get();
+  }
+}
+
+// equality operator and hasher functor are needed
+// so that connection_id_t could be used as key in unordered_map
+bool operator==(const connection_id_t& lhs, const connection_id_t& rhs) {
+  return lhs.broker == rhs.broker && lhs.user == rhs.user &&
+         lhs.password == rhs.password && lhs.ca_location == rhs.ca_location &&
+         lhs.mechanism == rhs.mechanism && lhs.ssl == rhs.ssl;
+}
+
+struct connection_id_hasher {
+  std::size_t operator()(const connection_id_t& k) const {
+    std::size_t h = 0;
+    boost::hash_combine(h, k.broker);
+    boost::hash_combine(h, k.user);
+    boost::hash_combine(h, k.password);
+    boost::hash_combine(h, k.ca_location);
+    boost::hash_combine(h, k.mechanism);
+    boost::hash_combine(h, k.ssl);
+    return h;
+  }
+};
+
+std::string to_string(const connection_id_t& id) {
+  return id.broker + ":" + id.user;
 }
 
 // convert int status to errno - both RGW and librdkafka values
@@ -169,8 +211,9 @@ void message_callback(rd_kafka_t* rk, const rd_kafka_message_t* rkmessage, void*
       ldout(conn->cct, 20) << "Kafka run: ack received with result=" <<
         rd_kafka_err2str(result) << dendl;
   } else {
-      ldout(conn->cct, 1) << "Kafka run: nack received with result=" <<
-        rd_kafka_err2str(result) << dendl;
+    ldout(conn->cct, 1) << "Kafka run: nack received with result="
+                        << rd_kafka_err2str(result)
+                        << " for broker: " << conn->broker << dendl;
   }
 
   if (!rkmessage->_private) {
@@ -331,18 +374,21 @@ conf_error:
 
 // struct used for holding messages in the message queue
 struct message_wrapper_t {
-  std::string conn_name; 
+  connection_id_t conn_id;
   std::string topic;
   std::string message;
   const reply_callback_t cb;
-  
-  message_wrapper_t(const std::string& _conn_name,
-      const std::string& _topic,
-      const std::string& _message,
-      reply_callback_t _cb) : conn_name(_conn_name), topic(_topic), message(_message), cb(_cb) {}
+
+  message_wrapper_t(const connection_id_t& _conn_id,
+                    const std::string& _topic,
+                    const std::string& _message,
+                    reply_callback_t _cb)
+      : conn_id(_conn_id), topic(_topic), message(_message), cb(_cb) {}
 };
 
-typedef std::unordered_map<std::string, connection_t_ptr> ConnectionList;
+typedef std::
+    unordered_map<connection_id_t, connection_t_ptr, connection_id_hasher>
+        ConnectionList;
 typedef boost::lockfree::queue<message_wrapper_t*, boost::lockfree::fixed_sized<true>> MessageQueue;
 
 class Manager {
@@ -365,7 +411,7 @@ private:
   // TODO use rd_kafka_produce_batch for better performance
   void publish_internal(message_wrapper_t* message) {
     const std::unique_ptr<message_wrapper_t> msg_deleter(message);
-    const auto conn_it = connections.find(message->conn_name);
+    const auto conn_it = connections.find(message->conn_id);
     if (conn_it == connections.end()) {
       ldout(cct, 1) << "Kafka publish: connection was deleted while message was in the queue" << dendl;
       if (message->cb) {
@@ -426,7 +472,9 @@ private:
             tag);
     if (rc == -1) {
       const auto err = rd_kafka_last_error();
-      ldout(conn->cct, 1) << "Kafka publish: failed to produce: " << rd_kafka_err2str(err) << dendl;
+      ldout(conn->cct, 1) << "Kafka publish: failed to produce for topic: "
+                          << message->topic
+                          << ". with error: " << rd_kafka_err2str(err) << dendl;
       // immediatly invoke callback on error if needed
       if (message->cb) {
         message->cb(-rd_kafka_err2errno(err));
@@ -545,14 +593,14 @@ public:
   }
 
   // connect to a broker, or reuse an existing connection if already connected
-  bool connect(std::string& broker,
-          const std::string& url, 
-          bool use_ssl,
-          bool verify_ssl,
-          boost::optional<const std::string&> ca_location,
-          boost::optional<const std::string&> mechanism,
-          boost::optional<const std::string&> topic_user_name,
-          boost::optional<const std::string&> topic_password) {
+  bool connect(connection_id_t& conn_id,
+               const std::string& url,
+               bool use_ssl,
+               bool verify_ssl,
+               boost::optional<const std::string&> ca_location,
+               boost::optional<const std::string&> mechanism,
+               boost::optional<const std::string&> topic_user_name,
+               boost::optional<const std::string&> topic_password) {
     if (stopped) {
       ldout(cct, 1) << "Kafka connect: manager is stopped" << dendl;
       return false;
@@ -560,6 +608,7 @@ public:
 
     std::string user;
     std::string password;
+    std::string broker;
     if (!parse_url_authority(url, broker, user, password)) {
       // TODO: increment counter
       ldout(cct, 1) << "Kafka connect: URL parsing failed" << dendl;
@@ -588,14 +637,17 @@ public:
       ldout(cct, 1) << "Kafka connect: user/password are only allowed over secure connection" << dendl;
       return false;
     }
-
+    connection_id_t tmp_id(broker, user, password, ca_location, mechanism,
+                           use_ssl);
     std::lock_guard lock(connections_lock);
-    const auto it = connections.find(broker);
+    const auto it = connections.find(tmp_id);
     // note that ssl vs. non-ssl connection to the same host are two separate connections
     if (it != connections.end()) {
       // connection found - return even if non-ok
-      ldout(cct, 20) << "Kafka connect: connection found" << dendl;
-      return it->second.get();
+      ldout(cct, 20) << "Kafka connect: connection found: " << to_string(tmp_id)
+                     << dendl;
+      conn_id = std::move(tmp_id);
+      return true;
     }
 
     // connection not found, creating a new one
@@ -611,20 +663,24 @@ public:
       return false;
     }
     ++connection_count;
-    connections.emplace(broker, std::move(conn));
+    connections.emplace(tmp_id, std::move(conn));
 
-    ldout(cct, 10) << "Kafka connect: new connection is created. Total connections: " << connection_count << dendl;
+    ldout(cct, 10) << "Kafka connect: new connection is created: "
+                   << to_string(tmp_id)
+                   << " . Total connections: " << connection_count << dendl;
+    conn_id = std::move(tmp_id);
     return true;
   }
 
   // TODO publish with confirm is needed in "none" case as well, cb should be invoked publish is ok (no ack)
-  int publish(const std::string& conn_name, 
-    const std::string& topic,
-    const std::string& message) {
+  int publish(const connection_id_t& conn_id,
+              const std::string& topic,
+              const std::string& message) {
     if (stopped) {
       return -ESRCH;
     }
-    auto message_wrapper = std::make_unique<message_wrapper_t>(conn_name, topic, message, nullptr);
+    auto message_wrapper =
+        std::make_unique<message_wrapper_t>(conn_id, topic, message, nullptr);
     if (messages.push(message_wrapper.get())) {
       std::ignore = message_wrapper.release();
       ++queued;
@@ -632,15 +688,16 @@ public:
     }
     return -EBUSY;
   }
-  
-  int publish_with_confirm(const std::string& conn_name, 
-    const std::string& topic,
-    const std::string& message,
-    reply_callback_t cb) {
+
+  int publish_with_confirm(const connection_id_t& conn_id,
+                           const std::string& topic,
+                           const std::string& message,
+                           reply_callback_t cb) {
     if (stopped) {
       return -ESRCH;
     }
-    auto message_wrapper = std::make_unique<message_wrapper_t>(conn_name, topic, message, cb);
+    auto message_wrapper =
+        std::make_unique<message_wrapper_t>(conn_id, topic, message, cb);
     if (messages.push(message_wrapper.get())) {
       std::ignore = message_wrapper.release();
       ++queued;
@@ -711,31 +768,35 @@ void shutdown() {
   s_manager = nullptr;
 }
 
-bool connect(std::string& broker, const std::string& url, bool use_ssl, bool verify_ssl,
-        boost::optional<const std::string&> ca_location,
-        boost::optional<const std::string&> mechanism,
-        boost::optional<const std::string&> user_name,
-        boost::optional<const std::string&> password) {
+bool connect(connection_id_t& conn_id,
+             const std::string& url,
+             bool use_ssl,
+             bool verify_ssl,
+             boost::optional<const std::string&> ca_location,
+             boost::optional<const std::string&> mechanism,
+             boost::optional<const std::string&> user_name,
+             boost::optional<const std::string&> password) {
   std::shared_lock lock(s_manager_mutex);
   if (!s_manager) return false;
-  return s_manager->connect(broker, url, use_ssl, verify_ssl, ca_location, mechanism, user_name, password);
+  return s_manager->connect(conn_id, url, use_ssl, verify_ssl, ca_location,
+                            mechanism, user_name, password);
 }
 
-int publish(const std::string& conn_name,
-    const std::string& topic,
-    const std::string& message) {
+int publish(const connection_id_t& conn_id,
+            const std::string& topic,
+            const std::string& message) {
   std::shared_lock lock(s_manager_mutex);
   if (!s_manager) return -ESRCH;
-  return s_manager->publish(conn_name, topic, message);
+  return s_manager->publish(conn_id, topic, message);
 }
 
-int publish_with_confirm(const std::string& conn_name,
-    const std::string& topic,
-    const std::string& message,
-    reply_callback_t cb) {
+int publish_with_confirm(const connection_id_t& conn_id,
+                         const std::string& topic,
+                         const std::string& message,
+                         reply_callback_t cb) {
   std::shared_lock lock(s_manager_mutex);
   if (!s_manager) return -ESRCH;
-  return s_manager->publish_with_confirm(conn_name, topic, message, cb);
+  return s_manager->publish_with_confirm(conn_id, topic, message, cb);
 }
 
 size_t get_connection_count() {

--- a/src/rgw/rgw_kafka.h
+++ b/src/rgw/rgw_kafka.h
@@ -21,28 +21,47 @@ bool init(CephContext* cct);
 // shutdown the kafka manager
 void shutdown();
 
+// key class for the connection list
+struct connection_id_t {
+  std::string broker;
+  std::string user;
+  std::string password;
+  std::string ca_location;
+  std::string mechanism;
+  bool ssl = false;
+  connection_id_t() = default;
+  connection_id_t(const std::string& _broker,
+                  const std::string& _user,
+                  const std::string& _password,
+                  const boost::optional<const std::string&>& _ca_location,
+                  const boost::optional<const std::string&>& _mechanism,
+                  bool _ssl);
+};
+
+std::string to_string(const connection_id_t& id);
+
 // connect to a kafka endpoint
-bool connect(std::string& broker,
-  const std::string& url,
-  bool use_ssl,
-  bool verify_ssl,
-  boost::optional<const std::string&> ca_location,
-  boost::optional<const std::string&> mechanism,
-  boost::optional<const std::string&> user_name,
-  boost::optional<const std::string&> password);
+bool connect(connection_id_t& conn_id,
+             const std::string& url,
+             bool use_ssl,
+             bool verify_ssl,
+             boost::optional<const std::string&> ca_location,
+             boost::optional<const std::string&> mechanism,
+             boost::optional<const std::string&> user_name,
+             boost::optional<const std::string&> password);
 
 // publish a message over a connection that was already created
-int publish(const std::string& conn_name,
-    const std::string& topic,
-    const std::string& message);
+int publish(const connection_id_t& conn_id,
+            const std::string& topic,
+            const std::string& message);
 
 // publish a message over a connection that was already created
 // and pass a callback that will be invoked (async) when broker confirms
 // receiving the message
-int publish_with_confirm(const std::string& conn_name,
-    const std::string& topic,
-    const std::string& message,
-    reply_callback_t cb);
+int publish_with_confirm(const connection_id_t& conn_id,
+                         const std::string& topic,
+                         const std::string& message,
+                         reply_callback_t cb);
 
 // convert the integer status returned from the "publish" function to a string
 std::string status_to_string(int s);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66805

---

backport of https://github.com/ceph/ceph/pull/57537
parent tracker: https://tracker.ceph.com/issues/66036

This commit was not cherrypicked and backported in https://github.com/ceph/ceph/pull/58851, so making a new PR for that commit.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
