### PR TITLE
reef:  client: ll_walk will process absolute paths as relative

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12587,9 +12587,7 @@ int Client::ll_walk(const char* name, Inode **out, struct ceph_statx *stx,
   if (!mref_reader.is_state_satisfied())
     return -CEPHFS_ENOTCONN;
 
-  filepath fp(name, 0);
   InodeRef in;
-  int rc;
   unsigned mask = statx_to_mask(flags, want);
 
   ldout(cct, 3) << __func__ << " " << name << dendl;
@@ -12597,7 +12595,7 @@ int Client::ll_walk(const char* name, Inode **out, struct ceph_statx *stx,
   tout(cct) << name << std::endl;
 
   std::scoped_lock lock(client_lock);
-  rc = path_walk(fp, &in, perms, !(flags & AT_SYMLINK_NOFOLLOW), mask);
+  int rc = path_walk(filepath(name), &in, perms, !(flags & AT_SYMLINK_NOFOLLOW), mask);
   if (rc < 0) {
     /* zero out mask, just in case... */
     stx->stx_mask = 0;

--- a/src/test/client/CMakeLists.txt
+++ b/src/test/client/CMakeLists.txt
@@ -2,6 +2,7 @@ if(${WITH_CEPHFS})
   add_executable(ceph_test_client
     main.cc
     alternate_name.cc
+    ll_api.cc
     ops.cc
     commands.cc
     syncio.cc

--- a/src/test/client/ll_api.cc
+++ b/src/test/client/ll_api.cc
@@ -1,0 +1,38 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 IBM, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <errno.h>
+
+#include <iostream>
+#include <string>
+
+#include <fmt/format.h>
+
+#include "test/client/TestClient.h"
+
+TEST_F(TestClient, LL_Walk) {
+  auto dir = fmt::format("/{}_{}", ::testing::UnitTest::GetInstance()->current_test_info()->name(), getpid());
+  ASSERT_EQ(0, client->mkdir(dir.c_str(), 0777, myperm));
+
+  ASSERT_EQ(0, client->chdir(dir.c_str(), myperm));
+  std::string cwd;
+  ASSERT_EQ(0, client->getcwd(cwd, myperm));
+  ASSERT_STREQ(cwd.c_str(), dir.c_str());
+
+  Inode* in = nullptr;
+  struct ceph_statx xbuf;
+  ASSERT_EQ(0, client->ll_walk(dir.c_str(), &in, &xbuf, 0, 0, myperm));
+
+  ASSERT_EQ(0, client->rmdir(dir.c_str(), myperm));
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70664

---

backport of https://github.com/ceph/ceph/pull/62406
parent tracker: https://tracker.ceph.com/issues/70573

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh