### PR TITLE
reef: mgr: add status command

### DIFF
--- a/qa/suites/rados/mgr/tasks/3-mgrmodules.yaml
+++ b/qa/suites/rados/mgr/tasks/3-mgrmodules.yaml
@@ -6,3 +6,6 @@ mgrmodules:
 tasks:
   - sequential:
       - mgrmodules
+      - exec:
+          mon.a:
+            - ceph tell mgr status

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -41,6 +41,27 @@ using std::map;
 using std::string;
 using std::vector;
 
+class MgrHook : public AdminSocketHook {
+  MgrStandby* mgr;
+public:
+  explicit MgrHook(MgrStandby *m) : mgr(m) {}
+  int call(std::string_view admin_command,
+           const cmdmap_t& cmdmap,
+           const bufferlist& inbl,
+           Formatter *f,
+           std::ostream& errss,
+           bufferlist& outbl) override {
+    int r = 0;
+    try {
+      r = mgr->asok_command(admin_command, cmdmap, f, errss);
+    } catch (const TOPNSPC::common::bad_cmd_get& e) {
+      errss << e.what();
+      r = -EINVAL;
+    }
+    return r;
+  }
+};
+
 MgrStandby::MgrStandby(int argc, const char **argv) :
   Dispatcher(g_ceph_context),
   monc{g_ceph_context, poolctx},
@@ -67,7 +88,12 @@ MgrStandby::MgrStandby(int argc, const char **argv) :
 {
 }
 
-MgrStandby::~MgrStandby() = default;
+MgrStandby::~MgrStandby() {
+  if (asok_hook) {
+    g_ceph_context->get_admin_socket()->unregister_commands(asok_hook.get());
+    asok_hook.reset();
+  }
+}
 
 const char** MgrStandby::get_tracked_conf_keys() const
 {
@@ -116,6 +142,18 @@ void MgrStandby::handle_conf_change(
   }
 }
 
+int MgrStandby::asok_command(std::string_view cmd, const cmdmap_t& cmdmap, Formatter* f, std::ostream& errss)
+{
+  dout(10) << __func__ << ": " << cmd << dendl;
+  if (cmd == "status") {
+    f->open_object_section("status");
+    f->close_section();
+    return 0;
+  } else {
+    return -ENOSYS;
+  }
+}
+
 int MgrStandby::init()
 {
   init_async_signal_handler();
@@ -133,6 +171,13 @@ int MgrStandby::init()
   client_messenger->add_dispatcher_head(&objecter);
   client_messenger->add_dispatcher_tail(&client);
   client_messenger->start();
+
+  AdminSocket *admin_socket = g_ceph_context->get_admin_socket();
+  asok_hook.reset(new MgrHook(this));
+  {
+    int r = admin_socket->register_command("status", asok_hook.get(), "show status");
+    ceph_assert(r == 0);
+  }
 
   poolctx.start(2);
 

--- a/src/mgr/MgrStandby.h
+++ b/src/mgr/MgrStandby.h
@@ -30,6 +30,7 @@
 class MMgrMap;
 class Mgr;
 class PyModuleConfig;
+class MgrHook;
 
 class MgrStandby : public Dispatcher,
 		   public md_config_obs_t {
@@ -38,6 +39,7 @@ public:
   const char** get_tracked_conf_keys() const override;
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set <std::string> &changed) override;
+  int asok_command(std::string_view cmd, const cmdmap_t& cmdmap, Formatter* f, std::ostream& errss);
 
 protected:
   ceph::async::io_context_pool poolctx;
@@ -57,6 +59,7 @@ protected:
 
   PyModuleRegistry py_module_registry;
   std::shared_ptr<Mgr> active_mgr;
+  std::unique_ptr<MgrHook> asok_hook;
 
   int orig_argc;
   const char **orig_argv;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70666

---

backport of https://github.com/ceph/ceph/pull/62465
parent tracker: https://tracker.ceph.com/issues/70571

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh