### PR TITLE
[Packaging]: Use system-defined location for home directories

### DIFF
--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -28,7 +28,6 @@ case "$1" in
          adduser --quiet \
                  --system \
                  --disabled-password \
-                 --home /home/cephadm \
                  --shell /bin/bash cephadm 2>/dev/null || true
          usermod --comment "cephadm user for mgr/cephadm" cephadm
          echo "..done"
@@ -42,15 +41,15 @@ case "$1" in
        fi
 
        # set up (initially empty) .ssh/authorized_keys file
-       if ! test -d /home/cephadm/.ssh; then
-           mkdir /home/cephadm/.ssh
-           chown --reference /home/cephadm /home/cephadm/.ssh
-           chmod 0700 /home/cephadm/.ssh
+       if ! test -d ~cephadm/.ssh; then
+           mkdir ~cephadm/.ssh
+           chown --reference ~cephadm ~cephadm/.ssh
+           chmod 0700 ~cephadm/.ssh
        fi
-       if ! test -e /home/cephadm/.ssh/authorized_keys; then
-           touch /home/cephadm/.ssh/authorized_keys
-           chown --reference /home/cephadm /home/cephadm/.ssh/authorized_keys
-           chmod 0600 /home/cephadm/.ssh/authorized_keys
+       if ! test -e ~cephadm/.ssh/authorized_keys; then
+           touch ~cephadm/.ssh/authorized_keys
+           chown --reference ~cephadm ~cephadm/.ssh/authorized_keys
+           chmod 0600 ~cephadm/.ssh/authorized_keys
        fi
 
     ;;

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -260,7 +260,7 @@ available options.
 
 * The ``--ssh-user *<user>*`` option makes it possible to designate which SSH
   user cephadm will use to connect to hosts. The associated SSH key will be
-  added to ``/home/*<user>*/.ssh/authorized_keys``. The user that you
+  added to ``~*<user>*/.ssh/authorized_keys``. The user that you
   designate with this option must have passwordless sudo access.
 
 * If you are using a container image from a registry that requires


### PR DESCRIPTION
This patch removes the assumption that user home directories always live under /home. If the user has set home directories to live under a different directory by changing /etc/adduser.conf, this will honor that setting.

Signed-off-by: Shawn Edwards <shedwards@nvidia.com>