### PR TITLE
Build system: Fix build on OS X in which libnbd.dylib is not found

### DIFF
--- a/cmake/modules/Findlibnbd.cmake
+++ b/cmake/modules/Findlibnbd.cmake
@@ -14,7 +14,7 @@ find_path(LIBNBD_INCLUDE_DIR
         PATHS ${PC_libnbd_INCLUDE_DIRS})
 
 find_library(LIBNBD_LIBRARIES
-        NAMES libnbd.so
+        NAMES libnbd
         PATHS ${PC_libnbd_LIBRARY_DIRS})
 
 set(LIBNBD_VERSION ${PC_libnbd_VERSION})


### PR DESCRIPTION
CMake automatically appends the system-specific library type using CMAKE_FIND_FRAMEWORK - https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_FRAMEWORK.html.

[ee9b90d](https://github.com/ceph/ceph/commit/ee9b90dbc9cd68837bca05e688ffc71284b81497) Fixes signed-off-by.  Back into development after too much hiatus in the closed-source & legal world.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

