### PR TITLE
squid: os/bluestore: use block size (4K) as minimal allocation unit for dedicated DB/WAL volumes

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -626,7 +626,8 @@ uint64_t BlueFS::_get_minimal_reserved(unsigned id) const
 uint64_t BlueFS::get_full_reserved(unsigned id)
 {
   if (!is_shared_alloc(id)) {
-    return locked_alloc[id].length + _get_minimal_reserved(id);
+    return locked_alloc[id].head_length + locked_alloc[id].tail_length +
+      _get_minimal_reserved(id);
   }
   return 0;
 }
@@ -694,6 +695,18 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   super.uuid.generate_random();
 
   _init_alloc();
+
+  // temporary lock candidate regions to forbid their use during mkfs
+  for (uint8_t i = 0; i < MAX_BDEV; i++) {
+    if (!alloc[i]) continue;
+    bluefs_locked_extents_t res_la = locked_alloc[i].get_merged();
+    if (res_la.head_length) {
+      alloc[i]->init_rm_free(res_la.head_offset, res_la.head_length);
+    }
+    if (res_la.tail_length) {
+      alloc[i]->init_rm_free(res_la.tail_offset, res_la.tail_length);
+    }
+  }
 
   // init log
   FileRef log_file = ceph::make_ref<File>();
@@ -779,7 +792,7 @@ void BlueFS::_init_alloc()
       continue;
     }
     ceph_assert(bdev[id]->get_size());
-    locked_alloc[id] = bluefs_extent_t();
+    locked_alloc[id].reset();
 
     if (is_shared_alloc(id)) {
       dout(1) << __func__ << " shared, id " << id << std::hex
@@ -796,37 +809,37 @@ void BlueFS::_init_alloc()
         name += to_string(uintptr_t(this));
 
       auto reserved = _get_minimal_reserved(id);
-      uint64_t locked_offs = 0;
-      {
-        // Try to lock tailing space at device if allocator controlled space
-        // isn't aligned with recommended alloc unit.
-        // Final decision whether locked tail to be maintained is made after
-        // BlueFS replay depending on existing allocations.
-        uint64_t size0 = _get_block_device_size(id);
-        uint64_t size = size0 - reserved;
-        size = p2align(size, alloc_size[id]) + reserved;
-        if (size < size0) {
-          locked_offs = size;
-          locked_alloc[id] = bluefs_extent_t(id, locked_offs, uint32_t(size0 - size));
-        }
+      uint64_t full_size = _get_block_device_size(id);
+      uint64_t free_end = p2align(full_size, alloc_size[id]);
+
+      // Trying to lock the following extents:
+      // [reserved, alloc_size] and [p2align(dev_size, alloc_size), dev_size]
+      // to make all the allocations alligned to alloc_size if possible.
+      // Final decision whether locked head/tail to be maintained is made after
+      // BlueFS replay depending on existing allocations.
+      auto &locked = locked_alloc[id];
+      locked.head_offset = reserved;
+      locked.head_length = p2nphase(reserved, alloc_size[id]);
+      if (free_end < full_size) {
+        locked.tail_offset = free_end;
+        locked.tail_length = full_size - free_end;
       }
       string alloc_type = cct->_conf->bluefs_allocator;
       dout(1) << __func__ << " new, id " << id << std::hex
               << ", allocator name " << name
               << ", allocator type " << alloc_type
-              << ", capacity 0x" << bdev[id]->get_size()
+              << ", capacity 0x" << full_size
               << ", reserved 0x" << reserved
-              << ", locked 0x" << locked_alloc[id].offset
-              << "~" << locked_alloc[id].length
+              << ", maybe locked " << locked
               << ", block size 0x" << bdev[id]->get_block_size()
               << ", alloc unit 0x" << alloc_size[id]
               << std::dec << dendl;
-      alloc[id] = Allocator::create(cct, alloc_type,
-				    bdev[id]->get_size(),
+      alloc[id] = Allocator::create(cct,
+                                    alloc_type,
+				    full_size,
 				    bdev[id]->get_block_size(),
 				    name);
-      uint64_t free_len = locked_offs ? locked_offs : _get_block_device_size(id) - reserved;
-      alloc[id]->init_add_free(reserved, free_len);
+      alloc[id]->init_add_free(reserved, full_size - reserved);
     }
   }
 }
@@ -1052,7 +1065,7 @@ int BlueFS::mount()
 
   // init freelist
   for (auto& p : nodes.file_map) {
-    dout(30) << __func__ << " noting alloc for " << p.second->fnode << dendl;
+    dout(20) << __func__ << " noting alloc for " << p.second->fnode << dendl;
     for (auto& q : p.second->fnode.extents) {
       bool is_shared = is_shared_alloc(q.bdev);
       ceph_assert(!is_shared || (is_shared && shared_alloc));
@@ -1060,24 +1073,26 @@ int BlueFS::mount()
         shared_alloc->bluefs_used += q.length;
         alloc[q.bdev]->init_rm_free(q.offset, q.length);
       } else if (!is_shared) {
-        if (locked_alloc[q.bdev].length) {
-          auto locked_offs = locked_alloc[q.bdev].offset;
-          if (q.offset + q.length > locked_offs) {
-            // we already have allocated extents in locked range,
-            // do not enforce this lock then.
-            bluefs_extent_t dummy;
-            std::swap(locked_alloc[q.bdev], dummy);
-            alloc[q.bdev]->init_add_free(dummy.offset, dummy.length);
-            dout(1) << __func__ << std::hex
-                    << " unlocked at " << q.bdev
-                    << " 0x" << dummy.offset << "~" << dummy.length
-                    << std::dec << dendl;
-          }
-        }
+        locked_alloc[q.bdev].reset_intersected(q);
         alloc[q.bdev]->init_rm_free(q.offset, q.length);
       }
     }
   }
+  // finalize and apply locked allocation regions
+  for (uint8_t i = 0; i < MAX_BDEV; i++) {
+    bluefs_locked_extents_t res_la = locked_alloc[i].finalize();
+    dout(1) << __func__ << std::hex
+            << " final locked allocations " << (int)i
+            << " " << locked_alloc[i] << " => " << res_la
+            << dendl;
+    if (res_la.head_length) {
+      alloc[i]->init_rm_free(res_la.head_offset, res_la.head_length);
+    }
+    if (res_la.tail_length) {
+      alloc[i]->init_rm_free(res_la.tail_offset, res_la.tail_length);
+    }
+  }
+
   if (shared_alloc) {
     shared_alloc->need_init = false;
     dout(1) << __func__ << " shared_bdev_used = "

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -600,8 +600,7 @@ uint64_t BlueFS::get_used(unsigned id)
 uint64_t BlueFS::_get_total(unsigned id) const
 {
   ceph_assert(id < bdev.size());
-  ceph_assert(id < block_reserved.size());
-  return get_block_device_size(id) - block_reserved[id];
+  return get_block_device_size(id);
 }
 
 uint64_t BlueFS::get_total(unsigned id)
@@ -788,9 +787,8 @@ void BlueFS::_init_alloc()
 				    bdev[id]->get_size(),
 				    alloc_size[id],
 				    name);
-      alloc[id]->init_add_free(
-        block_reserved[id],
-        _get_total(id));
+      auto reserved = block_reserved[id];
+      alloc[id]->init_add_free(reserved, _get_total(id) - reserved);
     }
   }
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -538,13 +538,6 @@ bool BlueFS::bdev_support_label(unsigned id)
   return bdev[id]->supported_bdev_label();
 }
 
-uint64_t BlueFS::get_block_device_size(unsigned id) const
-{
-  if (id < bdev.size() && bdev[id])
-    return bdev[id]->get_size();
-  return 0;
-}
-
 BlockDevice* BlueFS::get_block_device(unsigned id) const
 {
   if (id < bdev.size() && bdev[id])
@@ -595,7 +588,7 @@ uint64_t BlueFS::get_used(unsigned id)
 uint64_t BlueFS::_get_total(unsigned id) const
 {
   ceph_assert(id < bdev.size());
-  return get_block_device_size(id);
+  return bdev[id] ? bdev[id]->get_size() : 0;
 }
 
 uint64_t BlueFS::get_total(unsigned id)
@@ -688,9 +681,9 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   if (vselector == nullptr) {
     vselector.reset(
       new OriginalVolumeSelector(
-        get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100));
+        _get_total(BlueFS::BDEV_WAL) * 95 / 100,
+        _get_total(BlueFS::BDEV_DB) * 95 / 100,
+        _get_total(BlueFS::BDEV_SLOW) * 95 / 100));
   }
 
   _init_logger();
@@ -1043,9 +1036,9 @@ int BlueFS::mount()
   if (vselector == nullptr) {
     vselector.reset(
       new OriginalVolumeSelector(
-        get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-        get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100));
+        _get_total(BlueFS::BDEV_WAL) * 95 / 100,
+        _get_total(BlueFS::BDEV_DB) * 95 / 100,
+        _get_total(BlueFS::BDEV_SLOW) * 95 / 100));
   }
 
   _init_alloc();

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -125,7 +125,7 @@ private:
 	  f->open_object_section("dev");
 	  f->dump_string("device", bluefs->get_device_name(dev));
 	  ceph_assert(bluefs->alloc[dev]);
-          auto total = bluefs->get_total(dev);
+          auto total = bluefs->get_block_device_size(dev);
           auto free = bluefs->get_free(dev);
           auto used = bluefs->get_used(dev);
 
@@ -466,15 +466,15 @@ void BlueFS::_shutdown_logger()
 void BlueFS::_update_logger_stats()
 {
   if (alloc[BDEV_WAL]) {
-    logger->set(l_bluefs_wal_total_bytes, _get_total(BDEV_WAL));
+    logger->set(l_bluefs_wal_total_bytes, _get_block_device_size(BDEV_WAL));
     logger->set(l_bluefs_wal_used_bytes, _get_used(BDEV_WAL));
   }
   if (alloc[BDEV_DB]) {
-    logger->set(l_bluefs_db_total_bytes, _get_total(BDEV_DB));
+    logger->set(l_bluefs_db_total_bytes, _get_block_device_size(BDEV_DB));
     logger->set(l_bluefs_db_used_bytes, _get_used(BDEV_DB));
   }
   if (alloc[BDEV_SLOW]) {
-    logger->set(l_bluefs_slow_total_bytes, _get_total(BDEV_SLOW));
+    logger->set(l_bluefs_slow_total_bytes, _get_block_device_size(BDEV_SLOW));
     logger->set(l_bluefs_slow_used_bytes, _get_used(BDEV_SLOW));
   }
 }
@@ -573,7 +573,7 @@ uint64_t BlueFS::_get_used(unsigned id) const
   if (is_shared_alloc(id)) {
     used = shared_alloc->bluefs_used;
   } else {
-    used = _get_total(id) - alloc[id]->get_free();
+    used = _get_block_device_size(id) - alloc[id]->get_free();
   }
   return used;
 }
@@ -585,15 +585,15 @@ uint64_t BlueFS::get_used(unsigned id)
   return _get_used(id);
 }
 
-uint64_t BlueFS::_get_total(unsigned id) const
+uint64_t BlueFS::_get_block_device_size(unsigned id) const
 {
   ceph_assert(id < bdev.size());
   return bdev[id] ? bdev[id]->get_size() : 0;
 }
 
-uint64_t BlueFS::get_total(unsigned id)
+uint64_t BlueFS::get_block_device_size(unsigned id)
 {
-  return _get_total(id);
+  return _get_block_device_size(id);
 }
 
 uint64_t BlueFS::get_free(unsigned id)
@@ -644,7 +644,7 @@ void BlueFS::dump_block_extents(ostream& out)
     if (!bdev[i] || !alloc[i]) {
       continue;
     }
-    auto total = get_total(i) + block_reserved[i];
+    auto total = get_block_device_size(i);
     auto free = get_free(i);
 
     out << i << " : device size 0x" << std::hex << total
@@ -681,9 +681,9 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
   if (vselector == nullptr) {
     vselector.reset(
       new OriginalVolumeSelector(
-        _get_total(BlueFS::BDEV_WAL) * 95 / 100,
-        _get_total(BlueFS::BDEV_DB) * 95 / 100,
-        _get_total(BlueFS::BDEV_SLOW) * 95 / 100));
+        _get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
+        _get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
+        _get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100));
   }
 
   _init_logger();
@@ -802,7 +802,7 @@ void BlueFS::_init_alloc()
         // isn't aligned with recommended alloc unit.
         // Final decision whether locked tail to be maintained is made after
         // BlueFS replay depending on existing allocations.
-        uint64_t size0 = _get_total(id);
+        uint64_t size0 = _get_block_device_size(id);
         uint64_t size = size0 - reserved;
         size = p2align(size, alloc_size[id]) + reserved;
         if (size < size0) {
@@ -825,7 +825,7 @@ void BlueFS::_init_alloc()
 				    bdev[id]->get_size(),
 				    bdev[id]->get_block_size(),
 				    name);
-      uint64_t free_len = locked_offs ? locked_offs : _get_total(id) - reserved;
+      uint64_t free_len = locked_offs ? locked_offs : _get_block_device_size(id) - reserved;
       alloc[id]->init_add_free(reserved, free_len);
     }
   }
@@ -1036,9 +1036,9 @@ int BlueFS::mount()
   if (vselector == nullptr) {
     vselector.reset(
       new OriginalVolumeSelector(
-        _get_total(BlueFS::BDEV_WAL) * 95 / 100,
-        _get_total(BlueFS::BDEV_DB) * 95 / 100,
-        _get_total(BlueFS::BDEV_SLOW) * 95 / 100));
+        _get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
+        _get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
+        _get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100));
   }
 
   _init_alloc();

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -775,14 +775,16 @@ void BlueFS::_init_alloc()
         name += devnames[id];
       else
         name += to_string(uintptr_t(this));
+      string alloc_type = cct->_conf->bluefs_allocator;
+
       dout(1) << __func__ << " new, id " << id << std::hex
               << ", allocator name " << name
-              << ", allocator type " << cct->_conf->bluefs_allocator
+              << ", allocator type " << alloc_type
               << ", capacity 0x" << bdev[id]->get_size()
               << ", reserved 0x" << block_reserved[id]
               << ", block size 0x" << alloc_size[id]
               << std::dec << dendl;
-      alloc[id] = Allocator::create(cct, cct->_conf->bluefs_allocator,
+      alloc[id] = Allocator::create(cct, alloc_type,
 				    bdev[id]->get_size(),
 				    alloc_size[id],
 				    name);
@@ -1120,10 +1122,14 @@ int BlueFS::prepare_new_device(int id, const bluefs_layout_t& layout)
 
 void BlueFS::collect_metadata(map<string,string> *pm, unsigned skip_bdev_id)
 {
-  if (skip_bdev_id != BDEV_DB && bdev[BDEV_DB])
+  if (skip_bdev_id != BDEV_DB && bdev[BDEV_DB]) {
     bdev[BDEV_DB]->collect_metadata("bluefs_db_", pm);
-  if (bdev[BDEV_WAL])
+    (*pm)["bluefs_db_allocator"]= alloc[BDEV_DB] ? alloc[BDEV_DB]->get_type(): "null";
+  }
+  if (bdev[BDEV_WAL]) {
     bdev[BDEV_WAL]->collect_metadata("bluefs_wal_", pm);
+    (*pm)["bluefs_wal_allocator"]= alloc[BDEV_WAL] ? alloc[BDEV_WAL]->get_type(): "null";
+  }
 }
 
 void BlueFS::get_devices(set<string> *ls)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1847,6 +1847,26 @@ int BlueFS::_replay(bool noop, bool to_stdout)
   return 0;
 }
 
+int BlueFS::super_dump()
+{
+  // only dump superblock's content
+  _init_logger();
+  int r = _open_super();
+  if (r < 0) {
+    derr << __func__ << " failed to open super: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  ceph::JSONFormatter f(true);
+  f.open_object_section("superblock");
+  super.dump(&f);
+  f.close_section();
+  f.flush(std::cout);
+
+  _shutdown_logger();
+  super = bluefs_super_t();
+  return r;
+}
+
 int BlueFS::log_dump()
 {
   // only dump log file's content

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -688,7 +688,7 @@ int BlueFS::mkfs(uuid_d osd_uuid, const bluefs_layout_t& layout)
 
   _init_logger();
 
-  super.version = 0;
+  super.seq = 0;
   super.block_size = bdev[BDEV_DB]->get_block_size();
   super.osd_uuid = osd_uuid;
   super.uuid.generate_random();
@@ -1201,20 +1201,20 @@ int BlueFS::fsck()
 
 int BlueFS::_write_super(int dev)
 {
-  ++super.version;
+  ++super.seq;
   // build superblock
   bufferlist bl;
   encode(super, bl);
   uint32_t crc = bl.crc32c(-1);
   encode(crc, bl);
   dout(10) << __func__ << " super block length(encoded): " << bl.length() << dendl;
-  dout(10) << __func__ << " superblock " << super.version << dendl;
+  dout(10) << __func__ << " superblock " << super.seq << dendl;
   dout(10) << __func__ << " log_fnode " << super.log_fnode << dendl;
   ceph_assert_always(bl.length() <= get_super_length());
   bl.append_zero(get_super_length() - bl.length());
 
   bdev[dev]->write(get_super_offset(), bl, false, WRITE_LIFE_SHORT);
-  dout(20) << __func__ << " v " << super.version
+  dout(20) << __func__ << " seq " << super.seq
            << " crc 0x" << std::hex << crc
            << " offset 0x" << get_super_offset() << std::dec
            << dendl;
@@ -1249,7 +1249,7 @@ int BlueFS::_open_super()
          << dendl;
     return -EIO;
   }
-  dout(10) << __func__ << " superblock " << super.version << dendl;
+  dout(10) << __func__ << " superblock " << super.seq << dendl;
   dout(10) << __func__ << " log_fnode " << super.log_fnode << dendl;
   return 0;
 }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -557,7 +557,7 @@ private:
   void _pad_bl(ceph::buffer::list& bl, uint64_t pad_size = 0);
 
   uint64_t _get_used(unsigned id) const;
-  uint64_t _get_total(unsigned id) const;
+  uint64_t _get_block_device_size(unsigned id) const;
   uint64_t _get_minimal_reserved(unsigned id) const;
 
   FileRef _get_file(uint64_t ino);
@@ -712,7 +712,7 @@ public:
     const bluefs_layout_t& layout);
 
   uint64_t get_used();
-  uint64_t get_total(unsigned id);
+  uint64_t get_block_device_size(unsigned id);
   uint64_t get_free(unsigned id);
   uint64_t get_used(unsigned id);
   uint64_t get_full_reserved(unsigned id);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -691,6 +691,7 @@ public:
   int prepare_new_device(int id, const bluefs_layout_t& layout);
   
   int log_dump();
+  int super_dump();
 
   void collect_metadata(std::map<std::string,std::string> *pm, unsigned skip_bdev_id);
   void get_devices(std::set<std::string> *ls);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -521,9 +521,12 @@ private:
    */
   std::vector<BlockDevice*> bdev;                  ///< block devices we can use
   std::vector<IOContext*> ioc;                     ///< IOContexts for bdevs
-  std::vector<uint64_t> block_reserved;            ///< starting reserve extent per device
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
+  std::vector<bluefs_extent_t> locked_alloc;       ///< candidate extents for locked alocations,
+                                                   ///< no alloc/release reqs matching these space
+                                                   ///< to be issued to allocator.
+
 
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;
 
@@ -555,7 +558,7 @@ private:
 
   uint64_t _get_used(unsigned id) const;
   uint64_t _get_total(unsigned id) const;
-
+  uint64_t _get_minimal_reserved(unsigned id) const;
 
   FileRef _get_file(uint64_t ino);
   void _drop_link_DF(FileRef f);
@@ -711,6 +714,7 @@ public:
   uint64_t get_total(unsigned id);
   uint64_t get_free(unsigned id);
   uint64_t get_used(unsigned id);
+  uint64_t get_full_reserved(unsigned id);
   void dump_perf_counters(ceph::Formatter *f);
 
   void dump_block_extents(std::ostream& out);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -777,7 +777,6 @@ public:
   int add_block_device(unsigned bdev, const std::string& path, bool trim,
                        bluefs_shared_alloc_context_t* _shared_alloc = nullptr);
   bool bdev_support_label(unsigned id);
-  uint64_t get_block_device_size(unsigned bdev) const;
   BlockDevice* get_block_device(unsigned bdev) const;
 
   // handler for discard event

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -523,9 +523,11 @@ private:
   std::vector<IOContext*> ioc;                     ///< IOContexts for bdevs
   std::vector<Allocator*> alloc;                   ///< allocators for bdevs
   std::vector<uint64_t> alloc_size;                ///< alloc size for each device
-  std::vector<bluefs_extent_t> locked_alloc;       ///< candidate extents for locked alocations,
-                                                   ///< no alloc/release reqs matching these space
-                                                   ///< to be issued to allocator.
+  std::vector<bluefs_locked_extents_t> locked_alloc;  ///< candidate extents
+                                                      ///< at both dev's head and tail
+                                                      ///< locked for allocations,
+                                                      ///< no alloc/release reqs matching
+                                                      ///< these space to be issued to allocator.
 
 
   //std::vector<interval_set<uint64_t>> block_unused_too_granular;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7627,16 +7627,16 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
     }
     if (cct->_conf->bluestore_volume_selection_policy == "fit_to_fast") {
       vselector = new FitToFastVolumeSelector(
-        bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-        bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-        bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100);
+        bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
+        bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
+        bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100);
     } else {
       double reserved_factor = cct->_conf->bluestore_volume_selection_reserved_factor;
       vselector =
         new RocksDBBlueFSVolumeSelector(
-          bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
-          bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-          bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100,
+          bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
+          bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
+          bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100,
 	  rocks_opts.write_buffer_size * rocks_opts.max_write_buffer_number,
           rocks_opts.max_bytes_for_level_base,
           rocks_opts.max_bytes_for_level_multiplier,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7627,16 +7627,16 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
     }
     if (cct->_conf->bluestore_volume_selection_policy == "fit_to_fast") {
       vselector = new FitToFastVolumeSelector(
-        bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
-        bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
-        bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100);
+        bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
+        bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
+        bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100);
     } else {
       double reserved_factor = cct->_conf->bluestore_volume_selection_reserved_factor;
       vselector =
         new RocksDBBlueFSVolumeSelector(
-          bluefs->get_total(BlueFS::BDEV_WAL) * 95 / 100,
-          bluefs->get_total(BlueFS::BDEV_DB) * 95 / 100,
-          bluefs->get_total(BlueFS::BDEV_SLOW) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100,
 	  rocks_opts.write_buffer_size * rocks_opts.max_write_buffer_number,
           rocks_opts.max_bytes_for_level_base,
           rocks_opts.max_bytes_for_level_multiplier,
@@ -11976,7 +11976,7 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
     buf->internally_reserved = 0;
     // include dedicated db, too, if that isn't the shared device.
     if (bluefs_layout.shared_bdev != BlueFS::BDEV_DB) {
-      buf->total += bluefs->get_total(BlueFS::BDEV_DB);
+      buf->total += bluefs->get_block_device_size(BlueFS::BDEV_DB);
     }
     // call any non-omap bluefs space "internal metadata"
     buf->internal_metadata =
@@ -18889,7 +18889,7 @@ void BlueStore::_log_alerts(osd_alert_list_t& alerts)
     bluefs->get_used(BlueFS::BDEV_SLOW) : 0;
   if (used > 0) {
       auto db_used = bluefs->get_used(BlueFS::BDEV_DB);
-      auto db_total = bluefs->get_total(BlueFS::BDEV_DB);
+      auto db_total = bluefs->get_block_device_size(BlueFS::BDEV_DB);
       ostringstream ss;
       ss << "spilled over " << byte_u_t(used)
          << " metadata from 'db' device (" << byte_u_t(db_used)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11865,6 +11865,7 @@ void BlueStore::collect_metadata(map<string,string> *pm)
   }
   (*pm)["bluestore_min_alloc_size"] = stringify(min_alloc_size);
   (*pm)["bluestore_allocation_from_file"] = stringify(fm && fm->is_null_manager());
+  (*pm)["bluestore_allocator"] = alloc ? alloc->get_type() : "null";
 }
 
 int BlueStore::get_numa_node(

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -37,6 +37,102 @@ ostream& operator<<(ostream& out, const bluefs_extent_t& e)
 	     << std::dec;
 }
 
+bluefs_locked_extents_t::bluefs_locked_extents_t(uint64_t head_reserved,
+  uint64_t full_size, uint64_t alloc_size)
+{
+  // Calculating three extents which are potential candidates for locking:
+  // [start, end]
+  // - head: [reserved, p2nphase(reserved, alloc_size)]
+  // - gray_tail: an area which should be locked if head becomes void
+  // - tail: [p2align(full_size, alloc_size), full_size]
+  // Final decision whether locked extents to be maintained is made after
+  // BlueFS replay depending on existing allocations.
+  // This class performs that recalculation on  reset_intercepted() calls
+  // which indicate existing allocations to it.
+  //
+
+  head_offset = head_reserved;
+  head_length = p2nphase(head_reserved, alloc_size);
+  if (head_reserved) {
+    ceph_assert(full_size > head_reserved);
+    uint64_t gray_free_end = p2align(full_size - head_reserved, alloc_size);
+    gray_free_end += head_reserved;
+    if (gray_free_end < full_size) {
+      gray_tail_offset = gray_free_end;
+      gray_tail_length = full_size - gray_free_end;
+    }
+  }
+  uint64_t free_end = p2align(full_size, alloc_size);
+  if (free_end < full_size) {
+    tail_offset = free_end;
+    tail_length = full_size - free_end;
+  }
+}
+
+void bluefs_locked_extents_t::reset_intersected(const bluefs_extent_t& e)
+{
+  if (e.offset < head_end() && e.end() > head_offset) {
+    head_offset = 0;
+    head_length = 0;
+  }
+  if (e.offset < gray_tail_end() && e.end() > gray_tail_offset) {
+    gray_tail_offset = 0;
+    gray_tail_length = 0;
+  }
+  if (e.offset < tail_end() && e.end() > tail_offset) {
+    tail_offset = 0;
+    tail_length = 0;
+  }
+}
+
+bluefs_locked_extents_t bluefs_locked_extents_t::get_merged() const
+{
+  bluefs_locked_extents_t res;
+  res.head_offset = head_offset;
+  res.head_length = head_length;
+  if (gray_tail_length) {
+    if (tail_length) {
+      ceph_assert(gray_tail_offset > 0);
+      ceph_assert(tail_offset > 0);
+      res.tail_offset = std::min(tail_offset, gray_tail_offset);
+      res.tail_length = std::max(tail_end(), gray_tail_end()) - res.tail_offset;
+    } else {
+      res.tail_offset = gray_tail_offset;
+      res.tail_length = gray_tail_length;
+    }
+  } else {
+    res.tail_offset = tail_offset;
+    res.tail_length = tail_length;
+  }
+  return res;
+}
+
+bluefs_locked_extents_t bluefs_locked_extents_t::finalize() const
+{
+  bluefs_locked_extents_t res;
+  if (head_length) {
+    res.head_offset = head_offset;
+    res.head_length = head_length;
+    if (tail_length) {
+      res.tail_offset = tail_offset;
+      res.tail_length = tail_length;
+    }
+  } else {
+    res.tail_offset = gray_tail_offset;
+    res.tail_length = gray_tail_length;
+  }
+  return res;
+}
+
+ostream& operator<<(ostream& out, const bluefs_locked_extents_t& e)
+{
+  return out << std::hex
+             << "<0x" << e.head_offset << "~" << e.head_length
+             << ", [0x"  << e.gray_tail_offset << "~" << e.gray_tail_length
+             << "], 0x"  << e.tail_offset << "~" << e.tail_length << ">"
+	     << std::dec;
+}
+
 // bluefs_layout_t
 
 void bluefs_layout_t::encode(bufferlist& bl) const

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -74,6 +74,8 @@ void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
 }
 
 // bluefs_super_t
+bluefs_super_t::bluefs_super_t() : version(0), block_size(4096) {
+}
 
 void bluefs_super_t::encode(bufferlist& bl) const
 {

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -74,7 +74,7 @@ void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
 }
 
 // bluefs_super_t
-bluefs_super_t::bluefs_super_t() : version(0), block_size(4096) {
+bluefs_super_t::bluefs_super_t() : seq(0), block_size(4096) {
 }
 
 void bluefs_super_t::encode(bufferlist& bl) const
@@ -82,7 +82,7 @@ void bluefs_super_t::encode(bufferlist& bl) const
   ENCODE_START(2, 1, bl);
   encode(uuid, bl);
   encode(osd_uuid, bl);
-  encode(version, bl);
+  encode(seq, bl);
   encode(block_size, bl);
   encode(log_fnode, bl);
   encode(memorized_layout, bl);
@@ -94,7 +94,7 @@ void bluefs_super_t::decode(bufferlist::const_iterator& p)
   DECODE_START(2, p);
   decode(uuid, p);
   decode(osd_uuid, p);
-  decode(version, p);
+  decode(seq, p);
   decode(block_size, p);
   decode(log_fnode, p);
   if (struct_v >= 2) {
@@ -107,7 +107,7 @@ void bluefs_super_t::dump(Formatter *f) const
 {
   f->dump_stream("uuid") << uuid;
   f->dump_stream("osd_uuid") << osd_uuid;
-  f->dump_unsigned("version", version);
+  f->dump_unsigned("seq", seq);
   f->dump_unsigned("block_size", block_size);
   f->dump_object("log_fnode", log_fnode);
 }
@@ -116,7 +116,7 @@ void bluefs_super_t::generate_test_instances(list<bluefs_super_t*>& ls)
 {
   ls.push_back(new bluefs_super_t);
   ls.push_back(new bluefs_super_t);
-  ls.back()->version = 1;
+  ls.back()->seq = 1;
   ls.back()->block_size = 4096;
 }
 
@@ -124,7 +124,7 @@ ostream& operator<<(ostream& out, const bluefs_super_t& s)
 {
   return out << "super(uuid " << s.uuid
 	     << " osd " << s.osd_uuid
-	     << " v " << s.version
+	     << " seq " << s.seq
 	     << " block_size 0x" << std::hex << s.block_size
 	     << " log_fnode 0x" << s.log_fnode
 	     << std::dec << ")";

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -35,6 +35,37 @@ WRITE_CLASS_DENC(bluefs_extent_t)
 
 std::ostream& operator<<(std::ostream& out, const bluefs_extent_t& e);
 
+struct bluefs_locked_extents_t {
+  uint64_t head_offset = 0;
+  uint32_t head_length = 0;
+
+  uint64_t gray_tail_offset = 0;
+  uint32_t gray_tail_length = 0;
+
+  uint64_t tail_offset = 0;
+  uint32_t tail_length = 0;
+
+  bluefs_locked_extents_t() {}
+  bluefs_locked_extents_t(uint64_t head_reserved, uint64_t full_size, uint64_t alloc_size);
+
+  void reset() {
+    *this = bluefs_locked_extents_t();
+  }
+  uint64_t head_end() const { return head_offset + head_length; }
+  uint64_t gray_tail_end() const { return gray_tail_offset + gray_tail_length; }
+  uint64_t tail_end() const { return tail_offset + tail_length; }
+
+  void reset_intersected(const bluefs_extent_t& e);
+
+  // returns extents in a form where tails are merged
+  bluefs_locked_extents_t get_merged() const;
+
+  // returns final locked extents where head/tail are present only
+  bluefs_locked_extents_t finalize() const;
+};
+
+std::ostream& operator<<(std::ostream& out, const bluefs_locked_extents_t& e);
+
 struct bluefs_fnode_delta_t {
   uint64_t ino;
   uint64_t size;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -213,7 +213,7 @@ WRITE_CLASS_ENCODER(bluefs_layout_t)
 struct bluefs_super_t {
   uuid_d uuid;      ///< unique to this bluefs instance
   uuid_d osd_uuid;  ///< matches the osd that owns us
-  uint64_t version;
+  uint64_t version; ///< In fact that's update counter
   uint32_t block_size;
 
   bluefs_fnode_t log_fnode;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -213,7 +213,7 @@ WRITE_CLASS_ENCODER(bluefs_layout_t)
 struct bluefs_super_t {
   uuid_d uuid;      ///< unique to this bluefs instance
   uuid_d osd_uuid;  ///< matches the osd that owns us
-  uint64_t version; ///< In fact that's update counter
+  uint64_t seq;     ///< sequence counter
   uint32_t block_size;
 
   bluefs_fnode_t log_fnode;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -220,9 +220,7 @@ struct bluefs_super_t {
 
   std::optional<bluefs_layout_t> memorized_layout;
 
-  bluefs_super_t()
-    : version(0),
-      block_size(4096) { }
+  bluefs_super_t();
 
   uint64_t block_mask() const {
     return ~((uint64_t)block_size - 1);

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -214,6 +214,25 @@ void log_dump(
   delete fs;
 }
 
+void super_dump(
+  CephContext *cct,
+  const string& path,
+  const vector<string>& devs)
+{
+  validate_path(cct, path, true);
+  BlueFS *fs = new BlueFS(cct);
+
+  add_devices(fs, cct, devs);
+  int r = fs->super_dump();
+  if (r < 0) {
+    cerr << "super_dump failed" << ": "
+         << cpp_strerror(r) << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+  delete fs;
+}
+
 void inferring_bluefs_devices(vector<string>& devs, std::string& path)
 {
   cout << "inferring bluefs devices from bluestore path" << std::endl;
@@ -338,6 +357,7 @@ int main(int argc, char **argv)
         "set-label-key, "
         "rm-label-key, "
         "prime-osd-dir, "
+        "bluefs-super-dump, "
         "bluefs-log-dump, "
         "free-dump, "
         "free-score, "
@@ -510,6 +530,7 @@ int main(int argc, char **argv)
   }
   if (action == "bluefs-export" || 
       action == "bluefs-import" || 
+      action == "bluefs-super-dump" ||
       action == "bluefs-log-dump") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
@@ -975,6 +996,8 @@ int main(int argc, char **argv)
     delete fs;
   } else if (action == "bluefs-log-dump") {
     log_dump(cct.get(), path, devs);
+  } else if (action == "bluefs-super-dump") {
+    super_dump(cct.get(), path, devs);
   } else if (action == "bluefs-bdev-new-db" || action == "bluefs-bdev-new-wal") {
     map<string, int> cur_devs_map;
     bool need_db = action == "bluefs-bdev-new-db";

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11801,7 +11801,7 @@ TEST_P(StoreTestSpecificAUSize, BlueFSReservedTest) {
             g_conf()->bluefs_alloc_size);
 
   ASSERT_EQ(fs->get_full_reserved(BlueFS::BDEV_WAL),
-            wal_extra);
+            g_conf()->bluefs_alloc_size + wal_extra);
 }
 
 #endif  // WITH_BLUESTORE

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11732,7 +11732,6 @@ TEST_P(StoreTestOmapUpgrade, LargeLegacyToPG) {
   }
 }
 
-
 TEST_P(StoreTest, BlueFS_truncate_remove_race) {
   if (string(GetParam()) != "bluestore")
     GTEST_SKIP();
@@ -11777,6 +11776,32 @@ TEST_P(StoreTest, BlueFS_truncate_remove_race) {
   fs.unittest_inject_delay = nullptr;
   EXPECT_EQ(store->umount(), 0);
   EXPECT_EQ(store->mount(), 0);
+}
+
+TEST_P(StoreTestSpecificAUSize, BlueFSReservedTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  uint64_t db_size = 1ull << 32; // 4GiB
+  uint64_t wal_extra = 0x10000;
+  uint64_t wal_size = db_size + wal_extra; // 4GiB + 64K
+  SetVal(g_conf(), "bluestore_block_db_create", "true");
+  SetVal(g_conf(), "bluestore_block_db_size", stringify(db_size).c_str());
+  SetVal(g_conf(), "bluestore_block_wal_create", "true");
+  SetVal(g_conf(), "bluestore_block_wal_size", stringify(wal_size).c_str());
+
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(65536);
+  BlueStore* bstore = dynamic_cast<BlueStore*> (store.get());
+  ceph_assert(bstore);
+  BlueFS* fs = bstore->get_bluefs();
+
+  ASSERT_EQ(fs->get_full_reserved(BlueFS::BDEV_DB),
+            g_conf()->bluefs_alloc_size);
+
+  ASSERT_EQ(fs->get_full_reserved(BlueFS::BDEV_WAL),
+            wal_extra);
 }
 
 #endif  // WITH_BLUESTORE

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -107,8 +107,8 @@ TEST(BlueFS, mkfs_mount) {
   ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
-  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - SUPER_RESERVED);
-  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - SUPER_RESERVED);
+  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size);
+  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size);
   fs.umount();
 }
 

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -107,7 +107,7 @@ TEST(BlueFS, mkfs_mount) {
   ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
-  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size);
+  ASSERT_EQ(fs.get_block_device_size(BlueFS::BDEV_DB), size);
   ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size);
   fs.umount();
 }

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1749,6 +1749,297 @@ TEST(BlueFS, test_69481_truncate_asserts) {
   fs.umount();
 }
 
+TEST(bluefs_locked_extents_t, basics) {
+  const uint64_t M = 1 << 20;
+  {
+    uint64_t reserved = 0x2000;
+    uint64_t au = 1*M;
+    uint64_t fullsize = 128*M;
+    bluefs_locked_extents_t lcke(reserved, fullsize, au);
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - au + reserved);
+    ASSERT_EQ(lcke.gray_tail_length, au - reserved);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    // no ops
+    lcke.reset_intersected(bluefs_extent_t(0, 1*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 10*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 127*M, reserved));
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - au + reserved);
+    ASSERT_EQ(lcke.gray_tail_length, au - reserved);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    // get_merged verification
+    auto e1 = lcke.get_merged();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.gray_tail_offset, 0);
+    ASSERT_EQ(e1.gray_tail_length, 0);
+    ASSERT_EQ(e1.tail_offset, lcke.gray_tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.gray_tail_length);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.gray_tail_offset, 0);
+    ASSERT_EQ(e1.gray_tail_length, 0);
+    ASSERT_EQ(e1.tail_offset, lcke.tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.tail_length);
+
+    // head has intersection
+    lcke.reset_intersected(bluefs_extent_t(0, reserved, au));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - au + reserved);
+    ASSERT_EQ(lcke.gray_tail_length, au - reserved);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, lcke.gray_tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.gray_tail_length);
+
+    // gray_tail has intersections
+    lcke.reset_intersected(bluefs_extent_t(0, 127*M + reserved, 0x1000));
+    lcke.reset_intersected(bluefs_extent_t(0, 128*M - 0x1000, 0x1000));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, 0);
+    ASSERT_EQ(lcke.gray_tail_length, 0);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, 0);
+    ASSERT_EQ(e1.tail_length, 0);
+  }
+  {
+    uint64_t reserved = 0x1000;
+    uint64_t au = 1*M;
+    uint64_t extra_tail = 0x10000;
+    uint64_t fullsize = 128*M + extra_tail;
+    bluefs_locked_extents_t lcke(reserved, fullsize, au);
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - extra_tail + reserved);
+    ASSERT_EQ(lcke.gray_tail_length, extra_tail - reserved);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    // no ops
+    lcke.reset_intersected(bluefs_extent_t(0, 1*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 10*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 127*M, reserved));
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - extra_tail + reserved);
+    ASSERT_EQ(lcke.gray_tail_length, extra_tail - reserved);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    // get_merged verification
+    auto e1 = lcke.get_merged();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.gray_tail_offset, 0);
+    ASSERT_EQ(e1.gray_tail_length, 0);
+    ASSERT_EQ(e1.tail_offset, std::min(lcke.gray_tail_offset, lcke.tail_offset));
+    ASSERT_EQ(e1.tail_length, fullsize - e1.tail_offset);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.tail_offset, lcke.tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.tail_length);
+
+    // head has intersection
+    lcke.reset_intersected(bluefs_extent_t(0, reserved, au));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - extra_tail + reserved);
+    ASSERT_EQ(lcke.gray_tail_length, extra_tail - reserved);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, lcke.gray_tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.gray_tail_length);
+
+    // tail has intersections
+    lcke.reset_intersected(bluefs_extent_t(0, 128*M, 0x1000));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - extra_tail + reserved);
+    ASSERT_EQ(lcke.gray_tail_length, extra_tail - reserved);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    // gray_tail has intersections
+    lcke.reset_intersected(bluefs_extent_t(0, 128*M + reserved, 0x1000));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, 0);
+    ASSERT_EQ(lcke.gray_tail_length, 0);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, 0);
+    ASSERT_EQ(e1.tail_length, 0);
+  }
+  {
+    uint64_t reserved = 0x2000;
+    uint64_t au = 1*M;
+    uint64_t extra_tail = 0x1000;
+    uint64_t fullsize = 128*M + extra_tail;
+    bluefs_locked_extents_t lcke(reserved, fullsize, au);
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - au + reserved - extra_tail);
+    ASSERT_EQ(lcke.gray_tail_length, au - reserved + extra_tail);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    // no ops
+    lcke.reset_intersected(bluefs_extent_t(0, 1*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 10*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 127*M, reserved));
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - au + reserved - extra_tail);
+    ASSERT_EQ(lcke.gray_tail_length, au - reserved + extra_tail);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    // get_merged verification
+    auto e1 = lcke.get_merged();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.gray_tail_offset, 0);
+    ASSERT_EQ(e1.gray_tail_length, 0);
+    ASSERT_EQ(e1.tail_offset, std::min(lcke.gray_tail_offset, lcke.tail_offset));
+    ASSERT_EQ(e1.tail_length, fullsize - e1.tail_offset);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.tail_offset, lcke.tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.tail_length);
+
+    // head has intersection, hopefully partial
+    lcke.reset_intersected(bluefs_extent_t(reserved - 0x1000, reserved, au));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, fullsize - au + reserved - extra_tail);
+    ASSERT_EQ(lcke.gray_tail_length, au - reserved + extra_tail);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, lcke.gray_tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.gray_tail_length);
+
+    // tail&gray_tail have intersections
+    lcke.reset_intersected(bluefs_extent_t(0, 128*M, 0x1000));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, 0);
+    ASSERT_EQ(lcke.gray_tail_length, 0);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, 0);
+    ASSERT_EQ(e1.tail_length, 0);
+  }
+  {
+    uint64_t reserved = 0x2000;
+    uint64_t au = 1*M;
+    uint64_t extra_tail = 0x2000;
+    uint64_t fullsize = 128*M + extra_tail;
+    bluefs_locked_extents_t lcke(reserved, fullsize, au);
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, 0);
+    ASSERT_EQ(lcke.gray_tail_length, 0);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    // no ops
+    lcke.reset_intersected(bluefs_extent_t(0, 1*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 10*M, 1*M));
+    lcke.reset_intersected(bluefs_extent_t(0, 127*M, reserved));
+    ASSERT_EQ(lcke.head_offset, reserved);
+    ASSERT_EQ(lcke.head_length, au - reserved);
+    ASSERT_EQ(lcke.gray_tail_offset, 0);
+    ASSERT_EQ(lcke.gray_tail_length, 0);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    // get_merged verification
+    auto e1 = lcke.get_merged();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.gray_tail_offset, 0);
+    ASSERT_EQ(e1.gray_tail_length, 0);
+    ASSERT_EQ(e1.tail_offset, lcke.tail_offset);
+    ASSERT_EQ(e1.tail_length, fullsize - e1.tail_offset);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, lcke.head_offset);
+    ASSERT_EQ(e1.head_length, lcke.head_length);
+    ASSERT_EQ(e1.tail_offset, lcke.tail_offset);
+    ASSERT_EQ(e1.tail_length, lcke.tail_length);
+
+    // head has intersection, hopefully partial
+    lcke.reset_intersected(bluefs_extent_t(reserved - 0x1000, reserved, au));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, 0);
+    ASSERT_EQ(lcke.gray_tail_length, 0);
+    ASSERT_EQ(lcke.tail_offset, fullsize - extra_tail);
+    ASSERT_EQ(lcke.tail_length, extra_tail);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, 0);
+    ASSERT_EQ(e1.tail_length, 0);
+
+    // tail have intersections
+    lcke.reset_intersected(bluefs_extent_t(0, 128*M, 0x1000));
+    ASSERT_EQ(lcke.head_offset, 0);
+    ASSERT_EQ(lcke.head_length, 0);
+    ASSERT_EQ(lcke.gray_tail_offset, 0);
+    ASSERT_EQ(lcke.gray_tail_length, 0);
+    ASSERT_EQ(lcke.tail_offset, 0);
+    ASSERT_EQ(lcke.tail_length, 0);
+
+    e1 = lcke.finalize();
+    ASSERT_EQ(e1.head_offset, 0);
+    ASSERT_EQ(e1.head_length, 0);
+    ASSERT_EQ(e1.tail_offset, 0);
+    ASSERT_EQ(e1.tail_length, 0);
+  }
+}
+
 int main(int argc, char **argv) {
   auto args = argv_to_vec(argc, argv);
   map<string,string> defaults = {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/70711
Parent tracker: https://tracker.ceph.com/issues/68772
Backports: https://github.com/ceph/ceph/pull/62174

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
