### PR TITLE
squid: rgw/s3: remove local variable 'uri' that shadows member variable

### DIFF
--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -200,7 +200,6 @@ bool ACLGrant_S3::xml_end(const char *el) {
   ACLURI_S3 *acl_uri;
   ACLEmail_S3 *acl_email;
   ACLDisplayName_S3 *acl_name;
-  string uri;
 
   acl_grantee = static_cast<ACLGrantee_S3 *>(find_first("Grantee"));
   if (!acl_grantee)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69811

---

backport of https://github.com/ceph/ceph/pull/61368
parent tracker: https://tracker.ceph.com/issues/69527

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh