### PR TITLE
squid: mgr/dashboard: fix image filter's query on rbd-details grafana panel

### DIFF
--- a/monitoring/ceph-mixin/dashboards/rbd.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/rbd.libsonnet
@@ -80,7 +80,7 @@ local info_rbd_stats = std.join(
     .addTemplate(
       $.addTemplateSchema('image',
                           '$datasource',
-                          'label_values(ceph_rbd_read_ops{%(matchers)s, pool="$pool"}, image)' % $.matchers(),
+                          'label_values(ceph_rbd_read_ops{%(matchers)s pool="$pool"}, image)' % $.matchers(),
                           1,
                           false,
                           0,

--- a/monitoring/ceph-mixin/dashboards_out/rbd-details.json
+++ b/monitoring/ceph-mixin/dashboards_out/rbd-details.json
@@ -417,7 +417,7 @@
             "multi": false,
             "name": "image",
             "options": [ ],
-            "query": "label_values(ceph_rbd_read_ops{cluster=~\"$cluster\", , pool=\"$pool\"}, image)",
+            "query": "label_values(ceph_rbd_read_ops{cluster=~\"$cluster\",  pool=\"$pool\"}, image)",
             "refresh": 1,
             "regex": "",
             "sort": 0,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70686

---

backport of https://github.com/ceph/ceph/pull/62489
parent tracker: https://tracker.ceph.com/issues/70653

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh