### PR TITLE
reef: suites/rados/cephadm: add still running warning to the ignore list

### DIFF
--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -23,6 +23,7 @@ overrides:
     log-ignorelist:
       - OSD_DOWN
       - CEPHADM_FAILED_DAEMON
+      - but is still running
     conf:
       osd:
         osd shutdown pgref assert: true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70656

---

backport of https://github.com/ceph/ceph/pull/62329
parent tracker: https://tracker.ceph.com/issues/70465

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh