### PR TITLE
osd/../client_request: Fix clone replicated reads

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -903,6 +903,7 @@ pg_log_entry_t OpsExecuter::prepare_head_update(
 {
   LOG_PREFIX(OpsExecuter::prepare_head_update);
   assert(obc->obs.oi.soid.snap >= CEPH_MAXSNAP);
+  assert(obc->obs.oi.soid.is_head());
 
   update_clone_overlap();
   if (cloning_ctx) {

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -354,7 +354,8 @@ ClientRequest::process_op(
     }
 
     std::set<snapid_t> snaps = snaps_need_to_recover();
-    if (!snaps.empty()) {
+    if (!snaps.empty() &&
+        pg->is_missing_head_and_clones(m->get_hobj().get_head())) {
       co_await recover_missing_snaps(pg, snaps);
     }
   }

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -197,9 +197,10 @@ ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptib
     }
 
     pg.get_perf_logger().inc(l_osd_replica_read);
-    if (pg.is_unreadable_object(m->get_hobj())) {
-      DEBUGDPP("{}.{}: {} missing on replica, bouncing to primary",
-	       pg, *this, this_instance_id, m->get_hobj());
+    if (pg.is_missing_head_and_clones(m->get_hobj())) {
+      DEBUGDPP("{}.{}: {} possibly missing head or clone object on replica,"
+               " bouncing to primary",
+               pg, *this, this_instance_id, m->get_hobj());
       pg.get_perf_logger().inc(l_osd_replica_read_redirect_missing);
       co_await reply_op_error(pgref, -EAGAIN);
       co_return;

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -205,6 +205,8 @@ ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptib
       co_await reply_op_error(pgref, -EAGAIN);
       co_return;
     } else if (!pg.get_peering_state().can_serve_replica_read(m->get_hobj())) {
+      // Note: can_serve_replica_read checks for writes on the head object
+      //       as writes can only occur to head.
       DEBUGDPP("{}.{}: unstable write on replica, bouncing to primary",
 	       pg, *this, this_instance_id);
       pg.get_perf_logger().inc(l_osd_replica_read_redirect_conflict);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1511,6 +1511,10 @@ void PG::context_registry_on_change() {
   }
 }
 
+bool PG::is_missing_head_and_clones(const hobject_t &hoid) {
+  return peering_state.is_missing_any_head_or_clone_of(hoid);
+}
+
 bool PG::can_discard_op(const MOSDOp& m) const {
   if (m.get_map_epoch() <
       peering_state.get_info().history.same_primary_since) {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -952,6 +952,10 @@ private:
       !peering_state.get_missing_loc().readable_with_acting(
 	oid, get_actingset(), v);
   }
+
+  // check if any head or clone of this object is missing
+  bool is_missing_head_and_clones(const hobject_t &hoid);
+
   bool is_missing_on_peer(
     const pg_shard_t &peer,
     const hobject_t &soid) const {

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2441,6 +2441,10 @@ public:
   unsigned int get_num_missing() const {
     return pg_log.get_missing().num_missing();
   }
+  bool is_missing_any_head_or_clone_of(const hobject_t &hoid) {
+    const auto& missing = pg_log.get_missing();
+    return missing.is_missing_any_head_or_clone_of(hoid);
+  }
 
   const MissingLoc &get_missing_loc() const {
     return missing_loc;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4985,6 +4985,12 @@ public:
       return false;
     return true;
   }
+
+  bool is_missing_any_head_or_clone_of(const hobject_t& oid) const {
+    return missing.lower_bound(oid.get_object_boundary()) !=
+      missing.lower_bound(oid.get_max_object_boundary());
+  }
+
   eversion_t get_oldest_need() const {
     if (missing.empty()) {
       return eversion_t();

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1435,6 +1435,35 @@ TEST(pg_missing_t, split_into)
   EXPECT_TRUE(missing.is_missing(oid2));
 }
 
+TEST(pg_missing_t, is_missing_any_head_or_clone_of)
+{
+  hobject_t head_oid(object_t("objname"), "key", 123, 456, 0, "");
+  auto clone_oid = head_oid;
+  clone_oid.snap = 1;
+
+  // empty missing
+  pg_missing_t missing;
+  EXPECT_FALSE(missing.is_missing(head_oid));
+  EXPECT_FALSE(missing.is_missing_any_head_or_clone_of(head_oid));
+  EXPECT_FALSE(missing.is_missing(clone_oid));
+  EXPECT_FALSE(missing.is_missing_any_head_or_clone_of(clone_oid));
+
+  // only head is missing
+  missing.add(head_oid, eversion_t(), eversion_t(), false);
+  EXPECT_TRUE(missing.is_missing(head_oid));
+  EXPECT_TRUE(missing.is_missing_any_head_or_clone_of(head_oid));
+  EXPECT_FALSE(missing.is_missing(clone_oid));
+  EXPECT_TRUE(missing.is_missing_any_head_or_clone_of(clone_oid));
+
+  // only clone is missing
+  pg_missing_t missing2;
+  missing2.add(clone_oid, eversion_t(), eversion_t(), false);
+  EXPECT_FALSE(missing2.is_missing(head_oid));
+  EXPECT_TRUE(missing2.is_missing_any_head_or_clone_of(head_oid));
+  EXPECT_TRUE(missing2.is_missing(clone_oid));
+  EXPECT_TRUE(missing2.is_missing_any_head_or_clone_of(clone_oid));
+}
+
 TEST(pg_pool_t_test, get_pg_num_divisor) {
   pg_pool_t p;
   p.set_pg_num(16);


### PR DESCRIPTION
```
When handling a client request on a clone object, m->get_hobj() might
not actually represent the "actual" object from the OSD's prespective.
See: ObjectContext::resolve_oid for how this logic is handled.

If this replica has any missing clone objects that are either this object head
or any of this object's clones - drop this replicted read and bounce back to primary.

Keep the head missing check in order to avoid trying to find any
missing clones if this is not a clone.

We could possibly check if the head is not missing and then wait for
resolve_oid to lookup for the actual clone object (Which might exist!).
However, this seems to not be worth the complexity as the niche scenario
of being able to serve reads while having (possibly) releated missing objects.

Fixes (3/3): https://tracker.ceph.com/issues/70639
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
