### PR TITLE
rgw: send concurrent watch/unwatch operations

### DIFF
--- a/src/common/async/detail/spawn_throttle_impl.h
+++ b/src/common/async/detail/spawn_throttle_impl.h
@@ -169,7 +169,7 @@ struct spawn_throttle_handler {
   }
 };
 
-spawn_throttle_handler spawn_throttle_impl::get()
+inline spawn_throttle_handler spawn_throttle_impl::get()
 {
   report_exception(); // throw unreported exception
 
@@ -345,8 +345,8 @@ class async_spawn_throttle_impl final :
   }
 };
 
-auto spawn_throttle_impl::create(optional_yield y, size_t limit,
-                                 cancel_on_error on_error)
+inline auto spawn_throttle_impl::create(optional_yield y, size_t limit,
+                                        cancel_on_error on_error)
     -> boost::intrusive_ptr<spawn_throttle_impl>
 {
   if (y) {

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -1133,7 +1133,23 @@ options:
   default: 8
   services:
   - rgw
+  see_also:
+  - rgw_cache_enabled
+  - rgw_max_control_aio
   with_legacy: true
+- name: rgw_max_control_aio
+  type: int
+  level: advanced
+  desc: Maximum number of concurrent operations over control objects.
+  long_desc: When metadata caching is enabled, a watch operation is sent to each
+    control object on startup, with a corresponding unwatch on shutdown. To
+    accelerate startup/shutdown, allow several concurrent operations to be sent
+    at once.
+  default: 8
+  services:
+  - rgw
+  see_also:
+  - rgw_num_control_oids
 - name: rgw_verify_ssl
   type: bool
   level: advanced

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -116,6 +116,34 @@ int rgw_get_rados_ref(const DoutPrefixProvider* dpp, librados::Rados* rados,
   return 0;
 }
 
+int rgw_rados_ref::watch(const DoutPrefixProvider* dpp, uint64_t* handle,
+                         librados::WatchCtx2* ctx, optional_yield y)
+{
+  if (y) {
+    auto& yield = y.get_yield_context();
+    boost::system::error_code ec;
+    librados::async_watch(yield.get_executor(), ioctx, obj.oid,
+                          handle, ctx, 0, yield[ec]);
+    return ceph::from_error_code(ec);
+  } else {
+    maybe_warn_about_blocking(dpp);
+    return ioctx.watch2(obj.oid, handle, ctx);
+  }
+}
+
+int rgw_rados_ref::unwatch(const DoutPrefixProvider* dpp, uint64_t handle,
+                           optional_yield y)
+{
+  if (y) {
+    auto& yield = y.get_yield_context();
+    boost::system::error_code ec;
+    librados::async_unwatch(yield.get_executor(), ioctx, handle, yield[ec]);
+    return ceph::from_error_code(ec);
+  } else {
+    maybe_warn_about_blocking(dpp);
+    return ioctx.unwatch2(handle);
+  }
+}
 
 map<string, bufferlist>* no_change_attrs() {
   static map<string, bufferlist> no_change;

--- a/src/rgw/driver/rados/rgw_tools.h
+++ b/src/rgw/driver/rados/rgw_tools.h
@@ -128,18 +128,10 @@ struct rgw_rados_ref {
     return ioctx.aio_operate(obj.oid, c, op, pbl);
   }
 
-  int watch(uint64_t* handle, librados::WatchCtx2* ctx) {
-    return ioctx.watch2(obj.oid, handle, ctx);
-  }
+  int watch(const DoutPrefixProvider* dpp, uint64_t* handle,
+            librados::WatchCtx2* ctx, optional_yield y);
 
-  int aio_watch(librados::AioCompletion* c, uint64_t* handle,
-		librados::WatchCtx2 *ctx) {
-    return ioctx.aio_watch(obj.oid, c, handle, ctx);
-  }
-
-  int unwatch(uint64_t handle) {
-    return ioctx.unwatch2(handle);
-  }
+  int unwatch(const DoutPrefixProvider* dpp, uint64_t handle, optional_yield y);
 
   int notify(const DoutPrefixProvider* dpp, bufferlist& bl, uint64_t timeout_ms,
 	     bufferlist* pbl, optional_yield y) {

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -20,6 +20,7 @@ using namespace std;
 
 static string notify_oid_prefix = "notify";
 
+RGWSI_Notify::RGWSI_Notify(CephContext *cct) : RGWServiceInstance(cct) {}
 RGWSI_Notify::~RGWSI_Notify()
 {
   shutdown();
@@ -207,11 +208,11 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
   if (num_watchers <= 0)
     num_watchers = 1;
 
-  watchers = new RGWWatcher *[num_watchers];
-
   int error = 0;
 
   notify_objs.resize(num_watchers);
+
+  watchers.reserve(num_watchers);
 
   for (int i=0; i < num_watchers; i++) {
     string notify_oid;
@@ -239,10 +240,9 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
       return r;
     }
 
-    RGWWatcher *watcher = new RGWWatcher(cct, this, i, notify_obj);
-    watchers[i] = watcher;
+    auto& watcher = watchers.emplace_back(cct, this, i, notify_obj);
 
-    r = watcher->register_watch_async();
+    r = watcher.register_watch_async();
     if (r < 0) {
       ldpp_dout(dpp, 0) << "WARNING: register_watch_aio() returned " << r << dendl;
       error = r;
@@ -250,8 +250,8 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
     }
   }
 
-  for (int i = 0; i < num_watchers; ++i) {
-    int r = watchers[i]->register_watch_finish();
+  for (auto& watcher : watchers) {
+    int r = watcher.register_watch_finish();
     if (r < 0) {
       ldpp_dout(dpp, 0) << "WARNING: async watch returned " << r << dendl;
       error = r;
@@ -268,13 +268,10 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
 void RGWSI_Notify::finalize_watch()
 {
   for (int i = 0; i < num_watchers; i++) {
-    RGWWatcher *watcher = watchers[i];
     if (watchers_set.find(i) != watchers_set.end())
-      watcher->unregister_watch();
-    delete watcher;
+      watchers[i].unregister_watch();
   }
-
-  delete[] watchers;
+  watchers.clear();
 }
 
 int RGWSI_Notify::do_start(optional_yield y, const DoutPrefixProvider *dpp)

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -3,7 +3,9 @@
 
 #include "include/random.h"
 #include "include/Context.h"
+#include "common/async/spawn_throttle.h"
 #include "common/errno.h"
+#include "common/error_code.h"
 
 #include "rgw_cache.h"
 #include "svc_notify.h"
@@ -33,9 +35,7 @@ class RGWWatcher : public DoutPrefixProvider , public librados::WatchCtx2 {
   int index;
   rgw_rados_ref obj;
   uint64_t watch_handle;
-  int register_ret{0};
   bool unregister_done{false};
-  librados::AioCompletion *register_completion{nullptr};
   uint64_t retries = 0;
 
   class C_ReinitWatch : public Context {
@@ -99,7 +99,7 @@ public:
       abort();
     }
     if(!unregister_done) {
-      int ret = unregister_watch();
+      int ret = unregister_watch(null_yield);
       if (ret < 0) {
         ldout(cct, 0) << "ERROR: unregister_watch() returned ret=" << ret << dendl;
 	if (-2 == ret) {
@@ -111,7 +111,7 @@ public:
 	}
       }
     }
-    int ret = register_watch();
+    int ret = register_watch(null_yield);
     if (ret < 0) {
       ldout(cct, 0) << "ERROR: register_watch() returned ret=" << ret << dendl;
       ++retries;
@@ -120,8 +120,8 @@ public:
     }
   }
 
-  int unregister_watch() {
-    int r = svc->unwatch(obj, watch_handle);
+  int unregister_watch(optional_yield y) {
+    int r = svc->unwatch(this, obj, watch_handle, y);
     unregister_done = true;
     if (r < 0) {
       return r;
@@ -130,41 +130,8 @@ public:
     return 0;
   }
 
-  int register_watch_async() {
-    if (register_completion) {
-      register_completion->release();
-      register_completion = nullptr;
-    }
-    register_completion = librados::Rados::aio_create_completion(nullptr, nullptr);
-    register_ret = obj.aio_watch(register_completion, &watch_handle, this);
-    if (register_ret < 0) {
-      register_completion->release();
-      return register_ret;
-    }
-    return 0;
-  }
-
-  int register_watch_finish() {
-    if (register_ret < 0) {
-      return register_ret;
-    }
-    if (!register_completion) {
-      return -EINVAL;
-    }
-    register_completion->wait_for_complete();
-    int r = register_completion->get_return_value();
-    register_completion->release();
-    register_completion = nullptr;
-    if (r < 0) {
-      return r;
-    }
-    svc->add_watcher(index);
-    unregister_done = false;
-    return 0;
-  }
-
-  int register_watch() {
-    int r = obj.watch(&watch_handle, this);
+  int register_watch(optional_yield y) {
+    int r = obj.watch(this, &watch_handle, this, y);
     if (r < 0) {
       return r;
     }
@@ -211,8 +178,9 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
   if (num_watchers <= 0)
     num_watchers = 1;
 
-  int error = 0;
-
+  const size_t max_aio = cct->_conf.get_val<int64_t>("rgw_max_control_aio");
+  auto throttle = ceph::async::spawn_throttle{
+      y, max_aio, ceph::async::cancel_on_error::all};
   watchers.reserve(num_watchers);
 
   for (int i=0; i < num_watchers; i++) {
@@ -231,36 +199,34 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
       ldpp_dout(dpp, 0) << "ERROR: notify_obj.open() returned r=" << r << dendl;
       return r;
     }
-
-    librados::ObjectWriteOperation op;
-    op.create(false);
-
-    r = notify_obj.operate(dpp, std::move(op), y);
-    if (r < 0 && r != -EEXIST) {
-      ldpp_dout(dpp, 0) << "ERROR: notify_obj.operate() returned r=" << r << dendl;
-      return r;
-    }
-
     auto& watcher = watchers.emplace_back(cct, this, i, std::move(notify_obj));
 
-    r = watcher.register_watch_async();
-    if (r < 0) {
-      ldpp_dout(dpp, 0) << "WARNING: register_watch_aio() returned " << r << dendl;
-      error = r;
-      continue;
-    }
-  }
+    try {
+      throttle.spawn([dpp, &watcher] (boost::asio::yield_context yield) {
+            // create the object if it doesn't exist
+            librados::ObjectWriteOperation op;
+            op.create(false);
 
-  for (auto& watcher : watchers) {
-    int r = watcher.register_watch_finish();
-    if (r < 0) {
-      ldpp_dout(dpp, 0) << "WARNING: async watch returned " << r << dendl;
-      error = r;
-    }
-  }
+            int r = watcher.get_obj().operate(dpp, std::move(op), yield);
+            if (r < 0 && r != -EEXIST) {
+              ldpp_dout(dpp, 0) << "ERROR: notify_obj.operate() returned r=" << r << dendl;
+              throw boost::system::system_error(ceph::to_error_code(r));
+            }
 
-  if (error < 0) {
-    return error;
+            r = watcher.register_watch(yield);
+            if (r < 0) {
+              throw boost::system::system_error(ceph::to_error_code(r));
+            }
+          });
+    } catch (const boost::system::system_error& e) {
+      return ceph::from_error_code(e.code());
+    }
+  } // for num_watchers
+
+  try {
+    throttle.wait();
+  } catch (const boost::system::system_error& e) {
+    return ceph::from_error_code(e.code());
   }
 
   return 0;
@@ -268,10 +234,19 @@ int RGWSI_Notify::init_watch(const DoutPrefixProvider *dpp, optional_yield y)
 
 void RGWSI_Notify::finalize_watch()
 {
+  const size_t max_aio = cct->_conf.get_val<int64_t>("rgw_max_control_aio");
+  auto throttle = ceph::async::spawn_throttle{
+      null_yield, max_aio, ceph::async::cancel_on_error::all};
   for (int i = 0; i < num_watchers; i++) {
-    if (watchers_set.find(i) != watchers_set.end())
-      watchers[i].unregister_watch();
+    if (!watchers_set.contains(i)) {
+      continue;
+    }
+    throttle.spawn([&watcher = watchers[i]] (boost::asio::yield_context yield) {
+          std::ignore = watcher.unregister_watch(yield);
+        });
   }
+  throttle.wait();
+
   watchers.clear();
 }
 
@@ -325,9 +300,10 @@ void RGWSI_Notify::shutdown()
   finalized = true;
 }
 
-int RGWSI_Notify::unwatch(rgw_rados_ref& obj, uint64_t watch_handle)
+int RGWSI_Notify::unwatch(const DoutPrefixProvider* dpp, rgw_rados_ref& obj,
+                          uint64_t handle, optional_yield y)
 {
-  int r = obj.unwatch(watch_handle);
+  int r = obj.unwatch(dpp, handle, y);
   if (r < 0) {
     ldout(cct, 0) << "ERROR: rados->unwatch2() returned r=" << r << dendl;
     return r;

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -35,7 +35,7 @@ private:
   rgw_pool control_pool;
 
   int num_watchers{0};
-  RGWWatcher **watchers{nullptr};
+  std::vector<RGWWatcher> watchers;
   std::set<int> watchers_set;
   std::vector<rgw_rados_ref> notify_objs;
 
@@ -84,7 +84,7 @@ private:
 
   void schedule_context(Context *c);
 public:
-  RGWSI_Notify(CephContext *cct): RGWServiceInstance(cct) {}
+  RGWSI_Notify(CephContext *cct);
 
   virtual ~RGWSI_Notify() override;
 

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -66,7 +66,8 @@ private:
   int do_start(optional_yield, const DoutPrefixProvider *dpp) override;
   void shutdown() override;
 
-  int unwatch(rgw_rados_ref& obj, uint64_t watch_handle);
+  int unwatch(const DoutPrefixProvider* dpp, rgw_rados_ref& obj,
+              uint64_t handle, optional_yield y);
   void add_watcher(int i);
   void remove_watcher(int i);
 

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -37,7 +37,6 @@ private:
   int num_watchers{0};
   std::vector<RGWWatcher> watchers;
   std::set<int> watchers_set;
-  std::vector<rgw_rados_ref> notify_objs;
 
   bool enabled{false};
 


### PR DESCRIPTION
accelerate startup and shutdown of radosgw and radosgw-admin by sending concurrent watch/unwatch operations over the rgw_num_control_oid=8 objects

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
