### PR TITLE
mgr/cephadm: Add management commands and safety checks for scheduled daemon actions

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -104,6 +104,45 @@ new key) with the following command:
 For MDS, OSD, and Manager daemons, this does not require a daemon restart.  For other
 daemons, however (e.g., RGW), the daemon may be restarted to switch to the new key.
 
+Listing scheduled daemon actions
+--------------------------------
+
+Daemons and services can undergo actions including restarts can be performed on daemons and services.
+
+.. prompt:: bash #
+
+   ceph orch restart osd.all-available-devices
+
+::
+
+   Scheduled to restart osd.5 on host 'cephadm-2'
+   Scheduled to restart osd.2 on host 'cephadm-2'
+   Scheduled to restart osd.0 on host 'cephadm-3'
+   Scheduled to restart osd.3 on host 'cephadm-3'
+   Scheduled to restart osd.1 on host 'cephadm-4'
+   Scheduled to restart osd.4 on host 'cephadm-4'
+
+These scheduled actions are processed by cephadm asynchronously and we can list
+the ongoing actions with ``action ls`` command:
+
+.. prompt:: bash #
+
+   ceph orch action ls
+
+::
+
+   HOST      DAEMON  ACTION   FORCED
+   cephadm-2  osd.5   restart  No
+   cephadm-2  osd.2   restart  No
+   cephadm-3  osd.0   restart  No
+   cephadm-3  osd.3   restart  No
+   cephadm-4  osd.1   restart  No
+   cephadm-4  osd.4   restart  No
+
+By default, these scheduled actions are not forced and verify that it is safe to proceed by checking the daemon's internal ``ok-to-stop`` command.
+For example, ``osd.5`` will restart successfully if ``ceph osd ok-to-stop osd.5`` is true, which means no PGs will become inactive. This safety check is performed
+for the following actions: ``redeploy``, ``stop``, and ``restart``. Other actions such as ``start``, ``rotate-key``, and ``reconfig`` do not perform this safety check
+and ignore the force flag by default.
 
 .. _cephadm-logs:
 

--- a/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
@@ -107,6 +107,7 @@ tasks:
       - |
         set -ex
         FSID=$(/home/ubuntu/cephtest/cephadm shell -- ceph fsid)
+        ceph orch redeploy mon --force
         sleep 60
         # check extra container and entrypoint args written to mon unit run file
         grep "\-\-cpus=2" /var/lib/ceph/$FSID/mon.*/unit.run

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2603,7 +2603,7 @@ Then run the following:
         if not dds:
             raise OrchestratorError(f'No daemons exist under service name "{service_name}".'
                                     + ' View currently running services using "ceph orch ls"')
-        self.log.info('%s service %s' % (action.capitalize(), service_name))
+        self.log.info('%s service %s force=%s' % (action.capitalize(), service_name, force))
         return [
             self._schedule_daemon_action(dd.name(), action, force=force)
             for dd in dds

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4455,8 +4455,8 @@ Then run the following:
         """
         Cancel a scheduled daemon action
         """
-        for host, daemons, _ in self.cache.get_all_scheduled_actions():
-            if daemon_name in daemons:
+        for host, scheduled_daemon, _ in self.cache.get_all_scheduled_actions():
+            if daemon_name == scheduled_daemon:
                 self.cache.rm_scheduled_daemon_action(host, daemon_name)
                 self.cache.clear_force_action(host, daemon_name)
                 self.cache.save_host(host)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2598,26 +2598,26 @@ Then run the following:
                 result.append(dd)
         return result
 
-    def perform_service_action(self, action: str, service_name: str) -> List[str]:
+    def perform_service_action(self, action: str, service_name: str, force: bool = True) -> List[str]:
         dds: List[DaemonDescription] = self.cache.get_daemons_by_service(service_name)
         if not dds:
             raise OrchestratorError(f'No daemons exist under service name "{service_name}".'
                                     + ' View currently running services using "ceph orch ls"')
         self.log.info('%s service %s' % (action.capitalize(), service_name))
         return [
-            self._schedule_daemon_action(dd.name(), action)
+            self._schedule_daemon_action(dd.name(), action, force=force)
             for dd in dds
         ]
 
     @handle_orch_error
-    def service_action(self, action: str, service_name: str) -> List[str]:
+    def service_action(self, action: str, service_name: str, force: bool = True) -> List[str]:
         if service_name not in self.spec_store.all_specs.keys():
             raise OrchestratorError(f'Invalid service name "{service_name}".'
                                     + ' View currently running services using "ceph orch ls"')
-        if action == 'stop' and service_name.split('.')[0].lower() in ['mgr', 'mon', 'osd']:
+        if action == 'stop' and service_name.split('.')[0].lower() in ['mgr', 'mon', 'osd'] and not force:
             return [f'Stopping entire {service_name} service is prohibited.']
 
-        return self.perform_service_action(action, service_name)
+        return self.perform_service_action(action, service_name, force=force)
 
     def _rotate_daemon_key(self, daemon_spec: CephadmDaemonDeploySpec) -> str:
         self.log.info(f'Rotating authentication key for {daemon_spec.name()}')
@@ -2731,7 +2731,7 @@ Then run the following:
             })
 
     @handle_orch_error
-    def daemon_action(self, action: str, daemon_name: str, image: Optional[str] = None, force: bool = False) -> str:
+    def daemon_action(self, action: str, daemon_name: str, image: Optional[str] = None, force: bool = True) -> str:
         d = self.cache.get_daemon(daemon_name)
         assert d.daemon_type is not None
         assert d.daemon_id is not None
@@ -2757,7 +2757,7 @@ Then run the following:
         self._daemon_action_set_image(action, image, d.daemon_type, d.daemon_id)
 
         self.log.info(f'Schedule {action} daemon {daemon_name}')
-        return self._schedule_daemon_action(daemon_name, action)
+        return self._schedule_daemon_action(daemon_name, action, force)
 
     def daemon_is_self(self, daemon_type: str, daemon_id: str) -> bool:
         return daemon_type == 'mgr' and daemon_id == self.get_mgr_id()
@@ -2770,7 +2770,7 @@ Then run the following:
             self.cache.get_daemons_by_type('mgr')).container_image_digests
         return digests if digests else []
 
-    def _schedule_daemon_action(self, daemon_name: str, action: str) -> str:
+    def _schedule_daemon_action(self, daemon_name: str, action: str, force: bool = True) -> str:
         dd = self.cache.get_daemon(daemon_name)
         assert dd.daemon_type is not None
         assert dd.daemon_id is not None
@@ -2779,7 +2779,7 @@ Then run the following:
                 and not self.mgr_service.mgr_map_has_standby():
             raise OrchestratorError(
                 f'Unable to schedule redeploy for {daemon_name}: No standby MGRs')
-        self.cache.schedule_daemon_action(dd.hostname, dd.name(), action)
+        self.cache.schedule_daemon_action(dd.hostname, dd.name(), action, force)
         self.cache.save_host(dd.hostname)
         msg = "Scheduled to {} {} on host '{}'".format(action, daemon_name, dd.hostname)
         self._kick_serve_loop()
@@ -4436,3 +4436,72 @@ Then run the following:
     def trigger_connect_dashboard_rgw(self) -> None:
         self.need_connect_dashboard_rgw = True
         self.event.set()
+
+    @handle_orch_error
+    def list_daemon_actions(self) -> List[Tuple[str, str, str, bool]]:
+        """
+        List scheduled daemon actions
+        Returns:
+            List of tuples containing (host, daemon_name, action, is_forced)
+        """
+        result = []
+        for host, daemon_name, action in self.cache.get_all_scheduled_actions():
+            is_forced = self.cache.is_force_action(host, daemon_name)
+            result.append((host, daemon_name, action, is_forced))
+        return result
+
+    @handle_orch_error
+    def cancel_daemon_action(self, daemon_name: str) -> bool:
+        """
+        Cancel a scheduled daemon action
+        """
+        for host, daemons, _ in self.cache.get_all_scheduled_actions():
+            if daemon_name in daemons:
+                self.cache.rm_scheduled_daemon_action(host, daemon_name)
+                self.cache.clear_force_action(host, daemon_name)
+                self.cache.save_host(host)
+                return True
+        return False
+
+    @handle_orch_error
+    def cancel_service_actions(self, service_name: str) -> str:
+        """
+        Cancel all scheduled actions for a service
+        """
+        count = 0
+        daemons = self.cache.get_daemons_by_service(service_name)
+        daemon_names = [d.name() for d in daemons]
+
+        for host, daemon_name, action in self.cache.get_all_scheduled_actions():
+            if daemon_name in daemon_names:
+                self.cache.rm_scheduled_daemon_action(host, daemon_name)
+                self.cache.clear_force_action(host, daemon_name)
+                self.cache.save_host(host)
+                count += 1
+
+        if count == 0:
+            return f"No scheduled actions found for service {service_name}"
+        return f"Canceled {count} scheduled action(s) for service {service_name}"
+
+    @handle_orch_error
+    def rm_daemon_action(self, host: str, daemon_name: str) -> bool:
+        """
+        Remove a scheduled daemon action directly given the host and daemon_name
+        """
+        if self.cache.rm_scheduled_daemon_action(host, daemon_name):
+            self.cache.clear_force_action(host, daemon_name)
+            self.cache.save_host(host)
+            return True
+        return False
+
+    @handle_orch_error
+    def force_daemon_action(self, daemon_name: str, force: bool = True) -> bool:
+        """
+        Mark a daemon action as forced or not forced
+        """
+        for host, daemon, _ in self.cache.get_all_scheduled_actions():
+            if daemon_name == daemon:
+                self.cache.set_force_action(host, daemon_name, force)
+                self.cache.save_host(host)
+                return True
+        return False

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1204,10 +1204,19 @@ class CephadmServe:
             if action:
                 if scheduled_action == 'redeploy' and action == 'reconfig':
                     action = 'redeploy'
+
+                is_force = self.mgr.cache.is_force_action(dd.hostname, dd.name())
+                if not is_force and action in ['restart', 'stop', 'redeploy']:
+                    r = service_registry.get_service(daemon_type_to_service(
+                        dd.daemon_type)).ok_to_stop([dd.daemon_id])
+                    if r.retval:
+                        self.log.warning(r.stderr)
+                        continue
                 try:
                     daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(dd)
                     self.mgr._daemon_action(daemon_spec, action=action)
                     if self.mgr.cache.rm_scheduled_daemon_action(dd.hostname, dd.name()):
+                        self.mgr.cache.clear_force_action(dd.hostname, dd.name())
                         self.mgr.cache.save_host(dd.hostname)
                 except OrchestratorError as e:
                     self.log.exception(e)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -462,7 +462,7 @@ class TestCephadm(object):
 
                 now = str_to_datetime('2023-10-18T22:45:29.119250Z')
                 with mock.patch("cephadm.inventory.datetime_now", lambda: now):
-                    c = cephadm_module.daemon_action('redeploy', d_name)
+                    c = cephadm_module.daemon_action('redeploy', d_name, force=True)
                     assert wait(cephadm_module,
                                 c) == f"Scheduled to redeploy rgw.{daemon_id} on host 'test'"
 
@@ -474,7 +474,7 @@ class TestCephadm(object):
 
                 later = str_to_datetime('2023-10-18T23:46:37.119250Z')
                 with mock.patch("cephadm.inventory.datetime_now", lambda: later):
-                    c = cephadm_module.daemon_action('redeploy', d_name)
+                    c = cephadm_module.daemon_action('redeploy', d_name, force=True)
                     assert wait(cephadm_module,
                                 c) == f"Scheduled to redeploy rgw.{daemon_id} on host 'test'"
 
@@ -501,7 +501,7 @@ class TestCephadm(object):
             with with_service(cephadm_module, ServiceSpec(service_type='grafana'), CephadmOrchestrator.apply_grafana, 'test') as d_names:
                 [daemon_name] = d_names
 
-                cephadm_module._schedule_daemon_action(daemon_name, action)
+                cephadm_module._schedule_daemon_action(daemon_name, action, force=True)
 
                 assert cephadm_module.cache.get_scheduled_daemon_action(
                     'test', daemon_name) == action
@@ -3071,6 +3071,7 @@ Traceback (most recent call last):
 
                 cephadm_module.set_osd_spec('osd.foo', ['1'])
 
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.HostCache.save_host")
     def test_daemon_action_schedule_and_remove(self, _save_host, cephadm_module: CephadmOrchestrator):
         """
@@ -3143,10 +3144,10 @@ Traceback (most recent call last):
 
                 assert cephadm_module.cache.is_force_action('test', daemon_name) is False
 
-                assert cephadm_module.cache.set_force_action('test', daemon_name, True)
+                cephadm_module.cache.set_force_action('test', daemon_name, True)
                 assert cephadm_module.cache.is_force_action('test', daemon_name) is True
 
-                assert cephadm_module.cache.set_force_action('test', daemon_name, False)
+                cephadm_module.cache.set_force_action('test', daemon_name, False)
                 assert cephadm_module.cache.is_force_action('test', daemon_name) is False
 
                 actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
@@ -3157,4 +3158,3 @@ Traceback (most recent call last):
                 assert len(actions) == 0
 
                 _save_host.assert_called_with('test')
->>>>>>> 88230a8abe2 (mgr/cephadm: daemon actions done by cephadm default to force to pass ok-to-stop)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -390,11 +390,11 @@ class TestCephadm(object):
 
                 d_name = 'rgw.' + daemon_id
 
-                c = cephadm_module.daemon_action('redeploy', d_name)
+                c = cephadm_module.daemon_action('redeploy', d_name, force=False)
                 assert wait(cephadm_module,
                             c) == f"Scheduled to redeploy rgw.{daemon_id} on host 'test'"
 
-                c = cephadm_module.daemon_action('start', d_name)
+                c = cephadm_module.daemon_action('start', d_name, force=False)
                 assert wait(cephadm_module,
                             c) == F"Scheduled to start {d_name} on host 'test'"
 
@@ -405,7 +405,7 @@ class TestCephadm(object):
 
                 for what in ('stop', 'restart'):
                     with pytest.raises(OrchestratorError, match=f"Unable to {what} daemon {d_name}"):
-                        c = cephadm_module.daemon_action(what, d_name)
+                        c = cephadm_module.daemon_action(what, d_name, force=False)
                         wait(cephadm_module, c)
 
                 # Make sure, _check_daemons does a redeploy due to monmap change:
@@ -3070,3 +3070,91 @@ Traceback (most recent call last):
                 assert wait(cephadm_module, c) == ['Scheduled osd.foo update...']
 
                 cephadm_module.set_osd_spec('osd.foo', ['1'])
+
+    @mock.patch("cephadm.module.HostCache.save_host")
+    def test_daemon_action_schedule_and_remove(self, _save_host, cephadm_module: CephadmOrchestrator):
+        """
+        Test scheduling and removing a daemon action
+        """
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, RGWSpec(service_id='foo'), CephadmOrchestrator.apply_rgw, 'test') as d_names:
+                [daemon_name] = d_names
+
+                cephadm_module._schedule_daemon_action(daemon_name, 'restart', force=False)
+                assert cephadm_module.cache.get_scheduled_daemon_action('test', daemon_name) == 'restart'
+
+                actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
+                assert len(actions) == 1
+                assert actions[0] == ('test', daemon_name, 'restart', False)
+
+                # Verify that _check_daemons did not restart a daemon not passing ok-to-stop
+                CephadmServe(cephadm_module)._check_daemons()
+
+                actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
+                assert len(actions) == 1
+                assert actions[0] == ('test', daemon_name, 'restart', False)
+
+                assert wait(cephadm_module, cephadm_module.cancel_daemon_action(daemon_name)) is True
+                assert cephadm_module.cache.get_scheduled_daemon_action('test', daemon_name) is None
+
+                actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
+                assert len(actions) == 0
+
+                _save_host.assert_called_with('test')
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.HostCache.save_host")
+    def test_daemon_action_schedule_and_force(self, _save_host, cephadm_module: CephadmOrchestrator):
+        """
+        Test scheduling and setting force flag
+        """
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, RGWSpec(service_id='foo'), CephadmOrchestrator.apply_rgw, 'test') as d_names:
+                [daemon_name] = d_names
+
+                cephadm_module._schedule_daemon_action(daemon_name, 'stop', force=False)
+                assert cephadm_module.cache.get_scheduled_daemon_action('test', daemon_name) == 'stop'
+
+                actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
+                assert len(actions) == 1
+                assert actions[0] == ('test', daemon_name, 'stop', False)
+                assert wait(cephadm_module, cephadm_module.force_daemon_action(daemon_name=daemon_name, force=True)) is True
+
+                CephadmServe(cephadm_module)._check_daemons()
+
+                assert cephadm_module.cache.get_scheduled_daemon_action('test', daemon_name) is None
+                actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
+                assert len(actions) == 0
+
+                _save_host.assert_called_with('test')
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.module.HostCache.save_host")
+    def test_daemon_force_action_flags(self, _save_host, cephadm_module: CephadmOrchestrator):
+        """
+        Test to verify the behavior of force flag management functions:
+        """
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, RGWSpec(service_id='foo'), CephadmOrchestrator.apply_rgw, 'test') as d_names:
+                [daemon_name] = d_names
+
+                cephadm_module._schedule_daemon_action(daemon_name, 'stop', force=False)
+                assert cephadm_module.cache.get_scheduled_daemon_action('test', daemon_name) == 'stop'
+
+                assert cephadm_module.cache.is_force_action('test', daemon_name) is False
+
+                assert cephadm_module.cache.set_force_action('test', daemon_name, True)
+                assert cephadm_module.cache.is_force_action('test', daemon_name) is True
+
+                assert cephadm_module.cache.set_force_action('test', daemon_name, False)
+                assert cephadm_module.cache.is_force_action('test', daemon_name) is False
+
+                actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
+                assert len(actions) == 1
+                assert cephadm_module.cancel_service_actions("rgw.foo")
+
+                actions = wait(cephadm_module, cephadm_module.list_daemon_actions())
+                assert len(actions) == 0
+
+                _save_host.assert_called_with('test')
+>>>>>>> 88230a8abe2 (mgr/cephadm: daemon actions done by cephadm default to force to pass ok-to-stop)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -686,6 +686,7 @@ class Orchestrator(object):
         :param action: one of "start", "stop", "restart", "redeploy", "reconfig"
         :param service_name: service_type + '.' + service_id
                             (e.g. "mon", "mgr", "mds.mycephfs", "rgw.realm.zone", ...)
+        :param force: checks for ok-to-stop when doing action on each individual daemon
         :rtype: OrchResult
         """
         # assert action in ["start", "stop", "reload, "restart", "redeploy"]
@@ -698,6 +699,7 @@ class Orchestrator(object):
         :param action: one of "start", "stop", "restart", "redeploy", "reconfig"
         :param daemon_name: name of daemon
         :param image: Container image when redeploying that daemon
+        :param force: checks for ok-to-stop when doing action on daemon
         :rtype: OrchResult
         """
         # assert action in ["start", "stop", "reload, "restart", "redeploy"]

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -678,7 +678,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def service_action(self, action: str, service_name: str) -> OrchResult[List[str]]:
+    def service_action(self, action: str, service_name: str, force: bool = False) -> OrchResult[List[str]]:
         """
         Perform an action (start/stop/reload) on a service (i.e., all daemons
         providing the logical service).
@@ -979,6 +979,39 @@ class Orchestrator(object):
         Report on what versions are available to upgrade to
 
         :return: List of strings
+        """
+        raise NotImplementedError()
+
+    def list_daemon_actions(self) -> OrchResult[List[Tuple[str, str, str, bool]]]:
+        """
+        List scheduled daemon actions as tuples containing details
+
+        :returns: List of (host, daemon_name, action, force_status) tuples
+        """
+        raise NotImplementedError()
+
+    def cancel_daemon_action(self, daemon_name: str) -> OrchResult[bool]:
+        """
+        Cancel a scheduled daemon action
+
+        :param daemon_name: The name of the daemon (e.g., 'mon.myhost')
+        :returns: True if action was found and canceled, False otherwise
+        """
+        raise NotImplementedError()
+
+    def cancel_service_actions(self, service_name: str) -> OrchResult[str]:
+        """
+        Cancel all scheduled actions for a service
+
+        :param service_name: The name of the service (e.g., 'mon', 'mgr', 'mds.myfs')
+        :returns: Number of actions canceled
+        """
+        raise NotImplementedError()
+
+    def force_daemon_action(self, daemon_name: str, force: bool = True) -> OrchResult[bool]:
+        """
+        Mark a daemon action as forced or not forced
+        :returns: True if daemon was found and updated, False otherwise
         """
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1773,9 +1773,9 @@ Usage:
         return self._daemon_add_misc(spec)
 
     @OrchestratorCLICommand.Write('orch')
-    def _service_action(self, action: ServiceAction, service_name: str) -> HandleCommandResult:
+    def _service_action(self, action: ServiceAction, service_name: str, force: bool = False) -> HandleCommandResult:
         """Start, stop, restart, redeploy, or reconfig an entire service (i.e. all daemons)"""
-        completion = self.service_action(action.value, service_name)
+        completion = self.service_action(action.value, service_name, force=force)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
@@ -2633,3 +2633,83 @@ Usage:
         completion = self.update_service(service_type.value, service_type.name, image)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
+
+    @OrchestratorCLICommand.Write('orch action ls')
+    def _list_actions(self, format: Format = Format.plain) -> HandleCommandResult:
+        """
+        List scheduled daemon actions
+        """
+        completion = self.list_daemon_actions()
+        actions = raise_if_exception(completion)
+        if not actions:
+            return HandleCommandResult(stdout="No scheduled actions")
+
+        table = PrettyTable(
+            ['HOST', 'DAEMON', 'ACTION', 'FORCED'],
+            border=False)
+        table.align = 'l'
+        table.left_padding_width = 0
+        table.right_padding_width = 2
+
+        for host, daemon_name, action, is_forced in actions:
+            forced = 'Yes' if is_forced else 'No'
+            table.add_row([host, daemon_name, action, forced])
+
+        if format == Format.plain:
+            return HandleCommandResult(stdout=table.get_string())
+        else:
+            return HandleCommandResult(
+                stdout=to_format(
+                    [{
+                        'host': host,
+                        'daemon': daemon_name,
+                        'action': action,
+                        'forced': is_forced
+                    } for host, daemon_name, action, is_forced in actions],
+                    format,
+                    many=True,
+                    cls=None
+                )
+            )
+
+    @OrchestratorCLICommand.Write('orch daemon cancel action')
+    def _cancel_action(self, daemon_name: str) -> HandleCommandResult:
+        """
+        Cancel a scheduled daemon action
+        """
+        completion = self.cancel_daemon_action(daemon_name)
+        result = raise_if_exception(completion)
+        if not result:
+            return HandleCommandResult(stderr=f"No scheduled action found for daemon {daemon_name}")
+        return HandleCommandResult(stdout=f"Canceled scheduled action for daemon {daemon_name}")
+
+    @OrchestratorCLICommand.Write('orch service cancel action')
+    def _cancel_service_actions(self, service_name: str) -> HandleCommandResult:
+        """
+        Cancel all scheduled actions for a service
+        """
+        completion = self.cancel_service_actions(service_name)
+        result = raise_if_exception(completion)
+        return HandleCommandResult(stdout=result)
+
+    @OrchestratorCLICommand.Write('orch daemon action set-forced')
+    def _set_force_action(self, daemon_name: str) -> HandleCommandResult:
+        """
+        Set the force flag for a scheduled daemon action
+        """
+        completion = self.force_daemon_action(daemon_name, True)
+        result = raise_if_exception(completion)
+        if not result:
+            return HandleCommandResult(stderr=f"No scheduled action found for daemon {daemon_name}")
+        return HandleCommandResult(stdout=f"Action for daemon {daemon_name} is now forced")
+
+    @OrchestratorCLICommand.Write('orch daemon action unset-forced')
+    def _unset_force_action(self, daemon_name: str) -> HandleCommandResult:
+        """
+        Unset the force flag for a scheduled daemon action
+        """
+        completion = self.force_daemon_action(daemon_name, False)
+        result = raise_if_exception(completion)
+        if not result:
+            return HandleCommandResult(stderr=f"No scheduled action found for daemon {daemon_name}")
+        return HandleCommandResult(stdout=f"Action for daemon {daemon_name} is now not forced")

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1791,11 +1791,12 @@ Usage:
     @OrchestratorCLICommand.Write('orch daemon redeploy')
     def _daemon_action_redeploy(self,
                                 name: str,
-                                image: Optional[str] = None) -> HandleCommandResult:
+                                image: Optional[str] = None,
+                                force: bool = False) -> HandleCommandResult:
         """Redeploy a daemon (with a specific image)"""
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)
-        completion = self.daemon_action("redeploy", name, image=image)
+        completion = self.daemon_action("redeploy", name, image=image, force=force)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
@@ -2697,7 +2698,7 @@ Usage:
         """
         Set the force flag for a scheduled daemon action
         """
-        completion = self.force_daemon_action(daemon_name, True)
+        completion = self.force_daemon_action(daemon_name, force = True)
         result = raise_if_exception(completion)
         if not result:
             return HandleCommandResult(stderr=f"No scheduled action found for daemon {daemon_name}")
@@ -2708,7 +2709,7 @@ Usage:
         """
         Unset the force flag for a scheduled daemon action
         """
-        completion = self.force_daemon_action(daemon_name, False)
+        completion = self.force_daemon_action(daemon_name, force = False)
         result = raise_if_exception(completion)
         if not result:
             return HandleCommandResult(stderr=f"No scheduled action found for daemon {daemon_name}")

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2635,7 +2635,7 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @OrchestratorCLICommand.Write('orch action ls')
+    @OrchestratorCLICommand.Read('orch action ls')
     def _list_actions(self, format: Format = Format.plain) -> HandleCommandResult:
         """
         List scheduled daemon actions

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2698,7 +2698,7 @@ Usage:
         """
         Set the force flag for a scheduled daemon action
         """
-        completion = self.force_daemon_action(daemon_name, force = True)
+        completion = self.force_daemon_action(daemon_name, force=True)
         result = raise_if_exception(completion)
         if not result:
             return HandleCommandResult(stderr=f"No scheduled action found for daemon {daemon_name}")
@@ -2709,7 +2709,7 @@ Usage:
         """
         Unset the force flag for a scheduled daemon action
         """
-        completion = self.force_daemon_action(daemon_name, force = False)
+        completion = self.force_daemon_action(daemon_name, force=False)
         result = raise_if_exception(completion)
         if not result:
             return HandleCommandResult(stderr=f"No scheduled action found for daemon {daemon_name}")

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -241,7 +241,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         return ''
 
     @handle_orch_error
-    def service_action(self, action, service_name):
+    def service_action(self, action, service_name, force=True):
         return 'done'
 
     @handle_orch_error


### PR DESCRIPTION
Add new CLI commands to list all scheduled actions, cancel actions for entire services, and set or unset the force flag for actions. It also includes safety checks to ensure that actions such as restart, stop, or redeploy are only performed if it’s safe to stop the service (by checking ok-to-stop), unless the action is explicitly forced.

Fixes: https://tracker.ceph.com/issues/69937

Example 
```bash
root@debian-1:/# ceph orch ls
NAME                       PORTS        RUNNING  REFRESHED  AGE  PLACEMENT
alertmanager               ?:9093,9094      1/1  27s ago    41m  count:1
crash                                       4/4  102s ago   41m  *
grafana                    ?:3000           1/1  27s ago    41m  count:1
mgr                                         2/2  102s ago   31m  count:2
mon                                         4/5  102s ago   42m  count:5
node-exporter              ?:9100           4/4  102s ago   41m  *
osd.all-available-devices                     6  102s ago   35m  *
prometheus                 ?:9095           1/1  27s ago    41m  count:1
root@debian-1:/# ceph osd tree
ID  CLASS  WEIGHT   TYPE NAME          STATUS  REWEIGHT  PRI-AFF
-1         2.92978  root default
-7         0.97659      host debian-2
 2    hdd  0.48830          osd.2          up   1.00000  1.00000
 5    hdd  0.48830          osd.5          up   1.00000  1.00000
-5         0.97659      host debian-3
 0    hdd  0.48830          osd.0          up   1.00000  1.00000
 3    hdd  0.48830          osd.3          up   1.00000  1.00000
-3         0.97659      host debian-4
 1    hdd  0.48830          osd.1          up   1.00000  1.00000
 4    hdd  0.48830          osd.4          up   1.00000  1.00000
root@debian-1:/# ceph orch restart osd.all-available-devices
Scheduled to restart osd.5 on host 'debian-2'
Scheduled to restart osd.2 on host 'debian-2'
Scheduled to restart osd.0 on host 'debian-3'
Scheduled to restart osd.3 on host 'debian-3'
Scheduled to restart osd.1 on host 'debian-4'
Scheduled to restart osd.4 on host 'debian-4'
root@debian-1:/# ceph orch action ls
HOST      DAEMON  ACTION   FORCED
debian-2  osd.2   restart  No
debian-3  osd.0   restart  No
debian-3  osd.3   restart  No
debian-4  osd.1   restart  No
debian-4  osd.4   restart  No
root@debian-1:/# ceph orch action set-forced osd.3
Action for daemon osd.3 is now forced
root@debian-1:/# ceph orch action ls
HOST      DAEMON  ACTION   FORCED
debian-3  osd.0   restart  No
debian-3  osd.3   restart  Yes
debian-4  osd.1   restart  No
debian-4  osd.4   restart  No
```

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
