### PR TITLE
libcephfs: Implement `ceph_ll_get()` API

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13560,6 +13560,12 @@ bool Client::_ll_forget(Inode *in, uint64_t count)
   return last;
 }
 
+void Client::ll_get(Inode *in)
+{
+  std::scoped_lock lock(client_lock);
+  _ll_get(in);
+}
+
 bool Client::ll_forget(Inode *in, uint64_t count)
 {
   std::scoped_lock lock(client_lock);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -599,6 +599,7 @@ public:
   int ll_lookupx(Inode *parent, const char *name, Inode **out,
 			struct ceph_statx *stx, unsigned want, unsigned flags,
 			const UserPerm& perms);
+  void ll_get(Inode *in);
   bool ll_forget(Inode *in, uint64_t count);
   bool ll_put(Inode *in);
   int ll_get_snap_ref(snapid_t snap);

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1994,6 +1994,7 @@ int ceph_ll_lookup_root(struct ceph_mount_info *cmount,
 int ceph_ll_lookup(struct ceph_mount_info *cmount, Inode *parent,
 		   const char *name, Inode **out, struct ceph_statx *stx,
 		   unsigned want, unsigned flags, const UserPerm *perms);
+void ceph_ll_get(struct ceph_mount_info *cmount, struct Inode *in);
 int ceph_ll_put(struct ceph_mount_info *cmount, struct Inode *in);
 int ceph_ll_forget(struct ceph_mount_info *cmount, struct Inode *in,
 		   int count);

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2042,6 +2042,11 @@ extern "C" int ceph_ll_lookup(struct ceph_mount_info *cmount,
 					    flags, *perms);
 }
 
+extern "C" void ceph_ll_get(class ceph_mount_info *cmount, Inode *in)
+{
+  cmount->get_client()->ll_get(in);
+}
+
 extern "C" int ceph_ll_put(class ceph_mount_info *cmount, Inode *in)
 {
   return (cmount->get_client()->ll_put(in));


### PR DESCRIPTION
Provide an easy and convenient API to update the reference to the inode. Please note that this is built on top of existing internal __ll_get()_ function used almost everywhere in the client code base. Newly introduced `ceph_ll_get()` just exposes the __ll_get()_ functionality to outside consumers. 