### PR TITLE
src: migrate to fmt::formattable for format support

### DIFF
--- a/src/common/bitset_set.h
+++ b/src/common/bitset_set.h
@@ -412,7 +412,7 @@ class bitset_set {
   }
 
   std::string fmt_print() const
-  requires has_formatter<KeyT> {
+  requires fmt::formattable<KeyT> {
     std::string s = "{";
     int c = (int)size();
     for (auto k : *this) {

--- a/src/common/fmt_common.h
+++ b/src/common/fmt_common.h
@@ -2,7 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include <fmt/base.h>
 #include <optional>
+#include <type_traits>
 
 /**
  * \file default fmtlib formatters for specifically-tagged types
@@ -17,8 +19,13 @@
  * such classes in Crimson.
  */
 
-template <typename T>
-concept has_formatter = fmt::has_formatter<T, fmt::format_context>::value;
+#if FMT_VERSION < 110000
+// TODO: drop me once fmt v11 is required
+namespace fmt {
+  template <typename T, typename Char = char>
+  concept formattable = is_formattable<std::remove_reference_t<T>, Char>::value>;
+}
+#endif
 
 /**
  * Tagging classes that provide support for default fmtlib formatting,

--- a/src/common/interval_map.h
+++ b/src/common/interval_map.h
@@ -324,7 +324,7 @@ public:
   }
 
   std::string fmt_print() const
-  requires has_formatter<K> {
+  requires fmt::formattable<K> {
     std::string str = "{";
     bool first = true;
     for (auto &&i: *this) {

--- a/src/common/mini_flat_map.h
+++ b/src/common/mini_flat_map.h
@@ -495,7 +495,7 @@ class mini_flat_map {
   }
 
   std::string fmt_print() const
-  requires has_formatter<KeyT> && has_formatter<ValueT> {
+  requires fmt::formattable<KeyT> && fmt::formattable<ValueT> {
     int c = (int)_size;
     std::string s = "{";
     for (auto&& [k, v] : *this) {

--- a/src/crimson/osd/scrub/scrub_machine.h
+++ b/src/crimson/osd/scrub/scrub_machine.h
@@ -49,7 +49,7 @@ struct simple_event_t : sc::event<T> {
   }
 };
 
-template <typename T, has_formatter V>
+template <typename T, fmt::formattable V>
 struct value_event_t : sc::event<T> {
   const V value;
 

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -263,7 +263,7 @@ class interval_set {
   }
 
   std::string fmt_print() const
-  requires has_formatter<T> {
+  requires fmt::formattable<T> {
     std::string s = "[";
     bool first = true;
     for (const auto& [start, len] : *this) {

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -105,7 +105,7 @@ OP_EV(ReplicaReserveReq);
 /// explicit release request from the Primary
 OP_EV(ReplicaRelease);
 
-template <typename T, has_formatter V>
+template <typename T, fmt::formattable V>
 struct value_event_t : sc::event<T> {
   const V value;
 


### PR DESCRIPTION
Replace custom has_formatter concept with fmtlib's fmt::formattable

- Deprecate usage of fmt::has_formatter
- Resolve compiler warnings with recent fmtlib versions

The custom concept of has_formatter is no longer necessary with recent updates to the fmtlib library, as fmt::formattable was introduced in fmtlib v11.0.0. By switching to fmt::formattable, we simplify our code and stop using the deprecated `fmt::has_formatter` template.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
