### PR TITLE
osd/scrub: improve PgScrubber testability

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2795,7 +2795,7 @@ void PgScrubber::update_scrub_stats(ceph::coarse_real_clock::time_point now_is)
 
 // ///////////////////// preemption_data_t //////////////////////////////////
 
-PgScrubber::preemption_data_t::preemption_data_t(PG* pg) : m_pg{pg},
+PgScrubber::preemption_data_t::preemption_data_t(PG* pg) :
   osd_scrub_max_preemptions{pg->cct->_conf, "osd_scrub_max_preemptions"}
 {
   m_left = *osd_scrub_max_preemptions;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -1005,7 +1005,6 @@ class PgScrubber : public ScrubPgIF,
     }
 
    private:
-    PG* m_pg;
     mutable ceph::mutex m_preemption_lock = ceph::make_mutex("preemption_lock");
     bool m_preemptable{false};
     bool m_preempted{false};

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -84,6 +84,7 @@ Main Scrubber interfaces:
 #include "osd_scrub_sched.h"
 #include "scrub_backend.h"
 #include "scrub_machine_lstnr.h"
+#include "scrub_machine_if.h"
 #include "scrub_reservations.h"
 
 namespace Scrub {
@@ -693,7 +694,7 @@ class PgScrubber : public ScrubPgIF,
 			    hobject_t end,
 			    bool deep);
 
-  std::unique_ptr<Scrub::ScrubMachine> m_fsm;
+  std::unique_ptr<Scrub::ScrubFsmIf> m_fsm;
   /// the FSM state, as a string for logging
   const char* m_fsm_state_name{nullptr};
   const spg_t m_pg_id;	///< a local copy of m_pg->pg_id

--- a/src/osd/scrubber/scrub_machine_if.h
+++ b/src/osd/scrubber/scrub_machine_if.h
@@ -1,0 +1,59 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+/**
+ * \file the FSM API used by the scrubber
+ */
+#include <boost/statechart/event.hpp>
+#include <boost/statechart/event_base.hpp>
+#include <boost/statechart/simple_state.hpp>
+#include <boost/statechart/state.hpp>
+#include <boost/statechart/state_machine.hpp>
+
+#include "osd/scrubber_common.h"
+
+namespace Scrub {
+
+namespace sc = ::boost::statechart;
+
+
+/// the FSM API used by the scrubber
+class ScrubFsmIf {
+ public:
+  virtual ~ScrubFsmIf() = default;
+
+  virtual void process_event(const sc::event_base& evt) = 0;
+
+  /// 'true' if the FSM state is PrimaryActive/PrimaryIdle
+  [[nodiscard]] virtual bool is_primary_idle() const = 0;
+
+  /// 'true' if the FSM state is PrimaryActive/Session/ReservingReplicas
+  [[nodiscard]] virtual bool is_reserving() const = 0;
+
+  /// 'true' if the FSM state is PrimaryActive/Session/Act/WaitLastUpdate
+  [[nodiscard]] virtual bool is_accepting_updates() const = 0;
+
+  /// verify state is not any substate of PrimaryActive/Session
+  virtual void assert_not_in_session() const = 0;
+
+  /**
+   * time passed since entering the current scrubbing session.
+   * Specifically - since the Session ctor has completed.
+   */
+  virtual ceph::timespan get_time_scrubbing() const = 0;
+
+  /**
+   * if we are in the ReservingReplicas state - fetch the reservation status.
+   * The returned data names the last request sent to the replicas, and
+   * how many replicas responded / are yet expected to respond.
+   */
+  virtual std::optional<pg_scrubbing_status_t> get_reservation_status()
+      const = 0;
+
+  /// "initiate" the state machine (an internal state_chart function)
+  virtual void initiate() = 0;
+};
+
+}  // namespace Scrub
+


### PR DESCRIPTION
Reducing the amount of mocking required when creating an instance
of class PgScrubber for unit-tests.

1. (a minor change) removing the unneeded PG ref from the preemption_data_t subobject;
2. decoupling the PgScrubber objects from the scrub FSM:
The scrubber FSM has always been accessing the PgScrubber
object via an abstract interface (ScrubMachineListener).
But the reverse was not true: the PgScrubber owned a unique_ptr
directly to an instance of Scrubber::ScrubMachine.
This PR introduces a new interface, ScrubFsmIf, that is
implemented by the ScrubMachine. This simplifies
unit-testing the PgScrubber, as we can now inject a mock
implementation of the FSM interface.