### PR TITLE
squid: rgw: rgw_init_ioctx() adds set_pool_full_try()

### DIFF
--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -9,3 +9,4 @@ overrides:
     log-ignorelist:
       - reached quota
       - POOL_FULL
+      - pool(s) full

--- a/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
+++ b/qa/suites/rgw/verify/tasks/rados-pool-quota.yaml
@@ -9,4 +9,4 @@ overrides:
     log-ignorelist:
       - reached quota
       - POOL_FULL
-      - pool(s) full
+      - pool\(s\) full

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -437,7 +437,7 @@ RGWRadosRemoveCR::RGWRadosRemoveCR(rgw::sal::RadosStore* store, const rgw_raw_ob
 int RGWRadosRemoveCR::send_request(const DoutPrefixProvider *dpp)
 {
   auto rados = store->getRados()->get_rados_handle();
-  int r = rados->ioctx_create(obj.pool.name.c_str(), ioctx);
+  int r = rgw_init_ioctx(dpp, rados, obj.pool, ioctx);
   if (r < 0) {
     lderr(cct) << "ERROR: failed to open pool (" << obj.pool.name << ") ret=" << r << dendl;
     return r;

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -94,6 +94,8 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
   if (!pool.ns.empty()) {
     ioctx.set_namespace(pool.ns);
   }
+  // at pool quota, never block waiting for space - we want to error immediately
+  ioctx.set_pool_full_try();
   return 0;
 }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -138,6 +138,8 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_NO_SUCH_PUBLIC_ACCESS_BLOCK_CONFIGURATION, {404, "NoSuchPublicAccessBlockConfiguration"}},
     { ERR_ACCOUNT_EXISTS, {409, "AccountAlreadyExists"}},
     { ECANCELED, {409, "ConcurrentModification"}},
+    { EDQUOT, {507, "InsufficientCapacity"}},
+    { ENOSPC, {507, "InsufficientCapacity"}},
 });
 
 rgw_http_errors rgw_http_swift_errors({

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -83,6 +83,7 @@ const static struct rgw_http_status_code http_codes[] = {
   { 500, "Internal Server Error" },
   { 501, "Not Implemented" },
   { 503, "Slow Down"},
+  { 507, "Insufficient Storage"},
   { 0, NULL },
 };
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70517

---

backport of https://github.com/ceph/ceph/pull/62110
parent tracker: https://tracker.ceph.com/issues/69842

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh