### PR TITLE
rgw: BucketTrimShardCollectCR expect ENODATA as empty

### DIFF
--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -704,6 +704,7 @@ int RGWRadosBILogTrimCR::send_request(const DoutPrefixProvider *dpp)
   encode(call, in);
 
   librados::ObjectWriteOperation op;
+  op.assert_exists();
   op.exec(RGW_CLASS, RGW_BI_LOG_TRIM, in);
 
   cn = stack->create_completion_notifier();

--- a/src/rgw/driver/rados/rgw_trim_bilog.cc
+++ b/src/rgw/driver/rados/rgw_trim_bilog.cc
@@ -791,6 +791,12 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
       set_status("trimming bilog shards");
       yield call(new BucketTrimShardCollectCR(dpp, store, *pbucket_info, totrim.layout.in_index,
 					      min_markers));
+      if (retcode == -ENOENT) {
+        // this is not a fatal error to retry, as the shard seems to not exist
+        // anymore. This can happen if the shard was removed unexpectedly.
+        // should be already logged by the BucketTrimShardCollectCR().
+        retcode = 0;
+      }
       if (retcode < 0) {
 	ldpp_dout(dpp, 4) << "failed to trim bilog shards: "
 			  << cpp_strerror(retcode) << dendl;

--- a/src/rgw/driver/rados/rgw_trim_bilog.cc
+++ b/src/rgw/driver/rados/rgw_trim_bilog.cc
@@ -367,7 +367,7 @@ class BucketTrimShardCollectCR : public RGWShardCollectCR {
   size_t i{0}; //< index of current shard marker
 
   int handle_result(int r) override {
-    if (r == -ENOENT) { // ENOENT is not a fatal error
+    if (r == -ENODATA) { // ENODATA is not a fatal error
       return 0;
     }
     if (r < 0) {
@@ -791,10 +791,6 @@ int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
       set_status("trimming bilog shards");
       yield call(new BucketTrimShardCollectCR(dpp, store, *pbucket_info, totrim.layout.in_index,
 					      min_markers));
-      // ENODATA just means there were no keys to trim
-      if (retcode == -ENODATA) {
-	retcode = 0;
-      }
       if (retcode < 0) {
 	ldpp_dout(dpp, 4) << "failed to trim bilog shards: "
 			  << cpp_strerror(retcode) << dendl;


### PR DESCRIPTION
RGWRadosBILogTrimCR() returns ENODATA when nothing is found:
```
4 trim: failed to trim bilog shard: (61) No data available
```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
