### PR TITLE
mgr/dashboard: warn a user about unsaved form changes

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -56,7 +56,7 @@ import { SmbShareFormComponent } from './ceph/smb/smb-share-form/smb-share-form.
 import { SmbJoinAuthFormComponent } from './ceph/smb/smb-join-auth-form/smb-join-auth-form.component';
 import { SmbUsersgroupsFormComponent } from './ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component';
 import { NfsClusterComponent } from './ceph/nfs/nfs-cluster/nfs-cluster.component';
-import { UnsavedChangesGuard } from './shared/services/unsaved-changes-guard.service';
+
 
 @Injectable()
 export class PerformanceCounterBreadcrumbsResolver extends BreadcrumbsResolver {
@@ -377,7 +377,7 @@ const routes: Routes = [
         path: 'pool',
         data: { breadcrumbs: 'Cluster/Pools' },
         loadChildren: () => import('./ceph/pool/pool.module').then((m) => m.RoutedPoolModule),
-        canDeactivate: [UnsavedChangesGuard]
+      
       },
       // Block
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -56,6 +56,7 @@ import { SmbShareFormComponent } from './ceph/smb/smb-share-form/smb-share-form.
 import { SmbJoinAuthFormComponent } from './ceph/smb/smb-join-auth-form/smb-join-auth-form.component';
 import { SmbUsersgroupsFormComponent } from './ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component';
 import { NfsClusterComponent } from './ceph/nfs/nfs-cluster/nfs-cluster.component';
+import { UnsavedChangesGuard } from './shared/services/unsaved-changes-guard.service';
 
 @Injectable()
 export class PerformanceCounterBreadcrumbsResolver extends BreadcrumbsResolver {
@@ -375,7 +376,8 @@ const routes: Routes = [
       {
         path: 'pool',
         data: { breadcrumbs: 'Cluster/Pools' },
-        loadChildren: () => import('./ceph/pool/pool.module').then((m) => m.RoutedPoolModule)
+        loadChildren: () => import('./ceph/pool/pool.module').then((m) => m.RoutedPoolModule),
+        canDeactivate: [UnsavedChangesGuard]
       },
       // Block
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.ts
@@ -1,5 +1,4 @@
-import { Component } from '@angular/core';
-
+import { Component, HostListener } from '@angular/core';
 import { NgbPopoverConfig, NgbTooltipConfig } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
@@ -14,5 +13,17 @@ export class AppComponent {
     popoverConfig.placement = 'bottom';
 
     tooltipConfig.container = 'body';
+  }
+  @HostListener('window:beforeunload', ['$event'])
+  unloadNotification($event: any) {
+    // Check if any forms are dirty
+    const forms = document.getElementsByTagName('form');
+    for (let i = 0; i < forms.length; i++) {
+      if (forms[i].classList.contains('ng-dirty')) {
+        $event.returnValue = true;
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { CoreModule } from './core/core.module';
 import { ApiInterceptorService } from './shared/services/api-interceptor.service';
 import { JsErrorHandler } from './shared/services/js-error-handler.service';
 import { SharedModule } from './shared/shared.module';
+import { UnsavedChangesGuard } from './shared/services/unsaved-changes-guard.service';
 
 @NgModule({
   declarations: [AppComponent],
@@ -45,7 +46,9 @@ import { SharedModule } from './shared/shared.module';
       provide: APP_BASE_HREF,
       useValue: '/' + (window.location.pathname.split('/', 1)[1] || '')
     },
-    provideHttpClient(withInterceptorsFromDi())
+    provideHttpClient(withInterceptorsFromDi()),
+    UnsavedChangesGuard
+    
   ]
 })
 export class AppModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -72,6 +72,7 @@ import Close from '@carbon/icons/es/close/32';
 import AddFilled from '@carbon/icons/es/add--filled/32';
 import SubtractFilled from '@carbon/icons/es/subtract--filled/32';
 import Reset from '@carbon/icons/es/reset/32';
+import { UnsavedChangesGuard } from '~/app/shared/services/unsaved-changes-guard.service';
 
 @NgModule({
   imports: [
@@ -185,26 +186,31 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: RbdFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:image_spec`,
         component: RbdFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.EDIT }
       },
       {
         path: `${URLVerbs.CLONE}/:image_spec/:snap`,
         component: RbdFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.CLONE }
       },
       {
         path: `${URLVerbs.COPY}/:image_spec`,
         component: RbdFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.COPY }
       },
       {
         path: `${URLVerbs.COPY}/:image_spec/:snap`,
         component: RbdFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.COPY }
       }
     ]
@@ -249,11 +255,13 @@ const routes: Routes = [
           {
             path: URLVerbs.CREATE,
             component: IscsiTargetFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             data: { breadcrumbs: ActionLabels.CREATE }
           },
           {
             path: `${URLVerbs.EDIT}/:target_iqn`,
             component: IscsiTargetFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             data: { breadcrumbs: ActionLabels.EDIT }
           }
         ]
@@ -290,29 +298,34 @@ const routes: Routes = [
           {
             path: URLVerbs.CREATE,
             component: NvmeofSubsystemsFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           },
           // listeners
           {
             path: `${URLVerbs.CREATE}/:subsystem_nqn/listener`,
             component: NvmeofListenersFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           },
           // namespaces
           {
             path: `${URLVerbs.CREATE}/:subsystem_nqn/namespace`,
             component: NvmeofNamespacesFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           },
           {
             path: `${URLVerbs.EDIT}/:subsystem_nqn/namespace/:nsid`,
             component: NvmeofNamespacesFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           },
           // initiators
           {
             path: `${URLVerbs.ADD}/:subsystem_nqn/initiator`,
             component: NvmeofInitiatorsFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           }
         ]
@@ -323,6 +336,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [BlockModule, RouterModule.forChild(routes)]
+  imports: [BlockModule, RouterModule.forChild(routes)],
+  providers: [UnsavedChangesGuard]
+
 })
 export class RoutedBlockModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.ts
@@ -12,7 +12,7 @@ import { SelectMessages } from '~/app/shared/components/select/select-messages.m
 import { SelectOption } from '~/app/shared/components/select/select-option.model';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
@@ -27,7 +27,7 @@ import { IscsiTargetIqnSettingsModalComponent } from '../iscsi-target-iqn-settin
   templateUrl: './iscsi-target-form.component.html',
   styleUrls: ['./iscsi-target-form.component.scss']
 })
-export class IscsiTargetFormComponent extends CdForm implements OnInit {
+export class IscsiTargetFormComponent extends CdFormCanDeactivate implements OnInit {
   cephIscsiConfigVersion: number;
   targetForm: CdFormGroup;
   modalRef: NgbModalRef;
@@ -277,6 +277,10 @@ export class IscsiTargetFormComponent extends CdForm implements OnInit {
         this.onGroupMemberSelection({ option: new SelectOption(true, member, '') }, group_index);
       });
     });
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.targetForm;
   }
 
   hasAdvancedSettings(settings: any) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -12,7 +12,7 @@ import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import {
   RbdConfigurationEntry,
@@ -47,7 +47,7 @@ class ExternalData {
   templateUrl: './rbd-form.component.html',
   styleUrls: ['./rbd-form.component.scss']
 })
-export class RbdFormComponent extends CdForm implements OnInit {
+export class RbdFormComponent extends CdFormCanDeactivate implements OnInit {
   poolPermission: Permission;
   rbdForm: CdFormGroup;
   getDirtyConfigurationValues: (
@@ -229,6 +229,10 @@ export class RbdFormComponent extends CdForm implements OnInit {
       },
       this.validateRbdForm(this.formatter)
     );
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.rbdForm;
   }
 
   disableForEdit() {
@@ -449,8 +453,8 @@ export class RbdFormComponent extends CdForm implements OnInit {
     }
     this.dataPools = this.allDataPools
       ? this.allDataPools.filter((dataPool: any) => {
-          return dataPool.pool_name !== selectedPoolName;
-        })
+        return dataPool.pool_name !== selectedPoolName;
+      })
       : [];
     this.namespaces = null;
     if (selectedPoolName in this.namespacesByPoolCache) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-auth-modal/cephfs-auth-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-auth-modal/cephfs-auth-modal.component.ts
@@ -13,7 +13,7 @@ import { CephfsService } from '~/app/shared/api/cephfs.service';
 import { DirectoryStoreService } from '~/app/shared/api/directory-store.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
@@ -26,7 +26,7 @@ const DEBOUNCE_TIMER = 300;
   templateUrl: './cephfs-auth-modal.component.html',
   styleUrls: ['./cephfs-auth-modal.component.scss']
 })
-export class CephfsAuthModalComponent extends CdForm implements OnInit, AfterViewInit {
+export class CephfsAuthModalComponent extends CdFormCanDeactivate implements OnInit, AfterViewInit {
   subvolumeGroup: string;
   subvolume: string;
   isDefaultSubvolumeGroup = false;
@@ -88,6 +88,10 @@ export class CephfsAuthModalComponent extends CdForm implements OnInit, AfterVie
     } else {
       this.form.get('directory').disable();
     }
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.form;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
@@ -12,7 +12,7 @@ import { HostService } from '~/app/shared/api/host.service';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -27,7 +27,7 @@ import { Pool } from '../../pool/pool';
   templateUrl: './cephfs-form.component.html',
   styleUrls: ['./cephfs-form.component.scss']
 })
-export class CephfsVolumeFormComponent extends CdForm implements OnInit {
+export class CephfsVolumeFormComponent extends CdFormCanDeactivate implements OnInit {
   @ViewChild('crushInfoTabs') crushInfoTabs: NgbNav;
   @ViewChild('crushDeletionBtn') crushDeletionBtn: NgbTooltip;
   @ViewChild('ecpInfoTabs') ecpInfoTabs: NgbNav;
@@ -183,6 +183,10 @@ export class CephfsVolumeFormComponent extends CdForm implements OnInit {
     }
     this.orchStatus$ = this.orchService.status();
     this.loadingReady();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.form;
   }
 
   onPoolChange(poolName: string, metadataChange = false) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-form/cephfs-snapshotschedule-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-form/cephfs-snapshotschedule-form.component.ts
@@ -23,7 +23,7 @@ import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant'
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { RepeatFrequency } from '~/app/shared/enum/repeat-frequency.enum';
 import { RetentionFrequency } from '~/app/shared/enum/retention-frequency.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -42,7 +42,7 @@ const DEBOUNCE_TIMER = 300;
   templateUrl: './cephfs-snapshotschedule-form.component.html',
   styleUrls: ['./cephfs-snapshotschedule-form.component.scss']
 })
-export class CephfsSnapshotscheduleFormComponent extends CdForm implements OnInit {
+export class CephfsSnapshotscheduleFormComponent extends CdFormCanDeactivate implements OnInit {
   subvol!: string;
   group!: string;
   icons = Icons;
@@ -147,6 +147,10 @@ export class CephfsSnapshotscheduleFormComponent extends CdForm implements OnIni
 
   get retentionPolicies() {
     return this.snapScheduleForm.get('retentionPolicies') as FormArray;
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.snapScheduleForm;
   }
 
   search: OperatorFunction<string, readonly string[]> = (input: Observable<string>) =>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
@@ -12,7 +12,7 @@ import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { CephfsSubvolumeInfo } from '~/app/shared/models/cephfs-subvolume.model';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { OctalToHumanReadablePipe } from '~/app/shared/pipes/octal-to-human-readable.pipe';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
 import { CephfsSubvolumeGroup } from '~/app/shared/models/cephfs-subvolume-group.model';
 import { Observable } from 'rxjs';
@@ -22,7 +22,7 @@ import { Observable } from 'rxjs';
   templateUrl: './cephfs-subvolume-form.component.html',
   styleUrls: ['./cephfs-subvolume-form.component.scss']
 })
-export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
+export class CephfsSubvolumeFormComponent extends CdFormCanDeactivate implements OnInit {
   subvolumeForm: CdFormGroup;
 
   action: string;
@@ -93,6 +93,10 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
     this.createForm();
 
     this.isEdit ? this.populateForm() : this.loadingReady();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.subvolumeForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.ts
@@ -26,7 +26,7 @@ import { FinishedTask } from '~/app/shared/models/finished-task';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { FormControl } from '@angular/forms';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component';
 import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
 import { CephfsSubvolumeGroup } from '~/app/shared/models/cephfs-subvolume-group.model';
@@ -42,7 +42,7 @@ import { DeletionImpact } from '~/app/shared/enum/delete-confirmation-modal-impa
   templateUrl: './cephfs-subvolume-list.component.html',
   styleUrls: ['./cephfs-subvolume-list.component.scss']
 })
-export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnChanges {
+export class CephfsSubvolumeListComponent extends CdFormCanDeactivate implements OnInit, OnChanges {
   @ViewChild('quotaUsageTpl', { static: true })
   quotaUsageTpl: any;
 
@@ -196,6 +196,10 @@ export class CephfsSubvolumeListComponent extends CdForm implements OnInit, OnCh
         )
       )
     );
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.removeForm;
   }
 
   fetchData() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-form/cephfs-subvolume-snapshots-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-form/cephfs-subvolume-snapshots-form.component.ts
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { Observable } from 'rxjs';
 import { CephfsSubvolumeService } from '~/app/shared/api/cephfs-subvolume.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { CephfsSubvolume } from '~/app/shared/models/cephfs-subvolume.model';
@@ -16,7 +16,7 @@ import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
   templateUrl: './cephfs-subvolume-snapshots-form.component.html',
   styleUrls: ['./cephfs-subvolume-snapshots-form.component.scss']
 })
-export class CephfsSubvolumeSnapshotsFormComponent extends CdForm implements OnInit {
+export class CephfsSubvolumeSnapshotsFormComponent extends CdFormCanDeactivate implements OnInit {
   subVolumeGroups: string[];
 
   snapshotForm: CdFormGroup;
@@ -46,6 +46,11 @@ export class CephfsSubvolumeSnapshotsFormComponent extends CdForm implements OnI
 
     this.subVolumes$ = this.cephFsSubvolumeService.get(this.fsName, this.subVolumeGroupName, false);
     this.loadingReady();
+  }
+
+
+  getFormGroup(): CdFormGroup {
+    return this.snapshotForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolumegroup-form/cephfs-subvolumegroup-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolumegroup-form/cephfs-subvolumegroup-form.component.ts
@@ -10,7 +10,7 @@ import { FormatterService } from '~/app/shared/services/formatter.service';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import _ from 'lodash';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { OctalToHumanReadablePipe } from '~/app/shared/pipes/octal-to-human-readable.pipe';
 
@@ -19,7 +19,7 @@ import { OctalToHumanReadablePipe } from '~/app/shared/pipes/octal-to-human-read
   templateUrl: './cephfs-subvolumegroup-form.component.html',
   styleUrls: ['./cephfs-subvolumegroup-form.component.scss']
 })
-export class CephfsSubvolumegroupFormComponent extends CdForm implements OnInit {
+export class CephfsSubvolumegroupFormComponent extends CdFormCanDeactivate implements OnInit {
   subvolumegroupForm: CdFormGroup;
 
   action: string;
@@ -85,6 +85,11 @@ export class CephfsSubvolumegroupFormComponent extends CdForm implements OnInit 
     this.createForm();
 
     this.isEdit ? this.populateForm() : this.loadingReady();
+  }
+
+
+  getFormGroup(): CdFormGroup {
+    return this.subvolumegroupForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -9,7 +9,7 @@ import { ConfigFormModel } from '~/app/shared/components/config-option/config-op
 import { ConfigOptionTypes } from '~/app/shared/components/config-option/config-option.types';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { ConfigFormCreateRequestModel } from './configuration-form-create-request.model';
@@ -23,7 +23,7 @@ const RGW = 'rgw';
   templateUrl: './configuration-form.component.html',
   styleUrls: ['./configuration-form.component.scss']
 })
-export class ConfigurationFormComponent extends CdForm implements OnInit {
+export class ConfigurationFormComponent extends CdFormCanDeactivate implements OnInit {
   configForm: CdFormGroup;
   response: ConfigFormModel;
   type: string;
@@ -73,6 +73,11 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
         this.loadingReady();
       });
     });
+  }
+
+
+  getFormGroup(): CdFormGroup {
+    return this.configForm;
   }
 
   getValidators(configOption: any): ValidatorFn[] {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -6,7 +6,7 @@ import expand from 'brace-expansion';
 import { HostService } from '~/app/shared/api/host.service';
 import { SelectMessages } from '~/app/shared/components/select/select-messages.model';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
@@ -20,7 +20,7 @@ const HOSTS = 'hosts';
   templateUrl: './host-form.component.html',
   styleUrls: ['./host-form.component.scss']
 })
-export class HostFormComponent extends CdForm implements OnInit {
+export class HostFormComponent extends CdFormCanDeactivate implements OnInit {
   open: boolean = false;
   hostForm: CdFormGroup;
   action: string;
@@ -74,6 +74,10 @@ export class HostFormComponent extends CdForm implements OnInit {
         return { name: label, content: label };
       });
     });
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.hostForm;
   }
 
   // check if hostname is a single value or pattern to hide network address field

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
@@ -8,7 +8,7 @@ import { forkJoin as observableForkJoin } from 'rxjs';
 import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -19,7 +19,7 @@ import { NotificationService } from '~/app/shared/services/notification.service'
   templateUrl: './mgr-module-form.component.html',
   styleUrls: ['./mgr-module-form.component.scss']
 })
-export class MgrModuleFormComponent extends CdForm implements OnInit {
+export class MgrModuleFormComponent extends CdFormCanDeactivate implements OnInit {
   mgrModuleForm: CdFormGroup;
   moduleName = '';
   moduleOptions: any[] = [];
@@ -56,6 +56,10 @@ export class MgrModuleFormComponent extends CdForm implements OnInit {
         }
       );
     });
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.mgrModuleForm;
   }
 
   getValidators(moduleOption: any): ValidatorFn[] {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -19,7 +19,7 @@ import { OsdService } from '~/app/shared/api/osd.service';
 import { FormButtonPanelComponent } from '~/app/shared/components/form-button-panel/form-button-panel.component';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -42,7 +42,7 @@ import { OsdFeature } from './osd-feature.interface';
   templateUrl: './osd-form.component.html',
   styleUrls: ['./osd-form.component.scss']
 })
-export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
+export class OsdFormComponent extends CdFormCanDeactivate implements OnInit, OnDestroy {
   @ViewChild('dataDeviceSelectionGroups')
   dataDeviceSelectionGroups: OsdDevicesSelectionGroupsComponent;
 
@@ -154,6 +154,10 @@ export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
         .get(feature.key)
         .valueChanges.subscribe((value) => this.featureFormUpdate(feature.key, value));
     });
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.form;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -29,7 +29,7 @@ import {
   SSL_PROTOCOLS,
   SSL_CIPHERS
 } from '~/app/shared/constants/app.constants';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -44,7 +44,7 @@ import { TimerService } from '~/app/shared/services/timer.service';
   templateUrl: './service-form.component.html',
   styleUrls: ['./service-form.component.scss']
 })
-export class ServiceFormComponent extends CdForm implements OnInit {
+export class ServiceFormComponent extends CdFormCanDeactivate implements OnInit {
   public sub = new Subscription();
 
   readonly MDS_SVC_ID_PATTERN = /^[a-zA-Z_.-][a-zA-Z0-9_.-]*$/;
@@ -136,6 +136,10 @@ export class ServiceFormComponent extends CdForm implements OnInit {
       })
     };
     this.createForm();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.serviceForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -9,7 +9,7 @@ import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { TelemetryService } from '~/app/shared/api/telemetry.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -20,7 +20,7 @@ import { TelemetryNotificationService } from '~/app/shared/services/telemetry-no
   templateUrl: './telemetry.component.html',
   styleUrls: ['./telemetry.component.scss']
 })
-export class TelemetryComponent extends CdForm implements OnInit {
+export class TelemetryComponent extends CdFormCanDeactivate implements OnInit {
   configForm: CdFormGroup;
   licenseAgrmt = false;
   moduleEnabled: boolean;
@@ -82,6 +82,10 @@ export class TelemetryComponent extends CdForm implements OnInit {
         this.loadingError();
       }
     );
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.configForm;
   }
 
   private createConfigForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -18,7 +18,7 @@ import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
 import { RgwSiteService } from '~/app/shared/api/rgw-site.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -40,7 +40,7 @@ import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant'
   templateUrl: './nfs-form.component.html',
   styleUrls: ['./nfs-form.component.scss']
 })
-export class NfsFormComponent extends CdForm implements OnInit {
+export class NfsFormComponent extends CdFormCanDeactivate implements OnInit {
   @ViewChild('nfsClients', { static: true })
   nfsClients: NfsFormClientComponent;
 
@@ -169,6 +169,12 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.getData(promises);
     }
   }
+
+
+  getFormGroup(): CdFormGroup {
+    return this.nfsForm;
+  }
+
 
   getData(promises: Observable<any>[]) {
     forkJoin(promises).subscribe((data: any[]) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -39,6 +39,7 @@ import { Pool } from '../pool';
 import { PoolFormData } from './pool-form-data';
 import { PoolEditModeResponseModel } from '../../block/mirroring/pool-edit-mode-modal/pool-edit-mode-response.model';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { ComponentCanDeactivate } from '~/app/shared/services/unsaved-changes-guard.service';
 
 interface FormFieldDescription {
   externalFieldName: string;
@@ -54,7 +55,7 @@ interface FormFieldDescription {
   templateUrl: './pool-form.component.html',
   styleUrls: ['./pool-form.component.scss']
 })
-export class PoolFormComponent extends CdForm implements OnInit {
+export class PoolFormComponent extends CdForm implements OnInit, ComponentCanDeactivate {
   @ViewChild('crushInfoTabs') crushInfoTabs: NgbNav;
   @ViewChild('crushDeletionBtn') crushDeletionBtn: NgbTooltip;
   @ViewChild('ecpInfoTabs') ecpInfoTabs: NgbNav;
@@ -111,6 +112,11 @@ export class PoolFormComponent extends CdForm implements OnInit {
     this.resource = $localize`pool`;
     this.authenticate();
     this.createForm();
+  }
+
+  canDeactivate(): boolean | Observable<boolean> {
+    console.log('Component canDeactivate called');
+    return !this.form?.dirty || confirm('There are unsaved changes. Do you want to leave?');
   }
 
   authenticate() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -61,6 +61,7 @@ export class PoolFormComponent extends CdFormCanDeactivate implements OnInit {
   @ViewChild('ecpDeletionBtn') ecpDeletionBtn: NgbTooltip;
 
   permission: Permission;
+  form: CdFormGroup;
   ecProfiles: ErasureCodeProfile[];
   info: PoolFormInfo;
   routeParamsSubscribe: any;
@@ -112,6 +113,9 @@ export class PoolFormComponent extends CdFormCanDeactivate implements OnInit {
     this.createForm();
   }
 
+  getFormGroup(): CdFormGroup {
+    return this.form;
+  }
 
   authenticate() {
     this.permission = this.authStorageService.getPermissions().pool;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -15,7 +15,6 @@ import { DeleteConfirmationModalComponent } from '~/app/shared/components/delete
 import { SelectOption } from '~/app/shared/components/select/select-option.model';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import {
@@ -39,7 +38,7 @@ import { Pool } from '../pool';
 import { PoolFormData } from './pool-form-data';
 import { PoolEditModeResponseModel } from '../../block/mirroring/pool-edit-mode-modal/pool-edit-mode-response.model';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
-import { ComponentCanDeactivate } from '~/app/shared/services/unsaved-changes-guard.service';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 
 interface FormFieldDescription {
   externalFieldName: string;
@@ -55,14 +54,13 @@ interface FormFieldDescription {
   templateUrl: './pool-form.component.html',
   styleUrls: ['./pool-form.component.scss']
 })
-export class PoolFormComponent extends CdForm implements OnInit, ComponentCanDeactivate {
+export class PoolFormComponent extends CdFormCanDeactivate implements OnInit {
   @ViewChild('crushInfoTabs') crushInfoTabs: NgbNav;
   @ViewChild('crushDeletionBtn') crushDeletionBtn: NgbTooltip;
   @ViewChild('ecpInfoTabs') ecpInfoTabs: NgbNav;
   @ViewChild('ecpDeletionBtn') ecpDeletionBtn: NgbTooltip;
 
   permission: Permission;
-  form: CdFormGroup;
   ecProfiles: ErasureCodeProfile[];
   info: PoolFormInfo;
   routeParamsSubscribe: any;
@@ -114,10 +112,6 @@ export class PoolFormComponent extends CdForm implements OnInit, ComponentCanDea
     this.createForm();
   }
 
-  canDeactivate(): boolean | Observable<boolean> {
-    console.log('Component canDeactivate called');
-    return !this.form?.dirty || confirm('There are unsaved changes. Do you want to leave?');
-  }
 
   authenticate() {
     this.permission = this.authStorageService.getPermissions().pool;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -14,6 +14,7 @@ import { ErasureCodeProfileFormModalComponent } from './erasure-code-profile-for
 import { PoolDetailsComponent } from './pool-details/pool-details.component';
 import { PoolFormComponent } from './pool-form/pool-form.component';
 import { PoolListComponent } from './pool-list/pool-list.component';
+import { UnsavedChangesGuard } from '~/app/shared/services/unsaved-changes-guard.service';
 
 @NgModule({
   imports: [
@@ -42,16 +43,19 @@ const routes: Routes = [
   {
     path: URLVerbs.CREATE,
     component: PoolFormComponent,
+    canDeactivate: [UnsavedChangesGuard],
     data: { breadcrumbs: ActionLabels.CREATE }
   },
   {
     path: `${URLVerbs.EDIT}/:name`,
     component: PoolFormComponent,
+    canDeactivate: [UnsavedChangesGuard],
     data: { breadcrumbs: ActionLabels.EDIT }
   }
 ];
 
 @NgModule({
-  imports: [PoolModule, RouterModule.forChild(routes)]
+  imports: [PoolModule, RouterModule.forChild(routes)],
+  providers: [UnsavedChangesGuard]
 })
 export class RoutedPoolModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -19,7 +19,7 @@ import { RgwUserService } from '~/app/shared/api/rgw-user.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -47,7 +47,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
   templateUrl: './rgw-bucket-form.component.html',
   styleUrls: ['./rgw-bucket-form.component.scss']
 })
-export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewChecked {
+export class RgwBucketFormComponent extends CdFormCanDeactivate implements OnInit, AfterViewChecked {
   @ViewChild('bucketPolicyTextArea')
   public bucketPolicyTextArea: ElementRef<any>;
   @ViewChild('lifecycleTextArea')
@@ -111,6 +111,10 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
     this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
     this.resource = $localize`bucket`;
     this.createForm();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.bucketForm;
   }
 
   ngAfterViewChecked(): void {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-tiering-form/rgw-bucket-tiering-form.component.ts
@@ -17,7 +17,7 @@ import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
 import { BucketTieringUtils } from '../utils/rgw-bucket-tiering';
 import { StorageClass, ZoneGroupDetails } from '../models/rgw-storage-class.model';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { Router } from '@angular/router';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Lifecycle, Rule, Tag } from '../models/rgw-bucket-lifecycle';
@@ -32,7 +32,7 @@ export interface Tags {
   templateUrl: './rgw-bucket-tiering-form.component.html',
   styleUrls: ['./rgw-bucket-tiering-form.component.scss']
 })
-export class RgwBucketTieringFormComponent extends CdForm implements OnInit {
+export class RgwBucketTieringFormComponent extends CdFormCanDeactivate implements OnInit {
   tieringForm: CdFormGroup;
   tagsToRemove: Tags[] = [];
   storageClassList: StorageClass[] = null;
@@ -105,6 +105,10 @@ export class RgwBucketTieringFormComponent extends CdForm implements OnInit {
       days: [60, [Validators.required, CdValidators.number(false)]]
     });
     this.loadStorageClass();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.tieringForm;
   }
 
   checkIfRuleHasFilters(rule: Rule) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component.ts
@@ -18,7 +18,7 @@ import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { RgwMultisiteSyncPolicyStatus } from '../models/rgw-multisite';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import _ from 'lodash';
 
 @Component({
@@ -26,7 +26,7 @@ import _ from 'lodash';
   templateUrl: './rgw-multisite-sync-policy-form.component.html',
   styleUrls: ['./rgw-multisite-sync-policy-form.component.scss']
 })
-export class RgwMultisiteSyncPolicyFormComponent extends CdForm implements OnInit {
+export class RgwMultisiteSyncPolicyFormComponent extends CdFormCanDeactivate implements OnInit {
   syncPolicyForm: CdFormGroup;
   editing = false;
   action: string;
@@ -84,6 +84,10 @@ export class RgwMultisiteSyncPolicyFormComponent extends CdForm implements OnIni
         }
       });
     }
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.syncPolicyForm;
   }
 
   goToListView() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import _ from 'lodash';
@@ -27,7 +27,7 @@ import { NotificationService } from '~/app/shared/services/notification.service'
   templateUrl: './rgw-storage-class-form.component.html',
   styleUrls: ['./rgw-storage-class-form.component.scss']
 })
-export class RgwStorageClassFormComponent extends CdForm implements OnInit {
+export class RgwStorageClassFormComponent extends CdFormCanDeactivate implements OnInit {
   storageClassForm: CdFormGroup;
   action: string;
   resource: string;
@@ -120,6 +120,11 @@ export class RgwStorageClassFormComponent extends CdForm implements OnInit {
             .setValue(response.multipart_min_part_size || '');
         });
     }
+  }
+
+
+  getFormGroup(): CdFormGroup {
+    return this.storageClassForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-accounts-form/rgw-user-accounts-form.component.ts
@@ -3,7 +3,7 @@ import { AbstractControl, ValidationErrors, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RgwUserAccountsService } from '~/app/shared/api/rgw-user-accounts.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { Account } from '../models/rgw-user-accounts';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -19,7 +19,7 @@ import _ from 'lodash';
   templateUrl: './rgw-user-accounts-form.component.html',
   styleUrls: ['./rgw-user-accounts-form.component.scss']
 })
-export class RgwUserAccountsFormComponent extends CdForm implements OnInit {
+export class RgwUserAccountsFormComponent extends CdFormCanDeactivate implements OnInit {
   accountForm: CdFormGroup;
   action: string;
   resource: string;
@@ -89,6 +89,10 @@ export class RgwUserAccountsFormComponent extends CdForm implements OnInit {
         });
       });
     }
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.accountForm;
   }
 
   mapValuesForMode(value: any, formControlName: string) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -9,7 +9,7 @@ import { RgwUserService } from '~/app/shared/api/rgw-user.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -33,7 +33,7 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
   templateUrl: './rgw-user-form.component.html',
   styleUrls: ['./rgw-user-form.component.scss']
 })
-export class RgwUserFormComponent extends CdForm implements OnInit {
+export class RgwUserFormComponent extends CdFormCanDeactivate implements OnInit {
   userForm: CdFormGroup;
   editing = false;
   submitObservables: Observable<Object>[] = [];
@@ -70,6 +70,10 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
     this.editing = this.router.url.startsWith(`/rgw/user/${URLVerbs.EDIT}`);
     this.action = this.editing ? this.actionLabels.EDIT : this.actionLabels.CREATE;
     this.createForm();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.userForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -95,6 +95,7 @@ import { RgwBucketLifecycleListComponent } from './rgw-bucket-lifecycle-list/rgw
 import { RgwRateLimitComponent } from './rgw-rate-limit/rgw-rate-limit.component';
 import { RgwRateLimitDetailsComponent } from './rgw-rate-limit-details/rgw-rate-limit-details.component';
 import { NfsClusterComponent } from '../nfs/nfs-cluster/nfs-cluster.component';
+import { UnsavedChangesGuard } from '~/app/shared/services/unsaved-changes-guard.service';
 
 @NgModule({
   imports: [
@@ -213,11 +214,13 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: RgwUserFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:uid`,
         component: RgwUserFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.EDIT }
       }
     ]
@@ -230,11 +233,13 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: RgwUserAccountsFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:id`,
         component: RgwUserAccountsFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.EDIT }
       }
     ]
@@ -267,6 +272,7 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: CrudFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: {
           breadcrumbs: ActionLabels.CREATE
         }
@@ -274,6 +280,7 @@ const routes: Routes = [
       {
         path: URLVerbs.EDIT,
         component: CrudFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: {
           breadcrumbs: ActionLabels.EDIT
         }
@@ -288,11 +295,13 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: RgwBucketFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:bid`,
         component: RgwBucketFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.EDIT }
       }
     ]
@@ -327,16 +336,19 @@ const routes: Routes = [
           {
             path: `${URLVerbs.CREATE}`,
             component: RgwMultisiteSyncPolicyFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           },
           {
             path: `${URLVerbs.EDIT}/:groupName`,
             component: RgwMultisiteSyncPolicyFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           },
           {
             path: `${URLVerbs.EDIT}/:groupName/:bucketName`,
             component: RgwMultisiteSyncPolicyFormComponent,
+            canDeactivate: [UnsavedChangesGuard],
             outlet: 'modal'
           }
         ]
@@ -351,11 +363,13 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: RgwStorageClassFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:zonegroup_name/:placement_target/:storage_class`,
         component: RgwStorageClassFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.EDIT }
       }
     ]
@@ -378,11 +392,13 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: NfsFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:cluster_id/:export_id`,
         component: NfsFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
         data: { breadcrumbs: ActionLabels.EDIT }
       }
     ]
@@ -395,6 +411,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RgwModule, RouterModule.forChild(routes)]
+  imports: [RgwModule, RouterModule.forChild(routes)],
+  providers: [UnsavedChangesGuard]
+
 })
 export class RoutedRgwModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.ts
@@ -21,7 +21,7 @@ import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants
 import { Icons } from '~/app/shared/enum/icons.enum';
 
 import { FormArray, FormControl, UntypedFormControl, Validators } from '@angular/forms';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -42,7 +42,7 @@ import { UpperFirstPipe } from '~/app/shared/pipes/upper-first.pipe';
   templateUrl: './smb-cluster-form.component.html',
   styleUrls: ['./smb-cluster-form.component.scss']
 })
-export class SmbClusterFormComponent extends CdForm implements OnInit {
+export class SmbClusterFormComponent extends CdFormCanDeactivate implements OnInit {
   smbForm: CdFormGroup;
   hostsAndLabels$: Observable<{ hosts: any[]; labels: any[] }>;
   hasOrchestrator: boolean;
@@ -177,6 +177,10 @@ export class SmbClusterFormComponent extends CdForm implements OnInit {
     this.allClustering = Object.values(CLUSTERING);
     this.loadingReady();
     if (!this.isEdit) this.onAuthModeChange();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.smbForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-domain-setting-modal/smb-domain-setting-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-domain-setting-modal/smb-domain-setting-modal.component.ts
@@ -8,7 +8,7 @@ import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { RgwRealmService } from '~/app/shared/api/rgw-realm.service';
 import { SmbService } from '~/app/shared/api/smb.service';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { DomainSettings, JoinSource, SMBJoinAuth } from '../smb.model';
 import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
@@ -19,7 +19,7 @@ import { JOINAUTH_URL } from '../smb-join-auth-list/smb-join-auth-list.component
   templateUrl: './smb-domain-setting-modal.component.html',
   styleUrls: ['./smb-domain-setting-modal.component.scss']
 })
-export class SmbDomainSettingModalComponent extends CdForm implements OnInit {
+export class SmbDomainSettingModalComponent extends CdFormCanDeactivate implements OnInit {
   domainSettingsForm: CdFormGroup;
   realmNames: string[];
   joinAuths$: Observable<SMBJoinAuth[]>;
@@ -75,6 +75,10 @@ export class SmbDomainSettingModalComponent extends CdForm implements OnInit {
     } else {
       this.action = this.actionLabels.EDIT;
     }
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.domainSettingsForm;
   }
 
   submit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-form/smb-join-auth-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-form/smb-join-auth-form.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { SmbService } from '~/app/shared/api/smb.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -19,7 +19,7 @@ import { Location } from '@angular/common';
   templateUrl: './smb-join-auth-form.component.html',
   styleUrls: ['./smb-join-auth-form.component.scss']
 })
-export class SmbJoinAuthFormComponent extends CdForm implements OnInit {
+export class SmbJoinAuthFormComponent extends CdFormCanDeactivate implements OnInit {
   form: CdFormGroup;
   action: string;
   resource: string;
@@ -61,6 +61,10 @@ export class SmbJoinAuthFormComponent extends CdForm implements OnInit {
         this.form.get('linkedToCluster').setValue(joinAuth.linked_to_cluster);
       });
     }
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.form;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-share-form/smb-share-form.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 
@@ -33,7 +33,7 @@ import { CephfsSubvolumeService } from '~/app/shared/api/cephfs-subvolume.servic
   templateUrl: './smb-share-form.component.html',
   styleUrls: ['./smb-share-form.component.scss']
 })
-export class SmbShareFormComponent extends CdForm implements OnInit {
+export class SmbShareFormComponent extends CdFormCanDeactivate implements OnInit {
   smbShareForm: CdFormGroup;
   action: string;
   resource: string;
@@ -90,6 +90,10 @@ export class SmbShareFormComponent extends CdForm implements OnInit {
       });
     }
     this.loadingReady();
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.smbShareForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-form/smb-usersgroups-form.component.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 import { SmbService } from '~/app/shared/api/smb.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -19,7 +19,7 @@ import { USERSGROUPS_URL } from '../smb-usersgroups-list/smb-usersgroups-list.co
   templateUrl: './smb-usersgroups-form.component.html',
   styleUrls: ['./smb-usersgroups-form.component.scss']
 })
-export class SmbUsersgroupsFormComponent extends CdForm implements OnInit {
+export class SmbUsersgroupsFormComponent extends CdFormCanDeactivate implements OnInit {
   form: CdFormGroup;
   action: string;
   resource: string;
@@ -71,6 +71,10 @@ export class SmbUsersgroupsFormComponent extends CdForm implements OnInit {
     } else {
       this.addUser();
     }
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.form;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
@@ -41,6 +41,7 @@ import AddFilled from '@carbon/icons/es/add--filled/32';
 import SubtractFilled from '@carbon/icons/es/subtract--filled/32';
 import Reset from '@carbon/icons/es/reset/32';
 import EyeIcon from '@carbon/icons/es/view/16';
+import { UnsavedChangesGuard } from '~/app/shared/services/unsaved-changes-guard.service';
 @NgModule({
   imports: [
     CommonModule,
@@ -97,11 +98,15 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: UserFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
+
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:username`,
         component: UserFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
+
         data: { breadcrumbs: ActionLabels.EDIT }
       }
     ]
@@ -114,11 +119,15 @@ const routes: Routes = [
       {
         path: URLVerbs.CREATE,
         component: RoleFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
+
         data: { breadcrumbs: ActionLabels.CREATE }
       },
       {
         path: `${URLVerbs.EDIT}/:name`,
         component: RoleFormComponent,
+        canDeactivate: [UnsavedChangesGuard],
+
         data: { breadcrumbs: ActionLabels.EDIT }
       }
     ]
@@ -126,6 +135,8 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [AuthModule, RouterModule.forChild(routes)]
+  imports: [AuthModule, RouterModule.forChild(routes)],
+  providers: [UnsavedChangesGuard]
+
 })
 export class RoutedAuthModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.ts
@@ -9,7 +9,7 @@ import { RoleService } from '~/app/shared/api/role.service';
 import { ScopeService } from '~/app/shared/api/scope.service';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
@@ -22,7 +22,7 @@ import { RoleFormModel } from './role-form.model';
   templateUrl: './role-form.component.html',
   styleUrls: ['./role-form.component.scss']
 })
-export class RoleFormComponent extends CdForm implements OnInit {
+export class RoleFormComponent extends CdFormCanDeactivate implements OnInit {
   roleForm: CdFormGroup;
   response: RoleFormModel;
 
@@ -135,6 +135,12 @@ export class RoleFormComponent extends CdForm implements OnInit {
       });
     });
   }
+
+
+  getFormGroup(): CdFormGroup {
+    return this.roleForm;
+  }
+
 
   getRequest(): RoleFormModel {
     const roleFormModel = new RoleFormModel();

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -16,7 +16,7 @@ import { SelectMessages } from '~/app/shared/components/select/select-messages.m
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { Icons } from '~/app/shared/enum/icons.enum';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
-import { CdForm } from '~/app/shared/forms/cd-form';
+import { CdFormCanDeactivate } from '~/app/shared/forms/cd-form-can-deactivate';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -34,7 +34,7 @@ import { UserFormModel } from './user-form.model';
   templateUrl: './user-form.component.html',
   styleUrls: ['./user-form.component.scss']
 })
-export class UserFormComponent extends CdForm implements OnInit {
+export class UserFormComponent extends CdFormCanDeactivate implements OnInit {
   @ViewChild('removeSelfUserReadUpdatePermissionTpl', { static: true })
   removeSelfUserReadUpdatePermissionTpl: TemplateRef<any>;
 
@@ -75,6 +75,10 @@ export class UserFormComponent extends CdForm implements OnInit {
     this.resource = $localize`user`;
     this.createForm();
     this.messages = new SelectMessages({ empty: $localize`There are no roles.` });
+  }
+
+  getFormGroup(): CdFormGroup {
+    return this.userForm;
   }
 
   createForm() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
@@ -64,9 +64,6 @@ export class FormButtonPanelComponent implements OnInit {
   }
 
   backAction() {
-    const shouldStay = this.form?.dirty &&
-      !confirm($localize`You have unsaved changes. Are you sure you want to leave?`);
-    if (shouldStay) return;
     if (this.backActionEvent.observers.length === 0) {
       if (this.modalForm && this.cdsModalService.hasOpenModals()) {
         this.cdsModalService.dismissAll();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
@@ -64,6 +64,9 @@ export class FormButtonPanelComponent implements OnInit {
   }
 
   backAction() {
+    const shouldStay = this.form?.dirty &&
+      !confirm($localize`You have unsaved changes. Are you sure you want to leave?`);
+    if (shouldStay) return;
     if (this.backActionEvent.observers.length === 0) {
       if (this.modalForm && this.cdsModalService.hasOpenModals()) {
         this.cdsModalService.dismissAll();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-can-deactivate.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-can-deactivate.ts
@@ -1,0 +1,16 @@
+import { ComponentCanDeactivate } from '../services/unsaved-changes-guard.service';
+import { CdForm } from './cd-form';
+import { Observable } from 'rxjs';
+import { CdFormGroup } from './cd-form-group';
+
+export abstract class CdFormCanDeactivate extends CdForm implements ComponentCanDeactivate {
+  form: CdFormGroup;  // Define the form property here
+
+  canDeactivate(): boolean | Observable<boolean> {
+    console.log('canDeactivate called');
+    if (this.form?.dirty) {
+      return confirm('There are unsaved changes. Do you want to leave?');
+    }
+    return true;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-can-deactivate.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-can-deactivate.ts
@@ -4,13 +4,12 @@ import { Observable } from 'rxjs';
 import { CdFormGroup } from './cd-form-group';
 
 export abstract class CdFormCanDeactivate extends CdForm implements ComponentCanDeactivate {
-  form: CdFormGroup;  // Define the form property here
-
-  canDeactivate(): boolean | Observable<boolean> {
-    console.log('canDeactivate called');
-    if (this.form?.dirty) {
-      return confirm('There are unsaved changes. Do you want to leave?');
+    abstract getFormGroup(): CdFormGroup;
+    canDeactivate(): boolean | Observable<boolean> {
+        const form = this.getFormGroup();
+        if (form?.dirty) {
+            return confirm('There are unsaved changes. Do you want to leave?');
+        }
+        return true;
     }
-    return true;
-  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/unsaved-changes-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/unsaved-changes-guard.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export interface ComponentCanDeactivate {
+  canDeactivate: () => boolean | Observable<boolean>;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UnsavedChangesGuard implements CanDeactivate<ComponentCanDeactivate> {
+  canDeactivate(
+    component: ComponentCanDeactivate
+  ): boolean | Observable<boolean> {
+    if (!component) {
+      console.warn('Component is null in UnsavedChangesGuard');
+      return true;
+    }
+
+    if (typeof component.canDeactivate !== 'function') {
+      console.warn('Component does not implement canDeactivate method');
+      return true;
+    }
+
+    return component.canDeactivate();
+  }
+}


### PR DESCRIPTION
Added unsaved changes warning across Ceph Dashboard forms to prevent data loss when navigating away. Implemented the feature in key sections like pools, users, and images to enhance user experience and prevent accidental changes from being discarded.

Signed-off-by: Anikait Sehwag
anikaitsehwag.amg@gmail.com

![Screenshot from 2025-03-31 03-56-48](https://github.com/user-attachments/assets/11818ab7-be69-454f-afaf-31e4c96e761d)

![Screenshot from 2025-03-25 18-46-12](https://github.com/user-attachments/assets/e1bebbb4-d846-486e-8b51-17904a78bb24)


https://github.com/user-attachments/assets/fb1fb880-05cb-45d4-8106-0927a44a66b2


The solution involved adding event listeners to the form elements, monitoring changes dynamically, and flagging the form as "dirty" when modifications occur. Angular’s `CanDeactivate` route guard was utilized to intercept route navigation, prompting a confirmation dialog when users attempt to leave with unsaved data. This pattern ensures that users explicitly acknowledge and address potential data loss before exiting or reloading the page.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)

- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
