### PR TITLE
squid: blk/kerneldevice: fix invalid iterator usage after erase in discard_q…

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -771,11 +771,11 @@ void KernelDevice::_discard_thread(uint64_t tid)
       // It will also allow threads to finish in a timely manner.
       constexpr unsigned MAX_LOCAL_DISCARD = 32;
       unsigned count = 0;
-      for (auto p = discard_queued.begin();
-	   p != discard_queued.end() && count < MAX_LOCAL_DISCARD;
-	   ++p, ++count) {
-	discard_processing.insert(p.get_start(), p.get_len());
-	discard_queued.erase(p);
+      for (auto it = discard_queued.begin();
+           it != discard_queued.end() && count < MAX_LOCAL_DISCARD;
+           ++count) {
+        discard_processing.insert(it.get_start(), it.get_len());
+        it = discard_queued.erase(it);
       }
 
       // there are multiple active threads -> must use a counter instead of a flag

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -549,9 +549,9 @@ class interval_set {
     std::swap(_size, other._size);
   }    
   
-  void erase(const iterator &i) {
+  iterator erase(const iterator &i) {
     _size -= i.get_len();
-    m.erase(i._iter);
+    return iterator(m.erase(i._iter));
   }
 
   void erase(T val) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70671

---

backport of https://github.com/ceph/ceph/pull/62471
parent tracker: https://tracker.ceph.com/issues/70636

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh