### PR TITLE
qa/cephadm/smb: run setsebool with sudo

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_ctdb_node_gone_state.yaml
@@ -26,7 +26,7 @@ tasks:
     role: host.d
 - pexec:
     all:
-      - setsebool -P virt_sandbox_use_netlink 1 || true
+      - sudo setsebool -P virt_sandbox_use_netlink 1 || true
 - cephadm:
 
 - cephadm.shell:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_clustering_ips.yaml
@@ -28,7 +28,7 @@ tasks:
     count: 1
 - pexec:
     all:
-      - setsebool -P virt_sandbox_use_netlink 1 || true
+      - sudo setsebool -P virt_sandbox_use_netlink 1 || true
 - cephadm:
 
 - cephadm.shell:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
@@ -26,7 +26,7 @@ tasks:
     role: host.d
 - pexec:
     all:
-      - setsebool -P virt_sandbox_use_netlink 1 || true
+      - sudo setsebool -P virt_sandbox_use_netlink 1 || true
 - cephadm:
 
 - cephadm.shell:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_dom.yaml
@@ -26,7 +26,7 @@ tasks:
     role: host.d
 - pexec:
     all:
-      - setsebool -P virt_sandbox_use_netlink 1 || true
+      - sudo setsebool -P virt_sandbox_use_netlink 1 || true
 - cephadm:
 
 - cephadm.shell:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
@@ -28,7 +28,7 @@ tasks:
     count: 2
 - pexec:
     all:
-      - setsebool -P virt_sandbox_use_netlink 1 || true
+      - sudo setsebool -P virt_sandbox_use_netlink 1 || true
 - cephadm:
 
 - cephadm.shell:


### PR DESCRIPTION
Change 06fc55b0a4d994550f05625f10d8f7f0b11863eb added a setsebool command to nodes setup on ctdb enabled test. This should have prevented additional errors like:
```
failure_reason: 'SELinux denials found on
ubuntu@smithi066.front.sepia.ceph.com: [''type=AVC
  msg=audit(1743168241.024:10142): avc:  denied  { nlmsg_read } for
pid=60223 comm="ss"
  scontext=system_u:system_r:container_t:s0:c491,c612
tcontext=system_u:system_r:container_t:s0:c491,c612
  tclass=netlink_tcpdiag_socket permissive=1'', ''type=AVC
msg=audit(1743168185.768:10101):
  avc:  denied  { nlmsg_read } for  pid=58817 comm="ss"
scontext=system_u:system_r:container_t:s0:c491,c612
  tcontext=system_u:system_r:container_t:s0:c491,c612
tclass=netlink_tcpdiag_socket
  permissive=1'', ''type=AVC msg=audit(1743168210.896:10137): avc:
denied  { nlmsg_read
  } for  pid=59798 comm="ss"
scontext=system_u:system_r:container_t:s0:c491,c612
tcontext=system_u:system_r:container_t:s0:c491,c612
  tclass=netlink_tcpdiag_socket permissive=1'']'
```
But these were seen again:
https://qa-proxy.ceph.com/teuthology/adking-2025-03-28_12:13:17-orch:cephadm-wip-adk-testing-2025-03-27-1430-distro-default-smithi/8214681/teuthology.log

I think that the commands may not be getting run correctly because they need to be run with privs. Other pexec commands in the cephadm suite run with sudo, so try it here.







## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Fixes a test

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
