### PR TITLE
mgr/dashboard: add handling of delete errors for smb resource deletion

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/smb.py
+++ b/src/pybind/mgr/dashboard/controllers/smb.py
@@ -121,24 +121,27 @@ JOIN_AUTH_SCHEMA_RESULTS = add_results_to_schema(JOIN_AUTH_SCHEMA)
 USERSGROUPS_SCHEMA_RESULTS = add_results_to_schema(JOIN_AUTH_SCHEMA_RESULTS)
 
 
-def raise_on_failure(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        result = func(*args, **kwargs)
+def raise_on_failure(resource: str = '', title: str = ''):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            result = func(*args, **kwargs)
 
-        if isinstance(result, dict) and result.get('success') is False:
-            msg = 'Operation failed'
+            if isinstance(result, dict) and result.get('success') is False:
+                msg = 'Operation failed'
 
-            # Extracts the result msg from either of two possible response structures:
-            if 'results' in result:
-                msg = result['results'][0].get('msg', msg)
-            elif 'msg' in result:
-                msg = result['msg']
-            raise DashboardException(msg=msg, component='smb')
+                # Extracts the result msg from either of two possible response structures:
+                if 'results' in result:
+                    msg = result['results'][0].get('msg', msg)
+                elif 'msg' in result:
+                    msg = result['msg']
+                raise DashboardException(msg=msg,
+                                         component=resource or 'smb', title=title or func.__name__)
 
-        return result
+            return result
 
-    return wrapper
+        return wrapper
+    return decorator
 
 
 @APIRouter('/smb/cluster', Scope.SMB)
@@ -168,7 +171,7 @@ class SMBCluster(RESTController):
         """
         return mgr.remote('smb', 'show', [f'{self._resource}.{cluster_id}'])
 
-    @raise_on_failure
+    @raise_on_failure('cluster')
     @CreatePermission
     @EndpointDoc("Create smb cluster",
                  parameters={
@@ -191,6 +194,7 @@ class SMBCluster(RESTController):
         except RuntimeError as e:
             raise DashboardException(e, component='smb')
 
+    @raise_on_failure('cluster')
     @DeletePermission
     @EndpointDoc("Remove an smb cluster",
                  parameters={
@@ -235,7 +239,7 @@ class SMBShare(RESTController):
             [f'{self._resource}.{cluster_id}' if cluster_id else self._resource])
         return res['resources'] if 'resources' in res else [res]
 
-    @raise_on_failure
+    @raise_on_failure('share')
     @CreatePermission
     @EndpointDoc("Create smb share",
                  parameters={
@@ -271,7 +275,7 @@ class SMBShare(RESTController):
         """
         return mgr.remote('smb', 'show', [f'{self._resource}.{cluster_id}.{share_id}'])
 
-    @raise_on_failure
+    @raise_on_failure('share')
     @DeletePermission
     @EndpointDoc("Remove an smb share",
                  parameters={
@@ -332,6 +336,7 @@ class SMBJoinAuth(RESTController):
             [f'{self._resource}.{auth_id}'])
         return res['resources'] if 'resources' in res else res
 
+    @raise_on_failure('Active Directory')
     @CreatePermission
     @EndpointDoc("Create smb join auth",
                  parameters={
@@ -349,7 +354,8 @@ class SMBJoinAuth(RESTController):
         """
         return mgr.remote('smb', 'apply_resources', json.dumps(join_auth)).to_simplified()
 
-    @CreatePermission
+    @raise_on_failure('Active Directory')
+    @DeletePermission
     @EndpointDoc("Delete smb join auth",
                  parameters={
                      'auth_id': (str, 'auth_id')
@@ -406,6 +412,7 @@ class SMBUsersgroups(RESTController):
             [f'{self._resource}.{users_groups_id}'])
         return res['resources'] if 'resources' in res else res
 
+    @raise_on_failure('standalone')
     @CreatePermission
     @EndpointDoc("Create smb usersgroups",
                  parameters={
@@ -423,7 +430,8 @@ class SMBUsersgroups(RESTController):
         """
         return mgr.remote('smb', 'apply_resources', json.dumps(usersgroups)).to_simplified()
 
-    @CreatePermission
+    @raise_on_failure('standalone')
+    @DeletePermission
     @EndpointDoc("Delete smb join auth",
                  parameters={
                      'users_groups_id': (str, 'users_groups_id')

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -16,10 +16,13 @@ class DashboardException(Exception):
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, e=None, code=None, component=None, http_status_code=None, msg=None):
+    def __init__(self, e=None, code=None, component=None, http_status_code=None,
+                 msg=None, title=None):
         super(DashboardException, self).__init__(msg)
         self._code = code
         self.component = component
+        if title:
+            self.title = title
         if e:
             self.e = e
         if http_status_code:

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-list/smb-cluster-list.component.ts
@@ -118,12 +118,21 @@ export class SmbClusterListComponent extends ListWithDetails implements OnInit {
       itemDescription: $localize`Cluster`,
       itemNames: [cluster_id],
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask(`${CLUSTER_PATH}/${URLVerbs.DELETE}`, {
-            cluster_id: cluster_id
-          }),
-          call: this.smbService.removeCluster(cluster_id)
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask(`${CLUSTER_PATH}/${URLVerbs.DELETE}`, {
+              cluster_id: cluster_id
+            }),
+            call: this.smbService.removeCluster(cluster_id)
+          })
+          .subscribe({
+            error: () => {
+              this.modalService.dismissAll();
+            },
+            complete: () => {
+              this.modalService.dismissAll();
+            }
+          })
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-list/smb-join-auth-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-join-auth-list/smb-join-auth-list.component.ts
@@ -113,12 +113,21 @@ export class SmbJoinAuthListComponent implements OnInit {
       itemDescription: $localize`Active directory access resource`,
       itemNames: [authId],
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask(`${JOIN_AUTH_PATH}/${URLVerbs.DELETE}`, {
-            authId: authId
-          }),
-          call: this.smbService.deleteJoinAuth(authId)
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask(`${JOIN_AUTH_PATH}/${URLVerbs.DELETE}`, {
+              authId: authId
+            }),
+            call: this.smbService.deleteJoinAuth(authId)
+          })
+          .subscribe({
+            error: () => {
+              this.modalService.dismissAll();
+            },
+            complete: () => {
+              this.modalService.dismissAll();
+            }
+          })
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-list/smb-usersgroups-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-usersgroups-list/smb-usersgroups-list.component.ts
@@ -129,12 +129,21 @@ export class SmbUsersgroupsListComponent extends ListWithDetails implements OnIn
       itemDescription: $localize`Users and groups access resource`,
       itemNames: [usersGroupsId],
       submitActionObservable: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask(`${USERSGROUPS_PATH}/${URLVerbs.DELETE}`, {
-            usersGroupsId: usersGroupsId
-          }),
-          call: this.smbService.deleteUsersgroups(usersGroupsId)
-        })
+        this.taskWrapper
+          .wrapTaskAroundCall({
+            task: new FinishedTask(`${USERSGROUPS_PATH}/${URLVerbs.DELETE}`, {
+              usersGroupsId: usersGroupsId
+            }),
+            call: this.smbService.deleteUsersgroups(usersGroupsId)
+          })
+          .subscribe({
+            error: () => {
+              this.modalService.dismissAll();
+            },
+            complete: () => {
+              this.modalService.dismissAll();
+            }
+          })
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/task-exception.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/task-exception.ts
@@ -5,5 +5,6 @@ export class TaskException {
   code: number;
   component: string;
   detail: string;
+  title: string;
   task: Task;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -24,8 +24,8 @@ class TaskMessage {
   involves: (object: any) => string;
   errors: (metadata: any) => object;
 
-  failure(metadata: any): string {
-    return $localize`Failed to ${this.operation.failure} ${this.involves(metadata)}`;
+  failure(metadata: any, title: string = ''): string {
+    return $localize`Failed to ${title || this.operation.failure} ${this.involves(metadata)}`;
   }
 
   running(metadata: any): string {
@@ -688,8 +688,8 @@ export class TaskMessageService {
     );
   }
 
-  getErrorTitle(task: Task) {
-    return this._getTaskTitle(task).failure(task.metadata);
+  getErrorTitle(task: FinishedTask) {
+    return this._getTaskTitle(task).failure(task.metadata, task.exception?.title);
   }
 
   getRunningTitle(task: Task) {

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -33,6 +33,8 @@ def serialize_dashboard_exception(e, include_http_status=False, task=None):
         pass
     component = getattr(e, 'component', None)
     out['component'] = component if component else None
+    if title := getattr(e, 'title', None):
+        out['title'] = title
     if include_http_status:
         out['status'] = getattr(e, 'status', 500)  # type: ignore
     if task:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/70735


[screen-capture (93).webm](https://github.com/user-attachments/assets/8dab8925-1dd6-4f2e-9860-13a80ecd3dda)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
