### PR TITLE
squid: rgw: fixing tempest ObjectTestACLs and ObjectACLsNegativeTest cases

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2950,7 +2950,10 @@ int RGWHandler_REST_SWIFT::postauth_init(optional_yield y)
       && s->user->get_id().id == RGW_USER_ANON_ID) {
     s->bucket_tenant = s->account_name;
   } else {
-    s->bucket_tenant = s->auth.identity->get_tenant();
+    /* tenant must be taken from request. Can't use auth.identity->get_tenant(),
+       because there are cases when users from different tenant may be granted
+       access via ACL to this bucket */
+    s->bucket_tenant = s->user->get_tenant();
   }
   s->bucket_name = t->url_bucket;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70738

---

backport of https://github.com/ceph/ceph/pull/62286
parent tracker: https://tracker.ceph.com/issues/70540

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh