### PR TITLE
reef: cephfs-top, qa: Remove unnecessary global statements in tests

### DIFF
--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -326,7 +326,6 @@ def task(ctx, config):
     """
     Test radosgw-admin functionality against a running rgw instance.
     """
-    global log
 
     assert ctx.rgw.config, \
         "radosgw_admin task needs a config passed from the rgw task"

--- a/qa/workunits/dencoder/test_readable.py
+++ b/qa/workunits/dencoder/test_readable.py
@@ -95,7 +95,6 @@ def process_type(file_path, type):
     return 0  # File passed the test
 
 def test_object_wrapper(type, vdir, arversion, current_ver):
-    global incompat_paths
     _numtests = 0
     _failed = 0
     unrecognized = ""
@@ -155,8 +154,6 @@ def should_skip_object(type, arversion, current_ver):
     Note: The function relies on two global variables, 'backward_compat' and 'fast_shouldnt_skip',
     which should be defined and updated appropriately in the calling code.
     """
-    global backward_compat
-    global fast_shouldnt_skip
 
     if type in fast_shouldnt_skip:
         debug_print(f"fast Type {type} does not exist in the backward compatibility structure.")

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -341,7 +341,6 @@ class FSTop(FSTopBase):
         except Exception as e:
             raise FSTopException(f'Error in fs ls: {e}')
         fs_map = json.loads(buf.decode('utf-8'))
-        global fs_list
         fs_list.clear()
         for filesystem in fs_map:
             fs = filesystem['name']
@@ -469,7 +468,7 @@ class FSTop(FSTopBase):
         key = 0
         endwhile = False
         while not endwhile:
-            global current_states, fs_list
+            global fs_list
             fs_list = self.get_fs_names()
 
             if key == curses.KEY_UP and curr_row1 > 0:
@@ -875,7 +874,6 @@ class FSTop(FSTopBase):
                 xp += len(self.items(item)) + ITEMS_PAD_LEN
 
     def create_clients(self, stats_json, fs_name):
-        global metrics_dict, current_states
         counters = [m.upper() for m in stats_json[GLOBAL_COUNTERS_KEY]]
         self.tablehead_y += 2
         res = stats_json[GLOBAL_METRICS_KEY].get(fs_name, {})
@@ -914,7 +912,6 @@ class FSTop(FSTopBase):
         if not stats_json['version'] == FS_TOP_SUPPORTED_VER:
             self.header.addstr(0, 0, 'perf stats version mismatch!', curses.A_BOLD)
             return False
-        global fs_list
         for fs_name in fs_list:
             client_metadata = stats_json[CLIENT_METADATA_KEY].get(fs_name, {})
             client_cnt = len(client_metadata)
@@ -979,7 +976,7 @@ class FSTop(FSTopBase):
 
         curses.halfdelay(1)
         cmd = self.stdscr.getch()
-        global fs_list, current_states
+        global fs_list
         while not self.exit_ev.is_set():
             fs_list = self.get_fs_names()
             fs = current_states["last_fs"]
@@ -1119,7 +1116,7 @@ class FSTop(FSTopBase):
                     self.exit_ev.set()
 
             # header display
-            global fs_list, current_states
+            global fs_list
             fs_list = self.get_fs_names()
             current_states["last_fs"] = fs_list
             stats_json = self.perf_stats_query()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70754

---

backport of https://github.com/ceph/ceph/pull/62567
parent tracker: https://tracker.ceph.com/issues/70752

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh