### PR TITLE
doc/dev/release-process.rst: document new Jenkins job for containers

### DIFF
--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -228,86 +228,31 @@ the container, release builds do not, because the build does not
 sign the packages.  Thus, release builds do not build the containers.
 This must be done after :ref:`Signing and Publishing the Build`.
 
-Architecture-specific containers are built first, and pushed to
-quay.ceph.io/ceph/prerelease-{amd64,arm64}.  Note: this must be done on
-both architectures.
+A Jenkins job named ceph-release-containers exists so that we can
+test the images before release.  The job exists both for convenience and
+because it requires access to both x86_64 and arm64 builders.  Start the
+job manually on the Jenkins server.  This job:
 
-#. Use a host with a relatively-recent version of podman and skopeo available.
-   CentOS/RHEL/Fedora usually have later versions than Ubuntu, but Ubuntu 22.04
-   or later are probably ok.
+* builds the architecture-specific container imagess and pushes them to
+  quay.ceph.io/ceph/prerelease-amd64 and
+  quay.ceph.io/ceph/prerelease-arm64
 
-#. Copy and run this shell wrapper for building a container (in container/ is
-   assumed below, to invoke ``./build.sh``), replacing the values in ``<>`` as
-   appropriate:
+* fuses the architecture-specific images together into a 'manifest-list'
+  or 'fat' container image and pushes it to quay.ceph.io/ceph/prerelease
 
-     .. code-block:: bash
-
-        #!/bin/bash
-        set -xa
-
-        CI_CONTAINER=false
-        VERSION=19.2.1
-        FLAVOR=default
-        BRANCH=squid
-        ARCH=x86_64
-        CEPH_SHA1=58a7fab8be0a062d730ad7da874972fd3fba59fb
-        CONTAINER_REPO_HOSTNAME=quay.ceph.io
-        CONTAINER_REPO_ORGANIZATION=ceph
-        CONTAINER_REPO_USERNAME=<quay.ceph.io username>
-        CONTAINER_REPO_PASSWORD=<password for above>
-        PRERELEASE_USERNAME=<download.ceph.com prerelease username>
-        PRERELEASE_PASSWORD=<password for above>
-        unset NO_PUSH
-        ./build.sh  | tee build.sh.log
-
-#. Verify that the container images exist on
-   ``quay.ceph.io/ceph/prerelease-amd64`` and
-   ``quay.ceph.io/ceph/prerelease-arm64``.
-
-#. The prerelease manifest-list container, which refers to both arch-specific
-   containers, is built by using the command ``make-manifest-list.py`` in
-   ``ceph.git:src/container/make-manifest-list.py``. Note that you must be
-   logged into the appropriate container repos for any of these manipulations:
-   ``quay.ceph.io`` for fetching prerelease arch-specific containers and
-   pushing the prerelease manifest-list container, and ``quay.io`` for
-   promoting the prerelease containers to released containers.
-
-    .. prompt:: bash
-
-       cd <ceph-checkout>/container
-       ./make-manifest-list.py
-
-   Reasonable defaults are set for all inputs, but environment variables can be
-   used to override the following:
-
-    * ``ARCH_SPECIFIC_HOST`` (default 'quay.ceph.io'): host of prerelease repos
-    * ``AMD64_REPO`` (default 'ceph/prerelease-amd64') prerelease amd64 repo
-    * ``ARM64_REPO`` (default 'ceph/prerelease-arm64') prerelease arm64 repo
-
-   (prerelease arch-specific containers will be copied from here)
-
-    * ``MANIFEST_HOST`` (default 'quay.ceph.io') prerelease manifest-list host
-    * ``MANIFEST_REPO`` (default 'ceph/prerelease') prerelease manifest-list
-      repo
-
-   (prerelease manifest-list containers will be placed here)
-
-#. Finally, when all appropriate testing and verification is done on the
-   container images, you can use ``make-manifest-list.py`` to promote them to
-   their final release location on ``quay.io/ceph/ceph`` (again, be sure you're
-   logged into ``quay.io/ceph`` with appropriate permissions):
+Finally, when all appropriate testing and verification is done on the
+container images, run ``make-manifest-list.py --promote`` from the ceph
+source tree (at ``container/make-manifest-list.py``) to promote them to
+their final release location on ``quay.io/ceph/ceph`` (you must ensure
+you're logged into ``quay.io/ceph`` with appropriate permissions):
 
     .. prompt:: bash
 
        cd <ceph-checkout>/src/container
        ./make-manifest-list.py --promote
 
-   Two more environment variables can override the default destination for
-   promotion (the source of the prerelease container to be promoted is as
-   above, in ``MANIFEST_HOST/REPO``):
-
-    * ``RELEASE_MANIFEST_HOST`` (default 'quay.io') release host
-    * ``RELEASE_MANIFEST_REPO`` (default 'ceph/ceph') release repo
+The --promote step should only be performed as the final step in releasing
+containers, when the container images have been tested to be good.
 
 
 6. Announce the Release


### PR DESCRIPTION
The manual instructions for building release containers were complex and required access to an arm64 host; that was just too much, so I've created a Jenkins job to build all of the prerelease artifacts (see https://github.com/ceph/ceph-build/pull/2342). Change the documentation to reflect that.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
