### PR TITLE
mgr/dashboard: add enhancements for pool rulest

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.spec.ts
@@ -139,6 +139,7 @@ describe('CrushRuleFormComponent', () => {
     });
 
     it('should select all values automatically by selecting "ssd-host" as root', () => {
+      formHelper.setValue('device_class', 'ssd', true);
       assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
     });
 
@@ -149,7 +150,9 @@ describe('CrushRuleFormComponent', () => {
 
     it('should override automatic selections', () => {
       assert.formFieldValues(get.nodeByName('default'), 'osd-rack', '');
+      formHelper.setValue('device_class', 'ssd', true);
       assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
+      formHelper.setValue('device_class', '', true);
       assert.valuesOnRootChange('mix-host', 'osd-rack', '');
     });
 
@@ -160,6 +163,7 @@ describe('CrushRuleFormComponent', () => {
     });
 
     it('should preselect device by domain selection', () => {
+      formHelper.setValue('device_class', 'ssd', true);
       formHelper.setValue('failure_domain', 'osd', true);
       assert.formFieldValues(get.nodeByName('default'), 'osd', 'ssd');
     });
@@ -203,6 +207,7 @@ describe('CrushRuleFormComponent', () => {
     });
 
     it('creates a rule with all fields', () => {
+      formHelper.setValue('device_class', 'ssd', true);
       assert.valuesOnRootChange('ssd-host', 'osd', 'ssd');
       assert.creation(Mocks.getCrushRuleConfig('ssd-host-rule', 'ssd-host', 'osd', 'ssd'));
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.ts
@@ -76,7 +76,8 @@ export class CrushRuleFormModalComponent extends CrushNodeSelectionClass impleme
           nodes,
           this.form.get('root'),
           this.form.get('failure_domain'),
-          this.form.get('device_class')
+          this.form.get('device_class'),
+          false
         );
         this.names = names;
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
@@ -82,8 +82,11 @@
                   *ngIf="form.showError('k', frm, 'min')"
                   i18n>Must be equal to or greater than 2.</span>
             <span class="invalid-feedback"
-                  *ngIf="form.showError('k', frm, 'max')"
+                  *ngIf="form.showError('k', frm, 'max') && form.getValue('crushFailureDomain') === CrushFailureDomains.Osd"
                   i18n>Chunks (k+m) have exceeded the available OSDs of {{deviceCount}}.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('k', frm, 'max') && form.getValue('crushFailureDomain') === CrushFailureDomains.Host"
+                  i18n>Chunks (k+m+1) have exceeded the available hosts of {{deviceCount}}.</span>
             <span class="invalid-feedback"
                   *ngIf="form.showError('k', frm, 'unequal')"
                   i18n>For an equal distribution k has to be a multiple of (k+m)/l.</span>
@@ -119,8 +122,11 @@
                   *ngIf="form.showError('m', frm, 'min')"
                   i18n>Must be equal to or greater than 1.</span>
             <span class="invalid-feedback"
-                  *ngIf="form.showError('m', frm, 'max')"
+                  *ngIf="form.showError('m', frm, 'max') && form.getValue('crushFailureDomain') ===  CrushFailureDomains.Osd"
                   i18n>Chunks (k+m) have exceeded the available OSDs of {{deviceCount}}.</span>
+            <span class="invalid-feedback"
+                  *ngIf="form.showError('m', frm, 'max') && form.getValue('crushFailureDomain') ===  CrushFailureDomains.Host"
+                  i18n>Chunks (k+m+1) have exceeded the available hosts of {{deviceCount}}.</span>
           </div>
         </div>
 
@@ -240,7 +246,8 @@
             <select class="form-select"
                     id="crushFailureDomain"
                     name="crushFailureDomain"
-                    formControlName="crushFailureDomain">
+                    formControlName="crushFailureDomain"
+                    (change)="onCrushFailureDomainChane()">
               <option *ngIf="!failureDomains"
                       ngValue=""
                       i18n>Loading...</option>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.ts
@@ -11,7 +11,7 @@ import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { CrushNode } from '~/app/shared/models/crush-node';
-import { ErasureCodeProfile } from '~/app/shared/models/erasure-code-profile';
+import { ErasureCodeProfile, CrushFailureDomains } from '~/app/shared/models/erasure-code-profile';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 
@@ -46,6 +46,8 @@ export class ErasureCodeProfileFormModalComponent
   dCalc: boolean;
   lrcGroups: number;
   lrcMultiK: number;
+
+  public CrushFailureDomains = CrushFailureDomains;
 
   constructor(
     private formBuilder: CdFormBuilder,
@@ -144,9 +146,12 @@ export class ErasureCodeProfileFormModalComponent
 
   private baseValueValidation(dataChunk: boolean = false): boolean {
     return this.validValidation(() => {
+      const kMSum =
+        this.form.get('crushFailureDomain').value === CrushFailureDomains.Host
+          ? this.getKMSum() + 1
+          : this.getKMSum();
       return (
-        this.getKMSum() > this.deviceCount &&
-        this.form.getValue('k') > this.form.getValue('m') === dataChunk
+        kMSum > this.deviceCount && this.form.getValue('k') > this.form.getValue('m') === dataChunk
       );
     });
   }
@@ -468,5 +473,10 @@ export class ErasureCodeProfileFormModalComponent
     };
     const value = this.form.getValue(name);
     ecp[differentApiAttributes[name] || name] = name === 'crushRoot' ? value.name : value;
+  }
+
+  onCrushFailureDomainChane() {
+    this.form.get('k').updateValueAndValidity();
+    this.form.get('m').updateValueAndValidity();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.ts
@@ -3,6 +3,7 @@ import { AbstractControl } from '@angular/forms';
 import _ from 'lodash';
 
 import { CrushNode } from '../models/crush-node';
+import { CrushFailureDomains } from '../models/erasure-code-profile';
 
 export class CrushNodeSelectionClass {
   private nodes: CrushNode[] = [];
@@ -207,19 +208,26 @@ export class CrushNodeSelectionClass {
   }
 
   private updateDevices(failureDomain: string = this.controls.failure.value) {
-    const subNodes = _.flatten(
-      this.failureDomains[failureDomain].map((node) =>
-        CrushNodeSelectionClass.getSubNodes(node, this.idTree)
-      )
-    );
-    this.allDevices = subNodes.filter((n) => n.device_class).map((n) => n.device_class);
-    this.devices = _.uniq(this.allDevices).sort();
-    const device =
-      this.devices.length === 1
-        ? this.devices[0]
-        : this.getIncludedCustomValue(this.controls.device, this.devices);
-    if (this.autoDeviceUpdate) this.silentSet(this.controls.device, device);
-    this.onDeviceChange(device);
+    if (failureDomain === CrushFailureDomains.Host) {
+      this.allDevices = this.failureDomains[failureDomain]
+        .filter((fD) => fD.type)
+        .map((fD) => fD.type);
+      this.onDeviceChange('');
+    } else {
+      const subNodes = _.flatten(
+        this.failureDomains[failureDomain].map((node) =>
+          CrushNodeSelectionClass.getSubNodes(node, this.idTree)
+        )
+      );
+      this.allDevices = subNodes.filter((n) => n.device_class).map((n) => n.device_class);
+      this.devices = _.uniq(this.allDevices).sort();
+      const device =
+        this.devices.length === 1
+          ? this.devices[0]
+          : this.getIncludedCustomValue(this.controls.device, this.devices);
+      if (this.autoDeviceUpdate) this.silentSet(this.controls.device, device);
+      this.onDeviceChange(device);
+    }
   }
 
   private onDeviceChange(deviceType: string = this.controls.device.value) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/erasure-code-profile.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/erasure-code-profile.ts
@@ -17,3 +17,8 @@ export class ErasureCodeProfile {
   'crush-device-class'?: string;
   'directory'?: string;
 }
+
+export enum CrushFailureDomains {
+  Osd = 'osd',
+  Host = 'host'
+}


### PR DESCRIPTION

[screen-capture (95).webm](https://github.com/user-attachments/assets/8606ba02-1298-4eb5-a62f-2e50ed3efb39)


Fixes: https://tracker.ceph.com/issues/70764

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
