### PR TITLE
rgw: support 'Type' field in S3 key-value filters (IN/OUT)

### DIFF
--- a/src/rgw/rgw_s3_filter.h
+++ b/src/rgw/rgw_s3_filter.h
@@ -41,8 +41,39 @@ WRITE_CLASS_ENCODER(rgw_s3_key_filter)
 using KeyValueMap = boost::container::flat_map<std::string, std::string>;
 using KeyMultiValueMap = std::multimap<std::string, std::string>;
 
+struct KeyValueRule {
+  std::string type = "IN";
+  std::string key;
+  std::string value;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(type, bl);
+    encode(key, bl);
+    encode(value, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(type, bl);
+    decode(key, bl);
+    decode(value, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter* f) const {
+    f->open_object_section("FilterRule");
+    ::encode_json("Type", type, f);
+    ::encode_json("Name", key, f);
+    ::encode_json("Value", value, f);
+    f->close_section();
+  }
+};
+WRITE_CLASS_ENCODER(KeyValueRule)
+
 struct rgw_s3_key_value_filter {
-  KeyValueMap kv;
+  std::vector<KeyValueRule> kv;
 
   bool has_content() const;
 


### PR DESCRIPTION
## Summary

This draft PR is part of my Google Summer of Code (GSoC) application for the Ceph project idea: **"The More The Merrier"**.
https://gist.github.com/yuvalif/9c5a1ed326ca14cf4851d7a0b8ba0db8#design-considerations-for-the-proposal
This PR refactors the `rgw_s3_key_value_filter` logic to support an additional field `Type`, enabling filter rules with type `"IN"` or `"OUT"`. The default remains `"IN"`. 

## Details

- Introduced a new `KeyValueRule` struct to represent each rule with `Type`, `Name`, and `Value`.
- Updated XML encoding/decoding logic to handle this new structure.
- Updated match logic to support `"OUT"` type (negated match).
- Preserved backward compatibility by defaulting `Type` to `"IN"` if omitted.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket: https://tracker.ceph.com/issues/68788
- Component impact
  - [x] No impact that needs to be tracked
- Documentation
  - [x] No doc update is appropriate
- Tests
  - [x] No tests 

Signed-off-by: Haokun Wu <hw3068@columbia.edu>