### PR TITLE
squid: mgr/dashboard: enable ha by default on subsystem POST API

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -157,7 +157,7 @@ else:
         )
         @empty_response
         @handle_nvmeof_error
-        def create(self, nqn: str, enable_ha: bool, max_namespaces: int = 1024,
+        def create(self, nqn: str, enable_ha: bool = True, max_namespaces: int = 1024,
                    gw_group: Optional[str] = None):
             return NVMeoFClient(gw_group=gw_group).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -8099,6 +8099,7 @@ paths:
             schema:
               properties:
                 enable_ha:
+                  default: true
                   description: Enable high availability
                   type: boolean
                 gw_group:
@@ -8113,7 +8114,6 @@ paths:
                   type: string
               required:
               - nqn
-              - enable_ha
               type: object
       responses:
         '201':


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70762

---

backport of https://github.com/ceph/ceph/pull/62598
parent tracker: https://tracker.ceph.com/issues/70745

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh