### PR TITLE
squid: monitoring: Fix OSDs panel in host-details grafana dashboard

### DIFF
--- a/monitoring/ceph-mixin/dashboards/host.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/host.libsonnet
@@ -336,7 +336,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         'OSDs',
         '',
         'current',
-        'count(sum by (ceph_daemon) (ceph_osd_metadata{%(matchers)s}))' % $.matchers(),
+        'count(sum by (ceph_daemon) (ceph_osd_metadata{%(matchers)s hostname=~"$ceph_hosts"}))' % $.matchers(),
         null,
         'time_series',
         0,

--- a/monitoring/ceph-mixin/dashboards_out/host-details.json
+++ b/monitoring/ceph-mixin/dashboards_out/host-details.json
@@ -123,7 +123,7 @@
          "tableColumn": "",
          "targets": [
             {
-               "expr": "count(sum by (ceph_daemon) (ceph_osd_metadata{cluster=~\"$cluster\", }))",
+               "expr": "count(sum by (ceph_daemon) (ceph_osd_metadata{cluster=~\"$cluster\",  hostname=~\"$ceph_hosts\"}))",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70763

---

backport of https://github.com/ceph/ceph/pull/62047
parent tracker: https://tracker.ceph.com/issues/70226

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh