### PR TITLE
Add missing includes to various libraries

### DIFF
--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -18,6 +18,14 @@
 #include "Crypto.h"
 #include "common/ceph_json.h"
 #include "common/entity_name.h"
+#include "common/Formatter.h"
+#include "include/buffer.h"
+
+#include <cstdint>
+#include <iostream>
+#include <list>
+#include <map>
+#include <string>
 
 // The _MAX values are a bit wonky here because we are overloading the first
 // byte of the auth payload to identify both the type of authentication to be

--- a/src/auth/AuthClient.h
+++ b/src/auth/AuthClient.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 #include "include/buffer_fwd.h"
 

--- a/src/auth/AuthRegistry.h
+++ b/src/auth/AuthRegistry.h
@@ -3,14 +3,15 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <vector>
 
 #include "AuthAuthorizeHandler.h"
 #include "AuthMethodList.h"
 #include "common/ceph_mutex.h"
-#include "common/ceph_context.h"
-#include "common/config_cacher.h"
+#include "common/config_obs.h"
+#include "include/common_fwd.h" // for CephContext
 
 class AuthRegistry : public md_config_obs_t {
   CephContext *cct;

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -14,6 +14,7 @@
 
 #include "common/config.h"
 #include "CephxKeyServer.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/dout.h"
 #include <sstream>
 

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -17,6 +17,7 @@
 
 #include "auth/KeyRing.h"
 #include "CephxProtocol.h"
+#include "common/ceph_json.h"
 #include "common/ceph_mutex.h"
 #include "include/common_fwd.h"
 

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -17,9 +17,9 @@
 #include "CephxProtocol.h"
 #include "CephxKeyServer.h"
 #include <errno.h>
-#include <sstream>
 
 #include "include/random.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/config.h"
 #include "common/debug.h"
 

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -16,7 +16,6 @@
 #include "CephxProtocol.h"
 
 #include <errno.h>
-#include <sstream>
 
 #include "common/config.h"
 #include "include/ceph_features.h"

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -31,6 +31,7 @@
 
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
+#include "common/debug.h"
 #if defined(__linux__)
 #include "common/linux_version.h"
 #endif

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -17,6 +17,7 @@
 #include <fcntl.h>
 
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "common/config.h"

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -18,6 +18,7 @@
 #include <boost/scoped_ptr.hpp>
 
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "auth/KeyRing.h"

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -42,9 +42,11 @@
 #include "global/signal_handler.h"
 
 #include "include/color.h"
+#include "common/debug.h"
 #include "common/errno.h"
 #include "common/pick_address.h"
 
+#include "log/Log.h"
 #include "perfglue/heap_profiler.h"
 
 #include "include/ceph_assert.h"

--- a/src/client/ClientSnapRealm.h
+++ b/src/client/ClientSnapRealm.h
@@ -4,6 +4,10 @@
 #ifndef CEPH_CLIENT_SNAPREALM_H
 #define CEPH_CLIENT_SNAPREALM_H
 
+#include <iostream>
+#include <set>
+#include <vector>
+
 #include "include/types.h"
 #include "common/snap_types.h"
 #include "include/xlist.h"

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -20,6 +20,7 @@
 
 
 #include "common/config.h"
+#include "common/debug.h"
 #include "SyntheticClient.h"
 #include "osdc/Objecter.h"
 #include "osdc/Filer.h"

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -32,6 +32,7 @@
 #endif
 
 // ceph
+#include "common/debug.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "include/types.h"

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -31,6 +31,7 @@
 #include "include/str_list.h"
 #include "include/stringify.h"
 #include "include/object.h"
+#include "log/Log.h"
 #include "messages/MMonMap.h"
 #include "msg/Messenger.h"
 #include "include/ceph_assert.h"

--- a/src/log/SubsystemMap.h
+++ b/src/log/SubsystemMap.h
@@ -4,7 +4,8 @@
 #ifndef CEPH_LOG_SUBSYSTEMS
 #define CEPH_LOG_SUBSYSTEMS
 
-#include <string>
+#include <array>
+#include <cstdint>
 #include <vector>
 #include <algorithm>
 

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -15,13 +15,9 @@
 #ifndef CEPH_CONNECTION_H
 #define CEPH_CONNECTION_H
 
-#include <stdlib.h>
-#include <ostream>
-
 #include "auth/Auth.h"
 #include "common/RefCountedObj.h"
 #include "common/config.h"
-#include "common/debug.h"
 #include "common/ref.h"
 #include "common/ceph_mutex.h"
 #include "include/ceph_assert.h" // Because intusive_ptr clobbers our assert...

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -12,6 +12,7 @@
 #include "include/random.h"
 #include "auth/AuthClient.h"
 #include "auth/AuthServer.h"
+#include "auth/AuthSessionHandler.h" // for struct DecryptionError
 
 #define dout_subsys ceph_subsys_ms
 #undef dout_prefix

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -5,6 +5,7 @@
 #define _MSG_ASYNC_PROTOCOL_V2_
 
 #include "Protocol.h"
+#include "AsyncConnection.h"
 #include "crypto_onwire.h"
 #include "compression_meta.h"
 #include "compression_onwire.h"

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <sys/time.h>
 #include <sys/file.h>
+#include <boost/optional/optional_io.hpp>
 #include <boost/scope_exit.hpp>
 
 #include "common/admin_socket.h"


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490

This is a big PR that crosses various subsystems, and I thought it isn't worth it to have one PR per subsystem. The patches are trivial fixes for build failures I encountered because includes were missing.

(Please also consider merging https://github.com/ceph/ceph/pull/61800 which has been lingering for nearly two months.)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
