### PR TITLE
crimson/os/seastore: cleanups related to lba and cache

### DIFF
--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -190,7 +190,8 @@ public:
       auto &trans = extent.retired_transactions;
       unviewable = (trans.find(trans_id, trans_spec_view_t::cmp_t()) !=
 		 trans.end());
-      assert(unviewable == t.is_retired(extent.get_paddr(), extent.get_length()));
+      assert(unviewable ==
+             t.is_stable_extent_retired(extent.get_paddr(), extent.get_length()));
     }
     return unviewable;
   }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -51,43 +51,43 @@ Cache::~Cache()
 
 // TODO: this method can probably be removed in the future
 Cache::retire_extent_ret Cache::retire_extent_addr(
-  Transaction &t, paddr_t addr, extent_len_t length)
+  Transaction &t, paddr_t paddr, extent_len_t length)
 {
   LOG_PREFIX(Cache::retire_extent_addr);
-  TRACET("retire {}~0x{:x}", t, addr, length);
+  TRACET("retire {}~0x{:x}", t, paddr, length);
 
-  assert(addr.is_real() && !addr.is_block_relative());
+  assert(paddr.is_real() && !paddr.is_block_relative());
 
   CachedExtentRef ext;
-  auto result = t.get_extent(addr, &ext);
+  auto result = t.get_extent(paddr, &ext);
   if (result == Transaction::get_extent_ret::PRESENT) {
-    DEBUGT("retire {}~0x{:x} on t -- {}", t, addr, length, *ext);
-    t.add_present_to_retired_set(CachedExtentRef(&*ext));
+    DEBUGT("retire {}~0x{:x} on t -- {}",
+           t, paddr, length, *ext);
+    t.add_present_to_retired_set(ext);
     return retire_extent_iertr::now();
   } else if (result == Transaction::get_extent_ret::RETIRED) {
-    ERRORT("retire {}~0x{:x} failed, already retired -- {}", t, addr, length, *ext);
+    ERRORT("retire {}~0x{:x} failed, already retired -- {}",
+           t, paddr, length, *ext);
     ceph_abort();
   }
 
-  // any relative addr must have been on the transaction
-  assert(!addr.is_relative());
+  // any relative paddr must have been on the transaction
+  assert(!paddr.is_relative());
 
   // absent from transaction
   // retiring is not included by the cache hit metrics
-  ext = query_cache(addr);
+  ext = query_cache(paddr);
   if (ext) {
-    DEBUGT("retire {}~0x{:x} in cache -- {}", t, addr, length, *ext);
+    DEBUGT("retire {}~0x{:x} in cache -- {}", t, paddr, length, *ext);
   } else {
     // add a new placeholder to Cache
     ext = CachedExtent::make_cached_extent_ref<
       RetiredExtentPlaceholder>(length);
-    ext->init(CachedExtent::extent_state_t::CLEAN,
-              addr,
-              PLACEMENT_HINT_NULL,
-              NULL_GENERATION,
-	      TRANS_ID_NULL);
+    ext->init(
+      CachedExtent::extent_state_t::CLEAN, paddr,
+      PLACEMENT_HINT_NULL, NULL_GENERATION, TRANS_ID_NULL);
     DEBUGT("retire {}~0x{:x} as placeholder, add extent -- {}",
-           t, addr, length, *ext);
+           t, paddr, length, *ext);
     add_extent(ext);
   }
   t.add_absent_to_retired_set(ext);
@@ -95,26 +95,24 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
 }
 
 void Cache::retire_absent_extent_addr(
-  Transaction &t, paddr_t addr, extent_len_t length)
+  Transaction &t, paddr_t paddr, extent_len_t length)
 {
   CachedExtentRef ext;
 #ifndef NDEBUG
-  auto result = t.get_extent(addr, &ext);
+  auto result = t.get_extent(paddr, &ext);
   assert(result != Transaction::get_extent_ret::PRESENT
     && result != Transaction::get_extent_ret::RETIRED);
-  assert(!query_cache(addr));
+  assert(!query_cache(paddr));
 #endif
   LOG_PREFIX(Cache::retire_absent_extent_addr);
   // add a new placeholder to Cache
   ext = CachedExtent::make_cached_extent_ref<
     RetiredExtentPlaceholder>(length);
-  ext->init(CachedExtent::extent_state_t::CLEAN,
-	    addr,
-	    PLACEMENT_HINT_NULL,
-	    NULL_GENERATION,
-	    TRANS_ID_NULL);
+  ext->init(
+    CachedExtent::extent_state_t::CLEAN, paddr,
+    PLACEMENT_HINT_NULL, NULL_GENERATION, TRANS_ID_NULL);
   DEBUGT("retire {}~0x{:x} as placeholder, add extent -- {}",
-	 t, addr, length, *ext);
+	 t, paddr, length, *ext);
   add_extent(ext);
   t.add_absent_to_retired_set(ext);
 }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1060,7 +1060,7 @@ void Cache::on_transaction_destruct(Transaction& t)
   }
 }
 
-CachedExtentRef Cache::alloc_new_extent_by_type(
+CachedExtentRef Cache::alloc_new_non_data_extent_by_type(
   Transaction &t,        ///< [in, out] current transaction
   extent_types_t type,   ///< [in] type tag
   extent_len_t length,   ///< [in] length
@@ -1068,7 +1068,7 @@ CachedExtentRef Cache::alloc_new_extent_by_type(
   rewrite_gen_t gen      ///< [in] rewrite generation
 )
 {
-  LOG_PREFIX(Cache::alloc_new_extent_by_type);
+  LOG_PREFIX(Cache::alloc_new_non_data_extent_by_type);
   SUBDEBUGT(seastore_cache, "allocate {} 0x{:x}B, hint={}, gen={}",
             t, type, length, hint, rewrite_gen_printer_t{gen});
   ceph_assert(get_extent_category(type) == data_category_t::METADATA);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1179,7 +1179,6 @@ CachedExtentRef Cache::duplicate_for_write(
   assert(!i->prior_poffset);
   auto [iter, inserted] = i->mutation_pending_extents.insert(*ret);
   ceph_assert(inserted);
-  t.add_mutated_extent(ret);
   if (is_root_type(ret->get_type())) {
     t.root = ret->cast<RootBlock>();
   } else {
@@ -1194,6 +1193,8 @@ CachedExtentRef Cache::duplicate_for_write(
     assert(ret->is_logical());
     static_cast<LogicalCachedExtent&>(*ret).set_laddr(lextent.get_laddr());
   }
+
+  t.add_mutated_extent(ret);
   DEBUGT("{} -> {}", t, *i, *ret);
   return ret;
 }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1127,11 +1127,11 @@ public:
   }
 
   /**
-   * alloc_new_extent
+   * alloc_new_non_data_extent_by_type
    *
-   * Allocates a fresh extent.  addr will be relative until commit.
+   * Allocates a fresh non data extent.  addr will be relative until commit.
    */
-  CachedExtentRef alloc_new_extent_by_type(
+  CachedExtentRef alloc_new_non_data_extent_by_type(
     Transaction &t,        ///< [in, out] current transaction
     extent_types_t type,   ///< [in] type tag
     extent_len_t length,   ///< [in] length
@@ -1140,9 +1140,9 @@ public:
     );
 
   /**
-   * alloc_new_extent
+   * alloc_new_data_extents_by_type
    *
-   * Allocates a fresh extent.  addr will be relative until commit.
+   * Allocates fresh data extents.  addr will be relative until commit.
    */
   std::vector<CachedExtentRef> alloc_new_data_extents_by_type(
     Transaction &t,        ///< [in, out] current transaction

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -711,6 +711,8 @@ private:
       SUBDEBUG(seastore_cache,
           "{} {}~0x{:x} is absent(placeholder), add extent and reading range 0x{:x}~0x{:x} ... -- {}",
           T::TYPE, offset, length, partial_off, partial_len, *ret);
+      extent_init_func(*ret);
+      on_cache(*ret);
       extents_index.replace(*ret, *cached);
 
       // replace placeholder in transactions
@@ -720,8 +722,6 @@ private:
       }
 
       cached->state = CachedExtent::extent_state_t::INVALID;
-      extent_init_func(*ret);
-      on_cache(*ret);
       return read_extent<T>(
 	std::move(ret), partial_off, partial_len, p_src);
     }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1336,12 +1336,12 @@ public:
     : CachedExtent(CachedExtent::retired_placeholder_construct_t{}, length) {}
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
-    ceph_assert(0 == "Should never happen for a placeholder");
+    ceph_abort("Should never happen for a placeholder");
     return CachedExtentRef();
   }
 
   ceph::bufferlist get_delta() final {
-    ceph_assert(0 == "Should never happen for a placeholder");
+    ceph_abort("Should never happen for a placeholder");
     return ceph::bufferlist();
   }
 
@@ -1352,7 +1352,7 @@ public:
 
   void apply_delta_and_adjust_crc(
     paddr_t base, const ceph::bufferlist &bl) final {
-    ceph_assert(0 == "Should never happen for a placeholder");
+    ceph_abort("Should never happen for a placeholder");
   }
 
   void on_rewrite(Transaction &, CachedExtent&, extent_len_t) final {}
@@ -1362,7 +1362,7 @@ public:
   }
 
   void on_delta_write(paddr_t record_block_offset) final {
-    ceph_assert(0 == "Should never happen for a placeholder");
+    ceph_abort("Should never happen for a placeholder");
   }
 };
 
@@ -1420,10 +1420,13 @@ public:
     extent_len_t len;
   };
   virtual std::optional<modified_region_t> get_modified_region() {
+    ceph_abort("Unsupported");
     return std::nullopt;
   }
 
-  virtual void clear_modified_region() {}
+  virtual void clear_modified_region() {
+    ceph_abort("Unsupported");
+  }
 
   virtual ~LogicalCachedExtent() {}
 
@@ -1497,7 +1500,7 @@ template <typename T>
 using lextent_list_t = addr_extent_list_base_t<
   laddr_t, TCachedExtentRef<T>>;
 
-}
+} // namespace crimson::os::seastore
 
 #if FMT_VERSION >= 90000
 template <> struct fmt::formatter<crimson::os::seastore::CachedExtent> : fmt::ostream_formatter {};

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1258,6 +1258,14 @@ public:
     return extent_index.find(offset, paddr_cmp());
   }
 
+  bool exists(CachedExtent& extent) const {
+    auto iter = extent_index.find(extent.get_paddr(), paddr_cmp());
+    if (iter == extent_index.end()) {
+      return false;
+    }
+    return (&*iter == &extent);
+  }
+
   auto begin() {
     return extent_index.begin();
   }

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -6,27 +6,6 @@
 
 namespace crimson::os::seastore {
 
-LBAManager::update_mappings_ret
-LBAManager::update_mappings(
-  Transaction& t,
-  const std::list<LogicalChildNodeRef>& extents)
-{
-  return trans_intr::do_for_each(extents,
-				 [this, &t](auto &extent) {
-    return update_mapping(
-      t,
-      extent->get_laddr(),
-      extent->get_length(),
-      extent->get_prior_paddr_and_reset(),
-      extent->get_length(),
-      extent->get_paddr(),
-      extent->get_last_committed_crc(),
-      nullptr	// all the extents should have already been
-		// added to the fixed_kv_btree
-    ).discard_result();
-  });
-}
-
 LBAManagerRef lba_manager::create_lba_manager(Cache &cache) {
   return LBAManagerRef(new btree::BtreeLBAManager(cache));
 }

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -100,6 +100,7 @@ public:
     extent_len_t len) = 0;
 
   struct ref_update_result_t {
+    laddr_t direct_key;
     extent_ref_count_t refcount = 0;
     pladdr_t addr;
     extent_len_t length = 0;

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -192,7 +192,7 @@ public:
   /**
    * update_mapping
    *
-   * update lba mapping for a delayed allocated extent
+   * update lba mapping for rewrite
    */
   using update_mapping_iertr = base_iertr;
   using update_mapping_ret = base_iertr::future<extent_ref_count_t>;
@@ -201,10 +201,7 @@ public:
     laddr_t laddr,
     extent_len_t prev_len,
     paddr_t prev_addr,
-    extent_len_t len,
-    paddr_t paddr,
-    uint32_t checksum,
-    LogicalChildNode *nextent) = 0;
+    LogicalChildNode& nextent) = 0;
 
   /**
    * update_mappings
@@ -213,9 +210,9 @@ public:
    */
   using update_mappings_iertr = update_mapping_iertr;
   using update_mappings_ret = update_mappings_iertr::future<>;
-  update_mappings_ret update_mappings(
+  virtual update_mappings_ret update_mappings(
     Transaction& t,
-    const std::list<LogicalChildNodeRef>& extents);
+    const std::list<LogicalChildNodeRef>& extents) = 0;
 
   /**
    * get_physical_extent_if_live

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -435,13 +435,16 @@ BtreeLBAManager::_alloc_extents(
 	      ceph_assert(alloc_info.val.is_paddr());
 	      assert(alloc_info.val == iter.get_val().pladdr);
 	      assert(alloc_info.len == iter.get_val().len);
+	      assert(alloc_info.extent->is_logical());
 	      if (alloc_info.extent->has_laddr()) {
+	        // see TM::remap_pin()
 		assert(alloc_info.key == alloc_info.extent->get_laddr());
 		assert(alloc_info.key == iter.get_key());
 	      } else {
+		// see TM::alloc_non_data_extent()
+		//     TM::alloc_data_extents()
 		alloc_info.extent->set_laddr(iter.get_key());
 	      }
-	      alloc_info.extent->set_laddr(iter.get_key());
 	    }
 	    ceph_assert(inserted);
 	    rets.emplace_back(iter.get_pin(c));

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -702,13 +702,16 @@ private:
 
   using _get_mapping_ret = get_mapping_iertr::future<BtreeLBAMappingRef>;
   _get_mapping_ret _get_mapping(
-    Transaction &t,
+    op_context_t<laddr_t> c,
+    LBABtree& btree,
     laddr_t offset);
 
-  using _get_original_mappings_ret = get_mappings_ret;
-  _get_original_mappings_ret _get_original_mappings(
+  using _get_mappings_ret = get_mappings_iertr::future<std::list<BtreeLBAMappingRef>>;
+  _get_mappings_ret _get_mappings(
     op_context_t<laddr_t> c,
-    std::list<BtreeLBAMappingRef> &pin_list);
+    LBABtree& btree,
+    laddr_t offset,
+    extent_len_t length);
 
   using _decref_intermediate_ret = ref_iertr::future<
     std::optional<ref_update_result_t>>;

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -713,6 +713,14 @@ private:
     laddr_t offset,
     extent_len_t length);
 
+  using get_indirect_pin_ret = get_mappings_iertr::future<BtreeLBAMappingRef>;
+  get_indirect_pin_ret get_indirect_pin(
+    op_context_t<laddr_t> c,
+    LBABtree& btree,
+    laddr_t key,
+    laddr_t intermediate_key,
+    extent_len_t length);
+
   using _decref_intermediate_ret = ref_iertr::future<
     std::optional<ref_update_result_t>>;
   _decref_intermediate_ret _decref_intermediate(

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -306,8 +306,8 @@ public:
       extent_len_t len,
       paddr_t paddr,
       uint32_t checksum,
-      LogicalChildNode *extent) {
-      return {laddr, len, paddr, checksum, extent};
+      LogicalChildNode& extent) {
+      return {laddr, len, paddr, checksum, &extent};
     }
   };
 
@@ -384,7 +384,7 @@ public:
 	ext.get_length(),
 	ext.get_paddr(),
 	ext.get_last_committed_crc(),
-	&ext)};
+	ext)};
     return seastar::do_with(
       std::move(alloc_infos),
       [this, &t, hint, refcount](auto &alloc_infos) {
@@ -416,7 +416,7 @@ public:
 	  extent->get_length(),
 	  extent->get_paddr(),
 	  extent->get_last_committed_crc(),
-	  extent.get()));
+	  *extent));
     }
     return seastar::do_with(
       std::move(alloc_infos),

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -580,10 +580,11 @@ public:
     laddr_t laddr,
     extent_len_t prev_len,
     paddr_t prev_addr,
-    extent_len_t len,
-    paddr_t paddr,
-    uint32_t checksum,
-    LogicalChildNode*) final;
+    LogicalChildNode&) final;
+
+  update_mappings_ret update_mappings(
+    Transaction& t,
+    const std::list<LogicalChildNodeRef>& extents);
 
   get_physical_extent_if_live_ret get_physical_extent_if_live(
     Transaction &t,
@@ -593,7 +594,6 @@ public:
     extent_len_t len) final;
 private:
   Cache &cache;
-
 
   struct {
     uint64_t num_alloc_extents = 0;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -350,7 +350,7 @@ public:
     return inline_block_list;
   }
 
-  bool is_retired(paddr_t paddr, extent_len_t len) {
+  bool is_stable_extent_retired(paddr_t paddr, extent_len_t len) {
     auto iter = retired_set.lower_bound(paddr);
     if (iter == retired_set.end()) {
       return false;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -170,6 +170,7 @@ public:
       return false;
     }
 
+    assert(ref->is_stable());
     auto [exists, it] = lookup_read_set(ref);
     if (exists) {
       return false;
@@ -187,6 +188,7 @@ public:
       return;
     }
 
+    assert(ref->is_stable());
     auto [exists, it] = lookup_read_set(ref);
     assert(!exists);
 

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -285,8 +285,8 @@ public:
     if (!ref->is_exist_mutation_pending()) {
       write_set.insert(*ref);
     } else {
-      assert(write_set.find_offset(ref->get_paddr()) !=
-	     write_set.end());
+      // already added as fresh extent in write_set
+      assert(write_set.exists(*ref));
     }
   }
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -697,12 +697,13 @@ TransactionManager::get_extents_if_live(
   // as parallel transactions may split the extent at the same time.
   ceph_assert(paddr.get_addr_type() == paddr_types_t::SEGMENT);
 
-  return cache->get_extent_if_cached(t, paddr, type
+  return cache->get_extent_if_cached(t, paddr, len, type
   ).si_then([this, FNAME, type, paddr, laddr, len, &t](auto extent)
 	    -> get_extents_if_live_ret {
-    if (extent && extent->get_length() == len) {
+    if (extent) {
       DEBUGT("{} {}~0x{:x} {} is cached and alive -- {}",
              t, type, laddr, len, paddr, *extent);
+      assert(extent->get_length() == len);
       std::list<CachedExtentRef> res;
       res.emplace_back(std::move(extent));
       return get_extents_if_live_ret(

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -498,7 +498,7 @@ TransactionManager::rewrite_logical_extent(
   if (get_extent_category(extent->get_type()) == data_category_t::METADATA) {
     assert(extent->is_fully_loaded());
     cache->retire_extent(t, extent);
-    auto nextent = cache->alloc_new_extent_by_type(
+    auto nextent = cache->alloc_new_non_data_extent_by_type(
       t,
       extent->get_type(),
       extent->get_length(),

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -526,10 +526,7 @@ TransactionManager::rewrite_logical_extent(
       extent->get_laddr(),
       extent->get_length(),
       extent->get_paddr(),
-      nextent->get_length(),
-      nextent->get_paddr(),
-      nextent->get_last_committed_crc(),
-      nextent.get()
+      *nextent
     ).discard_result();
   } else {
     assert(get_extent_category(extent->get_type()) == data_category_t::DATA);
@@ -570,15 +567,13 @@ TransactionManager::rewrite_logical_extent(
            * avoid this complication. */
           auto fut = base_iertr::now();
           if (first_extent) {
+            assert(off == 0);
             fut = lba_manager->update_mapping(
               t,
-              (extent->get_laddr() + off).checked_to_laddr(),
+              extent->get_laddr(),
               extent->get_length(),
               extent->get_paddr(),
-              nextent->get_length(),
-              nextent->get_paddr(),
-              nextent->get_last_committed_crc(),
-              nextent.get()
+              *nextent
             ).si_then([&refcount](auto c) {
               refcount = c;
             });

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -210,9 +210,9 @@ public:
     ).si_then([this, FNAME, &t, offset, length] (auto pin)
       -> read_extent_ret<T> {
       if (length != pin->get_length() || !pin->get_val().is_real()) {
-        SUBERRORT(seastore_tm, "{}~0x{:x} {} got wrong {}",
+        SUBERRORT(seastore_tm, "{}~0x{:x} {} got wrong pin {}",
                   t, offset, length, T::TYPE, *pin);
-        ceph_assert(0 == "Should be impossible");
+        ceph_abort("Impossible");
       }
       return this->read_pin<T>(t, std::move(pin));
     });
@@ -235,9 +235,9 @@ public:
     ).si_then([this, FNAME, &t, offset] (auto pin)
       -> read_extent_ret<T> {
       if (!pin->get_val().is_real()) {
-        SUBERRORT(seastore_tm, "{} {} got wrong {}",
+        SUBERRORT(seastore_tm, "{} {} got wrong pin {}",
                   t, offset, T::TYPE, *pin);
-        ceph_assert(0 == "Should be impossible");
+        ceph_abort("Impossible");
       }
       return this->read_pin<T>(t, std::move(pin));
     });


### PR DESCRIPTION
Cleanups that might be generally benefitial, and some adjustments to make sure the code structure keeps friendly to integrate https://github.com/ceph/ceph/pull/62634.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
