### PR TITLE
rgw: only skip versioned to non-versioned buckets

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4434,6 +4434,12 @@ public:
             tn->log(0, SSTR("skipping entry due to object lock mismatch: " << key));
             goto done;
           }
+          // make sure versioned object only lands on versioned bucket
+          if (!key.instance.empty() && !sync_pipe.dest_bucket_info.versioned()) {
+            set_status("skipping entry due to versioning mismatch. cannot sync versioned object to non-versioned bucket");
+            tn->log(0, SSTR("skipping entry due to versioning mismatch. cannot sync versioned object to non-versioned bucket: " << key));
+            goto done;
+          }
 
           if (error_injection &&
               rand() % 10000 < cct->_conf->rgw_sync_data_inject_err_probability * 10000.0) {

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4427,6 +4427,14 @@ public:
             tn->log(0, "entry with empty obj name, skipping");
             goto done;
           }
+
+          // if object lock is enabled on either, the other should follow as well
+          if (sync_pipe.source_bucket_info.obj_lock_enabled() != sync_pipe.dest_bucket_info.obj_lock_enabled()) {
+            set_status("skipping entry due to object lock mismatch");
+            tn->log(0, SSTR("skipping entry due to object lock mismatch: " << key));
+            goto done;
+          }
+
           if (error_injection &&
               rand() % 10000 < cct->_conf->rgw_sync_data_inject_err_probability * 10000.0) {
             tn->log(0, SSTR(": injecting data sync error on key=" << key.name));

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -4467,7 +4467,9 @@ public:
 	      pretty_print(sc->env, "Deleting object s3://{}/{} in sync from zone {}\n",
 			   bs.bucket.name, key, zone_name);
 	    }
-            if (op == CLS_RGW_OP_UNLINK_INSTANCE) {
+            if (key.instance.empty() && sync_pipe.dest_bucket_info.versioned()) {
+              // if the object is not versioned, we need to treat it as deleting the null version
+              key.instance = "null";		
               versioned = true;
             }
             if (null_verid) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1381,6 +1381,28 @@ struct ReplicationConfiguration {
       }
       pipe->dest.bucket.emplace(dest_bk);
 
+      std::unique_ptr<rgw::sal::Bucket> dest_bucket;
+      if (int r = driver->load_bucket(s, *pipe->dest.bucket, &dest_bucket, s->yield); r < 0) {
+        if (r == -ENOENT) {
+          s->err.message = "Destination bucket must exist.";
+          return -EINVAL;
+        }
+
+        ldpp_dout(s, 0) << "ERROR: failed to load bucket info for bucket=" << *pipe->dest.bucket << " r=" << r << dendl;
+        return r;
+      }
+
+      // check versioning identicality
+      if (dest_bucket->get_info().versioned() != s->bucket->get_info().versioned()) {
+        s->err.message = "Versioning must be identical in source and destination buckets.";
+        return -EINVAL;
+      }
+      // check object lock identicality
+      if (dest_bucket->get_info().obj_lock_enabled() != s->bucket->get_info().obj_lock_enabled()) {
+        s->err.message = "Object lock must be identical in source and destination buckets.";
+        return -EINVAL;
+      }
+
       if (filter) {
         int r = filter->to_sync_pipe_filter(s->cct, &pipe->params.source.filter);
         if (r < 0) {


### PR DESCRIPTION
Since replication entries are compared against the current state of the bucket, delays—regardless of the cause—can lead to inconsistencies when a bucket transitions from non-versioned to versioned. Entries created before versioning was enabled may not have version IDs, which could result in discrepancies.

To address this, we will allow replication of non-versioned objects to versioned buckets as null versions while skipping only those entries that are versioned when the destination bucket is non-versioned.

The same approach applies to suspended versioning. Since suspended buckets generate objects with a null version ID, replication will be permitted to both versioned and non-versioned destinations.

Fixes: https://tracker.ceph.com/issues/70728 & https://tracker.ceph.com/issues/70486
~Will be rebased with https://github.com/ceph/ceph/pull/62637~

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
