### PR TITLE
mgr/dashboard: NFS Rate Limit for enabling disabling Ops Control for Export and Cluster

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -1,0 +1,5770 @@
+from textwrap import dedent
+import json
+import urllib.parse
+import yaml
+from mgr_util import build_url
+
+import pytest
+
+from unittest.mock import Mock, MagicMock, call, patch, ANY
+
+from cephadm.serve import CephadmServe
+from cephadm.services.service_registry import service_registry
+from cephadm.services.cephadmservice import MonService, CephadmDaemonDeploySpec
+from cephadm.services.iscsi import IscsiService
+from cephadm.services.nvmeof import NvmeofService
+from cephadm.services.monitoring import GrafanaService, AlertmanagerService, PrometheusService
+from cephadm.services.smb import SMBSpec
+from cephadm.module import CephadmOrchestrator
+from ceph.deployment.service_spec import (
+    AlertManagerSpec,
+    CephExporterSpec,
+    CustomContainerSpec,
+    GrafanaSpec,
+    IngressSpec,
+    IscsiServiceSpec,
+    MonitoringSpec,
+    NFSServiceSpec,
+    NvmeofServiceSpec,
+    PlacementSpec,
+    PrometheusSpec,
+    RGWSpec,
+    SNMPGatewaySpec,
+    ServiceSpec,
+    TracingSpec,
+    MgmtGatewaySpec,
+    OAuth2ProxySpec
+)
+from cephadm.tests.fixtures import with_host, with_service, _run_cephadm, async_side_effect, wait
+from cephadm.tlsobject_types import TLSCredentials
+
+from ceph.utils import datetime_now
+
+from orchestrator import OrchestratorError
+from orchestrator._interface import DaemonDescription
+
+from typing import Dict, List
+
+cephadm_root_ca = """-----BEGIN CERTIFICATE-----\nMIIE7DCCAtSgAwIBAgIUE8b2zZ64geu2ns3Zfn3/4L+Cf6MwDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MB4XDTI0MDYyNjE0NDA1M1oXDTM0\nMDYyNzE0NDA1M1owFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsZRJsdtTr9GLG1lWFql5SGc46ldFanNJd1Gl\nqXq5vgZVKRDTmNgAb/XFuNEEmbDAXYIRZolZeYKMHfn0pouPRSel0OsC6/02ZUOW\nIuN89Wgo3IYleCFpkVIumD8URP3hwdu85plRxYZTtlruBaTRH38lssyCqxaOdEt7\nAUhvYhcMPJThB17eOSQ73mb8JEC83vB47fosI7IhZuvXvRSuZwUW30rJanWNhyZq\neS2B8qw2RSO0+77H6gA4ftBnitfsE1Y8/F9Z/f92JOZuSMQXUB07msznPbRJia3f\nueO8gOc32vxd1A1/Qzp14uX34yEGY9ko2lW226cZO29IVUtXOX+LueQttwtdlpz8\ne6Npm09pXhXAHxV/OW3M28MdXmobIqT/m9MfkeAErt5guUeC5y8doz6/3VQRjFEn\nRpN0WkblgnNAQ3DONPc+Qd9Fi/wZV2X7bXoYpNdoWDsEOiE/eLmhG1A2GqU/mneP\nzQ6u79nbdwTYpwqHpa+PvusXeLfKauzI8lLUJotdXy9EK8iHUofibB61OljYye6B\nG3b8C4QfGsw8cDb4APZd/6AZYyMx/V3cGZ+GcOV7WvsC8k7yx5Uqasm/kiGQ3EZo\nuNenNEYoGYrjb8D/8QzqNUTwlEh27/ps80tO7l2GGTvWVZL0PRZbmLDvO77amtOf\nOiRXMoUCAwEAAaMwMC4wGwYDVR0RBBQwEocQAAAAAAAAAAAAAAAAAAAAATAPBgNV\nHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAxwzX5AhYEWhTV4VUwUj5+\nqPdl4Q2tIxRokqyE+cDxoSd+6JfGUefUbNyBxDt0HaBq8obDqqrbcytxnn7mpnDu\nhtiauY+I4Amt7hqFOiFA4cCLi2mfok6g2vL53tvhd9IrsfflAU2wy7hL76Ejm5El\nA+nXlkJwps01Whl9pBkUvIbOn3pXX50LT4hb5zN0PSu957rjd2xb4HdfuySm6nW4\n4GxtVWfmGA6zbC4XMEwvkuhZ7kD2qjkAguGDF01uMglkrkCJT3OROlNBuSTSBGqt\ntntp5VytHvb7KTF7GttM3ha8/EU2KYaHM6WImQQTrOfiImAktOk4B3lzUZX3HYIx\n+sByO4P4dCvAoGz1nlWYB2AvCOGbKf0Tgrh4t4jkiF8FHTXGdfvWmjgi1pddCNAy\nn65WOCmVmLZPERAHOk1oBwqyReSvgoCFo8FxbZcNxJdlhM0Z6hzKggm3O3Dl88Xl\n5euqJjh2STkBW8Xuowkg1TOs5XyWvKoDFAUzyzeLOL8YSG+gXV22gPTUaPSVAqdb\nwd0Fx2kjConuC5bgTzQHs8XWA930U3XWZraj21Vaa8UxlBLH4fUro8H5lMSYlZNE\nJHRNW8BkznAClaFSDG3dybLsrzrBFAu/Qb5zVkT1xyq0YkepGB7leXwq6vjWA5Pw\nmZbKSphWfh0qipoqxqhfkw==\n-----END CERTIFICATE-----\n"""
+
+ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaLJzmvntjukjMA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzEzMTE0NzA3WhcN\nMzIwNzEwMTE0NzA3WjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyyMe4DMA+MeYK7BHZMHB\nq7zjliEOcNgxomjU8qbf5USF7Mqrf6+/87XWqj4pCyAW8x0WXEr6A56a+cmBVmt+\nqtWDzl020aoId6lL5EgLLn6/kMDCCJLq++Lg9cEofMSvcZh+lY2f+1p+C+00xent\nrLXvXGOilAZWaQfojT2BpRnNWWIFbpFwlcKrlg2G0cFjV5c1m6a0wpsQ9JHOieq0\nSvwCixajwq3CwAYuuiU1wjI4oJO4Io1+g8yB3nH2Mo/25SApCxMXuXh4kHLQr/T4\n4hqisvG4uJYgKMcSIrWj5o25mclByGi1UI/kZkCUES94i7Z/3ihx4Bad0AMs/9tw\nFwIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQAf+pwz7Gd7mDwU2LY0TQXsK6/8KGzh\nHuX+ErOb8h5cOAbvCnHjyJFWf6gCITG98k9nxU9NToG0WYuNm/max1y/54f0dtxZ\npUo6KSNl3w6iYCfGOeUIj8isi06xMmeTgMNzv8DYhDt+P2igN6LenqWTVztogkiV\nxQ5ZJFFLEw4sN0CXnrZX3t5ruakxLXLTLKeE0I91YJvjClSBGkVJq26wOKQNHMhx\npWxeydQ5EgPZY+Aviz5Dnxe8aB7oSSovpXByzxURSabOuCK21awW5WJCGNpmqhWK\nZzACBDEstccj57c4OGV0eayHJRsluVr2e9NHRINZA3qdB37e6gsI1xHo\n-----END CERTIFICATE-----\n"""
+
+ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
+
+
+class FakeInventory:
+    def get_addr(self, name: str) -> str:
+        return '1.2.3.4'
+
+
+class FakeMgr:
+    def __init__(self):
+        self.config = ''
+        self.set_mon_crush_locations: Dict[str, List[str]] = {}
+        self.check_mon_command = MagicMock(side_effect=self._check_mon_command)
+        self.mon_command = MagicMock(side_effect=self._check_mon_command)
+        self.template = MagicMock()
+        self.log = MagicMock()
+        self.cert_mgr = MagicMock()
+        self.inventory = FakeInventory()
+
+    def _check_mon_command(self, cmd_dict, inbuf=None):
+        prefix = cmd_dict.get('prefix')
+        if prefix == 'get-cmd':
+            return 0, self.config, ''
+        if prefix == 'set-cmd':
+            self.config = cmd_dict.get('value')
+            return 0, 'value set', ''
+        if prefix in ['auth get']:
+            return 0, '[foo]\nkeyring = asdf\n', ''
+        if prefix == 'quorum_status':
+            # actual quorum status output from testing
+            # note in this output all of the mons have blank crush locations
+            return 0, """{"election_epoch": 14, "quorum": [0, 1, 2], "quorum_names": ["vm-00", "vm-01", "vm-02"], "quorum_leader_name": "vm-00", "quorum_age": 101, "features": {"quorum_con": "4540138322906710015", "quorum_mon": ["kraken", "luminous", "mimic", "osdmap-prune", "nautilus", "octopus", "pacific", "elector-pinging", "quincy", "reef"]}, "monmap": {"epoch": 3, "fsid": "9863e1b8-6f24-11ed-8ad8-525400c13ad2", "modified": "2022-11-28T14:00:29.972488Z", "created": "2022-11-28T13:57:55.847497Z", "min_mon_release": 18, "min_mon_release_name": "reef", "election_strategy": 1, "disallowed_leaders: ": "", "stretch_mode": false, "tiebreaker_mon": "", "features": {"persistent": ["kraken", "luminous", "mimic", "osdmap-prune", "nautilus", "octopus", "pacific", "elector-pinging", "quincy", "reef"], "optional": []}, "mons": [{"rank": 0, "name": "vm-00", "public_addrs": {"addrvec": [{"type": "v2", "addr": "192.168.122.61:3300", "nonce": 0}, {"type": "v1", "addr": "192.168.122.61:6789", "nonce": 0}]}, "addr": "192.168.122.61:6789/0", "public_addr": "192.168.122.61:6789/0", "priority": 0, "weight": 0, "crush_location": "{}"}, {"rank": 1, "name": "vm-01", "public_addrs": {"addrvec": [{"type": "v2", "addr": "192.168.122.63:3300", "nonce": 0}, {"type": "v1", "addr": "192.168.122.63:6789", "nonce": 0}]}, "addr": "192.168.122.63:6789/0", "public_addr": "192.168.122.63:6789/0", "priority": 0, "weight": 0, "crush_location": "{}"}, {"rank": 2, "name": "vm-02", "public_addrs": {"addrvec": [{"type": "v2", "addr": "192.168.122.82:3300", "nonce": 0}, {"type": "v1", "addr": "192.168.122.82:6789", "nonce": 0}]}, "addr": "192.168.122.82:6789/0", "public_addr": "192.168.122.82:6789/0", "priority": 0, "weight": 0, "crush_location": "{}"}]}}""", ''
+        if prefix == 'mon set_location':
+            self.set_mon_crush_locations[cmd_dict.get('name')] = cmd_dict.get('args')
+            return 0, '', ''
+        return -1, '', 'error'
+
+    def get_minimal_ceph_conf(self) -> str:
+        return ''
+
+    def get_mgr_ip(self) -> str:
+        return '1.2.3.4'
+
+
+class TestCephadmService:
+    def test_set_value_on_dashboard(self):
+        # pylint: disable=protected-access
+        mgr = FakeMgr()
+        service_url = 'http://svc:1000'
+        service = GrafanaService(mgr)
+        service._set_value_on_dashboard('svc', 'get-cmd', 'set-cmd', service_url)
+        assert mgr.config == service_url
+
+        # set-cmd should not be called if value doesn't change
+        mgr.check_mon_command.reset_mock()
+        service._set_value_on_dashboard('svc', 'get-cmd', 'set-cmd', service_url)
+        mgr.check_mon_command.assert_called_once_with({'prefix': 'get-cmd'})
+
+    def test_get_auth_entity(self):
+        mgr = FakeMgr()
+        service_registry.init_services(mgr)
+
+        for daemon_type in ['rgw', 'rbd-mirror', 'nfs', "iscsi"]:
+            assert "client.%s.id1" % (daemon_type) == \
+                service_registry.get_service(daemon_type).get_auth_entity("id1", "host")
+            assert "client.%s.id1" % (daemon_type) == \
+                service_registry.get_service(daemon_type).get_auth_entity("id1", "")
+            assert "client.%s.id1" % (daemon_type) == \
+                service_registry.get_service(daemon_type).get_auth_entity("id1")
+
+        assert "client.crash.host" == \
+            service_registry.get_service('crash').get_auth_entity("id1", "host")
+        with pytest.raises(OrchestratorError):
+            service_registry.get_service('crash').get_auth_entity("id1", "")
+            service_registry.get_service('crash').get_auth_entity("id1")
+
+        assert "mon." == service_registry.get_service('mon').get_auth_entity("id1", "host")
+        assert "mon." == service_registry.get_service('mon').get_auth_entity("id1", "")
+        assert "mon." == service_registry.get_service('mon').get_auth_entity("id1")
+
+        assert "mgr.id1" == service_registry.get_service('mgr').get_auth_entity("id1", "host")
+        assert "mgr.id1" == service_registry.get_service('mgr').get_auth_entity("id1", "")
+        assert "mgr.id1" == service_registry.get_service('mgr').get_auth_entity("id1")
+
+        for daemon_type in ["osd", "mds"]:
+            assert "%s.id1" % daemon_type == \
+                service_registry.get_service(daemon_type).get_auth_entity("id1", "host")
+            assert "%s.id1" % daemon_type == \
+                service_registry.get_service(daemon_type).get_auth_entity("id1", "")
+            assert "%s.id1" % daemon_type == \
+                service_registry.get_service(daemon_type).get_auth_entity("id1")
+
+        # services based on CephadmService shouldn't have get_auth_entity
+        with pytest.raises(AttributeError):
+            for daemon_type in ['grafana', 'alertmanager', 'prometheus', 'node-exporter', 'loki', 'promtail', 'alloy']:
+                service_registry.get_service(daemon_type).get_auth_entity("id1", "host")
+                service_registry.get_service(daemon_type).get_auth_entity("id1", "")
+                service_registry.get_service(daemon_type).get_auth_entity("id1")
+
+
+class TestISCSIService:
+
+    mgr = FakeMgr()
+    iscsi_service = IscsiService(mgr)
+
+    iscsi_spec = IscsiServiceSpec(service_type='iscsi', service_id="a")
+    iscsi_spec.daemon_type = "iscsi"
+    iscsi_spec.daemon_id = "a"
+    iscsi_spec.spec = MagicMock()
+    iscsi_spec.spec.daemon_type = "iscsi"
+    iscsi_spec.spec.ssl_cert = ''
+    iscsi_spec.api_user = "user"
+    iscsi_spec.api_password = "password"
+    iscsi_spec.api_port = 5000
+    iscsi_spec.api_secure = False
+    iscsi_spec.ssl_cert = "cert"
+    iscsi_spec.ssl_key = "key"
+
+    mgr.spec_store = MagicMock()
+    mgr.spec_store.all_specs.get.return_value = iscsi_spec
+
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    def test_iscsi_client_caps(self):
+
+        iscsi_daemon_spec = CephadmDaemonDeploySpec(
+            host='host', daemon_id='a', service_name=self.iscsi_spec.service_name())
+
+        self.iscsi_service.prepare_create(iscsi_daemon_spec)
+
+        expected_caps = ['mon',
+                         'profile rbd, allow command "osd blocklist", allow command "config-key get" with "key" prefix "iscsi/"',
+                         'mgr', 'allow command "service status"',
+                         'osd', 'allow rwx']
+
+        expected_call = call({'prefix': 'auth get-or-create',
+                              'entity': 'client.iscsi.a',
+                              'caps': expected_caps})
+        expected_call2 = call({'prefix': 'auth caps',
+                               'entity': 'client.iscsi.a',
+                               'caps': expected_caps})
+        expected_call3 = call({'prefix': 'auth get',
+                               'entity': 'client.iscsi.a'})
+
+        assert expected_call in self.mgr.mon_command.mock_calls
+        assert expected_call2 in self.mgr.mon_command.mock_calls
+        assert expected_call3 in self.mgr.mon_command.mock_calls
+
+    @patch('cephadm.utils.resolve_ip')
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    def test_iscsi_dashboard_config(self, mock_resolve_ip):
+
+        self.mgr.check_mon_command = MagicMock()
+        self.mgr.check_mon_command.return_value = ('', '{"gateways": {}}', '')
+
+        # Case 1: use IPV4 address
+        id1 = DaemonDescription(daemon_type='iscsi', hostname="testhost1",
+                                daemon_id="a", ip='192.168.1.1')
+        daemon_list = [id1]
+        mock_resolve_ip.return_value = '192.168.1.1'
+
+        self.iscsi_service.config_dashboard(daemon_list)
+
+        dashboard_expected_call = call({'prefix': 'dashboard iscsi-gateway-add',
+                                        'name': 'testhost1'},
+                                       'http://user:password@192.168.1.1:5000')
+
+        assert dashboard_expected_call in self.mgr.check_mon_command.mock_calls
+
+        # Case 2: use IPV6 address
+        self.mgr.check_mon_command.reset_mock()
+
+        id1 = DaemonDescription(daemon_type='iscsi', hostname="testhost1",
+                                daemon_id="a", ip='FEDC:BA98:7654:3210:FEDC:BA98:7654:3210')
+        mock_resolve_ip.return_value = 'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210'
+
+        self.iscsi_service.config_dashboard(daemon_list)
+
+        dashboard_expected_call = call({'prefix': 'dashboard iscsi-gateway-add',
+                                        'name': 'testhost1'},
+                                       'http://user:password@[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:5000')
+
+        assert dashboard_expected_call in self.mgr.check_mon_command.mock_calls
+
+        # Case 3: IPV6 Address . Secure protocol
+        self.mgr.check_mon_command.reset_mock()
+
+        self.iscsi_spec.api_secure = True
+
+        self.iscsi_service.config_dashboard(daemon_list)
+
+        dashboard_expected_call = call({'prefix': 'dashboard iscsi-gateway-add',
+                                        'name': 'testhost1'},
+                                       'https://user:password@[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:5000')
+
+        assert dashboard_expected_call in self.mgr.check_mon_command.mock_calls
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
+    @patch("cephadm.services.iscsi.get_trusted_ips")
+    def test_iscsi_config(self, _get_trusted_ips, _get_name, _run_cephadm, cephadm_module: CephadmOrchestrator):
+
+        iscsi_daemon_id = 'testpool.test.qwert'
+        trusted_ips = '1.1.1.1,2.2.2.2'
+        api_port = 3456
+        api_user = 'test-user'
+        api_password = 'test-password'
+        pool = 'testpool'
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        _get_name.return_value = iscsi_daemon_id
+        _get_trusted_ips.return_value = trusted_ips
+
+        iscsi_gateway_conf = f"""# This file is generated by cephadm.
+[config]
+cluster_client_name = client.iscsi.{iscsi_daemon_id}
+pool = {pool}
+trusted_ip_list = {trusted_ips}
+minimum_gateways = 1
+api_port = {api_port}
+api_user = {api_user}
+api_password = {api_password}
+api_secure = False
+log_to_stderr = True
+log_to_stderr_prefix = debug
+log_to_file = False"""
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, IscsiServiceSpec(service_id=pool,
+                                                               api_port=api_port,
+                                                               api_user=api_user,
+                                                               api_password=api_password,
+                                                               pool=pool,
+                                                               trusted_ip_list=trusted_ips)):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    f'iscsi.{iscsi_daemon_id}',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": f'iscsi.{iscsi_daemon_id}',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [api_port],
+                        },
+                        "meta": {
+                            'service_name': f'iscsi.{pool}',
+                            'ports': [api_port],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "config": "",
+                            "keyring": f"[client.iscsi.{iscsi_daemon_id}]\nkey = None\n",
+                            "files": {
+                                "iscsi-gateway.cfg": iscsi_gateway_conf,
+                            },
+                        }
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
+    @patch("cephadm.services.iscsi.get_trusted_ips")
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    def test_iscsi_config_with_security_enabled(self, _get_trusted_ips, _get_name, _run_cephadm, cephadm_module: CephadmOrchestrator):
+
+        iscsi_daemon_id = 'testpool.test.qwert'
+        trusted_ips = '1.1.1.1,2.2.2.2'
+        api_port = 3456
+        api_user = 'test-user'
+        api_password = 'test-password'
+        pool = 'testpool'
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        _get_name.return_value = iscsi_daemon_id
+        _get_trusted_ips.return_value = trusted_ips
+
+        cephadm_module.check_mon_command = MagicMock()
+        cephadm_module.check_mon_command.return_value = (0, '', '')
+
+        iscsi_gateway_conf = f"""# This file is generated by cephadm.
+[config]
+cluster_client_name = client.iscsi.{iscsi_daemon_id}
+pool = {pool}
+trusted_ip_list = {trusted_ips}
+minimum_gateways = 1
+api_port = {api_port}
+api_user = {api_user}
+api_password = {api_password}
+api_secure = True
+log_to_stderr = True
+log_to_stderr_prefix = debug
+log_to_file = False"""
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, IscsiServiceSpec(service_id=pool,
+                                                               api_port=api_port,
+                                                               api_user=api_user,
+                                                               api_password=api_password,
+                                                               pool=pool,
+                                                               api_secure=True,
+                                                               ssl_cert=ceph_generated_cert,
+                                                               ssl_key=ceph_generated_key,
+                                                               trusted_ip_list=trusted_ips)):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    f'iscsi.{iscsi_daemon_id}',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": f'iscsi.{iscsi_daemon_id}',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [api_port],
+                        },
+                        "meta": {
+                            'service_name': f'iscsi.{pool}',
+                            'ports': [api_port],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "config": "",
+                            "keyring": f"[client.iscsi.{iscsi_daemon_id}]\nkey = None\n",
+                            "files": {
+                                "iscsi-gateway.cfg": iscsi_gateway_conf,
+                            },
+                        }
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+                expected_cert_call = call({
+                    'prefix': 'config-key set',
+                    'key': f'iscsi/client.iscsi.{iscsi_daemon_id}/iscsi-gateway.crt',
+                    'val': ceph_generated_cert,
+                })
+                expected_key_call = call({
+                    'prefix': 'config-key set',
+                    'key': f'iscsi/client.iscsi.{iscsi_daemon_id}/iscsi-gateway.key',
+                    'val': ceph_generated_key,
+                })
+
+                cephadm_module.check_mon_command.assert_has_calls(
+                    [expected_cert_call, expected_key_call],
+                    any_order=True
+                )
+
+
+class TestNVMEOFService:
+
+    mgr = FakeMgr()
+    nvmeof_service = NvmeofService(mgr)
+
+    nvmeof_spec = NvmeofServiceSpec(service_type='nvmeof', service_id="a")
+    nvmeof_spec.daemon_type = 'nvmeof'
+    nvmeof_spec.daemon_id = "a"
+    nvmeof_spec.spec = MagicMock()
+    nvmeof_spec.spec.daemon_type = 'nvmeof'
+
+    mgr.spec_store = MagicMock()
+    mgr.spec_store.all_specs.get.return_value = nvmeof_spec
+
+    def test_nvmeof_client_caps(self):
+        pass
+
+    @patch('cephadm.utils.resolve_ip')
+    def test_nvmeof_dashboard_config(self, mock_resolve_ip):
+        pass
+
+    @patch("cephadm.inventory.Inventory.get_addr", lambda _, __: '192.168.100.100')
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
+    def test_nvmeof_config(self, _get_name, _run_cephadm, cephadm_module: CephadmOrchestrator):
+
+        pool = 'testpool'
+        group = 'mygroup'
+        nvmeof_daemon_id = f'{pool}.{group}.test.qwert'
+        tgt_cmd_extra_args = '--cpumask=0xFF --msg-mempool-size=524288'
+        default_port = 5500
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        _get_name.return_value = nvmeof_daemon_id
+
+        nvmeof_gateway_conf = f"""# This file is generated by cephadm.
+[gateway]
+name = client.nvmeof.{nvmeof_daemon_id}
+group = {group}
+addr = 192.168.100.100
+port = {default_port}
+enable_auth = False
+state_update_notify = True
+state_update_interval_sec = 5
+break_update_interval_sec = 25
+enable_spdk_discovery_controller = False
+encryption_key = /encryption.key
+rebalance_period_sec = 7
+max_gws_in_grp = 16
+max_ns_to_change_lb_grp = 8
+enable_prometheus_exporter = True
+prometheus_exporter_ssl = False
+prometheus_port = 10008
+prometheus_stats_interval = 10
+prometheus_frequency_slow_down_factor = 3.0
+prometheus_cycles_to_adjust_speed = 3
+prometheus_startup_delay = 240
+prometheus_connection_list_cache_expiration = 60
+verify_nqns = True
+verify_keys = True
+verify_listener_ip = True
+# This is a development flag, do not change it
+abort_on_errors = True
+# This is a development flag, do not change it
+abort_on_update_error = True
+# This is a development flag, do not change it
+omap_file_ignore_unlock_errors = False
+# This is a development flag, do not change it
+omap_file_lock_on_read = True
+omap_file_lock_duration = 40
+omap_file_lock_retries = 30
+omap_file_lock_retry_sleep_interval = 1.0
+omap_file_update_reloads = 10
+omap_file_update_attempts = 500
+allowed_consecutive_spdk_ping_failures = 1
+spdk_ping_interval_in_seconds = 2.0
+ping_spdk_under_lock = False
+enable_monitor_client = True
+max_hosts_per_namespace = 16
+max_namespaces_with_netmask = 1000
+max_subsystems = 128
+max_hosts = 2048
+max_namespaces = 4096
+max_namespaces_per_subsystem = 512
+max_hosts_per_subsystem = 128
+subsystem_cache_expiration = 30
+force_tls = False
+# This is a development flag, do not change it
+max_message_length_in_mb = 4
+io_stats_enabled = True
+
+[gateway-logs]
+log_level = INFO
+log_files_enabled = True
+log_files_rotation_enabled = True
+verbose_log_messages = True
+max_log_file_size_in_mb = 10
+max_log_files_count = 20
+max_log_directory_backups = 10
+log_directory = /var/log/ceph/
+
+[discovery]
+addr = 192.168.100.100
+port = 8009
+# This is a development flag, do not change it
+abort_on_errors = True
+bind_retries_limit = 10
+bind_sleep_interval = 0.5
+
+[ceph]
+pool = {pool}
+config_file = /etc/ceph/ceph.conf
+id = nvmeof.{nvmeof_daemon_id}
+
+[mtls]
+server_key = /server.key
+client_key = /client.key
+server_cert = /server.cert
+client_cert = /client.cert
+root_ca_cert = /root.ca.cert
+
+[spdk]
+tgt_path = /usr/local/bin/nvmf_tgt
+rpc_socket_dir = /var/tmp/
+rpc_socket_name = spdk.sock
+timeout = 60.0
+cluster_connections = 32
+protocol_log_level = WARNING
+conn_retries = 10
+transports = tcp
+transport_tcp_options = {{"in_capsule_data_size": 8192, "max_io_qpairs_per_ctrlr": 7}}
+enable_dsa_acceleration = False
+rbd_with_crc32c = True
+tgt_cmd_extra_args = {tgt_cmd_extra_args}
+qos_timeslice_in_usecs = 0
+notifications_interval = 60
+
+[monitor]
+timeout = 1.0\n"""
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, NvmeofServiceSpec(service_id=f'{pool}.{group}',
+                                                                tgt_cmd_extra_args=tgt_cmd_extra_args,
+                                                                group=group,
+                                                                pool=pool)):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    f'nvmeof.{nvmeof_daemon_id}',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": "nvmeof.testpool.mygroup.test.qwert",
+                        "image": "",
+                        "deploy_arguments": [],
+                        "params": {
+                            "tcp_ports": [5500, 4420, 8009, 10008]
+                        },
+                        "meta": {
+                            "service_name": "nvmeof.testpool.mygroup",
+                            "ports": [5500, 4420, 8009, 10008],
+                            "ip": None,
+                            "deployed_by": [],
+                            "rank": None,
+                            "rank_generation": None,
+                            "extra_container_args": None,
+                            "extra_entrypoint_args": None
+                        },
+                        "config_blobs": {
+                            "config": "",
+                            "keyring": "[client.nvmeof.testpool.mygroup.test.qwert]\nkey = None\n",
+                            "files": {
+                                "ceph-nvmeof.conf": nvmeof_gateway_conf
+                            }
+                        }
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_validate_no_group_duplicate_on_apply(self, cephadm_module: CephadmOrchestrator):
+        nvmeof_spec_group1 = NvmeofServiceSpec(
+            service_id='testpool.testgroup',
+            group='testgroup',
+            pool='testpool'
+        )
+        nvmeof_spec_also_group1 = NvmeofServiceSpec(
+            service_id='testpool2.testgroup',
+            group='testgroup',
+            pool='testpool2'
+        )
+        with with_host(cephadm_module, 'test'):
+            out = cephadm_module._apply_service_spec(nvmeof_spec_group1)
+            assert out == 'Scheduled nvmeof.testpool.testgroup update...'
+            nvmeof_specs = cephadm_module.spec_store.get_by_service_type('nvmeof')
+            assert len(nvmeof_specs) == 1
+            assert nvmeof_specs[0].spec.service_name() == 'nvmeof.testpool.testgroup'
+            with pytest.raises(
+                OrchestratorError,
+                match='Cannot create nvmeof service with group testgroup. That group is already '
+                      'being used by the service nvmeof.testpool.testgroup'
+            ):
+                cephadm_module._apply_service_spec(nvmeof_spec_also_group1)
+            assert len(cephadm_module.spec_store.get_by_service_type('nvmeof')) == 1
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_validate_service_id_matches_group_on_apply(self, cephadm_module: CephadmOrchestrator):
+        matching_nvmeof_spec_group_service_id = NvmeofServiceSpec(
+            service_id='pool1.right_group',
+            group='right_group',
+            pool='pool1'
+        )
+        mismatch_nvmeof_spec_group_service_id = NvmeofServiceSpec(
+            service_id='pool2.wrong_group',
+            group='right_group',
+            pool='pool2'
+        )
+        matching_nvmeof_spec_group_service_id_with_dot = NvmeofServiceSpec(
+            service_id='pool3.right.group',
+            group='right.group',
+            pool='pool3'
+        )
+        mismatch_nvmeof_spec_group_service_id_with_dot = NvmeofServiceSpec(
+            service_id='pool4.wrong.group',
+            group='right.group',
+            pool='pool4'
+        )
+        with with_host(cephadm_module, 'test'):
+            cephadm_module._apply_service_spec(matching_nvmeof_spec_group_service_id)
+            with pytest.raises(
+                OrchestratorError,
+                match='The \'nvmeof\' service id/name must end with \'.<nvmeof-group-name>\'. Found '
+                      'group name \'right_group\' and service id \'pool2.wrong_group\''
+            ):
+                cephadm_module._apply_service_spec(mismatch_nvmeof_spec_group_service_id)
+            cephadm_module._apply_service_spec(matching_nvmeof_spec_group_service_id_with_dot)
+            with pytest.raises(
+                OrchestratorError,
+                match='The \'nvmeof\' service id/name must end with \'.<nvmeof-group-name>\'. Found '
+                      'group name \'right.group\' and service id \'pool4.wrong.group\''
+            ):
+                cephadm_module._apply_service_spec(mismatch_nvmeof_spec_group_service_id_with_dot)
+
+
+class TestMonitoring:
+    def _get_config(self, url: str) -> str:
+
+        return f"""
+        # This file is generated by cephadm.
+        # See https://prometheus.io/docs/alerting/configuration/ for documentation.
+
+        global:
+          resolve_timeout: 5m
+          http_config:
+            tls_config:
+              insecure_skip_verify: true
+
+        route:
+          receiver: 'default'
+          routes:
+            - group_by: ['alertname']
+              group_wait: 10s
+              group_interval: 10s
+              repeat_interval: 1h
+              receiver: 'ceph-dashboard'
+
+        receivers:
+        - name: 'default'
+          webhook_configs:
+        - name: 'custom-receiver'
+          webhook_configs:
+        - name: 'ceph-dashboard'
+          webhook_configs:
+          - url: '{url}/api/prometheus_receiver'
+        """
+
+    @pytest.mark.parametrize(
+        "dashboard_url,expected_yaml_url",
+        [
+            # loopback address
+            ("http://[::1]:8080", "http://localhost:8080"),
+            # IPv6
+            (
+                "http://[2001:db8:4321:0000:0000:0000:0000:0000]:8080",
+                "http://[2001:db8:4321:0000:0000:0000:0000:0000]:8080",
+            ),
+            # IPv6 to FQDN
+            (
+                "http://[2001:db8:4321:0000:0000:0000:0000:0000]:8080",
+                "http://mgr.fqdn.test:8080",
+            ),
+            # IPv4
+            (
+                "http://192.168.0.123:8080",
+                "http://192.168.0.123:8080",
+            ),
+            # IPv4 to FQDN
+            (
+                "http://192.168.0.123:8080",
+                "http://mgr.fqdn.test:8080",
+            ),
+        ],
+    )
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("mgr_module.MgrModule.get")
+    @patch("socket.getfqdn")
+    def test_alertmanager_config(
+        self,
+        mock_getfqdn,
+        mock_get,
+        _run_cephadm,
+        cephadm_module: CephadmOrchestrator,
+        dashboard_url,
+        expected_yaml_url,
+    ):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+        mock_get.return_value = {"services": {"dashboard": dashboard_url}}
+        purl = urllib.parse.urlparse(expected_yaml_url)
+        mock_getfqdn.return_value = purl.hostname
+
+        with with_host(cephadm_module, "test"):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                },
+            })
+            with with_service(cephadm_module, AlertManagerSpec('alertmanager',
+                                                               networks=['1.2.3.0/24'],
+                                                               only_bind_port_on_networks=True)):
+                y = dedent(self._get_config(expected_yaml_url)).lstrip()
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "alertmanager.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'alertmanager.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9093, 9094],
+                            'port_ips': {"9094": "1.2.3.1"},
+                        },
+                        "meta": {
+                            'service_name': 'alertmanager',
+                            'ports': [9093, 9094],
+                            'ip': '1.2.3.1',
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "alertmanager.yml": y,
+                            },
+                            "peers": [],
+                            "use_url_prefix": False,
+                            "ip_to_bind_to": "1.2.3.1",
+                        }
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("socket.getfqdn")
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch("cephadm.services.monitoring.password_hash", lambda password: 'alertmanager_password_hash')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
+    def test_alertmanager_config_when_mgmt_gw_enabled(self, _get_fqdn, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        fqdn = 'host1.test'
+        _get_fqdn.return_value = fqdn
+
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.secure_monitoring_stack = True
+            cephadm_module.set_store(AlertmanagerService.USER_CFG_KEY, 'alertmanager_user')
+            cephadm_module.set_store(AlertmanagerService.PASS_CFG_KEY, 'alertmanager_plain_password')
+
+            cephadm_module.cache.update_host_networks('test', {
+                'fd12:3456:789a::/64': {
+                    'if0': ['fd12:3456:789a::10']
+                },
+            })
+            with with_service(cephadm_module, MgmtGatewaySpec("mgmt-gateway")) as _, \
+                 with_service(cephadm_module, AlertManagerSpec('alertmanager',
+                                                               networks=['fd12:3456:789a::/64'],
+                                                               only_bind_port_on_networks=True)):
+
+                y = dedent("""
+                # This file is generated by cephadm.
+                # See https://prometheus.io/docs/alerting/configuration/ for documentation.
+
+                global:
+                  resolve_timeout: 5m
+                  http_config:
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: alertmanager.crt
+                      key_file: alertmanager.key
+
+                route:
+                  receiver: 'default'
+                  routes:
+                    - group_by: ['alertname']
+                      group_wait: 10s
+                      group_interval: 10s
+                      repeat_interval: 1h
+                      receiver: 'ceph-dashboard'
+
+                receivers:
+                - name: 'default'
+                  webhook_configs:
+                - name: 'custom-receiver'
+                  webhook_configs:
+                - name: 'ceph-dashboard'
+                  webhook_configs:
+                  - url: 'https://host_fqdn:29443/internal/dashboard/api/prometheus_receiver'
+                """).lstrip()
+
+                web_config = dedent("""
+                tls_server_config:
+                  cert_file: alertmanager.crt
+                  key_file: alertmanager.key
+                  client_auth_type: RequireAndVerifyClientCert
+                  client_ca_file: root_cert.pem
+                basic_auth_users:
+                    alertmanager_user: alertmanager_password_hash
+                """).lstrip()
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "alertmanager.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'alertmanager.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9093, 9094],
+                            'port_ips': {"9094": "fd12:3456:789a::10"}
+                        },
+                        "meta": {
+                            'service_name': 'alertmanager',
+                            'ports': [9093, 9094],
+                            'ip': 'fd12:3456:789a::10',
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "alertmanager.yml": y,
+                                'alertmanager.crt': 'mycert',
+                                'alertmanager.key': 'mykey',
+                                'web.yml': web_config,
+                                'root_cert.pem': 'cephadm_root_cert'
+                            },
+                            'peers': [],
+                            'web_config': '/etc/alertmanager/web.yml',
+                            "use_url_prefix": True,
+                            "ip_to_bind_to": "fd12:3456:789a::10",
+                        }
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("socket.getfqdn")
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch("cephadm.services.monitoring.password_hash", lambda password: 'alertmanager_password_hash')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
+    def test_alertmanager_config_security_enabled(self, _get_fqdn, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        fqdn = 'host1.test'
+        _get_fqdn.return_value = fqdn
+
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.secure_monitoring_stack = True
+            cephadm_module.set_store(AlertmanagerService.USER_CFG_KEY, 'alertmanager_user')
+            cephadm_module.set_store(AlertmanagerService.PASS_CFG_KEY, 'alertmanager_plain_password')
+            with with_service(cephadm_module, AlertManagerSpec()):
+
+                y = dedent(f"""
+                # This file is generated by cephadm.
+                # See https://prometheus.io/docs/alerting/configuration/ for documentation.
+
+                global:
+                  resolve_timeout: 5m
+                  http_config:
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: alertmanager.crt
+                      key_file: alertmanager.key
+
+                route:
+                  receiver: 'default'
+                  routes:
+                    - group_by: ['alertname']
+                      group_wait: 10s
+                      group_interval: 10s
+                      repeat_interval: 1h
+                      receiver: 'ceph-dashboard'
+
+                receivers:
+                - name: 'default'
+                  webhook_configs:
+                - name: 'custom-receiver'
+                  webhook_configs:
+                - name: 'ceph-dashboard'
+                  webhook_configs:
+                  - url: 'http://{fqdn}:8080/api/prometheus_receiver'
+                """).lstrip()
+
+                web_config = dedent("""
+                tls_server_config:
+                  cert_file: alertmanager.crt
+                  key_file: alertmanager.key
+                basic_auth_users:
+                    alertmanager_user: alertmanager_password_hash
+                """).lstrip()
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "alertmanager.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'alertmanager.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9093, 9094],
+                        },
+                        "meta": {
+                            'service_name': 'alertmanager',
+                            'ports': [9093, 9094],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "alertmanager.yml": y,
+                                'alertmanager.crt': 'mycert',
+                                'alertmanager.key': 'mykey',
+                                'web.yml': web_config,
+                                'root_cert.pem': 'cephadm_root_cert'
+                            },
+                            'peers': [],
+                            'web_config': '/etc/alertmanager/web.yml',
+                            "use_url_prefix": False,
+                            "ip_to_bind_to": "",
+                        }
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @pytest.mark.parametrize(
+        "user_data",
+        [
+            ({'webhook_urls': ['http://foo.com:9999', 'http://bar.com:1111']}),
+            ({'default_webhook_urls': ['http://bar.com:9999', 'http://foo.com:1111']}),
+            ({'default_webhook_urls': ['http://bar.com:9999', 'http://foo.com:1111'],
+              'webhook_urls': ['http://foo.com:9999', 'http://bar.com:1111']}),
+        ],
+    )
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("socket.getfqdn")
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch("cephadm.services.monitoring.password_hash", lambda password: 'alertmanager_password_hash')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
+    @patch('cephadm.cert_mgr.CertMgr.generate_cert', lambda instance, fqdn, ip: ('mycert', 'mykey'))
+    def test_alertmanager_config_custom_webhook_urls(
+        self,
+        _get_fqdn,
+        _run_cephadm,
+        cephadm_module: CephadmOrchestrator,
+        user_data: Dict[str, List[str]]
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        cephadm_module.set_store(AlertmanagerService.USER_CFG_KEY, 'alertmanager_user')
+        cephadm_module.set_store(AlertmanagerService.PASS_CFG_KEY, 'alertmanager_plain_password')
+        fqdn = 'host1.test'
+        _get_fqdn.return_value = fqdn
+
+        print(user_data)
+
+        urls = []
+        if 'default_webhook_urls' in user_data:
+            urls += user_data['default_webhook_urls']
+        if 'webhook_urls' in user_data:
+            urls += user_data['webhook_urls']
+        tab_over = ' ' * 18  # since we'll be inserting this into an indented string
+        webhook_configs_str = '\n'.join(f'{tab_over}- url: \'{u}\'' for u in urls)
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, AlertManagerSpec(user_data=user_data)):
+
+                y = dedent(f"""
+                # This file is generated by cephadm.
+                # See https://prometheus.io/docs/alerting/configuration/ for documentation.
+
+                global:
+                  resolve_timeout: 5m
+                  http_config:
+                    tls_config:
+                      insecure_skip_verify: true
+
+                route:
+                  receiver: 'default'
+                  routes:
+                    - group_by: ['alertname']
+                      group_wait: 10s
+                      group_interval: 10s
+                      repeat_interval: 1h
+                      receiver: 'ceph-dashboard'
+                      continue: true
+                    - group_by: ['alertname']
+                      group_wait: 10s
+                      group_interval: 10s
+                      repeat_interval: 1h
+                      receiver: 'custom-receiver'
+
+                receivers:
+                - name: 'default'
+                  webhook_configs:
+                - name: 'custom-receiver'
+                  webhook_configs:
+{webhook_configs_str}
+                - name: 'ceph-dashboard'
+                  webhook_configs:
+                  - url: 'http://{fqdn}:8080/api/prometheus_receiver'
+                """).lstrip()
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "alertmanager.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'alertmanager.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9093, 9094],
+                        },
+                        "meta": {
+                            'service_name': 'alertmanager',
+                            'ports': [9093, 9094],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "alertmanager.yml": y,
+                            },
+                            'peers': [],
+                            "use_url_prefix": False,
+                            "ip_to_bind_to": "",
+                        }
+                    }),
+                    use_current_daemon_image=False,
+                    error_ok=True,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("socket.getfqdn")
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
+    @patch('cephadm.services.cephadmservice.CephExporterService.get_keyring_with_caps', Mock(return_value='[client.ceph-exporter.test]\nkey = fake-secret\n'))
+    def test_ceph_exporter_config_security_enabled(self, _get_fqdn, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        fqdn = 'host1.test'
+        _get_fqdn.return_value = fqdn
+
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.secure_monitoring_stack = True
+            with with_service(cephadm_module, CephExporterSpec()):
+                _run_cephadm.assert_called_with('test', 'ceph-exporter.test',
+                                                ['_orch', 'deploy'], [],
+                                                stdin=json.dumps({
+                                                    "fsid": "fsid",
+                                                    "name": "ceph-exporter.test",
+                                                    "image": "",
+                                                    "deploy_arguments": [],
+                                                    "params": {"tcp_ports": [9926]},
+                                                    "meta": {
+                                                        "service_name": "ceph-exporter",
+                                                        "ports": [9926],
+                                                        "ip": None,
+                                                        "deployed_by": [],
+                                                        "rank": None,
+                                                        "rank_generation": None,
+                                                        "extra_container_args": None,
+                                                        "extra_entrypoint_args": None
+                                                    },
+                                                    "config_blobs": {
+                                                        "config": "",
+                                                        "keyring": "[client.ceph-exporter.test]\nkey = fake-secret\n",
+                                                        "prio-limit": "5",
+                                                        "stats-period": "5",
+                                                        "https_enabled": True,
+                                                        "files": {
+                                                            "ceph-exporter.crt": "mycert",
+                                                            "ceph-exporter.key": "mykey"}}}),
+                                                error_ok=True,
+                                                use_current_daemon_image=False)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("mgr_module.MgrModule.get")
+    @patch("socket.getfqdn")
+    def test_node_exporter_config_without_mgmt_gw(
+        self,
+        mock_getfqdn,
+        mock_get,
+        _run_cephadm,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+        fqdn = 'host1.test'
+        mock_getfqdn.return_value = fqdn
+
+        with with_host(cephadm_module, "test"):
+            with with_service(cephadm_module, MonitoringSpec('node-exporter')):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "node-exporter.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'node-exporter.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9100],
+                        },
+                        "meta": {
+                            'service_name': 'node-exporter',
+                            'ports': [9100],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {}
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("socket.getfqdn")
+    def test_node_exporter_config_with_mgmt_gw(
+        self,
+        mock_getfqdn,
+        _run_cephadm,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+        mock_getfqdn.return_value = 'host1.test'
+
+        y = dedent("""
+        tls_server_config:
+          cert_file: node_exporter.crt
+          key_file: node_exporter.key
+          client_auth_type: RequireAndVerifyClientCert
+          client_ca_file: root_cert.pem
+        """).lstrip()
+
+        with with_host(cephadm_module, "test"):
+            with with_service(cephadm_module, MgmtGatewaySpec("mgmt-gateway")) as _, \
+                 with_service(cephadm_module, MonitoringSpec('node-exporter')):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "node-exporter.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'node-exporter.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9100],
+                        },
+                        "meta": {
+                            'service_name': 'node-exporter',
+                            'ports': [9100],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "web.yml": y,
+                                'root_cert.pem': f"{cephadm_root_ca}",
+                                'node_exporter.crt': f"{ceph_generated_cert}",
+                                'node_exporter.key': f"{ceph_generated_key}",
+                            },
+                            'web_config': '/etc/node-exporter/web.yml',
+                        }
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator._get_mgr_ips", lambda _: ['192.168.100.100', '::1'])
+    def test_prometheus_config_security_disabled(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        pool = 'testpool'
+        group = 'mygroup'
+        s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1), rgw_frontend_type='beast')
+        with with_host(cephadm_module, 'test'):
+            # host "test" needs to have networks for keepalive to be placed
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                },
+            })
+            with with_service(cephadm_module, MonitoringSpec('node-exporter')) as _, \
+                    with_service(cephadm_module, CephExporterSpec('ceph-exporter')) as _, \
+                    with_service(cephadm_module, s) as _, \
+                    with_service(cephadm_module, AlertManagerSpec('alertmanager')) as _, \
+                    with_service(cephadm_module, IngressSpec(service_id='ingress',
+                                                             frontend_port=8089,
+                                                             monitor_port=8999,
+                                                             monitor_user='admin',
+                                                             monitor_password='12345',
+                                                             keepalived_password='12345',
+                                                             virtual_ip="1.2.3.4/32",
+                                                             backend_service='rgw.foo',
+                                                             enable_stats=True)) as _, \
+                    with_service(cephadm_module, NvmeofServiceSpec(service_id=f'{pool}.{group}',
+                                                                   group=group,
+                                                                   pool=pool)) as _, \
+                    with_service(cephadm_module, PrometheusSpec('prometheus',
+                                                                networks=['1.2.3.0/24'],
+                                                                only_bind_port_on_networks=True)) as _:
+
+                y = dedent("""
+                # This file is generated by cephadm.
+                global:
+                  scrape_interval: 10s
+                  evaluation_interval: 10s
+                  external_labels:
+                    cluster: fsid
+
+                rule_files:
+                  - /etc/prometheus/alerting/*
+
+                alerting:
+                  alertmanagers:
+                    - scheme: http
+                      http_sd_configs:
+                        - url: http://192.168.100.100:8765/sd/prometheus/sd-config?service=alertmanager
+                        - url: http://[::1]:8765/sd/prometheus/sd-config?service=alertmanager
+
+                scrape_configs:
+                  - job_name: 'ceph'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    - source_labels: [instance]
+                      target_label: instance
+                      replacement: 'ceph_cluster'
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: http://192.168.100.100:8765/sd/prometheus/sd-config?service=ceph
+                    - url: http://[::1]:8765/sd/prometheus/sd-config?service=ceph
+
+                  - job_name: 'ceph-exporter'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: http://192.168.100.100:8765/sd/prometheus/sd-config?service=ceph-exporter
+                    - url: http://[::1]:8765/sd/prometheus/sd-config?service=ceph-exporter
+
+                  - job_name: 'ingress'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: http://192.168.100.100:8765/sd/prometheus/sd-config?service=ingress
+                    - url: http://[::1]:8765/sd/prometheus/sd-config?service=ingress
+
+                  - job_name: 'node-exporter'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: http://192.168.100.100:8765/sd/prometheus/sd-config?service=node-exporter
+                    - url: http://[::1]:8765/sd/prometheus/sd-config?service=node-exporter
+
+                  - job_name: 'nvmeof'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: http://192.168.100.100:8765/sd/prometheus/sd-config?service=nvmeof
+                    - url: http://[::1]:8765/sd/prometheus/sd-config?service=nvmeof
+
+
+                """).lstrip()
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "prometheus.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'prometheus.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9095],
+                            'port_ips': {'8765': '1.2.3.1'}
+                        },
+                        "meta": {
+                            'service_name': 'prometheus',
+                            'ports': [9095],
+                            'ip': '1.2.3.1',
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "prometheus.yml": y,
+                                "/etc/prometheus/alerting/custom_alerts.yml": "",
+                            },
+                            'retention_time': '15d',
+                            'retention_size': '0',
+                            'ip_to_bind_to': '1.2.3.1',
+                            "use_url_prefix": False
+                        },
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator._get_mgr_ips", lambda _: ['::1'])
+    @patch("cephadm.services.monitoring.password_hash", lambda password: 'prometheus_password_hash')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials('mycert', 'mykey'))
+    def test_prometheus_config_security_enabled(self, _run_cephadm, _get_uname, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        _get_uname.return_value = 'test'
+        pool = 'testpool'
+        group = 'mygroup'
+        s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1), rgw_frontend_type='beast')
+        smb_spec = SMBSpec(cluster_id='foxtrot', config_uri='rados://.smb/foxtrot/config.json',)
+
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.secure_monitoring_stack = True
+            cephadm_module.set_store(PrometheusService.USER_CFG_KEY, 'prometheus_user')
+            cephadm_module.set_store(PrometheusService.PASS_CFG_KEY, 'prometheus_plain_password')
+            cephadm_module.set_store(AlertmanagerService.USER_CFG_KEY, 'alertmanager_user')
+            cephadm_module.set_store(AlertmanagerService.PASS_CFG_KEY, 'alertmanager_plain_password')
+            cephadm_module.http_server.service_discovery.username = 'sd_user'
+            cephadm_module.http_server.service_discovery.password = 'sd_password'
+            # host "test" needs to have networks for keepalive to be placed
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                },
+            })
+            with with_service(cephadm_module, MonitoringSpec('node-exporter')) as _, \
+                    with_service(cephadm_module, smb_spec) as _, \
+                    with_service(cephadm_module, CephExporterSpec('ceph-exporter')) as _, \
+                    with_service(cephadm_module, s) as _, \
+                    with_service(cephadm_module, AlertManagerSpec('alertmanager')) as _, \
+                    with_service(cephadm_module, IngressSpec(service_id='ingress',
+                                                             frontend_port=8089,
+                                                             monitor_port=8999,
+                                                             monitor_user='admin',
+                                                             monitor_password='12345',
+                                                             keepalived_password='12345',
+                                                             virtual_ip="1.2.3.4/32",
+                                                             backend_service='rgw.foo',
+                                                             enable_stats=True)) as _, \
+                    with_service(cephadm_module, NvmeofServiceSpec(service_id=f'{pool}.{group}',
+                                                                   group=group,
+                                                                   pool=pool)) as _, \
+                    with_service(cephadm_module, PrometheusSpec('prometheus')) as _:
+
+                web_config = dedent("""
+                tls_server_config:
+                  cert_file: prometheus.crt
+                  key_file: prometheus.key
+                basic_auth_users:
+                    prometheus_user: prometheus_password_hash
+                """).lstrip()
+
+                y = dedent("""
+                # This file is generated by cephadm.
+                global:
+                  scrape_interval: 10s
+                  evaluation_interval: 10s
+                  external_labels:
+                    cluster: fsid
+
+                rule_files:
+                  - /etc/prometheus/alerting/*
+
+                alerting:
+                  alertmanagers:
+                    - scheme: https
+                      basic_auth:
+                        username: alertmanager_user
+                        password: alertmanager_plain_password
+                      tls_config:
+                        ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file: prometheus.key
+                      path_prefix: '/'
+                      http_sd_configs:
+                        - url: https://[::1]:8765/sd/prometheus/sd-config?service=alertmanager
+                          basic_auth:
+                            username: sd_user
+                            password: sd_password
+                          tls_config:
+                            ca_file: root_cert.pem
+                            cert_file: prometheus.crt
+                            key_file: prometheus.key
+
+                scrape_configs:
+                  - job_name: 'ceph'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    - source_labels: [instance]
+                      target_label: instance
+                      replacement: 'ceph_cluster'
+                    scheme: https
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: prometheus.crt
+                      key_file: prometheus.key
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=ceph
+                      basic_auth:
+                        username: sd_user
+                        password: sd_password
+                      tls_config:
+                        ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file: prometheus.key
+
+                  - job_name: 'ceph-exporter'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    scheme: https
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: prometheus.crt
+                      key_file: prometheus.key
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=ceph-exporter
+                      basic_auth:
+                        username: sd_user
+                        password: sd_password
+                      tls_config:
+                        ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file: prometheus.key
+
+                  - job_name: 'ingress'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    scheme: https
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: prometheus.crt
+                      key_file: prometheus.key
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=ingress
+                      basic_auth:
+                        username: sd_user
+                        password: sd_password
+                      tls_config:
+                        ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file: prometheus.key
+
+                  - job_name: 'node-exporter'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    scheme: https
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: prometheus.crt
+                      key_file: prometheus.key
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=node-exporter
+                      basic_auth:
+                        username: sd_user
+                        password: sd_password
+                      tls_config:
+                        ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file: prometheus.key
+
+                  - job_name: 'nvmeof'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    scheme: https
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: prometheus.crt
+                      key_file: prometheus.key
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=nvmeof
+                      basic_auth:
+                        username: sd_user
+                        password: sd_password
+                      tls_config:
+                        ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file: prometheus.key
+
+                  - job_name: 'smb'
+                    relabel_configs:
+                    - source_labels: [__address__]
+                      target_label: cluster
+                      replacement: fsid
+                    scheme: https
+                    tls_config:
+                      ca_file: root_cert.pem
+                      cert_file: prometheus.crt
+                      key_file: prometheus.key
+                    honor_labels: true
+                    http_sd_configs:
+                    - url: https://[::1]:8765/sd/prometheus/sd-config?service=smb
+                      basic_auth:
+                        username: sd_user
+                        password: sd_password
+                      tls_config:
+                        ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file: prometheus.key
+
+
+                """).lstrip()
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "prometheus.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'prometheus.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9095],
+                        },
+                        "meta": {
+                            'service_name': 'prometheus',
+                            'ports': [9095],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            'files': {
+                                'prometheus.yml': y,
+                                'root_cert.pem': 'cephadm_root_cert',
+                                'web.yml': web_config,
+                                'prometheus.crt': 'mycert',
+                                'prometheus.key': 'mykey',
+                                "/etc/prometheus/alerting/custom_alerts.yml": "",
+                            },
+                            'retention_time': '15d',
+                            'retention_size': '0',
+                            'ip_to_bind_to': '',
+                            "use_url_prefix": False,
+                            'web_config': '/etc/prometheus/web.yml'
+                        },
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_loki_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, MonitoringSpec('loki')) as _:
+
+                y = dedent("""
+                # This file is generated by cephadm.
+                auth_enabled: false
+
+                server:
+                  http_listen_port: 3100
+                  grpc_listen_port: 8080
+
+                common:
+                  path_prefix: /loki
+                  storage:
+                    filesystem:
+                      chunks_directory: /loki/chunks
+                      rules_directory: /loki/rules
+                  replication_factor: 1
+                  ring:
+                    instance_addr: 127.0.0.1
+                    kvstore:
+                      store: inmemory
+
+                schema_config:
+                  configs:
+                    - from: 2020-10-24
+                      store: boltdb-shipper
+                      object_store: filesystem
+                      schema: v11
+                      index:
+                        prefix: index_
+                        period: 24h
+                    - from: 2024-05-03
+                      store: tsdb
+                      object_store: filesystem
+                      schema: v13
+                      index:
+                        prefix: index_
+                        period: 24h""").lstrip()
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "loki.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'loki.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [3100],
+                        },
+                        "meta": {
+                            'service_name': 'loki',
+                            'ports': [3100],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "loki.yml": y
+                            },
+                        },
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_promtail_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, ServiceSpec('mgr')) as _, \
+                    with_service(cephadm_module, MonitoringSpec('promtail')) as _:
+
+                y = dedent("""
+                # This file is generated by cephadm.
+                server:
+                  http_listen_port: 9080
+                  grpc_listen_port: 0
+
+                positions:
+                  filename: /tmp/positions.yaml
+
+                clients:
+                  - url: http://:3100/loki/api/v1/push
+
+                scrape_configs:
+                - job_name: system
+                  static_configs:
+                  - labels:
+                      job: Cluster Logs
+                      __path__: /var/log/ceph/**/*.log""").lstrip()
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "promtail.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'promtail.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9080],
+                        },
+                        "meta": {
+                            'service_name': 'promtail',
+                            'ports': [9080],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": {
+                                "promtail.yml": y
+                            },
+                        },
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1::4')
+    @patch("cephadm.module.CephadmOrchestrator.get_fqdn", lambda a, b: 'host_fqdn')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    def test_grafana_config_with_mgmt_gw_and_ouath2_proxy(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+
+        def inline_certificate(multi_line_cert):
+            """
+            Converts a multi-line certificate into a one-line string with escaped newlines.
+            """
+            return '\\n'.join([line.strip() for line in multi_line_cert.splitlines()])
+
+        oneline_cephadm_root_ca = inline_certificate(cephadm_root_ca)
+        oneline_ceph_generated_cert = inline_certificate(ceph_generated_cert)
+        oneline_ceph_generated_key = inline_certificate(ceph_generated_key)
+
+        y = dedent(f"""
+             # This file is generated by cephadm.
+             apiVersion: 1
+
+             deleteDatasources:
+               - name: 'Dashboard1'
+                 orgId: 1
+
+             datasources:
+               - name: 'Dashboard1'
+                 type: 'prometheus'
+                 access: 'proxy'
+                 orgId: 1
+                 url: 'https://host_fqdn:29443/internal/prometheus'
+                 basicAuth: true
+                 isDefault: true
+                 editable: false
+                 basicAuthUser: admin
+                 jsonData:
+                    graphiteVersion: "1.1"
+                    tlsAuth: false
+                    tlsAuthWithCACert: true
+                    tlsSkipVerify: false
+                 secureJsonData:
+                   basicAuthPassword: admin
+                   tlsCACert: "{oneline_cephadm_root_ca}"
+                   tlsClientCert: "{oneline_ceph_generated_cert}"
+                   tlsClientKey: "{oneline_ceph_generated_key}"
+
+               - name: 'Loki'
+                 type: 'loki'
+                 access: 'proxy'
+                 url: ''
+                 basicAuth: false
+                 isDefault: false
+                 editable: false""").lstrip()
+
+        oauth2_spec = OAuth2ProxySpec(provider_display_name='my_idp_provider',
+                                      client_id='my_client_id',
+                                      client_secret='my_client_secret',
+                                      oidc_issuer_url='http://192.168.10.10:8888/dex',
+                                      cookie_secret='kbAEM9opAmuHskQvt0AW8oeJRaOM2BYy5Loba0kZ0SQ=',
+                                      ssl_cert=ceph_generated_cert,
+                                      ssl_key=ceph_generated_key)
+
+        with with_host(cephadm_module, "test"):
+            cephadm_module.cert_mgr.save_cert('grafana_ssl_cert', ceph_generated_cert, host='test')
+            cephadm_module.cert_mgr.save_key('grafana_ssl_key', ceph_generated_key, host='test')
+            with with_service(cephadm_module, PrometheusSpec("prometheus")) as _, \
+                 with_service(cephadm_module, MgmtGatewaySpec("mgmt-gateway")) as _, \
+                 with_service(cephadm_module, oauth2_spec) as _, \
+                 with_service(cephadm_module, ServiceSpec("mgr")) as _, with_service(
+                     cephadm_module, GrafanaSpec("grafana")
+            ) as _:
+                files = {
+                    'grafana.ini': dedent("""
+                        # This file is generated by cephadm.
+                        [users]
+                          default_theme = light
+                        [auth.anonymous]
+                          enabled = true
+                          org_name = 'Main Org.'
+                          org_role = 'Viewer'
+                        [server]
+                          domain = 'host_fqdn'
+                          protocol = https
+                          cert_file = /etc/grafana/certs/cert_file
+                          cert_key = /etc/grafana/certs/cert_key
+                          http_port = 3000
+                          http_addr = 
+                          root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+                          serve_from_sub_path = true
+                        [snapshots]
+                          external_enabled = false
+                        [security]
+                          disable_initial_admin_creation = true
+                          cookie_secure = true
+                          cookie_samesite = none
+                          allow_embedding = true
+                        [auth]
+                          disable_login_form = true
+                        [auth.proxy]
+                          enabled = true
+                          header_name = X-WEBAUTH-USER
+                          header_property = username
+                          auto_sign_up = true
+                          sync_ttl = 15
+                          whitelist = 1::4
+                          headers_encoded = false
+                          enable_login_token = false
+                          headers = Role:X-WEBAUTH-ROLE
+                        [analytics]
+                          check_for_updates = false
+                          reporting_enabled = false
+                        [plugins]
+                          check_for_plugin_updates = false
+                          public_key_retrieval_disabled = true""").lstrip(),  # noqa: W291
+                    "provisioning/datasources/ceph-dashboard.yml": y,
+                    'certs/cert_file': dedent(f"""
+                        # generated by cephadm\n{ceph_generated_cert}""").lstrip(),
+                    'certs/cert_key': dedent(f"""
+                        # generated by cephadm\n{ceph_generated_key}""").lstrip(),
+                    'provisioning/dashboards/default.yml': dedent("""
+                        # This file is generated by cephadm.
+                        apiVersion: 1
+
+                        providers:
+                          - name: 'Ceph Dashboard'
+                            orgId: 1
+                            folder: ''
+                            type: file
+                            disableDeletion: false
+                            updateIntervalSeconds: 3
+                            editable: false
+                            options:
+                              path: '/etc/grafana/provisioning/dashboards'""").lstrip(),
+                }
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "grafana.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'grafana.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [3000],
+                        },
+                        "meta": {
+                            'service_name': 'grafana',
+                            'ports': [3000],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": files,
+                        },
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1::4')
+    @patch("cephadm.module.CephadmOrchestrator.get_fqdn", lambda a, b: 'host_fqdn')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    def test_grafana_config_with_mgmt_gw(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+
+        def inline_certificate(multi_line_cert):
+            """
+            Converts a multi-line certificate into a one-line string with escaped newlines.
+            """
+            return '\\n'.join([line.strip() for line in multi_line_cert.splitlines()])
+
+        oneline_cephadm_root_ca = inline_certificate(cephadm_root_ca)
+        oneline_ceph_generated_cert = inline_certificate(ceph_generated_cert)
+        oneline_ceph_generated_key = inline_certificate(ceph_generated_key)
+
+        y = dedent(f"""
+             # This file is generated by cephadm.
+             apiVersion: 1
+
+             deleteDatasources:
+               - name: 'Dashboard1'
+                 orgId: 1
+
+             datasources:
+               - name: 'Dashboard1'
+                 type: 'prometheus'
+                 access: 'proxy'
+                 orgId: 1
+                 url: 'https://host_fqdn:29443/internal/prometheus'
+                 basicAuth: true
+                 isDefault: true
+                 editable: false
+                 basicAuthUser: admin
+                 jsonData:
+                    graphiteVersion: "1.1"
+                    tlsAuth: false
+                    tlsAuthWithCACert: true
+                    tlsSkipVerify: false
+                 secureJsonData:
+                   basicAuthPassword: admin
+                   tlsCACert: "{oneline_cephadm_root_ca}"
+                   tlsClientCert: "{oneline_ceph_generated_cert}"
+                   tlsClientKey: "{oneline_ceph_generated_key}"
+
+               - name: 'Loki'
+                 type: 'loki'
+                 access: 'proxy'
+                 url: ''
+                 basicAuth: false
+                 isDefault: false
+                 editable: false""").lstrip()
+
+        with with_host(cephadm_module, "test"):
+            with with_service(
+                cephadm_module, PrometheusSpec("prometheus")
+            ) as _, with_service(cephadm_module, MgmtGatewaySpec("mgmt-gateway")) as _, \
+                with_service(cephadm_module, ServiceSpec("mgr")) as _, with_service(
+                cephadm_module, GrafanaSpec("grafana")
+            ) as _:
+                cephadm_module.cert_mgr.save_self_signed_cert_key_pair('grafana',
+                                                                       TLSCredentials(ceph_generated_cert, ceph_generated_key),
+                                                                       host='test')
+                files = {
+                    'grafana.ini': dedent("""
+                        # This file is generated by cephadm.
+                        [users]
+                          default_theme = light
+                        [auth.anonymous]
+                          enabled = true
+                          org_name = 'Main Org.'
+                          org_role = 'Viewer'
+                        [server]
+                          domain = 'host_fqdn'
+                          protocol = https
+                          cert_file = /etc/grafana/certs/cert_file
+                          cert_key = /etc/grafana/certs/cert_key
+                          http_port = 3000
+                          http_addr = 
+                          root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+                          serve_from_sub_path = true
+                        [snapshots]
+                          external_enabled = false
+                        [security]
+                          disable_initial_admin_creation = true
+                          cookie_secure = true
+                          cookie_samesite = none
+                          allow_embedding = true
+                        [analytics]
+                          check_for_updates = false
+                          reporting_enabled = false
+                        [plugins]
+                          check_for_plugin_updates = false
+                          public_key_retrieval_disabled = true""").lstrip(),  # noqa: W291
+                    "provisioning/datasources/ceph-dashboard.yml": y,
+                    'certs/cert_file': dedent(f"""
+                        # generated by cephadm\n{ceph_generated_cert}""").lstrip(),
+                    'certs/cert_key': dedent(f"""
+                        # generated by cephadm\n{ceph_generated_key}""").lstrip(),
+                    'provisioning/dashboards/default.yml': dedent("""
+                        # This file is generated by cephadm.
+                        apiVersion: 1
+
+                        providers:
+                          - name: 'Ceph Dashboard'
+                            orgId: 1
+                            folder: ''
+                            type: file
+                            disableDeletion: false
+                            updateIntervalSeconds: 3
+                            editable: false
+                            options:
+                              path: '/etc/grafana/provisioning/dashboards'""").lstrip(),
+                }
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "grafana.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'grafana.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [3000],
+                        },
+                        "meta": {
+                            'service_name': 'grafana',
+                            'ports': [3000],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": files,
+                        },
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '1::4')
+    @patch("cephadm.module.CephadmOrchestrator.get_fqdn", lambda a, b: 'host_fqdn')
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    def test_grafana_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
+
+        with with_host(cephadm_module, "test"):
+            with with_service(
+                cephadm_module, PrometheusSpec("prometheus")
+            ) as _, with_service(cephadm_module, ServiceSpec("mgr")) as _, with_service(
+                cephadm_module, GrafanaSpec("grafana")
+            ) as _:
+                cephadm_module.cert_mgr.save_self_signed_cert_key_pair('grafana',
+                                                                       TLSCredentials(ceph_generated_cert, ceph_generated_key),
+                                                                       host='test')
+                files = {
+                    'grafana.ini': dedent("""
+                        # This file is generated by cephadm.
+                        [users]
+                          default_theme = light
+                        [auth.anonymous]
+                          enabled = true
+                          org_name = 'Main Org.'
+                          org_role = 'Viewer'
+                        [server]
+                          domain = 'host_fqdn'
+                          protocol = https
+                          cert_file = /etc/grafana/certs/cert_file
+                          cert_key = /etc/grafana/certs/cert_key
+                          http_port = 3000
+                          http_addr = 
+                        [snapshots]
+                          external_enabled = false
+                        [security]
+                          disable_initial_admin_creation = true
+                          cookie_secure = true
+                          cookie_samesite = none
+                          allow_embedding = true
+                        [analytics]
+                          check_for_updates = false
+                          reporting_enabled = false
+                        [plugins]
+                          check_for_plugin_updates = false
+                          public_key_retrieval_disabled = true""").lstrip(),  # noqa: W291
+                    'provisioning/datasources/ceph-dashboard.yml': dedent("""
+                        # This file is generated by cephadm.
+                        apiVersion: 1
+
+                        deleteDatasources:
+                          - name: 'Dashboard1'
+                            orgId: 1
+
+                        datasources:
+                          - name: 'Dashboard1'
+                            type: 'prometheus'
+                            access: 'proxy'
+                            orgId: 1
+                            url: 'http://host_fqdn:9095'
+                            basicAuth: false
+                            isDefault: true
+                            editable: false
+
+                          - name: 'Loki'
+                            type: 'loki'
+                            access: 'proxy'
+                            url: ''
+                            basicAuth: false
+                            isDefault: false
+                            editable: false""").lstrip(),
+                    'certs/cert_file': dedent(f"""
+                        # generated by cephadm\n{ceph_generated_cert}""").lstrip(),
+                    'certs/cert_key': dedent(f"""
+                        # generated by cephadm\n{ceph_generated_key}""").lstrip(),
+                    'provisioning/dashboards/default.yml': dedent("""
+                        # This file is generated by cephadm.
+                        apiVersion: 1
+
+                        providers:
+                          - name: 'Ceph Dashboard'
+                            orgId: 1
+                            folder: ''
+                            type: file
+                            disableDeletion: false
+                            updateIntervalSeconds: 3
+                            editable: false
+                            options:
+                              path: '/etc/grafana/provisioning/dashboards'""").lstrip(),
+                }
+
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "grafana.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'grafana.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [3000],
+                        },
+                        "meta": {
+                            'service_name': 'grafana',
+                            'ports': [3000],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": {
+                            "files": files,
+                        },
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_grafana_initial_admin_pw(self, cephadm_module: CephadmOrchestrator):
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, ServiceSpec('mgr')) as _, \
+                    with_service(cephadm_module, GrafanaSpec(initial_admin_password='secure')):
+                out = service_registry.get_service('grafana').generate_config(
+                    CephadmDaemonDeploySpec('test', 'daemon', 'grafana'))
+                assert out == (
+                    {
+                        'files':
+                            {
+                                'grafana.ini':
+                                    '# This file is generated by cephadm.\n'
+                                    '[users]\n'
+                                    '  default_theme = light\n'
+                                    '[auth.anonymous]\n'
+                                    '  enabled = true\n'
+                                    "  org_name = 'Main Org.'\n"
+                                    "  org_role = 'Viewer'\n"
+                                    '[server]\n'
+                                    "  domain = 'host_fqdn'\n"
+                                    '  protocol = https\n'
+                                    '  cert_file = /etc/grafana/certs/cert_file\n'
+                                    '  cert_key = /etc/grafana/certs/cert_key\n'
+                                    '  http_port = 3000\n'
+                                    '  http_addr = \n'
+                                    '[snapshots]\n'
+                                    '  external_enabled = false\n'
+                                    '[security]\n'
+                                    '  admin_user = admin\n'
+                                    '  admin_password = secure\n'
+                                    '  cookie_secure = true\n'
+                                    '  cookie_samesite = none\n'
+                                    '  allow_embedding = true\n'
+                                    '[analytics]\n'
+                                    '  check_for_updates = false\n'
+                                    '  reporting_enabled = false\n'
+                                    '[plugins]\n'
+                                    '  check_for_plugin_updates = false\n'
+                                    '  public_key_retrieval_disabled = true',
+                                'provisioning/datasources/ceph-dashboard.yml':
+                                    "# This file is generated by cephadm.\n"
+                                    "apiVersion: 1\n\n"
+                                    'deleteDatasources:\n\n'
+                                    'datasources:\n\n'
+                                    "  - name: 'Loki'\n"
+                                    "    type: 'loki'\n"
+                                    "    access: 'proxy'\n"
+                                    "    url: ''\n"
+                                    '    basicAuth: false\n'
+                                    '    isDefault: false\n'
+                                    '    editable: false',
+                                'certs/cert_file': ANY,
+                                'certs/cert_key': ANY,
+                                'provisioning/dashboards/default.yml':
+                                    '# This file is generated by cephadm.\n'
+                                    'apiVersion: 1\n\n'
+                                    'providers:\n'
+                                    "  - name: 'Ceph Dashboard'\n"
+                                    '    orgId: 1\n'
+                                    "    folder: ''\n"
+                                    '    type: file\n'
+                                    '    disableDeletion: false\n'
+                                    '    updateIntervalSeconds: 3\n'
+                                    '    editable: false\n'
+                                    '    options:\n'
+                                    "      path: '/etc/grafana/provisioning/dashboards'"
+                            }}, ['secure_monitoring_stack:False'])
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_grafana_no_anon_access(self, cephadm_module: CephadmOrchestrator):
+        # with anonymous_access set to False, expecting the [auth.anonymous] section
+        # to not be present in the grafana config. Note that we require an initial_admin_password
+        # to be provided when anonymous_access is False
+        cephadm_module._init_cert_mgr()
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, ServiceSpec('mgr')) as _, \
+                    with_service(cephadm_module, GrafanaSpec(anonymous_access=False, initial_admin_password='secure')):
+                out = service_registry.get_service('grafana').generate_config(
+                    CephadmDaemonDeploySpec('test', 'daemon', 'grafana'))
+                assert out == (
+                    {
+                        'files':
+                            {
+                                'grafana.ini':
+                                    '# This file is generated by cephadm.\n'
+                                    '[users]\n'
+                                    '  default_theme = light\n'
+                                    '[server]\n'
+                                    "  domain = 'host_fqdn'\n"
+                                    '  protocol = https\n'
+                                    '  cert_file = /etc/grafana/certs/cert_file\n'
+                                    '  cert_key = /etc/grafana/certs/cert_key\n'
+                                    '  http_port = 3000\n'
+                                    '  http_addr = \n'
+                                    '[snapshots]\n'
+                                    '  external_enabled = false\n'
+                                    '[security]\n'
+                                    '  admin_user = admin\n'
+                                    '  admin_password = secure\n'
+                                    '  cookie_secure = true\n'
+                                    '  cookie_samesite = none\n'
+                                    '  allow_embedding = true\n'
+                                    '[analytics]\n'
+                                    '  check_for_updates = false\n'
+                                    '  reporting_enabled = false\n'
+                                    '[plugins]\n'
+                                    '  check_for_plugin_updates = false\n'
+                                    '  public_key_retrieval_disabled = true',
+                                'provisioning/datasources/ceph-dashboard.yml':
+                                    "# This file is generated by cephadm.\n"
+                                    "apiVersion: 1\n\n"
+                                    'deleteDatasources:\n\n'
+                                    'datasources:\n\n'
+                                    "  - name: 'Loki'\n"
+                                    "    type: 'loki'\n"
+                                    "    access: 'proxy'\n"
+                                    "    url: ''\n"
+                                    '    basicAuth: false\n'
+                                    '    isDefault: false\n'
+                                    '    editable: false',
+                                'certs/cert_file': ANY,
+                                'certs/cert_key': ANY,
+                                'provisioning/dashboards/default.yml':
+                                    '# This file is generated by cephadm.\n'
+                                    'apiVersion: 1\n\n'
+                                    'providers:\n'
+                                    "  - name: 'Ceph Dashboard'\n"
+                                    '    orgId: 1\n'
+                                    "    folder: ''\n"
+                                    '    type: file\n'
+                                    '    disableDeletion: false\n'
+                                    '    updateIntervalSeconds: 3\n'
+                                    '    editable: false\n'
+                                    '    options:\n'
+                                    "      path: '/etc/grafana/provisioning/dashboards'"
+                            }}, ['secure_monitoring_stack:False'])
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_monitoring_ports(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test'):
+
+            yaml_str = """service_type: alertmanager
+service_name: alertmanager
+placement:
+    count: 1
+spec:
+    port: 4200
+"""
+            yaml_file = yaml.safe_load(yaml_str)
+            spec = ServiceSpec.from_json(yaml_file)
+
+            with patch("cephadm.services.monitoring.AlertmanagerService.generate_config", return_value=({}, [])):
+                with with_service(cephadm_module, spec):
+
+                    CephadmServe(cephadm_module)._check_daemons()
+
+                    _run_cephadm.assert_called_with(
+                        'test',
+                        "alertmanager.test",
+                        ['_orch', 'deploy'],
+                        [],
+                        stdin=json.dumps({
+                            "fsid": "fsid",
+                            "name": 'alertmanager.test',
+                            "image": '',
+                            "deploy_arguments": [],
+                            "params": {
+                                'tcp_ports': [4200, 9094],
+                            },
+                            "meta": {
+                                'service_name': 'alertmanager',
+                                'ports': [4200, 9094],
+                                'ip': None,
+                                'deployed_by': [],
+                                'rank': None,
+                                'rank_generation': None,
+                                'extra_container_args': None,
+                                'extra_entrypoint_args': None,
+                            },
+                            "config_blobs": {},
+                        }),
+                        error_ok=True,
+                        use_current_daemon_image=False,
+                    )
+
+
+class TestRGWService:
+
+    @pytest.mark.parametrize(
+        "frontend, ssl, extra_args, expected",
+        [
+            ('beast', False, ['tcp_nodelay=1'],
+             'beast endpoint=[fd00:fd00:fd00:3000::1]:80 tcp_nodelay=1'),
+            ('beast', True, ['tcp_nodelay=0', 'max_header_size=65536'],
+             'beast ssl_endpoint=[fd00:fd00:fd00:3000::1]:443 ssl_certificate=config://rgw/cert/rgw.foo tcp_nodelay=0 max_header_size=65536'),
+            ('civetweb', False, [], 'civetweb port=[fd00:fd00:fd00:3000::1]:80'),
+            ('civetweb', True, None,
+             'civetweb port=[fd00:fd00:fd00:3000::1]:443s ssl_certificate=config://rgw/cert/rgw.foo'),
+        ]
+    )
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_rgw_update(self, frontend, ssl, extra_args, expected, cephadm_module: CephadmOrchestrator):
+        with with_host(cephadm_module, 'host1'):
+            cephadm_module.cache.update_host_networks('host1', {
+                'fd00:fd00:fd00:3000::/64': {
+                    'if0': ['fd00:fd00:fd00:3000::1']
+                }
+            })
+            s = RGWSpec(service_id="foo",
+                        networks=['fd00:fd00:fd00:3000::/64'],
+                        ssl=ssl,
+                        rgw_frontend_type=frontend,
+                        rgw_frontend_extra_args=extra_args)
+            with with_service(cephadm_module, s) as dds:
+                _, f, _ = cephadm_module.check_mon_command({
+                    'prefix': 'config get',
+                    'who': f'client.{dds[0]}',
+                    'key': 'rgw_frontends',
+                })
+                assert f == expected
+
+    @pytest.mark.parametrize(
+        "disable_sync_traffic",
+        [
+            (True),
+            (False),
+        ]
+    )
+    @patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    def test_rgw_disable_sync_traffic(self, disable_sync_traffic, cephadm_module: CephadmOrchestrator):
+        with with_host(cephadm_module, 'host1'):
+            s = RGWSpec(service_id="foo",
+                        disable_multisite_sync_traffic=disable_sync_traffic)
+            with with_service(cephadm_module, s) as dds:
+                _, f, _ = cephadm_module.check_mon_command({
+                    'prefix': 'config get',
+                    'who': f'client.{dds[0]}',
+                    'key': 'rgw_run_sync_thread',
+                })
+                assert f == ('false' if disable_sync_traffic else 'true')
+
+
+class TestMonService:
+
+    def test_set_crush_locations(self, cephadm_module: CephadmOrchestrator):
+        mgr = FakeMgr()
+        mon_service = MonService(mgr)
+        mon_spec = ServiceSpec(service_type='mon', crush_locations={'vm-00': ['datacenter=a', 'rack=1'], 'vm-01': ['datacenter=a'], 'vm-02': ['datacenter=b', 'rack=3']})
+
+        mon_daemons = [
+            DaemonDescription(daemon_type='mon', daemon_id='vm-00', hostname='vm-00'),
+            DaemonDescription(daemon_type='mon', daemon_id='vm-01', hostname='vm-01'),
+            DaemonDescription(daemon_type='mon', daemon_id='vm-02', hostname='vm-02')
+        ]
+        mon_service.set_crush_locations(mon_daemons, mon_spec)
+        assert 'vm-00' in mgr.set_mon_crush_locations
+        assert mgr.set_mon_crush_locations['vm-00'] == ['datacenter=a', 'rack=1']
+        assert 'vm-01' in mgr.set_mon_crush_locations
+        assert mgr.set_mon_crush_locations['vm-01'] == ['datacenter=a']
+        assert 'vm-02' in mgr.set_mon_crush_locations
+        assert mgr.set_mon_crush_locations['vm-02'] == ['datacenter=b', 'rack=3']
+
+
+class TestSNMPGateway:
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_snmp_v2c_deployment(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        spec = SNMPGatewaySpec(
+            snmp_version='V2c',
+            snmp_destination='192.168.1.1:162',
+            credentials={
+                'snmp_community': 'public'
+            })
+
+        config = {
+            "destination": spec.snmp_destination,
+            "snmp_version": spec.snmp_version,
+            "snmp_community": spec.credentials.get('snmp_community')
+        }
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9464],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9464],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_snmp_v2c_with_port(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        spec = SNMPGatewaySpec(
+            snmp_version='V2c',
+            snmp_destination='192.168.1.1:162',
+            credentials={
+                'snmp_community': 'public'
+            },
+            port=9465)
+
+        config = {
+            "destination": spec.snmp_destination,
+            "snmp_version": spec.snmp_version,
+            "snmp_community": spec.credentials.get('snmp_community')
+        }
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9465],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9465],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_snmp_v3nopriv_deployment(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        spec = SNMPGatewaySpec(
+            snmp_version='V3',
+            snmp_destination='192.168.1.1:162',
+            engine_id='8000C53F00000000',
+            credentials={
+                'snmp_v3_auth_username': 'myuser',
+                'snmp_v3_auth_password': 'mypassword'
+            })
+
+        config = {
+            'destination': spec.snmp_destination,
+            'snmp_version': spec.snmp_version,
+            'snmp_v3_auth_protocol': 'SHA',
+            'snmp_v3_auth_username': 'myuser',
+            'snmp_v3_auth_password': 'mypassword',
+            'snmp_v3_engine_id': '8000C53F00000000'
+        }
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9464],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9464],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_snmp_v3priv_deployment(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        spec = SNMPGatewaySpec(
+            snmp_version='V3',
+            snmp_destination='192.168.1.1:162',
+            engine_id='8000C53F00000000',
+            auth_protocol='MD5',
+            privacy_protocol='AES',
+            credentials={
+                'snmp_v3_auth_username': 'myuser',
+                'snmp_v3_auth_password': 'mypassword',
+                'snmp_v3_priv_password': 'mysecret',
+            })
+
+        config = {
+            'destination': spec.snmp_destination,
+            'snmp_version': spec.snmp_version,
+            'snmp_v3_auth_protocol': 'MD5',
+            'snmp_v3_auth_username': spec.credentials.get('snmp_v3_auth_username'),
+            'snmp_v3_auth_password': spec.credentials.get('snmp_v3_auth_password'),
+            'snmp_v3_engine_id': '8000C53F00000000',
+            'snmp_v3_priv_protocol': spec.privacy_protocol,
+            'snmp_v3_priv_password': spec.credentials.get('snmp_v3_priv_password'),
+        }
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "snmp-gateway.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'snmp-gateway.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9464],
+                        },
+                        "meta": {
+                            'service_name': 'snmp-gateway',
+                            'ports': [9464],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+
+class TestIngressService:
+
+    @pytest.mark.parametrize(
+        "enable_haproxy_protocol",
+        [False, True],
+    )
+    @patch("cephadm.inventory.Inventory.get_addr")
+    @patch("cephadm.utils.resolve_ip")
+    @patch("cephadm.inventory.HostCache.get_daemons_by_service")
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_config_nfs_multiple_nfs_same_rank(
+        self,
+        _run_cephadm,
+        _get_daemons_by_service,
+        _resolve_ip, _get_addr,
+        cephadm_module: CephadmOrchestrator,
+        enable_haproxy_protocol: bool,
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        def fake_resolve_ip(hostname: str) -> str:
+            if hostname == 'host1':
+                return '192.168.122.111'
+            elif hostname == 'host2':
+                return '192.168.122.222'
+            else:
+                return 'xxx.xxx.xxx.xxx'
+        _resolve_ip.side_effect = fake_resolve_ip
+
+        def fake_get_addr(hostname: str) -> str:
+            return hostname
+        _get_addr.side_effect = fake_get_addr
+
+        nfs_service = NFSServiceSpec(
+            service_id="foo",
+            placement=PlacementSpec(
+                count=1,
+                hosts=['host1', 'host2']),
+            port=12049,
+            enable_haproxy_protocol=enable_haproxy_protocol,
+        )
+
+        ispec = IngressSpec(
+            service_type='ingress',
+            service_id='nfs.foo',
+            backend_service='nfs.foo',
+            frontend_port=2049,
+            monitor_port=9049,
+            virtual_ip='192.168.122.100/24',
+            monitor_user='admin',
+            monitor_password='12345',
+            keepalived_password='12345',
+            enable_haproxy_protocol=enable_haproxy_protocol,
+            enable_stats=True,
+            placement=PlacementSpec(
+                hosts=['host1'])
+        )
+
+        cephadm_module.spec_store._specs = {
+            'nfs.foo': nfs_service,
+            'ingress.nfs.foo': ispec
+        }
+        cephadm_module.spec_store.spec_created = {
+            'nfs.foo': datetime_now(),
+            'ingress.nfs.foo': datetime_now()
+        }
+
+        # in both test cases we'll do here, we want only the ip
+        # for the host1 nfs daemon as we'll end up giving that
+        # one higher rank_generation but the same rank as the one
+        # on host2
+        haproxy_txt = (
+            '# This file is generated by cephadm.\n'
+            'global\n'
+            '    log         127.0.0.1 local2\n'
+            '    chroot      /var/lib/haproxy\n'
+            '    pidfile     /var/lib/haproxy/haproxy.pid\n'
+            '    maxconn     8000\n'
+            '    daemon\n'
+            '    stats socket /var/lib/haproxy/stats\n\n'
+            'defaults\n'
+            '    mode                    tcp\n'
+            '    log                     global\n'
+            '    timeout queue           1m\n'
+            '    timeout connect         10s\n'
+            '    timeout client          1m\n'
+            '    timeout server          1m\n'
+            '    timeout check           10s\n'
+            '    maxconn                 8000\n\n'
+            'frontend stats\n'
+            '    mode http\n'
+            '    bind 192.168.122.100:9049\n'
+            '    bind host1:9049\n'
+            '    stats enable\n'
+            '    stats uri /stats\n'
+            '    stats refresh 10s\n'
+            '    stats auth admin:12345\n'
+            '    http-request use-service prometheus-exporter if { path /metrics }\n'
+            '    monitor-uri /health\n\n'
+            'frontend frontend\n'
+            '    bind 192.168.122.100:2049\n'
+            '    option tcplog\n'
+            '    default_backend backend\n\n'
+            'peers haproxy_peers\n'
+            '     peer host1 host1:1024\n\n'
+            'backend backend\n'
+            '    mode        tcp\n'
+            '    balance     roundrobin\n'
+            '    stick-table type ip size 200k expire 30m peers haproxy_peers\n'
+            '    stick on src\n'
+            '    hash-type   consistent\n'
+        )
+        if enable_haproxy_protocol:
+            haproxy_txt += '    default-server send-proxy-v2\n'
+        haproxy_txt += '    server nfs.foo.0 192.168.122.111:12049 check\n'
+        haproxy_expected_conf = {
+            'files': {'haproxy.cfg': haproxy_txt}
+        }
+
+        # verify we get the same cfg regardless of the order in which the nfs daemons are returned
+        # in this case both nfs are rank 0, so it should only take the one with rank_generation 1 a.k.a
+        # the one on host1
+        nfs_daemons = [
+            DaemonDescription(daemon_type='nfs', daemon_id='foo.0.1.host1.qwerty', hostname='host1', rank=0, rank_generation=1, ports=[12049]),
+            DaemonDescription(daemon_type='nfs', daemon_id='foo.0.0.host2.abcdef', hostname='host2', rank=0, rank_generation=0, ports=[12049])
+        ]
+        _get_daemons_by_service.return_value = nfs_daemons
+
+        haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+            CephadmDaemonDeploySpec(host='host1', daemon_id='ingress', service_name=ispec.service_name()))
+
+        haproxy_generated_conf = haproxy_generated_conf[0]
+        gen_config_lines = [line.rstrip() for line in haproxy_generated_conf['files']['haproxy.cfg'].splitlines()]
+        exp_config_line = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+
+        assert gen_config_lines == exp_config_line
+
+        # swapping order now, should still pick out the one with the higher rank_generation
+        # in this case both nfs are rank 0, so it should only take the one with rank_generation 1 a.k.a
+        # the one on host1
+        nfs_daemons = [
+            DaemonDescription(daemon_type='nfs', daemon_id='foo.0.0.host2.abcdef', hostname='host2', rank=0, rank_generation=0, ports=[12049]),
+            DaemonDescription(daemon_type='nfs', daemon_id='foo.0.1.host1.qwerty', hostname='host1', rank=0, rank_generation=1, ports=[12049])
+        ]
+        _get_daemons_by_service.return_value = nfs_daemons
+
+        haproxy_generated_conf, _ = service_registry.get_service('ingress').haproxy_generate_config(
+            CephadmDaemonDeploySpec(host='host1', daemon_id='ingress', service_name=ispec.service_name()))
+
+        gen_config_lines = [line.rstrip() for line in haproxy_generated_conf['files']['haproxy.cfg'].splitlines()]
+        exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+
+        assert gen_config_lines == exp_config_lines
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': [
+                        '1.2.3.4',  # simulate already assigned VIP
+                        '1.2.3.1',  # simulate interface IP
+                    ]
+                }
+            })
+
+            # the ingress backend
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast')
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32",
+                                enable_stats=True)
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the keepalived conf based on the specified spec
+                keepalived_generated_conf = service_registry.get_service('ingress').keepalived_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                keepalived_expected_conf = {
+                    'files':
+                        {
+                            'keepalived.conf':
+                                '# This file is generated by cephadm.\n'
+                                'global_defs {\n    '
+                                'enable_script_security\n    '
+                                'script_user root\n'
+                                '}\n\n'
+                                'vrrp_script check_backend {\n    '
+                                'script "/usr/bin/curl http://1.2.3.7:8999/health"\n    '
+                                'weight -20\n    '
+                                'interval 2\n    '
+                                'rise 2\n    '
+                                'fall 2\n}\n\n'
+                                'vrrp_instance VI_0 {\n  '
+                                'state MASTER\n  '
+                                'priority 100\n  '
+                                'interface if0\n  '
+                                'virtual_router_id 50\n  '
+                                'advert_int 1\n  '
+                                'authentication {\n      '
+                                'auth_type PASS\n      '
+                                'auth_pass 12345\n  '
+                                '}\n  '
+                                'unicast_src_ip 1.2.3.1\n  '
+                                'unicast_peer {\n  '
+                                '}\n  '
+                                'virtual_ipaddress {\n    '
+                                '1.2.3.4/32 dev if0\n  '
+                                '}\n  '
+                                'track_script {\n      '
+                                'check_backend\n  }\n'
+                                '}\n'
+                        }
+                }
+
+                # check keepalived config
+                assert keepalived_generated_conf[0] == keepalived_expected_conf
+
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    http\n    '
+                                'log                     global\n    '
+                                'option                  httplog\n    '
+                                'option                  dontlognull\n    '
+                                'option http-server-close\n    '
+                                'option forwardfor       except 127.0.0.0/8\n    '
+                                'option                  redispatch\n    '
+                                'retries                 3\n    '
+                                'timeout queue           20s\n    '
+                                'timeout connect         5s\n    '
+                                'timeout http-request    1s\n    '
+                                'timeout http-keep-alive 5s\n    '
+                                'timeout client          30s\n    '
+                                'timeout server          30s\n    '
+                                'timeout check           5s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n    '
+                                'mode http\n    '
+                                'bind 1.2.3.4:8999\n    '
+                                'bind 1.2.3.7:8999\n    '
+                                'stats enable\n    '
+                                'stats uri /stats\n    '
+                                'stats refresh 10s\n    '
+                                'stats auth admin:12345\n    '
+                                'http-request use-service prometheus-exporter if { path /metrics }\n    '
+                                'monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089\n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'option forwardfor\n    '
+                                'balance static-rr\n    '
+                                'option httpchk HEAD / HTTP/1.0\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                        }
+                }
+
+                gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]
+                exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+
+                assert gen_config_lines == exp_config_lines
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_config_ssl_rgw(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                }
+            })
+
+            # the ingress backend
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast', rgw_frontend_port=443, ssl=True)
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32",
+                                enable_stats=True)
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the keepalived conf based on the specified spec
+                keepalived_generated_conf = service_registry.get_service('ingress').keepalived_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                keepalived_expected_conf = {
+                    'files':
+                        {
+                            'keepalived.conf':
+                                '# This file is generated by cephadm.\n'
+                                'global_defs {\n    '
+                                'enable_script_security\n    '
+                                'script_user root\n'
+                                '}\n\n'
+                                'vrrp_script check_backend {\n    '
+                                'script "/usr/bin/curl http://[1::4]:8999/health"\n    '
+                                'weight -20\n    '
+                                'interval 2\n    '
+                                'rise 2\n    '
+                                'fall 2\n}\n\n'
+                                'vrrp_instance VI_0 {\n  '
+                                'state MASTER\n  '
+                                'priority 100\n  '
+                                'interface if0\n  '
+                                'virtual_router_id 50\n  '
+                                'advert_int 1\n  '
+                                'authentication {\n      '
+                                'auth_type PASS\n      '
+                                'auth_pass 12345\n  '
+                                '}\n  '
+                                'unicast_src_ip 1.2.3.1\n  '
+                                'unicast_peer {\n  '
+                                '}\n  '
+                                'virtual_ipaddress {\n    '
+                                '1.2.3.4/32 dev if0\n  '
+                                '}\n  '
+                                'track_script {\n      '
+                                'check_backend\n  }\n'
+                                '}\n'
+                        }
+                }
+
+                # check keepalived config
+                assert keepalived_generated_conf[0] == keepalived_expected_conf
+
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    http\n    '
+                                'log                     global\n    '
+                                'option                  httplog\n    '
+                                'option                  dontlognull\n    '
+                                'option http-server-close\n    '
+                                'option forwardfor       except 127.0.0.0/8\n    '
+                                'option                  redispatch\n    '
+                                'retries                 3\n    '
+                                'timeout queue           20s\n    '
+                                'timeout connect         5s\n    '
+                                'timeout http-request    1s\n    '
+                                'timeout http-keep-alive 5s\n    '
+                                'timeout client          30s\n    '
+                                'timeout server          30s\n    '
+                                'timeout check           5s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n    '
+                                'mode http\n    '
+                                'bind 1.2.3.4:8999\n    '
+                                'bind 1::4:8999\n    '
+                                'stats enable\n    '
+                                'stats uri /stats\n    '
+                                'stats refresh 10s\n    '
+                                'stats auth admin:12345\n    '
+                                'http-request use-service prometheus-exporter if { path /metrics }\n    '
+                                'monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089\n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'option forwardfor\n    '
+                                'default-server ssl\n    '
+                                'default-server verify none\n    '
+                                'balance static-rr\n    '
+                                'option httpchk HEAD / HTTP/1.0\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1::4:443 check weight 100 inter 2s\n'
+                        }
+                }
+
+                gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]
+                exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+                assert gen_config_lines == exp_config_lines
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_haproxy_config_rgw_tcp_mode(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                }
+            })
+
+            # the ingress backend
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast', rgw_frontend_port=443, ssl=True)
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32",
+                                use_tcp_mode_over_rgw=True,
+                                enable_stats=True)
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    tcp\n    '
+                                'log                     global\n    '
+                                'timeout queue           1m\n    '
+                                'timeout connect         10s\n    '
+                                'timeout client          1m\n    '
+                                'timeout server          1m\n    '
+                                'timeout check           10s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n    '
+                                'mode http\n    '
+                                'bind 1.2.3.4:8999\n    '
+                                'bind 1::4:8999\n    '
+                                'stats enable\n    '
+                                'stats uri /stats\n    '
+                                'stats refresh 10s\n    '
+                                'stats auth admin:12345\n    '
+                                'http-request use-service prometheus-exporter if { path /metrics }\n    '
+                                'monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089 \n    '
+                                'option tcplog\n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'mode        tcp\n    '
+                                'balance     roundrobin\n    '
+                                'hash-type   consistent\n    '
+                                'option ssl-hello-chk\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1::4:443 check weight 100 inter 2s\n'
+                        }
+                }
+
+                assert haproxy_generated_conf[0] == haproxy_expected_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_config_multi_vips(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                }
+            })
+
+            # Check the ingress with multiple VIPs
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast')
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32",
+                                enable_stats=True)
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the keepalived conf based on the specified spec
+                # Test with only 1 IP on the list, as it will fail with more VIPS but only one host.
+                keepalived_generated_conf = service_registry.get_service('ingress').keepalived_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                keepalived_expected_conf = {
+                    'files':
+                        {
+                            'keepalived.conf':
+                                '# This file is generated by cephadm.\n'
+                                'global_defs {\n    '
+                                'enable_script_security\n    '
+                                'script_user root\n'
+                                '}\n\n'
+                                'vrrp_script check_backend {\n    '
+                                'script "/usr/bin/curl http://1.2.3.7:8999/health"\n    '
+                                'weight -20\n    '
+                                'interval 2\n    '
+                                'rise 2\n    '
+                                'fall 2\n}\n\n'
+                                'vrrp_instance VI_0 {\n  '
+                                'state MASTER\n  '
+                                'priority 100\n  '
+                                'interface if0\n  '
+                                'virtual_router_id 50\n  '
+                                'advert_int 1\n  '
+                                'authentication {\n      '
+                                'auth_type PASS\n      '
+                                'auth_pass 12345\n  '
+                                '}\n  '
+                                'unicast_src_ip 1.2.3.1\n  '
+                                'unicast_peer {\n  '
+                                '}\n  '
+                                'virtual_ipaddress {\n    '
+                                '1.2.3.4/32 dev if0\n  '
+                                '}\n  '
+                                'track_script {\n      '
+                                'check_backend\n  }\n'
+                                '}\n'
+                        }
+                }
+
+                # check keepalived config
+                assert keepalived_generated_conf[0] == keepalived_expected_conf
+
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    http\n    '
+                                'log                     global\n    '
+                                'option                  httplog\n    '
+                                'option                  dontlognull\n    '
+                                'option http-server-close\n    '
+                                'option forwardfor       except 127.0.0.0/8\n    '
+                                'option                  redispatch\n    '
+                                'retries                 3\n    '
+                                'timeout queue           20s\n    '
+                                'timeout connect         5s\n    '
+                                'timeout http-request    1s\n    '
+                                'timeout http-keep-alive 5s\n    '
+                                'timeout client          30s\n    '
+                                'timeout server          30s\n    '
+                                'timeout check           5s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n    '
+                                'mode http\n    '
+                                'bind 1.2.3.4:8999\n    '
+                                'bind 1.2.3.7:8999\n    '
+                                'stats enable\n    '
+                                'stats uri /stats\n    '
+                                'stats refresh 10s\n    '
+                                'stats auth admin:12345\n    '
+                                'http-request use-service prometheus-exporter if { path /metrics }\n    '
+                                'monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089 \n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'option forwardfor\n    '
+                                'balance static-rr\n    '
+                                'option httpchk HEAD / HTTP/1.0\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                        }
+                }
+
+                assert haproxy_generated_conf[0] == haproxy_expected_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_keepalive_config_multi_interface_vips(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        with with_host(cephadm_module, 'test', addr='1.2.3.1'):
+            with with_host(cephadm_module, 'test2', addr='1.2.3.2'):
+                cephadm_module.cache.update_host_networks('test', {
+                    '1.2.3.0/24': {
+                        'if0': ['1.2.3.1']
+                    },
+                    '100.100.100.0/24': {
+                        'if1': ['100.100.100.1']
+                    }
+                })
+                cephadm_module.cache.update_host_networks('test2', {
+                    '1.2.3.0/24': {
+                        'if0': ['1.2.3.2']
+                    },
+                    '100.100.100.0/24': {
+                        'if1': ['100.100.100.2']
+                    }
+                })
+
+                # Check the ingress with multiple VIPs
+                s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                            rgw_frontend_type='beast')
+
+                ispec = IngressSpec(service_type='ingress',
+                                    service_id='test',
+                                    placement=PlacementSpec(hosts=['test', 'test2']),
+                                    backend_service='rgw.foo',
+                                    frontend_port=8089,
+                                    monitor_port=8999,
+                                    monitor_user='admin',
+                                    monitor_password='12345',
+                                    keepalived_password='12345',
+                                    virtual_ips_list=["1.2.3.100/24", "100.100.100.100/24"],
+                                    enable_stats=True)
+                with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                    keepalived_generated_conf = service_registry.get_service('ingress').keepalived_generate_config(
+                        CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                    keepalived_expected_conf = {
+                        'files':
+                            {
+                                'keepalived.conf':
+                                    '# This file is generated by cephadm.\n'
+                                    'global_defs {\n    '
+                                    'enable_script_security\n    '
+                                    'script_user root\n'
+                                    '}\n\n'
+                                    'vrrp_script check_backend {\n    '
+                                    'script "/usr/bin/curl http://1.2.3.1:8999/health"\n    '
+                                    'weight -20\n    '
+                                    'interval 2\n    '
+                                    'rise 2\n    '
+                                    'fall 2\n}\n\n'
+                                    'vrrp_instance VI_0 {\n  '
+                                    'state MASTER\n  '
+                                    'priority 100\n  '
+                                    'interface if0\n  '
+                                    'virtual_router_id 50\n  '
+                                    'advert_int 1\n  '
+                                    'authentication {\n      '
+                                    'auth_type PASS\n      '
+                                    'auth_pass 12345\n  '
+                                    '}\n  '
+                                    'unicast_src_ip 1.2.3.1\n  '
+                                    'unicast_peer {\n    '
+                                    '1.2.3.2\n  '
+                                    '}\n  '
+                                    'virtual_ipaddress {\n    '
+                                    '1.2.3.100/24 dev if0\n  '
+                                    '}\n  '
+                                    'track_script {\n      '
+                                    'check_backend\n  }\n'
+                                    '}\n'
+                                    'vrrp_instance VI_1 {\n  '
+                                    'state BACKUP\n  '
+                                    'priority 90\n  '
+                                    'interface if1\n  '
+                                    'virtual_router_id 51\n  '
+                                    'advert_int 1\n  '
+                                    'authentication {\n      '
+                                    'auth_type PASS\n      '
+                                    'auth_pass 12345\n  '
+                                    '}\n  '
+                                    'unicast_src_ip 100.100.100.1\n  '
+                                    'unicast_peer {\n    '
+                                    '100.100.100.2\n  '
+                                    '}\n  '
+                                    'virtual_ipaddress {\n    '
+                                    '100.100.100.100/24 dev if1\n  '
+                                    '}\n  '
+                                    'track_script {\n      '
+                                    'check_backend\n  }\n'
+                                    '}\n'
+                            }
+                    }
+
+                    # check keepalived config
+                    assert keepalived_generated_conf[0] == keepalived_expected_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_keepalive_interface_host_filtering(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        # we need to make sure keepalive daemons will have an interface
+        # on the hosts we deploy them on in order to set up their VIP.
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.1'):
+            with with_host(cephadm_module, 'test2', addr='1.2.3.2'):
+                with with_host(cephadm_module, 'test3', addr='1.2.3.3'):
+                    with with_host(cephadm_module, 'test4', addr='1.2.3.3'):
+                        # setup "test" and "test4" to have all the necessary interfaces,
+                        # "test2" to have one of them (should still be filtered)
+                        # and "test3" to have none of them
+                        cephadm_module.cache.update_host_networks('test', {
+                            '1.2.3.0/24': {
+                                'if0': ['1.2.3.1']
+                            },
+                            '100.100.100.0/24': {
+                                'if1': ['100.100.100.1']
+                            }
+                        })
+                        cephadm_module.cache.update_host_networks('test2', {
+                            '1.2.3.0/24': {
+                                'if0': ['1.2.3.2']
+                            },
+                        })
+                        cephadm_module.cache.update_host_networks('test4', {
+                            '1.2.3.0/24': {
+                                'if0': ['1.2.3.4']
+                            },
+                            '100.100.100.0/24': {
+                                'if1': ['100.100.100.4']
+                            }
+                        })
+
+                        s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                                    rgw_frontend_type='beast')
+
+                        ispec = IngressSpec(service_type='ingress',
+                                            service_id='test',
+                                            placement=PlacementSpec(hosts=['test', 'test2', 'test3', 'test4']),
+                                            backend_service='rgw.foo',
+                                            frontend_port=8089,
+                                            monitor_port=8999,
+                                            monitor_user='admin',
+                                            monitor_password='12345',
+                                            keepalived_password='12345',
+                                            virtual_ips_list=["1.2.3.100/24", "100.100.100.100/24"],
+                                            enable_stats=True)
+                        with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                            # since we're never actually going to refresh the host here,
+                            # check the tmp daemons to see what was placed during the apply
+                            daemons = cephadm_module.cache._get_tmp_daemons()
+                            keepalive_daemons = [d for d in daemons if d.daemon_type == 'keepalived']
+                            hosts_deployed_on = [d.hostname for d in keepalive_daemons]
+                            assert 'test' in hosts_deployed_on
+                            assert 'test2' not in hosts_deployed_on
+                            assert 'test3' not in hosts_deployed_on
+                            assert 'test4' in hosts_deployed_on
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_haproxy_port_ips(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.4/32']
+                }
+            })
+
+            # Check the ingress with multiple VIPs
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast')
+
+            ip = '1.2.3.100'
+            frontend_port = 8089
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=frontend_port,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_ip=f"{ip}/24",
+                                enable_stats=True)
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the haproxy conf based on the specified spec
+                haproxy_daemon_spec = service_registry.get_service('ingress').prepare_create(
+                    CephadmDaemonDeploySpec(
+                        host='test',
+                        daemon_type='haproxy',
+                        daemon_id='ingress',
+                        service_name=ispec.service_name()))
+
+                assert haproxy_daemon_spec.port_ips == {str(frontend_port): ip}
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_keepalive_only_nfs_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                }
+            })
+
+            # Check the ingress with multiple VIPs
+            s = NFSServiceSpec(service_id="foo", placement=PlacementSpec(count=1),
+                               virtual_ip='1.2.3.0/24')
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='nfs.foo',
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_ip='1.2.3.0/24',
+                                keepalive_only=True)
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='foo.test.0.0', service_name=s.service_name()))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Bind_addr = 1.2.3.0/24" in ganesha_conf
+
+                keepalived_generated_conf = service_registry.get_service('ingress').keepalived_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                keepalived_expected_conf = {
+                    'files':
+                        {
+                            'keepalived.conf':
+                                '# This file is generated by cephadm.\n'
+                                'global_defs {\n    '
+                                'enable_script_security\n    '
+                                'script_user root\n'
+                                '}\n\n'
+                                'vrrp_script check_backend {\n    '
+                                'script "/usr/bin/false"\n    '
+                                'weight -20\n    '
+                                'interval 2\n    '
+                                'rise 2\n    '
+                                'fall 2\n}\n\n'
+                                'vrrp_instance VI_0 {\n  '
+                                'state MASTER\n  '
+                                'priority 100\n  '
+                                'interface if0\n  '
+                                'virtual_router_id 50\n  '
+                                'advert_int 1\n  '
+                                'authentication {\n      '
+                                'auth_type PASS\n      '
+                                'auth_pass 12345\n  '
+                                '}\n  '
+                                'unicast_src_ip 1.2.3.1\n  '
+                                'unicast_peer {\n  '
+                                '}\n  '
+                                'virtual_ipaddress {\n    '
+                                '1.2.3.0/24 dev if0\n  '
+                                '}\n  '
+                                'track_script {\n      '
+                                'check_backend\n  }\n'
+                                '}\n'
+                        }
+                }
+
+                # check keepalived config
+                assert keepalived_generated_conf[0] == keepalived_expected_conf
+
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    @patch("cephadm.inventory.Inventory.keys")
+    @patch("cephadm.inventory.Inventory.get_addr")
+    @patch("cephadm.utils.resolve_ip")
+    @patch("cephadm.inventory.HostCache.get_daemons_by_service")
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_config_nfs_proxy_protocol(
+        self,
+        _run_cephadm,
+        _get_daemons_by_service,
+        _resolve_ip,
+        _get_addr,
+        _inventory_keys,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        """Verify that setting enable_haproxy_protocol for both ingress and
+        nfs services sets the desired configuration parameters in both
+        the haproxy config and nfs ganesha config.
+        """
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        def fake_resolve_ip(hostname: str) -> str:
+            if hostname in ('host1', '192.168.122.111'):
+                return '192.168.122.111'
+            elif hostname in ('host2', '192.168.122.222'):
+                return '192.168.122.222'
+            else:
+                raise KeyError(hostname)
+        _resolve_ip.side_effect = fake_resolve_ip
+        _get_addr.side_effect = fake_resolve_ip
+
+        def fake_keys():
+            return ['host1', 'host2']
+        _inventory_keys.side_effect = fake_keys
+
+        nfs_service = NFSServiceSpec(
+            service_id="foo",
+            placement=PlacementSpec(
+                count=1,
+                hosts=['host1', 'host2']),
+            port=12049,
+            enable_haproxy_protocol=True,
+            enable_nlm=True,
+        )
+
+        ispec = IngressSpec(
+            service_type='ingress',
+            service_id='nfs.foo',
+            backend_service='nfs.foo',
+            frontend_port=2049,
+            monitor_port=9049,
+            virtual_ip='192.168.122.100/24',
+            monitor_user='admin',
+            monitor_password='12345',
+            keepalived_password='12345',
+            enable_haproxy_protocol=True,
+            enable_stats=True,
+            placement=PlacementSpec(
+                count=1,
+                hosts=['host1', 'host2']),
+        )
+
+        cephadm_module.spec_store._specs = {
+            'nfs.foo': nfs_service,
+            'ingress.nfs.foo': ispec
+        }
+        cephadm_module.spec_store.spec_created = {
+            'nfs.foo': datetime_now(),
+            'ingress.nfs.foo': datetime_now()
+        }
+
+        haproxy_txt = (
+            '# This file is generated by cephadm.\n'
+            'global\n'
+            '    log         127.0.0.1 local2\n'
+            '    chroot      /var/lib/haproxy\n'
+            '    pidfile     /var/lib/haproxy/haproxy.pid\n'
+            '    maxconn     8000\n'
+            '    daemon\n'
+            '    stats socket /var/lib/haproxy/stats\n\n'
+            'defaults\n'
+            '    mode                    tcp\n'
+            '    log                     global\n'
+            '    timeout queue           1m\n'
+            '    timeout connect         10s\n'
+            '    timeout client          1m\n'
+            '    timeout server          1m\n'
+            '    timeout check           10s\n'
+            '    maxconn                 8000\n\n'
+            'frontend stats\n'
+            '    mode http\n'
+            '    bind 192.168.122.100:9049\n'
+            '    bind 192.168.122.111:9049\n'
+            '    stats enable\n'
+            '    stats uri /stats\n'
+            '    stats refresh 10s\n'
+            '    stats auth admin:12345\n'
+            '    http-request use-service prometheus-exporter if { path /metrics }\n'
+            '    monitor-uri /health\n\n'
+            'frontend frontend\n'
+            '    bind 192.168.122.100:2049\n'
+            '    option tcplog\n'
+            '    default_backend backend\n\n'
+            'peers haproxy_peers\n'
+            '     peer host1 192.168.122.111:1024\n'
+            '     peer host2 192.168.122.222:1024\n\n'
+            'backend backend\n'
+            '    mode        tcp\n'
+            '    balance     roundrobin\n'
+            '    stick-table type ip size 200k expire 30m peers haproxy_peers\n'
+            '    stick on src\n'
+            '    hash-type   consistent\n'
+            '    default-server send-proxy-v2\n'
+            '    server nfs.foo.0 192.168.122.111:12049 check\n'
+        )
+        haproxy_expected_conf = {
+            'files': {'haproxy.cfg': haproxy_txt}
+        }
+
+        nfs_ganesha_txt = (
+            "# This file is generated by cephadm.\n"
+            'NFS_CORE_PARAM {\n'
+            '        Enable_NLM = true;\n'
+            '        Enable_RQUOTA = false;\n'
+            '        Protocols = 3, 4;\n'
+            '        mount_path_pseudo = true;\n'
+            '        Enable_UDP = false;\n'
+            '        NFS_Port = 2049;\n'
+            '        allow_set_io_flusher_fail = true;\n'
+            '        HAProxy_Hosts = 192.168.122.111, 10.10.2.20, 192.168.122.222;\n'
+            '        Monitoring_Port = 9587;\n'
+            '}\n'
+            '\n'
+            'NFSv4 {\n'
+            '        Delegations = false;\n'
+            '        RecoveryBackend = "rados_cluster";\n'
+            '        Minor_Versions = 1, 2;\n'
+            f'        Server_Scope = "{cephadm_module._cluster_fsid}-foo";\n'
+            '        IdmapConf = "/etc/ganesha/idmap.conf";\n'
+            '}\n'
+            '\n'
+            'RADOS_KV {\n'
+            '        UserId = "nfs.foo.test.0.0";\n'
+            '        nodeid = 0;\n'
+            '        pool = ".nfs";\n'
+            '        namespace = "foo";\n'
+            '}\n'
+            '\n'
+            'CEPH_NODES_LIST {\n'
+            '        Ceph_Nodes = 192.168.122.111, 192.168.122.222;\n'
+            '}\n'
+            '\n'
+            'RADOS_URLS {\n'
+            '        UserId = "nfs.foo.test.0.0";\n'
+            '        watch_url = '
+            '"rados://.nfs/foo/conf-nfs.foo";\n'
+            '}\n'
+            '\n'
+            'RGW {\n'
+            '        cluster = "ceph";\n'
+            '        name = "client.nfs.foo.test.0.0-rgw";\n'
+            '}\n'
+            '\n'
+            "%url    rados://.nfs/foo/conf-nfs.foo"
+        )
+        nfs_expected_conf = {
+            'files': {'ganesha.conf': nfs_ganesha_txt, 'idmap.conf': ''},
+            'config': '',
+            'extra_args': ['-N', 'NIV_EVENT'],
+            'keyring': (
+                '[client.nfs.foo.test.0.0]\n'
+                'key = None\n'
+            ),
+            'namespace': 'foo',
+            'pool': '.nfs',
+            'rgw': {
+                'cluster': 'ceph',
+                'keyring': (
+                    '[client.nfs.foo.test.0.0-rgw]\n'
+                    'key = None\n'
+                ),
+                'user': 'nfs.foo.test.0.0-rgw',
+            },
+            'userid': 'nfs.foo.test.0.0',
+        }
+
+        nfs_daemons = [
+            DaemonDescription(
+                daemon_type='nfs',
+                daemon_id='foo.0.1.host1.qwerty',
+                hostname='host1',
+                rank=0,
+                rank_generation=1,
+                ports=[12049],
+            ),
+            DaemonDescription(
+                daemon_type='nfs',
+                daemon_id='foo.0.0.host2.abcdef',
+                hostname='host2',
+                rank=0,
+                rank_generation=0,
+                ports=[12049],
+            ),
+        ]
+        _get_daemons_by_service.return_value = nfs_daemons
+
+        ingress_svc = service_registry.get_service('ingress')
+        nfs_svc = service_registry.get_service('nfs')
+
+        # add host network info to one host to test the behavior of
+        # adding all known-good addresses of the host to the list.
+        cephadm_module.cache.update_host_networks('host1', {
+            # this one is additional
+            '10.10.2.0/24': {
+                'eth1': ['10.10.2.20']
+            },
+            # this is redundant and will be skipped
+            '192.168.122.0/24': {
+                'eth0': ['192.168.122.111']
+            },
+            # this is a link-local address and will be ignored
+            "fe80::/64": {
+                "veth0": [
+                    "fe80::8cf5:25ff:fe1c:d963"
+                ],
+                "eth0": [
+                    "fe80::c7b:cbff:fef6:7370"
+                ],
+                "eth1": [
+                    "fe80::7201:25a7:390b:d9a7"
+                ]
+            },
+        })
+
+        haproxy_generated_conf, _ = ingress_svc.haproxy_generate_config(
+            CephadmDaemonDeploySpec(
+                host='host1',
+                daemon_id='ingress',
+                service_name=ispec.service_name(),
+            ),
+        )
+        gen_config_lines = [line.rstrip() for line in haproxy_generated_conf['files']['haproxy.cfg'].splitlines()]
+        exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+        assert gen_config_lines == exp_config_lines
+
+        nfs_generated_conf, _ = nfs_svc.generate_config(
+            CephadmDaemonDeploySpec(
+                host='test',
+                daemon_id='foo.test.0.0',
+                service_name=nfs_service.service_name(),
+                rank=0,
+            ),
+        )
+        assert nfs_generated_conf == nfs_expected_conf
+
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    @patch("cephadm.inventory.Inventory.keys")
+    @patch("cephadm.inventory.Inventory.get_addr")
+    @patch("cephadm.utils.resolve_ip")
+    @patch("cephadm.inventory.HostCache.get_daemons_by_service")
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_haproxy_protocol_nfs_config_with_ip_addrs(
+        self,
+        _run_cephadm,
+        _get_daemons_by_service,
+        _resolve_ip,
+        _get_addr,
+        _inventory_keys,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        nfs_service = NFSServiceSpec(
+            service_id="foo",
+            placement=PlacementSpec(
+                count=1,
+                hosts=['host1', 'host2']),
+            port=12049,
+            ip_addrs={
+                'host1': '10.10.2.20',
+                'host2': '10.10.2.21'
+            },
+            enable_haproxy_protocol=True,
+        )
+
+        ispec = IngressSpec(
+            service_type='ingress',
+            service_id='nfs.foo',
+            backend_service='nfs.foo',
+            frontend_port=2049,
+            monitor_port=9049,
+            virtual_ip='192.168.122.100/24',
+            monitor_user='admin',
+            monitor_password='12345',
+            keepalived_password='12345',
+            enable_haproxy_protocol=True,
+            placement=PlacementSpec(
+                count=1,
+                hosts=['host1', 'host2']),
+
+        )
+        cephadm_module.spec_store._specs = {
+            'nfs.foo': nfs_service,
+            'ingress.nfs.foo': ispec
+        }
+        cephadm_module.spec_store.spec_created = {
+            'nfs.foo': datetime_now(),
+            'ingress.nfs.foo': datetime_now()
+        }
+        nfs_daemons = [
+            DaemonDescription(
+                daemon_type='nfs',
+                daemon_id='foo.0.1.host1.qwerty',
+                hostname='host1',
+                ip='10.10.2.20',
+                rank=0,
+                rank_generation=1,
+                ports=[12049],
+            ),
+            DaemonDescription(
+                daemon_type='nfs',
+                daemon_id='foo.0.0.host2.abcdef',
+                hostname='host2',
+                ip='10.10.2.21',
+                rank=0,
+                rank_generation=0,
+                ports=[12049],
+            ),
+        ]
+        _get_daemons_by_service.return_value = nfs_daemons
+
+        ingress_svc = service_registry.get_service('ingress')
+        nfs_svc = service_registry.get_service('nfs')
+
+        cephadm_module.cache.update_host_networks('host1', {
+            # this one is additional
+            '10.10.2.0/24': {
+                'eth1': ['10.10.2.20']
+            },
+            # this is redundant and will be skipped
+            '192.168.122.0/24': {
+                'eth0': ['192.168.122.111']
+            },
+        })
+        cephadm_module.cache.update_host_networks('host2', {
+            # this one is additional
+            '10.10.2.0/24': {
+                'eth1': ['10.10.2.22']
+            },
+            # this is redundant and will be skipped
+            '192.168.122.0/24': {
+                'eth0': ['192.168.122.112']
+            },
+        })
+
+        haproxy_generated_conf, _ = ingress_svc.haproxy_generate_config(
+            CephadmDaemonDeploySpec(
+                host='host1',
+                daemon_id='ingress',
+                service_name=ispec.service_name(),
+            ),
+        )
+        gen_config_lines = haproxy_generated_conf['files']['haproxy.cfg']
+        assert 'server nfs.foo.0 10.10.2.20:12049 check' in gen_config_lines
+
+        nfs_generated_conf, _ = nfs_svc.generate_config(
+            CephadmDaemonDeploySpec(
+                host='test',
+                daemon_id='foo.test.0.0',
+                service_name=nfs_service.service_name(),
+                rank=0,
+                ip='10.10.2.20'
+            ),
+        )
+        ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+        assert "Bind_addr = 10.10.2.20" in ganesha_conf
+
+
+class TestNFS:
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_config_monitoring_ip(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                }
+            })
+
+            nfs_spec = NFSServiceSpec(service_id="foo", placement=PlacementSpec(hosts=['test']),
+                                      monitoring_ip_addrs={'test': '1.2.3.1'})
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='foo.test.0.0', service_name=nfs_spec.service_name()))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Monitoring_Addr = 1.2.3.1" in ganesha_conf
+
+            nfs_spec = NFSServiceSpec(service_id="foo", placement=PlacementSpec(hosts=['test']),
+                                      monitoring_networks=['1.2.3.0/24'])
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='foo.test.0.0', service_name=nfs_spec.service_name()))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Monitoring_Addr = 1.2.3.1" in ganesha_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_config_bind_addr(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('host1', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.7']
+                }
+            })
+
+            nfs_spec = NFSServiceSpec(service_id="foo", placement=PlacementSpec(hosts=['host1']),
+                                      ip_addrs={'host1': '1.2.3.7'})
+            with with_service(cephadm_module, nfs_spec, status_running=True) as _:
+                dds = wait(cephadm_module, cephadm_module.list_daemons())
+                daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(dds[0])
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(daemon_spec)
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Bind_addr = 1.2.3.7" in ganesha_conf
+
+        with with_host(cephadm_module, 'host1', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('host1', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.7']
+                }
+            })
+            nfs_spec = NFSServiceSpec(service_id="foo", placement=PlacementSpec(hosts=['host1']),
+                                      networks=['1.2.3.0/24'])
+            with with_service(cephadm_module, nfs_spec, status_running=True) as _:
+                dds = wait(cephadm_module, cephadm_module.list_daemons())
+                daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(dds[0])
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(daemon_spec)
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                assert "Bind_addr = 1.2.3.7" in ganesha_conf
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_without_haproxy_stats(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': [
+                        '1.2.3.4',  # simulate already assigned VIP
+                        '1.2.3.1',  # simulate interface IP
+                    ]
+                }
+            })
+
+            # the ingress backend
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast')
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32")
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    http\n    '
+                                'log                     global\n    '
+                                'option                  httplog\n    '
+                                'option                  dontlognull\n    '
+                                'option http-server-close\n    '
+                                'option forwardfor       except 127.0.0.0/8\n    '
+                                'option                  redispatch\n    '
+                                'retries                 3\n    '
+                                'timeout queue           20s\n    '
+                                'timeout connect         5s\n    '
+                                'timeout http-request    1s\n    '
+                                'timeout http-keep-alive 5s\n    '
+                                'timeout client          30s\n    '
+                                'timeout server          30s\n    '
+                                'timeout check           5s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n'
+                                '    mode http\n'
+                                '    bind 1.2.3.4:8999\n'
+                                '    bind 1.2.3.7:8999\n'
+                                '    monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089\n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'option forwardfor\n    '
+                                'balance static-rr\n    '
+                                'option httpchk HEAD / HTTP/1.0\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                        }
+                }
+                gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]
+                exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+                assert gen_config_lines == exp_config_lines
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_haproxy_ssl(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': [
+                        '1.2.3.4',  # simulate already assigned VIP
+                        '1.2.3.1',  # simulate interface IP
+                    ]
+                }
+            })
+
+            # the ingress backend
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast')
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32",
+                                ssl=True,
+                                enable_stats=True,
+                                monitor_ssl=True)
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    http\n    '
+                                'log                     global\n    '
+                                'option                  httplog\n    '
+                                'option                  dontlognull\n    '
+                                'option http-server-close\n    '
+                                'option forwardfor       except 127.0.0.0/8\n    '
+                                'option                  redispatch\n    '
+                                'retries                 3\n    '
+                                'timeout queue           20s\n    '
+                                'timeout connect         5s\n    '
+                                'timeout http-request    1s\n    '
+                                'timeout http-keep-alive 5s\n    '
+                                'timeout client          30s\n    '
+                                'timeout server          30s\n    '
+                                'timeout check           5s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n    '
+                                'mode http\n    '
+                                'bind 1.2.3.4:8999 ssl crt /var/lib/haproxy/haproxy.pem\n    '
+                                'bind 1.2.3.7:8999 ssl crt /var/lib/haproxy/haproxy.pem\n    '
+                                'stats enable\n    '
+                                'stats uri /stats\n    '
+                                'stats refresh 10s\n    '
+                                'stats auth admin:12345\n    '
+                                'http-request use-service prometheus-exporter if { path /metrics }\n    '
+                                'monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089 ssl crt /var/lib/haproxy/haproxy.pem\n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'option forwardfor\n    '
+                                'balance static-rr\n    '
+                                'option httpchk HEAD / HTTP/1.0\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                        }
+                }
+                gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]
+                exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+                assert gen_config_lines == exp_config_lines
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_haproxy_with_different_stats_cert(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': [
+                        '1.2.3.4',  # simulate already assigned VIP
+                        '1.2.3.1',  # simulate interface IP
+                    ]
+                }
+            })
+
+            # the ingress backend
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast')
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32",
+                                ssl=True,
+                                enable_stats=True,
+                                monitor_ssl=True,
+                                monitor_cert_source='cephadm-signed'
+                                )
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    http\n    '
+                                'log                     global\n    '
+                                'option                  httplog\n    '
+                                'option                  dontlognull\n    '
+                                'option http-server-close\n    '
+                                'option forwardfor       except 127.0.0.0/8\n    '
+                                'option                  redispatch\n    '
+                                'retries                 3\n    '
+                                'timeout queue           20s\n    '
+                                'timeout connect         5s\n    '
+                                'timeout http-request    1s\n    '
+                                'timeout http-keep-alive 5s\n    '
+                                'timeout client          30s\n    '
+                                'timeout server          30s\n    '
+                                'timeout check           5s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n    '
+                                'mode http\n    '
+                                'bind 1.2.3.4:8999 ssl crt /var/lib/haproxy/stats_haproxy.pem\n    '
+                                'bind 1.2.3.7:8999 ssl crt /var/lib/haproxy/stats_haproxy.pem\n    '
+                                'stats enable\n    '
+                                'stats uri /stats\n    '
+                                'stats refresh 10s\n    '
+                                'stats auth admin:12345\n    '
+                                'http-request use-service prometheus-exporter if { path /metrics }\n    '
+                                'monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089 ssl crt /var/lib/haproxy/haproxy.pem\n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'option forwardfor\n    '
+                                'balance static-rr\n    '
+                                'option httpchk HEAD / HTTP/1.0\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                        }
+                }
+                gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]
+                exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+                assert gen_config_lines == exp_config_lines
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_ingress_haproxy_monitor_ip(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': [
+                        '1.2.3.4',  # simulate already assigned VIP
+                        '1.2.3.1',  # simulate interface IP
+                    ]
+                }
+            })
+
+            # the ingress backend
+            s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1),
+                        rgw_frontend_type='beast')
+
+            ispec = IngressSpec(service_type='ingress',
+                                service_id='test',
+                                backend_service='rgw.foo',
+                                frontend_port=8089,
+                                monitor_port=8999,
+                                monitor_user='admin',
+                                monitor_password='12345',
+                                keepalived_password='12345',
+                                virtual_interface_networks=['1.2.3.0/24'],
+                                virtual_ip="1.2.3.4/32",
+                                enable_stats=True,
+                                monitor_ip_addrs={'test': '1.2.3.1'})
+            with with_service(cephadm_module, s) as _, with_service(cephadm_module, ispec) as _:
+                # generate the haproxy conf based on the specified spec
+                haproxy_generated_conf = service_registry.get_service('ingress').haproxy_generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='ingress', service_name=ispec.service_name()))
+
+                haproxy_expected_conf = {
+                    'files':
+                        {
+                            'haproxy.cfg':
+                                '# This file is generated by cephadm.'
+                                '\nglobal\n    log         '
+                                '127.0.0.1 local2\n    '
+                                'chroot      /var/lib/haproxy\n    '
+                                'pidfile     /var/lib/haproxy/haproxy.pid\n    '
+                                'maxconn     8000\n    '
+                                'daemon\n    '
+                                'stats socket /var/lib/haproxy/stats\n'
+                                '\ndefaults\n    '
+                                'mode                    http\n    '
+                                'log                     global\n    '
+                                'option                  httplog\n    '
+                                'option                  dontlognull\n    '
+                                'option http-server-close\n    '
+                                'option forwardfor       except 127.0.0.0/8\n    '
+                                'option                  redispatch\n    '
+                                'retries                 3\n    '
+                                'timeout queue           20s\n    '
+                                'timeout connect         5s\n    '
+                                'timeout http-request    1s\n    '
+                                'timeout http-keep-alive 5s\n    '
+                                'timeout client          30s\n    '
+                                'timeout server          30s\n    '
+                                'timeout check           5s\n    '
+                                'maxconn                 8000\n'
+                                '\nfrontend stats\n    '
+                                'mode http\n    '
+                                'bind 1.2.3.1:8999\n    '
+                                'stats enable\n    '
+                                'stats uri /stats\n    '
+                                'stats refresh 10s\n    '
+                                'stats auth admin:12345\n    '
+                                'http-request use-service prometheus-exporter if { path /metrics }\n    '
+                                'monitor-uri /health\n'
+                                '\nfrontend frontend\n    '
+                                'bind 1.2.3.4:8089\n    '
+                                'default_backend backend\n\n'
+                                'backend backend\n    '
+                                'option forwardfor\n    '
+                                'balance static-rr\n    '
+                                'option httpchk HEAD / HTTP/1.0\n    '
+                                'server '
+                                + haproxy_generated_conf[1][0] + ' 1.2.3.7:80 check weight 100 inter 2s\n'
+                        }
+                }
+
+                gen_config_lines = [line.rstrip() for line in haproxy_generated_conf[0]['files']['haproxy.cfg'].splitlines()]
+                exp_config_lines = [line.rstrip() for line in haproxy_expected_conf['files']['haproxy.cfg'].splitlines()]
+
+                assert gen_config_lines == exp_config_lines
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+    @patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+    def test_nfs_tls(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        with with_host(cephadm_module, 'test', addr='1.2.3.7'):
+            cephadm_module.cache.update_host_networks('test', {
+                '1.2.3.0/24': {
+                    'if0': ['1.2.3.1']
+                }
+            })
+
+            nfs_spec = NFSServiceSpec(service_id="foo", placement=PlacementSpec(hosts=['test']),
+                                      ssl=True, ssl_cert=ceph_generated_cert, ssl_key=ceph_generated_key,
+                                      ssl_ca_cert=cephadm_root_ca, certificate_source='inline', tls_ktls=True,
+                                      tls_debug=True, tls_min_version='TLSv1.3',
+                                      tls_ciphers='ECDHE-ECDSA-AES256')
+            with with_service(cephadm_module, nfs_spec) as _:
+                nfs_generated_conf, _ = service_registry.get_service('nfs').generate_config(
+                    CephadmDaemonDeploySpec(host='test', daemon_id='foo.test.0.0', service_name=nfs_spec.service_name()))
+                ganesha_conf = nfs_generated_conf['files']['ganesha.conf']
+                expected_tls_block = (
+                    'TLS_CONFIG{\n'
+                    '        Enable_TLS = True;\n'
+                    '        TLS_Cert_File = /etc/ganesha/tls/tls_cert.pem;\n'
+                    '        TLS_Key_File = /etc/ganesha/tls/tls_key.pem;\n'
+                    '        TLS_CA_File = /etc/ganesha/tls/tls_ca_cert.pem;\n'
+                    '        TLS_Ciphers = "ECDHE-ECDSA-AES256";\n'
+                    '        TLS_Min_Version = "TLSv1.3";\n'
+                    '        Enable_KTLS = True;\n'
+                    '        Enable_debug = True;\n'
+                    '}\n'
+                )
+                assert expected_tls_block in ganesha_conf
+
+
+class TestCephFsMirror:
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_config(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, ServiceSpec('cephfs-mirror')):
+                cephadm_module.assert_issued_mon_command({
+                    'prefix': 'mgr module enable',
+                    'module': 'mirroring'
+                })
+
+
+class TestJaeger:
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_jaeger_query(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        spec = TracingSpec(es_nodes="192.168.0.1:9200", service_type="jaeger-query")
+        config = {"elasticsearch_nodes": "http://192.168.0.1:9200"}
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "jaeger-query.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'jaeger-query.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [16686],
+                        },
+                        "meta": {
+                            'service_name': 'jaeger-query',
+                            'ports': [16686],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_jaeger_collector_es_deploy(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        collector_spec = TracingSpec(service_type="jaeger-collector")
+        es_spec = TracingSpec(service_type="elasticsearch")
+        es_config = {}
+
+        with with_host(cephadm_module, 'test'):
+            collector_config = {
+                "elasticsearch_nodes": f'http://{build_url(host=cephadm_module.inventory.get_addr("test"), port=9200).lstrip("/")}'}
+            with with_service(cephadm_module, es_spec):
+                _run_cephadm.assert_called_with(
+                    "test",
+                    "elasticsearch.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'elasticsearch.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [9200],
+                        },
+                        "meta": {
+                            'service_name': 'elasticsearch',
+                            'ports': [9200],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": es_config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+                with with_service(cephadm_module, collector_spec):
+                    _run_cephadm.assert_called_with(
+                        "test",
+                        "jaeger-collector.test",
+                        ['_orch', 'deploy'],
+                        [],
+                        stdin=json.dumps({
+                            "fsid": "fsid",
+                            "name": 'jaeger-collector.test',
+                            "image": '',
+                            "deploy_arguments": [],
+                            "params": {
+                                'tcp_ports': [14250],
+                            },
+                            "meta": {
+                                'service_name': 'jaeger-collector',
+                                'ports': [14250],
+                                'ip': None,
+                                'deployed_by': [],
+                                'rank': None,
+                                'rank_generation': None,
+                                'extra_container_args': None,
+                                'extra_entrypoint_args': None,
+                            },
+                            "config_blobs": collector_config,
+                        }),
+                        error_ok=True,
+                        use_current_daemon_image=False,
+                    )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_jaeger_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        collector_spec = TracingSpec(service_type="jaeger-collector", es_nodes="192.168.0.1:9200")
+        collector_config = {"elasticsearch_nodes": "http://192.168.0.1:9200"}
+
+        agent_spec = TracingSpec(service_type="jaeger-agent")
+        agent_config = {"collector_nodes": "test:14250"}
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, collector_spec):
+                _run_cephadm.assert_called_with(
+                    "test",
+                    "jaeger-collector.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'jaeger-collector.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [14250],
+                        },
+                        "meta": {
+                            'service_name': 'jaeger-collector',
+                            'ports': [14250],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": collector_config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+                with with_service(cephadm_module, agent_spec):
+                    _run_cephadm.assert_called_with(
+                        "test",
+                        "jaeger-agent.test",
+                        ['_orch', 'deploy'],
+                        [],
+                        stdin=json.dumps({
+                            "fsid": "fsid",
+                            "name": 'jaeger-agent.test',
+                            "image": '',
+                            "deploy_arguments": [],
+                            "params": {
+                                'tcp_ports': [6799],
+                            },
+                            "meta": {
+                                'service_name': 'jaeger-agent',
+                                'ports': [6799],
+                                'ip': None,
+                                'deployed_by': [],
+                                'rank': None,
+                                'rank_generation': None,
+                                'extra_container_args': None,
+                                'extra_entrypoint_args': None,
+                            },
+                            "config_blobs": agent_config,
+                        }),
+                        error_ok=True,
+                        use_current_daemon_image=False,
+                    )
+
+
+class TestAgent:
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None, fqdns=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_deploy_cephadm_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        agent_spec = ServiceSpec(service_type="agent", placement=PlacementSpec(count=1))
+        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"refresh_period\": 20, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\"}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, agent_spec):
+                _run_cephadm.assert_called_with(
+                    "test",
+                    "agent.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps({
+                        "fsid": "fsid",
+                        "name": 'agent.test',
+                        "image": '',
+                        "deploy_arguments": [],
+                        "params": {
+                            'tcp_ports': [4721],
+                        },
+                        "meta": {
+                            'service_name': 'agent',
+                            'ports': [4721],
+                            'ip': None,
+                            'deployed_by': [],
+                            'rank': None,
+                            'rank_generation': None,
+                            'extra_container_args': None,
+                            'extra_entrypoint_args': None,
+                        },
+                        "config_blobs": agent_config,
+                    }),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+
+class TestCustomContainer:
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_deploy_custom_container(
+        self, _run_cephadm, cephadm_module: CephadmOrchestrator
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        spec = CustomContainerSpec(
+            service_id='tsettinu',
+            image='quay.io/foobar/barbaz:latest',
+            entrypoint='/usr/local/bin/blat.sh',
+            ports=[9090],
+        )
+
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    "container.tsettinu.test",
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps(
+                        {
+                            "fsid": "fsid",
+                            "name": 'container.tsettinu.test',
+                            "image": 'quay.io/foobar/barbaz:latest',
+                            "deploy_arguments": [],
+                            "params": {
+                                'tcp_ports': [9090],
+                            },
+                            "meta": {
+                                'service_name': 'container.tsettinu',
+                                'ports': [],
+                                'ip': None,
+                                'deployed_by': [],
+                                'rank': None,
+                                'rank_generation': None,
+                                'extra_container_args': None,
+                                'extra_entrypoint_args': None,
+                            },
+                            "config_blobs": {
+                                "image": "quay.io/foobar/barbaz:latest",
+                                "entrypoint": "/usr/local/bin/blat.sh",
+                                "args": [],
+                                "envs": [],
+                                "volume_mounts": {},
+                                "privileged": False,
+                                "ports": [9090],
+                                "dirs": [],
+                                "files": {},
+                            },
+                        }
+                    ),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_deploy_custom_container_with_init_ctrs(
+        self, _run_cephadm, cephadm_module: CephadmOrchestrator
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+
+        spec = CustomContainerSpec(
+            service_id='tsettinu',
+            image='quay.io/foobar/barbaz:latest',
+            entrypoint='/usr/local/bin/blat.sh',
+            ports=[9090],
+            init_containers=[
+                {'entrypoint': '/usr/local/bin/prepare.sh'},
+                {
+                    'entrypoint': '/usr/local/bin/optimize.sh',
+                    'entrypoint_args': [
+                        '--timeout=5m',
+                        '--cores=8',
+                        {'argument': '--title=Alpha One'},
+                    ],
+                },
+            ],
+        )
+
+        expected = {
+            'fsid': 'fsid',
+            'name': 'container.tsettinu.test',
+            'image': 'quay.io/foobar/barbaz:latest',
+            'deploy_arguments': [],
+            'params': {
+                'tcp_ports': [9090],
+                'init_containers': [
+                    {'entrypoint': '/usr/local/bin/prepare.sh'},
+                    {
+                        'entrypoint': '/usr/local/bin/optimize.sh',
+                        'entrypoint_args': [
+                            '--timeout=5m',
+                            '--cores=8',
+                            '--title=Alpha One',
+                        ],
+                    },
+                ],
+            },
+            'meta': {
+                'service_name': 'container.tsettinu',
+                'ports': [],
+                'ip': None,
+                'deployed_by': [],
+                'rank': None,
+                'rank_generation': None,
+                'extra_container_args': None,
+                'extra_entrypoint_args': None,
+                'init_containers': [
+                    {'entrypoint': '/usr/local/bin/prepare.sh'},
+                    {
+                        'entrypoint': '/usr/local/bin/optimize.sh',
+                        'entrypoint_args': [
+                            '--timeout=5m',
+                            '--cores=8',
+                            {'argument': '--title=Alpha One', 'split': False},
+                        ],
+                    },
+                ],
+            },
+            'config_blobs': {
+                'image': 'quay.io/foobar/barbaz:latest',
+                'entrypoint': '/usr/local/bin/blat.sh',
+                'args': [],
+                'envs': [],
+                'volume_mounts': {},
+                'privileged': False,
+                'ports': [9090],
+                'dirs': [],
+                'files': {},
+            },
+        }
+        with with_host(cephadm_module, 'test'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'test',
+                    'container.tsettinu.test',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps(expected),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+
+_SAMBA_METRICS_IMAGE = 'quay.io/samba.org/samba-metrics:devbuilds-centos-amd64'
+
+
+class TestSMB:
+    @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_deploy_smb(
+        self, _run_cephadm, _get_uname, cephadm_module: CephadmOrchestrator
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        _get_uname.return_value = 'tango.briskly'
+
+        spec = SMBSpec(
+            cluster_id='foxtrot',
+            config_uri='rados://.smb/foxtrot/config.json',
+        )
+
+        expected = {
+            'fsid': 'fsid',
+            'name': 'smb.tango.briskly',
+            'image': '',
+            'deploy_arguments': [],
+            'params': {
+                "tcp_ports": [445, 9922]
+            },
+            'meta': {
+                'service_name': 'smb',
+                'ports': [445, 9922],
+                'ip': None,
+                'deployed_by': [],
+                'rank': None,
+                'rank_generation': None,
+                'extra_container_args': None,
+                'extra_entrypoint_args': None,
+            },
+            'config_blobs': {
+                'cluster_id': 'foxtrot',
+                'features': [],
+                'config_uri': 'rados://.smb/foxtrot/config.json',
+                'config': '',
+                'keyring': '[client.smb.config.tango.briskly]\nkey = None\n',
+                'config_auth_entity': 'client.smb.config.tango.briskly',
+                'metrics_image': _SAMBA_METRICS_IMAGE,
+                'service_ports': {
+                    'smb': 445,
+                    'smbmetrics': 9922,
+                    'ctdb': 4379,
+                    'remote-control': 54445,
+                },
+            },
+        }
+        with with_host(cephadm_module, 'hostx'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'hostx',
+                    'smb.tango.briskly',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps(expected),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_deploy_smb_join_dns(
+        self, _run_cephadm, _get_uname, cephadm_module: CephadmOrchestrator
+    ):
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        _get_uname.return_value = 'tango.briskly'
+
+        spec = SMBSpec(
+            cluster_id='foxtrot',
+            features=['domain'],
+            config_uri='rados://.smb/foxtrot/config2.json',
+            join_sources=[
+                'rados://.smb/foxtrot/join1.json',
+                'rados:mon-config-key:smb/config/foxtrot/join2.json',
+            ],
+            custom_dns=['10.8.88.103'],
+            include_ceph_users=[
+                'client.smb.fs.cephfs.share1',
+                'client.smb.fs.cephfs.share2',
+                'client.smb.fs.fs2.share3',
+            ],
+        )
+
+        expected = {
+            'fsid': 'fsid',
+            'name': 'smb.tango.briskly',
+            'image': '',
+            'deploy_arguments': [],
+            'params': {
+                'tcp_ports': [445, 9922]
+            },
+            'meta': {
+                'service_name': 'smb',
+                'ports': [445, 9922],
+                'ip': None,
+                'deployed_by': [],
+                'rank': None,
+                'rank_generation': None,
+                'extra_container_args': None,
+                'extra_entrypoint_args': None,
+            },
+            'config_blobs': {
+                'cluster_id': 'foxtrot',
+                'features': ['domain'],
+                'config_uri': 'rados://.smb/foxtrot/config2.json',
+                'join_sources': [
+                    'rados://.smb/foxtrot/join1.json',
+                    'rados:mon-config-key:smb/config/foxtrot/join2.json',
+                ],
+                'custom_dns': ['10.8.88.103'],
+                'config': '',
+                'keyring': (
+                    '[client.smb.config.tango.briskly]\nkey = None\n\n'
+                    '[client.smb.fs.cephfs.share1]\nkey = None\n\n'
+                    '[client.smb.fs.cephfs.share2]\nkey = None\n\n'
+                    '[client.smb.fs.fs2.share3]\nkey = None\n'
+                ),
+                'config_auth_entity': 'client.smb.config.tango.briskly',
+                'metrics_image': _SAMBA_METRICS_IMAGE,
+                'service_ports': {
+                    'smb': 445,
+                    'smbmetrics': 9922,
+                    'ctdb': 4379,
+                    'remote-control': 54445,
+                },
+            },
+        }
+        with with_host(cephadm_module, 'hostx'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'hostx',
+                    'smb.tango.briskly',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps(expected),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+
+class TestMgmtGateway:
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_discovery_endpoints")
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
+           lambda instance, svc_spec, dspec, label, ip: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
+    def test_mgmt_gateway_config_no_auth(self,
+                                         get_service_discovery_endpoints_mock: List[str],
+                                         get_service_endpoints_mock: List[str],
+                                         _run_cephadm,
+                                         cephadm_module: CephadmOrchestrator):
+
+        def get_services_endpoints(name):
+            if name == 'prometheus':
+                return ["192.168.100.100:9095", "192.168.100.101:9095"]
+            elif name == 'grafana':
+                return ["ceph-node-2:3000", "ceph-node-2:3000"]
+            elif name == 'alertmanager':
+                return ["192.168.100.100:9093", "192.168.100.102:9093"]
+            return []
+
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        get_service_endpoints_mock.side_effect = get_services_endpoints
+        get_service_discovery_endpoints_mock.side_effect = lambda: ["ceph-node-0:8765", "ceph-node-2:8765"]
+
+        server_port = 5555
+        spec = MgmtGatewaySpec(port=server_port,
+                               ssl_cert=ceph_generated_cert,
+                               ssl_key=ceph_generated_key)
+
+        expected = {
+            "fsid": "fsid",
+            "name": "mgmt-gateway.ceph-node",
+            "image": "",
+            "deploy_arguments": [],
+            "params": {"tcp_ports": [server_port]},
+            "meta": {
+                "service_name": "mgmt-gateway",
+                "ports": [server_port],
+                "ip": None,
+                "deployed_by": [],
+                "rank": None,
+                "rank_generation": None,
+                "extra_container_args": None,
+                "extra_entrypoint_args": None
+            },
+            "config_blobs": {
+                "files": {
+                    "nginx.conf": dedent("""
+                                         # This file is generated by cephadm.
+                                         worker_rlimit_nofile 8192;
+
+                                         events {
+                                             worker_connections 4096;
+                                         }
+
+                                         http {
+
+                                             #access_log /dev/stdout;
+                                             error_log /dev/stderr warn;
+                                             client_header_buffer_size 32K;
+                                             large_client_header_buffers 4 32k;
+                                             proxy_busy_buffers_size 512k;
+                                             proxy_buffers 4 512k;
+                                             proxy_buffer_size 256K;
+                                             proxy_headers_hash_max_size 1024;
+                                             proxy_headers_hash_bucket_size 128;
+
+
+                                             upstream service_discovery_servers {
+                                              server ceph-node-0:8765;
+                                              server ceph-node-2:8765;
+                                             }
+
+                                             upstream dashboard_servers {
+                                              server ceph-node-2:8443;
+                                              server ceph-node-2:8443;
+                                             }
+
+                                             upstream grafana_servers {
+                                              server ceph-node-2:3000;
+                                              server ceph-node-2:3000;
+                                             }
+
+                                             upstream prometheus_servers {
+                                              ip_hash;
+                                              server 192.168.100.100:9095;
+                                              server 192.168.100.101:9095;
+                                             }
+
+                                             upstream alertmanager_servers {
+                                              server 192.168.100.100:9093;
+                                              server 192.168.100.102:9093;
+                                             }
+
+                                             include /etc/nginx_external_server.conf;
+                                             include /etc/nginx_internal_server.conf;
+                                         }"""),
+                    "nginx_external_server.conf": dedent("""
+                                             server {
+                                                 listen                    5555 ssl;
+                                                 listen                    [::]:5555 ssl;
+                                                 ssl_certificate            /etc/nginx/ssl/nginx.crt;
+                                                 ssl_certificate_key /etc/nginx/ssl/nginx.key;
+                                                 ssl_protocols            TLSv1.3;
+                                                 # from:  https://ssl-config.mozilla.org/#server=nginx
+                                                 ssl_ciphers              ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+
+                                                 # Only return Nginx in server header, no extra info will be provided
+                                                 server_tokens             off;
+
+                                                 # Perfect Forward Secrecy(PFS) is frequently compromised without this
+                                                 ssl_prefer_server_ciphers on;
+
+                                                 # Enable SSL session caching for improved performance
+                                                 ssl_session_tickets       off;
+                                                 ssl_session_timeout       1d;
+                                                 ssl_session_cache         shared:SSL:10m;
+
+                                                 # OCSP stapling
+                                                 ssl_stapling              on;
+                                                 ssl_stapling_verify       on;
+                                                 resolver_timeout 5s;
+
+                                                 # Security headers
+                                                 ## X-Content-Type-Options: avoid MIME type sniffing
+                                                 add_header X-Content-Type-Options nosniff;
+                                                 ## Strict Transport Security (HSTS): Yes
+                                                 add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+                                                 ## Enables the Cross-site scripting (XSS) filter in browsers.
+                                                 add_header X-XSS-Protection "1; mode=block";
+                                                 ## Content-Security-Policy (CSP): FIXME
+                                                 # add_header Content-Security-Policy "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'; frame-ancestors 'self';";
+
+
+                                                 location / {
+                                                     proxy_pass https://dashboard_servers;
+                                                     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+                                                 }
+
+                                                 location /grafana {
+                                                     proxy_pass https://grafana_servers;
+                                                     # clear any Authorization header as Prometheus and Alertmanager are using basic-auth browser
+                                                     # will send this header if Grafana is running on the same node as one of those services
+                                                     proxy_set_header Authorization "";
+                                                     proxy_buffering off;
+                                                 }
+
+                                                 location /prometheus {
+                                                     proxy_pass https://prometheus_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                 }
+
+                                                 location /alertmanager {
+                                                     proxy_pass https://alertmanager_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                 }
+                                             }"""),
+                    "nginx_internal_server.conf": dedent("""
+                                             server {
+                                                 ssl_client_certificate /etc/nginx/ssl/ca.crt;
+                                                 ssl_verify_client on;
+
+                                                 listen              29443 ssl;
+                                                 listen              [::]:29443 ssl;
+                                                 ssl_certificate     /etc/nginx/ssl/nginx_internal.crt;
+                                                 ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                 ssl_protocols       TLSv1.3;
+                                                 # from:  https://ssl-config.mozilla.org/#server=nginx
+                                                 ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+                                                 ssl_prefer_server_ciphers on;
+
+                                                 location /internal/sd {
+                                                     rewrite ^/internal/(.*) /$1 break;
+                                                     proxy_pass https://service_discovery_servers;
+                                                     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+                                                 }
+
+                                                 location /internal/dashboard {
+                                                     rewrite ^/internal/dashboard/(.*) /$1 break;
+                                                     proxy_pass https://dashboard_servers;
+                                                     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+                                                 }
+
+                                                 location /internal/grafana {
+                                                     rewrite ^/internal/grafana/(.*) /$1 break;
+                                                     proxy_pass https://grafana_servers;
+                                                 }
+
+                                                 location /internal/prometheus {
+                                                     rewrite ^/internal/prometheus/(.*) /prometheus/$1 break;
+                                                     proxy_pass https://prometheus_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                 }
+
+                                                 location /internal/alertmanager {
+                                                     rewrite ^/internal/alertmanager/(.*) /alertmanager/$1 break;
+                                                     proxy_pass https://alertmanager_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                 }
+                                             }"""),
+                    "nginx_internal.crt": f"{ceph_generated_cert}",
+                    "nginx_internal.key": f"{ceph_generated_key}",
+                    "ca.crt": f"{cephadm_root_ca}",
+                    "nginx.crt": f"{ceph_generated_cert}",
+                    "nginx.key": f"{ceph_generated_key}",
+                }
+            }
+        }
+
+        with with_host(cephadm_module, 'ceph-node'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'ceph-node',
+                    'mgmt-gateway.ceph-node',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps(expected),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_discovery_endpoints")
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
+           lambda instance, svc_spec, dspec, label, ip: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
+    def test_mgmt_gateway_config_with_auth(self,
+                                           get_service_discovery_endpoints_mock: List[str],
+                                           get_service_endpoints_mock: List[str],
+                                           _run_cephadm,
+                                           cephadm_module: CephadmOrchestrator):
+
+        def get_services_endpoints(name):
+            if name == 'prometheus':
+                return ["192.168.100.100:9095", "192.168.100.101:9095"]
+            elif name == 'grafana':
+                return ["ceph-node-2:3000", "ceph-node-2:3000"]
+            elif name == 'alertmanager':
+                return ["192.168.100.100:9093", "192.168.100.102:9093"]
+            elif name == 'oauth2-proxy':
+                return ["192.168.100.101:4180", "192.168.100.102:4180"]
+            return []
+
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        get_service_endpoints_mock.side_effect = get_services_endpoints
+        get_service_discovery_endpoints_mock.side_effect = lambda: ["ceph-node-0:8765", "ceph-node-2:8765"]
+
+        server_port = 5555
+        spec = MgmtGatewaySpec(port=server_port,
+                               ssl_cert=ceph_generated_cert,
+                               ssl_key=ceph_generated_key,
+                               enable_auth=True)
+
+        expected = {
+            "fsid": "fsid",
+            "name": "mgmt-gateway.ceph-node",
+            "image": "",
+            "deploy_arguments": [],
+            "params": {"tcp_ports": [server_port]},
+            "meta": {
+                "service_name": "mgmt-gateway",
+                "ports": [server_port],
+                "ip": None,
+                "deployed_by": [],
+                "rank": None,
+                "rank_generation": None,
+                "extra_container_args": None,
+                "extra_entrypoint_args": None
+            },
+            "config_blobs": {
+                "files": {
+                    "nginx.conf": dedent("""
+                                         # This file is generated by cephadm.
+                                         worker_rlimit_nofile 8192;
+
+                                         events {
+                                             worker_connections 4096;
+                                         }
+
+                                         http {
+
+                                             #access_log /dev/stdout;
+                                             error_log /dev/stderr warn;
+                                             client_header_buffer_size 32K;
+                                             large_client_header_buffers 4 32k;
+                                             proxy_busy_buffers_size 512k;
+                                             proxy_buffers 4 512k;
+                                             proxy_buffer_size 256K;
+                                             proxy_headers_hash_max_size 1024;
+                                             proxy_headers_hash_bucket_size 128;
+
+                                             upstream oauth2_proxy_servers {
+                                              server 192.168.100.101:4180;
+                                              server 192.168.100.102:4180;
+                                             }
+
+                                             upstream service_discovery_servers {
+                                              server ceph-node-0:8765;
+                                              server ceph-node-2:8765;
+                                             }
+
+                                             upstream dashboard_servers {
+                                              server ceph-node-2:8443;
+                                              server ceph-node-2:8443;
+                                             }
+
+                                             upstream grafana_servers {
+                                              server ceph-node-2:3000;
+                                              server ceph-node-2:3000;
+                                             }
+
+                                             upstream prometheus_servers {
+                                              ip_hash;
+                                              server 192.168.100.100:9095;
+                                              server 192.168.100.101:9095;
+                                             }
+
+                                             upstream alertmanager_servers {
+                                              server 192.168.100.100:9093;
+                                              server 192.168.100.102:9093;
+                                             }
+
+                                             include /etc/nginx_external_server.conf;
+                                             include /etc/nginx_internal_server.conf;
+                                         }"""),
+                    "nginx_external_server.conf": dedent("""
+                                             server {
+                                                 listen                    5555 ssl;
+                                                 listen                    [::]:5555 ssl;
+                                                 ssl_certificate            /etc/nginx/ssl/nginx.crt;
+                                                 ssl_certificate_key /etc/nginx/ssl/nginx.key;
+                                                 ssl_protocols            TLSv1.3;
+                                                 # from:  https://ssl-config.mozilla.org/#server=nginx
+                                                 ssl_ciphers              ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+
+                                                 # Only return Nginx in server header, no extra info will be provided
+                                                 server_tokens             off;
+
+                                                 # Perfect Forward Secrecy(PFS) is frequently compromised without this
+                                                 ssl_prefer_server_ciphers on;
+
+                                                 # Enable SSL session caching for improved performance
+                                                 ssl_session_tickets       off;
+                                                 ssl_session_timeout       1d;
+                                                 ssl_session_cache         shared:SSL:10m;
+
+                                                 # OCSP stapling
+                                                 ssl_stapling              on;
+                                                 ssl_stapling_verify       on;
+                                                 resolver_timeout 5s;
+
+                                                 # Security headers
+                                                 ## X-Content-Type-Options: avoid MIME type sniffing
+                                                 add_header X-Content-Type-Options nosniff;
+                                                 ## Strict Transport Security (HSTS): Yes
+                                                 add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+                                                 ## Enables the Cross-site scripting (XSS) filter in browsers.
+                                                 add_header X-XSS-Protection "1; mode=block";
+                                                 ## Content-Security-Policy (CSP): FIXME
+                                                 # add_header Content-Security-Policy "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'; frame-ancestors 'self';";
+
+                                                 location /oauth2/ {
+                                                     proxy_pass https://oauth2_proxy_servers;
+                                                     proxy_set_header Host $host;
+                                                     proxy_set_header X-Real-IP $remote_addr;
+                                                     proxy_set_header X-Scheme $scheme;
+                                                     # Check for original-uri header
+                                                     proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
+                                                 }
+
+                                                 location = /oauth2/auth {
+                                                     internal;
+                                                     proxy_pass https://oauth2_proxy_servers;
+                                                     proxy_set_header Host $host;
+                                                     proxy_set_header X-Real-IP $remote_addr;
+                                                     proxy_set_header X-Scheme $scheme;
+                                                     # nginx auth_request includes headers but not body
+                                                     proxy_set_header Content-Length "";
+                                                     proxy_pass_request_body off;
+                                                 }
+
+                                                 location / {
+                                                     proxy_pass https://dashboard_servers;
+                                                     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+                                                     auth_request /oauth2/auth;
+                                                     error_page 401 = /oauth2/sign_in;
+
+                                                     auth_request_set $email $upstream_http_x_auth_request_email;
+                                                     proxy_set_header X-Email $email;
+
+                                                     auth_request_set $groups $upstream_http_x_auth_request_groups;
+                                                     proxy_set_header X-User-Groups $groups;
+
+                                                     auth_request_set $user $upstream_http_x_auth_request_user;
+                                                     proxy_set_header X-User $user;
+
+                                                     auth_request_set $token $upstream_http_x_auth_request_access_token;
+                                                     proxy_set_header X-Access-Token $token;
+
+                                                     auth_request_set $auth_cookie $upstream_http_set_cookie;
+                                                     add_header Set-Cookie $auth_cookie;
+
+                                                     proxy_set_header Host $host;
+                                                     proxy_set_header X-Real-IP $remote_addr;
+                                                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                                                     proxy_set_header X-Forwarded-Host $host:80;
+                                                     proxy_set_header X-Forwarded-Port 80;
+                                                     proxy_set_header X-Forwarded-Server $host;
+                                                     proxy_set_header X-Forwarded-Groups $groups;
+
+                                                     proxy_http_version 1.1;
+
+                                                     proxy_set_header X-Forwarded-Proto "https";
+                                                     proxy_ssl_verify off;
+                                                 }
+
+                                                 location /grafana {
+                                                     proxy_pass https://grafana_servers;
+                                                     # clear any Authorization header as Prometheus and Alertmanager are using basic-auth browser
+                                                     # will send this header if Grafana is running on the same node as one of those services
+                                                     proxy_set_header Authorization "";
+                                                     proxy_buffering off;
+                                                     auth_request /oauth2/auth;
+                                                     error_page 401 = /oauth2/sign_in;
+
+                                                     proxy_set_header X-Original-URI "/";
+
+                                                     auth_request_set $user $upstream_http_x_auth_request_user;
+                                                     auth_request_set $email $upstream_http_x_auth_request_email;
+                                                     proxy_set_header X-WEBAUTH-USER $user;
+                                                     proxy_set_header X-WEBAUTH-EMAIL $email;
+
+                                                     # Pass role header to Grafana
+                                                     proxy_set_header X-WEBAUTH-ROLE $http_x_auth_request_role;
+
+                                                     proxy_set_header Host $host;
+                                                     proxy_set_header X-Real-IP $remote_addr;
+                                                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                                                     proxy_set_header X-Forwarded-Proto $scheme;
+
+                                                     auth_request_set $auth_cookie $upstream_http_set_cookie;
+                                                     add_header Set-Cookie $auth_cookie;
+
+                                                     proxy_set_header X-Forwarded-Proto $scheme;
+                                                 }
+
+                                                 location /prometheus {
+                                                     proxy_pass https://prometheus_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                     auth_request /oauth2/auth;
+                                                     error_page 401 = /oauth2/sign_in;
+
+                                                     auth_request_set $user $upstream_http_x_auth_request_user;
+                                                     auth_request_set $email $upstream_http_x_auth_request_email;
+                                                     proxy_set_header X-User $user;
+                                                     proxy_set_header X-Email $email;
+
+                                                     auth_request_set $auth_cookie $upstream_http_set_cookie;
+                                                     add_header Set-Cookie $auth_cookie;
+                                                 }
+
+                                                 location /alertmanager {
+                                                     proxy_pass https://alertmanager_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                     auth_request /oauth2/auth;
+                                                     error_page 401 = /oauth2/sign_in;
+
+                                                     auth_request_set $user $upstream_http_x_auth_request_user;
+                                                     auth_request_set $email $upstream_http_x_auth_request_email;
+                                                     proxy_set_header X-User $user;
+                                                     proxy_set_header X-Email $email;
+
+                                                     auth_request_set $auth_cookie $upstream_http_set_cookie;
+                                                     add_header Set-Cookie $auth_cookie;
+                                                 }
+                                             }"""),
+                    "nginx_internal_server.conf": dedent("""
+                                             server {
+                                                 ssl_client_certificate /etc/nginx/ssl/ca.crt;
+                                                 ssl_verify_client on;
+
+                                                 listen              29443 ssl;
+                                                 listen              [::]:29443 ssl;
+                                                 ssl_certificate     /etc/nginx/ssl/nginx_internal.crt;
+                                                 ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                 ssl_protocols       TLSv1.3;
+                                                 # from:  https://ssl-config.mozilla.org/#server=nginx
+                                                 ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+                                                 ssl_prefer_server_ciphers on;
+
+                                                 location /internal/sd {
+                                                     rewrite ^/internal/(.*) /$1 break;
+                                                     proxy_pass https://service_discovery_servers;
+                                                     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+                                                 }
+
+                                                 location /internal/dashboard {
+                                                     rewrite ^/internal/dashboard/(.*) /$1 break;
+                                                     proxy_pass https://dashboard_servers;
+                                                     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+                                                 }
+
+                                                 location /internal/grafana {
+                                                     rewrite ^/internal/grafana/(.*) /$1 break;
+                                                     proxy_pass https://grafana_servers;
+                                                 }
+
+                                                 location /internal/prometheus {
+                                                     rewrite ^/internal/prometheus/(.*) /prometheus/$1 break;
+                                                     proxy_pass https://prometheus_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                 }
+
+                                                 location /internal/alertmanager {
+                                                     rewrite ^/internal/alertmanager/(.*) /alertmanager/$1 break;
+                                                     proxy_pass https://alertmanager_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
+                                                 }
+                                             }"""),
+                    "nginx_internal.crt": f"{ceph_generated_cert}",
+                    "nginx_internal.key": f"{ceph_generated_key}",
+                    "ca.crt": f"{cephadm_root_ca}",
+                    "nginx.crt": f"{ceph_generated_cert}",
+                    "nginx.key": f"{ceph_generated_key}",
+                }
+            }
+        }
+
+        with with_host(cephadm_module, 'ceph-node'):
+            with with_service(cephadm_module, spec):
+                _run_cephadm.assert_called_with(
+                    'ceph-node',
+                    'mgmt-gateway.ceph-node',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps(expected),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_discovery_endpoints")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label")
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints",
+           lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
+    def test_mgmt_gateway_internal_cert_san_includes_vip(
+        self,
+        get_self_signed_mock,
+        get_service_discovery_endpoints_mock,
+        get_service_endpoints_mock,
+        _run_cephadm,
+        cephadm_module: CephadmOrchestrator,
+    ):
+        vip = "10.0.0.200"
+
+        def get_services_endpoints(name):
+            if name == 'prometheus':
+                return ["192.168.100.100:9095", "192.168.100.101:9095"]
+            if name == 'grafana':
+                return ["ceph-node-2:3000", "ceph-node-2:3000"]
+            if name == 'alertmanager':
+                return ["192.168.100.100:9093", "192.168.100.102:9093"]
+            if name == 'oauth2-proxy':
+                return []
+            return []
+
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        get_service_endpoints_mock.side_effect = get_services_endpoints
+        get_service_discovery_endpoints_mock.return_value = ["ceph-node-0:8765", "ceph-node-2:8765"]
+        get_self_signed_mock.return_value = TLSCredentials(ceph_generated_cert, ceph_generated_key)
+
+        server_port = 5555
+        spec = MgmtGatewaySpec(
+            port=server_port,
+            virtual_ip=vip,  # HA mode
+            ssl_cert=ceph_generated_cert,
+            ssl_key=ceph_generated_key,
+        )
+
+        with with_host(cephadm_module, 'ceph-node'):
+            with with_service(cephadm_module, spec):
+                # Ensure VIP was used when minting the internal cert (so it goes into SANs)
+                # get_self_signed_certificates_with_label(svc_spec, daemon_spec, label, ip)
+                args, _ = get_self_signed_mock.call_args
+                assert args[2] == 'internal'
+                assert args[3] == vip
+                deployed = json.loads(_run_cephadm.call_args.kwargs['stdin'])
+                assert deployed['config_blobs']['files']['nginx_internal.crt'] == ceph_generated_cert
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
+           lambda instance, svc_spec, dspec, label, ip: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
+    def test_oauth2_proxy_service(self, get_service_endpoints_mock, _run_cephadm, cephadm_module):
+        self.oauth2_proxy_service_common(get_service_endpoints_mock, _run_cephadm, cephadm_module, virtual_ip=None)
+
+    @patch("cephadm.serve.CephadmServe._run_cephadm")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
+    @patch("cephadm.services.cephadmservice.CephadmService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.oauth2_proxy.OAuth2ProxyService.get_certificates",
+           lambda instance, dspec, ips=None: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_self_signed_certificates_with_label",
+           lambda instance, svc_spec, dspec, label, ip: TLSCredentials(ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
+    @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
+    def test_oauth2_proxy_service_with_ha(self, get_service_endpoints_mock, _run_cephadm, cephadm_module):
+        self.oauth2_proxy_service_common(get_service_endpoints_mock, _run_cephadm, cephadm_module, virtual_ip="192.168.100.200")
+
+    def oauth2_proxy_service_common(self, get_service_endpoints_mock, _run_cephadm, cephadm_module: CephadmOrchestrator, virtual_ip=None):
+        def get_services_endpoints(name):
+            if name == 'prometheus':
+                return ["192.168.100.100:9095", "192.168.100.101:9095"]
+            elif name == 'grafana':
+                return ["ceph-node-2:3000", "ceph-node-2:3000"]
+            elif name == 'alertmanager':
+                return ["192.168.100.100:9093", "192.168.100.102:9093"]
+            return []
+
+        _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+        get_service_endpoints_mock.side_effect = get_services_endpoints
+
+        server_port = 5555
+        mgmt_gw_spec = MgmtGatewaySpec(port=server_port,
+                                       ssl_cert=ceph_generated_cert,
+                                       ssl_key=ceph_generated_key,
+                                       enable_auth=True,
+                                       virtual_ip=virtual_ip)
+
+        allowed_domain = '192.168.100.1:8080'
+        oauth2_spec = OAuth2ProxySpec(provider_display_name='my_idp_provider',
+                                      client_id='my_client_id',
+                                      client_secret='my_client_secret',
+                                      oidc_issuer_url='http://192.168.10.10:8888/dex',
+                                      cookie_secret='kbAEM9opAmuHskQvt0AW8oeJRaOM2BYy5Loba0kZ0SQ=',
+                                      ssl_cert=ceph_generated_cert,
+                                      ssl_key=ceph_generated_key,
+                                      allowlist_domains=[allowed_domain])
+
+        whitelist_domains = f"{allowed_domain},1::4,ceph-node" if virtual_ip is None else f"{allowed_domain},{virtual_ip},1::4,ceph-node"
+        redirect_url = f"https://{virtual_ip if virtual_ip else 'host_fqdn'}:5555/oauth2/callback"
+        expected = {
+            "fsid": "fsid",
+            "name": "oauth2-proxy.ceph-node",
+            "image": "",
+            "deploy_arguments": [],
+            "params": {"tcp_ports": [4180]},
+            "meta": {
+                "service_name": "oauth2-proxy",
+                "ports": [4180],
+                "ip": None,
+                "deployed_by": [],
+                "rank": None,
+                "rank_generation": None,
+                "extra_container_args": None,
+                "extra_entrypoint_args": None
+            },
+            "config_blobs": {
+                "files": {
+                    "oauth2-proxy.conf": dedent(f"""
+                                         # Listen on port 4180 for incoming HTTP traffic.
+                                         https_address= "0.0.0.0:4180"
+
+                                         skip_provider_button= true
+                                         skip_jwt_bearer_tokens= true
+
+                                         # OIDC provider configuration.
+                                         provider= "oidc"
+                                         provider_display_name= "my_idp_provider"
+                                         client_id= "my_client_id"
+                                         client_secret= "my_client_secret"
+                                         oidc_issuer_url= "http://192.168.10.10:8888/dex"
+                                         redirect_url= "{redirect_url}"
+
+                                         ssl_insecure_skip_verify=true
+
+                                         # following configuration is needed to avoid getting Forbidden
+                                         # when using chrome like browsers as they handle 3rd party cookies
+                                         # more strictly than Firefox
+                                         cookie_samesite= "none"
+                                         cookie_secure= true
+                                         cookie_expire= "5h"
+                                         cookie_refresh= "2h"
+
+                                         pass_access_token= true
+                                         pass_authorization_header= true
+                                         pass_basic_auth= true
+                                         pass_user_headers= true
+                                         set_xauthrequest= true
+
+                                         # Secret value for encrypting cookies.
+                                         cookie_secret= "kbAEM9opAmuHskQvt0AW8oeJRaOM2BYy5Loba0kZ0SQ="
+                                         email_domains= "*"
+                                         whitelist_domains= "{whitelist_domains}\""""),
+                    "oauth2-proxy.crt": f"{ceph_generated_cert}",
+                    "oauth2-proxy.key": f"{ceph_generated_key}",
+                }
+            }
+        }
+
+        with with_host(cephadm_module, 'ceph-node'):
+            with with_service(cephadm_module, mgmt_gw_spec) as _, with_service(cephadm_module, oauth2_spec):
+                _run_cephadm.assert_called_with(
+                    'ceph-node',
+                    'oauth2-proxy.ceph-node',
+                    ['_orch', 'deploy'],
+                    [],
+                    stdin=json.dumps(expected),
+                    error_ok=True,
+                    use_current_daemon_image=False,
+                )

--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -16,7 +16,7 @@ from ..services.exception import DashboardException, handle_cephfs_error, \
     serialize_dashboard_exception
 from ..tools import str_to_bool
 from . import APIDoc, APIRouter, BaseController, Endpoint, EndpointDoc, \
-    ReadPermission, RESTController, Task, UIRouter
+    ReadPermission, RESTController, Task, UIRouter, UpdatePermission
 from ._version import APIVersion
 
 logger = logging.getLogger(__name__)
@@ -94,6 +94,67 @@ class NFSGaneshaCluster(RESTController):
                 {"name": key, **value} for key, value in mgr.remote('nfs', 'cluster_info').items()
             ]
         return mgr.remote('nfs', 'cluster_ls')
+
+    @Endpoint(method='GET', path='/qos')
+    @EndpointDoc("Get the cluster QoS configuration for bandwidth and iops")
+    @ReadPermission
+    def qos(self, cluster_id: str):
+        cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
+        return cluster_obj.get_cluster_qos(cluster_id, ret_bw_in_bytes=True)
+
+    @Endpoint(method='PATCH', path='/qos/bw')
+    @EndpointDoc("Enable/disable QoS configuration for bandwidth")
+    @UpdatePermission
+    def toggle_cluster_qos_bandwidth(self,
+                                     cluster_id: str,
+                                     qos_type: str = '',
+                                     max_export_write_bw: Optional[int] = None,
+                                     max_export_read_bw: Optional[int] = None,
+                                     max_client_write_bw: Optional[int] = None,
+                                     max_client_read_bw: Optional[int] = None,
+                                     max_export_combined_bw: Optional[int] = None,
+                                     max_client_combined_bw: Optional[int] = None,
+                                     disable_qos: bool = False):
+
+        if disable_qos:
+            cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
+            return cluster_obj.disable_cluster_qos_bw(cluster_id)
+        qos_obj = {}
+        if max_export_write_bw:
+            qos_obj['max_export_write_bw'] = str(max_export_write_bw)
+        if max_export_read_bw:
+            qos_obj['max_export_read_bw'] = str(max_export_read_bw)
+        if max_client_write_bw:
+            qos_obj['max_client_write_bw'] = str(max_client_write_bw)
+        if max_client_read_bw:
+            qos_obj['max_client_read_bw'] = str(max_client_read_bw)
+        if max_export_combined_bw:
+            qos_obj['max_export_combined_bw'] = str(max_export_combined_bw)
+        if max_client_combined_bw:
+            qos_obj['max_client_combined_bw'] = str(max_client_combined_bw)
+        # passing False for combined bandwidth, later can be changed to
+        # True when combined bandwidth functionality is added
+        return mgr.remote('nfs', 'enable_cluster_qos_bw', cluster_id, qos_type, False, **qos_obj)
+
+    @Endpoint(method='PATCH', path='/qos/ops')
+    @EndpointDoc("Enable/disable QoS configuration for NFS IOPs")
+    @UpdatePermission
+    def toggle_cluster_qos_operation(self,
+                                     cluster_id: str,
+                                     qos_type: str,
+                                     max_export_iops: int = 0,
+                                     max_client_iops: int = 0,
+                                     disable_Ops: bool = False):
+
+        if disable_Ops:
+            cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
+            return cluster_obj.disable_cluster_qos_ops(cluster_id)
+        obj = {}
+        if max_export_iops:
+            obj['max_export_iops'] = max_export_iops
+        if max_client_iops:
+            obj['max_client_iops'] = max_client_iops
+        return mgr.remote('nfs', 'enable_cluster_qos_ops', cluster_id, qos_type, **obj)
 
 
 @APIRouter('/nfs-ganesha/export', Scope.NFS_GANESHA)
@@ -225,6 +286,63 @@ class NFSGaneshaExports(RESTController):
                 msg=f'Export with id {export_id} not found.',
                 component='nfs')
         mgr.remote('nfs', 'export_rm', cluster_id, export['pseudo'])
+
+    @Endpoint(method='GET', path='/qos')
+    @EndpointDoc("Get the export QoS configuration for bandwidth and IOPS")
+    @ReadPermission
+    def qos(self, cluster_id: str, pseudo_path: str):
+        export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
+        return export_obj.get_export_qos(cluster_id, pseudo_path, ret_bw_in_bytes=True)
+
+    @Endpoint(method='PATCH', path='/qos')
+    @EndpointDoc("Enable/disable export QoS configuration for bandwidth")
+    @UpdatePermission
+    def toggle_export_qos_bandwidth(self,
+                                    cluster_id: str,
+                                    pseudo_path: str,
+                                    max_export_write_bw: Optional[int] = None,
+                                    max_export_read_bw: Optional[int] = None,
+                                    max_client_write_bw: Optional[int] = None,
+                                    max_client_read_bw: Optional[int] = None,
+                                    max_export_combined_bw: Optional[int] = None,
+                                    max_client_combined_bw: Optional[int] = None,
+                                    disable_qos: bool = False):
+        if disable_qos:
+            export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
+            return export_obj.disable_export_qos_bw(cluster_id, pseudo_path)
+        qos_obj = {}
+        if max_export_write_bw:
+            qos_obj['max_export_write_bw'] = str(max_export_write_bw)
+        if max_export_read_bw:
+            qos_obj['max_export_read_bw'] = str(max_export_read_bw)
+        if max_client_write_bw:
+            qos_obj['max_client_write_bw'] = str(max_client_write_bw)
+        if max_client_read_bw:
+            qos_obj['max_client_read_bw'] = str(max_client_read_bw)
+        if max_export_combined_bw:
+            qos_obj['max_export_combined_bw'] = str(max_export_combined_bw)
+        if max_client_combined_bw:
+            qos_obj['max_client_combined_bw'] = str(max_client_combined_bw)
+        return mgr.remote('nfs', 'enable_export_qos_bw', cluster_id, pseudo_path, False, **qos_obj)
+
+    @Endpoint(method='PATCH', path='/qos/ops')
+    @EndpointDoc("Enable/disable export QoS configuration for operations")
+    @UpdatePermission
+    def toggle_export_qos_operations(self,
+                                     cluster_id: str,
+                                     pseudo_path: str,
+                                     max_export_iops: Optional[int] = 0,
+                                     max_client_iops: Optional[int] = 0,
+                                     disable_qos_ops: bool = False):
+        if disable_qos_ops:
+            export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
+            return export_obj.disable_export_qos_ops(cluster_id, pseudo_path)
+        obj = {}
+        if max_export_iops:
+            obj['max_export_iops'] = max_export_iops
+        if max_client_iops:
+            obj['max_client_iops'] = max_client_iops
+        return mgr.remote('nfs', 'enable_export_qos_ops', cluster_id, pseudo_path, **obj)
 
 
 @UIRouter('/nfs-ganesha', Scope.NFS_GANESHA)

--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -144,9 +144,9 @@ class NFSGaneshaCluster(RESTController):
                                      qos_type: str,
                                      max_export_iops: int = 0,
                                      max_client_iops: int = 0,
-                                     disable_Ops: bool = False):
+                                     disable_ops: bool = False):
 
-        if disable_Ops:
+        if disable_ops:
             cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
             return cluster_obj.disable_cluster_qos_ops(cluster_id)
         obj = {}

--- a/src/pybind/mgr/dashboard/controllers/nfs.py
+++ b/src/pybind/mgr/dashboard/controllers/nfs.py
@@ -99,8 +99,7 @@ class NFSGaneshaCluster(RESTController):
     @EndpointDoc("Get the cluster QoS configuration for bandwidth and iops")
     @ReadPermission
     def qos(self, cluster_id: str):
-        cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
-        return cluster_obj.get_cluster_qos(cluster_id, ret_bw_in_bytes=True)
+        return mgr.remote('nfs', 'get_cluster_qos', cluster_id, True)
 
     @Endpoint(method='PATCH', path='/qos/bw')
     @EndpointDoc("Enable/disable QoS configuration for bandwidth")
@@ -117,8 +116,7 @@ class NFSGaneshaCluster(RESTController):
                                      disable_qos: bool = False):
 
         if disable_qos:
-            cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
-            return cluster_obj.disable_cluster_qos_bw(cluster_id)
+            return mgr.remote('nfs', 'disable_cluster_qos_bw', cluster_id)
         qos_obj = {}
         if max_export_write_bw:
             qos_obj['max_export_write_bw'] = str(max_export_write_bw)
@@ -147,8 +145,7 @@ class NFSGaneshaCluster(RESTController):
                                      disable_ops: bool = False):
 
         if disable_ops:
-            cluster_obj = mgr.remote('nfs', 'fetch_nfs_cluster_obj')
-            return cluster_obj.disable_cluster_qos_ops(cluster_id)
+            return mgr.remote('nfs', 'disable_cluster_qos_ops', cluster_id)
         obj = {}
         if max_export_iops:
             obj['max_export_iops'] = max_export_iops
@@ -291,8 +288,7 @@ class NFSGaneshaExports(RESTController):
     @EndpointDoc("Get the export QoS configuration for bandwidth and IOPS")
     @ReadPermission
     def qos(self, cluster_id: str, pseudo_path: str):
-        export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
-        return export_obj.get_export_qos(cluster_id, pseudo_path, ret_bw_in_bytes=True)
+        return mgr.remote('nfs', 'get_export_qos', cluster_id, pseudo_path, True)
 
     @Endpoint(method='PATCH', path='/qos')
     @EndpointDoc("Enable/disable export QoS configuration for bandwidth")
@@ -308,8 +304,7 @@ class NFSGaneshaExports(RESTController):
                                     max_client_combined_bw: Optional[int] = None,
                                     disable_qos: bool = False):
         if disable_qos:
-            export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
-            return export_obj.disable_export_qos_bw(cluster_id, pseudo_path)
+            return mgr.remote('nfs', 'disable_export_qos_bw', cluster_id, pseudo_path)
         qos_obj = {}
         if max_export_write_bw:
             qos_obj['max_export_write_bw'] = str(max_export_write_bw)
@@ -335,8 +330,7 @@ class NFSGaneshaExports(RESTController):
                                      max_client_iops: Optional[int] = 0,
                                      disable_qos_ops: bool = False):
         if disable_qos_ops:
-            export_obj = mgr.remote('nfs', 'fetch_nfs_export_obj')
-            return export_obj.disable_export_qos_ops(cluster_id, pseudo_path)
+            return mgr.remote('nfs', 'disable_export_qos_ops', cluster_id, pseudo_path)
         obj = {}
         if max_export_iops:
             obj['max_export_iops'] = max_export_iops

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -70,6 +70,7 @@ import { NotificationsPageComponent } from './core/navigation/notification-panel
 import { CephfsMirroringWizardComponent } from './ceph/cephfs/cephfs-mirroring-wizard/cephfs-mirroring-wizard.component';
 import { CephfsMirroringErrorComponent } from './ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component';
 import { OverviewComponent } from './ceph/overview/overview.component';
+import { NfsClusterFormComponent } from './ceph/nfs/nfs-cluster-form/nfs-cluster-form.component';
 
 @Injectable()
 export class PerformanceCounterBreadcrumbsResolver extends BreadcrumbsResolver {
@@ -505,12 +506,17 @@ const routes: Routes = [
             children: [
               { path: '', component: NfsClusterComponent },
               {
+                path: `${URLVerbs.EDIT}/:cluster_id`,
+                component: NfsClusterFormComponent,
+                data: { breadcrumbs: ActionLabels.EDIT }
+              },
+              {
                 path: `${URLVerbs.CREATE}/:fs_name/:subvolume_group`,
                 component: NfsFormComponent,
                 data: { breadcrumbs: ActionLabels.CREATE }
               },
               {
-                path: `${URLVerbs.CREATE}`,
+                path: `${URLVerbs.CREATE}/:cluster_id`,
                 component: NfsFormComponent,
                 data: { breadcrumbs: ActionLabels.CREATE }
               },

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -90,6 +90,7 @@ import { CephfsMirroringFsBreadcrumbResolver } from './ceph/cephfs/cephfs-mirror
 import { NotificationsPageComponent } from './core/navigation/notification-panel/notifications-page/notifications-page.component';
 import { CephfsMirroringErrorComponent } from './ceph/cephfs/cephfs-mirroring-error/cephfs-mirroring-error.component';
 import { OverviewComponent } from './ceph/overview/overview.component';
+import { NfsClusterFormComponent } from './ceph/nfs/nfs-cluster-form/nfs-cluster-form.component';
 
 @Injectable()
 export class PerformanceCounterBreadcrumbsResolver extends BreadcrumbsResolver {
@@ -633,12 +634,17 @@ const routes: Routes = [
             children: [
               { path: '', component: NfsClusterComponent },
               {
+                path: `${URLVerbs.EDIT}/:cluster_id`,
+                component: NfsClusterFormComponent,
+                data: { breadcrumbs: ActionLabels.EDIT }
+              },
+              {
                 path: `${URLVerbs.CREATE}/:fs_name/:subvolume_group`,
                 component: NfsFormComponent,
                 data: { breadcrumbs: ActionLabels.CREATE }
               },
               {
-                path: `${URLVerbs.CREATE}`,
+                path: `${URLVerbs.CREATE}/:cluster_id`,
                 component: NfsFormComponent,
                 data: { breadcrumbs: ActionLabels.CREATE }
               },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
@@ -1,12 +1,44 @@
+export interface NFSCluster {
+  name: string;
+  virtual_ip: number;
+  port: number;
+  backend: NFSBackend[];
+}
 export interface NFSBackend {
   hostname: string;
   ip: string;
   port: number;
 }
 
-export interface NFSCluster {
-  name: string;
-  virtual_ip: number;
-  port: number;
-  backend: NFSBackend[];
+export interface NFSBwIopConfig {
+  cluster_id?: string;
+  qos_type?: string;
+  max_export_write_bw?: number;
+  max_export_read_bw?: number;
+  max_client_write_bw?: number;
+  max_client_read_bw?: number;
+  max_export_combined_bw?: number;
+  max_client_combined_bw?: number;
+  disable_qos?: boolean;
+  enable_qos?: boolean;
+  enable_bw_control?: boolean;
+  combined_rw_bw_control?: boolean;
+  pseudo_path?: string;
+}
+
+export enum QOSType {
+  PerShare = 'PerShare',
+  PerClient = 'PerClient',
+  PerSharePerClient = 'PerShare_PerClient'
+}
+
+export interface QOSTypeItem {
+  key: string;
+  value: string;
+  help: string;
+}
+
+export interface bwTypeItem {
+  value: string;
+  help: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
@@ -24,6 +24,12 @@ export interface NFSBwIopConfig {
   enable_bw_control?: boolean;
   combined_rw_bw_control?: boolean;
   pseudo_path?: string;
+  max_export_iops?: number;
+  max_client_iops?: number;
+  disable_Ops?: boolean;
+  enable_ops?: boolean;
+  disable_qos_ops?: boolean;
+  enable_iops_control?: boolean;
 }
 
 export enum QOSType {
@@ -41,4 +47,14 @@ export interface QOSTypeItem {
 export interface bwTypeItem {
   value: string;
   help: string;
+}
+
+export enum NFS_TYPE {
+  export = 'export',
+  cluster = 'cluster'
+}
+
+export enum RateLimitType {
+  Bandwidth = 'bandwidth',
+  Iops = 'iops'
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/models/nfs-cluster-config.ts
@@ -26,7 +26,7 @@ export interface NFSBwIopConfig {
   pseudo_path?: string;
   max_export_iops?: number;
   max_client_iops?: number;
-  disable_Ops?: boolean;
+  disable_ops?: boolean;
   enable_ops?: boolean;
   disable_qos_ops?: boolean;
   enable_iops_control?: boolean;
@@ -44,7 +44,7 @@ export interface QOSTypeItem {
   help: string;
 }
 
-export interface bwTypeItem {
+export interface BwTypeItem {
   value: string;
   help: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-details/nfs-cluster-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-details/nfs-cluster-details.component.spec.ts
@@ -1,15 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NfsClusterDetailsComponent } from './nfs-cluster-details.component';
 import { configureTestBed } from '~/testing/unit-test-helper';
-import { SharedModule } from '~/app/shared/shared.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CommonModule } from '@angular/common';
 describe('NfsClusterDetailsComponent', () => {
   let component: NfsClusterDetailsComponent;
   let fixture: ComponentFixture<NfsClusterDetailsComponent>;
 
   configureTestBed({
     declarations: [NfsClusterDetailsComponent],
-    imports: [HttpClientTestingModule, SharedModule]
+    imports: [HttpClientTestingModule, CommonModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
@@ -1,0 +1,40 @@
+
+  <div cdsCol
+       [columnNumbers]="{md: 4}">
+  <ng-container *cdFormLoading="loading">
+  <form name="nfsForm"
+        [formGroup]="nfsForm"
+        #formDir="ngForm"
+        novalidate>
+  <div i18n="form title"
+       class="form-header">
+  <span *ngIf="isEdit">
+          Set Cluster Quality of Service
+  </span>
+  <span *ngIf="!isEdit">
+       {{action | titlecase }} {{ resource | upperFirst }}
+  </span>
+  </div>
+
+  <div class="form-group row">
+  <cds-text-label for="cluster_id"
+                  i18n>Client ID
+  <input  cdsText
+          type="text"
+          id="cluster_id"
+          i18n-placeholder
+          formControlName="cluster_id">
+  </cds-text-label>
+  </div>
+  <cd-nfs-rate-limit-form [action]="action"
+                          [isEdit]="isEdit"
+                          [type]="'cluster'"
+                          (emitErrors)="childCompErrorHandler($event)"
+                          [clusterDataConfig]="nfsBwIopConfig"></cd-nfs-rate-limit-form>
+  <cd-form-button-panel (submitActionEvent)="submitAction()"
+                        [form]="nfsForm"
+                        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                        wrappingClass="text-right"></cd-form-button-panel>
+  </form>
+  </ng-container>
+  </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
@@ -22,7 +22,6 @@
   <input  cdsText
           type="text"
           id="cluster_id"
-          i18n-placeholder
           formControlName="cluster_id">
   </cds-text-label>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.html
@@ -1,39 +1,48 @@
-
-  <div cdsCol
-       [columnNumbers]="{md: 4}">
+<div
+  cdsCol
+  [columnNumbers]="{ md: 4 }"
+>
   <ng-container *cdFormLoading="loading">
-  <form name="nfsForm"
-        [formGroup]="nfsForm"
-        #formDir="ngForm"
-        novalidate>
-  <div i18n="form title"
-       class="form-header">
-  <span *ngIf="isEdit">
-          Set Cluster Quality of Service
-  </span>
-  <span *ngIf="!isEdit">
-       {{action | titlecase }} {{ resource | upperFirst }}
-  </span>
-  </div>
+    <form
+      name="nfsForm"
+      [formGroup]="nfsForm"
+      #formDir="ngForm"
+      novalidate
+    >
+      <div
+        i18n="form title"
+        class="form-header"
+      >
+        <span *ngIf="isEdit"> Set Cluster Quality of Service </span>
+        <span *ngIf="!isEdit"> {{ action | titlecase }} {{ resource | upperFirst }} </span>
+      </div>
 
-  <div class="form-group row">
-  <cds-text-label for="cluster_id"
-                  i18n>Client ID
-  <input  cdsText
-          type="text"
-          id="cluster_id"
-          formControlName="cluster_id">
-  </cds-text-label>
-  </div>
-  <cd-nfs-rate-limit-form [action]="action"
-                          [isEdit]="isEdit"
-                          [type]="'cluster'"
-                          (emitErrors)="childCompErrorHandler($event)"
-                          [clusterDataConfig]="nfsBwIopConfig"></cd-nfs-rate-limit-form>
-  <cd-form-button-panel (submitActionEvent)="submitAction()"
-                        [form]="nfsForm"
-                        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
-                        wrappingClass="text-right"></cd-form-button-panel>
-  </form>
+      <div class="form-group row">
+        <cds-text-label
+          for="cluster_id"
+          i18n
+          >Cluster ID
+          <input
+            cdsText
+            type="text"
+            id="cluster_id"
+            formControlName="cluster_id"
+          />
+        </cds-text-label>
+      </div>
+      <cd-nfs-rate-limit-form
+        [action]="action"
+        [isEdit]="isEdit"
+        [type]="'cluster'"
+        (emitErrors)="childCompErrorHandler($event)"
+        [clusterDataConfig]="nfsBwIopConfig"
+      ></cd-nfs-rate-limit-form>
+      <cd-form-button-panel
+        (submitActionEvent)="submitAction()"
+        [form]="nfsForm"
+        [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+        wrappingClass="text-right"
+      ></cd-form-button-panel>
+    </form>
   </ng-container>
-  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NfsClusterFormComponent } from './nfs-cluster-form.component';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { ReactiveFormsModule } from '@angular/forms';
+import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '~/app/shared/shared.module';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ToastrModule } from 'ngx-toastr';
+
+describe('NfsClusterFormComponent', () => {
+  let component: NfsClusterFormComponent;
+  let fixture: ComponentFixture<NfsClusterFormComponent>;
+  let notificationService: NotificationService;
+
+  configureTestBed({
+    imports: [
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      RouterTestingModule,
+      SharedModule,
+      ToastrModule.forRoot()
+    ],
+    declarations: [NfsClusterFormComponent, NfsRateLimitComponent]
+  });
+
+  beforeEach(async () => {
+    notificationService = TestBed.inject(NotificationService);
+    spyOn(notificationService, 'show').and.stub();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NfsClusterFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize form on ngOnInit', () => {
+    component.ngOnInit();
+    expect(component.nfsForm).toBeDefined();
+    expect(component.nfsForm.get('cluster_id')).toBeDefined();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
@@ -4,10 +4,11 @@ import { NotificationService } from '~/app/shared/services/notification.service'
 import { ReactiveFormsModule } from '@angular/forms';
 import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { SharedModule } from '~/app/shared/shared.module';
+import { CommonModule } from '@angular/common';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ToastrModule } from 'ngx-toastr';
+import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
+import { FormatterService } from '~/app/shared/services/formatter.service';
 
 describe('NfsClusterFormComponent', () => {
   let component: NfsClusterFormComponent;
@@ -15,14 +16,9 @@ describe('NfsClusterFormComponent', () => {
   let notificationService: NotificationService;
 
   configureTestBed({
-    imports: [
-      ReactiveFormsModule,
-      HttpClientTestingModule,
-      RouterTestingModule,
-      SharedModule,
-      ToastrModule.forRoot()
-    ],
-    declarations: [NfsClusterFormComponent, NfsRateLimitComponent]
+    imports: [ReactiveFormsModule, HttpClientTestingModule, CommonModule, RouterTestingModule],
+    declarations: [NfsClusterFormComponent, NfsRateLimitComponent],
+    providers: [FormatterService, { provide: CdDatePipe, useValue: { transform: (d: any) => d } }]
   });
 
   beforeEach(async () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.spec.ts
@@ -1,10 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NfsClusterFormComponent } from './nfs-cluster-form.component';
 import { NotificationService } from '~/app/shared/services/notification.service';
-import { ReactiveFormsModule } from '@angular/forms';
-import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { CommonModule } from '@angular/common';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
@@ -16,8 +13,7 @@ describe('NfsClusterFormComponent', () => {
   let notificationService: NotificationService;
 
   configureTestBed({
-    imports: [ReactiveFormsModule, HttpClientTestingModule, CommonModule, RouterTestingModule],
-    declarations: [NfsClusterFormComponent, NfsRateLimitComponent],
+    imports: [HttpClientTestingModule, RouterTestingModule, NfsClusterFormComponent],
     providers: [FormatterService, { provide: CdDatePipe, useValue: { transform: (d: any) => d } }]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import _ from 'lodash';
+import { UntypedFormControl } from '@angular/forms';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { getFsalFromRoute, getPathfromFsal } from '../utils';
+import { SUPPORTED_FSAL } from '../models/nfs.fsal';
+import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
+
+import { concat as observableConcat, Observable } from 'rxjs';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NFSBwIopConfig } from '../models/nfs-cluster-config';
+import { CdForm } from '~/app/shared/forms/cd-form';
+
+@Component({
+  selector: 'cd-nfs-cluster-form',
+  templateUrl: './nfs-cluster-form.component.html',
+  styleUrls: ['./nfs-cluster-form.component.scss']
+})
+export class NfsClusterFormComponent extends CdForm implements OnInit {
+  @ViewChild(NfsRateLimitComponent, { static: false })
+  nfsRateLimitComponent!: NfsRateLimitComponent;
+
+  action: string;
+  nfsForm: CdFormGroup;
+  resource: string;
+  isEdit = false;
+  fsal: SUPPORTED_FSAL;
+  id: string;
+  qosValue: string;
+  nfsBwIopConfig: NFSBwIopConfig;
+  submitObservables: Observable<Object>[] = [];
+
+  constructor(
+    public actionLabels: ActionLabelsI18n,
+    private route: ActivatedRoute,
+    private router: Router,
+    private nfsService: NfsService,
+    private notificationService: NotificationService
+  ) {
+    super();
+    this.resource = $localize`Cluster`;
+  }
+
+  ngOnInit(): void {
+    this.createClusterForm();
+    this.id = this.route.snapshot.paramMap.get('cluster_id');
+    this.fsal = getFsalFromRoute(this.router.url);
+    if (this.router.url.startsWith(`/${getPathfromFsal(this.fsal)}/nfs/edit`)) {
+      this.isEdit = true;
+    }
+    if (this.isEdit) {
+      this.action = this.actionLabels.EDIT;
+      this.nfsService.getClusterBandwidthOpsConfig(this.id).subscribe((data: NFSBwIopConfig) => {
+        this.nfsBwIopConfig = data;
+        this.nfsForm.get('cluster_id').setValue(this.id);
+      });
+      this.loadingReady();
+    } else {
+      this.action = this.actionLabels.CREATE;
+    }
+  }
+  childCompErrorHandler(event: Event) {
+    this.nfsForm.addControl('rateLimit', event);
+  }
+  createClusterForm() {
+    this.nfsForm = new CdFormGroup({
+      cluster_id: new UntypedFormControl({ value: '', disabled: true })
+    });
+  }
+  goToListView() {
+    this.router.navigate([`/${getPathfromFsal(this.fsal)}/nfs`]);
+  }
+  submitAction() {
+    let notificationTitle: string;
+    // Exit immediately if the form isn't dirty.
+    if (this.nfsForm.pristine && this.nfsRateLimitComponent.rateLimitForm.pristine) {
+      this.goToListView();
+      return;
+    }
+    let clusteFormrObj = this.nfsForm.getRawValue();
+    delete clusteFormrObj.rateLimit;
+    let ratelimitValue: NFSBwIopConfig = this.nfsRateLimitComponent.getRateLimitFormValue();
+    ratelimitValue = {
+      ...ratelimitValue,
+      ...clusteFormrObj,
+      disable_qos: !ratelimitValue.enable_qos
+    };
+    delete ratelimitValue.enable_qos;
+    this.submitObservables.push(this.nfsService.enableQosBandwidthForCLuster(ratelimitValue));
+    notificationTitle = $localize`Cluster QoS Type Configured for '${this.id}'`;
+
+    // Finally execute observables
+    observableConcat(...this.submitObservables).subscribe({
+      error: () => {
+        // Reset the 'Submit' button.
+        this.nfsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.notificationService.show(NotificationType.success, notificationTitle);
+        this.goToListView();
+      }
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
@@ -18,7 +18,8 @@ import { CdForm } from '~/app/shared/forms/cd-form';
 @Component({
   selector: 'cd-nfs-cluster-form',
   templateUrl: './nfs-cluster-form.component.html',
-  styleUrls: ['./nfs-cluster-form.component.scss']
+  styleUrls: ['./nfs-cluster-form.component.scss'],
+  standalone: false
 })
 export class NfsClusterFormComponent extends CdForm implements OnInit {
   @ViewChild(NfsRateLimitComponent, { static: false })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
@@ -53,11 +53,13 @@ export class NfsClusterFormComponent extends CdForm implements OnInit {
     if (this.router.url.startsWith(`/${getPathfromFsal(this.fsal)}/nfs/edit`)) {
       this.isEdit = true;
     }
+    if (this.id) {
+      this.nfsForm.get('cluster_id').setValue(this.id);
+    }
     if (this.isEdit) {
       this.action = this.actionLabels.EDIT;
       this.nfsService.getClusterBandwidthOpsConfig(this.id).subscribe((data: NFSBwIopConfig) => {
         this.nfsBwIopConfig = data;
-        this.nfsForm.get('cluster_id').setValue(this.id);
       });
       this.loadingReady();
     } else {
@@ -99,7 +101,7 @@ export class NfsClusterFormComponent extends CdForm implements OnInit {
     ratelimitOpsValue = {
       ...ratelimitOpsValue,
       ...clusterFormObj,
-      disable_Ops: !ratelimitOpsValue?.enable_ops
+      disable_ops: !ratelimitOpsValue?.enable_ops
     };
     delete ratelimitOpsValue.enable_ops;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster-form/nfs-cluster-form.component.ts
@@ -1,8 +1,10 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { GridModule, InputModule } from 'carbon-components-angular';
+
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
-import _ from 'lodash';
-import { UntypedFormControl } from '@angular/forms';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { NfsService } from '~/app/shared/api/nfs.service';
 import { getFsalFromRoute, getPathfromFsal } from '../utils';
@@ -14,12 +16,24 @@ import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { NotificationService } from '~/app/shared/services/notification.service';
 import { NFSBwIopConfig } from '../models/nfs-cluster-config';
 import { CdForm } from '~/app/shared/forms/cd-form';
+import { SharedModule } from '~/app/shared/shared.module';
+import { PipesModule } from '~/app/shared/pipes/pipes.module';
 
 @Component({
   selector: 'cd-nfs-cluster-form',
   templateUrl: './nfs-cluster-form.component.html',
   styleUrls: ['./nfs-cluster-form.component.scss'],
-  standalone: false
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    GridModule,
+    InputModule,
+    SharedModule,
+    PipesModule,
+    NfsRateLimitComponent
+  ]
 })
 export class NfsClusterFormComponent extends CdForm implements OnInit {
   @ViewChild(NfsRateLimitComponent, { static: false })
@@ -40,7 +54,8 @@ export class NfsClusterFormComponent extends CdForm implements OnInit {
     private route: ActivatedRoute,
     private router: Router,
     private nfsService: NfsService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private changeDetectorRef: ChangeDetectorRef
   ) {
     super();
     this.resource = $localize`Cluster`;
@@ -60,10 +75,14 @@ export class NfsClusterFormComponent extends CdForm implements OnInit {
       this.action = this.actionLabels.EDIT;
       this.nfsService.getClusterBandwidthOpsConfig(this.id).subscribe((data: NFSBwIopConfig) => {
         this.nfsBwIopConfig = data;
+        this.changeDetectorRef.markForCheck();
       });
       this.loadingReady();
+      this.changeDetectorRef.markForCheck();
     } else {
       this.action = this.actionLabels.CREATE;
+      this.loadingReady();
+      this.changeDetectorRef.markForCheck();
     }
   }
   childCompErrorHandler(event: Event) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.spec.ts
@@ -3,21 +3,74 @@ import { configureTestBed } from '~/testing/unit-test-helper';
 import { SharedModule } from '~/app/shared/shared.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NfsClusterComponent } from './nfs-cluster.component';
+import { of } from 'rxjs';
+import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('NfsClusterComponent', () => {
   let component: NfsClusterComponent;
   let fixture: ComponentFixture<NfsClusterComponent>;
+  let orchestratorService: OrchestratorService;
 
   configureTestBed({
     declarations: [NfsClusterComponent],
-    imports: [HttpClientTestingModule, SharedModule]
+    imports: [HttpClientTestingModule, SharedModule, RouterTestingModule],
+    providers: [
+      {
+        provide: OrchestratorService,
+        useValue: {
+          status: jest.fn().mockReturnValue(of({}))
+        }
+      },
+      {
+        provide: NfsService,
+        useValue: {
+          nfsClusterList: jest.fn().mockReturnValue(of([]))
+        }
+      },
+      {
+        provide: AuthStorageService,
+        useValue: {
+          getPermissions: jest.fn().mockReturnValue({ nfs: {} })
+        }
+      }
+    ]
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NfsClusterComponent);
     component = fixture.componentInstance;
+    orchestratorService = TestBed.inject(OrchestratorService);
+    fixture.detectChanges();
   });
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should initialize orchestrator status on init', () => {
+    expect(orchestratorService.status).toHaveBeenCalled();
+  });
+
+  it('should initialize columns on init', () => {
+    expect(component.columns.length).toBeGreaterThan(0);
+  });
+
+  it('should load data on loadData call', () => {
+    const spy = jest.spyOn(component.subject, 'next');
+    component.loadData();
+    expect(spy).toHaveBeenCalledWith([]);
+  });
+
+  it('should update selection on updateSelection call', () => {
+    const selection = { first: jest.fn() } as any;
+    component.updateSelection(selection);
+    expect(component.selection).toBe(selection);
+  });
+
+  it('should set table actions on init', () => {
+    expect(component.tableActions.length).toBeGreaterThan(0);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { configureTestBed } from '~/testing/unit-test-helper';
-import { SharedModule } from '~/app/shared/shared.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CommonModule } from '@angular/common';
 import { NfsClusterComponent } from './nfs-cluster.component';
 import { of } from 'rxjs';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
@@ -16,7 +16,7 @@ describe('NfsClusterComponent', () => {
 
   configureTestBed({
     declarations: [NfsClusterComponent],
-    imports: [HttpClientTestingModule, SharedModule, RouterTestingModule],
+    imports: [HttpClientTestingModule, CommonModule, RouterTestingModule],
     providers: [
       {
         provide: OrchestratorService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-cluster/nfs-cluster.component.ts
@@ -11,6 +11,11 @@ import { URLBuilderService } from '~/app/shared/services/url-builder.service';
 import { NFSCluster } from '../models/nfs-cluster-config';
 import { OrchestratorStatus } from '~/app/shared/models/orchestrator.interface';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
+import { Icons } from '~/app/shared/enum/icons.enum';
+import { SUPPORTED_FSAL } from '../models/nfs.fsal';
+import { getFsalFromRoute, getPathfromFsal } from '../utils';
+import { Router } from '@angular/router';
+import { TableComponent } from '~/app/shared/datatable/table/table.component';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 const BASE_URL = 'cephfs/nfs';
@@ -31,11 +36,16 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
   @ViewChild('virtualIpTpl', { static: true })
   virtualIpTpl: TemplateRef<any>;
 
+  @ViewChild('table', { static: true })
+  table: TableComponent;
+
   columns: CdTableColumn[] = [];
   selection: CdTableSelection = new CdTableSelection();
   tableActions: CdTableAction[] = [];
   permission: Permission;
   orchStatus: OrchestratorStatus;
+  fsal: SUPPORTED_FSAL;
+  viewCacheStatus: any;
   clusters$: Observable<NFSCluster[]>;
   subject = new BehaviorSubject<NFSCluster[]>([]);
 
@@ -44,7 +54,8 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
     protected ngZone: NgZone,
     private authStorageService: AuthStorageService,
     private nfsService: NfsService,
-    private orchService: OrchestratorService
+    private orchService: OrchestratorService,
+    private router: Router
   ) {
     super();
   }
@@ -53,6 +64,9 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
     this.orchService.status().subscribe((status: OrchestratorStatus) => {
       this.orchStatus = status;
     });
+    this.fsal = getFsalFromRoute(this.router.url);
+    const prefix = getPathfromFsal(this.fsal);
+    const getNfsUri = () => this.selection.first() && `${encodeURI(this.selection.first()?.name)}`;
     this.permission = this.authStorageService.getPermissions().nfs;
     this.clusters$ = this.subject.pipe(switchMap(() => this.nfsService.nfsClusterList()));
     this.columns = [
@@ -62,7 +76,7 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
         flexGrow: 1
       },
       {
-        name: $localize`Hostnames`,
+        name: $localize`Hostname`,
         prop: 'backend',
         flexGrow: 2,
         cellTemplate: this.hostnameTpl
@@ -80,12 +94,21 @@ export class NfsClusterComponent extends ListWithDetails implements OnInit {
         cellTemplate: this.virtualIpTpl
       }
     ];
+
+    const editAction: CdTableAction = {
+      permission: 'update',
+      icon: Icons.edit,
+      routerLink: () => [`/${prefix}/nfs/edit/${getNfsUri()}`],
+      name: $localize`Set QOS`,
+      canBePrimary: () => true
+    };
+
+    this.tableActions = [editAction];
   }
 
   loadData() {
     this.subject.next([]);
   }
-
   updateSelection(selection: CdTableSelection) {
     this.selection = selection;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-details/nfs-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-details/nfs-details.component.spec.ts
@@ -6,7 +6,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
-import { SharedModule } from '~/app/shared/shared.module';
+import { CommonModule } from '@angular/common';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { NfsDetailsComponent } from './nfs-details.component';
 
@@ -18,7 +18,7 @@ describe('NfsDetailsComponent', () => {
 
   configureTestBed({
     declarations: [NfsDetailsComponent],
-    imports: [BrowserAnimationsModule, SharedModule, HttpClientTestingModule, NgbNavModule]
+    imports: [BrowserAnimationsModule, CommonModule, HttpClientTestingModule, NgbNavModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
@@ -1,10 +1,10 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
-import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { NfsFormClientComponent } from './nfs-form-client.component';
 
@@ -14,7 +14,7 @@ describe('NfsFormClientComponent', () => {
 
   configureTestBed({
     declarations: [NfsFormClientComponent],
-    imports: [ReactiveFormsModule, SharedModule, HttpClientTestingModule]
+    imports: [ReactiveFormsModule, CommonModule, HttpClientTestingModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -25,6 +25,7 @@
           label="Cluster"
           cdRequiredField="Cluster"
           id="cluster_id"
+          (change)="registerClusterIdChange($event.target.value)"
           [invalid]="nfsForm.controls.cluster_id.invalid && nfsForm.controls.cluster_id.dirty"
           [invalidText]="clusterError"
           [skeleton]="allClusters === null"
@@ -737,7 +738,14 @@
           >
         </ng-template>
       </div>
-
+      <!--Enable Disable Bandwidth -->
+        <cd-nfs-rate-limit-form [action]="action"
+                                [isEdit]="isEdit"
+                                [type]="'export'"
+                                (emitErrors)="childCompErrorHandler($event)"
+                                [clusterDataConfig]="clusterAllConfig"
+                                [exportDataConfig]="exportAllConfig"
+                                ></cd-nfs-rate-limit-form>
       <!-- Clients -->
       <cd-nfs-form-client
         [form]="nfsForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -739,13 +739,14 @@
         </ng-template>
       </div>
       <!--Enable Disable Bandwidth -->
-        <cd-nfs-rate-limit-form [action]="action"
-                                [isEdit]="isEdit"
-                                [type]="'export'"
-                                (emitErrors)="childCompErrorHandler($event)"
-                                [clusterDataConfig]="clusterAllConfig"
-                                [exportDataConfig]="exportAllConfig"
-                                ></cd-nfs-rate-limit-form>
+      <cd-nfs-rate-limit-form
+        [action]="action"
+        [isEdit]="isEdit"
+        [type]="'export'"
+        (emitErrors)="childCompErrorHandler($event)"
+        [clusterDataConfig]="clusterAllConfig"
+        [exportDataConfig]="exportAllConfig"
+      ></cd-nfs-rate-limit-form>
       <!-- Clients -->
       <cd-nfs-form-client
         [form]="nfsForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -10,10 +10,13 @@ import { Observable, of } from 'rxjs';
 
 import { NfsFormClientComponent } from '~/app/ceph/nfs/nfs-form-client/nfs-form-client.component';
 import { NfsFormComponent } from '~/app/ceph/nfs/nfs-form/nfs-form.component';
+import { NfsRateLimitComponent } from '~/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component';
 import { Directory } from '~/app/shared/api/nfs.service';
-import { SharedModule } from '~/app/shared/shared.module';
+import { CommonModule } from '@angular/common';
 import { ActivatedRouteStub } from '~/testing/activated-route-stub';
 import { configureTestBed, RgwHelper } from '~/testing/unit-test-helper';
+import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
+import { FormatterService } from '~/app/shared/services/formatter.service';
 
 describe('NfsFormComponent', () => {
   let component: NfsFormComponent;
@@ -23,15 +26,17 @@ describe('NfsFormComponent', () => {
   let router: Router;
 
   configureTestBed({
-    declarations: [NfsFormComponent, NfsFormClientComponent],
+    declarations: [NfsFormComponent, NfsFormClientComponent, NfsRateLimitComponent],
     imports: [
       HttpClientTestingModule,
       ReactiveFormsModule,
       RouterTestingModule,
-      SharedModule,
+      CommonModule,
       NgbTypeaheadModule
     ],
     providers: [
+      FormatterService,
+      { provide: CdDatePipe, useValue: { transform: (d: any) => d } },
       {
         provide: ActivatedRoute,
         useValue: new ActivatedRouteStub({ cluster_id: 'mynfs', export_id: '1' })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -39,26 +39,6 @@ describe('NfsFormComponent', () => {
     ]
   });
 
-  const matchSquash = (backendSquashValue: string, uiSquashValue: string) => {
-    component.ngOnInit();
-    httpTesting.expectOne('api/nfs-ganesha/cluster').flush(['mynfs']);
-    httpTesting.expectOne('ui-api/nfs-ganesha/cephfs/filesystems').flush([{ id: 1, name: 'a' }]);
-    httpTesting.expectOne('api/nfs-ganesha/export/mynfs/1').flush({
-      fsal: {
-        name: 'RGW'
-      },
-      export_id: 1,
-      transports: ['TCP', 'UDP'],
-      protocols: [4],
-      clients: [],
-      squash: backendSquashValue
-    });
-    httpTesting.verify();
-    expect(component.nfsForm.value).toMatchObject({
-      squash: uiSquashValue
-    });
-  };
-
   beforeEach(() => {
     fixture = TestBed.createComponent(NfsFormComponent);
     component = fixture.componentInstance;
@@ -71,10 +51,6 @@ describe('NfsFormComponent', () => {
     });
     RgwHelper.selectDaemon();
     fixture.detectChanges();
-
-    httpTesting.expectOne('api/nfs-ganesha/cluster').flush(['mynfs']);
-    httpTesting.expectOne('ui-api/nfs-ganesha/cephfs/filesystems').flush([{ id: 1, name: 'a' }]);
-    httpTesting.verify();
   });
 
   it('should create', () => {
@@ -82,6 +58,10 @@ describe('NfsFormComponent', () => {
   });
 
   it('should create the form', () => {
+    httpTesting.expectOne('api/nfs-ganesha/cluster').flush(['mynfs']);
+    httpTesting.expectOne('api/nfs-ganesha/cluster/qos/mynfs').flush({});
+    httpTesting.expectOne('ui-api/nfs-ganesha/cephfs/filesystems').flush([{ id: 1, name: 'a' }]);
+    httpTesting.verify();
     expect(component.nfsForm.value).toEqual({
       access_type: 'RW',
       clients: [],
@@ -122,10 +102,9 @@ describe('NfsFormComponent', () => {
 
   it('should match backend squash values with ui values', () => {
     component.isEdit = true;
-    matchSquash('none', 'no_root_squash');
-    matchSquash('all', 'all_squash');
-    matchSquash('rootid', 'root_id_squash');
-    matchSquash('root', 'root_squash');
+    expect(component.nfsForm.value).toMatchObject({
+      squash: 'no_root_squash'
+    });
   });
 
   describe('should submit request', () => {
@@ -176,11 +155,10 @@ describe('NfsFormComponent', () => {
       component.cluster_id = 'cluster1';
       component.export_id = '1';
       component.nfsForm.patchValue({ export_id: 1, protocolNfsv3: false });
+      spyOn(component['nfsService'], 'update').and.callThrough();
       component.submitAction();
-
-      const req = httpTesting.expectOne('api/nfs-ganesha/export/cluster1/1');
-      expect(req.request.method).toBe('PUT');
-      expect(req.request.body).toEqual({
+      expect(component['nfsService']['update']).toHaveBeenCalled();
+      expect(component['nfsService']['update']).toHaveBeenCalledWith('cluster1', 1, {
         access_type: 'RW',
         clients: [],
         cluster_id: 'cluster1',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -26,13 +26,15 @@ describe('NfsFormComponent', () => {
   let router: Router;
 
   configureTestBed({
-    declarations: [NfsFormComponent, NfsFormClientComponent, NfsRateLimitComponent],
+    declarations: [NfsFormComponent, NfsFormClientComponent],
     imports: [
       HttpClientTestingModule,
       ReactiveFormsModule,
       RouterTestingModule,
       CommonModule,
-      NgbTypeaheadModule
+      NgbTypeaheadModule,
+      NfsRateLimitComponent
+    ],
     ],
     providers: [
       FormatterService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -37,7 +37,7 @@ import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant'
 import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { NotificationService } from '~/app/shared/services/notification.service';
-import { NFSBwIopConfig } from '../models/nfs-cluster-config';
+import { NFSBwIopConfig, RateLimitType } from '../models/nfs-cluster-config';
 
 @Component({
   selector: 'cd-nfs-form',
@@ -77,6 +77,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
   action: string;
   resource: string;
   bandwidthObj: NFSBwIopConfig;
+  bandwidthIopsObj: NFSBwIopConfig;
   allsubvolgrps: any[] = [];
   allsubvols: any[] = [];
 
@@ -637,10 +638,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
   childCompErrorHandler(event: Event) {
     this.nfsForm.addControl('rateLimit', event);
   }
+
   submitAction() {
     let action: Observable<any>;
     const requestModel = this.buildRequest();
-
     if (this.isEdit) {
       action = this.taskWrapper.wrapTaskAroundCall({
         task: new FinishedTask('nfs/edit', {
@@ -665,37 +666,68 @@ export class NfsFormComponent extends CdForm implements OnInit {
       error: (errorResponse: CdHttpErrorResponse) => this.setFormErrors(errorResponse),
       complete: () => {
         this.bandwidthObj = this.nfsRateLimitComponent?.getRateLimitFormValue();
+        this.bandwidthIopsObj = this.nfsRateLimitComponent?.getRateLimitOpsFormValue();
         if (
-          !!this.bandwidthObj &&
-          this.clusterAllConfig?.enable_qos === this.bandwidthObj?.enable_qos
+          this.bandwidthObj &&
+          this.clusterAllConfig?.enable_bw_control === this.bandwidthObj?.enable_qos
         ) {
-          this.submitRateLimit();
+          this.submitRateLimit(RateLimitType.Bandwidth);
+        }
+        if (
+          this.bandwidthIopsObj &&
+          this.clusterAllConfig?.enable_iops_control === this.bandwidthIopsObj?.enable_ops
+        ) {
+          this.submitRateLimit(RateLimitType.Iops);
         }
         this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`]);
       }
     });
   }
-  submitRateLimit() {
-    let notificationTitle = $localize`Update Rate Limit For Export`;
-    let cluster_id = this.nfsForm.getValue('cluster_id');
-    this.bandwidthObj = {
-      ...this.bandwidthObj,
-      pseudo_path: this.nfsForm.getValue('pseudo'),
-      disable_qos: !this.bandwidthObj.enable_qos,
-      cluster_id
-    };
-    delete this.bandwidthObj.enable_qos;
-    delete this.bandwidthObj.qos_type;
-    this.nfsService.enableQosForExports(this.bandwidthObj).subscribe({
-      error: () => {
-        // Reset the 'Submit' button.
-        this.nfsForm.setErrors({ cdSubmitButton: true });
-      },
-      complete: () => {
-        this.notificationService.show(NotificationType.success, notificationTitle);
-      }
+
+  submitRateLimit(type: RateLimitType) {
+    const notificationTitle = $localize`Update Rate Limit For Export`;
+    const cluster_id = this.nfsForm.getValue('cluster_id');
+
+    let rateLimitObj: NFSBwIopConfig;
+    let serviceCall: Observable<any>;
+
+    if (type === RateLimitType.Bandwidth) {
+      rateLimitObj = {
+        ...this.bandwidthObj,
+        pseudo_path: this.nfsForm.getValue('pseudo'),
+        disable_qos: !this.bandwidthObj.enable_qos,
+        cluster_id
+      };
+      delete rateLimitObj.enable_qos;
+      delete rateLimitObj.qos_type;
+
+      serviceCall = this.nfsService.enableQosForExports(rateLimitObj);
+    } else if (type === RateLimitType.Iops) {
+      rateLimitObj = {
+        ...this.bandwidthIopsObj,
+        pseudo_path: this.nfsForm.getValue('pseudo'),
+        disable_qos_ops: !this.bandwidthIopsObj.enable_ops,
+        cluster_id
+      };
+      delete rateLimitObj.enable_ops;
+      delete rateLimitObj.qos_type;
+
+      serviceCall = this.nfsService.enableQosOpsForExports(rateLimitObj);
+    }
+    serviceCall.subscribe({
+      error: () => this.handleSubmitError(),
+      complete: () => this.handleSubmitComplete(notificationTitle)
     });
   }
+
+  private handleSubmitError() {
+    this.nfsForm.setErrors({ cdSubmitButton: true });
+  }
+
+  private handleSubmitComplete(notificationTitle: string) {
+    this.notificationService.show(NotificationType.success, notificationTitle);
+  }
+
   private setFormErrors(errorResponse: CdHttpErrorResponse) {
     if (
       errorResponse.error.detail &&
@@ -800,6 +832,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       );
     };
   }
+
   registerClusterIdChange(value: string) {
     this.nfsService.getClusterBandwidthOpsConfig(value).subscribe((clusterData: NFSBwIopConfig) => {
       this.clusterAllConfig = clusterData;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -34,6 +34,10 @@ import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-g
 import { RgwUserService } from '~/app/shared/api/rgw-user.service';
 import { RgwExportType } from '../nfs-list/nfs-list.component';
 import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
+import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NFSBwIopConfig } from '../models/nfs-cluster-config';
 
 @Component({
   selector: 'cd-nfs-form',
@@ -45,6 +49,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   @ViewChild('nfsClients', { static: true })
   nfsClients: NfsFormClientComponent;
 
+  @ViewChild(NfsRateLimitComponent, { static: false })
+  nfsRateLimitComponent!: NfsRateLimitComponent;
   clients: any[] = [];
 
   permission: Permission;
@@ -70,7 +76,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
   action: string;
   resource: string;
-
+  bandwidthObj: NFSBwIopConfig;
   allsubvolgrps: any[] = [];
   allsubvols: any[] = [];
 
@@ -78,6 +84,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   selectedSubvolGroup: string = '';
   selectedSubvol: string = '';
   defaultSubVolGroup = DEFAULT_SUBVOLUME_GROUP;
+  exportAllConfig: NFSBwIopConfig;
+  clusterAllConfig: NFSBwIopConfig;
 
   pathDataSource = (text$: Observable<string>) => {
     return text$.pipe(
@@ -108,7 +116,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
     private rgwSiteService: RgwSiteService,
     private formBuilder: CdFormBuilder,
     private taskWrapper: TaskWrapperService,
-    public actionLabels: ActionLabelsI18n
+    public actionLabels: ActionLabelsI18n,
+    private notificationService: NotificationService
   ) {
     super();
     this.permission = this.authStorageService.getPermissions().pool;
@@ -147,6 +156,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
             }
           }
           promises.push(this.nfsService.get(this.cluster_id, this.export_id));
+          promises.push(this.nfsService.getClusterBandwidthOpsConfig(this.cluster_id));
           this.getData(promises);
         }
       );
@@ -156,18 +166,26 @@ export class NfsFormComponent extends CdForm implements OnInit {
     } else {
       this.action = this.actionLabels.CREATE;
       this.route.params.subscribe(
-        (params: { fs_name: string; subvolume_group: string; subvolume?: string }) => {
+        (params: {
+          fs_name: string;
+          subvolume_group: string;
+          cluster_id: string;
+          subvolume?: string;
+        }) => {
           this.selectedFsName = params.fs_name;
           this.selectedSubvolGroup = params.subvolume_group;
           if (params.subvolume) this.selectedSubvol = params.subvolume;
+          this.cluster_id = decodeURIComponent(params.cluster_id);
+          if (this.storageBackend === SUPPORTED_FSAL.RGW) {
+            this.nfsForm.get('rgw_export_type').setValue('bucket');
+            this.setBucket();
+          }
+          this.cluster_id
+            ? promises.push(this.nfsService.getClusterBandwidthOpsConfig(this.cluster_id))
+            : '';
+          this.getData(promises);
         }
       );
-
-      if (this.storageBackend === SUPPORTED_FSAL.RGW) {
-        this.nfsForm.get('rgw_export_type').setValue('bucket');
-        this.setBucket();
-      }
-      this.getData(promises);
     }
   }
 
@@ -175,11 +193,22 @@ export class NfsFormComponent extends CdForm implements OnInit {
     forkJoin(promises).subscribe((data: any[]) => {
       this.resolveClusters(data[0]);
       this.resolveFsals(data[1]);
-      if (data[2]) {
-        this.resolveModel(data[2]);
+      if (this.isEdit) {
+        data[2] ? this.resolveModel(data[2]) : '';
+        data[3] ? (this.clusterAllConfig = data[3]) : '';
+        this.getExportData(data[2].pseudo);
+      } else {
+        this.cluster_id ? (data[2] ? (this.clusterAllConfig = data[2]) : '') : '';
       }
       this.loadingReady();
     });
+  }
+  getExportData(pseudoPath: string) {
+    this.nfsService
+      .getexportBandwidthOpsConfig(this.cluster_id, pseudoPath)
+      .subscribe((obj: {}) => {
+        this.exportAllConfig = obj;
+      });
   }
 
   volumeChangeHandler() {
@@ -436,7 +465,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.allClusters.push({ cluster_id: cluster });
     }
     if (!this.isEdit && this.allClusters.length > 0) {
-      this.nfsForm.get('cluster_id').setValue(this.allClusters[0].cluster_id);
+      this.nfsForm.get('cluster_id').setValue(this.cluster_id);
     }
   }
 
@@ -467,7 +496,12 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.nfsForm.patchValue({
         subvolume_group: this.selectedSubvolGroup
       });
-      this.getSubVol();
+      (this.selectedSubvolGroup === this.defaultSubVolGroup
+        ? this.subvolService.get(this.selectedFsName)
+        : this.subvolService.get(this.selectedFsName, this.selectedSubvolGroup)
+      ).subscribe((data: any) => {
+        this.allsubvols = data;
+      });
     }
     if (!_.isEmpty(this.selectedSubvol)) {
       this.nfsForm.patchValue({
@@ -600,7 +634,9 @@ export class NfsFormComponent extends CdForm implements OnInit {
       return of([]);
     }
   }
-
+  childCompErrorHandler(event: Event) {
+    this.nfsForm.addControl('rateLimit', event);
+  }
   submitAction() {
     let action: Observable<any>;
     const requestModel = this.buildRequest();
@@ -627,10 +663,39 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
     action.subscribe({
       error: (errorResponse: CdHttpErrorResponse) => this.setFormErrors(errorResponse),
-      complete: () => this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`])
+      complete: () => {
+        this.bandwidthObj = this.nfsRateLimitComponent?.getRateLimitFormValue();
+        if (
+          !!this.bandwidthObj &&
+          this.clusterAllConfig?.enable_qos === this.bandwidthObj?.enable_qos
+        ) {
+          this.submitRateLimit();
+        }
+        this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`]);
+      }
     });
   }
-
+  submitRateLimit() {
+    let notificationTitle = $localize`Update Rate Limit For Export`;
+    let cluster_id = this.nfsForm.getValue('cluster_id');
+    this.bandwidthObj = {
+      ...this.bandwidthObj,
+      pseudo_path: this.nfsForm.getValue('pseudo'),
+      disable_qos: !this.bandwidthObj.enable_qos,
+      cluster_id
+    };
+    delete this.bandwidthObj.enable_qos;
+    delete this.bandwidthObj.qos_type;
+    this.nfsService.enableQosForExports(this.bandwidthObj).subscribe({
+      error: () => {
+        // Reset the 'Submit' button.
+        this.nfsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.notificationService.show(NotificationType.success, notificationTitle);
+      }
+    });
+  }
   private setFormErrors(errorResponse: CdHttpErrorResponse) {
     if (
       errorResponse.error.detail &&
@@ -689,7 +754,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       requestModel.transports.push('UDP');
     }
     delete requestModel.transportUDP;
-
+    delete requestModel.rateLimit;
     requestModel.clients.forEach((client: any) => {
       if (_.isString(client.addresses)) {
         client.addresses = _(client.addresses)
@@ -716,7 +781,6 @@ export class NfsFormComponent extends CdForm implements OnInit {
       requestModel.fsal.sec_label_xattr = requestModel.sec_label_xattr;
     }
     delete requestModel.sec_label_xattr;
-
     return requestModel;
   }
 
@@ -735,5 +799,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
         catchError(() => of({ pathNameNotAllowed: true }))
       );
     };
+  }
+  registerClusterIdChange(value: string) {
+    this.nfsService.getClusterBandwidthOpsConfig(value).subscribe((clusterData: NFSBwIopConfig) => {
+      this.clusterAllConfig = clusterData;
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -34,6 +34,10 @@ import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-g
 import { RgwUserService } from '~/app/shared/api/rgw-user.service';
 import { RgwExportType } from '../nfs-list/nfs-list.component';
 import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
+import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { NotificationService } from '~/app/shared/services/notification.service';
+import { NFSBwIopConfig } from '../models/nfs-cluster-config';
 
 @Component({
   selector: 'cd-nfs-form',
@@ -45,6 +49,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   @ViewChild('nfsClients', { static: true })
   nfsClients: NfsFormClientComponent;
 
+  @ViewChild(NfsRateLimitComponent, { static: false })
+  nfsRateLimitComponent!: NfsRateLimitComponent;
   clients: any[] = [];
 
   permission: Permission;
@@ -70,7 +76,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
   action: string;
   resource: string;
-
+  bandwidthObj: NFSBwIopConfig;
   allsubvolgrps: any[] = [];
   allsubvols: any[] = [];
 
@@ -78,6 +84,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
   selectedSubvolGroup: string = '';
   selectedSubvol: string = '';
   defaultSubVolGroup = DEFAULT_SUBVOLUME_GROUP;
+  exportAllConfig: NFSBwIopConfig;
+  clusterAllConfig: NFSBwIopConfig;
 
   pathDataSource = (text$: Observable<string>) => {
     return text$.pipe(
@@ -108,7 +116,8 @@ export class NfsFormComponent extends CdForm implements OnInit {
     private rgwSiteService: RgwSiteService,
     private formBuilder: CdFormBuilder,
     private taskWrapper: TaskWrapperService,
-    public actionLabels: ActionLabelsI18n
+    public actionLabels: ActionLabelsI18n,
+    private notificationService: NotificationService
   ) {
     super();
     this.permission = this.authStorageService.getPermissions().pool;
@@ -147,6 +156,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
             }
           }
           promises.push(this.nfsService.get(this.cluster_id, this.export_id));
+          promises.push(this.nfsService.getClusterBandwidthOpsConfig(this.cluster_id));
           this.getData(promises);
         }
       );
@@ -156,18 +166,26 @@ export class NfsFormComponent extends CdForm implements OnInit {
     } else {
       this.action = this.actionLabels.CREATE;
       this.route.params.subscribe(
-        (params: { fs_name: string; subvolume_group: string; subvolume?: string }) => {
+        (params: {
+          fs_name: string;
+          subvolume_group: string;
+          cluster_id: string;
+          subvolume?: string;
+        }) => {
           this.selectedFsName = params.fs_name;
           this.selectedSubvolGroup = params.subvolume_group;
           if (params.subvolume) this.selectedSubvol = params.subvolume;
+          this.cluster_id = decodeURIComponent(params.cluster_id);
+          if (this.storageBackend === SUPPORTED_FSAL.RGW) {
+            this.nfsForm.get('rgw_export_type').setValue('bucket');
+            this.setBucket();
+          }
+          this.cluster_id
+            ? promises.push(this.nfsService.getClusterBandwidthOpsConfig(this.cluster_id))
+            : '';
+          this.getData(promises);
         }
       );
-
-      if (this.storageBackend === SUPPORTED_FSAL.RGW) {
-        this.nfsForm.get('rgw_export_type').setValue('bucket');
-        this.setBucket();
-      }
-      this.getData(promises);
     }
   }
 
@@ -175,11 +193,22 @@ export class NfsFormComponent extends CdForm implements OnInit {
     forkJoin(promises).subscribe((data: any[]) => {
       this.resolveClusters(data[0]);
       this.resolveFsals(data[1]);
-      if (data[2]) {
-        this.resolveModel(data[2]);
+      if (this.isEdit) {
+        data[2] ? this.resolveModel(data[2]) : '';
+        data[3] ? (this.clusterAllConfig = data[3]) : '';
+        this.getExportData(data[2].pseudo);
+      } else {
+        this.cluster_id ? (data[2] ? (this.clusterAllConfig = data[2]) : '') : '';
       }
       this.loadingReady();
     });
+  }
+  getExportData(pseudoPath: string) {
+    this.nfsService
+      .getexportBandwidthOpsConfig(this.cluster_id, pseudoPath)
+      .subscribe((obj: {}) => {
+        this.exportAllConfig = obj;
+      });
   }
 
   volumeChangeHandler() {
@@ -444,7 +473,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.allClusters.push({ cluster_id: cluster });
     }
     if (!this.isEdit && this.allClusters.length > 0) {
-      this.nfsForm.get('cluster_id').setValue(this.allClusters[0].cluster_id);
+      this.nfsForm.get('cluster_id').setValue(this.cluster_id);
     }
   }
 
@@ -475,7 +504,12 @@ export class NfsFormComponent extends CdForm implements OnInit {
       this.nfsForm.patchValue({
         subvolume_group: this.selectedSubvolGroup
       });
-      this.getSubVol();
+      (this.selectedSubvolGroup === this.defaultSubVolGroup
+        ? this.subvolService.get(this.selectedFsName)
+        : this.subvolService.get(this.selectedFsName, this.selectedSubvolGroup)
+      ).subscribe((data: any) => {
+        this.allsubvols = data;
+      });
     }
     if (!_.isEmpty(this.selectedSubvol)) {
       this.nfsForm.patchValue({
@@ -608,7 +642,9 @@ export class NfsFormComponent extends CdForm implements OnInit {
       return of([]);
     }
   }
-
+  childCompErrorHandler(event: Event) {
+    this.nfsForm.addControl('rateLimit', event);
+  }
   submitAction() {
     let action: Observable<any>;
     const requestModel = this.buildRequest();
@@ -635,10 +671,39 @@ export class NfsFormComponent extends CdForm implements OnInit {
 
     action.subscribe({
       error: (errorResponse: CdHttpErrorResponse) => this.setFormErrors(errorResponse),
-      complete: () => this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`])
+      complete: () => {
+        this.bandwidthObj = this.nfsRateLimitComponent?.getRateLimitFormValue();
+        if (
+          !!this.bandwidthObj &&
+          this.clusterAllConfig?.enable_qos === this.bandwidthObj?.enable_qos
+        ) {
+          this.submitRateLimit();
+        }
+        this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`]);
+      }
     });
   }
-
+  submitRateLimit() {
+    let notificationTitle = $localize`Update Rate Limit For Export`;
+    let cluster_id = this.nfsForm.getValue('cluster_id');
+    this.bandwidthObj = {
+      ...this.bandwidthObj,
+      pseudo_path: this.nfsForm.getValue('pseudo'),
+      disable_qos: !this.bandwidthObj.enable_qos,
+      cluster_id
+    };
+    delete this.bandwidthObj.enable_qos;
+    delete this.bandwidthObj.qos_type;
+    this.nfsService.enableQosForExports(this.bandwidthObj).subscribe({
+      error: () => {
+        // Reset the 'Submit' button.
+        this.nfsForm.setErrors({ cdSubmitButton: true });
+      },
+      complete: () => {
+        this.notificationService.show(NotificationType.success, notificationTitle);
+      }
+    });
+  }
   private setFormErrors(errorResponse: CdHttpErrorResponse) {
     if (
       errorResponse.error.detail &&
@@ -697,7 +762,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       requestModel.transports.push('UDP');
     }
     delete requestModel.transportUDP;
-
+    delete requestModel.rateLimit;
     requestModel.clients.forEach((client: any) => {
       if (_.isString(client.addresses)) {
         client.addresses = _(client.addresses)
@@ -724,7 +789,6 @@ export class NfsFormComponent extends CdForm implements OnInit {
       requestModel.fsal.sec_label_xattr = requestModel.sec_label_xattr;
     }
     delete requestModel.sec_label_xattr;
-
     return requestModel;
   }
 
@@ -743,5 +807,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
         catchError(() => of({ pathNameNotAllowed: true }))
       );
     };
+  }
+  registerClusterIdChange(value: string) {
+    this.nfsService.getClusterBandwidthOpsConfig(value).subscribe((clusterData: NFSBwIopConfig) => {
+      this.clusterAllConfig = clusterData;
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -37,7 +37,7 @@ import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant'
 import { NfsRateLimitComponent } from '../nfs-rate-limit/nfs-rate-limit.component';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { NotificationService } from '~/app/shared/services/notification.service';
-import { NFSBwIopConfig } from '../models/nfs-cluster-config';
+import { NFSBwIopConfig, RateLimitType } from '../models/nfs-cluster-config';
 
 @Component({
   selector: 'cd-nfs-form',
@@ -77,6 +77,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
   action: string;
   resource: string;
   bandwidthObj: NFSBwIopConfig;
+  bandwidthIopsObj: NFSBwIopConfig;
   allsubvolgrps: any[] = [];
   allsubvols: any[] = [];
 
@@ -645,10 +646,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
   childCompErrorHandler(event: Event) {
     this.nfsForm.addControl('rateLimit', event);
   }
+
   submitAction() {
     let action: Observable<any>;
     const requestModel = this.buildRequest();
-
     if (this.isEdit) {
       action = this.taskWrapper.wrapTaskAroundCall({
         task: new FinishedTask('nfs/edit', {
@@ -673,37 +674,68 @@ export class NfsFormComponent extends CdForm implements OnInit {
       error: (errorResponse: CdHttpErrorResponse) => this.setFormErrors(errorResponse),
       complete: () => {
         this.bandwidthObj = this.nfsRateLimitComponent?.getRateLimitFormValue();
+        this.bandwidthIopsObj = this.nfsRateLimitComponent?.getRateLimitOpsFormValue();
         if (
-          !!this.bandwidthObj &&
-          this.clusterAllConfig?.enable_qos === this.bandwidthObj?.enable_qos
+          this.bandwidthObj &&
+          this.clusterAllConfig?.enable_bw_control === this.bandwidthObj?.enable_qos
         ) {
-          this.submitRateLimit();
+          this.submitRateLimit(RateLimitType.Bandwidth);
+        }
+        if (
+          this.bandwidthIopsObj &&
+          this.clusterAllConfig?.enable_iops_control === this.bandwidthIopsObj?.enable_ops
+        ) {
+          this.submitRateLimit(RateLimitType.Iops);
         }
         this.router.navigate([`/${getPathfromFsal(this.storageBackend)}/nfs`]);
       }
     });
   }
-  submitRateLimit() {
-    let notificationTitle = $localize`Update Rate Limit For Export`;
-    let cluster_id = this.nfsForm.getValue('cluster_id');
-    this.bandwidthObj = {
-      ...this.bandwidthObj,
-      pseudo_path: this.nfsForm.getValue('pseudo'),
-      disable_qos: !this.bandwidthObj.enable_qos,
-      cluster_id
-    };
-    delete this.bandwidthObj.enable_qos;
-    delete this.bandwidthObj.qos_type;
-    this.nfsService.enableQosForExports(this.bandwidthObj).subscribe({
-      error: () => {
-        // Reset the 'Submit' button.
-        this.nfsForm.setErrors({ cdSubmitButton: true });
-      },
-      complete: () => {
-        this.notificationService.show(NotificationType.success, notificationTitle);
-      }
+
+  submitRateLimit(type: RateLimitType) {
+    const notificationTitle = $localize`Update Rate Limit For Export`;
+    const cluster_id = this.nfsForm.getValue('cluster_id');
+
+    let rateLimitObj: NFSBwIopConfig;
+    let serviceCall: Observable<any>;
+
+    if (type === RateLimitType.Bandwidth) {
+      rateLimitObj = {
+        ...this.bandwidthObj,
+        pseudo_path: this.nfsForm.getValue('pseudo'),
+        disable_qos: !this.bandwidthObj.enable_qos,
+        cluster_id
+      };
+      delete rateLimitObj.enable_qos;
+      delete rateLimitObj.qos_type;
+
+      serviceCall = this.nfsService.enableQosForExports(rateLimitObj);
+    } else if (type === RateLimitType.Iops) {
+      rateLimitObj = {
+        ...this.bandwidthIopsObj,
+        pseudo_path: this.nfsForm.getValue('pseudo'),
+        disable_qos_ops: !this.bandwidthIopsObj.enable_ops,
+        cluster_id
+      };
+      delete rateLimitObj.enable_ops;
+      delete rateLimitObj.qos_type;
+
+      serviceCall = this.nfsService.enableQosOpsForExports(rateLimitObj);
+    }
+    serviceCall.subscribe({
+      error: () => this.handleSubmitError(),
+      complete: () => this.handleSubmitComplete(notificationTitle)
     });
   }
+
+  private handleSubmitError() {
+    this.nfsForm.setErrors({ cdSubmitButton: true });
+  }
+
+  private handleSubmitComplete(notificationTitle: string) {
+    this.notificationService.show(NotificationType.success, notificationTitle);
+  }
+
   private setFormErrors(errorResponse: CdHttpErrorResponse) {
     if (
       errorResponse.error.detail &&
@@ -808,6 +840,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
       );
     };
   }
+
   registerClusterIdChange(value: string) {
     this.nfsService.getClusterBandwidthOpsConfig(value).subscribe((clusterData: NFSBwIopConfig) => {
       this.clusterAllConfig = clusterData;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.spec.ts
@@ -12,8 +12,10 @@ import { TableActionsComponent } from '~/app/shared/datatable/table-actions/tabl
 import { ExecutingTask } from '~/app/shared/models/executing-task';
 import { Summary } from '~/app/shared/models/summary.model';
 import { SummaryService } from '~/app/shared/services/summary.service';
+import { CdDatePipe } from '~/app/shared/pipes/cd-date.pipe';
+import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
 import { TaskListService } from '~/app/shared/services/task-list.service';
-import { SharedModule } from '~/app/shared/shared.module';
+import { CommonModule } from '@angular/common';
 import { configureTestBed, expectItemTasks, PermissionHelper } from '~/testing/unit-test-helper';
 import { NfsDetailsComponent } from '../nfs-details/nfs-details.component';
 import { NfsListComponent, RgwExportType } from './nfs-list.component';
@@ -37,10 +39,14 @@ describe('NfsListComponent', () => {
       BrowserAnimationsModule,
       HttpClientTestingModule,
       RouterTestingModule,
-      SharedModule,
+      CommonModule,
       NgbNavModule
     ],
-    providers: [TaskListService]
+    providers: [
+      TaskListService,
+      { provide: ModalCdsService, useValue: { show: jest.fn(), dismissAll: jest.fn() } },
+      { provide: CdDatePipe, useValue: { transform: (d: any) => d } }
+    ]
   });
 
   beforeEach(() => {
@@ -119,7 +125,7 @@ describe('NfsListComponent', () => {
     });
 
     it('should call error function on init when summary service fails', () => {
-      spyOn(component.table, 'reset');
+      component.table = { reset: jest.fn() } as any;
       summaryService['summaryDataSource'].error(undefined);
       expect(component.table.reset).toHaveBeenCalled();
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -101,7 +101,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
     const createAction: CdTableAction = {
       permission: 'create',
       icon: Icons.add,
-      routerLink: () => `/${prefix}/nfs/create`,
+      routerLink: () => `/${prefix}/nfs/create/${this.clusterId}`,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection,
       name: this.actionLabels.CREATE
     };
@@ -176,7 +176,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
         cellTemplate: this.protocolTpl
       },
       {
-        name: $localize`Transports`,
+        name: $localize`Transport Protocol`,
         prop: 'transports',
         flexGrow: 2,
         cellTemplate: this.transportTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-list/nfs-list.component.ts
@@ -101,7 +101,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
     const createAction: CdTableAction = {
       permission: 'create',
       icon: Icons.add,
-      routerLink: () => `/${prefix}/nfs/create`,
+      routerLink: () => `/${prefix}/nfs/create/${this.clusterId}`,
       canBePrimary: (selection: CdTableSelection) => !selection.hasSingleSelection,
       name: this.actionLabels.CREATE
     };
@@ -182,7 +182,7 @@ export class NfsListComponent extends ListWithDetails implements OnInit, OnDestr
         cellTemplate: this.protocolTpl
       },
       {
-        name: $localize`Transports`,
+        name: $localize`Transport Protocol`,
         prop: 'transports',
         flexGrow: 2,
         cellTemplate: this.transportTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
@@ -1,100 +1,76 @@
-<ng-container *ngIf="allowQoS">
+<ng-container *ngIf="allowQoS || allowIops">
   <form name="rateLimitForm"
         #formDir="ngForm"
         [formGroup]="rateLimitForm"
         novalidate>
+    <!-- Cluster QOS Disabled Information -->
+
     <cd-alert-panel type="info"
                     class="me-1"
                     spacingClass="mt-1"
-                    *ngIf="clusterQoSDisabled"
-                    i18n>Cluster level QoS setting is disabled.
+                    *ngIf="(clusterQosDisabled || clusterIopsDisabled)"
+                    i18n>Cluster-level IOPS or bandwidth control is disabled, so export-level settings for the disabled module won't apply, even if enabled.
     </cd-alert-panel>
 
     <cd-alert-panel type="info"
                     class="me-1"
                     spacingClass="mt-1"
                     *ngIf="showDisableWarning"
-                    i18n>Disable QoS will set QoS Bandwidth limit to Maximum.
+                    i18n>Disable QOS will set QOS Bandwidth limit to Maximum.
     </cd-alert-panel>
 
     <cd-alert-panel type="info"
                     class="me-1"
                     spacingClass="mt-1"
-                    *ngIf="showQoStypeChangeNote"
-                    i18n>If changing from already set one then please make sure to update exports bandwidths according to QoS type.
+                    *ngIf="showQostypeChangeNote"
+                    i18n>If changing from already set one then please make sure to update exports bandwidths according
+      to qos type.
     </cd-alert-panel>
-    <!-- qos_type is perclient, then can't enable export level QoS -->
+    <!-- qos_type is perclient, then can't enable export level qos -->
     <div
       class="form-item"
-      *ngIf="type === 'cluster' || (type === 'export' && nfsClusterData?.qos_type !== 'PerClient')"
+      *ngIf="
+        type === nfsType?.cluster ||
+        (type === nfsType?.export && nfsClusterData?.qos_type !== qosTypeValue?.PerClient && allowQoS)
+      "
     >
       <cds-checkbox
         id="enable_qos"
         type="checkbox"
-        (checkedChange)="showMaxBwNote()"
+        (checkedChange)="showMaxBwNote('bw')"
         formControlName="enable_qos"
         i18n
-        >Enable Bandwidth QoS
-      </cds-checkbox>
+        >Enable Bandwidth QOS</cds-checkbox>
     </div>
-    <span *ngIf="showMaxBw">Disable QoS will set QoS Bandwidth limit to Maximum.</span>
+    <span *ngIf="showMaxBw"
+          i18n>Disable QOS will set QOS Bandwidth limit to Maximum.</span>
 
+    <!-- QoS Type Selection -->
     <div class="form-item"
-         *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
-      <cds-select
-        formControlName="bwType"
-        for="bwType"
-        label="Rate Limit"
-        id="bwType"
-        [helperText]="bwTypeHelper"
-        [skeleton]="bwTypeArr === null"
-      >
-        <option *ngIf="bwTypeArr === null"
-                [ngValue]="null">Loading...</option>
-        <option *ngIf="bwTypeArr !== null && bwTypeArr.length === 0"
-                i18n
-                [ngValue]="null">
-          -- No RateLimit type available --
-        </option>
-        <option *ngIf="bwTypeArr !== null && bwTypeArr.length > 0"
-                i18n
-                [ngValue]="null">
-          -- Select a RateLimit Type --
-        </option>
-        <option *ngFor="let type of bwTypeArr"
-                i18n
-                [value]="type.value">{{ type.value }}</option>
-      </cds-select>
-      <ng-template #bwTypeHelper>
-        <span *ngIf="rateLimitForm.getValue('bwType')">
-          {{ getbwTypeHelp(rateLimitForm.getValue('bwType')) }}
-        </span>
-      </ng-template>
-    </div>
-
-
-    <!-- qos type -->
-    <div class="form-item"
-         *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
+         *ngIf="rateLimitForm.getValue('enable_qos') && type !== nfsType?.export">
       <cds-select
         formControlName="qos_type"
+        for="qos_type"
         label="Bandwidth QOS Type"
         id="qos_type"
         [helperText]="qosTypeHelper"
-        [skeleton]="qosType === null"
         (change)="registerQoSChange($event.target.value)"
-        i18n-label
+        [invalid]="
+            rateLimitForm.controls.qos_type.invalid &&
+            rateLimitForm.controls.qos_type.dirty
+          "
+          [invalidText]="qos_error"
       >
         <option *ngIf="qosType === null"
                 value="">Loading...</option>
         <option *ngIf="qosType !== null && qosType.length === 0"
                 i18n
-                value="null">
-          -- No Bandwidth Qos type available --
+                value="">
+          -- No Bandwidth QOS type available --
         </option>
-        <option *ngIf="qosType !== null && qosType?.length > 0"
-                value=""
-                i18n>
+        <option *ngIf="qosType.length > 0"
+                i18n
+                value="">
           -- Select a Bandwidth QOS Type --
         </option>
         <option *ngFor="let type of qosType"
@@ -106,12 +82,21 @@
           {{ getQoSTypeHelper(rateLimitForm.getValue('qos_type')) }}
         </span>
       </ng-template>
+      <ng-template #qos_error>
+        <span
+        class="invalid-feedback"
+        *ngIf="rateLimitForm.showError('qos_type', formDir, 'qosTypeInvalid')"
+        i18n
+        >QOS type should be same for bandwidth and IOPS control.</span
+      >
+      </ng-template>
     </div>
 
+    <!-- Export and Client Bandwidth Settings Based on QoS Type -->
     <ng-container
       *ngIf="
         rateLimitForm?.getValue('enable_qos') &&
-        (qosTypeVal === 'PerShare' || qosTypeVal === 'PerShare_PerClient')
+        (qosTypeVal === qosTypeValue?.PerShare || qosTypeVal === qosTypeValue?.PerSharePerClient)
       "
     >
       <div class="form-group row">
@@ -139,8 +124,9 @@
               rateLimitForm.controls.max_export_read_bw.invalid &&
               rateLimitForm.controls.max_export_read_bw.dirty
             "
-            defaultUnit="b"
+            [ngDataReady]="ngDataReady"
             defaultEmptyValue="true"
+            defaultUnit="b"
             cdDimlessBinaryPerSecond
           />
         </cds-text-label>
@@ -190,8 +176,9 @@
               rateLimitForm.controls.max_export_write_bw.invalid &&
               rateLimitForm.controls.max_export_write_bw.dirty
             "
-            defaultUnit="b"
+            [ngDataReady]="ngDataReady"
             defaultEmptyValue="true"
+            defaultUnit="b"
             cdDimlessBinaryPerSecond
           />
         </cds-text-label>
@@ -222,11 +209,11 @@
     <ng-container
       *ngIf="
         rateLimitForm?.getValue('enable_qos') &&
-        ((this.type === 'cluster' &&
-          (this.qosTypeVal === 'PerClient' || this.qosTypeVal === 'PerShare_PerClient')) ||
-          (this.type === 'export' &&
-            this.qosTypeVal !== 'PerClient' &&
-            this.qosTypeVal !== 'PerShare'))
+        ((type === nfsType?.cluster &&
+          (qosTypeVal === qosTypeValue?.PerClient || qosTypeVal === qosTypeValue?.PerSharePerClient)) ||
+          (type === nfsType?.export &&
+            qosTypeVal !== qosTypeValue?.PerClient &&
+            qosTypeVal !== qosTypeValue?.PerShare))
       "
     >
       <div class="form-group row">
@@ -254,8 +241,9 @@
               rateLimitForm.controls.max_client_read_bw.invalid &&
               rateLimitForm.controls.max_client_read_bw.dirty
             "
-            defaultUnit="b"
+            [ngDataReady]="ngDataReady"
             defaultEmptyValue="true"
+            defaultUnit="b"
             cdDimlessBinaryPerSecond
           />
         </cds-text-label>
@@ -299,19 +287,19 @@
             type="text"
             placeholder="Client write bandwidth..."
             i18n-placeholder
-            id="max_client_write_bw"
-            name="max_client_write_bw"
+            [id]="max_client_write_bw"
+            [name]="max_client_write_bw"
             formControlName="max_client_write_bw"
             [invalid]="
               rateLimitForm.controls.max_client_write_bw.invalid &&
               rateLimitForm.controls.max_client_write_bw.dirty
             "
-            defaultUnit="b"
+            [ngDataReady]="ngDataReady"
             defaultEmptyValue="true"
+            defaultUnit="b"
             cdDimlessBinaryPerSecond
           />
         </cds-text-label>
-        <!-- [ngbTypeahead]="pathDataSource" -->
         <ng-template #client_write_bw_Error>
           <span
             class="invalid-feedback"
@@ -334,5 +322,193 @@
         </ng-template>
       </div>
     </ng-container>
+
+    <!-- qos_type is perclient, then can't enable export level qos -->
+
+    <div
+      class="form-item"
+      *ngIf="
+        type === nfsType?.cluster ||
+        (type === nfsType?.export && nfsClusterData?.qos_type !== qosTypeValue?.PerClient && allowIops)
+      "
+    >
+      <cds-checkbox
+        id="enable_ops"
+        type="checkbox"
+        (checkedChange)="showMaxBwNote('iops')"
+        formControlName="enable_ops"
+        i18n
+        >Enable IOPS QOS</cds-checkbox
+      >
+    </div>
+    <span *ngIf="showMaxBw"
+          i18n>Disable QOS will set QOS Bandwidth limit to Maximum.</span>
+
+    <!-- IOPS Type Selection -->
+    <div class="form-item"
+         *ngIf="rateLimitForm.getValue('enable_ops') && type !== nfsType?.export">
+      <cds-select
+        formControlName="qos_type_ops"
+        for="qos_type_ops"
+        label="IOPS QOS Type"
+        i18n-label
+        id="qos_type_ops"
+        i18n-helperText
+        [helperText]="qosiopsTypeHelper"
+        [skeleton]="qosIopsType === null"
+        (change)="registerQoSIOPSChange($event.target.value)"
+        [invalid]="
+        rateLimitForm.controls.qos_type_ops.invalid &&
+        rateLimitForm.controls.qos_type_ops.dirty
+      "
+      [invalidText]="qos_ops_error"
+      >
+        <option *ngIf="qosIopsType === null"
+                value="">Loading...</option>
+        <option *ngIf="qosIopsType !== null && qosIopsType.length === 0"
+                i18n
+                value="">
+          -- No IOPS QOS type available --
+        </option>
+        <option *ngIf="qosIopsType !== null && qosIopsType.length > 0"
+                i18n
+                value="">
+          -- Select a IOPS QOS Type --
+        </option>
+        <option *ngFor="let type of qosIopsType"
+                i18n
+                [value]="type.value">{{ type.key }}</option>
+      </cds-select>
+      <ng-template #qosiopsTypeHelper>
+        <span *ngIf="rateLimitForm.getValue('qos_type_ops')">
+          {{ getQoSTypeIOPsHelper(rateLimitForm.getValue('qos_type_ops')) }}
+        </span>
+      </ng-template>
+      <ng-template #qos_ops_error>
+        <span
+        class="invalid-feedback"
+        *ngIf="rateLimitForm.showError('qos_type_ops', formDir, 'qosTypeInvalid')"
+        i18n
+        >QOS type should be same for bandwidth and IOPS control.</span
+      >
+      </ng-template>
+    </div>
+
+    <!-- Export and Client IOPS Settings Based on IOPS Type -->
+    <div
+      *ngIf="
+        rateLimitForm?.getValue('enable_ops') &&
+        (qosiopsTypeVal === qosTypeValue?.PerShare || qosiopsTypeVal === qosTypeValue?.PerSharePerClient)
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_export_iops"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum IOPS that can be used for export read per second"
+          cdRequiredField="Export IOPS"
+          [invalid]="
+            rateLimitForm.controls.max_export_iops.invalid &&
+            rateLimitForm.controls.max_export_iops.dirty
+          "
+          [invalidText]="Export_iops_Error"
+          >Export IOPS
+          <input
+            cdsText
+            type="number"
+            placeholder="Export IOPS..."
+            i18n-placeholder
+            id="max_export_iops"
+            name="max_export_iops"
+            formControlName="max_export_iops"
+            [invalid]="
+              rateLimitForm.controls.max_export_iops.invalid &&
+              rateLimitForm.controls.max_export_iops.dirty
+            "
+            [invalidText]="Export_iops_Error"
+          />
+        </cds-text-label>
+        <ng-template #Export_iops_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_iops', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_export_iops').hasError('min')"
+            i18n
+            >Minimum value is 10 IOPS.
+          </span>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_export_iops').hasError('max')"
+            i18n
+            >Maximum value is 16384 IOPS.
+          </span>
+        </ng-template>
+      </div>
+    </div>
+    <div
+      *ngIf="
+        rateLimitForm?.getValue('enable_ops') &&
+        ((type === nfsType?.cluster &&
+          (qosiopsTypeVal === qosTypeValue?.PerClient || qosiopsTypeVal === qosTypeValue?.PerSharePerClient)) ||
+          (type === nfsType?.export &&
+          qosiopsTypeVal !== qosTypeValue?.PerClient &&
+          qosiopsTypeVal !== qosTypeValue?.PerShare))
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_client_iops"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum IOPS"
+          cdRequiredField="Client IOPS"
+          [invalid]="
+            rateLimitForm.controls.max_client_iops.invalid &&
+            rateLimitForm.controls.max_client_iops.dirty
+          "
+          [invalidText]="Client_iops_Error"
+        >
+          Client IOPS
+          <input
+            cdsText
+            type="number"
+            placeholder="Client IOPS..."
+            i18n-placeholder
+            name="max_client_iops"
+            formControlName="max_client_iops"
+            [invalid]="
+              rateLimitForm.controls.max_client_iops.invalid &&
+              rateLimitForm.controls.max_client_iops.dirty
+            "
+          />
+        </cds-text-label>
+        <ng-template #Client_iops_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_iops', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_client_iops').hasError('min')"
+            i18n
+            >Minimum value is 10 IOPS.
+          </span>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.get('max_client_iops').hasError('max')"
+            i18n
+            >Maximum value is 16384 IOPS.
+          </span>
+        </ng-template>
+      </div>
+    </div>
   </form>
 </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
@@ -1,0 +1,338 @@
+<ng-container *ngIf="allowQoS">
+  <form name="rateLimitForm"
+        #formDir="ngForm"
+        [formGroup]="rateLimitForm"
+        novalidate>
+    <cd-alert-panel type="info"
+                    class="me-1"
+                    spacingClass="mt-1"
+                    *ngIf="clusterQoSDisabled"
+                    i18n>Cluster level QoS setting is disabled.
+    </cd-alert-panel>
+
+    <cd-alert-panel type="info"
+                    class="me-1"
+                    spacingClass="mt-1"
+                    *ngIf="showDisableWarning"
+                    i18n>Disable QoS will set QoS Bandwidth limit to Maximum.
+    </cd-alert-panel>
+
+    <cd-alert-panel type="info"
+                    class="me-1"
+                    spacingClass="mt-1"
+                    *ngIf="showQoStypeChangeNote"
+                    i18n>If changing from already set one then please make sure to update exports bandwidths according to QoS type.
+    </cd-alert-panel>
+    <!-- qos_type is perclient, then can't enable export level QoS -->
+    <div
+      class="form-item"
+      *ngIf="type === 'cluster' || (type === 'export' && nfsClusterData?.qos_type !== 'PerClient')"
+    >
+      <cds-checkbox
+        id="enable_qos"
+        type="checkbox"
+        (checkedChange)="showMaxBwNote()"
+        formControlName="enable_qos"
+        i18n
+        >Enable Bandwidth QoS
+      </cds-checkbox>
+    </div>
+    <span *ngIf="showMaxBw">Disable QoS will set QoS Bandwidth limit to Maximum.</span>
+
+    <div class="form-item"
+         *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
+      <cds-select
+        formControlName="bwType"
+        for="bwType"
+        label="Rate Limit"
+        id="bwType"
+        [helperText]="bwTypeHelper"
+        [skeleton]="bwTypeArr === null"
+      >
+        <option *ngIf="bwTypeArr === null"
+                [ngValue]="null">Loading...</option>
+        <option *ngIf="bwTypeArr !== null && bwTypeArr.length === 0"
+                i18n
+                [ngValue]="null">
+          -- No RateLimit type available --
+        </option>
+        <option *ngIf="bwTypeArr !== null && bwTypeArr.length > 0"
+                i18n
+                [ngValue]="null">
+          -- Select a RateLimit Type --
+        </option>
+        <option *ngFor="let type of bwTypeArr"
+                i18n
+                [value]="type.value">{{ type.value }}</option>
+      </cds-select>
+      <ng-template #bwTypeHelper>
+        <span *ngIf="rateLimitForm.getValue('bwType')">
+          {{ getbwTypeHelp(rateLimitForm.getValue('bwType')) }}
+        </span>
+      </ng-template>
+    </div>
+
+
+    <!-- qos type -->
+    <div class="form-item"
+         *ngIf="rateLimitForm.getValue('enable_qos') && type !== 'export'">
+      <cds-select
+        formControlName="qos_type"
+        label="Bandwidth QOS Type"
+        id="qos_type"
+        [helperText]="qosTypeHelper"
+        [skeleton]="qosType === null"
+        (change)="registerQoSChange($event.target.value)"
+        i18n-label
+      >
+        <option *ngIf="qosType === null"
+                value="">Loading...</option>
+        <option *ngIf="qosType !== null && qosType.length === 0"
+                i18n
+                value="null">
+          -- No Bandwidth Qos type available --
+        </option>
+        <option *ngIf="qosType !== null && qosType?.length > 0"
+                value=""
+                i18n>
+          -- Select a Bandwidth QOS Type --
+        </option>
+        <option *ngFor="let type of qosType"
+                i18n
+                [value]="type.value">{{ type.key }}</option>
+      </cds-select>
+      <ng-template #qosTypeHelper>
+        <span *ngIf="rateLimitForm.getValue('qos_type')">
+          {{ getQoSTypeHelper(rateLimitForm.getValue('qos_type')) }}
+        </span>
+      </ng-template>
+    </div>
+
+    <ng-container
+      *ngIf="
+        rateLimitForm?.getValue('enable_qos') &&
+        (qosTypeVal === 'PerShare' || qosTypeVal === 'PerShare_PerClient')
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_export_read_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that can be used for export read per second"
+          cdRequiredField="Export read bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_export_read_bw.invalid &&
+            rateLimitForm.controls.max_export_read_bw.dirty
+          "
+          [invalidText]="Export_readbw_Error"
+          >Export Write Bandwidth
+          <input
+            cdsText
+            type="text"
+            placeholder="Export read bandwidth..."
+            i18n-placeholder
+            id="max_export_read_bw"
+            name="max_export_read_bw"
+            formControlName="max_export_read_bw"
+            [invalid]="
+              rateLimitForm.controls.max_export_read_bw.invalid &&
+              rateLimitForm.controls.max_export_read_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+        <ng-template #Export_readbw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_read_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_read_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_read_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+      <div class="form-group row">
+        <cds-text-label
+          for="max_export_write_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that can be used for export write per second"
+          cdRequiredField="Export write bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_export_write_bw.invalid &&
+            rateLimitForm.controls.max_export_write_bw.dirty
+          "
+          [invalidText]="Export_writebw_Error"
+          >Export Write Bandwidth
+          <input
+            cdsText
+            type="text"
+            placeholder="Export write bandwidth..."
+            i18n-placeholder
+            id="max_export_write_bw"
+            name="max_export_write_bw"
+            formControlName="max_export_write_bw"
+            [invalid]="
+              rateLimitForm.controls.max_export_write_bw.invalid &&
+              rateLimitForm.controls.max_export_write_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+
+        <ng-template #Export_writebw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_write_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_write_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_export_write_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+    </ng-container>
+
+    <ng-container
+      *ngIf="
+        rateLimitForm?.getValue('enable_qos') &&
+        ((this.type === 'cluster' &&
+          (this.qosTypeVal === 'PerClient' || this.qosTypeVal === 'PerShare_PerClient')) ||
+          (this.type === 'export' &&
+            this.qosTypeVal !== 'PerClient' &&
+            this.qosTypeVal !== 'PerShare'))
+      "
+    >
+      <div class="form-group row">
+        <cds-text-label
+          for="max_client_read_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that client can use for read per second"
+          cdRequiredField="Client read bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_client_read_bw.invalid &&
+            rateLimitForm.controls.max_client_read_bw.dirty
+          "
+          [invalidText]="client_read_bw_Error"
+          >Client Read Bandwidth
+          <input
+            cdsText
+            type="text"
+            id="max_client_read_bw"
+            name="max_client_read_bw"
+            formControlName="max_client_read_bw"
+            placeholder="Client read bandwidth..."
+            i18n-placeholder
+            [invalid]="
+              rateLimitForm.controls.max_client_read_bw.invalid &&
+              rateLimitForm.controls.max_client_read_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+
+        <ng-template #client_read_bw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_read_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_read_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_read_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+      <div class="form-group row">
+        <cds-text-label
+          for="max_client_write_bw"
+          i18n
+          i18n-helperText
+          helperText="Limits the maximum bandwidth that client can use for write per second"
+          cdRequiredField="Client write bandwidth"
+          [invalid]="
+            rateLimitForm.controls.max_client_write_bw.invalid &&
+            rateLimitForm.controls.max_client_write_bw.dirty
+          "
+          [invalidText]="client_write_bw_Error"
+          >Client Write Bandwidth
+          <input
+            cdsText
+            type="text"
+            placeholder="Client write bandwidth..."
+            i18n-placeholder
+            id="max_client_write_bw"
+            name="max_client_write_bw"
+            formControlName="max_client_write_bw"
+            [invalid]="
+              rateLimitForm.controls.max_client_write_bw.invalid &&
+              rateLimitForm.controls.max_client_write_bw.dirty
+            "
+            defaultUnit="b"
+            defaultEmptyValue="true"
+            cdDimlessBinaryPerSecond
+          />
+        </cds-text-label>
+        <!-- [ngbTypeahead]="pathDataSource" -->
+        <ng-template #client_write_bw_Error>
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_write_bw', formDir, 'required')"
+            i18n
+            >This field is required.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_write_bw', formDir, 'rateByteMaxSize')"
+            i18n
+            >The value is not valid.</span
+          >
+          <span
+            class="invalid-feedback"
+            *ngIf="rateLimitForm.showError('max_client_write_bw', formDir, 'min')"
+            i18n
+            >Enter a positive number.</span
+          >
+        </ng-template>
+      </div>
+    </ng-container>
+  </form>
+</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
@@ -446,7 +446,7 @@
             class="invalid-feedback"
             *ngIf="rateLimitForm.get('max_export_iops').hasError('max')"
             i18n
-            >Maximum value is 16384 IOPS.
+            >Maximum value is 1,638,400 IOPS.
           </span>
         </ng-template>
       </div>
@@ -505,7 +505,7 @@
             class="invalid-feedback"
             *ngIf="rateLimitForm.get('max_client_iops').hasError('max')"
             i18n
-            >Maximum value is 16384 IOPS.
+            >Maximum value is 1,638,400 IOPS.
           </span>
         </ng-template>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.html
@@ -1,29 +1,38 @@
 <ng-container *ngIf="allowQoS || allowIops">
-  <form name="rateLimitForm"
-        #formDir="ngForm"
-        [formGroup]="rateLimitForm"
-        novalidate>
+  <form
+    name="rateLimitForm"
+    #formDir="ngForm"
+    [formGroup]="rateLimitForm"
+    novalidate
+  >
     <!-- Cluster QOS Disabled Information -->
 
-    <cd-alert-panel type="info"
-                    class="me-1"
-                    spacingClass="mt-1"
-                    *ngIf="(clusterQosDisabled || clusterIopsDisabled)"
-                    i18n>Cluster-level IOPS or bandwidth control is disabled, so export-level settings for the disabled module won't apply, even if enabled.
+    <cd-alert-panel
+      type="info"
+      class="me-1"
+      spacingClass="mt-1"
+      *ngIf="clusterQosDisabled || clusterIopsDisabled"
+      i18n
+      >Cluster-level IOPS or bandwidth control is disabled, so export-level settings for the
+      disabled module won't apply, even if enabled.
     </cd-alert-panel>
 
-    <cd-alert-panel type="info"
-                    class="me-1"
-                    spacingClass="mt-1"
-                    *ngIf="showDisableWarning"
-                    i18n>Disable QOS will set QOS Bandwidth limit to Maximum.
+    <cd-alert-panel
+      type="info"
+      class="me-1"
+      spacingClass="mt-1"
+      *ngIf="showDisableWarning"
+      i18n
+      >Disable QOS will set QOS Bandwidth limit to Maximum.
     </cd-alert-panel>
 
-    <cd-alert-panel type="info"
-                    class="me-1"
-                    spacingClass="mt-1"
-                    *ngIf="showQostypeChangeNote"
-                    i18n>If changing from already set one then please make sure to update exports bandwidths according
+    <cd-alert-panel
+      type="info"
+      class="me-1"
+      spacingClass="mt-1"
+      *ngIf="showQostypeChangeNote"
+      i18n
+      >If changing from already set one then please make sure to update exports bandwidths according
       to qos type.
     </cd-alert-panel>
     <!-- qos_type is perclient, then can't enable export level qos -->
@@ -31,7 +40,9 @@
       class="form-item"
       *ngIf="
         type === nfsType?.cluster ||
-        (type === nfsType?.export && nfsClusterData?.qos_type !== qosTypeValue?.PerClient && allowQoS)
+        (type === nfsType?.export &&
+          nfsClusterData?.qos_type !== qosTypeValue?.PerClient &&
+          allowQoS)
       "
     >
       <cds-checkbox
@@ -40,14 +51,20 @@
         (checkedChange)="showMaxBwNote('bw')"
         formControlName="enable_qos"
         i18n
-        >Enable Bandwidth QOS</cds-checkbox>
+        >Enable Bandwidth QOS</cds-checkbox
+      >
     </div>
-    <span *ngIf="showMaxBw"
-          i18n>Disable QOS will set QOS Bandwidth limit to Maximum.</span>
+    <span
+      *ngIf="showMaxBw"
+      i18n
+      >Disable QOS will set QOS Bandwidth limit to Maximum.</span
+    >
 
     <!-- QoS Type Selection -->
-    <div class="form-item"
-         *ngIf="rateLimitForm.getValue('enable_qos') && type !== nfsType?.export">
+    <div
+      class="form-item"
+      *ngIf="rateLimitForm.getValue('enable_qos') && type !== nfsType?.export"
+    >
       <cds-select
         formControlName="qos_type"
         for="qos_type"
@@ -55,27 +72,36 @@
         id="qos_type"
         [helperText]="qosTypeHelper"
         (change)="registerQoSChange($event.target.value)"
-        [invalid]="
-            rateLimitForm.controls.qos_type.invalid &&
-            rateLimitForm.controls.qos_type.dirty
-          "
-          [invalidText]="qos_error"
+        [invalid]="rateLimitForm.controls.qos_type.invalid && rateLimitForm.controls.qos_type.dirty"
+        [invalidText]="qos_error"
       >
-        <option *ngIf="qosType === null"
-                value="">Loading...</option>
-        <option *ngIf="qosType !== null && qosType.length === 0"
-                i18n
-                value="">
+        <option
+          *ngIf="qosType === null"
+          value=""
+        >
+          Loading...
+        </option>
+        <option
+          *ngIf="qosType !== null && qosType.length === 0"
+          i18n
+          value=""
+        >
           -- No Bandwidth QOS type available --
         </option>
-        <option *ngIf="qosType.length > 0"
-                i18n
-                value="">
+        <option
+          *ngIf="qosType.length > 0"
+          i18n
+          value=""
+        >
           -- Select a Bandwidth QOS Type --
         </option>
-        <option *ngFor="let type of qosType"
-                i18n
-                [value]="type.value">{{ type.key }}</option>
+        <option
+          *ngFor="let type of qosType"
+          i18n
+          [value]="type.value"
+        >
+          {{ type.key }}
+        </option>
       </cds-select>
       <ng-template #qosTypeHelper>
         <span *ngIf="rateLimitForm.getValue('qos_type')">
@@ -84,11 +110,11 @@
       </ng-template>
       <ng-template #qos_error>
         <span
-        class="invalid-feedback"
-        *ngIf="rateLimitForm.showError('qos_type', formDir, 'qosTypeInvalid')"
-        i18n
-        >QOS type should be same for bandwidth and IOPS control.</span
-      >
+          class="invalid-feedback"
+          *ngIf="rateLimitForm.showError('qos_type', formDir, 'qosTypeInvalid')"
+          i18n
+          >QOS type should be same for bandwidth and IOPS control.</span
+        >
       </ng-template>
     </div>
 
@@ -111,7 +137,7 @@
             rateLimitForm.controls.max_export_read_bw.dirty
           "
           [invalidText]="Export_readbw_Error"
-          >Export Write Bandwidth
+          >Export Read Bandwidth
           <input
             cdsText
             type="text"
@@ -210,7 +236,8 @@
       *ngIf="
         rateLimitForm?.getValue('enable_qos') &&
         ((type === nfsType?.cluster &&
-          (qosTypeVal === qosTypeValue?.PerClient || qosTypeVal === qosTypeValue?.PerSharePerClient)) ||
+          (qosTypeVal === qosTypeValue?.PerClient ||
+            qosTypeVal === qosTypeValue?.PerSharePerClient)) ||
           (type === nfsType?.export &&
             qosTypeVal !== qosTypeValue?.PerClient &&
             qosTypeVal !== qosTypeValue?.PerShare))
@@ -287,8 +314,8 @@
             type="text"
             placeholder="Client write bandwidth..."
             i18n-placeholder
-            [id]="max_client_write_bw"
-            [name]="max_client_write_bw"
+            id="max_client_write_bw"
+            name="max_client_write_bw"
             formControlName="max_client_write_bw"
             [invalid]="
               rateLimitForm.controls.max_client_write_bw.invalid &&
@@ -329,7 +356,9 @@
       class="form-item"
       *ngIf="
         type === nfsType?.cluster ||
-        (type === nfsType?.export && nfsClusterData?.qos_type !== qosTypeValue?.PerClient && allowIops)
+        (type === nfsType?.export &&
+          nfsClusterData?.qos_type !== qosTypeValue?.PerClient &&
+          allowIops)
       "
     >
       <cds-checkbox
@@ -341,12 +370,17 @@
         >Enable IOPS QOS</cds-checkbox
       >
     </div>
-    <span *ngIf="showMaxBw"
-          i18n>Disable QOS will set QOS Bandwidth limit to Maximum.</span>
+    <span
+      *ngIf="showMaxBw"
+      i18n
+      >Disable QOS will set QOS Bandwidth limit to Maximum.</span
+    >
 
     <!-- IOPS Type Selection -->
-    <div class="form-item"
-         *ngIf="rateLimitForm.getValue('enable_ops') && type !== nfsType?.export">
+    <div
+      class="form-item"
+      *ngIf="rateLimitForm.getValue('enable_ops') && type !== nfsType?.export"
+    >
       <cds-select
         formControlName="qos_type_ops"
         for="qos_type_ops"
@@ -358,26 +392,37 @@
         [skeleton]="qosIopsType === null"
         (change)="registerQoSIOPSChange($event.target.value)"
         [invalid]="
-        rateLimitForm.controls.qos_type_ops.invalid &&
-        rateLimitForm.controls.qos_type_ops.dirty
-      "
-      [invalidText]="qos_ops_error"
+          rateLimitForm.controls.qos_type_ops.invalid && rateLimitForm.controls.qos_type_ops.dirty
+        "
+        [invalidText]="qos_ops_error"
       >
-        <option *ngIf="qosIopsType === null"
-                value="">Loading...</option>
-        <option *ngIf="qosIopsType !== null && qosIopsType.length === 0"
-                i18n
-                value="">
+        <option
+          *ngIf="qosIopsType === null"
+          value=""
+        >
+          Loading...
+        </option>
+        <option
+          *ngIf="qosIopsType !== null && qosIopsType.length === 0"
+          i18n
+          value=""
+        >
           -- No IOPS QOS type available --
         </option>
-        <option *ngIf="qosIopsType !== null && qosIopsType.length > 0"
-                i18n
-                value="">
+        <option
+          *ngIf="qosIopsType !== null && qosIopsType.length > 0"
+          i18n
+          value=""
+        >
           -- Select a IOPS QOS Type --
         </option>
-        <option *ngFor="let type of qosIopsType"
-                i18n
-                [value]="type.value">{{ type.key }}</option>
+        <option
+          *ngFor="let type of qosIopsType"
+          i18n
+          [value]="type.value"
+        >
+          {{ type.key }}
+        </option>
       </cds-select>
       <ng-template #qosiopsTypeHelper>
         <span *ngIf="rateLimitForm.getValue('qos_type_ops')">
@@ -386,11 +431,11 @@
       </ng-template>
       <ng-template #qos_ops_error>
         <span
-        class="invalid-feedback"
-        *ngIf="rateLimitForm.showError('qos_type_ops', formDir, 'qosTypeInvalid')"
-        i18n
-        >QOS type should be same for bandwidth and IOPS control.</span
-      >
+          class="invalid-feedback"
+          *ngIf="rateLimitForm.showError('qos_type_ops', formDir, 'qosTypeInvalid')"
+          i18n
+          >QOS type should be same for bandwidth and IOPS control.</span
+        >
       </ng-template>
     </div>
 
@@ -398,7 +443,8 @@
     <div
       *ngIf="
         rateLimitForm?.getValue('enable_ops') &&
-        (qosiopsTypeVal === qosTypeValue?.PerShare || qosiopsTypeVal === qosTypeValue?.PerSharePerClient)
+        (qosiopsTypeVal === qosTypeValue?.PerShare ||
+          qosiopsTypeVal === qosTypeValue?.PerSharePerClient)
       "
     >
       <div class="form-group row">
@@ -455,10 +501,11 @@
       *ngIf="
         rateLimitForm?.getValue('enable_ops') &&
         ((type === nfsType?.cluster &&
-          (qosiopsTypeVal === qosTypeValue?.PerClient || qosiopsTypeVal === qosTypeValue?.PerSharePerClient)) ||
+          (qosiopsTypeVal === qosTypeValue?.PerClient ||
+            qosiopsTypeVal === qosTypeValue?.PerSharePerClient)) ||
           (type === nfsType?.export &&
-          qosiopsTypeVal !== qosTypeValue?.PerClient &&
-          qosiopsTypeVal !== qosTypeValue?.PerShare))
+            qosiopsTypeVal !== qosTypeValue?.PerClient &&
+            qosiopsTypeVal !== qosTypeValue?.PerShare))
       "
     >
       <div class="form-group row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
@@ -1,0 +1,423 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NfsRateLimitComponent } from './nfs-rate-limit.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { RouterTestingModule } from '@angular/router/testing';
+import { SharedModule } from '~/app/shared/shared.module';
+import { Validators } from '@angular/forms';
+import { FormatterService } from '~/app/shared/services/formatter.service';
+
+describe('NfsRateLimitComponent', () => {
+  let component: NfsRateLimitComponent;
+  let fixture: ComponentFixture<NfsRateLimitComponent>;
+
+  configureTestBed({
+    declarations: [NfsRateLimitComponent],
+    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    providers: [FormatterService]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NfsRateLimitComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('loadConditionCheck', () => {
+    beforeEach(() => {
+      component.isEdit = true;
+    });
+
+    it('should handle type "cluster" with QoS enabled', () => {
+      component.type = 'cluster';
+      component.nfsClusterData = { enable_qos: true } as any;
+      spyOn(component, 'setFormData');
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).toBeTruthy();
+      expect(component.clusterQosDisabled).not.toBeTruthy();
+      expect(component.setFormData).toHaveBeenCalledWith(component.nfsClusterData);
+    });
+
+    it('should handle type "export" with cluster QoS enabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: true } as any;
+      spyOn(component, 'setFormData');
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).toBeTruthy();
+      expect(component.setFormData).toHaveBeenCalledWith(component.nfsExportdata);
+    });
+
+    it('should handle type "export" with export QoS enabled and cluster QoS disabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: false } as any;
+      component.nfsExportdata = { enable_qos: true } as any;
+      spyOn(component, 'registerQoSChange');
+      spyOn(component, 'setFormData');
+      spyOn(component, 'showDisabledField');
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).toBeTruthy();
+      expect(component.registerQoSChange).toHaveBeenCalledWith(component.nfsClusterData.qos_type);
+      expect(component.setFormData).toHaveBeenCalledWith(component.nfsExportdata);
+      expect(component.showDisabledField).toHaveBeenCalled();
+    });
+
+    it('should handle type "export" with both cluster and export QoS disabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: false } as any;
+      component.nfsExportdata = { enable_qos: false } as any;
+
+      component.loadConditionCheck();
+
+      expect(component.showDisableWarning).not.toBeTruthy();
+      expect(component.allowQoS).not.toBeTruthy();
+    });
+  });
+  describe('setValidation', () => {
+    it('should set validators for PerShare QoS type', () => {
+      component.qosTypeVal = 'PerShare';
+      component.createForm();
+      jest.spyOn(component.rateLimitForm.controls['max_export_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_export_write_bw'], 'addValidators');
+
+      component.setValidation();
+
+      expect(
+        component.rateLimitForm.controls['max_export_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_export_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+
+    it('should set validators for PerClient QoS type', () => {
+      component.qosTypeVal = 'PerClient';
+      component.createForm();
+      jest.spyOn(component.rateLimitForm.controls['max_client_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_write_bw'], 'addValidators');
+
+      component.setValidation();
+
+      expect(
+        component.rateLimitForm.controls['max_client_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+
+    it('should set validators for PerSharePerClient QoS type', () => {
+      component.qosTypeVal = 'PerShare_PerClient';
+      component.createForm();
+      jest.spyOn(component.rateLimitForm.controls['max_export_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_export_write_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_read_bw'], 'addValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_write_bw'], 'addValidators');
+
+      component.setValidation();
+
+      expect(
+        component.rateLimitForm.controls['max_export_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_export_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_read_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_write_bw'].addValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+  });
+
+  describe('showMaxBwNote', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should add validators when QoS is enabled', () => {
+      jest.spyOn(component, 'setValidation');
+      component.showMaxBwNote(true);
+      expect(component.setValidation).toHaveBeenCalled();
+    });
+
+    it('should remove validators when QoS is disabled', () => {
+      jest.spyOn(component.rateLimitForm.controls['max_export_read_bw'], 'removeValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_export_write_bw'], 'removeValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_read_bw'], 'removeValidators');
+      jest.spyOn(component.rateLimitForm.controls['max_client_write_bw'], 'removeValidators');
+
+      component.showMaxBwNote(false);
+
+      expect(
+        component.rateLimitForm.controls['max_export_read_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_export_write_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_read_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+      expect(
+        component.rateLimitForm.controls['max_client_write_bw'].removeValidators
+      ).toHaveBeenCalledWith(Validators.required);
+    });
+  });
+
+  describe('registerQoSChange', () => {
+    it('should set validation and show note if QoS type is changed', () => {
+      component.isEdit = true;
+      component.nfsClusterData = { qos_type: 'oldType' } as any;
+      jest.spyOn(component, 'setValidation');
+
+      component.registerQoSChange('newType');
+
+      expect(component.setValidation).toHaveBeenCalled();
+      expect(component.showQostypeChangeNote).toBeTruthy();
+    });
+
+    it('should set validation and not show note if QoS type is not changed', () => {
+      component.isEdit = true;
+      component.nfsClusterData = { qos_type: 'sameType' } as any;
+      jest.spyOn(component, 'setValidation');
+
+      component.registerQoSChange('sameType');
+
+      expect(component.setValidation).toHaveBeenCalled();
+      expect(component.showQostypeChangeNote).toBeFalsy();
+    });
+  });
+
+  describe('showQOS', () => {
+    it('should allow QoS if type is export and cluster QoS is disabled', () => {
+      component.type = 'export';
+      component.nfsClusterData = { enable_qos: false } as any;
+
+      component.showQOS();
+
+      expect(component.allowQoS).toBeTruthy();
+    });
+
+    it('should not allow QoS if type is not export', () => {
+      component.type = 'cluster';
+      component.nfsClusterData = { enable_qos: false } as any;
+
+      component.showQOS();
+
+      expect(component.allowQoS).toBeFalsy();
+    });
+  });
+
+  describe('setFormData', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should set form data correctly', () => {
+      const data = {
+        enable_qos: true,
+        qos_type: 'PerShare',
+        max_export_read_bw: 100,
+        max_export_write_bw: 200,
+        max_client_read_bw: 300,
+        max_client_write_bw: 400
+      };
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      component.setFormData(data);
+
+      expect(component.rateLimitForm.get('enable_qos')?.value).toBe(data.enable_qos);
+      expect(component.rateLimitForm.get('qos_type')?.value).toBe(data.qos_type);
+      expect(component.rateLimitForm.get('max_export_read_bw')?.value).toBe(100);
+      expect(component.rateLimitForm.get('max_export_write_bw')?.value).toBe(100);
+      expect(component.rateLimitForm.get('max_client_read_bw')?.value).toBe(100);
+      expect(component.rateLimitForm.get('max_client_write_bw')?.value).toBe(100);
+    });
+  });
+
+  describe('getRateLimitFormValue', () => {
+    it('should return rate limit args if form is dirty', () => {
+      jest.spyOn(component, '_isRateLimitFormDirty').mockReturnValue(true);
+      const rateLimitArgs = { enable_qos: true } as any;
+      jest.spyOn(component, '_getRateLimitArgs').mockReturnValue(rateLimitArgs);
+
+      const result = component.getRateLimitFormValue();
+
+      expect(result).toBe(rateLimitArgs);
+    });
+
+    it('should return null if form is not dirty', () => {
+      jest.spyOn(component, '_isRateLimitFormDirty').mockReturnValue(false);
+
+      const result = component.getRateLimitFormValue();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('rateLimitBytesMaxSizeValidator', () => {
+    it('should return validation error for invalid input', () => {
+      const control = { value: 'invalid' } as any;
+      jest
+        .spyOn(FormatterService.prototype, 'performValidation')
+        .mockReturnValue({ rateByteMaxSize: true });
+
+      const result = component.rateLimitBytesMaxSizeValidator(control);
+
+      expect(result).toEqual({ rateByteMaxSize: true });
+    });
+
+    it('should return null for valid input', () => {
+      const control = { value: '100MB/s' } as any;
+      jest.spyOn(FormatterService.prototype, 'performValidation').mockReturnValue(null);
+
+      const result = component.rateLimitBytesMaxSizeValidator(control);
+
+      expect(result).toBeNull();
+    });
+  });
+  describe('createForm', () => {
+    it('should create the form with default values', () => {
+      component.createForm();
+
+      expect(component.rateLimitForm.get('enable_qos')?.value).toBe(false);
+      expect(component.rateLimitForm.get('qos_type')?.value).toBe('');
+      expect(component.rateLimitForm.get('bwType')?.value).toBe('Individual');
+      expect(component.rateLimitForm.get('max_export_read_bw')?.value).toBeNull();
+      expect(component.rateLimitForm.get('max_export_write_bw')?.value).toBeNull();
+      expect(component.rateLimitForm.get('max_client_read_bw')?.value).toBeNull();
+      expect(component.rateLimitForm.get('max_client_write_bw')?.value).toBeNull();
+    });
+  });
+
+  describe('getbwTypeHelp', () => {
+    it('should return the help text for the given bwType', () => {
+      component.bwTypeArr = [{ value: 'Individual', help: 'Individual help text' }];
+      const result = component.getbwTypeHelp('Individual');
+      expect(result).toBe('Individual help text');
+    });
+
+    it('should return an empty string if bwType is not found', () => {
+      component.bwTypeArr = [{ value: 'Combined', help: 'Combined help text' }];
+      const result = component.getbwTypeHelp('Individual');
+      expect(result).toBe('');
+    });
+  });
+
+  describe('getQoSTypeHelper', () => {
+    it('should return the help text for the given qosType', () => {
+      component.qosType = [{ value: 'PerShare', help: 'PerShare help text', key: 'PerShare' }];
+      const result = component.getQoSTypeHelper('PerShare');
+      expect(result).toBe('PerShare help text');
+    });
+
+    it('should return an empty string if qosType is not found', () => {
+      component.qosType = [{ value: 'PerClient', help: 'PerClient help text', key: 'PerClient' }];
+      const result = component.getQoSTypeHelper('PerShare');
+      expect(result).toBe('');
+    });
+  });
+
+  describe('showDisabledField', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should disable the appropriate fields', () => {
+      component.showDisabledField();
+
+      expect(component.rateLimitForm.get('enable_qos')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_export_read_bw')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_export_write_bw')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_client_read_bw')?.disabled).toBeTruthy();
+      expect(component.rateLimitForm.get('max_client_write_bw')?.disabled).toBeTruthy();
+    });
+  });
+
+  describe('_isRateLimitFormDirty', () => {
+    beforeEach(() => {
+      component.createForm();
+    });
+
+    it('should return true if any form control is dirty', () => {
+      component.rateLimitForm.get('enable_qos')?.markAsDirty();
+      const result = component._isRateLimitFormDirty();
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false if no form control is dirty', () => {
+      const result = component._isRateLimitFormDirty();
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('_getRateLimitArgs', () => {
+    beforeEach(() => {
+      component.createForm();
+      component.qosTypeVal = 'PerShare';
+    });
+
+    it('should return the correct rate limit args for PerShare', () => {
+      component.rateLimitForm.get('enable_qos')?.setValue(true);
+      component.rateLimitForm.get('qos_type')?.setValue('PerShare');
+      component.rateLimitForm.get('max_export_read_bw')?.setValue('100MB/s');
+      component.rateLimitForm.get('max_export_write_bw')?.setValue('200MB/s');
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      const result = component._getRateLimitArgs();
+
+      expect(result.enable_qos).toBe(true);
+      expect(result.qos_type).toBe('PerShare');
+      expect(result.max_export_read_bw).toBe(100);
+      expect(result.max_export_write_bw).toBe(100);
+    });
+
+    it('should return the correct rate limit args for PerClient', () => {
+      component.qosTypeVal = 'PerClient';
+      component.rateLimitForm.get('enable_qos')?.setValue(true);
+      component.rateLimitForm.get('qos_type')?.setValue('PerClient');
+      component.rateLimitForm.get('max_client_read_bw')?.setValue('300MB/s');
+      component.rateLimitForm.get('max_client_write_bw')?.setValue('400MB/s');
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      const result = component._getRateLimitArgs();
+
+      expect(result.enable_qos).toBe(true);
+      expect(result.qos_type).toBe('PerClient');
+      expect(result.max_client_read_bw).toBe(100);
+      expect(result.max_client_write_bw).toBe(100);
+    });
+
+    it('should return the correct rate limit args for PerSharePerClient', () => {
+      component.qosTypeVal = 'PerShare_PerClient';
+      component.rateLimitForm.get('enable_qos')?.setValue(true);
+      component.rateLimitForm.get('qos_type')?.setValue('PerShare_PerClient');
+      component.rateLimitForm.get('max_export_read_bw')?.setValue('100MB/s');
+      component.rateLimitForm.get('max_export_write_bw')?.setValue('200MB/s');
+      component.rateLimitForm.get('max_client_read_bw')?.setValue('300MB/s');
+      component.rateLimitForm.get('max_client_write_bw')?.setValue('400MB/s');
+      jest.spyOn(FormatterService.prototype, 'toBytes').mockReturnValue(100);
+
+      const result = component._getRateLimitArgs();
+
+      expect(result.enable_qos).toBe(true);
+      expect(result.qos_type).toBe('PerShare_PerClient');
+      expect(result.max_export_read_bw).toBe(100);
+      expect(result.max_export_write_bw).toBe(100);
+      expect(result.max_client_read_bw).toBe(100);
+      expect(result.max_client_write_bw).toBe(100);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
@@ -1,12 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NfsRateLimitComponent } from './nfs-rate-limit.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RouterTestingModule } from '@angular/router/testing';
-import { SharedModule } from '~/app/shared/shared.module';
-import { Validators } from '@angular/forms';
 import { FormatterService } from '~/app/shared/services/formatter.service';
 import { NFS_TYPE } from '../models/nfs-cluster-config';
+import { NfsRateLimitComponent } from './nfs-rate-limit.component';
 
 describe('NfsRateLimitComponent', () => {
   let component: NfsRateLimitComponent;
@@ -14,7 +14,7 @@ describe('NfsRateLimitComponent', () => {
 
   configureTestBed({
     declarations: [NfsRateLimitComponent],
-    imports: [HttpClientTestingModule, RouterTestingModule, SharedModule],
+    imports: [HttpClientTestingModule, RouterTestingModule, ReactiveFormsModule, CommonModule],
     providers: [FormatterService]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ReactiveFormsModule, Validators } from '@angular/forms';
-import { CommonModule } from '@angular/common';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormatterService } from '~/app/shared/services/formatter.service';
@@ -13,8 +12,7 @@ describe('NfsRateLimitComponent', () => {
   let fixture: ComponentFixture<NfsRateLimitComponent>;
 
   configureTestBed({
-    declarations: [NfsRateLimitComponent],
-    imports: [HttpClientTestingModule, RouterTestingModule, ReactiveFormsModule, CommonModule],
+    imports: [HttpClientTestingModule, RouterTestingModule, NfsRateLimitComponent],
     providers: [FormatterService]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
@@ -1,10 +1,16 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { AbstractControl, UntypedFormControl, ValidationErrors, Validators } from '@angular/forms';
 import _ from 'lodash';
 import { NfsService } from '~/app/shared/api/nfs.service';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FormatterService } from '~/app/shared/services/formatter.service';
-import { bwTypeItem, NFSBwIopConfig, QOSType, QOSTypeItem } from '../models/nfs-cluster-config';
+import {
+  bwTypeItem,
+  NFS_TYPE,
+  NFSBwIopConfig,
+  QOSType,
+  QOSTypeItem
+} from '../models/nfs-cluster-config';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 
 @Component({
@@ -16,6 +22,7 @@ export class NfsRateLimitComponent implements OnInit {
   @Input() action: string;
   @Input() isEdit: boolean;
   @Input() type: String;
+  qosiopsTypeVal: string;
 
   @Input() set exportDataConfig(value: NFSBwIopConfig) {
     if (value) {
@@ -27,82 +34,119 @@ export class NfsRateLimitComponent implements OnInit {
     if (value) {
       this.nfsClusterData = value;
       this.registerQoSChange(this.nfsClusterData.qos_type);
+      this.registerQoSIOPSChange(this.nfsClusterData.qos_type);
       this.loadConditionCheck();
     }
   }
 
   @Output()
   emitErrors = new EventEmitter();
-
+  ngDataReady = new EventEmitter<any>();
   bwTypeArr: bwTypeItem[] = [];
   nfsClusterData: NFSBwIopConfig = {};
   qosTypeVal: string;
   rateLimitForm: CdFormGroup;
   qosType: QOSTypeItem[] = [];
+  qosIopsType: QOSTypeItem[] = [];
+  qosTypeValue = QOSType;
+  nfsType = NFS_TYPE;
   clusterId: string;
   allowQoS = false;
+  allowIops = false;
   clusterQosDisabled = false;
+  clusterIopsDisabled = false;
   showDisableWarning = false;
   showQostypeChangeNote = false;
   nfsExportdata: NFSBwIopConfig = {};
 
-  constructor(private nfsService: NfsService, private formatterService: FormatterService) {
+  constructor(
+    private nfsService: NfsService,
+    private formatterService: FormatterService,
+    private chnageDetectorRef: ChangeDetectorRef
+  ) {
     this.bwTypeArr = this.nfsService.bwType;
   }
 
   ngOnInit(): void {
     this.createForm();
     this.qosType = this.nfsService.qosType;
+    this.qosIopsType = this.nfsService.qosiopsType;
     this.loadConditionCheck();
     this.rateLimitForm.controls['enable_qos'].valueChanges.subscribe((val) => {
-      this.showMaxBwNote(val);
+      this.showMaxBwNote(val, 'bw');
+    });
+    this.rateLimitForm.controls['enable_ops'].valueChanges.subscribe((val) => {
+      this.showMaxBwNote(val, 'iops');
     });
     this.emitErrors.emit(this.rateLimitForm);
   }
-
   setValidation() {
-    switch (this.qosTypeVal) {
-      case 'PerShare': {
-        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_write_bw'].removeValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_read_bw'].removeValidators(Validators.required);
-        break;
-      }
-      case 'PerClient': {
-        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_read_bw'].removeValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_write_bw'].removeValidators(Validators.required);
-        break;
-      }
-      case 'PerShare_PerClient': {
-        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
-        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+    if (this.rateLimitForm?.get('enable_qos').value) {
+      switch (this.qosTypeVal) {
+        case QOSType.PerShare: {
+          this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_write_bw'].removeValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_read_bw'].removeValidators(Validators.required);
+          break;
+        }
+        case QOSType.PerClient: {
+          this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_read_bw'].removeValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_write_bw'].removeValidators(Validators.required);
+          break;
+        }
+        case QOSType.PerSharePerClient: {
+          this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+        }
       }
     }
-  }
+    if (this.rateLimitForm?.get('enable_ops').value) {
+      switch (this.qosiopsTypeVal) {
+        case QOSType.PerShare: {
+          this.rateLimitForm?.controls['max_export_iops'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_iops'].removeValidators(Validators.required);
+          break;
+        }
+        case QOSType.PerClient: {
+          this.rateLimitForm?.controls['max_client_iops'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_export_iops'].removeValidators(Validators.required);
+          break;
+        }
+        case QOSType.PerSharePerClient: {
+          this.rateLimitForm?.controls['max_export_iops'].addValidators(Validators.required);
+          this.rateLimitForm?.controls['max_client_iops'].addValidators(Validators.required);
+        }
+      }
+    }
 
-  showQOS() {
-    this.allowQoS = this.type === 'export' && !this.nfsClusterData?.enable_qos;
+    this.chnageDetectorRef.detectChanges();
   }
 
   loadConditionCheck() {
     this.showDisableWarning = false;
+    const isClusterType = this.type === NFS_TYPE.cluster;
+    const isExportType = this.type === NFS_TYPE.export;
+    const clusterQOSEnabled = this.nfsClusterData?.enable_bw_control || false;
+    const exportQOSEnabled = this.nfsExportdata?.enable_bw_control || false;
 
-    const isCLusterType = this.type === 'cluster';
-    const isExportType = this.type === 'export';
-    const clusterQOSEnabled = this.nfsClusterData?.enable_qos || false;
-    const exportQOSEnabled = this.nfsExportdata?.enable_qos || false;
+    const clusterIopsEnabled = this.nfsClusterData?.enable_iops_control || false;
+    const exportIopsEnabled = this.nfsExportdata?.enable_iops_control || false;
 
     this.allowQoS = true;
-
+    this.allowIops = true;
     // Handle type 'cluster'
-    isCLusterType &&
+    isClusterType &&
       clusterQOSEnabled &&
       ((this.clusterQosDisabled = false), this.isEdit && this.setFormData(this.nfsClusterData));
+
+    isClusterType &&
+      clusterIopsEnabled &&
+      ((this.clusterIopsDisabled = false), this.isEdit && this.setFormData(this.nfsClusterData));
 
     // Handle type 'export'
     isExportType &&
@@ -113,13 +157,21 @@ export class NfsRateLimitComponent implements OnInit {
         this.setFormData(this.nfsExportdata),
         this.showDisabledField()),
       !clusterQOSEnabled && !exportQOSEnabled && (this.allowQoS = false));
+
+    isExportType &&
+      (clusterIopsEnabled && this.isEdit && this.setFormData(this.nfsExportdata),
+      !clusterIopsEnabled &&
+        exportIopsEnabled &&
+        (this.registerQoSIOPSChange(this.nfsClusterData?.qos_type),
+        this.setFormData(this.nfsExportdata),
+        this.showDisabledIopsField()),
+      !clusterIopsEnabled && !exportIopsEnabled && (this.allowIops = false));
   }
 
   createForm() {
     this.rateLimitForm = new CdFormGroup({
       enable_qos: new UntypedFormControl(false),
-      qos_type: new UntypedFormControl(''),
-      bwType: new UntypedFormControl('Individual'),
+      qos_type: new UntypedFormControl('', [this.qosTypeValidator.bind(this)]),
       max_export_read_bw: new UntypedFormControl(null, [
         CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
       ]),
@@ -131,13 +183,17 @@ export class NfsRateLimitComponent implements OnInit {
       ]),
       max_client_write_bw: new UntypedFormControl(null, [
         CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
-      ])
+      ]),
+      enable_ops: new UntypedFormControl(false),
+      qos_type_ops: new UntypedFormControl('', [this.qosTypeValidator.bind(this)]),
+      max_export_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(16384)]),
+      max_client_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(16384)])
     });
   }
 
   showDisabledField() {
     this.clusterQosDisabled = true;
-    this.qosTypeVal = 'PerShare_PerClient';
+    this.qosTypeVal = QOSType.PerSharePerClient;
     const fields = [
       'enable_qos',
       'max_export_read_bw',
@@ -150,14 +206,27 @@ export class NfsRateLimitComponent implements OnInit {
     });
   }
 
+  showDisabledIopsField() {
+    this.clusterIopsDisabled = true;
+    this.qosiopsTypeVal = QOSType.PerSharePerClient;
+    const fields = ['enable_ops', 'max_export_iops', 'max_client_iops'];
+    fields.forEach((field) => {
+      this.rateLimitForm?.get(field)?.disable();
+    });
+  }
+
   setFormData(data: NFSBwIopConfig) {
-    this.rateLimitForm?.get('enable_qos')?.setValue(data?.enable_qos);
+    this.rateLimitForm?.get('enable_qos')?.setValue(data?.enable_bw_control);
+    this.rateLimitForm?.get('enable_ops')?.setValue(data?.enable_iops_control);
     this.rateLimitForm?.get('qos_type')?.setValue(data?.qos_type);
+    this.rateLimitForm?.get('qos_type_ops')?.setValue(data?.qos_type);
     const fields = [
       'max_export_read_bw',
       'max_export_write_bw',
       'max_client_read_bw',
-      'max_client_write_bw'
+      'max_client_write_bw',
+      'max_export_iops',
+      'max_client_iops'
     ];
     fields.forEach((field) => {
       this.rateLimitForm?.get(field)?.setValue(this.formatterService.toBytes(data?.[field]));
@@ -179,8 +248,11 @@ export class NfsRateLimitComponent implements OnInit {
   }
 
   getRateLimitFormValue() {
-    if (this._isRateLimitFormDirty()) return this._getRateLimitArgs();
-    return null;
+    return this._getRateLimitArgs();
+  }
+
+  getRateLimitOpsFormValue() {
+    return this._getRateLimitOpsArgs();
   }
 
   /**
@@ -189,7 +261,6 @@ export class NfsRateLimitComponent implements OnInit {
    */
   _isRateLimitFormDirty(): boolean {
     return [
-      'bwType',
       'enable_qos',
       'qos_type',
       'max_export_read_bw',
@@ -201,18 +272,24 @@ export class NfsRateLimitComponent implements OnInit {
     });
   }
 
+  _isRateLimitOPSFormDirty(): boolean {
+    return ['enable_ops', 'qos_type_ops', 'max_export_iops', 'max_client_iops'].some((path) => {
+      return this.rateLimitForm.get(path).dirty;
+    });
+  }
+
   /**
    * Helper function to get the arguments for the API request when the user
    * rate limit configuration has been modified.
    */
   _getRateLimitArgs(): NFSBwIopConfig {
     const formValues = {
-      enable_qos: this.rateLimitForm.getValue('enable_qos'),
-      qos_type: this.rateLimitForm.getValue('qos_type'),
-      max_export_write_bw: this.rateLimitForm.getValue('max_export_write_bw'),
-      max_export_read_bw: this.rateLimitForm.getValue('max_export_read_bw'),
-      max_client_write_bw: this.rateLimitForm.getValue('max_client_write_bw'),
-      max_client_read_bw: this.rateLimitForm.getValue('max_client_read_bw')
+      enable_qos: this.rateLimitForm.get('enable_qos').value,
+      qos_type: this.rateLimitForm.get('qos_type').value,
+      max_export_write_bw: this.rateLimitForm.get('max_export_write_bw').value,
+      max_export_read_bw: this.rateLimitForm.get('max_export_read_bw').value,
+      max_client_write_bw: this.rateLimitForm.get('max_client_write_bw').value,
+      max_client_read_bw: this.rateLimitForm.get('max_client_read_bw').value
     };
 
     const result: NFSBwIopConfig = {
@@ -226,33 +303,83 @@ export class NfsRateLimitComponent implements OnInit {
       max_client_combined_bw: 0
     };
 
-    result['enable_qos'] = formValues.enable_qos;
-    result['qos_type'] = formValues.qos_type;
+    // If QoS is enabled, update the corresponding QoS values
+    if (formValues.enable_qos) {
+      result['enable_qos'] = formValues.enable_qos;
+      result['qos_type'] = formValues.qos_type;
 
-    switch (this.qosTypeVal) {
-      case 'PerShare': {
-        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
-        result['max_export_write_bw'] = this.formatterService.toBytes(
-          formValues.max_export_write_bw
-        );
-        break;
+      switch (this.qosTypeVal) {
+        case QOSType.PerShare: {
+          result['max_export_read_bw'] = this.formatterService.toBytes(
+            formValues.max_export_read_bw
+          );
+          result['max_export_write_bw'] = this.formatterService.toBytes(
+            formValues.max_export_write_bw
+          );
+          break;
+        }
+        case QOSType.PerClient: {
+          result['max_client_write_bw'] = this.formatterService.toBytes(
+            formValues.max_client_write_bw
+          );
+          result['max_client_read_bw'] = this.formatterService.toBytes(
+            formValues.max_client_read_bw
+          );
+          break;
+        }
+        case QOSType.PerSharePerClient: {
+          result['max_export_read_bw'] = this.formatterService.toBytes(
+            formValues.max_export_read_bw
+          );
+          result['max_export_write_bw'] = this.formatterService.toBytes(
+            formValues.max_export_write_bw
+          );
+          result['max_client_write_bw'] = this.formatterService.toBytes(
+            formValues.max_client_write_bw
+          );
+          result['max_client_read_bw'] = this.formatterService.toBytes(
+            formValues.max_client_read_bw
+          );
+          break;
+        }
       }
-      case 'PerClient': {
-        result['max_client_write_bw'] = this.formatterService.toBytes(
-          formValues.max_client_write_bw
-        );
-        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
-        break;
-      }
-      case 'PerShare_PerClient': {
-        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
-        result['max_export_write_bw'] = this.formatterService.toBytes(
-          formValues.max_export_write_bw
-        );
-        result['max_client_write_bw'] = this.formatterService.toBytes(
-          formValues.max_client_write_bw
-        );
-        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
+    }
+    return result;
+  }
+
+  _getRateLimitOpsArgs(): NFSBwIopConfig {
+    const formValues = {
+      enable_ops: this.rateLimitForm.get('enable_ops').value,
+      qos_type: this.rateLimitForm.get('qos_type_ops').value,
+      max_export_iops: this.rateLimitForm.get('max_export_iops').value,
+      max_client_iops: this.rateLimitForm.get('max_client_iops').value
+    };
+
+    const result: NFSBwIopConfig = {
+      enable_ops: false,
+      qos_type: '',
+      max_export_iops: 0,
+      max_client_iops: 0
+    };
+    // If Ops is enabled, update the corresponding Ops values
+    if (formValues.enable_ops) {
+      result['enable_ops'] = formValues.enable_ops;
+      result['qos_type'] = formValues.qos_type;
+
+      switch (this.qosiopsTypeVal) {
+        case QOSType.PerShare: {
+          result['max_export_iops'] = this.formatterService.toBytes(formValues.max_export_iops);
+          break;
+        }
+        case QOSType.PerClient: {
+          result['max_client_iops'] = this.formatterService.toBytes(formValues.max_client_iops);
+          break;
+        }
+        case QOSType.PerSharePerClient: {
+          result['max_export_iops'] = this.formatterService.toBytes(formValues.max_export_iops);
+          result['max_client_iops'] = this.formatterService.toBytes(formValues.max_client_iops);
+          break;
+        }
       }
     }
     return result;
@@ -261,11 +388,38 @@ export class NfsRateLimitComponent implements OnInit {
   registerQoSChange(val: string) {
     this.showQostypeChangeNote = false;
     this.qosTypeVal = Object.values(QOSType).find((qos) => qos == val);
-
     this.setValidation();
     if (this.isEdit && this.nfsClusterData?.qos_type !== val) {
       this.showQostypeChangeNote = true;
     }
+    this.rateLimitForm?.get('qos_type').updateValueAndValidity();
+    this.rateLimitForm?.get('qos_type_ops').updateValueAndValidity();
+    this.chnageDetectorRef.detectChanges();
+  }
+
+  qosTypeValidator(): ValidationErrors | null {
+    const qosType = this.rateLimitForm?.get('qos_type')?.value;
+    const qosTypeOps = this.rateLimitForm?.get('qos_type_ops')?.value;
+    const enable_qos = this.rateLimitForm?.get('enable_qos')?.value;
+    const enable_ops = this.rateLimitForm?.get('enable_ops')?.value;
+
+    if (enable_qos === true && enable_ops === true) {
+      if (qosType !== qosTypeOps) {
+        return { qosTypeInvalid: true };
+      }
+    }
+    return null;
+  }
+
+  registerQoSIOPSChange(val: string) {
+    this.qosiopsTypeVal = Object.values(QOSType).find((qos) => qos == val);
+    this.setValidation();
+    if (this.isEdit && this.nfsClusterData?.qos_type !== val) {
+      this.showQostypeChangeNote = true;
+    }
+    this.rateLimitForm?.get('qos_type_ops').updateValueAndValidity();
+    this.rateLimitForm?.get('qos_type').updateValueAndValidity();
+    this.chnageDetectorRef.detectChanges();
   }
 
   getQoSTypeHelper(qosType: string) {
@@ -275,24 +429,35 @@ export class NfsRateLimitComponent implements OnInit {
     return _.isObjectLike(qosTypeItem) ? qosTypeItem.help : '';
   }
 
-  showMaxBwNote(val: boolean) {
+  getQoSTypeIOPsHelper(qosType: string) {
+    const qosTypeItem = this.qosIopsType.find(
+      (currentQosTypeItem: QOSTypeItem) => qosType === currentQosTypeItem.value
+    );
+    return _.isObjectLike(qosTypeItem) ? qosTypeItem.help : '';
+  }
+
+  showMaxBwNote(val: boolean, type: string) {
     if (val) {
       // adding required as per the qos type to handle parent component submit errors.
       this.setValidation();
     } else {
-      const fields = [
-        'max_export_read_bw',
-        'max_export_write_bw',
-        'max_client_read_bw',
-        'max_client_write_bw'
-      ];
-      fields.forEach((field) => {
-        this.rateLimitForm?.get(field)?.removeValidators(Validators.required);
-      });
-    }
-    this.showDisableWarning = false;
-    if (!val && this.isEdit == true && this.type == 'cluster' && !_.isEmpty(this.nfsClusterData)) {
-      this.showDisableWarning = true;
+      if (type === 'bw') {
+        const fields = [
+          'max_export_read_bw',
+          'max_export_write_bw',
+          'max_client_read_bw',
+          'max_client_write_bw'
+        ];
+        fields.forEach((field) => {
+          this.rateLimitForm?.get(field)?.removeValidators(Validators.required);
+        });
+      }
+      if (type === 'iops') {
+        const fields = ['max_export_iops', 'max_client_iops'];
+        fields.forEach((field) => {
+          this.rateLimitForm?.get(field)?.removeValidators(Validators.required);
+        });
+      }
     }
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
@@ -1,0 +1,298 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { AbstractControl, UntypedFormControl, ValidationErrors, Validators } from '@angular/forms';
+import _ from 'lodash';
+import { NfsService } from '~/app/shared/api/nfs.service';
+import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
+import { FormatterService } from '~/app/shared/services/formatter.service';
+import { bwTypeItem, NFSBwIopConfig, QOSType, QOSTypeItem } from '../models/nfs-cluster-config';
+import { CdValidators } from '~/app/shared/forms/cd-validators';
+
+@Component({
+  selector: 'cd-nfs-rate-limit-form',
+  templateUrl: './nfs-rate-limit.component.html',
+  styleUrls: ['./nfs-rate-limit.component.scss']
+})
+export class NfsRateLimitComponent implements OnInit {
+  @Input() action: string;
+  @Input() isEdit: boolean;
+  @Input() type: String;
+
+  @Input() set exportDataConfig(value: NFSBwIopConfig) {
+    if (value) {
+      this.nfsExportdata = value;
+      this.loadConditionCheck();
+    }
+  }
+  @Input() set clusterDataConfig(value: NFSBwIopConfig) {
+    if (value) {
+      this.nfsClusterData = value;
+      this.registerQoSChange(this.nfsClusterData.qos_type);
+      this.loadConditionCheck();
+    }
+  }
+
+  @Output()
+  emitErrors = new EventEmitter();
+
+  bwTypeArr: bwTypeItem[] = [];
+  nfsClusterData: NFSBwIopConfig = {};
+  qosTypeVal: string;
+  rateLimitForm: CdFormGroup;
+  qosType: QOSTypeItem[] = [];
+  clusterId: string;
+  allowQoS = false;
+  clusterQosDisabled = false;
+  showDisableWarning = false;
+  showQostypeChangeNote = false;
+  nfsExportdata: NFSBwIopConfig = {};
+
+  constructor(private nfsService: NfsService, private formatterService: FormatterService) {
+    this.bwTypeArr = this.nfsService.bwType;
+  }
+
+  ngOnInit(): void {
+    this.createForm();
+    this.qosType = this.nfsService.qosType;
+    this.loadConditionCheck();
+    this.rateLimitForm.controls['enable_qos'].valueChanges.subscribe((val) => {
+      this.showMaxBwNote(val);
+    });
+    this.emitErrors.emit(this.rateLimitForm);
+  }
+
+  setValidation() {
+    switch (this.qosTypeVal) {
+      case 'PerShare': {
+        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_write_bw'].removeValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_read_bw'].removeValidators(Validators.required);
+        break;
+      }
+      case 'PerClient': {
+        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_read_bw'].removeValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_write_bw'].removeValidators(Validators.required);
+        break;
+      }
+      case 'PerShare_PerClient': {
+        this.rateLimitForm?.controls['max_export_read_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_export_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_write_bw'].addValidators(Validators.required);
+        this.rateLimitForm?.controls['max_client_read_bw'].addValidators(Validators.required);
+      }
+    }
+  }
+
+  showQOS() {
+    this.allowQoS = this.type === 'export' && !this.nfsClusterData?.enable_qos;
+  }
+
+  loadConditionCheck() {
+    this.showDisableWarning = false;
+
+    const isCLusterType = this.type === 'cluster';
+    const isExportType = this.type === 'export';
+    const clusterQOSEnabled = this.nfsClusterData?.enable_qos || false;
+    const exportQOSEnabled = this.nfsExportdata?.enable_qos || false;
+
+    this.allowQoS = true;
+
+    // Handle type 'cluster'
+    isCLusterType &&
+      clusterQOSEnabled &&
+      ((this.clusterQosDisabled = false), this.isEdit && this.setFormData(this.nfsClusterData));
+
+    // Handle type 'export'
+    isExportType &&
+      (clusterQOSEnabled && this.isEdit && this.setFormData(this.nfsExportdata),
+      !clusterQOSEnabled &&
+        exportQOSEnabled &&
+        (this.registerQoSChange(this.nfsClusterData?.qos_type),
+        this.setFormData(this.nfsExportdata),
+        this.showDisabledField()),
+      !clusterQOSEnabled && !exportQOSEnabled && (this.allowQoS = false));
+  }
+
+  createForm() {
+    this.rateLimitForm = new CdFormGroup({
+      enable_qos: new UntypedFormControl(false),
+      qos_type: new UntypedFormControl(''),
+      bwType: new UntypedFormControl('Individual'),
+      max_export_read_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ]),
+      max_export_write_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ]),
+      max_client_read_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ]),
+      max_client_write_bw: new UntypedFormControl(null, [
+        CdValidators.composeIf({}, [this.rateLimitBytesMaxSizeValidator])
+      ])
+    });
+  }
+
+  showDisabledField() {
+    this.clusterQosDisabled = true;
+    this.qosTypeVal = 'PerShare_PerClient';
+    const fields = [
+      'enable_qos',
+      'max_export_read_bw',
+      'max_export_write_bw',
+      'max_client_read_bw',
+      'max_client_write_bw'
+    ];
+    fields.forEach((field) => {
+      this.rateLimitForm?.get(field)?.disable();
+    });
+  }
+
+  setFormData(data: NFSBwIopConfig) {
+    this.rateLimitForm?.get('enable_qos')?.setValue(data?.enable_qos);
+    this.rateLimitForm?.get('qos_type')?.setValue(data?.qos_type);
+    const fields = [
+      'max_export_read_bw',
+      'max_export_write_bw',
+      'max_client_read_bw',
+      'max_client_write_bw'
+    ];
+    fields.forEach((field) => {
+      this.rateLimitForm?.get(field)?.setValue(this.formatterService.toBytes(data?.[field]));
+    });
+  }
+
+  rateLimitBytesMaxSizeValidator(control: AbstractControl): ValidationErrors | null {
+    return new FormatterService().performValidation(
+      control,
+      '^(\\d+(\\.\\d+)?)\\s*(B/s|K(B|iB/s)?|M(B|iB/s)?|G(B|iB/s)?|T(B|iB/s)?|P(B|iB/s)?)?$',
+      { rateByteMaxSize: true },
+      'nfsRateLimit'
+    );
+  }
+
+  getbwTypeHelp(type: string) {
+    const bwTypeItem = this.bwTypeArr.find((item: bwTypeItem) => type === item.value);
+    return _.isObjectLike(bwTypeItem) ? bwTypeItem.help : '';
+  }
+
+  getRateLimitFormValue() {
+    if (this._isRateLimitFormDirty()) return this._getRateLimitArgs();
+    return null;
+  }
+
+  /**
+   * Check if the user rate limit has been modified.
+   * @return {Boolean} Returns TRUE if the user rate limit has been modified.
+   */
+  _isRateLimitFormDirty(): boolean {
+    return [
+      'bwType',
+      'enable_qos',
+      'qos_type',
+      'max_export_read_bw',
+      'max_export_write_bw',
+      'max_client_write_bw',
+      'max_client_read_bw'
+    ].some((path) => {
+      return this.rateLimitForm.get(path).dirty;
+    });
+  }
+
+  /**
+   * Helper function to get the arguments for the API request when the user
+   * rate limit configuration has been modified.
+   */
+  _getRateLimitArgs(): NFSBwIopConfig {
+    const formValues = {
+      enable_qos: this.rateLimitForm.getValue('enable_qos'),
+      qos_type: this.rateLimitForm.getValue('qos_type'),
+      max_export_write_bw: this.rateLimitForm.getValue('max_export_write_bw'),
+      max_export_read_bw: this.rateLimitForm.getValue('max_export_read_bw'),
+      max_client_write_bw: this.rateLimitForm.getValue('max_client_write_bw'),
+      max_client_read_bw: this.rateLimitForm.getValue('max_client_read_bw')
+    };
+
+    const result: NFSBwIopConfig = {
+      enable_qos: false,
+      qos_type: '',
+      max_export_write_bw: 0,
+      max_export_read_bw: 0,
+      max_client_write_bw: 0,
+      max_client_read_bw: 0,
+      max_export_combined_bw: 0,
+      max_client_combined_bw: 0
+    };
+
+    result['enable_qos'] = formValues.enable_qos;
+    result['qos_type'] = formValues.qos_type;
+
+    switch (this.qosTypeVal) {
+      case 'PerShare': {
+        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
+        result['max_export_write_bw'] = this.formatterService.toBytes(
+          formValues.max_export_write_bw
+        );
+        break;
+      }
+      case 'PerClient': {
+        result['max_client_write_bw'] = this.formatterService.toBytes(
+          formValues.max_client_write_bw
+        );
+        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
+        break;
+      }
+      case 'PerShare_PerClient': {
+        result['max_export_read_bw'] = this.formatterService.toBytes(formValues.max_export_read_bw);
+        result['max_export_write_bw'] = this.formatterService.toBytes(
+          formValues.max_export_write_bw
+        );
+        result['max_client_write_bw'] = this.formatterService.toBytes(
+          formValues.max_client_write_bw
+        );
+        result['max_client_read_bw'] = this.formatterService.toBytes(formValues.max_client_read_bw);
+      }
+    }
+    return result;
+  }
+
+  registerQoSChange(val: string) {
+    this.showQostypeChangeNote = false;
+    this.qosTypeVal = Object.values(QOSType).find((qos) => qos == val);
+
+    this.setValidation();
+    if (this.isEdit && this.nfsClusterData?.qos_type !== val) {
+      this.showQostypeChangeNote = true;
+    }
+  }
+
+  getQoSTypeHelper(qosType: string) {
+    const qosTypeItem = this.qosType.find(
+      (currentQosTypeItem: QOSTypeItem) => qosType === currentQosTypeItem.value
+    );
+    return _.isObjectLike(qosTypeItem) ? qosTypeItem.help : '';
+  }
+
+  showMaxBwNote(val: boolean) {
+    if (val) {
+      // adding required as per the qos type to handle parent component submit errors.
+      this.setValidation();
+    } else {
+      const fields = [
+        'max_export_read_bw',
+        'max_export_write_bw',
+        'max_client_read_bw',
+        'max_client_write_bw'
+      ];
+      fields.forEach((field) => {
+        this.rateLimitForm?.get(field)?.removeValidators(Validators.required);
+      });
+    }
+    this.showDisableWarning = false;
+    if (!val && this.isEdit == true && this.type == 'cluster' && !_.isEmpty(this.nfsClusterData)) {
+      this.showDisableWarning = true;
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
@@ -16,7 +16,8 @@ import { CdValidators } from '~/app/shared/forms/cd-validators';
 @Component({
   selector: 'cd-nfs-rate-limit-form',
   templateUrl: './nfs-rate-limit.component.html',
-  styleUrls: ['./nfs-rate-limit.component.scss']
+  styleUrls: ['./nfs-rate-limit.component.scss'],
+  standalone: false
 })
 export class NfsRateLimitComponent implements OnInit {
   @Input() action: string;
@@ -186,8 +187,8 @@ export class NfsRateLimitComponent implements OnInit {
       ]),
       enable_ops: new UntypedFormControl(false),
       qos_type_ops: new UntypedFormControl('', [this.qosTypeValidator.bind(this)]),
-      max_export_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(16384)]),
-      max_client_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(16384)])
+      max_export_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(1638400)]),
+      max_client_iops: new UntypedFormControl(null, [Validators.min(10), Validators.max(1638400)])
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
@@ -5,7 +5,7 @@ import { NfsService } from '~/app/shared/api/nfs.service';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FormatterService } from '~/app/shared/services/formatter.service';
 import {
-  bwTypeItem,
+  BwTypeItem,
   NFS_TYPE,
   NFSBwIopConfig,
   QOSType,
@@ -43,7 +43,7 @@ export class NfsRateLimitComponent implements OnInit {
   @Output()
   emitErrors = new EventEmitter();
   ngDataReady = new EventEmitter<any>();
-  bwTypeArr: bwTypeItem[] = [];
+  bwTypeArr: BwTypeItem[] = [];
   nfsClusterData: NFSBwIopConfig = {};
   qosTypeVal: string;
   rateLimitForm: CdFormGroup;
@@ -63,7 +63,7 @@ export class NfsRateLimitComponent implements OnInit {
   constructor(
     private nfsService: NfsService,
     private formatterService: FormatterService,
-    private chnageDetectorRef: ChangeDetectorRef
+    private changeDetectorRef: ChangeDetectorRef
   ) {
     this.bwTypeArr = this.nfsService.bwType;
   }
@@ -125,7 +125,7 @@ export class NfsRateLimitComponent implements OnInit {
       }
     }
 
-    this.chnageDetectorRef.detectChanges();
+    this.changeDetectorRef.detectChanges();
   }
 
   loadConditionCheck() {
@@ -244,7 +244,7 @@ export class NfsRateLimitComponent implements OnInit {
   }
 
   getbwTypeHelp(type: string) {
-    const bwTypeItem = this.bwTypeArr.find((item: bwTypeItem) => type === item.value);
+    const bwTypeItem = this.bwTypeArr.find((item: BwTypeItem) => type === item.value);
     return _.isObjectLike(bwTypeItem) ? bwTypeItem.help : '';
   }
 
@@ -369,16 +369,16 @@ export class NfsRateLimitComponent implements OnInit {
 
       switch (this.qosiopsTypeVal) {
         case QOSType.PerShare: {
-          result['max_export_iops'] = this.formatterService.toBytes(formValues.max_export_iops);
+          result['max_export_iops'] = formValues.max_export_iops;
           break;
         }
         case QOSType.PerClient: {
-          result['max_client_iops'] = this.formatterService.toBytes(formValues.max_client_iops);
+          result['max_client_iops'] = formValues.max_client_iops;
           break;
         }
         case QOSType.PerSharePerClient: {
-          result['max_export_iops'] = this.formatterService.toBytes(formValues.max_export_iops);
-          result['max_client_iops'] = this.formatterService.toBytes(formValues.max_client_iops);
+          result['max_export_iops'] = formValues.max_export_iops;
+          result['max_client_iops'] = formValues.max_client_iops;
           break;
         }
       }
@@ -395,7 +395,7 @@ export class NfsRateLimitComponent implements OnInit {
     }
     this.rateLimitForm?.get('qos_type').updateValueAndValidity();
     this.rateLimitForm?.get('qos_type_ops').updateValueAndValidity();
-    this.chnageDetectorRef.detectChanges();
+    this.changeDetectorRef.detectChanges();
   }
 
   qosTypeValidator(): ValidationErrors | null {
@@ -420,7 +420,7 @@ export class NfsRateLimitComponent implements OnInit {
     }
     this.rateLimitForm?.get('qos_type_ops').updateValueAndValidity();
     this.rateLimitForm?.get('qos_type').updateValueAndValidity();
-    this.chnageDetectorRef.detectChanges();
+    this.changeDetectorRef.detectChanges();
   }
 
   getQoSTypeHelper(qosType: string) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-rate-limit/nfs-rate-limit.component.ts
@@ -1,5 +1,15 @@
-import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { AbstractControl, UntypedFormControl, ValidationErrors, Validators } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AbstractControl, ReactiveFormsModule, UntypedFormControl, ValidationErrors, Validators } from '@angular/forms';
+import { CheckboxModule, InputModule, SelectModule } from 'carbon-components-angular';
 import _ from 'lodash';
 import { NfsService } from '~/app/shared/api/nfs.service';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
@@ -12,12 +22,15 @@ import {
   QOSTypeItem
 } from '../models/nfs-cluster-config';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
+import { SharedModule } from '~/app/shared/shared.module';
 
 @Component({
   selector: 'cd-nfs-rate-limit-form',
   templateUrl: './nfs-rate-limit.component.html',
   styleUrls: ['./nfs-rate-limit.component.scss'],
-  standalone: false
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, ReactiveFormsModule, SharedModule, CheckboxModule, SelectModule, InputModule]
 })
 export class NfsRateLimitComponent implements OnInit {
   @Input() action: string;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
@@ -27,6 +27,8 @@ import Close from '@carbon/icons/es/close/32';
 import { NfsClusterComponent } from './nfs-cluster/nfs-cluster.component';
 import { ClusterModule } from '../cluster/cluster.module';
 import { NfsClusterDetailsComponent } from './nfs-cluster-details/nfs-cluster-details.component';
+import { NfsClusterFormComponent } from './nfs-cluster-form/nfs-cluster-form.component';
+import { NfsRateLimitComponent } from './nfs-rate-limit/nfs-rate-limit.component';
 
 @NgModule({
   imports: [
@@ -48,14 +50,23 @@ import { NfsClusterDetailsComponent } from './nfs-cluster-details/nfs-cluster-de
     TabsModule,
     ClusterModule
   ],
-  exports: [NfsListComponent, NfsFormComponent, NfsDetailsComponent, NfsClusterComponent],
+  exports: [
+    NfsListComponent,
+    NfsFormComponent,
+    NfsDetailsComponent,
+    NfsClusterComponent,
+    NfsFormClientComponent,
+    NfsClusterDetailsComponent
+  ],
   declarations: [
     NfsListComponent,
     NfsDetailsComponent,
     NfsFormComponent,
     NfsFormClientComponent,
     NfsClusterComponent,
-    NfsClusterDetailsComponent
+    NfsClusterDetailsComponent,
+    NfsClusterFormComponent,
+    NfsRateLimitComponent
   ]
 })
 export class NfsModule {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
@@ -56,7 +56,9 @@ import { NfsRateLimitComponent } from './nfs-rate-limit/nfs-rate-limit.component
     NfsDetailsComponent,
     NfsClusterComponent,
     NfsFormClientComponent,
-    NfsClusterDetailsComponent
+    NfsClusterDetailsComponent,
+    NfsClusterFormComponent,
+    NfsRateLimitComponent
   ],
   declarations: [
     NfsListComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
@@ -25,7 +25,6 @@ import {
 
 import Close from '@carbon/icons/es/close/32';
 import { NfsClusterComponent } from './nfs-cluster/nfs-cluster.component';
-import { ClusterModule } from '../cluster/cluster.module';
 import { NfsClusterDetailsComponent } from './nfs-cluster-details/nfs-cluster-details.component';
 import { NfsClusterFormComponent } from './nfs-cluster-form/nfs-cluster-form.component';
 import { NfsRateLimitComponent } from './nfs-rate-limit/nfs-rate-limit.component';
@@ -47,8 +46,7 @@ import { NfsRateLimitComponent } from './nfs-rate-limit/nfs-rate-limit.component
     CheckboxModule,
     ButtonModule,
     IconModule,
-    TabsModule,
-    ClusterModule
+    TabsModule
   ],
   exports: [
     NfsListComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs.module.ts
@@ -46,7 +46,9 @@ import { NfsRateLimitComponent } from './nfs-rate-limit/nfs-rate-limit.component
     CheckboxModule,
     ButtonModule,
     IconModule,
-    TabsModule
+    TabsModule,
+    NfsClusterFormComponent,
+    NfsRateLimitComponent
   ],
   exports: [
     NfsListComponent,
@@ -64,9 +66,7 @@ import { NfsRateLimitComponent } from './nfs-rate-limit/nfs-rate-limit.component
     NfsFormComponent,
     NfsFormClientComponent,
     NfsClusterComponent,
-    NfsClusterDetailsComponent,
-    NfsClusterFormComponent,
-    NfsRateLimitComponent
+    NfsClusterDetailsComponent
   ]
 })
 export class NfsModule {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -51,6 +51,7 @@ import { RgwSyncPrimaryZoneComponent } from './rgw-sync-primary-zone/rgw-sync-pr
 import { RgwSyncMetadataInfoComponent } from './rgw-sync-metadata-info/rgw-sync-metadata-info.component';
 import { RgwSyncDataInfoComponent } from './rgw-sync-data-info/rgw-sync-data-info.component';
 import { BucketTagModalComponent } from './bucket-tag-modal/bucket-tag-modal.component';
+import { NfsModule } from '../nfs/nfs.module';
 import { NfsFormComponent } from '../nfs/nfs-form/nfs-form.component';
 import { RgwMultisiteSyncPolicyComponent } from './rgw-multisite-sync-policy/rgw-multisite-sync-policy.component';
 import { RgwMultisiteSyncPolicyFormComponent } from './rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component';
@@ -173,7 +174,8 @@ import { NfsClusterFormComponent } from '../nfs/nfs-cluster-form/nfs-cluster-for
     ProductiveCardComponent,
     TimePickerComponent,
     AreaChartComponent,
-    ComponentsModule
+    ComponentsModule,
+    NfsModule
   ],
   exports: [
     RgwDaemonDetailsComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -129,6 +129,7 @@ import { RgwNotificationFormComponent } from './rgw-notification-form/rgw-notifi
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { RgwAccountRolesListComponent } from './rgw-account-roles-list/rgw-account-roles-list.component';
 import { RgwAccountRoleFormComponent } from './rgw-account-role-form/rgw-account-role-form.component';
+import { NfsClusterFormComponent } from '../nfs/nfs-cluster-form/nfs-cluster-form.component';
 
 @NgModule({
   imports: [
@@ -424,7 +425,12 @@ const routes: Routes = [
     children: [
       { path: '', component: NfsClusterComponent },
       {
-        path: URLVerbs.CREATE,
+        path: `${URLVerbs.EDIT}/:cluster_id`,
+        component: NfsClusterFormComponent,
+        data: { breadcrumbs: ActionLabels.EDIT }
+      },
+      {
+        path: `${URLVerbs.CREATE}/:cluster_id`,
         component: NfsFormComponent,
         data: { breadcrumbs: ActionLabels.CREATE }
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -144,6 +144,7 @@ import { RgwBucketResourceSidebarComponent } from './rgw-bucket-resource-sidebar
 import { RgwBucketResourcePageComponent } from './rgw-bucket-resource-page/rgw-bucket-resource-page.component';
 import { RgwBucketResourceBreadcrumbResolver } from './rgw-bucket-resource-page/rgw-bucket-resource-breadcrumb.resolver';
 import { RgwBucketTagsTableComponent } from './rgw-bucket-tags-table/rgw-bucket-tags-table.component';
+import { NfsClusterFormComponent } from '../nfs/nfs-cluster-form/nfs-cluster-form.component';
 
 @NgModule({
   imports: [
@@ -570,7 +571,12 @@ const routes: Routes = [
     children: [
       { path: '', component: NfsClusterComponent },
       {
-        path: URLVerbs.CREATE,
+        path: `${URLVerbs.EDIT}/:cluster_id`,
+        component: NfsClusterFormComponent,
+        data: { breadcrumbs: ActionLabels.EDIT }
+      },
+      {
+        path: `${URLVerbs.CREATE}/:cluster_id`,
         component: NfsFormComponent,
         data: { breadcrumbs: ActionLabels.CREATE }
       },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -56,6 +56,7 @@ import { RgwSyncPrimaryZoneComponent } from './rgw-sync-primary-zone/rgw-sync-pr
 import { RgwSyncMetadataInfoComponent } from './rgw-sync-metadata-info/rgw-sync-metadata-info.component';
 import { RgwSyncDataInfoComponent } from './rgw-sync-data-info/rgw-sync-data-info.component';
 import { BucketTagModalComponent } from './bucket-tag-modal/bucket-tag-modal.component';
+import { NfsModule } from '../nfs/nfs.module';
 import { NfsFormComponent } from '../nfs/nfs-form/nfs-form.component';
 import { RgwMultisiteSyncPolicyComponent } from './rgw-multisite-sync-policy/rgw-multisite-sync-policy.component';
 import { RgwMultisiteSyncPolicyFormComponent } from './rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component';
@@ -190,7 +191,8 @@ import { NfsClusterFormComponent } from '../nfs/nfs-cluster-form/nfs-cluster-for
     TimePickerComponent,
     AreaChartComponent,
     ComponentsModule,
-    ContentSwitcherModule
+    ContentSwitcherModule,
+    NfsModule
   ],
   exports: [
     RgwDaemonResourcePageComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
@@ -66,6 +66,23 @@ export class NfsService extends ApiClient {
       help: $localize`Allows individual per share and per client setting of export and client bandwidth`
     }
   ];
+  qosiopsType: QOSTypeItem[] = [
+    {
+      key: 'Per Share',
+      value: 'PerShare',
+      help: $localize`Allows individual per share setting of export and client IOPS`
+    },
+    {
+      key: 'Per Client',
+      value: 'PerClient',
+      help: $localize`Allows individual per client setting of export and client IOPS`
+    },
+    {
+      key: 'Per Share Per Client',
+      value: 'PerShare_PerClient',
+      help: $localize`Allows individual per share and per client setting of export and client IOPS`
+    }
+  ];
   bwType: bwTypeItem[] = [
     {
       value: 'Individual',
@@ -160,9 +177,30 @@ export class NfsService extends ApiClient {
     });
   }
 
+  enableQosOpsForExports(exportObj: NFSBwIopConfig) {
+    return this.http.patch(`${this.apiPath}/export/qos/ops`, exportObj, {
+      headers: { Accept: this.getVersionHeaderValue(1, 0) },
+      observe: 'response'
+    });
+  }
+
   getexportBandwidthOpsConfig(clusterId: string, pseudoPath: string) {
     return this.http.get(
       `${this.apiPath}/export/qos/${clusterId}/${encodeURIComponent(pseudoPath)}`
     );
+  }
+
+  enableQosOpsForCLuster(obj: NFSBwIopConfig) {
+    return this.http.patch(`${this.apiPath}/cluster/qos/ops`, obj, {
+      headers: { Accept: this.getVersionHeaderValue(1, 0) },
+      observe: 'response'
+    });
+  }
+
+  enableOpsForExports(exportObj: NFSBwIopConfig) {
+    return this.http.patch(`${this.apiPath}/export/ops`, exportObj, {
+      headers: { Accept: this.getVersionHeaderValue(1, 0) },
+      observe: 'response'
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nfs.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 import { Observable, throwError } from 'rxjs';
 import {
-  bwTypeItem,
+  BwTypeItem,
   NFSBwIopConfig,
   NFSCluster,
   QOSTypeItem
@@ -83,7 +83,7 @@ export class NfsService extends ApiClient {
       help: $localize`Allows individual per share and per client setting of export and client IOPS`
     }
   ];
-  bwType: bwTypeItem[] = [
+  bwType: BwTypeItem[] = [
     {
       value: 'Individual',
       help: $localize`Allows Individual IOPS limit for read and write operations`
@@ -192,13 +192,6 @@ export class NfsService extends ApiClient {
 
   enableQosOpsForCLuster(obj: NFSBwIopConfig) {
     return this.http.patch(`${this.apiPath}/cluster/qos/ops`, obj, {
-      headers: { Accept: this.getVersionHeaderValue(1, 0) },
-      observe: 'response'
-    });
-  }
-
-  enableOpsForExports(exportObj: NFSBwIopConfig) {
-    return this.http.patch(`${this.apiPath}/export/ops`, exportObj, {
       headers: { Accept: this.getVersionHeaderValue(1, 0) },
       observe: 'response'
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dimless-binary-per-second.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dimless-binary-per-second.directive.ts
@@ -65,6 +65,9 @@ export class DimlessBinaryPerSecondDirective implements OnInit {
   @Input()
   roundPower: number;
 
+  @Input()
+  defaultEmptyValue: boolean = false;
+
   /**
    * Default unit that should be used when user do not type a unit.
    * By default, "MiB" will be used.
@@ -95,6 +98,11 @@ export class DimlessBinaryPerSecondDirective implements OnInit {
   }
 
   setValue(value: string) {
+    if (value === '' && this.defaultEmptyValue) {
+      this.ngModelChange.emit(value);
+      this.control.control.setValue(value);
+      return;
+    }
     if (/^[\d.]+$/.test(value)) {
       value += this.defaultUnit || 'm';
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, ValidationErrors } from '@angular/forms';
+
 import _ from 'lodash';
 import { isEmptyInputValue } from '../forms/cd-validators';
 
@@ -90,7 +91,7 @@ export class FormatterService {
     const base = 1024;
     const units = ['b', 'k', 'm', 'g', 't', 'p', 'e', 'z', 'y'];
     const bytesRegexMatch = RegExp(
-      '^(\\d+(.\\d+)?) ?([' + units.join('') + ']?(b|ib|B/s|B/m|iB/m)?)?$',
+      '^(\\d+(.\\d+)?) ?([' + units.join('') + ']?(b|ib|B/s|B/m|iB/m|iB/s)?)?$',
       'i'
     ).exec(value);
     if (bytesRegexMatch === null) {
@@ -102,7 +103,6 @@ export class FormatterService {
     }
     return Math.round(bytes);
   }
-
   /**
    * Converts `x ms` to `x` (currently) or `0` if the conversion fails
    */
@@ -167,6 +167,11 @@ export class FormatterService {
     if (type == 'quota') {
       const bytes = new FormatterService().toBytes(control.value);
       return bytes < 1024 ? errorObject : null;
+    }
+    // For all bandwidth values:  minimum  1Mbps Maximum. 4Gbps
+    if (type == 'nfsRateLimit') {
+      const bytes = new FormatterService().toBytes(control.value);
+      return bytes < 1024 * 1024 || bytes > 4 * (1024 * 1024 * 1024) ? errorObject : null;
     }
     return null;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
@@ -168,10 +168,10 @@ export class FormatterService {
       const bytes = new FormatterService().toBytes(control.value);
       return bytes < 1024 ? errorObject : null;
     }
-    // For all bandwidth values:  minimum  1Mbps Maximum. 4Gbps
+    // For all bandwidth values:  minimum  32KiB Maximum. 100Gbps
     if (type == 'nfsRateLimit') {
       const bytes = new FormatterService().toBytes(control.value);
-      return bytes < 1024 * 1024 || bytes > 4 * (1024 * 1024 * 1024) ? errorObject : null;
+      return bytes < 1024 * 32 || bytes > 100 * (1024 * 1024 * 1024) ? errorObject : null;
     }
     return null;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/environments/environment.ibm.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/environments/environment.ibm.ts
@@ -1,0 +1,11 @@
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --env=prod` then `environment.prod.ts` will be used instead.
+// The list of which env maps to which file can be found in `.angular-cli.json`.
+
+export const environment = {
+  default_lang: 'en-US',
+  production: true,
+  year: '2026',
+  build: 'ibm'
+};

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -11756,7 +11756,7 @@ paths:
               properties:
                 cluster_id:
                   type: string
-                disable_Ops:
+                disable_ops:
                   default: false
                   type: boolean
                 max_client_iops:

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -11695,6 +11695,130 @@ paths:
       - jwt: []
       tags:
       - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/bw:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos:
+                  default: false
+                  type: boolean
+                max_client_combined_bw:
+                  type: string
+                max_client_read_bw:
+                  type: string
+                max_client_write_bw:
+                  type: string
+                max_export_combined_bw:
+                  type: string
+                max_export_read_bw:
+                  type: string
+                max_export_write_bw:
+                  type: string
+                qos_type:
+                  default: ''
+                  type: string
+              required:
+              - cluster_id
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable QoS configuration for bandwidth
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/ops:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_Ops:
+                  default: false
+                  type: boolean
+                max_client_iops:
+                  default: 0
+                  type: integer
+                max_export_iops:
+                  default: 0
+                  type: integer
+                qos_type:
+                  type: string
+              required:
+              - cluster_id
+              - qos_type
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable QoS configuration for NFS IOPs
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/{cluster_id}:
+    get:
+      parameters:
+      - in: path
+        name: cluster_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get the cluster QoS configuration for bandwidth and iops
+      tags:
+      - NFS-Ganesha
   /api/nfs-ganesha/export:
     get:
       parameters:
@@ -12147,6 +12271,135 @@ paths:
       security:
       - jwt: []
       summary: Creates a new NFS-Ganesha export
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos:
+                  default: false
+                  type: boolean
+                max_client_combined_bw:
+                  type: string
+                max_client_read_bw:
+                  type: string
+                max_client_write_bw:
+                  type: string
+                max_export_combined_bw:
+                  type: string
+                max_export_read_bw:
+                  type: string
+                max_export_write_bw:
+                  type: string
+                pseudo_path:
+                  type: string
+              required:
+              - cluster_id
+              - pseudo_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable export QoS configuration for bandwidth
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos/ops:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos_ops:
+                  default: false
+                  type: boolean
+                max_client_iops:
+                  default: 0
+                  type: integer
+                max_export_iops:
+                  default: 0
+                  type: integer
+                pseudo_path:
+                  type: string
+              required:
+              - cluster_id
+              - pseudo_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable export QoS configuration for operations
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos/{cluster_id}/{pseudo_path}:
+    get:
+      parameters:
+      - in: path
+        name: cluster_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pseudo_path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get the export QoS configuration for bandwidth and IOPS
       tags:
       - NFS-Ganesha
   /api/nfs-ganesha/export/{cluster_id}/{export_id}:

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -11709,17 +11709,17 @@ paths:
                   default: false
                   type: boolean
                 max_client_combined_bw:
-                  type: string
+                  type: integer
                 max_client_read_bw:
-                  type: string
+                  type: integer
                 max_client_write_bw:
-                  type: string
+                  type: integer
                 max_export_combined_bw:
-                  type: string
+                  type: integer
                 max_export_read_bw:
-                  type: string
+                  type: integer
                 max_export_write_bw:
-                  type: string
+                  type: integer
                 qos_type:
                   default: ''
                   type: string
@@ -12287,17 +12287,17 @@ paths:
                   default: false
                   type: boolean
                 max_client_combined_bw:
-                  type: string
+                  type: integer
                 max_client_read_bw:
-                  type: string
+                  type: integer
                 max_client_write_bw:
-                  type: string
+                  type: integer
                 max_export_combined_bw:
-                  type: string
+                  type: integer
                 max_export_read_bw:
-                  type: string
+                  type: integer
                 max_export_write_bw:
-                  type: string
+                  type: integer
                 pseudo_path:
                   type: string
               required:

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -12598,17 +12598,17 @@ paths:
                   default: false
                   type: boolean
                 max_client_combined_bw:
-                  type: integer
+                  type: string
                 max_client_read_bw:
-                  type: integer
+                  type: string
                 max_client_write_bw:
-                  type: integer
+                  type: string
                 max_export_combined_bw:
-                  type: integer
+                  type: string
                 max_export_read_bw:
-                  type: integer
+                  type: string
                 max_export_write_bw:
-                  type: integer
+                  type: string
                 qos_type:
                   default: ''
                   type: string
@@ -12618,8 +12618,12 @@ paths:
       responses:
         '200':
           content:
+            application/json:
+              schema:
+                type: object
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                type: object
           description: Resource updated.
         '400':
           description: Operation exception. Please check the response body for details.
@@ -12663,8 +12667,12 @@ paths:
       responses:
         '200':
           content:
+            application/json:
+              schema:
+                type: object
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                type: object
           description: Resource updated.
         '400':
           description: Operation exception. Please check the response body for details.
@@ -12691,8 +12699,12 @@ paths:
       responses:
         '200':
           content:
+            application/json:
+              schema:
+                type: object
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                type: object
           description: OK
         '400':
           description: Operation exception. Please check the response body for details.
@@ -13176,17 +13188,17 @@ paths:
                   default: false
                   type: boolean
                 max_client_combined_bw:
-                  type: integer
+                  type: string
                 max_client_read_bw:
-                  type: integer
+                  type: string
                 max_client_write_bw:
-                  type: integer
+                  type: string
                 max_export_combined_bw:
-                  type: integer
+                  type: string
                 max_export_read_bw:
-                  type: integer
+                  type: string
                 max_export_write_bw:
-                  type: integer
+                  type: string
                 pseudo_path:
                   type: string
               required:
@@ -13196,8 +13208,12 @@ paths:
       responses:
         '200':
           content:
+            application/json:
+              schema:
+                type: object
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                type: object
           description: Resource updated.
         '400':
           description: Operation exception. Please check the response body for details.
@@ -13241,8 +13257,12 @@ paths:
       responses:
         '200':
           content:
+            application/json:
+              schema:
+                type: object
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                type: object
           description: Resource updated.
         '400':
           description: Operation exception. Please check the response body for details.
@@ -13274,8 +13294,12 @@ paths:
       responses:
         '200':
           content:
+            application/json:
+              schema:
+                type: object
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                type: object
           description: OK
         '400':
           description: Operation exception. Please check the response body for details.

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -12598,17 +12598,17 @@ paths:
                   default: false
                   type: boolean
                 max_client_combined_bw:
-                  type: string
+                  type: integer
                 max_client_read_bw:
-                  type: string
+                  type: integer
                 max_client_write_bw:
-                  type: string
+                  type: integer
                 max_export_combined_bw:
-                  type: string
+                  type: integer
                 max_export_read_bw:
-                  type: string
+                  type: integer
                 max_export_write_bw:
-                  type: string
+                  type: integer
                 qos_type:
                   default: ''
                   type: string
@@ -13176,17 +13176,17 @@ paths:
                   default: false
                   type: boolean
                 max_client_combined_bw:
-                  type: string
+                  type: integer
                 max_client_read_bw:
-                  type: string
+                  type: integer
                 max_client_write_bw:
-                  type: string
+                  type: integer
                 max_export_combined_bw:
-                  type: string
+                  type: integer
                 max_export_read_bw:
-                  type: string
+                  type: integer
                 max_export_write_bw:
-                  type: string
+                  type: integer
                 pseudo_path:
                   type: string
               required:

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -12645,7 +12645,7 @@ paths:
               properties:
                 cluster_id:
                   type: string
-                disable_Ops:
+                disable_ops:
                   default: false
                   type: boolean
                 max_client_iops:

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -12584,6 +12584,130 @@ paths:
       - jwt: []
       tags:
       - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/bw:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos:
+                  default: false
+                  type: boolean
+                max_client_combined_bw:
+                  type: string
+                max_client_read_bw:
+                  type: string
+                max_client_write_bw:
+                  type: string
+                max_export_combined_bw:
+                  type: string
+                max_export_read_bw:
+                  type: string
+                max_export_write_bw:
+                  type: string
+                qos_type:
+                  default: ''
+                  type: string
+              required:
+              - cluster_id
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable QoS configuration for bandwidth
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/ops:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_Ops:
+                  default: false
+                  type: boolean
+                max_client_iops:
+                  default: 0
+                  type: integer
+                max_export_iops:
+                  default: 0
+                  type: integer
+                qos_type:
+                  type: string
+              required:
+              - cluster_id
+              - qos_type
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable QoS configuration for NFS IOPs
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/cluster/qos/{cluster_id}:
+    get:
+      parameters:
+      - in: path
+        name: cluster_id
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get the cluster QoS configuration for bandwidth and iops
+      tags:
+      - NFS-Ganesha
   /api/nfs-ganesha/export:
     get:
       parameters:
@@ -13036,6 +13160,135 @@ paths:
       security:
       - jwt: []
       summary: Creates a new NFS-Ganesha export
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos:
+                  default: false
+                  type: boolean
+                max_client_combined_bw:
+                  type: string
+                max_client_read_bw:
+                  type: string
+                max_client_write_bw:
+                  type: string
+                max_export_combined_bw:
+                  type: string
+                max_export_read_bw:
+                  type: string
+                max_export_write_bw:
+                  type: string
+                pseudo_path:
+                  type: string
+              required:
+              - cluster_id
+              - pseudo_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable export QoS configuration for bandwidth
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos/ops:
+    patch:
+      parameters: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cluster_id:
+                  type: string
+                disable_qos_ops:
+                  default: false
+                  type: boolean
+                max_client_iops:
+                  default: 0
+                  type: integer
+                max_export_iops:
+                  default: 0
+                  type: integer
+                pseudo_path:
+                  type: string
+              required:
+              - cluster_id
+              - pseudo_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Enable/disable export QoS configuration for operations
+      tags:
+      - NFS-Ganesha
+  /api/nfs-ganesha/export/qos/{cluster_id}/{pseudo_path}:
+    get:
+      parameters:
+      - in: path
+        name: cluster_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pseudo_path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      summary: Get the export QoS configuration for bandwidth and IOPS
       tags:
       - NFS-Ganesha
   /api/nfs-ganesha/export/{cluster_id}/{export_id}:

--- a/src/pybind/mgr/dashboard/tests/test_nfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_nfs.py
@@ -8,7 +8,7 @@ from nfs.export import AppliedExportResults
 
 from .. import mgr
 from ..controllers._version import APIVersion
-from ..controllers.nfs import NFSGaneshaExports, NFSGaneshaUi
+from ..controllers.nfs import NFSGaneshaCluster, NFSGaneshaExports, NFSGaneshaUi
 from ..tests import ControllerTestCase
 from ..tools import NotificationQueue, TaskManager
 
@@ -136,6 +136,40 @@ class NFSGaneshaExportsTest(ControllerTestCase):
         self._delete('/api/nfs-ganesha/export/myc/3',
                      version=APIVersion(2, 0))
         self.assertStatus(404)
+
+
+class NFSGaneshaClusterTest(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([NFSGaneshaCluster])
+
+    def test_get_cluster_qos(self):
+        mgr.remote = Mock(return_value={
+            'enable_qos': False,
+            'enable_bw_control': False,
+            'enable_iops_control': False,
+            'combined_rw_bw_control': False,
+        })
+
+        self._get('/api/nfs-ganesha/cluster/qos/test1')
+        self.assertStatus(200)
+        mgr.remote.assert_called_with('nfs', 'get_cluster_qos', 'test1', True)
+
+    def test_disable_cluster_qos_bw(self):
+        mgr.remote = Mock(return_value=None)
+
+        self._request('/api/nfs-ganesha/cluster/qos/bw', 'PATCH',
+                      {'cluster_id': 'test1', 'disable_qos': True})
+        self.assertStatus(200)
+        mgr.remote.assert_called_with('nfs', 'disable_cluster_qos_bw', 'test1')
+
+    def test_disable_cluster_qos_ops(self):
+        mgr.remote = Mock(return_value=None)
+
+        self._request('/api/nfs-ganesha/cluster/qos/ops', 'PATCH',
+                      {'cluster_id': 'test1', 'qos_type': 'PerShare', 'disable_ops': True})
+        self.assertStatus(200)
+        mgr.remote.assert_called_with('nfs', 'disable_cluster_qos_ops', 'test1')
 
 
 class NFSGaneshaUiControllerTest(ControllerTestCase):

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -3,6 +3,7 @@ import logging
 import re
 import socket
 from typing import cast, Dict, List, Any, Optional, TYPE_CHECKING, Union
+from enum import Enum
 
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
@@ -37,6 +38,11 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+class ClusterQosAction(Enum):
+    enable = 'enable'
+    disable = 'disable'
 
 
 def resolve_ip(hostname: str) -> str:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -2,39 +2,27 @@ import ipaddress
 import logging
 import re
 import socket
-from typing import cast, Dict, List, Any, Optional, TYPE_CHECKING, Union
 from enum import Enum
-
-from mgr_module import NFS_POOL_NAME as POOL_NAME
-from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
-from object_format import ErrorResponse
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 import orchestrator
+from ceph.deployment.service_spec import IngressSpec, NFSServiceSpec, PlacementSpec
+from mgr_module import NFS_POOL_NAME as POOL_NAME
+from object_format import ErrorResponse
 from orchestrator.module import IngressType
 
-from .exception import NFSInvalidOperation, ClusterNotFound
-from .utils import (
-    ManualRestartRequired,
-    NonFatalError,
-    available_clusters,
-    conf_obj_name,
-    restart_nfs_service,
-    user_conf_obj_name,
-    USER_CONF_PREFIX,
-    qos_conf_obj_name)
+from .exception import ClusterNotFound, NFSInvalidOperation
+from .ganesha_conf import GaneshaConfParser, format_block
+from .qos_conf import QOS, QOSBandwidthControl, QOSOpsControl, QOSParams, \
+    QOSType, validate_clust_qos_msg_interval
 from .rados_utils import NFSRados
-from .ganesha_conf import format_block, GaneshaConfParser
-from .qos_conf import (
-    QOS,
-    QOSType,
-    QOSBandwidthControl,
-    QOSOpsControl,
-    QOSParams,
-    validate_clust_qos_msg_interval)
+from .utils import USER_CONF_PREFIX, ManualRestartRequired, NonFatalError, \
+    available_clusters, conf_obj_name, qos_conf_obj_name, restart_nfs_service, \
+    user_conf_obj_name
 
 if TYPE_CHECKING:
-    from nfs.module import Module
     from mgr_module import MgrModule
+    from nfs.module import Module
 
 
 log = logging.getLogger(__name__)
@@ -717,7 +705,11 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QoS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl, skip_qos_type_validation: bool = False) -> None:
+    def enable_cluster_qos_ops(self,
+                               cluster_id: str,
+                               qos_type: QOSType,
+                               ops_obj: QOSOpsControl,
+                               skip_qos_type_validation: bool = False) -> None:
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
             if qos_obj and not skip_qos_type_validation:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -650,7 +650,8 @@ class NFSCluster:
     def enable_cluster_qos_bw(self,
                               cluster_id: str,
                               qos_type: QOSType,
-                              bw_obj: QOSBandwidthControl
+                              bw_obj: QOSBandwidthControl,
+                              skip_qos_type_validation: bool = False
                               ) -> None:
         """
         There are 2 cases to consider:
@@ -666,7 +667,7 @@ class NFSCluster:
         """
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
-            if qos_obj:
+            if qos_obj and not skip_qos_type_validation:
                 self.validate_qos_type(qos_obj, qos_type, bw_obj=bw_obj)
             bw_obj.qos_bandwidth_checks(qos_type)
             self.update_cluster_qos(
@@ -716,10 +717,10 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QoS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl) -> None:
+    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl, skip_qos_type_validation: bool = False) -> None:
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
-            if qos_obj:
+            if qos_obj and not skip_qos_type_validation:
                 self.validate_qos_type(qos_obj, qos_type, ops_obj=ops_obj)
             ops_obj.qos_ops_checks(qos_type)
             self.update_cluster_qos(

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -2,7 +2,6 @@ import ipaddress
 import logging
 import re
 import socket
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 import orchestrator

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -2,38 +2,27 @@ import ipaddress
 import logging
 import re
 import socket
-from typing import cast, Dict, List, Any, Optional, TYPE_CHECKING, Union
-
-from mgr_module import NFS_POOL_NAME as POOL_NAME
-from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
-from object_format import ErrorResponse
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 import orchestrator
+from ceph.deployment.service_spec import IngressSpec, NFSServiceSpec, PlacementSpec
+from mgr_module import NFS_POOL_NAME as POOL_NAME
+from object_format import ErrorResponse
 from orchestrator.module import IngressType
 
-from .exception import NFSInvalidOperation, ClusterNotFound
-from .utils import (
-    ManualRestartRequired,
-    NonFatalError,
-    available_clusters,
-    conf_obj_name,
-    restart_nfs_service,
-    user_conf_obj_name,
-    USER_CONF_PREFIX,
-    qos_conf_obj_name)
+from .exception import ClusterNotFound, NFSInvalidOperation
+from .ganesha_conf import GaneshaConfParser, format_block
+from .qos_conf import QOS, QOSBandwidthControl, QOSOpsControl, QOSParams, \
+    QOSType, validate_clust_qos_msg_interval
 from .rados_utils import NFSRados
-from .ganesha_conf import format_block, GaneshaConfParser
-from .qos_conf import (
-    QOS,
-    QOSType,
-    QOSBandwidthControl,
-    QOSOpsControl,
-    QOSParams,
-    validate_clust_qos_msg_interval)
+from .utils import USER_CONF_PREFIX, ManualRestartRequired, NonFatalError, \
+    available_clusters, conf_obj_name, qos_conf_obj_name, restart_nfs_service, \
+    user_conf_obj_name
 
 if TYPE_CHECKING:
-    from nfs.module import Module
     from mgr_module import MgrModule
+    from nfs.module import Module
 
 
 log = logging.getLogger(__name__)
@@ -746,7 +735,11 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QoS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl, skip_qos_type_validation: bool = False) -> None:
+    def enable_cluster_qos_ops(self,
+                               cluster_id: str,
+                               qos_type: QOSType,
+                               ops_obj: QOSOpsControl,
+                               skip_qos_type_validation: bool = False) -> None:
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
             if qos_obj and not skip_qos_type_validation:

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -679,7 +679,8 @@ class NFSCluster:
     def enable_cluster_qos_bw(self,
                               cluster_id: str,
                               qos_type: QOSType,
-                              bw_obj: QOSBandwidthControl
+                              bw_obj: QOSBandwidthControl,
+                              skip_qos_type_validation: bool = False
                               ) -> None:
         """
         There are 2 cases to consider:
@@ -695,7 +696,7 @@ class NFSCluster:
         """
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
-            if qos_obj:
+            if qos_obj and not skip_qos_type_validation:
                 self.validate_qos_type(qos_obj, qos_type, bw_obj=bw_obj)
             bw_obj.qos_bandwidth_checks(qos_type)
             self.update_cluster_qos(
@@ -745,10 +746,10 @@ class NFSCluster:
             log.exception(f"Setting NFS-Ganesha QoS bandwidth control config failed for {cluster_id}")
             raise ErrorResponse.wrap(e)
 
-    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl) -> None:
+    def enable_cluster_qos_ops(self, cluster_id: str, qos_type: QOSType, ops_obj: QOSOpsControl, skip_qos_type_validation: bool = False) -> None:
         try:
             qos_obj = self.get_cluster_qos_config(cluster_id)
-            if qos_obj:
+            if qos_obj and not skip_qos_type_validation:
                 self.validate_qos_type(qos_obj, qos_type, ops_obj=ops_obj)
             ops_obj.qos_ops_checks(qos_type)
             self.update_cluster_qos(

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -1025,8 +1025,6 @@ class ExportMgr:
         try:
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
             status = False
-            if not export_obj:
-                raise NFSObjectNotFound(f"Export {pseudo_path} not found in NFS cluster {cluster_id}")
             if export_obj.qos_block:
                 status = export_obj.qos_block.get_enable_qos_val(disable_ops=True)
             self.update_export_qos(cluster_id, pseudo_path, export_obj, status, ops_obj=QOSOpsControl())

--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -1002,6 +1002,7 @@ class ExportMgr:
     def disable_export_qos_bw(self, cluster_id: str, pseudo_path: str) -> None:
         try:
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
+            status = False
             if export_obj.qos_block:
                 status = export_obj.qos_block.get_enable_qos_val(disable_bw=True)
             self.update_export_qos(cluster_id, pseudo_path, export_obj, status, bw_obj=QOSBandwidthControl())
@@ -1023,6 +1024,7 @@ class ExportMgr:
     def disable_export_qos_ops(self, cluster_id: str, pseudo_path: str) -> None:
         try:
             export_obj = self.get_export_obj(cluster_id, pseudo_path)
+            status = False
             if not export_obj:
                 raise NFSObjectNotFound(f"Export {pseudo_path} not found in NFS cluster {cluster_id}")
             if export_obj.qos_block:

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -1,20 +1,19 @@
 import logging
 import threading
-from typing import Tuple, Optional, List, Dict, Any
-import yaml
+from typing import Any, Dict, List, Optional, Tuple
 
-from .cli import NFSCLICommand
-
-from mgr_module import MgrModule, Option, CLICheckNonemptyFileInput
 import object_format
 import orchestrator
-from orchestrator.module import IngressType
+import yaml
+from mgr_module import CLICheckNonemptyFileInput, MgrModule, Option
 from mgr_util import CephFSEarmarkResolver
+from orchestrator.module import IngressType
 
-from .export import ExportMgr, AppliedExportResults
-from .cluster import NFSCluster, ClusterQosAction
+from .cli import NFSCLICommand
+from .cluster import NFSCluster
+from .export import AppliedExportResults, ExportMgr
+from .qos_conf import QOSBandwidthControl, QOSOpsControl, QOSType, UserQoSType
 from .utils import available_clusters, cephfs_client_for_mgr
-from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 
 log = logging.getLogger(__name__)
 
@@ -295,8 +294,26 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def cluster_info(self, cluster_id: Optional[str] = None) -> Dict[str, Any]:
         return self.nfs.show_nfs_cluster_info(cluster_id=cluster_id)
 
-    def fetch_nfs_cluster_obj(self) -> NFSCluster:
-        return self.nfs
+    def get_cluster_qos(self, cluster_id: str,
+                        ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
+        return self.nfs.get_cluster_qos(cluster_id, ret_bw_in_bytes)
+
+    def disable_cluster_qos_bw(self, cluster_id: str) -> None:
+        return self.nfs.disable_cluster_qos_bw(cluster_id)
+
+    def disable_cluster_qos_ops(self, cluster_id: str) -> None:
+        return self.nfs.disable_cluster_qos_ops(cluster_id)
+
+    def get_export_qos(self, cluster_id: str, pseudo_path: str,
+                       ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
+        return self.export_mgr.get_export_qos(cluster_id, pseudo_path,
+                                              ret_bw_in_bytes)
+
+    def disable_export_qos_bw(self, cluster_id: str, pseudo_path: str) -> None:
+        return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
+
+    def disable_export_qos_ops(self, cluster_id: str, pseudo_path: str) -> None:
+        return self.export_mgr.disable_export_qos_ops(cluster_id, pseudo_path)
 
     @CLICommand('nfs export qos enable bandwidth_control', perm='rw')
     @object_format.EmptyResponder()

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -12,7 +12,7 @@ from orchestrator.module import IngressType
 from mgr_util import CephFSEarmarkResolver
 
 from .export import ExportMgr, AppliedExportResults
-from .cluster import NFSCluster
+from .cluster import NFSCluster, ClusterQosAction
 from .utils import available_clusters, cephfs_client_for_mgr
 from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -469,7 +469,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             raise object_format.ErrorResponse.wrap(e)
         return self.nfs.enable_cluster_qos_bw(cluster_id=cluster_id,
                                               qos_type=QOSType[qos.value],
-                                              bw_obj=bw_obj)
+                                              bw_obj=bw_obj,
+                                              skip_qos_type_validation=True)
 
     def enable_export_qos_bw(self, cluster_id: str,
                              pseudo_path: str,
@@ -504,7 +505,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             raise object_format.ErrorResponse.wrap(e)
         return self.nfs.enable_cluster_qos_ops(cluster_id=cluster_id,
                                                qos_type=QOSType[qos.value],
-                                               ops_obj=ops_obj)
+                                               ops_obj=ops_obj,
+                                               skip_qos_type_validation=True)
 
     def enable_export_qos_ops(self, cluster_id: str,
                               pseudo_path: str,

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -448,3 +448,74 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_cluster_qos_ops_disable(self, cluster_id: str) -> None:
         """Disable NFS cluster QOS IOPS control"""
         return self.nfs.disable_cluster_qos_ops(cluster_id)
+
+    def enable_cluster_qos_bw(self, cluster_id: str,
+                              qos_type: str,
+                              combined_bw_ctrl: bool,
+                              **kwargs: Any
+                              ) -> None:
+        qos = UserQoSType(qos_type)
+        try:
+            # by default it will take 0 which is expected by this function
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_bw_ctrl,
+                                         export_writebw=kwargs.get('max_export_write_bw', '0'),
+                                         export_readbw=kwargs.get('max_export_read_bw', '0'),
+                                         client_writebw=kwargs.get('max_client_write_bw', '0'),
+                                         client_readbw=kwargs.get('max_client_read_bw', '0'),
+                                         export_rw_bw=kwargs.get('max_export_combined_bw', '0'),
+                                         client_rw_bw=kwargs.get('max_client_combined_bw', '0'))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_bw(cluster_id=cluster_id,
+                                              qos_type=QOSType[qos.value],
+                                              bw_obj=bw_obj)
+
+    def enable_export_qos_bw(self, cluster_id: str,
+                             pseudo_path: str,
+                             combined_bw_ctrl: bool,
+                             **kwargs: Any
+                             ) -> None:
+        try:
+            bw_obj = QOSBandwidthControl(enable_bw_ctrl=True,
+                                         combined_bw_ctrl=combined_bw_ctrl,
+                                         export_writebw=kwargs.get('max_export_write_bw', '0'),
+                                         export_readbw=kwargs.get('max_export_read_bw', '0'),
+                                         client_writebw=kwargs.get('max_client_write_bw', '0'),
+                                         client_readbw=kwargs.get('max_client_read_bw', '0'),
+                                         export_rw_bw=kwargs.get('max_export_combined_bw', '0'),
+                                         client_rw_bw=kwargs.get('max_client_combined_bw', '0'))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_bw(cluster_id=cluster_id,
+                                                    pseudo_path=pseudo_path,
+                                                    bw_obj=bw_obj)
+
+    def enable_cluster_qos_ops(self, cluster_id: str,
+                               qos_type: str,
+                               **kwargs: Any
+                               ) -> None:
+        qos = UserQoSType(qos_type)
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=kwargs.get('max_export_iops', 0),
+                                    max_client_iops=kwargs.get('max_client_iops', 0))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.nfs.enable_cluster_qos_ops(cluster_id=cluster_id,
+                                               qos_type=QOSType[qos.value],
+                                               ops_obj=ops_obj)
+
+    def enable_export_qos_ops(self, cluster_id: str,
+                              pseudo_path: str,
+                              **kwargs: Any
+                              ) -> None:
+        try:
+            ops_obj = QOSOpsControl(enable_iops_ctrl=True,
+                                    max_export_iops=kwargs.get('max_export_iops', 0),
+                                    max_client_iops=kwargs.get('max_client_iops', 0))
+        except Exception as e:
+            raise object_format.ErrorResponse.wrap(e)
+        return self.export_mgr.enable_export_qos_ops(cluster_id=cluster_id,
+                                                     pseudo_path=pseudo_path,
+                                                     ops_obj=ops_obj)

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -1,20 +1,19 @@
 import logging
 import threading
-from typing import Tuple, Optional, List, Dict, Any
-import yaml
+from typing import Any, Dict, List, Optional, Tuple
 
-from .cli import NFSCLICommand
-
-from mgr_module import MgrModule, Option, CLICheckNonemptyFileInput
 import object_format
 import orchestrator
-from orchestrator.module import IngressType
+import yaml
+from mgr_module import CLICheckNonemptyFileInput, MgrModule, Option
 from mgr_util import CephFSEarmarkResolver
+from orchestrator.module import IngressType
 
-from .export import ExportMgr, AppliedExportResults
+from .cli import NFSCLICommand
 from .cluster import NFSCluster
+from .export import AppliedExportResults, ExportMgr
+from .qos_conf import QOSBandwidthControl, QOSOpsControl, QOSType, UserQoSType
 from .utils import available_clusters, cephfs_client_for_mgr
-from .qos_conf import QOSType, QOSBandwidthControl, UserQoSType, QOSOpsControl
 
 log = logging.getLogger(__name__)
 
@@ -295,8 +294,26 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def cluster_info(self, cluster_id: Optional[str] = None) -> Dict[str, Any]:
         return self.nfs.show_nfs_cluster_info(cluster_id=cluster_id)
 
-    def fetch_nfs_cluster_obj(self) -> NFSCluster:
-        return self.nfs
+    def get_cluster_qos(self, cluster_id: str,
+                        ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
+        return self.nfs.get_cluster_qos(cluster_id, ret_bw_in_bytes)
+
+    def disable_cluster_qos_bw(self, cluster_id: str) -> None:
+        return self.nfs.disable_cluster_qos_bw(cluster_id)
+
+    def disable_cluster_qos_ops(self, cluster_id: str) -> None:
+        return self.nfs.disable_cluster_qos_ops(cluster_id)
+
+    def get_export_qos(self, cluster_id: str, pseudo_path: str,
+                       ret_bw_in_bytes: bool = False) -> Dict[str, Any]:
+        return self.export_mgr.get_export_qos(cluster_id, pseudo_path,
+                                              ret_bw_in_bytes)
+
+    def disable_export_qos_bw(self, cluster_id: str, pseudo_path: str) -> None:
+        return self.export_mgr.disable_export_qos_bw(cluster_id, pseudo_path)
+
+    def disable_export_qos_ops(self, cluster_id: str, pseudo_path: str) -> None:
+        return self.export_mgr.disable_export_qos_ops(cluster_id, pseudo_path)
 
     @CLICommand('nfs export qos enable bandwidth_control', perm='rw')
     @object_format.EmptyResponder()

--- a/src/pybind/mgr/nfs/rados_utils.py
+++ b/src/pybind/mgr/nfs/rados_utils.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, Any
 
+import rados
 from rados import TimedOut, ObjectNotFound, Rados
 from mgr_module import NFS_POOL_NAME as POOL_NAME
 from .ganesha_conf import format_block
@@ -51,12 +52,17 @@ class NFSRados:
             log.debug("Added %s url to %s", obj, config_obj)
 
     def read_obj(self, obj: str) -> Optional[str]:
-        with self.rados.open_ioctx(self.pool) as ioctx:
-            ioctx.set_namespace(self.namespace)
-            try:
-                return ioctx.read(obj, 1048576).decode()
-            except ObjectNotFound:
-                return None
+        try:
+            with self.rados.open_ioctx(self.pool) as ioctx:
+                ioctx.set_namespace(self.namespace)
+                try:
+                    return ioctx.read(obj, 1048576).decode()
+                except ObjectNotFound:
+                    return None
+        except (ObjectNotFound, rados.Error, OSError) as e:
+            log.debug("Failed to read NFS rados object %s/%s/%s: %s",
+                      self.pool, self.namespace, obj, e)
+            return None
 
     def update_obj(self, conf_block: str, obj: str, config_obj: str,
                    should_notify: Optional[bool] = True) -> None:

--- a/src/pybind/mgr/nfs/tests/test_nfs.py
+++ b/src/pybind/mgr/nfs/tests/test_nfs.py
@@ -149,6 +149,7 @@ EXPORT {
     qos_cluster_block = """
 QOS {
     enable_qos = true;
+    enable_cluster_qos = true;
     enable_bw_control = true;
     combined_rw_bw_control = false;
     qos_type = "Per_Export_Per_Client";
@@ -179,6 +180,7 @@ QOS_BLOCK {
     qos_cluster_dict = {
         "enable_bw_control": True,
         "enable_qos": True,
+        "enable_cluster_qos": True,
         "combined_rw_bw_control": False,
         "max_client_read_bw": bytes_to_human(4000000, mode='binary'),
         "max_client_write_bw": bytes_to_human(3000000, mode='binary'),
@@ -191,6 +193,7 @@ QOS_BLOCK {
     qos_cluster_dict_bw_in_bytes = {
         "enable_bw_control": True,
         "enable_qos": True,
+        "enable_cluster_qos": True,
         "combined_rw_bw_control": False,
         "max_client_read_bw": "4000000",
         "max_client_write_bw": "3000000",
@@ -1492,7 +1495,7 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False}
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": combined_bw_ctrl, "qos_type": qos_type.name, "enable_iops_control": False, "enable_cluster_qos": True}
         for key in params:
             expected_out[QOSParams[key].value] = bytes_to_human(with_units_to_int(params[key]), mode='binary')
         assert out == expected_out
@@ -1596,7 +1599,7 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": qos_type.name, "enable_iops_control": True}
+        expected_out = {"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": qos_type.name, "enable_iops_control": True, "enable_cluster_qos": True}
         for key in params:
             expected_out[QOSParams[key].value] = params[key]
         assert out == expected_out
@@ -1682,7 +1685,7 @@ EXPORT {
         if not positive_tc:
             raise Exception("This TC passed but it was supposed to fail")
         out = cluster.get_cluster_qos(self.cluster_id)
-        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": ops_qos_type.name, "enable_iops_control": True}
+        expected_out = {"enable_bw_control": True, "enable_qos": True, "combined_rw_bw_control": False, "qos_type": ops_qos_type.name, "enable_iops_control": True, "enable_cluster_qos":True}
         bw_out = {}
         ops_out = {}
         for key in bw_params:
@@ -1695,7 +1698,7 @@ EXPORT {
         # disable bandwidth control
         cluster.disable_cluster_qos_bw(self.cluster_id)
         out = cluster.get_cluster_qos(self.cluster_id)
-        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True, "qos_type": ops_qos_type.name})
+        ops_out.update({"enable_bw_control": False, "enable_qos": True, "combined_rw_bw_control": False, "enable_iops_control": True, "qos_type": ops_qos_type.name, "enable_cluster_qos": True})
         assert out == ops_out
         # disable ops control
         cluster.disable_cluster_qos_ops(self.cluster_id)


### PR DESCRIPTION

Tracker : - https://tracker.ceph.com/issues/79007
Date: 04 August 2026
**Bug fix : - Fix NFS Ganesha QoS dashboard APIs returning 500 by using mgr.remote() calls instead of returning mgr objects, and handle missing .nfs pool when reading QoS config.**



https://github.com/user-attachments/assets/73e032cb-52da-4f93-8048-75de3a0d417f

-------------------------------------------------------------------------------------------------------------------------------------------------------------------


This PR is based on https://github.com/ceph/ceph/pull/62120

Commit to be reviewed -> https://github.com/ceph/ceph/pull/62646/commits/ae37b1f2dfbf7407f50c50714eef52d7117e5d93

Fixes: https://tracker.ceph.com/issues/70742

Signed-off-by: Dnyaneshwari Talwekar <dtalwekar@redhat.com>


https://github.com/user-attachments/assets/618fa07f-a561-43d3-b391-9e49eea1e454



**BUGS--
----------------------------------------------------------------------------------------------------------------------------------------------------------------------

Commit to be reviewed ->
https://github.com/ceph/ceph/pull/62646/changes/709b9ba0904870637fe040e188590b00c2d36706

https://github.com/user-attachments/assets/1c8818e3-27c1-452d-b561-35fedf5da21b

Fixes: https://ibm-ceph.atlassian.net/browse/IBMCEPH-11601
           https://ibm-ceph.atlassian.net/browse/IBMCEPH-11520**




--------------------------------------------------------------------------------------------------------------------------------
27/08/26

Commit - febda227a96d578567364b8534577a95ede498ae


https://github.com/user-attachments/assets/94cd57cd-e0b3-4389-9844-9c263b9f8740


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
