### PR TITLE
squid: mgr/dashboard: add prometheus read permission to cluster_mgr role

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -246,6 +246,7 @@ CLUSTER_MGR_ROLE = Role(
         Scope.CONFIG_OPT: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.LOG: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.GRAFANA: [_P.READ],
+        Scope.PROMETHEUS: [_P.READ]
     })
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70777

---

backport of https://github.com/ceph/ceph/pull/62629
parent tracker: https://tracker.ceph.com/issues/70768

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh