### PR TITLE
mgr/cephadm: migrate nvmeof specs cluster_connections

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -26,7 +26,11 @@ from orchestrator import OrchestratorError, HostSpec, OrchestratorEvent, service
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 
 from .utils import resolve_ip, SpecialHostLabels
-from .migrations import queue_migrate_nfs_spec, queue_migrate_rgw_spec
+from .migrations import (
+    queue_migrate_nfs_spec,
+    queue_migrate_rgw_spec,
+    queue_migrate_nvmeof_spec,
+)
 
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
@@ -307,6 +311,12 @@ class SpecStore():
                         and j['spec'].get('service_type') == 'rgw'
                 ):
                     queue_migrate_rgw_spec(self.mgr, j)
+
+                if (
+                        (self.mgr.migration_current or 0) < 8
+                        and j['spec'].get('service_type') == 'nvmeof'
+                ):
+                    queue_migrate_nvmeof_spec(self.mgr, j)
 
                 spec = ServiceSpec.from_json(j['spec'])
                 created = str_to_datetime(cast(str, j['created']))

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -3,7 +3,13 @@ import re
 import logging
 from typing import TYPE_CHECKING, Iterator, Optional, Dict, Any, List
 
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec, RGWSpec
+from ceph.deployment.service_spec import (
+    PlacementSpec,
+    ServiceSpec,
+    HostPlacementSpec,
+    RGWSpec,
+    NvmeofServiceSpec,
+)
 from cephadm.schedule import HostAssignment
 from cephadm.utils import SpecialHostLabels
 import rados
@@ -14,7 +20,7 @@ from orchestrator import OrchestratorError, DaemonDescription
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 7
+LAST_MIGRATION = 8
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +46,9 @@ class Migrations:
 
         r = mgr.get_store('rgw_migration_queue')
         self.rgw_migration_queue = json.loads(r) if r else []
+
+        n = mgr.get_store('nvmeof_migration_queue')
+        self.nvmeof_migration_queue = json.loads(n) if n else []
 
         # for some migrations, we don't need to do anything except for
         # incrementing migration_current.
@@ -108,6 +117,10 @@ class Migrations:
         if self.mgr.migration_current == 6:
             if self.migrate_6_7():
                 self.set(7)
+
+        if self.mgr.migration_current == 7:
+            if self.migrate_7_8():
+                self.set(8)
 
     def migrate_0_1(self) -> bool:
         """
@@ -441,6 +454,67 @@ class Migrations:
         # and appeared to just be generated at daemon deploy time if secure_monitoring_stack
         # was set to true. Therefore we have nothing to migrate for those daemons
         return True
+
+    # Migration of spdk cluster connection allocation strategy
+    nvmeof_spdk_alloc_legacy_policy = "bdevs_per_cluster"
+    nvmeof_spdk_alloc_new_policy = "cluster_connections"
+    nvmeof_spdk_alloc_default_value = 32
+
+    def migrate_nvmeof_spec(
+        self, spec: Dict[Any, Any], migration_counter: int
+    ) -> Optional[NvmeofServiceSpec]:
+        """replaces the default value of bdevs_per_cluster with cluster_connections in nvmeof spec"""
+        new_spec = spec.copy()
+        # Note: replace legacy default strategy with the new one
+        new_spec["spec"].pop(Migrations.nvmeof_spdk_alloc_legacy_policy)
+        new_spec["spec"][Migrations.nvmeof_spdk_alloc_new_policy] = Migrations.nvmeof_spdk_alloc_default_value
+
+        return NvmeofServiceSpec.from_json(new_spec)
+
+    def nvmeof_spec_needs_migration(self, spec: Dict[Any, Any]) -> bool:
+        spec = spec.get('spec', None)
+        # If 'bdevs_per_cluster' was changed before upgrade (i.e it is not 32)
+        # leave it to be the policy also after upgrade.
+        # If 'bdevs_per_cluster' == 32 (i.e. was not changed by the user)
+        # move to the new policy.
+        return (
+            bool(spec)
+            and Migrations.nvmeof_spdk_alloc_legacy_policy in spec
+            and spec[Migrations.nvmeof_spdk_alloc_legacy_policy] == Migrations.nvmeof_spdk_alloc_default_value
+        )
+
+    def migrate_7_8(self) -> bool:
+        """
+        Migrate default spdk cluster connection allocation strategy
+        """
+        self.mgr.log.debug(f'Starting nvmeof migration (queue length is {len(self.nvmeof_migration_queue)})')
+        migrated_spec_counter = 0
+        for s in self.nvmeof_migration_queue:
+            spec = s['spec']
+            if self.nvmeof_spec_needs_migration(spec):
+                nvmeof_spec = self.migrate_nvmeof_spec(spec, migrated_spec_counter)
+                if nvmeof_spec is not None:
+                    logger.info(f"Migrated nvmeof spec: {spec} migration: {nvmeof_spec}")
+                    self.mgr.spec_store.save(nvmeof_spec)
+                    migrated_spec_counter += 1
+            else:
+                logger.info(f"No Migration is needed for nvmeof spec: {spec}")
+        self.nvmeof_migration_queue = []
+        return True
+
+
+def queue_migrate_nvmeof_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]) -> None:
+    """
+    group has become a required field for nvmeof specs and has been added
+    to spec validation. We need to assign a default group to nvmeof specs
+    that don't have one
+    """
+    service_id = spec_dict['spec']['service_id']
+    queued = mgr.get_store('nvmeof_migration_queue') or '[]'
+    ls = json.loads(queued)
+    ls.append(spec_dict)
+    mgr.set_store('nvmeof_migration_queue', json.dumps(ls))
+    mgr.log.info(f'Queued nvmeof.{service_id} for migration')
 
 
 def queue_migrate_rgw_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]) -> None:


### PR DESCRIPTION
#mgr/cephadm: migrate nvmeof specs cluster_connections

based on `mgr/cephadm: migrate nvmeof specs without group field` d7b00eab08b006c5d10268a5aab7bc8dfc146c08

If 'bdevs_per_cluster' was changed before upgrade (i.e it is not 32) - leave it to be the policy also after upgrade. If 'bdevs_per_cluster' == 32 (i.e. was not changed by the user) - move to the new policy.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
