### PR TITLE
erasure-code: Handle review comments from #61804 to tidy up EC plugin changes

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -111,7 +111,7 @@ int ErasureCode::sanity_check_k_m(int k, int m, ostream *ss)
     *ss << "m=" << m << " must be >= 1" << std::endl;
     return -EINVAL;
   }
-  int max_k_plus_m = std::numeric_limits<decltype(shard_id_t::id)>::max();
+  auto max_k_plus_m = std::numeric_limits<decltype(shard_id_t::id)>::max();
   if (k+m > max_k_plus_m) {
     *ss << "(k+m)=" << (k+m) << " must be <= " << max_k_plus_m << std::endl;
     return -EINVAL;
@@ -136,7 +136,7 @@ int ErasureCode::_minimum_to_decode(const set<int> &want_to_read,
                                    set<int> *minimum)
 {
   if (includes(available_chunks.begin(), available_chunks.end(),
-	       want_to_read.begin(), want_to_read.end())) {
+               want_to_read.begin(), want_to_read.end())) {
     *minimum = want_to_read;
   } else {
     unsigned int k = get_data_chunk_count();
@@ -447,7 +447,7 @@ int ErasureCode::_decode(const shard_id_set &want_to_read,
       (*decoded)[i].rebuild_aligned(SIMD_ALIGN);
     }
     bufferlist &bl = (*decoded)[i];
-    if (bl.length() != bl.begin().get_current_ptr().length()) {
+    if (!bl.is_contiguous()) {
       bl.rebuild();
     }
   }

--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -309,15 +309,13 @@ namespace ceph {
     virtual int minimum_to_decode(const shard_id_set &want_to_read,
                           const shard_id_set &available,
                           shard_id_set &minimum_set,
-                          mini_flat_map<shard_id_t, std::vector<std::pair<int, int>>>
-                          *minimum_sub_chunks) = 0;
+                          mini_flat_map<shard_id_t, std::vector<std::pair<int, int>>> *minimum_sub_chunks) = 0;
 
     // Interface for legacy EC.
     [[deprecated]]
     virtual int minimum_to_decode(const std::set<int> &want_to_read,
                                   const std::set<int> &available,
-                                  std::map<int, std::vector<std::pair<int, int>>> 
-                                  *minimum) = 0;
+                                  std::map<int, std::vector<std::pair<int, int>>> *minimum) = 0;
 
     /**
      * Compute the smallest subset of **available** chunks that needs

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -83,7 +83,7 @@ public:
                     ceph::bufferptr *delta_maybe_in_place);
 
   void apply_delta(const shard_id_map<ceph::bufferptr> &in,
-                           shard_id_map<ceph::bufferptr> &out) = 0;
+                   shard_id_map<ceph::bufferptr> &out) = 0;
 
   int init(ceph::ErasureCodeProfile &profile, std::ostream *ss) override;
 

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -1104,8 +1104,11 @@ int ErasureCodeLrc::decode_chunks(const shard_id_set &want_to_read,
   }
 
   for (const auto& [shard, ptr] : out) {
-    if (chunk_size == 0) chunk_size = ptr.length();
-    else ceph_assert(chunk_size == ptr.length());
+    if (chunk_size == 0) {
+      chunk_size = ptr.length();
+    } else {
+      ceph_assert(chunk_size == ptr.length());
+    }
     erasures.insert(shard);
   }
 
@@ -1132,10 +1135,12 @@ int ErasureCodeLrc::decode_chunks(const shard_id_set &want_to_read,
       {
         shard_id_t cs(*c);
         if (!erasures.contains(cs)) {
-          if (in.contains(cs)) layer_in[j] = in[cs];
-          else layer_in[j] = out[cs];
-        }
-        else {
+          if (in.contains(cs)) {
+            layer_in[j] = in[cs];
+          } else {
+            layer_in[j] = out[cs];
+          }
+        } else {
           layer_out[j] = out[cs];
         }
         ++j;

--- a/src/osd/ECTypes.h
+++ b/src/osd/ECTypes.h
@@ -46,14 +46,6 @@ struct raw_shard_id_t {
 
   const static raw_shard_id_t NO_SHARD;
 
-  void encode(ceph::buffer::list &bl) const {
-    using ceph::encode;
-    encode(id, bl);
-  }
-  void decode(ceph::buffer::list::const_iterator &bl) {
-    using ceph::decode;
-    decode(id, bl);
-  }
   void dump(ceph::Formatter *f) const {
     f->dump_int("id", id);
   }

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -185,9 +185,7 @@ public:
     unsigned int chunk_length = get_chunk_size(in.length());
     bufferlist out(in);
     unsigned int width = get_chunk_count() * get_chunk_size(in.length());
-    bufferptr pad(width - in.length());
-    pad.zero(0, get_data_chunk_count());
-    out.push_back(pad);
+    out.append_zero(width - in.length());
     //
     // compute the coding chunk with first chunk ^ second chunk
     //


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
