### PR TITLE
libcephfs_proxy: Remove arithmetic on `void*`

### DIFF
--- a/src/libcephfs_proxy/CMakeLists.txt
+++ b/src/libcephfs_proxy/CMakeLists.txt
@@ -4,10 +4,8 @@ set(libcephfs_proxy_srcs libcephfs_proxy.c ${proxy_common_srcs})
 
 add_executable(libcephfsd ${libcephfsd_srcs})
 add_library(cephfs_proxy ${CEPH_SHARED} ${libcephfs_proxy_srcs})
-target_compile_options(cephfs_proxy PRIVATE "-Wno-gnu-pointer-arith")
 
 target_link_libraries(libcephfsd cephfs ${CRYPTO_LIBS})
-target_compile_options(libcephfsd PRIVATE "-Wno-gnu-pointer-arith")
 
 if(ENABLE_SHARED)
   set_target_properties(cephfs_proxy PROPERTIES

--- a/src/libcephfs_proxy/libcephfsd.c
+++ b/src/libcephfs_proxy/libcephfsd.c
@@ -238,7 +238,7 @@ static int32_t libcephfsd_conf_set(proxy_client_t *client, proxy_req_t *req,
 	if (err >= 0) {
 		option = CEPH_STR_GET(req->conf_set, option, data);
 		value = CEPH_STR_GET(req->conf_set, value,
-				     data + req->conf_set.option);
+				     (const char *)(data) + req->conf_set.option);
 
 		err = proxy_mount_set(mount, option, value);
 		TRACE("ceph_conf_set(%p, '%s', '%s') -> %d", mount, option,
@@ -810,7 +810,7 @@ static int32_t libcephfsd_ll_rename(proxy_client_t *client, proxy_req_t *req,
 	if (err >= 0) {
 		old_name = CEPH_STR_GET(req->ll_rename, old_name, data);
 		new_name = CEPH_STR_GET(req->ll_rename, new_name,
-					data + req->ll_rename.old_name);
+					(const char *)data + req->ll_rename.old_name);
 
 		err = ceph_ll_rename(proxy_cmount(mount), old_parent, old_name,
 				     new_parent, new_name, perms);
@@ -1220,7 +1220,7 @@ static int32_t libcephfsd_ll_setxattr(proxy_client_t *client, proxy_req_t *req,
 	}
 	if (err >= 0) {
 		name = CEPH_STR_GET(req->ll_setxattr, name, data);
-		value = data + req->ll_setxattr.name;
+		value = (const char *)data + req->ll_setxattr.name;
 		size = req->ll_setxattr.size;
 		flags = req->ll_setxattr.flags;
 
@@ -1326,7 +1326,7 @@ static int32_t libcephfsd_ll_symlink(proxy_client_t *client, proxy_req_t *req,
 	if (err >= 0) {
 		name = CEPH_STR_GET(req->ll_symlink, name, data);
 		value = CEPH_STR_GET(req->ll_symlink, target,
-				     data + req->ll_symlink.name);
+				     (const char *)data + req->ll_symlink.name);
 		want = req->ll_symlink.want;
 		flags = req->ll_symlink.flags;
 

--- a/src/libcephfs_proxy/proxy_link.c
+++ b/src/libcephfs_proxy/proxy_link.c
@@ -89,7 +89,7 @@ static int32_t proxy_link_read(proxy_link_t *link, int32_t sd, void *buffer,
 			return proxy_log(LOG_ERR, EPIPE, "Partial read");
 		}
 
-		buffer += len;
+		buffer = (char *)buffer + len;
 		size -= len;
 	}
 
@@ -117,7 +117,7 @@ static int32_t proxy_link_write(proxy_link_t *link, int32_t sd, void *buffer,
 			return proxy_log(LOG_ERR, EPIPE, "Partial write");
 		}
 
-		buffer += len;
+		buffer = (char *)buffer + len;
 		size -= len;
 	}
 
@@ -239,13 +239,13 @@ static int32_t proxy_link_negotiate_read(proxy_link_t *link, int32_t sd,
 					 proxy_link_negotiate_t *neg)
 {
 	char buffer[128];
-	void *ptr;
+	char *ptr;
 	uint32_t size, len;
 	int32_t err;
 
 	memset(neg, 0, sizeof(proxy_link_negotiate_t));
 
-	ptr = neg;
+	ptr = (char *)neg;
 
 	err = proxy_link_read(link, sd, ptr, sizeof(neg->v0));
 	if (err < 0) {
@@ -706,7 +706,7 @@ int32_t proxy_link_send(int32_t sd, struct iovec *iov, int32_t count)
 		}
 
 		if (count > 0) {
-			iov->iov_base += len;
+			iov->iov_base = (char *)iov->iov_base + len;
 			iov->iov_len -= len;
 		}
 	}
@@ -746,7 +746,7 @@ int32_t proxy_link_recv(int32_t sd, struct iovec *iov, int32_t count)
 		}
 
 		if (count > 0) {
-			iov->iov_base += len;
+			iov->iov_base = (char *)iov->iov_base + len;
 			iov->iov_len -= len;
 		}
 	}
@@ -806,7 +806,7 @@ int32_t proxy_link_req_recv(int32_t sd, struct iovec *iov, int32_t count)
 			return proxy_log(LOG_ERR, ENOBUFS,
 					 "Request is too long");
 		}
-		iov->iov_base += sizeof(proxy_link_req_t);
+		iov->iov_base = (char *)iov->iov_base + sizeof(proxy_link_req_t);
 		iov->iov_len = req->header_len - sizeof(proxy_link_req_t);
 	} else {
 		iov++;
@@ -877,7 +877,7 @@ int32_t proxy_link_ans_recv(int32_t sd, struct iovec *iov, int32_t count)
 			return proxy_log(LOG_ERR, ENOBUFS,
 					 "Answer is too long");
 		}
-		iov->iov_base += sizeof(proxy_link_ans_t);
+		iov->iov_base = (char *)iov->iov_base + sizeof(proxy_link_ans_t);
 		iov->iov_len = ans->header_len - sizeof(proxy_link_ans_t);
 	} else {
 		iov++;


### PR DESCRIPTION
GCC 14 warns as this is apparently widely supported but Technically Incorrect.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
