### PR TITLE
include/any: Remove use of boost::shared_ptr

### DIFF
--- a/src/include/any.h
+++ b/src/include/any.h
@@ -22,9 +22,6 @@
 #include <typeinfo>
 #include <type_traits>
 
-#include <boost/smart_ptr/shared_ptr.hpp>
-#include <boost/smart_ptr/make_shared.hpp>
-
 namespace ceph {
 
 namespace _any {
@@ -83,7 +80,7 @@ inline void op_func(const op o, void* p) noexcept {
 }
 using func_t = void (*)(const op, void* p) noexcept;
 
-// The base class 
+// The base class
 // --------------
 //
 // The `storage_t` parameter gives the type of the value that manages
@@ -210,9 +207,9 @@ private:
 
 protected:
 
-  // We hold the storage, even if the superclass class manipulates it,
-  // so that its default initialization comes soon enough for us to
-  // use it in our constructors.
+  // We hold the storage, even if the subclass manipulates it, so that
+  // its default initialization comes soon enough for us to use it in
+  // our constructors.
   //
   storage_t storage;
 
@@ -642,8 +639,8 @@ inline unique_any make_unique_any(std::initializer_list<U> i, Args&& ...args) {
 // This is both copyable *and* movable. In case you need that sort of
 // thing. It seemed a reasonable completion.
 //
-class shared_any : public _any::base<shared_any, boost::shared_ptr<std::byte[]>> {
-  using base = _any::base<shared_any, boost::shared_ptr<std::byte[]>>;
+class shared_any : public _any::base<shared_any, std::shared_ptr<std::byte[]>> {
+  using base = _any::base<shared_any, std::shared_ptr<std::byte[]>>;
   friend base;
 
   using base::storage;
@@ -652,10 +649,7 @@ class shared_any : public _any::base<shared_any, boost::shared_ptr<std::byte[]>>
   // -----------------------
   //
   // Our storage is a single chunk of RAM allocated from the
-  // heap. This time it's owned by a `boost::shared_ptr` so we can use
-  // `boost::make_shared_noinit`. (This lets us get the optimization
-  // that allocates array and control block in one without wasting
-  // time on `memset`.)
+  // heap.
   //
   static constexpr std::size_t capacity = _any::dynamic;
   void* ptr() const noexcept {
@@ -663,7 +657,7 @@ class shared_any : public _any::base<shared_any, boost::shared_ptr<std::byte[]>>
   }
 
   void* alloc_storage(std::size_t n) {
-    storage = boost::make_shared_noinit<std::byte[]>(n);
+    storage = std::make_shared_for_overwrite<std::byte[]>(n);
     return ptr();
   }
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -23,6 +23,7 @@
 #include <limits.h>
 #include <cstring>
 #include <boost/scope_exit.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include "json_spirit/json_spirit_reader.h"


### PR DESCRIPTION
Since C++20 has `std::make_shared_for_overwrite` we don't need `boost::shared_ptr` to get similar functionality.

This also lets us drop includes that were hitting Boost's deprecation warnings.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
