### PR TITLE
Add rgw-gap-list test coverage (Task #70786)

### DIFF
--- a/qa/workunits/rgw/test_rgw_gap_list.sh
+++ b/qa/workunits/rgw/test_rgw_gap_list.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+
+# Configuration
+data_pool=default.rgw.buckets.data
+gap_list_out=/tmp/gap_list.out.$$
+rgw_host="$(hostname --fqdn)"
+rgw_port=80
+
+export RGW_ACCESS_KEY="0555b35654ad1656d804"
+export RGW_SECRET_KEY="h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=="
+export RGW_HOST="${RGW_HOST:-$rgw_host}"
+
+bucket="gap-list-bkt-$((RANDOM % 899999 + 100000))"
+object_prefix="gap-test-obj"
+object_count=20
+
+# Create the RGW user if it does not exist
+if ! radosgw-admin user info --access-key "$RGW_ACCESS_KEY" &>/dev/null; then
+    radosgw-admin user create --uid testid \
+        --access-key "$RGW_ACCESS_KEY" \
+        --secret "$RGW_SECRET_KEY" \
+        --display-name "Tester" --email tester@ceph.com
+fi
+
+
+s3cmd --access_key="$RGW_ACCESS_KEY" --secret_key="$RGW_SECRET_KEY" \
+      --host="$RGW_HOST" --host-bucket="$RGW_HOST" \
+      mb s3://"$bucket"
+
+# Upload test objects (simulate missing objects to test for gaps)
+for i in $(seq 1 "$object_count"); do
+    if (( i % 5 == 0 )); then
+        continue 
+    fi
+    echo "data-$i" > "/tmp/${object_prefix}-$i"
+    s3cmd --access_key="$RGW_ACCESS_KEY" --secret_key="$RGW_SECRET_KEY" \
+          --host="$RGW_HOST" --host-bucket="$RGW_HOST" \
+          put "/tmp/${object_prefix}-$i" s3://"$bucket"/"${object_prefix}-$i"
+done
+
+# Allow time for metadata consistency
+sleep 5
+
+# Execute rgw-gap-list to identify missing objects
+rgw-gap-list "$data_pool" > "$gap_list_out"
+
+# Validate whether rgw-gap-list successfully identified gaps
+if grep -q "$bucket" "$gap_list_out"; then
+    echo "Gap(s) detected successfully in bucket: $bucket"
+else
+    echo "ERROR: No gaps detected. Verification failed."
+    exit 1
+fi
+
+s3cmd --access_key="$RGW_ACCESS_KEY" --secret_key="$RGW_SECRET_KEY" \
+      --host="$RGW_HOST" --host-bucket="$RGW_HOST" \
+      rb --recursive s3://"$bucket"
+
+rm -f /tmp/"$object_prefix"-* "$gap_list_out"
+echo "Test test_rgw_gap_list.sh completed."


### PR DESCRIPTION
Implements `test_rgw_gap_list.sh` to add basic test coverage for `rgw-gap-list`, (Task [#70786](https://tracker.ceph.com/issues/70786)).

The script:
- Uploads a set of test objects to a bucket.
- Skips a few objects to simulate missing data.
- Executes `rgw-gap-list` and checks that the gaps are correctly reported.

The goal is to have similar test coverage for `rgw-gap-list` like we already do for `rgw-orphan-list`.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  + [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  + [x]  No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  + [x]  No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  + [x]  Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>