### PR TITLE
mgr/cephadm: Give warning for moving last nvmeof host to maintainane mode

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -192,10 +192,15 @@ class NvmeofService(CephService):
             return HandleCommandResult(-errno.EBUSY, '', warn_message)
 
         # if reached here, there is > 1 nvmeof daemon. make sure none are down
-        warn_message = ('ALERT: 1 nvmeof daemon is already down. Please bring it back up before stopping this one')
-        nvmeof_daemons = self.mgr.cache.get_daemons_by_type(self.TYPE)
-        for i in nvmeof_daemons:
-            if i.status != DaemonDescriptionStatus.running:
+        if not force:
+            warn_message = ('ALERT: Only 1 nvmeof daemon is up. Please bring 1 nvmeof daemon back up before stopping this one')
+            up_daemon_cnt = 0
+            hosts_in_maintainance_mode = self.mgr.inventory.get_host_with_state("maintenance")
+            nvmeof_daemons = self.mgr.cache.get_daemons_by_type(self.TYPE)
+            for i in nvmeof_daemons:
+                if i.status == DaemonDescriptionStatus.running and i.hostname not in hosts_in_maintainance_mode:
+                    up_daemon_cnt += 1
+            if up_daemon_cnt < 2:
                 return HandleCommandResult(-errno.EBUSY, '', warn_message)
 
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]


### PR DESCRIPTION
Currently 'ceph orch host maintenance enter' command does not give any warning while moving last nvmeof host to maintenance mode.



Fixes: https://tracker.ceph.com/issues/70800
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                     PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT                
crash                                                6/6  7m ago     14m  *                        
mgr                                                  2/2  5m ago     14m  count:2                  
mon                                                  5/5  6m ago     14m  count:5                  
nvmeof.nvmeof_pool.grp1  ?:4420,5500,8009,10008      2/2  83s ago    2m   ceph-node-5;ceph-node-4  
osd.default                                            4  5m ago     6m   ceph-node-1              
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph orch host maintenance enter ceph-node-5
Daemons for Ceph cluster c9377498-114e-11f0-a7d7-525400624b0d stopped on host ceph-node-5. Host ceph-node-5 moved to maintenance mode
[ceph: root@ceph-node-0 /]# ceph orch host maintenance enter ceph-node-4
ALERT: Only 1 nvmeof daemon is up. Please bring 1 nvmeof daemon back up before stopping this one
Note: Warnings can be bypassed with the --force flag
[ceph: root@ceph-node-0 /]# ceph orch host maintenance enter ceph-node-4 --force
Daemons for Ceph cluster c9377498-114e-11f0-a7d7-525400624b0d stopped on host ceph-node-4. Host ceph-node-4 moved to maintenance mode
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                     PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT                
crash                                                4/6  10m ago    18m  *                        
mgr                                                  2/2  10m ago    18m  count:2                  
mon                                                  3/5  10m ago    18m  count:5                  
nvmeof.nvmeof_pool.grp1  ?:4420,5500,8009,10008      0/2  6m ago     7m   ceph-node-5;ceph-node-4  
osd.default                                            4  10m ago    10m  ceph-node-1              
[ceph: root@ceph-node-0 /]# 

```




## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
