### PR TITLE
rgw: support zone-based filtering for bucket notifications

### DIFF
--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -554,16 +554,23 @@ Parameters are XML encoded in the body of the request, in the following format:
 |                               |           | All filter rules in the list must match the tags defined on the object. However,     |          |
 |                               |           | the object still match it it has other tags not listed in the filter.                |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Key.FilterRule``          | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would  be: ``prefix``, ``suffix``  | Yes      |
-|                               |           | or ``regex``. The ``Value`` would hold the key prefix, key suffix or a regular       |          |
-|                               |           | expression for matching the key, accordingly.                                        |          |
+| ``S3Key.FilterRule``          | Container | Holding ``Name``, ``Value`` and ``Type`` entities. ``Name`` would  be: ``prefix``,   | Yes      |
+|                               |           | ``suffix``, or ``regex``. The ``Value`` would hold the key prefix, key suffix        |          |
+|                               |           | or a regular expression for matching the key, accordingly. The ``Type`` entity is    |          |
+|                               |           | optional, and can hold ``IN`` or ``OUT``. It defaults to ``IN`` when not specified.  |          |
+|                               |           | ``IN`` means the key must match the rule, ``OUT`` means the key must not match the   |          |
+|                               |           | rule.                                                                                |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Metadata.FilterRule``     | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would be the name of the metadata  | Yes      |
-|                               |           | attribute (e.g. ``x-amz-meta-xxx``). The ``Value`` would be the expected value for   |          | 
-|                               |           | this attribute.                                                                      |          |
+| ``S3Metadata.FilterRule``     | Container | Holding ``Name``, ``Value`` and ``Type`` entities. ``Name`` would be the name of     | Yes      |
+|                               |           | the metadata attribute (e.g., ``x-amz-meta-xxx``). The ``Value`` would be the        |          |
+|                               |           | expected value for this attribute. The ``Type`` entity is optional, and can hold     |          |
+|                               |           | ``IN`` or ``OUT``. It defaults to ``IN`` when not specified. ``IN`` means the        |          |
+|                               |           | metadata must match the rule, ``OUT`` means the metadata must not match the rule.    |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Tags.FilterRule``         | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would be the tag key,              |  Yes     |
-|                               |           | and ``Value`` would be the tag value.                                                |          | 
+| ``S3Tags.FilterRule``         | Container | Holding ``Name``, ``Value`` and ``Type`` entities. ``Name`` would be the tag key,    | Yes      |
+|                               |           | and ``Value`` would be the tag value. The ``Type`` entity is optional, and can hold  |          |
+|                               |           | ``IN`` or ``OUT``. It defaults to ``IN`` when not specified. ``IN`` means the tag    |          |
+|                               |           | must match the rule, ``OUT`` means the tag must not match the rule.                  |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
 
 

--- a/src/rgw/rgw_s3_filter.h
+++ b/src/rgw/rgw_s3_filter.h
@@ -14,6 +14,8 @@ struct rgw_s3_key_filter {
   std::string suffix_rule;
   std::string regex_rule;
 
+  bool negative_filter{false};
+
   bool has_content() const;
 
   void dump(Formatter *f) const;
@@ -21,18 +23,22 @@ struct rgw_s3_key_filter {
   void dump_xml(Formatter *f) const;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
       encode(prefix_rule, bl);
       encode(suffix_rule, bl);
       encode(regex_rule, bl);
+      encode(negative_filter, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
       decode(prefix_rule, bl);
       decode(suffix_rule, bl);
       decode(regex_rule, bl);
+      if(struct_v >= 2) {
+        decode(negative_filter, bl);
+      }
     DECODE_FINISH(bl);
   }
 };
@@ -43,7 +49,8 @@ using KeyMultiValueMap = std::multimap<std::string, std::string>;
 
 struct rgw_s3_key_value_filter {
   KeyValueMap kv;
-
+  bool negative_filter{false};
+  
   bool has_content() const;
 
   void dump(Formatter *f) const;
@@ -51,13 +58,17 @@ struct rgw_s3_key_value_filter {
   void dump_xml(Formatter *f) const;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
       encode(kv, bl);
+      encode(negative_filter, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
       decode(kv, bl);
+      if(struct_v >= 2) {
+        decode(negative_filter, bl);
+      }
     DECODE_FINISH(bl);
   }
 };

--- a/src/rgw/rgw_s3_filter.h
+++ b/src/rgw/rgw_s3_filter.h
@@ -74,10 +74,39 @@ struct rgw_s3_key_value_filter {
 };
 WRITE_CLASS_ENCODER(rgw_s3_key_value_filter)
 
+
+struct rgw_s3_zone_filter {
+  std::set<std::string> zones;
+  bool negative_filter{false};
+
+  bool has_content() const;
+
+  void dump(Formatter* f) const;
+  void dump_xml(Formatter* f) const;
+  bool decode_xml(XMLObj* obj);
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+      encode(zones, bl);
+      encode(negative_filter, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+      decode(zones, bl);
+      decode(negative_filter, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(rgw_s3_zone_filter)
+
+
 struct rgw_s3_filter {
   rgw_s3_key_filter key_filter;
   rgw_s3_key_value_filter metadata_filter;
   rgw_s3_key_value_filter tag_filter;
+  rgw_s3_zone_filter zone_filter;  
 
   bool has_content() const;
 
@@ -86,19 +115,23 @@ struct rgw_s3_filter {
   void dump_xml(Formatter *f) const;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
       encode(key_filter, bl);
       encode(metadata_filter, bl);
       encode(tag_filter, bl);
+      encode(zone_filter, bl);  
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
       decode(key_filter, bl);
       decode(metadata_filter, bl);
       if (struct_v >= 2) {
         decode(tag_filter, bl);
+      }
+      if (struct_v >= 3) {
+        decode(zone_filter, bl);
       }
     DECODE_FINISH(bl);
   }
@@ -110,5 +143,7 @@ bool match(const rgw_s3_key_filter& filter, const std::string& key);
 bool match(const rgw_s3_key_value_filter& filter, const KeyValueMap& kv);
 
 bool match(const rgw_s3_key_value_filter& filter, const KeyMultiValueMap& kv);
+
+bool match(const rgw_s3_zone_filter& filter, const std::string& zone);
 
 bool match(const rgw_s3_filter& filter, const rgw::sal::Object* obj);


### PR DESCRIPTION
This PR introduces support for zone-based filtering in bucket notifications by adding a <Zones> field to the S3 FilterRule XML structure. This allows users to configure notification triggers that are specific to certain zone IDs, providing greater control in multi-zone deployments.

This is part of 2025 GSoC evaluation stage. 
This PR is based on another PR [#68788](https://github.com/ceph/ceph/pull/61965).

Fixes: https://tracker.ceph.com/issues/68789
Signed-off-by: Haokun Wu <hw3068@columbia.edu>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
