### PR TITLE
crimson/common/errorator: rework aborts error handlers

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -225,7 +225,7 @@ struct unthrowable_wrapper : error_t<unthrowable_wrapper<ErrorT, ErrorV>> {
         pre_assert();
       }
       if (msg) {
-        ceph_abort(msg);
+        ceph_abort_msg(msg);
       } else {
         ceph_abort();
       }
@@ -319,7 +319,7 @@ struct stateful_error_t : error_t<stateful_error_t<ErrorT>> {
         }
       }
       if (msg) {
-        ceph_abort(msg);
+        ceph_abort_msg(msg);
       } else {
         ceph_abort();
       }
@@ -1351,7 +1351,7 @@ namespace ct_error {
         pre_assert();
       }
       if (msg) {
-        ceph_abort(msg);
+        ceph_abort_msg(msg);
       } else {
         ceph_abort();
       }

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -1331,21 +1331,15 @@ namespace ct_error {
 
   class assert_all {
     const char* const msg = nullptr;
-    std::function<void()> pre_assert;
   public:
     template <std::size_t N>
     assert_all(const char (&msg)[N])
       : msg(msg) {
     }
     assert_all() = default;
-    assert_all(std::function<void()> &&f)
-      : pre_assert(std::move(f)) {}
 
     template <class ErrorT>
     no_touch_error_marker operator()(ErrorT&& raw_error) {
-      if (pre_assert) {
-        pre_assert();
-      }
       using decayed_t = std::decay_t<ErrorT>;
       decayed_t::error_t::handle([this] (auto&& error_v) {
         ceph_abort_msgf("%s: %s", msg ? msg : "", error_v.message().c_str());

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -409,6 +409,8 @@ public:
       // However, this shouldn't be a big issue for `errorator` as
       // ErrorVisitorT are already checked for exhaustiveness at compile-time.
       if (type_info == ErrorT::error_t::get_exception_ptr_type_info()) {
+
+        // TODO: add missing explanation
         if constexpr (std::is_assignable_v<decltype(result), return_t>) {
           result = std::invoke(std::forward<ErrorVisitorT>(errfunc),
                                ErrorT::error_t::from_exception_ptr(std::move(ep)));

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -965,8 +965,7 @@ public:
   class assert_all {
     const char* const msg = nullptr;
   public:
-    template <std::size_t N>
-    assert_all(const char (&msg)[N])
+    assert_all(const char* msg)
       : msg(msg) {
     }
     assert_all() = default;
@@ -1332,8 +1331,7 @@ namespace ct_error {
   class assert_all {
     const char* const msg = nullptr;
   public:
-    template <std::size_t N>
-    assert_all(const char (&msg)[N])
+    assert_all(const char* msg)
       : msg(msg) {
     }
     assert_all() = default;

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -360,6 +360,10 @@ class maybe_handle_error_t {
   ErrorVisitorT errfunc;
 
 public:
+  // NOTE: `__cxa_exception_type()` is an extension of the language.
+  // It should be available both in GCC and Clang but a fallback
+  // (based on `std::rethrow_exception()` and `catch`) can be made
+  // to handle other platforms if necessary.
   maybe_handle_error_t(ErrorVisitorT&& errfunc, std::exception_ptr ep)
     : type_info(*ep.__cxa_exception_type()),
       result(FuturatorT::make_exception_future(std::move(ep))),
@@ -403,11 +407,6 @@ public:
       // `catch` would allow to match against a base class as well.
       // However, this shouldn't be a big issue for `errorator` as Error
       // Visitors are already checked for exhaustiveness at compile-time.
-      //
-      // NOTE: `__cxa_exception_type()` is an extension of the language.
-      // It should be available both in GCC and Clang but a fallback
-      // (based on `std::rethrow_exception()` and `catch`) can be made
-      // to handle other platforms if necessary.
       if (type_info == ErrorT::error_t::get_exception_ptr_type_info()) {
         // set `state::invalid` in internals of `seastar::future` to not
         // call `report_failed_future()` during `operator=()`.

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -194,11 +194,8 @@ public:
     return shard_stores.invoke_on_all(
       [](auto &local_store) {
       return local_store.mount().handle_error(
-      crimson::stateful_ec::assert_failure([](const auto& ec) {
-        crimson::get_logger(ceph_subsys_cyanstore).error(
-	    "error mounting cyanstore: ({}) {}",
-            ec.value(), ec.message());
-      }));
+      crimson::stateful_ec::assert_failure(
+        fmt::format("error mounting cyanstore").c_str()));
     });
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -428,9 +428,8 @@ eagain_ifuture<Ref<Node>> Node::load_root(context_t c, RootNodeTracker& root_tra
   return c.nm.get_super(c.t, root_tracker
   ).handle_error_interruptible(
     eagain_iertr::pass_further{},
-    crimson::ct_error::input_output_error::assert_failure([FNAME, c] {
-      ERRORT("EIO during get_super()", c.t);
-    })
+    crimson::ct_error::input_output_error::assert_failure(fmt::format(
+        "{} EIO during get_super()", FNAME).c_str())
   ).si_then([c, &root_tracker, FNAME](auto&& _super) {
     assert(_super);
     auto root_addr = _super->get_root_laddr();
@@ -691,26 +690,8 @@ eagain_ifuture<Ref<Node>> Node::load(
   return c.nm.read_extent(c.t, addr
   ).handle_error_interruptible(
     eagain_iertr::pass_further{},
-    crimson::ct_error::input_output_error::assert_failure(
-        [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("EIO -- addr={}, is_level_tail={}",
-             c.t, addr, expect_is_level_tail);
-    }),
-    crimson::ct_error::invarg::assert_failure(
-        [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("EINVAL -- addr={}, is_level_tail={}",
-             c.t, addr, expect_is_level_tail);
-    }),
-    crimson::ct_error::enoent::assert_failure(
-        [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("ENOENT -- addr={}, is_level_tail={}",
-             c.t, addr, expect_is_level_tail);
-    }),
-    crimson::ct_error::erange::assert_failure(
-        [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("ERANGE -- addr={}, is_level_tail={}",
-             c.t, addr, expect_is_level_tail);
-    })
+    crimson::ct_error::assert_all(fmt::format(
+      "{} -- addr={}, is_level_tail={}", FNAME, addr, expect_is_level_tail).c_str())
   ).si_then([FNAME, c, addr, expect_is_level_tail](auto extent)
 	      -> eagain_ifuture<Ref<Node>> {
     assert(extent);
@@ -2145,9 +2126,8 @@ eagain_ifuture<Ref<LeafNode>> LeafNode::allocate_root(
     return c.nm.get_super(c.t, root_tracker
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::assert_failure([FNAME, c] {
-        ERRORT("EIO during get_super()", c.t);
-      })
+      crimson::ct_error::input_output_error::assert_failure(fmt::format(
+        "{} EIO during get_super()", FNAME).c_str())
     ).si_then([c, root](auto&& super) {
       assert(super);
       root->make_root_new(c, std::move(super));

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -523,12 +523,9 @@ class NodeExtentAccessorT {
     return c.nm.alloc_extent(c.t, hint, alloc_size
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::assert_failure(
-          [FNAME, c, alloc_size, l_to_discard = extent->get_laddr()] {
-        SUBERRORT(seastore_onode,
-            "EIO during allocate -- node_size={}, to_discard={}",
-            c.t, alloc_size, l_to_discard);
-      })
+      crimson::ct_error::input_output_error::assert_failure(fmt::format(
+        "{} during allocate -- node_size={}, to_discard={}",
+        FNAME, alloc_size, extent->get_laddr()).c_str())
     ).si_then([this, c, FNAME] (auto fresh_extent) {
       SUBDEBUGT(seastore_onode,
           "update addr from {} to {} ...",
@@ -551,20 +548,9 @@ class NodeExtentAccessorT {
       return c.nm.retire_extent(c.t, to_discard
       ).handle_error_interruptible(
         eagain_iertr::pass_further{},
-        crimson::ct_error::input_output_error::assert_failure(
-            [FNAME, c, l_to_discard = to_discard->get_laddr(),
-             l_fresh = fresh_extent->get_laddr()] {
-          SUBERRORT(seastore_onode,
-              "EIO during retire -- to_disgard={}, fresh={}",
-              c.t, l_to_discard, l_fresh);
-        }),
-        crimson::ct_error::enoent::assert_failure(
-            [FNAME, c, l_to_discard = to_discard->get_laddr(),
-             l_fresh = fresh_extent->get_laddr()] {
-          SUBERRORT(seastore_onode,
-              "ENOENT during retire -- to_disgard={}, fresh={}",
-              c.t, l_to_discard, l_fresh);
-        })
+        crimson::ct_error::assert_all(fmt::format(
+          "{} during retire -- to_disgard={}, fresh={}",
+          FNAME, to_discard->get_laddr(), fresh_extent->get_laddr()).c_str())
       );
     }).si_then([this, c] {
       boost::ignore_unused(c);  // avoid clang warning;
@@ -580,14 +566,8 @@ class NodeExtentAccessorT {
     return c.nm.retire_extent(c.t, std::move(extent)
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::assert_failure(
-          [FNAME, c, addr] {
-        SUBERRORT(seastore_onode, "EIO -- addr={}", c.t, addr);
-      }),
-      crimson::ct_error::enoent::assert_failure(
-          [FNAME, c, addr] {
-        SUBERRORT(seastore_onode, "ENOENT -- addr={}", c.t, addr);
-      })
+      crimson::ct_error::assert_all(fmt::format(
+        "{} addr={}", FNAME, addr).c_str())
 #ifndef NDEBUG
     ).si_then([c] {
       assert(!c.t.is_conflicted());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -78,12 +78,9 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     return c.nm.alloc_extent(c.t, hint, extent_size
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::assert_failure(
-          [FNAME, c, extent_size, is_level_tail, level] {
-        SUBERRORT(seastore_onode,
-            "EIO -- extent_size={}, is_level_tail={}, level={}",
-            c.t, extent_size, is_level_tail, level);
-      })
+      crimson::ct_error::input_output_error::assert_failure(fmt::format(
+        "{} extent_size={}, is_level_tail={}, level={}",
+        FNAME, extent_size, is_level_tail, level).c_str())
     ).si_then([is_level_tail, level](auto extent) {
       assert(extent);
       assert(extent->is_initial_pending());

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -280,18 +280,16 @@ seastar::future<> OSD::mkfs(
   co_await store.start();
 
   co_await store.mkfs(osd_uuid).handle_error(
-    crimson::stateful_ec::assert_failure([FNAME] (const auto& ec) {
-      ERROR("error creating empty object store in {}: ({}) {}",
-	    local_conf().get_val<std::string>("osd_data"),
-	    ec.value(), ec.message());
-    }));
+    crimson::stateful_ec::assert_failure(fmt::format(
+      "{} error creating empty object store in {}",
+       FNAME, local_conf().get_val<std::string>("osd_data")).c_str())
+  );
 
   co_await store.mount().handle_error(
-    crimson::stateful_ec::assert_failure([FNAME](const auto& ec) {
-      ERROR("error mounting object store in {}: ({}) {}",
-	    local_conf().get_val<std::string>("osd_data"),
-	    ec.value(), ec.message());
-    }));
+    crimson::stateful_ec::assert_failure(fmt::format(
+      "{} error mounting object store in {}",
+      FNAME, local_conf().get_val<std::string>("osd_data")).c_str())
+  );
 
   {
     auto meta_coll = co_await open_or_create_meta_coll(store);
@@ -477,11 +475,10 @@ seastar::future<> OSD::start()
 	whoami, get_shard_services(),
 	*monc, *hb_front_msgr, *hb_back_msgr});
     return store.mount().handle_error(
-      crimson::stateful_ec::assert_failure([FNAME] (const auto& ec) {
-        ERROR("error mounting object store in {}: ({}) {}",
-	      local_conf().get_val<std::string>("osd_data"),
-	      ec.value(), ec.message());
-      }));
+      crimson::stateful_ec::assert_failure(fmt::format(
+        "{} error mounting object store in {}",
+        FNAME, local_conf().get_val<std::string>("osd_data")).c_str())
+    );
   }).then([this, FNAME] {
     auto stats_seconds = local_conf().get_val<int64_t>("crimson_osd_stat_interval");
     if (stats_seconds > 0) {

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -316,7 +316,7 @@ ClientRequest::recover_missing_snaps(
     }
     return seastar::now();
   }).handle_error_interruptible(
-    crimson::ct_error::assert_all("unexpected error")
+    crimson::ct_error::assert_all(fmt::format("{} {} error", *pg, FNAME).c_str())
   );
   co_await std::move(resolve_oids);
 

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -412,7 +412,8 @@ SnapTrimObjSubEvent::start()
     obc_manager, RWState::RWWRITE
   ).handle_error_interruptible(
     remove_or_update_iertr::pass_further{},
-    crimson::ct_error::assert_all{"unexpected error in SnapTrimObjSubEvent"}
+    crimson::ct_error::assert_all{fmt::format(
+      "{} error SnapTrimObjSubEvent::snap_trim_obj_subevent_ret_t with {}", *this, coid).c_str()}
   );
 
   logger().debug("{}: got obc={}", *this, obc_manager.get_obc()->get_oid());

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -730,7 +730,8 @@ seastar::future<> PG::init(
         t.touch(coll_ref->get_cid(), pgid.make_snapmapper_oid());
       }
     },
-    ::crimson::ct_error::assert_all{"unexpected eio"}
+    ::crimson::ct_error::assert_all{fmt::format(
+      "{} {} unexpected eio", *this, __func__).c_str()}
   );
 }
 

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1759,8 +1759,9 @@ PGBackend::tmapup_iertr::future<> PGBackend::tmapup(
       return seastar::make_ready_future<bufferlist>();
     }),
     PGBackend::write_iertr::pass_further{},
-    crimson::ct_error::assert_all{"read error in mutate_object_contents"}
-  ).si_then([this, &os, &osd_op, &txn,
+    crimson::ct_error::assert_all{fmt::format(
+      "read error in mutate_object_contents of {}", os.oi.soid).c_str()
+    }).si_then([this, &os, &osd_op, &txn,
 	     &delta_stats, &osd_op_params]
 	    (auto &&bl) mutable -> PGBackend::tmapup_iertr::future<> {
     auto result = crimson::common::do_tmap_up(

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -246,7 +246,7 @@ RecoveryBackend::scan_for_backfill(
       crimson::ct_error::enoent::handle([](auto) {
 	return false;
       }),
-      crimson::ct_error::assert_all("unexpected error")
+      crimson::ct_error::assert_all(fmt::format("{} {} error when loading obc", pg, FNAME).c_str())
     );
     if (!found) {
       // if the object does not exist here, it must have been removed

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -153,7 +153,8 @@ ReplicatedRecoveryBackend::maybe_pull_missing_obj(
       return recovery_waiter.wait_for_pull();
     });
   }).handle_error_interruptible(
-    crimson::ct_error::assert_all("unexpected error")
+    crimson::ct_error::assert_all(fmt::format(
+      "{} {} error with {} need {} ", pg, FNAME, soid, need).c_str())
   );
 }
 
@@ -746,7 +747,8 @@ ReplicatedRecoveryBackend::read_omap_for_push_op(
       return seastar::make_ready_future<seastar::stop_iteration>(
         stop ? seastar::stop_iteration::yes : seastar::stop_iteration::no
       );
-    }, crimson::os::FuturizedStore::Shard::read_errorator::assert_all{});
+    }, crimson::os::FuturizedStore::Shard::read_errorator::assert_all(fmt::format(
+         "{} ReplicatedRecoveryBackend::read_omap_for_push_op error with {}", pg, oid).c_str()));
   });
 }
 

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -185,12 +185,10 @@ seastar::future<> FSDriver::mkfs()
     uuid_d uuid;
     uuid.generate_random();
     return fs->mkfs(uuid).handle_error(
-      crimson::stateful_ec::assert_failure([] (const auto& ec) {
-        crimson::get_logger(ceph_subsys_test)
-          .error("error creating empty object store in {}: ({}) {}",
-          crimson::common::local_conf().get_val<std::string>("osd_data"),
-          ec.value(), ec.message());
-      }));
+      crimson::stateful_ec::assert_failure(fmt::format(
+        "error creating empty object store in {}",
+        crimson::common::local_conf().get_val<std::string>("osd_data")).c_str())
+);
   }).then([this] {
     return fs->stop();
   }).then([this] {
@@ -198,15 +196,10 @@ seastar::future<> FSDriver::mkfs()
   }).then([this] {
     return fs->mount(
     ).handle_error(
-      crimson::stateful_ec::assert_failure([] (const auto& ec) {
-        crimson::get_logger(
-	  ceph_subsys_test
-	).error(
-	  "error mounting object store in {}: ({}) {}",
-	  crimson::common::local_conf().get_val<std::string>("osd_data"),
-	  ec.value(),
-	  ec.message());
-      }));
+      crimson::stateful_ec::assert_failure(fmt::format(
+        "error creating empty object store in {}",
+        crimson::common::local_conf().get_val<std::string>("osd_data")).c_str())
+    );
   }).then([this] {
     return seastar::do_for_each(
       boost::counting_iterator<unsigned>(0),
@@ -239,15 +232,10 @@ seastar::future<> FSDriver::mount()
   }).then([this] {
     return fs->mount(
     ).handle_error(
-      crimson::stateful_ec::assert_failure([] (const auto& ec) {
-        crimson::get_logger(
-	  ceph_subsys_test
-	).error(
-	  "error mounting object store in {}: ({}) {}",
-	  crimson::common::local_conf().get_val<std::string>("osd_data"),
-	  ec.value(),
-	  ec.message());
-      }));
+      crimson::stateful_ec::assert_failure(fmt::format(
+        "error creating empty object store in {}",
+        crimson::common::local_conf().get_val<std::string>("osd_data")).c_str())
+    );
   }).then([this] {
     return seastar::do_for_each(
       boost::counting_iterator<unsigned>(0),

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -111,6 +111,12 @@ target_link_libraries(
 add_ceph_unittest(unittest-seastar-errorator
   --memory 256M --smp 1)
 
+add_executable(unittest-seastar-errorator-abort
+  test_errorator_abort.cc)
+target_link_libraries(
+  unittest-seastar-errorator-abort
+  crimson::gtest)
+
 add_executable(unittest-crimson-coroutine
   test_crimson_coroutine.cc)
 target_link_libraries(

--- a/src/test/crimson/test_errorator_abort.cc
+++ b/src/test/crimson/test_errorator_abort.cc
@@ -1,0 +1,93 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/iterator/counting_iterator.hpp>
+#include <numeric>
+
+#include "test/crimson/gtest_seastar.h"
+
+#include "crimson/common/errorator.h"
+#include "crimson/common/errorator-loop.h"
+#include "crimson/common/log.h"
+#include "seastar/core/sleep.hh"
+
+struct errorator_abort_test_t : public seastar_test_suite_t {
+  using ertr = crimson::errorator<crimson::ct_error::invarg>;
+
+  ertr::future<> invarg_foo() {
+    return crimson::ct_error::invarg::make();
+  };
+
+  ertr::future<> clean_foo() {
+    return ertr::now();
+  };
+
+  struct noncopyable_t {
+    constexpr noncopyable_t() = default;
+    ~noncopyable_t() = default;
+    noncopyable_t(noncopyable_t&&) = default;
+  private:
+    noncopyable_t(const noncopyable_t&) = delete;
+    noncopyable_t& operator=(const noncopyable_t&) = delete;
+  };
+};
+
+// --- The following tests must abort ---
+
+/*
+TEST_F(errorator_abort_test_t, abort_vanilla)
+{
+  run_async([this] {
+    abort();
+    return seastar::now().get();
+  });
+}
+*/
+
+/*
+TEST_F(errorator_abort_test_t, abort_ignored)
+{
+  run_async([this] {
+    auto foo = []() -> seastar::future<> {
+      abort();
+      return seastar::now();
+    };
+
+    std::ignore = foo();
+    return seastar::now().get();
+  });
+}
+*/
+
+/*
+TEST_F(errorator_abort_test_t, assert_all)
+{
+  run_async([this] {
+    return invarg_foo().handle_error(
+      crimson::ct_error::assert_all("unexpected error")
+    ).get();
+  });
+}
+*/
+
+/*
+TEST_F(errorator_abort_test_t, ignore_assert_all)
+{
+  run_async([this] {
+    std::ignore = invarg_foo().handle_error(
+      crimson::ct_error::assert_all("unexpected error")
+    );
+    return seastar::now().get();
+  });
+}
+
+TEST_F(errorator_abort_test_t, ignore_assert_failure)
+{
+  run_async([this] {
+    std::ignore = invarg_foo().handle_error(
+      crimson::ct_error::invarg::assert_failure{"unexpected invarg"}
+    );
+    return seastar::now().get();
+  });
+}
+*/


### PR DESCRIPTION
This came up during: https://tracker.ceph.com/issues/69406#note-25
Where an "assert_all" was called but didn't cause an abort.

This PR is a rework of errorator aborting paths with fixes and some cleanups.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
