### PR TITLE
osd/scrub: force configuration cache refresh in change path

### DIFF
--- a/src/common/config_cacher.h
+++ b/src/common/config_cacher.h
@@ -61,6 +61,16 @@ public:
   ValueT operator*() const {
     return value_cache.load();
   }
+
+  /*
+   * Allow caller to refresh the cached value on demand,
+   * avoiding a possible race condition where the cached value may be stale
+   * when accessed from a different change handler (note that
+   * the order of execution of the handlers is undefined).
+   */
+  void refresh() {
+    value_cache.store(conf.get_val<ValueT>(option_name));
+  }
 };
 
 #endif // CEPH_CONFIG_CACHER_H

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1297,16 +1297,12 @@ double PG::next_deepscrub_interval() const
   return info.history.last_deep_scrub_stamp + deep_scrub_interval;
 }
 
-void PG::on_scrub_schedule_input_change(Scrub::delay_ready_t delay_ready)
+void PG::on_scrub_schedule_input_change()
 {
   if (is_active() && is_primary() && !is_scrub_queued_or_active()) {
-    dout(10) << fmt::format(
-		    "{}: active/primary. delay_ready={:c}", __func__,
-		    (delay_ready == Scrub::delay_ready_t::delay_ready) ? 't'
-								       : 'f')
-	     << dendl;
+    dout(10) << fmt::format("{}: active/primary", __func__) << dendl;
     ceph_assert(m_scrubber);
-    m_scrubber->update_scrub_job(delay_ready);
+    m_scrubber->update_scrub_job();
   } else {
     dout(10) << fmt::format(
 		    "{}: inactive, non-primary - or already scrubbing",
@@ -2209,7 +2205,7 @@ void PG::handle_activate_map(PeeringCtx &rctx, epoch_t range_starts_at)
   // on_scrub_schedule_input_change() as pool.info contains scrub scheduling
   // parameters.
   if (pool.info.last_change >= range_starts_at) {
-    on_scrub_schedule_input_change(Scrub::delay_ready_t::delay_ready);
+    on_scrub_schedule_input_change();
   }
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -262,7 +262,7 @@ public:
 	set_last_scrub_stamp(t, history, stats);
 	return true;
       });
-    on_scrub_schedule_input_change();
+    on_scrub_schedule_input_change(Scrub::force_refresh_t::no_refresh);
   }
 
   static void set_last_deep_scrub_stamp(
@@ -278,7 +278,7 @@ public:
 	set_last_scrub_stamp(t, history, stats);
 	return true;
       });
-    on_scrub_schedule_input_change();
+    on_scrub_schedule_input_change(Scrub::force_refresh_t::no_refresh);
   }
 
   static void add_objects_scrubbed_count(
@@ -510,8 +510,16 @@ public:
    *   osd_scrub_max_interval
    * - pg stat scrub timestamps
    * - etc
+   *
+   * \param refresh_config is set when on_scrub_schedule_input_change() is
+   * invoked from a configuration-change handler (specifically -
+   * from OsdScrub::on_config_change()).
+   * When set, the Scrubber "manually" refreshes all its cached
+   * scheduling-related configuration values, making sure the latest values
+   * are available (even if the corresponding configuration change handlers
+   * have not executed yet).
    */
-  void on_scrub_schedule_input_change();
+  void on_scrub_schedule_input_change(Scrub::force_refresh_t refresh_config);
 
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) override;
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -262,7 +262,7 @@ public:
 	set_last_scrub_stamp(t, history, stats);
 	return true;
       });
-    on_scrub_schedule_input_change(Scrub::delay_ready_t::delay_ready);
+    on_scrub_schedule_input_change();
   }
 
   static void set_last_deep_scrub_stamp(
@@ -278,7 +278,7 @@ public:
 	set_last_scrub_stamp(t, history, stats);
 	return true;
       });
-    on_scrub_schedule_input_change(Scrub::delay_ready_t::delay_ready);
+    on_scrub_schedule_input_change();
   }
 
   static void add_objects_scrubbed_count(
@@ -511,7 +511,7 @@ public:
    * - pg stat scrub timestamps
    * - etc
    */
-  void on_scrub_schedule_input_change(Scrub::delay_ready_t delay_ready);
+  void on_scrub_schedule_input_change();
 
   void scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type) override;
 

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -258,8 +258,7 @@ void OsdScrub::on_config_change()
 		    "updating scrub schedule on {}",
 		    (locked_pg->pg())->get_pgid())
 	     << dendl;
-    locked_pg->pg()->on_scrub_schedule_input_change(
-	Scrub::delay_ready_t::no_delay);
+    locked_pg->pg()->on_scrub_schedule_input_change();
   }
 }
 

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -258,7 +258,8 @@ void OsdScrub::on_config_change()
 		    "updating scrub schedule on {}",
 		    (locked_pg->pg())->get_pgid())
 	     << dendl;
-    locked_pg->pg()->on_scrub_schedule_input_change();
+    locked_pg->pg()->on_scrub_schedule_input_change(
+        Scrub::force_refresh_t::force_refresh);
   }
 }
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -478,11 +478,10 @@ void PgScrubber::update_targets(utime_t scrub_clock_now)
 
   // the next periodic scrubs:
   m_scrub_job->adjust_shallow_schedule(
-      m_pg->info.history.last_scrub_stamp, applicable_conf, scrub_clock_now,
-      delay_ready_t::delay_ready);
+      m_pg->info.history.last_scrub_stamp, applicable_conf, scrub_clock_now);
   m_scrub_job->adjust_deep_schedule(
       m_pg->info.history.last_deep_scrub_stamp, applicable_conf,
-      scrub_clock_now, delay_ready_t::delay_ready);
+      scrub_clock_now);
 
   dout(10) << fmt::format("{}: adjusted:{}", __func__, *m_scrub_job) << dendl;
 }
@@ -497,7 +496,7 @@ void PgScrubber::schedule_scrub_with_osd()
 		  "{}: state at entry: {}", __func__, m_scrub_job->state_desc())
 	   << dendl;
   m_scrub_job->registered = true;
-  update_scrub_job(delay_ready_t::delay_ready);
+  update_scrub_job();
 }
 
 
@@ -521,7 +520,7 @@ void PgScrubber::on_primary_active_clean()
  * - in the 2nd case - we know the PG state and we know we are only called
  *   for a Primary.
  */
-void PgScrubber::update_scrub_job(Scrub::delay_ready_t delay_ready)
+void PgScrubber::update_scrub_job()
 {
   if (!is_primary() || !m_scrub_job) {
     dout(10) << fmt::format(
@@ -2034,7 +2033,7 @@ void PgScrubber::scrub_finish()
     request_rescrubbing();
   }
   // determine the next scrub time
-  update_scrub_job(delay_ready_t::delay_ready);
+  update_scrub_job();
 
   if (m_pg->is_active() && m_pg->is_primary()) {
     m_pg->recovery_state.share_pg_info();

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2511,6 +2511,17 @@ PgScrubber::PgScrubber(PG* pg)
   m_scrub_job.emplace(m_osds->cct, m_pg->pg_id, m_osds->get_nodeid());
 }
 
+void PgScrubber::refresh_config_params()
+{
+  osd_scrub_chunk_max.refresh();
+  osd_shallow_scrub_chunk_max.refresh();
+  osd_scrub_chunk_min.refresh();
+  osd_shallow_scrub_chunk_min.refresh();
+  osd_stats_update_period_scrubbing.refresh();
+  osd_stats_update_period_not_scrubbing.refresh();
+  // osd_deep_scrub_interval_cv.refresh();
+}
+
 void PgScrubber::set_scrub_duration(std::chrono::milliseconds duration)
 {
   dout(20) << fmt::format("{}: to {}", __func__, duration) << dendl;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -275,7 +275,7 @@ class PgScrubber : public ScrubPgIF,
 
   // managing scrub op registration
 
-  void update_scrub_job(Scrub::delay_ready_t delay_ready) final;
+  void update_scrub_job() final;
 
   void rm_from_osd_scrubbing() final;
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -381,6 +381,19 @@ class PgScrubber : public ScrubPgIF,
 		 Formatter* f,
 		 std::stringstream& ss) override;
 
+
+  /**
+   * forces a manual update of configuration parameters cached
+   * using md_config_cacher_t objects.
+   *
+   * The refresh is required whenever the conf parameter is used
+   * by a Scrubber method that was called from the OSD Queue config
+   * change handler. As the order of execution of the handlers is
+   * undefined, we are not guaranteed that the separate config-cachers'
+   * handlers were called before the Osd Queue handler.
+   */
+  void refresh_config_params() final;
+
   int m_debug_blockrange{0};
 
   // --------------------------------------------------------------------------

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -235,14 +235,12 @@ class ScrubJob {
   void adjust_shallow_schedule(
     utime_t last_scrub,
     const Scrub::sched_conf_t& app_conf,
-    utime_t scrub_clock_now,
-    delay_ready_t modify_ready_targets);
+    utime_t scrub_clock_now);
 
   void adjust_deep_schedule(
     utime_t last_deep,
     const Scrub::sched_conf_t& app_conf,
-    utime_t scrub_clock_now,
-    delay_ready_t modify_ready_targets);
+    utime_t scrub_clock_now);
 
   /**
    * For the level specified, set the 'not-before' time to 'now+delay',

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -161,10 +161,6 @@ struct scrub_schedule_t {
   bool operator==(const scrub_schedule_t& rhs) const = default;
 };
 
-
-/// rescheduling param: should we delay jobs already ready to execute?
-enum class delay_ready_t : bool { delay_ready = true, no_delay = false };
-
 }  // namespace Scrub
 
 namespace fmt {
@@ -487,7 +483,7 @@ struct ScrubPgIF {
    *
    * Dequeues the scrub job, and re-queues it with the new schedule.
    */
-  virtual void update_scrub_job(Scrub::delay_ready_t delay_ready) = 0;
+  virtual void update_scrub_job() = 0;
 
   virtual scrub_level_t scrub_requested(
       scrub_level_t scrub_level,

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -161,6 +161,9 @@ struct scrub_schedule_t {
   bool operator==(const scrub_schedule_t& rhs) const = default;
 };
 
+/// rescheduling param: should we force configuration refresh?
+enum class force_refresh_t : bool { force_refresh = true, no_refresh = false };
+
 }  // namespace Scrub
 
 namespace fmt {
@@ -484,6 +487,17 @@ struct ScrubPgIF {
    * Dequeues the scrub job, and re-queues it with the new schedule.
    */
   virtual void update_scrub_job() = 0;
+
+  /**
+   * forces a manual update of configuration parameters
+   * cached using md_config_cacher_t.
+   * The refresh is required whenever the conf parameter is used
+   * by a Scrubber method that was called from the OSD Queue conig
+   * change handler. As the order of execution of the handlers is
+   * undefined, we cannot be sure that the separate config-cachers
+   * handlers were called before or after the Osd Queue handler.
+   */
+  virtual void refresh_config_params() = 0;
 
   virtual scrub_level_t scrub_requested(
       scrub_level_t scrub_level,


### PR DESCRIPTION
Whenever a scrub scheduling configuration parameter changes, the change is detected and acted upon by two
"conf-change" handlers: PG::on_scrub_schedule_input_change() on the one hand, and the named
PgScrubber-owned md_config_cacher_t object. As the execution order between the two is unknown, the scrub rescheduling triggered by on_scrub_schedule_input_change() risks using a stale configuration value.

Here we add a 'force_refresh_t' parameter to PG::on_scrub_schedule_input_change() . When set - it triggers a
manual update of the relevant configuration parameters.