### PR TITLE
squid: rgw: fix bug with rgw-gap-list

### DIFF
--- a/src/rgw/rgw-gap-list
+++ b/src/rgw/rgw-gap-list
@@ -400,8 +400,11 @@ BEGIN {
   f1_count++
   if(f2_eof==0) {
     if(test_lines()==2) {
-      while ($1>b[1]) {
+      while ($1>b[1] && !f2_eof) {
         advance_f2()
+      }
+      if (f2_eof) {
+        line_out()
       }
       test_lines()
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70827

---

backport of https://github.com/ceph/ceph/pull/62524
parent tracker: https://tracker.ceph.com/issues/70680

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh