### PR TITLE
cephadm: still set keep_container_info key in CoreStatusUpdater when cinfo is None

### DIFF
--- a/src/cephadm/cephadmlib/container_lookup.py
+++ b/src/cephadm/cephadmlib/container_lookup.py
@@ -134,7 +134,9 @@ def infer_local_ceph_image(
     images_in_use_by_daemon = set(
         d.image_id for d, n in matching_daemons if n == daemon_name
     )
-    images_in_use = set(d.image_id for d, _ in matching_daemons)
+    images_in_use = set(
+        d.image_id for d, _ in matching_daemons if d is not None
+    )
 
     # prioritize images
     def _keyfunc(image: ImageInfo) -> Tuple[bool, bool, str]:

--- a/src/cephadm/cephadmlib/listing_updaters.py
+++ b/src/cephadm/cephadmlib/listing_updaters.py
@@ -59,9 +59,9 @@ class CoreStatusUpdater(DaemonStatusUpdater):
             data_dir, identity.fsid, identity.daemon_name
         )
         cinfo = get_container_stats(ctx, identity)
+        if self.keep_container_info:
+            val[self.keep_container_info] = cinfo
         if cinfo:
-            if self.keep_container_info:
-                val[self.keep_container_info] = cinfo
             container_id = cinfo.container_id
             image_name = cinfo.image_name
             image_id = cinfo.image_id

--- a/src/cephadm/tests/test_listing.py
+++ b/src/cephadm/tests/test_listing.py
@@ -229,6 +229,28 @@ def test_list_daemons_detail_minimal(cephadm_fs, funkypatch):
     edl.assert_checked_all()
 
 
+def test_core_status_update_no_cinfo(cephadm_fs, funkypatch):
+    _cephadm = import_cephadm()
+
+    _get_container_stats = funkypatch.patch('cephadmlib.container_types.get_container_stats')
+    _get_container_stats.return_value = None
+
+    fsid = 'dc93cfee-ddc5-11ef-a056-525400220000'
+    _cinfo_key = '_keep_container_info'
+
+    updater = _cephadm.CoreStatusUpdater(keep_container_info=_cinfo_key)
+    d_id = _cephadm.DaemonIdentity(
+        fsid = fsid,
+        daemon_type = 'mon',
+        daemon_id = 'host1',
+    )
+    val = {}
+    with with_cephadm_ctx([], mock_cephadm_call_fn=False) as ctx:
+        updater.update(val, ctx, d_id, f'/var/lib/ceph/{fsid}')
+    assert _cinfo_key in val
+    assert val[_cinfo_key] is None
+
+
 def test_list_daemons_detail_mgrnotrunning(cephadm_fs, funkypatch):
     _cephadm = import_cephadm()
     _call = funkypatch.patch('cephadmlib.call_wrappers.call')


### PR DESCRIPTION
When testing an unrelated thing with rm-cluster cleaning up OSD devices, I was hitting

```
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/sbin/cephadm/__main__.py", line 5400, in <module>
  File "/usr/sbin/cephadm/__main__.py", line 5388, in main
  File "/usr/sbin/cephadm/__main__.py", line 3996, in command_rm_cluster
  File "/usr/sbin/cephadm/__main__.py", line 4034, in _rm_cluster
  File "/usr/sbin/cephadm/__main__.py", line 428, in _infer_image
  File "/usr/sbin/cephadm/cephadmlib/container_lookup.py", line 127, in infer_local_ceph_image
  File "/usr/sbin/cephadm/cephadmlib/container_lookup.py", line 128, in <listcomp>
KeyError: '_container_info'
```

which appears to have been caused by the CoreStatusUpdater only setting the "keep_container_info" key entry when the container info it gets back from get_container_stats is not None. This patch has it set that key entry even when the container info is None, and updates infer_local_ceph_image to be able to handle the container info at that entry being None as well.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
