### PR TITLE
squid: mgr/dashboard: Fix empty ceph version in GET api/hosts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -146,7 +146,7 @@ def get_hosts(sources=None):
             hosts = [
                 merge_dicts(
                     {
-                        'ceph_version': '',
+                        'ceph_version': mgr.version,
                         'services': [],
                         'sources': {
                             'ceph': False,

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -187,6 +187,7 @@ class HostControllerTest(ControllerTestCase):
 
     def test_get_3(self):
         mgr.list_servers.return_value = []
+        mgr.version = 'ceph version 16.0.0-3151-gf202994fcf'
 
         with patch_orch(True, hosts=[HostSpec('node1')]):
             self._get('{}/node1'.format(self.URL_HOST))
@@ -197,6 +198,7 @@ class HostControllerTest(ControllerTestCase):
 
     def test_populate_service_instances(self):
         mgr.list_servers.return_value = []
+        mgr.version = 'ceph version 16.0.0-3151-gf202994fcf'
 
         node1_daemons = [
             DaemonDescription(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70836

---

backport of https://github.com/ceph/ceph/pull/62716
parent tracker: https://tracker.ceph.com/issues/70821

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh