### PR TITLE
mgr/dashboard: allow selecting target gw in nvmeof cli/api endpoints

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -35,8 +35,8 @@ else:
         @NvmeofCLICommand("nvmeof gw info")
         @convert_to_model(model.GatewayInfo)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.get_gateway_info(
+        def list(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
 
@@ -58,8 +58,8 @@ else:
         @NvmeofCLICommand("nvmeof gw version")
         @convert_to_model(model.GatewayVersion)
         @handle_nvmeof_error
-        def version(self, gw_group: Optional[str] = None):
-            gw_info = NVMeoFClient(gw_group=gw_group).stub.get_gateway_info(
+        def version(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            gw_info = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
             return NVMeoFClient.pb2.gw_version(status=gw_info.status,
@@ -71,8 +71,9 @@ else:
         @NvmeofCLICommand("nvmeof gw get_log_level")
         @convert_to_model(model.GatewayLogLevelInfo)
         @handle_nvmeof_error
-        def get_log_level(self, gw_group: Optional[str] = None):
-            gw_log_level = NVMeoFClient(gw_group=gw_group).stub.get_gateway_log_level(
+        def get_log_level(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            gw_log_level = NVMeoFClient(gw_group=gw_group,
+                                        traddr=traddr).stub.get_gateway_log_level(
                 NVMeoFClient.pb2.get_gateway_log_level_req()
             )
             return gw_log_level
@@ -82,9 +83,11 @@ else:
         @NvmeofCLICommand("nvmeof gw set_log_level")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
-        def set_log_level(self, log_level: str, gw_group: Optional[str] = None):
+        def set_log_level(self, log_level: str, gw_group: Optional[str] = None,
+                          traddr: Optional[str] = None):
             log_level = log_level.lower()
-            gw_log_level = NVMeoFClient(gw_group=gw_group).stub.set_gateway_log_level(
+            gw_log_level = NVMeoFClient(gw_group=gw_group,
+                                        traddr=traddr).stub.set_gateway_log_level(
                 NVMeoFClient.pb2.set_gateway_log_level_req(log_level=log_level)
             )
             return gw_log_level
@@ -97,8 +100,9 @@ else:
         @NvmeofCLICommand("nvmeof spdk_log_level get")
         @convert_to_model(model.SpdkNvmfLogFlagsAndLevelInfo)
         @handle_nvmeof_error
-        def get_spdk_log_level(self, gw_group: Optional[str] = None):
-            spdk_log_level = NVMeoFClient(gw_group=gw_group).stub.get_spdk_nvmf_log_flags_and_level(
+        def get_spdk_log_level(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            spdk_log_level = NVMeoFClient(gw_group=gw_group,
+                                          traddr=traddr).stub.get_spdk_nvmf_log_flags_and_level(
                 NVMeoFClient.pb2.get_spdk_nvmf_log_flags_and_level_req()
             )
             return spdk_log_level
@@ -109,10 +113,12 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def set_spdk_log_level(self, log_level: Optional[str] = None,
-                               print_level: Optional[str] = None, gw_group: Optional[str] = None):
+                               print_level: Optional[str] = None,
+                               gw_group: Optional[str] = None, traddr: Optional[str] = None):
             log_level = log_level.upper() if log_level else None
             print_level = print_level.upper() if print_level else None
-            spdk_log_level = NVMeoFClient(gw_group=gw_group).stub.set_gateway_log_level(
+            spdk_log_level = NVMeoFClient(gw_group=gw_group,
+                                          traddr=traddr).stub.set_gateway_log_level(
                 NVMeoFClient.pb2.set_spdk_nvmf_logs_req(log_level=log_level,
                                                         print_level=print_level)
             )
@@ -123,8 +129,10 @@ else:
         @NvmeofCLICommand("nvmeof spdk_log_level disable")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
-        def disable_spdk_log_level(self, gw_group: Optional[str] = None):
-            spdk_log_level = NVMeoFClient(gw_group=gw_group).stub.disable_spdk_nvmf_logs(
+        def disable_spdk_log_level(self, gw_group: Optional[str] = None,
+                                   traddr: Optional[str] = None):
+            spdk_log_level = NVMeoFClient(gw_group=gw_group,
+                                          traddr=traddr).stub.disable_spdk_nvmf_logs(
                 NVMeoFClient.pb2.disable_spdk_nvmf_logs_req()
             )
             return spdk_log_level
@@ -137,8 +145,8 @@ else:
         @NvmeofCLICommand("nvmeof subsystem list")
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def list(self, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.list_subsystems(
+        def list(self, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req()
             )
 
@@ -153,8 +161,8 @@ else:
         @NvmeofCLICommand("nvmeof subsystem get")
         @convert_to_model(model.SubsystemList)
         @handle_nvmeof_error
-        def get(self, nqn: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.list_subsystems(
+        def get(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req(subsystem_nqn=nqn)
             )
 
@@ -172,8 +180,8 @@ else:
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
         def create(self, nqn: str, enable_ha: bool = True, max_namespaces: int = 1024,
-                   gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.create_subsystem(
+                   gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
                     subsystem_nqn=nqn, max_namespaces=max_namespaces, enable_ha=enable_ha
                 )
@@ -191,8 +199,9 @@ else:
         @NvmeofCLICommand("nvmeof subsystem del")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
-        def delete(self, nqn: str, force: Optional[str] = "false", gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.delete_subsystem(
+        def delete(self, nqn: str, force: Optional[str] = "false", gw_group: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.delete_subsystem(
                 NVMeoFClient.pb2.delete_subsystem_req(
                     subsystem_nqn=nqn, force=str_to_bool(force)
                 )
@@ -212,8 +221,8 @@ else:
         @NvmeofCLICommand("nvmeof listener list")
         @convert_to_model(model.ListenerList)
         @handle_nvmeof_error
-        def list(self, nqn: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.list_listeners(
+        def list(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_listeners(
                 NVMeoFClient.pb2.list_listeners_req(subsystem=nqn)
             )
 
@@ -301,8 +310,8 @@ else:
         @NvmeofCLICommand("nvmeof ns list")
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
-        def list(self, nqn: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.list_namespaces(
+        def list(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn)
             )
 
@@ -318,8 +327,9 @@ else:
         @NvmeofCLICommand("nvmeof ns get")
         @convert_to_model(model.NamespaceList)
         @handle_nvmeof_error
-        def get(self, nqn: str, nsid: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.list_namespaces(
+        def get(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
+                traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn, nsid=int(nsid))
             )
 
@@ -336,8 +346,9 @@ else:
         @NvmeofCLICommand("nvmeof ns get_io_stats")
         @convert_to_model(model.NamespaceIOStats)
         @handle_nvmeof_error
-        def io_stats(self, nqn: str, nsid: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.namespace_get_io_stats(
+        def io_stats(self, nqn: str, nsid: str, gw_group: Optional[str] = None,
+                     traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_get_io_stats(
                 NVMeoFClient.pb2.namespace_get_io_stats_req(
                     subsystem_nqn=nqn, nsid=int(nsid))
             )
@@ -380,10 +391,11 @@ else:
             block_size: int = 512,
             load_balancing_group: Optional[int] = None,
             gw_group: Optional[str] = None,
+            traddr: Optional[str] = None,
             force: Optional[bool] = False,
             no_auto_visible: Optional[bool] = False
         ):
-            return NVMeoFClient(gw_group=gw_group).stub.namespace_add(
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_add(
                 NVMeoFClient.pb2.namespace_add_req(
                     subsystem_nqn=nqn,
                     rbd_image_name=rbd_image_name,
@@ -428,6 +440,7 @@ else:
             r_mbytes_per_second: Optional[int] = None,
             w_mbytes_per_second: Optional[int] = None,
             gw_group: Optional[str] = None,
+            traddr: Optional[str] = None,
             trash_image: Optional[bool] = None,
         ):
             contains_failure = False
@@ -436,7 +449,7 @@ else:
                 mib = 1024 * 1024
                 new_size_mib = int((rbd_image_size + mib - 1) / mib)
 
-                resp = NVMeoFClient(gw_group=gw_group).stub.namespace_resize(
+                resp = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_resize(
                     NVMeoFClient.pb2.namespace_resize_req(
                         subsystem_nqn=nqn, nsid=int(nsid), new_size=new_size_mib
                     )
@@ -482,7 +495,7 @@ else:
             if contains_failure:
                 cherrypy.response.status = 202
 
-            response = NVMeoFClient(gw_group=gw_group).stub.list_namespaces(
+            response = NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_namespaces(
                 NVMeoFClient.pb2.list_namespaces_req(subsystem=nqn, nsid=int(nsid))
             )
             return response
@@ -505,9 +518,10 @@ else:
             nqn: str,
             nsid: str,
             gw_group: Optional[str] = None,
+            traddr: Optional[str] = None,
             force: Optional[str] = "false"
         ):
-            return NVMeoFClient(gw_group=gw_group).stub.namespace_delete(
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.namespace_delete(
                 NVMeoFClient.pb2.namespace_delete_req(
                     subsystem_nqn=nqn,
                     nsid=int(nsid),
@@ -536,8 +550,8 @@ else:
             else o,
         )
         @handle_nvmeof_error
-        def list(self, nqn: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.list_hosts(
+        def list(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_hosts(
                 NVMeoFClient.pb2.list_hosts_req(subsystem=nqn)
             )
 
@@ -553,8 +567,9 @@ else:
         @NvmeofCLICommand("nvmeof host add")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
-        def create(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.add_host(
+        def create(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.add_host(
                 NVMeoFClient.pb2.add_host_req(subsystem_nqn=nqn, host_nqn=host_nqn)
             )
 
@@ -570,8 +585,9 @@ else:
         @NvmeofCLICommand("nvmeof host del")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
-        def delete(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.remove_host(
+        def delete(self, nqn: str, host_nqn: str, gw_group: Optional[str] = None,
+                   traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.remove_host(
                 NVMeoFClient.pb2.remove_host_req(subsystem_nqn=nqn, host_nqn=host_nqn)
             )
 
@@ -589,8 +605,8 @@ else:
         @NvmeofCLICommand("nvmeof connection list")
         @convert_to_model(model.ConnectionList)
         @handle_nvmeof_error
-        def list(self, nqn: str, gw_group: Optional[str] = None):
-            return NVMeoFClient(gw_group=gw_group).stub.list_connections(
+        def list(self, nqn: str, gw_group: Optional[str] = None, traddr: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_connections(
                 NVMeoFClient.pb2.list_connections_req(subsystem=nqn)
             )
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -8242,6 +8242,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -8292,6 +8297,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -8321,6 +8331,8 @@ paths:
                 gw_group:
                   type: string
                 log_level:
+                  type: string
+                traddr:
                   type: string
               required:
               - log_level
@@ -8357,6 +8369,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -8382,6 +8399,11 @@ paths:
       - allowEmptyValue: true
         in: query
         name: gw_group
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -8415,6 +8437,8 @@ paths:
                 log_level:
                   type: string
                 print_level:
+                  type: string
+                traddr:
                   type: string
               type: object
       responses:
@@ -8451,6 +8475,8 @@ paths:
               properties:
                 gw_group:
                   type: string
+                traddr:
+                  type: string
               type: object
       responses:
         '200':
@@ -8482,6 +8508,11 @@ paths:
       - allowEmptyValue: true
         in: query
         name: gw_group
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -8524,6 +8555,8 @@ paths:
                   type: integer
                 nqn:
                   description: NVMeoF subsystem NQN
+                  type: string
+                traddr:
                   type: string
               required:
               - nqn
@@ -8574,6 +8607,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -8613,6 +8651,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -8648,6 +8691,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -8681,6 +8729,11 @@ paths:
         description: NVMeoF gateway group
         in: query
         name: gw_group
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -8721,6 +8774,8 @@ paths:
                   type: string
                 host_nqn:
                   description: NVMeoF host NQN. Use "*" to allow any host.
+                  type: string
+                traddr:
                   type: string
               required:
               - host_nqn
@@ -8771,6 +8826,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -8809,6 +8869,11 @@ paths:
         description: NVMeoF gateway group
         in: query
         name: gw_group
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -8974,6 +9039,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -9044,6 +9114,8 @@ paths:
                   default: 1024
                   description: RBD image size
                   type: integer
+                traddr:
+                  type: string
                 trash_image:
                   default: false
                   description: Trash the RBD image when namespace is removed
@@ -9097,6 +9169,11 @@ paths:
         name: gw_group
         schema:
           type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
+        schema:
+          type: string
       - default: 'false'
         description: Force remove the RBD image
         in: query
@@ -9146,6 +9223,11 @@ paths:
         description: NVMeoF gateway group
         in: query
         name: gw_group
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
         schema:
           type: string
       responses:
@@ -9205,6 +9287,8 @@ paths:
                 rw_mbytes_per_second:
                   description: Read/Write MB/s
                   type: integer
+                traddr:
+                  type: string
                 trash_image:
                   description: Trash RBD image after removing namespace
                   type: boolean
@@ -9251,6 +9335,11 @@ paths:
         description: NVMeoF gateway group
         in: query
         name: gw_group
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: traddr
         schema:
           type: string
       responses:


### PR DESCRIPTION

allow selecting a specifc gw for your cli command across all API/CLI routes.
This is needed mainly for testing, but might also be useful for production debugging.
I wonder if I should keep the `traddr` terminology or change it to `gw_address`, WDYT? 

in the example below you can see the `addr` field changes according to the `traddr` parameter
`[root@cephnvme-vm29 ~]# ceph nvmeof gw info
{"cli_version": "", "version": "1.5.2", "name": "client.nvmeof.mypool.mygroup1.cephnvme-vm29.ynjpsd", "group": "mygroup1", "addr": "10.242.64.51", "port": "5500", "load_balancing_group": 1, "spdk_version": "SPDK v24.09"}
[root@cephnvme-vm29 ~]# ceph nvmeof gw info --traddr=10.242.64.50
{"cli_version": "", "version": "1.5.2", "name": "client.nvmeof.mypool.mygroup1.cephnvme-vm28.mtzqyc", "group": "mygroup1", "addr": "10.242.64.50", "port": "5500", "load_balancing_group": 2, "spdk_version": "SPDK v24.09"}`

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
