### PR TITLE
squid: rgw: revert PR #41897 to allow multiple delete markers to be created

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1670,28 +1670,6 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
     return ret;
   }
 
-  BIOLHEntry olh(hctx, op.key);
-  bool olh_read_attempt = false;
-  bool olh_found = false;
-  if (!existed && op.delete_marker) {
-    /* read olh */
-    ret = olh.init(&olh_found);
-    if (ret < 0) {
-      return ret;
-    }
-    olh_read_attempt = true;
-
-    // if we're deleting (i.e., adding a delete marker, and the OLH
-    // indicates it already refers to a delete marker, error out)
-    if (olh_found && olh.get_entry().delete_marker) {
-      CLS_LOG(10,
-	      "%s: delete marker received for \"%s\" although OLH"
-	      " already refers to a delete marker",
-	      __func__, escape_str(op.key.to_string()).c_str());
-      return -ENOENT;
-    }
-  }
-
   if (existed && !real_clock::is_zero(op.unmod_since)) {
     timespec mtime = ceph::real_clock::to_timespec(obj.mtime());
     timespec unmod = ceph::real_clock::to_timespec(op.unmod_since);
@@ -1744,12 +1722,11 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   }
 
   /* read olh */
-  if (!olh_read_attempt) { // only read if we didn't attempt earlier
-    ret = olh.init(&olh_found);
-    if (ret < 0) {
-      return ret;
-    }
-    olh_read_attempt = true;
+  BIOLHEntry olh(hctx, op.key);
+  bool olh_found = false;
+  ret = olh.init(&olh_found);
+  if (ret < 0) {
+    return ret;
   }
 
   const uint64_t prev_epoch = olh.get_epoch();

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1081,6 +1081,8 @@ def test_delete_marker_full_sync():
         # create a delete marker
         key2 = new_key(zone, bucket, 'obj')
         key2.delete()
+        key2.delete()
+        key2.delete()
 
     # wait for full sync
     for _, bucket in zone_bucket:
@@ -1105,10 +1107,39 @@ def test_suspended_delete_marker_full_sync():
         # create a delete marker
         key2 = new_key(zone, bucket, 'obj')
         key2.delete()
+        key2.delete()
+        key2.delete()
 
     # wait for full sync
     for _, bucket in zone_bucket:
         zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+
+def test_concurrent_delete_markers_incremental_sync():
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    zone = zonegroup_conns.rw_zones[0]
+
+    # create a versioned bucket
+    bucket = zone.create_bucket(gen_bucket_name())
+    log.debug('created bucket=%s', bucket.name)
+    bucket.configure_versioning(True)
+
+    zonegroup_meta_checkpoint(zonegroup)
+
+    obj = 'obj'
+
+    # upload a dummy object and wait for sync. this forces each zone to finish
+    # a full sync and switch to incremental
+    new_key(zone, bucket, obj).set_contents_from_string('')
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+
+    # create several concurrent delete markers on each zone and let them race to sync
+    for i in range(2):
+        for zone_conn in zonegroup_conns.rw_zones:
+            key = new_key(zone_conn, bucket, obj)
+            key.delete()
+
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
 
 def test_bucket_versioning():
     buckets, zone_bucket = create_bucket_per_zone_in_realm()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70637

---

backport of https://github.com/ceph/ceph/pull/54957
parent tracker: https://tracker.ceph.com/issues/63799

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh