### PR TITLE
mgr/cephadm/module.py: Run ok_to_stop logic for stop

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2667,7 +2667,7 @@ Then run the following:
             raise OrchestratorError(
                 f'Unable to schedule redeploy for {daemon_name}: No standby MGRs')
 
-        if action == 'restart' and not force:
+        if action in ['restart', 'stop'] and not force:
             r = service_registry.get_service(daemon_type_to_service(
                 d.daemon_type)).ok_to_stop([d.daemon_id], force=False)
             if r.retval:

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -393,19 +393,20 @@ class TestCephadm(object):
                 assert wait(cephadm_module,
                             c) == f"Scheduled to redeploy rgw.{daemon_id} on host 'test'"
 
-                for what in ('start', 'stop'):
-                    c = cephadm_module.daemon_action(what, d_name)
-                    assert wait(cephadm_module,
-                                c) == F"Scheduled to {what} {d_name} on host 'test'"
+                c = cephadm_module.daemon_action('start', d_name)
+                assert wait(cephadm_module,
+                            c) == F"Scheduled to start {d_name} on host 'test'"
 
                 for what in ('start', 'stop', 'restart'):
                     c = cephadm_module.daemon_action(what, d_name, force=True)
                     assert wait(cephadm_module,
                                 c) == F"Scheduled to {what} {d_name} on host 'test'"
 
-                with pytest.raises(OrchestratorError, match=f"Unable to restart daemon {d_name}"):
-                    c = cephadm_module.daemon_action('restart', d_name)
-                    wait(cephadm_module, c)
+                for what in ('stop', 'restart'):
+                    with pytest.raises(OrchestratorError, match=f"Unable to {what} daemon {d_name}"):
+                        c = cephadm_module.daemon_action(what, d_name)
+                        wait(cephadm_module, c)
+
                 # Make sure, _check_daemons does a redeploy due to monmap change:
                 cephadm_module._store['_ceph_get/mon_map'] = {
                     'modified': datetime_to_str(datetime_now()),


### PR DESCRIPTION
Also run ok_to_stop logic for daemons when
stopping a daemon with "ceph orch daemon stop <daemon>"

```
[root@cephnvme-devel-server-vallari ~]# ceph orch ps
NAME                                                        HOST                           PORTS                   STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION                IMAGE ID      CONTAINER ID
alertmanager.cephnvme-devel-server-vallari                  cephnvme-devel-server-vallari  *:9093,9094             running (5m)     3m ago   6m    14.7M        -  0.27.0                 11f11916f8cd  cae7a194f273
ceph-exporter.cephnvme-devel-server-vallari                 cephnvme-devel-server-vallari  *:9926                  running (6m)     3m ago   6m    7963k        -  20.0.0-1260-gf20e4428  baa96de07d1f  1c5ce2eb38fe
crash.cephnvme-devel-server-vallari                         cephnvme-devel-server-vallari                          running (6m)     3m ago   6m    7296k        -  20.0.0-1260-gf20e4428  baa96de07d1f  c1e39878de8c
grafana.cephnvme-devel-server-vallari                       cephnvme-devel-server-vallari  *:3000                  running (5m)     3m ago   5m    72.4M        -  10.4.16                d63ef5ea68f6  6572df6dd3f7
mgr.cephnvme-devel-server-vallari.hmrxvp                    cephnvme-devel-server-vallari  *:8443,8765             running (5m)     3m ago   5m     463M        -  20.0.0-1260-gf20e4428  baa96de07d1f  934aafb1c707
mgr.cephnvme-devel-server-vallari.ywgyiv                    cephnvme-devel-server-vallari  *:9283,8765,8443        running (7m)     3m ago   7m     511M        -  20.0.0-1260-gf20e4428  baa96de07d1f  27b4db9c5a9b
mon.cephnvme-devel-server-vallari                           cephnvme-devel-server-vallari                          running (7m)     3m ago   7m    42.2M    2048M  20.0.0-1260-gf20e4428  baa96de07d1f  a3a1b81f1341
node-exporter.cephnvme-devel-server-vallari                 cephnvme-devel-server-vallari  *:9100                  running (6m)     3m ago   6m    9171k        -  1.7.0                  72c9c2088986  709312fe27f7
nvmeof.mypool.mygroup.cephnvme-devel-server-vallari.cpojly  cephnvme-devel-server-vallari  *:5500,4420,8009,10008  running          3m ago   3m        -        -  <unknown>              <unknown>     <unknown>
osd.0                                                       cephnvme-devel-server-vallari                          running (4m)     3m ago   4m    53.1M    7856M  20.0.0-1260-gf20e4428  baa96de07d1f  fbc87e2b5466
prometheus.cephnvme-devel-server-vallari                    cephnvme-devel-server-vallari  *:9095                  running (5m)     3m ago   5m    38.7M        -  2.51.0                 1d3b7f56885b  00bf66adccca

[root@cephnvme-devel-server-vallari ~]# ceph orch daemon stop nvmeof.mypool.mygroup.cephnvme-devel-server-vallari.cpojly
Error EINVAL: Unable to stop daemon nvmeof.mypool.mygroup.cephnvme-devel-server-vallari.cpojly: ALERT: Cannot stop ['nvmeof.mypool.mygroup.cephnvme-devel-server-vallari.cpojly'] in Nvmeof service. Not enough remaining Nvmeof daemons. Please deploy at least 2 Nvmeof daemons before stopping ['nvmeof.mypool.mygroup.cephnvme-devel-server-vallari.cpojly'].
Note: Warnings can be bypassed with the --force flag

[root@cephnvme-devel-server-vallari ~]# ceph orch daemon stop nvmeof.mypool.mygroup.cephnvme-devel-server-vallari.cpojly --force
Scheduled to stop nvmeof.mypool.mygroup.cephnvme-devel-server-vallari.cpojly on host 'cephnvme-devel-server-vallari'
```


Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2279225





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
