### PR TITLE
test: add replica pool support to ceph_test_rados_io_sequence

### DIFF
--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -48,7 +48,8 @@ class RadosIo : public Model {
           const std::string& pool, const std::string& oid,
           const std::optional<std::vector<int>>& cached_shard_order,
           uint64_t block_size, int seed, int threads, ceph::mutex& lock,
-          ceph::condition_variable& cond, bool ec_optimizations);
+          ceph::condition_variable& cond, bool is_replicated_pool,
+          bool ec_optimizations);
 
   ~RadosIo();
 

--- a/src/common/json/OSDStructures.cc
+++ b/src/common/json/OSDStructures.cc
@@ -60,12 +60,36 @@ void OSDPoolGetRequest::decode_json(JSONObj* obj) {
 }
 
 void OSDPoolGetReply::dump(Formatter* f) const {
+  encode_json("size", size, f);
+  encode_json("min_size", min_size, f);
+  encode_json("pg_num", pg_num, f);
+  encode_json("pgp_num", pgp_num, f);
+  encode_json("crush_rule", crush_rule, f);
+  encode_json("allow_ec_overwrites", allow_ec_overwrites, f);
+  encode_json("nodelete", nodelete, f);
+  encode_json("nopgchange", nopgchange, f);
+  encode_json("nosizechange", nosizechange, f);
+  encode_json("noscrub", noscrub, f);
+  encode_json("nodeep-scrub", nodeep_scrub, f);
   encode_json("erasure_code_profile", erasure_code_profile, f);
+  encode_json("fast_read", fast_read, f);
   encode_json("allow_ec_optimizations", allow_ec_optimizations, f);
 }
 
 void OSDPoolGetReply::decode_json(JSONObj* obj) {
+  JSONDecoder::decode_json("size", size, obj);
+  JSONDecoder::decode_json("min_size", min_size, obj);
+  JSONDecoder::decode_json("pg_num", pg_num, obj);
+  JSONDecoder::decode_json("pgp_num", pgp_num, obj);
+  JSONDecoder::decode_json("crush_rule", crush_rule, obj);
+  JSONDecoder::decode_json("allow_ec_overwrites", allow_ec_overwrites, obj);
+  JSONDecoder::decode_json("nodelete", nodelete, obj);
+  JSONDecoder::decode_json("nopgchange", nopgchange, obj);
+  JSONDecoder::decode_json("nosizechange", nosizechange, obj);
+  JSONDecoder::decode_json("noscrub", noscrub, obj);
+  JSONDecoder::decode_json("nodeep-scrub", nodeep_scrub, obj);
   JSONDecoder::decode_json("erasure_code_profile", erasure_code_profile, obj);
+  JSONDecoder::decode_json("fast_read", fast_read, obj);
   JSONDecoder::decode_json("allow_ec_optimizations", allow_ec_optimizations, obj);
 }
 

--- a/src/common/json/OSDStructures.h
+++ b/src/common/json/OSDStructures.h
@@ -41,7 +41,7 @@ struct OSDMapReply {
 
 struct OSDPoolGetRequest {
   std::string pool;
-  std::string var = "erasure_code_profile";
+  std::string var;
   std::string format = "json";
 
   void dump(Formatter* f) const;
@@ -49,8 +49,21 @@ struct OSDPoolGetRequest {
 };
 
 struct OSDPoolGetReply {
-  std::string erasure_code_profile;
-  bool allow_ec_optimizations;
+  std::optional<int> size;
+  std::optional<int> min_size;
+  std::optional<int> pg_num;
+  std::optional<int> pgp_num;
+  std::optional<std::string> crush_rule;
+  std::optional<bool> allow_ec_overwrites;
+  std::optional<bool> nodelete;
+  std::optional<bool> nopgchange;
+  std::optional<bool> nosizechange;
+  std::optional<bool> noscrub;
+  std::optional<bool> nodeep_scrub;
+  std::optional<std::string> erasure_code_profile;
+  std::optional<int> fast_read;
+  std::optional<bool> allow_ec_optimizations;
+
   void dump(Formatter* f) const;
   void decode_json(JSONObj* obj);
 };

--- a/src/erasure-code/consistency/RadosCommands.cc
+++ b/src/erasure-code/consistency/RadosCommands.cc
@@ -54,7 +54,7 @@ int RadosCommands::get_primary_osd(const std::string& pool_name,
  */
 bool RadosCommands::get_pool_allow_ec_optimizations(const std::string& pool_name)
 {
-  ceph::messaging::osd::OSDPoolGetRequest osd_pool_get_request{pool_name, "allow_ec_optimizations"};
+  ceph::messaging::osd::OSDPoolGetRequest osd_pool_get_request{pool_name, "all"};
   encode_json("OSDPoolGetRequest", osd_pool_get_request, formatter.get());
 
   std::ostringstream oss;
@@ -71,7 +71,7 @@ bool RadosCommands::get_pool_allow_ec_optimizations(const std::string& pool_name
   ceph::messaging::osd::OSDPoolGetReply osd_pool_get_reply;
   osd_pool_get_reply.decode_json(&p);
 
-  return osd_pool_get_reply.allow_ec_optimizations;
+  return osd_pool_get_reply.allow_ec_optimizations.value_or(false);
 }
 
 /**
@@ -83,7 +83,7 @@ bool RadosCommands::get_pool_allow_ec_optimizations(const std::string& pool_name
  */
 std::string RadosCommands::get_pool_ec_profile_name(const std::string& pool_name)
 {
-  ceph::messaging::osd::OSDPoolGetRequest osd_pool_get_request{pool_name};
+  ceph::messaging::osd::OSDPoolGetRequest osd_pool_get_request{pool_name, "all"};
   encode_json("OSDPoolGetRequest", osd_pool_get_request, formatter.get());
 
   std::ostringstream oss;
@@ -100,7 +100,12 @@ std::string RadosCommands::get_pool_ec_profile_name(const std::string& pool_name
   ceph::messaging::osd::OSDPoolGetReply osd_pool_get_reply;
   osd_pool_get_reply.decode_json(&p);
 
-  return osd_pool_get_reply.erasure_code_profile;
+  if (!osd_pool_get_reply.erasure_code_profile) {
+    throw std::runtime_error("No profile for given pool. "
+                             "Is it an Erasure Coded pool?");
+  }
+
+  return *osd_pool_get_reply.erasure_code_profile;
 }
 
 /**

--- a/src/erasure-code/consistency/ceph_ec_consistency_checker.cc
+++ b/src/erasure-code/consistency/ceph_ec_consistency_checker.cc
@@ -71,9 +71,14 @@ int main(int argc, char **argv)
   guard.emplace(boost::asio::make_work_guard(asio));
   thread = make_named_thread("io_thread",[&asio] { asio.run(); });
 
-  auto checker = ceph::consistency::ConsistencyChecker(rados, asio, pool);
-  checker.single_read_and_check_consistency(oid, blocksize, offset, length);
-  checker.print_results(std::cout);
+  try {
+    auto checker = ceph::consistency::ConsistencyChecker(rados, asio, pool);
+    checker.single_read_and_check_consistency(oid, blocksize, offset, length);
+    checker.print_results(std::cout);
+  } catch (std::runtime_error& e) {
+    std::cerr << e.what() << std::endl;
+    exit(1);
+  }
 
   exit(0);
 }

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -831,7 +831,8 @@ const std::string ceph::io_sequence::tester::SelectErasurePool::select() {
       bufferlist inbl, outbl;
       auto formatter = std::make_shared<JSONFormatter>(false);
 
-      ceph::messaging::osd::OSDPoolGetRequest osdPoolGetRequest{*force_value};
+      ceph::messaging::osd::OSDPoolGetRequest osdPoolGetRequest{*force_value,
+                                                                "all"};
       rc = send_mon_command(osdPoolGetRequest, rados, "OSDPoolGetRequest", inbl,
                             &outbl, formatter.get());
       ceph_assert(rc == 0);

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -388,6 +388,7 @@ class SelectErasurePool : public ProgramOptionReader<std::string> {
                     bool allow_pool_balancer,
                     bool allow_pool_deep_scrubbing,
                     bool allow_pool_scrubbing,
+                    bool check_consistency,
                     bool test_recovery,
                     bool allow_pool_ec_optimizations);
   const std::string select() override;
@@ -402,6 +403,9 @@ class SelectErasurePool : public ProgramOptionReader<std::string> {
   inline bool get_allow_pool_ec_optimizations() {
     return allow_pool_ec_optimizations;
   }
+
+  inline bool is_replicated_pool() const { return pool_type
+                                              == pg_pool_t::TYPE_REPLICATED; }
   inline std::optional<Profile> getProfile() { return profile; }
 
  private:
@@ -412,8 +416,12 @@ class SelectErasurePool : public ProgramOptionReader<std::string> {
   bool allow_pool_balancer;
   bool allow_pool_deep_scrubbing;
   bool allow_pool_scrubbing;
+  bool check_consistency;
   bool test_recovery;
   bool allow_pool_ec_optimizations;
+
+  using PoolType = int;
+  PoolType pool_type;
 
   bool first_use;
 
@@ -422,6 +430,7 @@ class SelectErasurePool : public ProgramOptionReader<std::string> {
   std::optional<Profile> profile;
 
   void configureServices(const std::string& pool_name,
+                         PoolType pool_type,
                          bool allow_pool_autoscaling,
                          bool allow_pool_balancer,
                          bool allow_pool_deep_scrubbing,


### PR DESCRIPTION
Make 'ceph_test_rados_io_sequenece --pool rbd' work, replica pools don't have an erasure code profile and do not have the ec_allow_overwrites or ec_allow_optimizations flags

Fixes: https://tracker.ceph.com/issues/70844

PR is rebased on top of [#64564](https://github.com/ceph/ceph/pull/64564)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
