### PR TITLE
mgr/volumes: add support to search with specific strings while running ls commands

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -89,6 +89,12 @@ List volumes by running the following command:
 
    ceph fs volume ls
 
+List volumes using search string filter by running following command:
+
+.. prompt:: bash #
+
+   ceph fs volume ls [--vol_filter <filter_string>]
+
 Rename a volume by running a command of the following form:
 
 .. prompt:: bash #
@@ -227,6 +233,12 @@ List subvolume groups by running a command of the following form:
 
    ceph fs subvolumegroup ls <vol_name>
 
+List subvolume groups using search string filter by running a command of the following form:
+
+.. prompt:: bash #
+
+   ceph fs subvolumegroup ls <vol_name> [--group_filter <filter_string>]
+
 .. note:: Subvolume group snapshot feature is no longer supported in mainline CephFS (existing group
           snapshots can still be listed and deleted).
 
@@ -301,6 +313,12 @@ List snapshots of a subvolume group by running a command of the following form:
 .. prompt:: bash #
 
    ceph fs subvolumegroup snapshot ls <vol_name> <group_name>
+
+List snapshots of a subvolume group with search string filter by running a command of the following form:
+
+.. prompt:: bash #
+
+   ceph fs subvolumegroup snapshot ls <vol_name> <group_name> [--snap_filter <filter_string>]
 
 
 FS Subvolumes
@@ -546,6 +564,12 @@ Use a command of the following form to list subvolumes:
 
    ceph fs subvolume ls <vol_name> [--group_name <subvol_group_name>]
 
+Use a command of the following form to list subvolumes with search string filter:
+
+.. prompt:: bash #
+
+   ceph fs subvolume ls <vol_name> [--group_name <subvol_group_name>] [--subvol_filter <filter_string>]
+
 .. note:: Subvolumes that have been removed but have snapshots retained, are
    also listed.
 
@@ -686,6 +710,12 @@ Use a command of the following from to list the snapshots of a subvolume:
 .. prompt:: bash #
 
    ceph fs subvolume snapshot ls <vol_name> <subvol_name> [--group_name <subvol_group_name>]
+
+Use a command of the following from to list the snapshots of a subvolume with search string filter:
+
+.. prompt:: bash #
+
+   ceph fs subvolume snapshot ls <vol_name> <subvol_name> [--group_name <subvol_group_name>] [--snap_filter <filter_string>]
 
 Fetching a Snapshot's Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -626,6 +626,33 @@ class TestVolumes(TestVolumesHelper):
             for volume in volumenames:
                 self._fs_cmd("volume", "rm", volume, "--yes-i-really-mean-it")
 
+    def test_volume_ls_with_search_filter(self):
+        """
+        That the volumes can be listed using search filter and
+        finally cleans up.
+        """        
+        #create new volumes and add it to the existing list of volumes
+        self._fs_cmd("volume", "create", "vol")
+        self._fs_cmd("volume", "create", "test_volume1")
+        self._fs_cmd("volume", "create", "test_volume2")
+
+        search_filter = "test"
+
+        # list volumes
+        try:
+            volumels = json.loads(self._fs_cmd('volume', 'ls', f"--vol_filter={search_filter}"))
+            if len(volumels) !=2 or "test_volume1" not in volumels or 
+               "test_volume2" not in volumels:
+                raise RuntimeError("Error in listing volumes")
+        finally:
+            # clean up
+            self._fs_cmd("volume", "rm", "vol", "--yes-i-really-mean-it")
+            self._fs_cmd("volume", "rm", "test_volume1", "--yes-i-really-mean-it")
+            self._fs_cmd("volume", "rm", "test_volume2", "--yes-i-really-mean-it")
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+
     def test_volume_rm(self):
         """
         That the volume can only be removed when --yes-i-really-mean-it is used
@@ -2158,6 +2185,29 @@ class TestSubvolumeGroups(TestVolumesHelper):
             subvolgroupnames = [subvolumegroup['name'] for subvolumegroup in subvolumegroupls]
             if collections.Counter(subvolgroupnames) != collections.Counter(subvolumegroups):
                 raise RuntimeError("Error creating or listing subvolume groups")
+            
+    def test_subvolume_group_ls_with_search_filter(self):
+        # tests the 'fs subvolumegroup ls' command with search filter
+
+        #create subvolumegroups
+        self._fs_cmd("subvolumegroup", "create", self.volname, "group")
+        self._fs_cmd("subvolumegroup", "create", self.volname, 'test_subvolumegroup1')
+        self._fs_cmd("subvolumegroup", "create", self.volname, 'test_subvolumegroup2')
+
+        search_filter = 'test'
+
+        subvolumegroupls = json.loads(self._fs_cmd('subvolumegroup', 'ls', self.volname, f"--group_filter={search_filter}"))
+        if len(subvolumegroupls) != 2 or "test_subvolumegroup1" not in subvolumegroupls or 
+           "test_subvolumegroup2" not in subvolumegroupls:
+            raise RuntimeError("Error in listing subvolume groups")
+        
+        # remove subvolumegroup
+        self._fs_cmd("subvolumegroup", "rm", self.volname, "group")
+        self._fs_cmd("subvolumegroup", "rm", self.volname, "test_subvolumegroup1")
+        self._fs_cmd("subvolumegroup", "rm", self.volname, "test_subvolumegroup2")
+        
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
 
     def test_subvolume_group_ls_filter(self):
         # tests the 'fs subvolumegroup ls' command filters '_deleting' directory
@@ -3183,6 +3233,30 @@ class TestSubvolumes(TestVolumesHelper):
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
+    def test_subvolume_ls_with_search_filter(self):
+        # tests the 'fs subvolume ls' command using search filter
+
+        # create subvolumes
+        self._fs_cmd("subvolume", "create", self.volname, "subvol")
+        self._fs_cmd("subvolume", "create", self.volname, "test_subvol1")
+        self._fs_cmd("subvolume", "create", self.volname, "test_subvol2")
+
+        search_filter = "test"
+
+        # list subvolumes
+        subvolumels = json.loads(self._fs_cmd('subvolume', 'ls', self.volname, f"--subvol_filter={search_filter}"))
+        if len(subvolumels) != 2 or "test_subvol1" not in subvolumels or 
+           "test_subvol2" not in subvolumels:
+            raise RuntimeError("Error in listing subvolumes")
+
+        # remove subvolume
+        self._fs_cmd("subvolume", "rm", self.volname, "subvol")        
+        self._fs_cmd("subvolume", "rm", self.volname, "test_subvol1")
+        self._fs_cmd("subvolume", "rm", self.volname, "test_subvol2")
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+    
     def test_subvolume_ls_with_groupname_as_internal_directory(self):
         # tests the 'fs subvolume ls' command when the default groupname as internal directories
         # Eg: '_nogroup', '_legacy', '_deleting', '_index'.
@@ -5654,6 +5728,37 @@ class TestSubvolumeSnapshots(TestVolumesHelper):
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
+    def test_subvolume_snapshot_ls_with_search_filter(self):
+        # tests the 'fs subvolume snapshot ls' command using search filter
+
+        # create subvolume
+        subvolume = self._gen_subvol_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolume)
+
+        # create subvolume snapshots
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, "snap")
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, "test_snapshot1")
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, "test_snapshot2")
+
+        search_filter = "test"
+
+        subvolsnapshotls = json.loads(self._fs_cmd('subvolume', 'snapshot', 'ls', self.volname, subvolume, f"--snap_filter={search_filter}"))
+        if len(subvolsnapshotls) != 2 or "test_snapshot1" not in subvolsnapshotls or 
+           "test_snapshot2" not in subvolsnapshotls:
+            raise RuntimeError("Error in listing subvolume snapshots")
+
+        # remove snapshot
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, "snap")
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, "test_snapshot1")
+        self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, "test_snapshot2")
+
+
+        # remove subvolume
+        self._fs_cmd("subvolume", "rm", self.volname, subvolume)
+
+        # verify trash dir is clean
+        self._wait_for_trash_empty()
+    
     def test_subvolume_inherited_snapshot_ls(self):
         # tests the scenario where 'fs subvolume snapshot ls' command
         # should not list inherited snapshots created as part of snapshot

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -42,7 +42,8 @@ def mgr_cmd_wrap(f):
 class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     COMMANDS = [
         {
-            'cmd': 'fs volume ls',
+            'cmd': 'fs volume ls '
+                   'name=vol_filter,type=CephString,req=false',
             'desc': "List volumes",
             'perm': 'r'
         },
@@ -79,7 +80,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'fs subvolumegroup ls '
-            'name=vol_name,type=CephString ',
+            'name=vol_name,type=CephString '
+            'name=group_filter,type=CephString,req=false',
             'desc': "List subvolumegroups",
             'perm': 'r'
         },
@@ -131,7 +133,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         {
             'cmd': 'fs subvolume ls '
                    'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   'name=group_name,type=CephString,req=false '
+                   'name=subvol_filter,type=CephString,req=false',
             'desc': "List subvolumes",
             'perm': 'r'
         },
@@ -365,7 +368,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         {
             'cmd': 'fs subvolumegroup snapshot ls '
                    'name=vol_name,type=CephString '
-                   'name=group_name,type=CephString ',
+                   'name=group_name,type=CephString '
+                   'name=snap_filter,type=CephString,req=false',
             'desc': "List subvolumegroup snapshots",
             'perm': 'r'
         },
@@ -390,7 +394,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             'cmd': 'fs subvolume snapshot ls '
                    'name=vol_name,type=CephString '
                    'name=sub_name,type=CephString '
-                   'name=group_name,type=CephString,req=false ',
+                   'name=group_name,type=CephString,req=false '
+                   'name=snap_filter,type=CephString,req=false',
             'desc': "List subvolume snapshots",
             'perm': 'r'
         },
@@ -725,7 +730,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_volume_ls(self, inbuf, cmd):
-        return self.vc.list_fs_volumes()
+        vol_filter = cmd.get('vol_filter', None)
+        return self.vc.list_fs_volumes(vol_filter)
 
     @mgr_cmd_wrap
     def _cmd_fs_volume_rename(self, inbuf, cmd):
@@ -773,7 +779,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_ls(self, inbuf, cmd):
-        return self.vc.list_subvolume_groups(vol_name=cmd['vol_name'])
+        return self.vc.list_subvolume_groups(vol_name=cmd['vol_name'],
+                                             group_filter=cmd.get('group_filter', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_exist(self, inbuf, cmd):
@@ -853,7 +860,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_ls(self, inbuf, cmd):
         return self.vc.list_subvolumes(vol_name=cmd['vol_name'],
-                                       group_name=cmd.get('group_name', None))
+                                       group_name=cmd.get('group_name', None),
+                                       subvol_filter=cmd.get('subvol_filter', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_getpath(self, inbuf, cmd):
@@ -968,7 +976,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_snapshot_ls(self, inbuf, cmd):
         return self.vc.list_subvolume_group_snapshots(vol_name=cmd['vol_name'],
-                                                      group_name=cmd['group_name'])
+                                                      group_name=cmd['group_name'],
+                                                      snap_filter=cmd.get('snap_filter', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_create(self, inbuf, cmd):
@@ -1029,7 +1038,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_fs_subvolume_snapshot_ls(self, inbuf, cmd):
         return self.vc.list_subvolume_snapshots(vol_name=cmd['vol_name'],
                                                 sub_name=cmd['sub_name'],
-                                                group_name=cmd.get('group_name', None))
+                                                group_name=cmd.get('group_name', None),
+                                                snap_filter=cmd.get('snap_filter', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_snapshot_getpath(self, inbuf, cmd):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/70688
Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
