### PR TITLE
squid: mgr/dashboard: introduce dashboard setting to resolve rgw hostname

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -429,6 +429,19 @@ the host name:
 
    ceph dashboard set-rgw-api-ssl-verify False
 
+To set a custom hostname or address for an RGW gateway, set the value of ``RGW_HOSTNAME_PER_DAEMON``
+accordingly:
+
+.. promt:: bash $
+
+   ceph dashboard set-rgw-hostname <gateway_name> <hostname>
+
+The setting can be unset using:
+
+.. promt:: bash $
+
+   ceph dashboard unset-rgw-hostname <gateway_name>
+
 If the Object Gateway takes too long to process requests and the dashboard runs
 into timeouts, you can set the timeout value to your needs:
 

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -32,7 +32,7 @@ from .grafana import push_local_dashboards
 from .services import nvmeof_cli  # noqa # pylint: disable=unused-import
 from .services.auth import AuthManager, AuthManagerTool, JwtManager
 from .services.exception import dashboard_exception_handler
-from .services.rgw_client import configure_rgw_credentials
+from .services.rgw_client import configure_rgw_credentials, set_rgw_hostname, unset_rgw_hostname
 from .services.sso import SSO_COMMANDS, handle_sso_command
 from .settings import handle_option_command, options_command_list, options_schema_list
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
@@ -482,6 +482,22 @@ class Module(MgrModule, CherryPyConfig):
             return -errno.EINVAL, '', str(error)
 
         return 0, 'RGW credentials configured', ''
+
+    @CLIWriteCommand("dashboard set-rgw-hostname")
+    def set_rgw_hostname(self, daemon_name: str, hostname: str):
+        try:
+            set_rgw_hostname(daemon_name, hostname)
+            return 0, f'RGW hostname for daemon {daemon_name} configured', ''
+        except Exception as error:
+            return -errno.EINVAL, '', str(error)
+
+    @CLIWriteCommand("dashboard unset-rgw-hostname")
+    def unset_rgw_hostname(self, daemon_name: str):
+        try:
+            unset_rgw_hostname(daemon_name)
+            return 0, f'RGW hostname for daemon {daemon_name} resetted', ''
+        except Exception as error:
+            return -errno.EINVAL, '', str(error)
 
     @CLIWriteCommand("dashboard set-login-banner")
     def set_login_banner(self, inbuf: str):

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -18,7 +18,7 @@ try:
 except ModuleNotFoundError:
     logging.error("Module 'xmltodict' is not installed.")
 
-from mgr_util import build_url, name_to_config_section
+from mgr_util import build_url
 
 from .. import mgr
 from ..awsauth import S3Auth
@@ -103,9 +103,12 @@ def _determine_rgw_addr(daemon_info: Dict[str, Any]) -> RgwDaemon:
     Parse RGW daemon info to determine the configured host (IP address) and port.
     """
     daemon = RgwDaemon()
-    rgw_dns_name = CephService.send_command('mon', 'config get',
-                                            who=name_to_config_section('rgw.' + daemon_info['metadata']['id']),  # noqa E501 #pylint: disable=line-too-long
-                                            key='rgw_dns_name').rstrip()
+    rgw_dns_name = ''
+    if (
+        Settings.RGW_HOSTNAME_PER_DAEMON
+        and daemon_info['metadata']['id'] in Settings.RGW_HOSTNAME_PER_DAEMON
+    ):
+        rgw_dns_name = Settings.RGW_HOSTNAME_PER_DAEMON[daemon_info['metadata']['id']]
 
     daemon.port, daemon.ssl = _parse_frontend_config(daemon_info['metadata']['frontend_config#0'])
 
@@ -294,6 +297,23 @@ def configure_rgw_credentials():
         logger.exception(error)
         raise NoCredentialsException
 
+def set_rgw_hostname(daemon_name: str, hostname: str):
+    if not Settings.RGW_HOSTNAME_PER_DAEMON:
+        Settings.RGW_HOSTNAME_PER_DAEMON = {daemon_name: hostname}
+        return
+
+    rgw_hostname_setting = Settings.RGW_HOSTNAME_PER_DAEMON
+    rgw_hostname_setting[daemon_name] = hostname
+    Settings.RGW_HOSTNAME_PER_DAEMON = rgw_hostname_setting
+
+def unset_rgw_hostname(daemon_name: str):
+    if not Settings.RGW_HOSTNAME_PER_DAEMON:
+        return
+
+    rgw_hostname_setting = Settings.RGW_HOSTNAME_PER_DAEMON
+    rgw_hostname_setting.pop(daemon_name, None)
+    Settings.RGW_HOSTNAME_PER_DAEMON = rgw_hostname_setting
+
 
 # pylint: disable=R0904
 class RgwClient(RestClient):
@@ -351,7 +371,9 @@ class RgwClient(RestClient):
         return (Settings.RGW_API_ACCESS_KEY,
                 Settings.RGW_API_SECRET_KEY,
                 Settings.RGW_API_ADMIN_RESOURCE,
-                Settings.RGW_API_SSL_VERIFY)
+                Settings.RGW_API_SSL_VERIFY,
+                Settings.RGW_HOSTNAME_PER_DAEMON
+                )
 
     @staticmethod
     def instance(userid: Optional[str] = None,

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -67,6 +67,7 @@ class Options(object):
     RGW_API_SECRET_KEY = Setting('', [dict, str])
     RGW_API_ADMIN_RESOURCE = Setting('admin', [str])
     RGW_API_SSL_VERIFY = Setting(True, [bool])
+    RGW_HOSTNAME_PER_DAEMON = Setting('', [dict, str])
 
     # Ceph Issue Tracker API Access Key
     ISSUE_TRACKER_API_KEY = Setting('', [str])

--- a/src/pybind/mgr/dashboard/tests/test_rgw_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw_client.py
@@ -6,8 +6,8 @@ from unittest.mock import Mock, patch
 
 from .. import mgr
 from ..exceptions import DashboardException
-from ..services.rgw_client import NoCredentialsException, \
-    NoRgwDaemonsException, RgwClient, _parse_frontend_config
+from ..services.rgw_client import NoCredentialsException, RgwClient, \
+    _determine_rgw_addr, NoRgwDaemonsException, RgwClient, _parse_frontend_config
 from ..settings import Settings
 from ..tests import CLICommandTestMixin, RgwStub
 
@@ -272,6 +272,57 @@ class RgwClientTest(TestCase, CLICommandTestMixin):
                 retention_period_days=days,
                 retention_period_years=years
             ))
+
+    def test_set_rgw_hostname(self):
+        result = self.exec_cmd(
+            'set-rgw-hostname',
+            daemon_name='test_daemon',
+            hostname='example.hostname.com'
+        )
+        self.assertEqual(
+            result,
+            'RGW hostname for daemon test_daemon configured'
+        )
+        self.assertEqual(
+            Settings.RGW_HOSTNAME_PER_DAEMON,
+            {'test_daemon': 'example.hostname.com'}
+        )
+
+    @patch("dashboard.services.rgw_client.RgwDaemon")
+    def test_hostname_when_rgw_hostname_config_is_set(self, mock_daemons):
+        mock_instance = Mock()
+        mock_daemons.return_value = mock_instance
+
+        self.test_set_rgw_hostname()
+
+        daemon_info = {
+            'metadata': {
+                'id': 'test_daemon',
+                'hostname': 'my-hostname.com',
+                'frontend_config#0': 'beast port=8000'
+            },
+            'addr': '192.0.2.1'
+        }
+
+        result = _determine_rgw_addr(daemon_info)
+        self.assertEqual(result.host, "example.hostname.com")
+
+    @patch("dashboard.services.rgw_client.RgwDaemon")
+    def test_hostname_when_rgw_hostname_config_is_not_set(self, mock_daemons):
+        mock_instance = Mock()
+        mock_daemons.return_value = mock_instance
+
+        daemon_info = {
+            'metadata': {
+                'id': 'test_daemon',
+                'hostname': 'my.hostname.com',
+                'frontend_config#0': 'beast port=8000'
+            },
+            'addr': '192.168.178.3:49774/1534999298'
+        }
+
+        result = _determine_rgw_addr(daemon_info)
+        self.assertEqual(result.host, "192.168.178.3")
 
 
 class RgwClientHelperTest(TestCase):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70809

---

backport of https://github.com/ceph/ceph/pull/62596
parent tracker: https://tracker.ceph.com/issues/70744

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh