### PR TITLE
mgr/dashboard: bucket ratelimit API failing while changing owner with ratelimit config

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -21,6 +21,8 @@ import { RgwBucketFormComponent } from './rgw-bucket-form.component';
 import { RgwRateLimitComponent } from '../rgw-rate-limit/rgw-rate-limit.component';
 import { CheckboxModule, SelectModule } from 'carbon-components-angular';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { LoadingStatus } from '~/app/shared/forms/cd-form';
 
 describe('RgwBucketFormComponent', () => {
   let component: RgwBucketFormComponent;
@@ -30,6 +32,7 @@ describe('RgwBucketFormComponent', () => {
   let rgwBucketServiceGetSpy: jasmine.Spy;
   let enumerateSpy: jasmine.Spy;
   let formHelper: FormHelper;
+  let childComponent: RgwRateLimitComponent;
 
   configureTestBed({
     declarations: [RgwBucketFormComponent, RgwRateLimitComponent],
@@ -337,5 +340,91 @@ describe('RgwBucketFormComponent', () => {
     const updateValidationSpy = jest.spyOn(component.bucketForm, 'updateValueAndValidity');
     component.deleteTag(0);
     expect(updateValidationSpy).toHaveBeenCalled();
+  });
+
+  describe('should call bucket ratelimit API with correct bucket name', () => {
+    beforeEach(() => {
+      component.loading = LoadingStatus.Ready;
+      fixture.detectChanges();
+      childComponent = fixture.debugElement.query(By.directive(RgwRateLimitComponent))
+        .componentInstance;
+    });
+    it('Scenario 1: tenanted owner with tenanted bucket name', () => {
+      const rateLimitSpy = spyOn(rgwBucketService, 'updateBucketRateLimit').and.returnValue(
+        observableOf([])
+      );
+      component.editing = true;
+      formHelper.setMultipleValues({
+        bid: 'tenant/bucket1',
+        owner: 'tenant$user1'
+      });
+      childComponent.form.patchValue({
+        rate_limit_enabled: true,
+        rate_limit_max_readOps: 100,
+        rate_limit_max_writeOps: 200,
+        rate_limit_max_readBytes: '10MB',
+        rate_limit_max_writeBytes: '20MB',
+        rate_limit_max_readOps_unlimited: true, // Unlimited
+        rate_limit_max_writeOps_unlimited: true, // Unlimited
+        rate_limit_max_readBytes_unlimited: true, // Unlimited
+        rate_limit_max_writeBytes_unlimited: true // Unlimited
+      });
+      childComponent.form.get('rate_limit_enabled').markAsDirty();
+      const rateLimitConfig = childComponent.getRateLimitFormValue();
+      component.updateBucketRateLimit();
+      expect(rateLimitSpy).toHaveBeenCalledWith('tenant/bucket1', rateLimitConfig);
+    });
+
+    it('Scenario 2: non tenanted owner with tenanted bucket name', () => {
+      const rateLimitSpy = spyOn(rgwBucketService, 'updateBucketRateLimit').and.returnValue(
+        observableOf([])
+      );
+      component.editing = true;
+      formHelper.setMultipleValues({
+        bid: 'tenant/bucket1',
+        owner: 'non_tenanted_user'
+      });
+      childComponent.form.patchValue({
+        rate_limit_enabled: true,
+        rate_limit_max_readOps: 100,
+        rate_limit_max_writeOps: 200,
+        rate_limit_max_readBytes: '10MB',
+        rate_limit_max_writeBytes: '20MB',
+        rate_limit_max_readOps_unlimited: true, // Unlimited
+        rate_limit_max_writeOps_unlimited: true, // Unlimited
+        rate_limit_max_readBytes_unlimited: true, // Unlimited
+        rate_limit_max_writeBytes_unlimited: true // Unlimited
+      });
+      childComponent.form.get('rate_limit_enabled').markAsDirty();
+      const rateLimitConfig = childComponent.getRateLimitFormValue();
+      component.updateBucketRateLimit();
+      expect(rateLimitSpy).toHaveBeenCalledWith('bucket1', rateLimitConfig);
+    });
+
+    it('Scenario 3: tenanted owner and with non-tenanted bucket name', () => {
+      const rateLimitSpy = spyOn(rgwBucketService, 'updateBucketRateLimit').and.returnValue(
+        observableOf([])
+      );
+      component.editing = true;
+      formHelper.setMultipleValues({
+        bid: 'bucket1',
+        owner: 'tenant$user1'
+      });
+      childComponent.form.patchValue({
+        rate_limit_enabled: true,
+        rate_limit_max_readOps: 100,
+        rate_limit_max_writeOps: 200,
+        rate_limit_max_readBytes: '10MB',
+        rate_limit_max_writeBytes: '20MB',
+        rate_limit_max_readOps_unlimited: true, // Unlimited
+        rate_limit_max_writeOps_unlimited: true, // Unlimited
+        rate_limit_max_readBytes_unlimited: true, // Unlimited
+        rate_limit_max_writeBytes_unlimited: true // Unlimited
+      });
+      childComponent.form.get('rate_limit_enabled').markAsDirty();
+      const rateLimitConfig = childComponent.getRateLimitFormValue();
+      component.updateBucketRateLimit();
+      expect(rateLimitSpy).toHaveBeenCalledWith('tenant/bucket1', rateLimitConfig);
+    });
   });
 });


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/70874

PR covers & fixes below scenarios:
Whenever we change the owner of bucket from non-tenanted to tenanted and vice-versa with the rate-limit changes, there was issue in sending bucket name 
Scenario 1: Changing the bucket owner from tenanted to non-tenanted 
Scenario 2: Changing the bucket owner from non-tenanted to tenanted 
Scenario 3: Keeping the owner(tenanted) same and changing only rate limit





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
