### PR TITLE
rgw: add CreateBucket extension for zone-local buckets

### DIFF
--- a/doc/dev/radosgw/nonreplicated_bucket.md
+++ b/doc/dev/radosgw/nonreplicated_bucket.md
@@ -1,0 +1,41 @@
+## use case
+
+in a replicated zonegroup, create a non-replicated bucket for data that doesn't require redundancy. if requirements change, reenable redundancy on the bucket
+
+## design
+
+extend the [CreateBucketConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucketConfiguration.html) xml document so it can specify a non-replicated bucket. when requested by [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html), the bucket is "pinned" to the zone that creates it
+
+when requests on that bucket are sent to other zones, they're redirected to the pinned zone. these redirects prevent object uploads on other zones, and DeleteBucket requests are redirected and processed without ambiguity
+
+if the pinned zone gets removed from the zonegroup, other zones no longer redirect but instead return an error like [410 Gone](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/410). if the pinned zone is never restored, the bucket must be removed by an admin before the bucket name can be reused elsewhere
+
+the contents of pinned buckets are not replicated unless requested by bucket replication policy (to a different destination bucket)
+
+to transition a non-replicated bucket to a replicated one:
+* clear the pinned zone id in the bucket metadata so other zones stop redirecting, and
+* write a datalog entry for every index shard so other zones start full syncing
+
+without an S3 API for this, the transition would require a radosgw-admin command
+
+transitioning in the other direction may require deleting data on multiple zones, and is probably not worth implementing. the user can instead create a new non-replicated bucket then server-side copy their objects into it
+
+the same method can transition from non-replicated to replicated, avoiding the need for radosgw-admin access so S3 users can do it themselves
+
+as an alternative to a custom rgw-only extension, there's a [DataRedundancy](https://docs.aws.amazon.com/AmazonS3/latest/API/API_BucketInfo.html#AmazonS3-Type-BucketInfo-DataRedundancy) member of CreateBucketConfiguration:
+
+> The number of Zone (Availability Zone or Local Zone) that's used for redundancy for the bucket.
+> 
+> Type: String
+> 
+> Valid Values: SingleAvailabilityZone | SingleLocalZone
+> 
+> Required: No
+
+it's related to directory buckets so not a perfect fit, but we might still consider using `<DataRedundancy> SingleAvailabilityZone` for this
+
+## tasks
+* CreateBucket parses xml extension and stores pinned zone id with bucket instance metadata
+* requests on pinned buckets redirect or 410
+* data sync skips processing of pinned buckets
+* optional: radosgw-admin command to reenable replication

--- a/examples/rgw/boto3/create_bucket_zone_redundancy.py
+++ b/examples/rgw/boto3/create_bucket_zone_redundancy.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+import boto3
+import sys
+
+if len(sys.argv) != 2:
+    print('Usage: ' + sys.argv[0] + ' <bucket>')
+    sys.exit(1)
+
+# bucket name as first argument
+bucketname = sys.argv[1]
+
+# endpoint and keys from vstart
+endpoint = 'http://127.0.0.1:8000'
+access_key='0555b35654ad1656d804'
+secret_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
+
+client = boto3.client('s3',
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key)
+
+client.create_bucket(
+    Bucket=bucketname,
+    CreateBucketConfiguration={'DataRedundancy': 'SingleZone'})

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -418,6 +418,10 @@
                 "BucketIndex":{
                     "shape":"BucketIndex",
                     "documentation":"<p>Configuration to customize the bucket index layout.</p> <note> <p>This element is a Ceph RGW extension.</p> </note>"
+                },
+                "DataRedundancy":{
+                    "shape":"CreateBucketDataRedundancy",
+                    "documentation":"<p>Objects are replicated across all zones in the bucket's <code>ZoneGroup</code> by default, but this can be disabled on bucket creation. Buckets with <code>SingleZone</code> redundancy are instead pinned to the zone they're created on, and other zones will redirect requests for this bucket. Bucket Replication Policy can still be used to replicate objects to/from other buckets in the zonegroup, but cross-zonegroup replication policy is not supported.</p> <note> <p>This element is a Ceph RGW extension.</p> </note>"
                 }
             }
         },
@@ -444,7 +448,14 @@
                 "Indexless"
             ]
         },
-        "BucketIndexNumShards":{"type":"integer"}
+        "BucketIndexNumShards":{"type":"integer"},
+        "CreateBucketDataRedundancy":{
+            "type":"string",
+            "enum":[
+                "ZoneGroup",
+                "SingleZone"
+            ]
+        }
     },
     "documentation":"<p/>"
 }

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -5795,6 +5795,12 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
       return set_cr_error(retcode);
     }
 
+    // skip same-bucket replication for zone-local buckets
+    if (!sync_pipe.source_bucket_info.local_zone_id.empty() &&
+        sync_pair.source_bs.bucket == sync_pair.dest_bucket) {
+      return set_cr_done();
+    }
+
     yield call(new RGWSyncGetBucketInfoCR(env, sync_pair.dest_bucket, &sync_pipe.dest_bucket_info,
                                           &sync_pipe.dest_bucket_attrs, tn));
     if (retcode < 0) {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -3406,7 +3406,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   state = NULL;
 
   if (versioned_op && meta.olh_epoch) {
-    bool add_log = log_op && store->svc.zone->need_to_log_data();
+    bool add_log = log_op
+        && target->bucket_info.local_zone_id.empty()
+        && store->svc.zone->need_to_log_data();
     r = store->set_olh(rctx.dpp, target->get_ctx(), target->get_bucket_info(), obj, false, NULL, *meta.olh_epoch, real_time(), false, rctx.y, meta.zones_trace, add_log);
     if (r < 0) {
       return r;
@@ -6317,7 +6319,9 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y,
   bool explicit_marker_version = (!params.marker_version_id.empty());
 
   if (params.versioning_status & BUCKET_VERSIONED || explicit_marker_version) {
-    bool add_log = log_op && store->svc.zone->need_to_log_data();
+    bool add_log = log_op
+        && target->bucket_info.local_zone_id.empty()
+        && store->svc.zone->need_to_log_data();
 
     if (instance.empty() || explicit_marker_version) {
       rgw_obj marker = obj;
@@ -7724,7 +7728,9 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
   ent.meta.content_type = content_type;
   ent.meta.appendable = appendable;
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  bool add_log = log_op
+      && target->bucket_info.local_zone_id.empty()
+      && store->svc.zone->need_to_log_data();
 
   ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace, add_log);
   if (add_log) {
@@ -7754,7 +7760,9 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  bool add_log = log_op
+      && target->bucket_info.local_zone_id.empty()
+      && store->svc.zone->need_to_log_data();
 
   ret = store->cls_obj_complete_del(*bs, optag, poolid, epoch, obj, removed_mtime, remove_objs, bilog_flags, zones_trace, add_log);
 
@@ -7778,7 +7786,9 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp,
   RGWRados *store = target->get_store();
   BucketShard *bs;
 
-  bool add_log = log_op && store->svc.zone->need_to_log_data();
+  bool add_log = log_op
+      && target->bucket_info.local_zone_id.empty()
+      && store->svc.zone->need_to_log_data();
 
   int ret = guard_reshard(dpp, obj, &bs, [&](BucketShard *bs) -> int {
 				 return store->cls_obj_complete_cancel(*bs, optag, obj, remove_objs, bilog_flags, zones_trace, add_log);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -2396,6 +2396,7 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
                             const rgw_bucket& bucket,
                             const rgw_owner& owner,
                             const std::string& zonegroup_id,
+                            const std::string& local_zone_id,
                             const rgw_placement_rule& placement_rule,
                             const RGWZonePlacementInfo* zone_placement,
                             const std::map<std::string, bufferlist>& attrs,
@@ -2425,6 +2426,7 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
 
     info.owner = owner;
     info.zonegroup = zonegroup_id;
+    info.local_zone_id  = local_zone_id;
     info.placement_rule = placement_rule;
     info.swift_versioning = swift_ver_location.has_value();
     if (swift_ver_location) {

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -636,6 +636,7 @@ public:
                     const rgw_bucket& bucket,
                     const rgw_owner& owner,
                     const std::string& zonegroup_id,
+                    const std::string& local_zone_id,
                     const rgw_placement_rule& placement_rule,
                     const RGWZonePlacementInfo* zone_placement,
                     const std::map<std::string, bufferlist>& attrs,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -169,7 +169,7 @@ int RadosBucket::create(const DoutPrefixProvider* dpp,
   key.bucket_id = params.bucket_id;
 
   int ret = store->getRados()->create_bucket(
-      dpp, y, key, params.owner, params.zonegroup_id,
+      dpp, y, key, params.owner, params.zonegroup_id, params.local_zone_id,
       params.placement_rule, params.zone_placement, params.attrs,
       params.obj_lock_enabled, params.swift_ver_location,
       params.quota, params.creation_time, params.index_type,

--- a/src/rgw/driver/rados/rgw_zone.h
+++ b/src/rgw/driver/rados/rgw_zone.h
@@ -241,7 +241,7 @@ struct RGWZoneGroup {
   std::string id;
   std::string name;
   std::string api_name;
-  std::list<std::string> endpoints;
+  std::vector<std::string> endpoints;
   bool is_master = false;
 
   rgw_zone_id master_zone;
@@ -278,9 +278,6 @@ struct RGWZoneGroup {
   RGWZoneGroup(): is_master(false){}
   RGWZoneGroup(const std::string &_id, const std::string &_name):id(_id), name(_name) {}
   explicit RGWZoneGroup(const std::string &_name):name(_name) {}
-  RGWZoneGroup(const std::string &_name, bool _is_master, const std::string& _realm_id,
-               const std::list<std::string>& _endpoints)
-    : name(_name), endpoints(_endpoints), is_master(_is_master), realm_id(_realm_id) {}
 
   const std::string& get_name() const { return name; }
   const std::string& get_id() const { return id; }

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -1919,7 +1919,8 @@ static int send_to_remote_gateway(RGWRESTConn* conn, req_info& info,
 
   ceph::bufferlist response;
   rgw_user user;
-  auto result = conn->forward(dpp(), user, info, MAX_REST_RESPONSE, &in_data, &response, null_yield);
+  auto result = conn->forward(dpp(), user, info, MAX_REST_RESPONSE,
+                              param_vec_t{}, &in_data, &response, null_yield);
   if (!result) {
     return result.error();
   }

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -5566,7 +5566,7 @@ int main(int argc, const char **argv)
         zonegroup.name = zonegroup_name;
         zonegroup.is_master = is_master;
         zonegroup.realm_id = realm.get_id();
-        zonegroup.endpoints = endpoints;
+        zonegroup.endpoints.assign(endpoints.begin(), endpoints.end());
         zonegroup.api_name = (api_name.empty() ? zonegroup_name : api_name);
 
         zonegroup.enabled_features = enable_features;
@@ -5718,7 +5718,7 @@ int main(int argc, const char **argv)
         }
 
         if (!endpoints.empty()) {
-          zonegroup.endpoints = endpoints;
+          zonegroup.endpoints.assign(endpoints.begin(), endpoints.end());
           need_update = true;
         }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -144,6 +144,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ECANCELED, {409, "ConcurrentModification"}},
     { EDQUOT, {507, "InsufficientCapacity"}},
     { ENOSPC, {507, "InsufficientCapacity"}},
+    { ERR_REDIRECT_ZONE_GONE, {410, "Gone"}},
 });
 
 rgw_http_errors rgw_http_swift_errors({

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -349,6 +349,7 @@ inline constexpr const char* RGW_REST_STS_XMLNS =
 #define ERR_PRESIGNED_URL_DISABLED     2224
 #define ERR_AUTHORIZATION        2225 // SNS 403 AuthorizationError
 #define ERR_ILLEGAL_LOCATION_CONSTRAINT_EXCEPTION 2226
+#define ERR_REDIRECT_ZONE_GONE   2227
 
 #define ERR_BUSY_RESHARDING      2300 // also in cls_rgw_types.h, don't change!
 #define ERR_NO_SUCH_ENTITY       2301

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1106,6 +1106,9 @@ struct RGWBucketInfo {
   RGWObjectLock obj_lock;
 
   std::optional<rgw_sync_policy_info> sync_policy;
+  // When not empty, this bucket is pinned to the given zone of the zonegroup.
+  // Requests for this bucket's data get redirected to this zone.
+  std::string local_zone_id;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1577,6 +1577,12 @@ void RGWPutBucketReplication::execute(optional_yield y) {
   }
 
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this, y] {
+    // TODO: validate destination buckets too
+    if (!s->bucket->get_info().local_zone_id.empty()) {
+      s->err.message = "Cannot set replication policy on zone-local buckets.";
+      return -ERR_INVALID_BUCKET_STATE;
+    }
+
     auto sync_policy = (s->bucket->get_info().sync_policy ? *s->bucket->get_info().sync_policy : rgw_sync_policy_info());
 
     for (auto& group : sync_policy_groups) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -148,7 +148,7 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
                                   const rgw_owner& effective_owner,
                                   bufferlist* indata, JSONParser* jp,
                                   const req_info& req, rgw_err& err,
-                                  optional_yield y)
+                                  optional_yield y, param_vec_t params)
 {
   const auto& period = site.get_period();
   if (!period) {
@@ -179,8 +179,8 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
                           creds, site.get_zonegroup().id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
-  auto result = conn.forward(dpp, effective_owner, req,
-                             max_response_size, indata, &outdata, y);
+  auto result = conn.forward(dpp, effective_owner, req, max_response_size,
+                             std::move(params), indata, &outdata, y);
   if (!result) {
     return result.error();
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3901,9 +3901,16 @@ void RGWCreateBucket::execute(optional_yield y)
 
   if (!driver->is_meta_master()) {
     // apply bucket creation on the master zone first
+    param_vec_t params;
+    if (!createparams.local_zone_id.empty()) {
+      // zone-local buckets must forward their own zone id
+      params.emplace_back(RGW_SYS_PARAM_PREFIX "local-zone-id",
+                          createparams.local_zone_id);
+    }
     JSONParser jp;
     op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                           &in_data, &jp, s->info, s->err, y);
+                                           &in_data, &jp, s->info, s->err,
+                                           y, std::move(params));
     if (op_ret < 0) {
       return;
     }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -48,6 +48,7 @@
 #include "rgw_sal.h"
 #include "rgw_compression_types.h"
 #include "rgw_log.h"
+#include "rgw_http_client.h"
 
 #include "rgw_lc.h"
 #include "rgw_tag.h"
@@ -75,7 +76,7 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
                                   const rgw_owner& effective_owner,
                                   bufferlist* indata, JSONParser* jp,
                                   const req_info& req, rgw_err& err,
-                                  optional_yield y);
+                                  optional_yield y, param_vec_t params = {});
 
 int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
                                        CephContext *cct,

--- a/src/rgw/rgw_period_puller.cc
+++ b/src/rgw/rgw_period_puller.cc
@@ -43,7 +43,8 @@ int pull_period(const DoutPrefixProvider *dpp, RGWRESTConn* conn, const std::str
 
   bufferlist data;
 #define MAX_REST_RESPONSE (128 * 1024)
-  auto result = conn->forward(dpp, user, info, MAX_REST_RESPONSE, nullptr, &data, y);
+  auto result = conn->forward(dpp, user, info, MAX_REST_RESPONSE,
+                              param_vec_t{}, nullptr, &data, y);
   if (!result) {
     return result.error();
   }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Driver* driver,
                          const string& _remote_id,
-                         const list<string>& remote_endpoints,
+                         const vector<string>& remote_endpoints,
                          std::optional<string> _api_name,
                          HostStyle _host_style)
   : cct(_cct),
@@ -36,7 +36,7 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Driver* driver,
 
 RGWRESTConn::RGWRESTConn(CephContext *_cct,
                          const string& _remote_id,
-                         const list<string>& remote_endpoints,
+                         const vector<string>& remote_endpoints,
                          RGWAccessKey _cred,
                          std::string _zone_group,
                          std::optional<string> _api_name,

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -156,7 +156,8 @@ void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, con
 
 auto RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
                           const req_info& info, size_t max_response,
-                          bufferlist *inbl, bufferlist *outbl, optional_yield y)
+                          param_vec_t extra_params, bufferlist *inbl,
+                          bufferlist *outbl, optional_yield y)
   -> tl::expected<int, int>
 {
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
@@ -166,7 +167,7 @@ auto RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
     if (ret < 0) {
       return tl::unexpected(ret);
     }
-    param_vec_t params;
+    param_vec_t params = extra_params;
     populate_params(params, &uid, self_zone_group);
     RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params, api_name);
     auto result = req.forward_request(dpp, key, info, max_response, inbl, outbl, y);

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -132,7 +132,8 @@ public:
   /* sync request */
   auto forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
                const req_info& info, size_t max_response,
-               bufferlist *inbl, bufferlist *outbl, optional_yield y)
+               param_vec_t extra_params, bufferlist *inbl,
+               bufferlist *outbl, optional_yield y)
     -> tl::expected<int, int>;
 
   /* sync request */

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -85,12 +85,12 @@ public:
   RGWRESTConn(CephContext *_cct,
               rgw::sal::Driver* driver,
               const std::string& _remote_id,
-              const std::list<std::string>& endpoints,
+              const std::vector<std::string>& endpoints,
               std::optional<std::string> _api_name,
               HostStyle _host_style = PathStyle);
   RGWRESTConn(CephContext *_cct,
 	      const std::string& _remote_id,
-	      const std::list<std::string>& endpoints,
+	      const std::vector<std::string>& endpoints,
 	      RGWAccessKey _cred,
 	      std::string _zone_group,
 	      std::optional<std::string> _api_name,
@@ -243,9 +243,9 @@ class S3RESTConn : public RGWRESTConn {
 
 public:
 
-  S3RESTConn(CephContext *_cct, rgw::sal::Driver* driver, const std::string& _remote_id, const std::list<std::string>& endpoints, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle) :
+  S3RESTConn(CephContext *_cct, rgw::sal::Driver* driver, const std::string& _remote_id, const std::vector<std::string>& endpoints, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle) :
     RGWRESTConn(_cct, driver, _remote_id, endpoints, _api_name, _host_style) {}
-  S3RESTConn(CephContext *_cct, const std::string& _remote_id, const std::list<std::string>& endpoints, RGWAccessKey _cred, std::string _zone_group, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle):
+  S3RESTConn(CephContext *_cct, const std::string& _remote_id, const std::vector<std::string>& endpoints, RGWAccessKey _cred, std::string _zone_group, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle):
     RGWRESTConn(_cct, _remote_id, endpoints, _cred, _zone_group, _api_name, _host_style) {}
   ~S3RESTConn() override = default;
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -885,6 +885,7 @@ class Bucket {
     struct CreateParams {
       rgw_owner owner;
       std::string zonegroup_id;
+      std::string local_zone_id; //< id for zone-local buckets
       rgw_placement_rule placement_rule;
       // zone placement is optional on buckets created for another zonegroup
       const RGWZonePlacementInfo* zone_placement = nullptr;

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -769,7 +769,7 @@ int add_zone_to_group(const DoutPrefixProvider* dpp, RGWZoneGroup& zonegroup,
   zone.id = zone_params.id;
   zone.name = zone_params.name;
   if (!endpoints.empty()) {
-    zone.endpoints = endpoints;
+    zone.endpoints.assign(endpoints.begin(), endpoints.end());
   }
   if (pread_only) {
     zone.read_only = *pread_only;

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -316,7 +316,7 @@ WRITE_CLASS_ENCODER(RGWZonePlacementInfo)
 struct RGWZone {
   std::string id;
   std::string name;
-  std::list<std::string> endpoints; // std::vector?
+  std::vector<std::string> endpoints;
   bool log_meta;
   bool log_data;
   bool read_only;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -453,6 +453,18 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
                                         const rgw::bucket_index_layout_generation& idx_layout,
                                         bool judge_support_logrecord)
 {
+  // only create the index for buckets located on this zone/zonegroup
+  if (bucket_info.zonegroup != svc.zone->get_zonegroup().id) {
+    ldpp_dout(dpp, 10) << "not creating index for bucket on "
+        "remote zonegroup " << bucket_info.zonegroup << dendl;
+    return 0;
+  }
+  if (!bucket_info.local_zone_id.empty() &&
+      bucket_info.local_zone_id != svc.zone->zone_id().id) {
+    ldpp_dout(dpp, 10) << "not creating index for zone-local bucket "
+        "on remote zone " << bucket_info.local_zone_id << dendl;
+    return 0;
+  }
   if (idx_layout.layout.type != rgw::BucketIndexType::Normal) {
     return 0;
   }


### PR DESCRIPTION
design doc: https://gist.github.com/cbodley/0bc29a6258825f6d912d91c961ca1fd6
Fixes: https://tracker.ceph.com/issues/70876

TODO:
- [x] forwarded requests on master set source zone
- [x] avoid creating bucket index on other zones

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
