### PR TITLE
doc: minor additions based on the latest mods

### DIFF
--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -96,9 +96,9 @@ We'll use a stable/regular 15.2.17 release of Octopus as an example throughout t
 2. Log in with GitHub OAuth
 3. Set the parameters as necessary::
 
-    BRANCH=octopus
+    BRANCH=squid
     TAG=checked
-    VERSION=15.2.17
+    VERSION=19.2.2
     RELEASE_TYPE=STABLE
     ARCHS=x86_64 arm64
 
@@ -147,21 +147,27 @@ See `the Ceph Tracker wiki page that explains how to write the release notes <ht
 
    Example::
 
-      $ sync-pull ceph octopus 8a82819d84cf884bd39c17e3236e0632ac146dc4
-      sync for: ceph octopus
+      $ sync-pull ceph squid 0eceb0defba60152a8182f7bd87d164b639885b8
+      sync for: ceph squid
       ********************************************
-      Found the most packages (332) in ubuntu/bionic.
-      No JSON object could be decoded
-      No JSON object could be decoded
-      ubuntu@chacra.ceph.com:/opt/repos/ceph/octopus/8a82819d84cf884bd39c17e3236e0632ac146dc4/ubuntu/bionic/flavors/default/* /opt/repos/ceph/octopus-15.2.17/debian/jessie/
-      --------------------------------------------
-      receiving incremental file list
-      db/
-       db/checksums.db
-              180.22K 100%    2.23MB/s    0:00:00 (xfr#1, to-chk=463/467)
-      db/contents.cache.db
-              507.90K 100%    1.95MB/s    0:00:00 (xfr#2, to-chk=462/467)
-      db/packages.db
+      + : 0eceb0defba60152a8182f7bd87d164b639885b8
+      + project=ceph
+      + release=squid
+      + sha1=0eceb0defba60152a8182f7bd87d164b639885b8
+      + echo 'sync for: ceph squid'
+      sync for: ceph squid
+      + echo '********************************************'
+      ********************************************
+      + [[ ceph == \c\e\p\h ]]
+      + current_highest_count=0
+      + for combo in debian/bookworm debian/bullseye ubuntu/bionic ubuntu/focal ubuntu/jammy
+      ++ wc -l
+      ++ curl -fs https://chacra.ceph.com/r/ceph/squid/0eceb0defba60152a8182f7bd87d164b639885b8/debian/bookworm/flavors/default/pool/main/c/ceph/
+      + combo_count=161
+      + [[ 0 -eq 22 ]]
+      + '[' 161 -gt 0 ']'
+      + current_highest_count=161
+      + highest_combo=debian/bookworm
 
       etc...
 
@@ -169,20 +175,16 @@ See `the Ceph Tracker wiki page that explains how to write the release notes <ht
 
    .. prompt:: bash
 
-      merfi gpg /opt/repos/ceph/octopus-15.2.17/debian
+      merfi gpg /opt/repos/ceph/squid-19.2.2/debian/
 
    Example::
 
-      $ merfi gpg /opt/repos/ceph/octopus-15.2.17/debian
       --> Starting path collection, looking for files to sign
-      --> 18 matching paths found
-      --> will sign with the following commands:
-      --> gpg --batch --yes --armor --detach-sig --output Release.gpg Release
-      --> gpg --batch --yes --clearsign --output InRelease Release
-      --> signing: /opt/repos/ceph/octopus-15.2.17/debian/jessie/dists/bionic/Release
+      --> 1 repos found
+      --> signing: /opt/repos/ceph/squid-19.2.2/debian/jessie/dists/bookworm/Release
       --> Running command: gpg --batch --yes --armor --detach-sig --output Release.gpg Release
       --> Running command: gpg --batch --yes --clearsign --output InRelease Release
-      --> signing: /opt/repos/ceph/octopus-15.2.17/debian/jessie/dists/focal/Release
+      --> signing: /opt/repos/ceph/squid-19.2.2/debian/jessie/dists/jammy/Release
       --> Running command: gpg --batch --yes --armor --detach-sig --output Release.gpg Release
       --> Running command: gpg --batch --yes --clearsign --output InRelease Release
 
@@ -192,17 +194,35 @@ See `the Ceph Tracker wiki page that explains how to write the release notes <ht
 
    .. prompt:: bash
 
-      sign-rpms ceph octopus
+      sign-rpms ceph squid
 
    Example::
 
-      $ sign-rpms ceph octopus
-      Checking packages in: /opt/repos/ceph/octopus-15.2.17/centos/7
-      signing:  /opt/repos/ceph/octopus-15.2.17/centos/7/SRPMS/ceph-release-1-1.el7.src.rpm
-      /opt/repos/ceph/octopus-15.2.17/centos/7/SRPMS/ceph-release-1-1.el7.src.rpm:
-      signing:  /opt/repos/ceph/octopus-15.2.17/centos/7/SRPMS/ceph-15.2.17-0.el7.src.rpm
-      /opt/repos/ceph/octopus-15.2.17/centos/7/SRPMS/ceph-15.2.17-0.el7.src.rpm:
-      signing:  /opt/repos/ceph/octopus-15.2.17/centos/7/noarch/ceph-mgr-modules-core-15.2.17-0.el7.noarch.rpm
+      $ sign-rpms ceph squid
+
+      + [[ 2 -lt 1 ]]
+      + project=ceph
+      + shift
+      + '[' 1 -eq 0 ']'
+      + releases=("$@")
+      + distros=(centos rhel)
+      + distro_versions=(7 8 9)
+      + read -s -p 'Key Passphrase: ' GPG_PASSPHRASE
+      Key Passphrase: + echo
+
+      + for release in "${releases[@]}"
+      + for distro in "${distros[@]}"
+      + for distro_version in "${distro_versions[@]}"
+      + for path in /opt/repos/$project/$release*
+      + '[' -d /opt/repos/ceph/squid-19.1.0/centos/7 ']'
+      ...
+      + echo 'Checking packages in: /opt/repos/ceph/squid-19.1.0/centos/9'
+      Checking packages in: /opt/repos/ceph/squid-19.1.0/centos/9
+      + update_repo=0
+      + cd /opt/repos/ceph/squid-19.1.0/centos/9
+      ++ find -name '*.rpm'
+      + for rpm in `find -name "*.rpm"`
+      ++ grep '^Signature'
 
       etc...
 
@@ -210,7 +230,7 @@ See `the Ceph Tracker wiki page that explains how to write the release notes <ht
 
    .. prompt:: bash $
 
-      sync-push ceph octopus
+      sync-push ceph squid-19.2.2 2
 
 This leaves the packages, and the tarball, in a password-protected
 prerelease area at https://download.ceph.com/prerelease/ceph.  Verify them
@@ -230,8 +250,9 @@ This must be done after :ref:`Signing and Publishing the Build`.
 
 A Jenkins job named ``ceph-release-containers`` exists so that we can test the
 images before release. The job exists both for convenience and because it
-requires access to both x86_64 and arm64 builders. Start the job manually on
-the Jenkins server. This job:
+requires access to both x86_64 and arm64 builders. Start the job as Build with Parameters on
+the Jenkins server, set ``BRANCH``, ``SHA1`` and ``VERSION`` fields and leave other fields as defaults. 
+This job:
 
 * builds the architecture-specific container imagess and pushes them to
   ``quay.ceph.io/ceph/prerelease-amd64`` and
@@ -244,7 +265,7 @@ Finally, when all appropriate testing and verification is done on the
 container images, run ``make-manifest-list.py --promote`` from the Ceph
 source tree (at ``container/make-manifest-list.py``) to promote them to
 their final release location on ``quay.io/ceph/ceph`` (you must ensure
-that you're logged into ``quay.io/ceph`` with appropriate permissions):
+that you're logged into ``quay.io/ceph`` and ``quay.ceph.io/ceph`` with appropriate permissions):
 
     .. prompt:: bash
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
