### PR TITLE
reef: ceph-volume: fix regex usage in `set_dmcrypt_no_workqueue`

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
@@ -1,6 +1,44 @@
 from ceph_volume.util import encryption
-from mock.mock import patch
+from mock.mock import patch, Mock
 import base64
+import pytest
+
+
+class TestNoWorkqueue:
+    def setup_method(self):
+        encryption.conf.dmcrypt_no_workqueue = None
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=(['cryptsetup 2.7.2 flags: UDEV BLKID KEYRING' \
+                               'FIPS KERNEL_CAPI PWQUALITY '], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_true(self):
+        encryption.set_dmcrypt_no_workqueue()
+        assert encryption.conf.dmcrypt_no_workqueue
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=(['cryptsetup 2.0.0'], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_false(self):
+        encryption.set_dmcrypt_no_workqueue()
+        assert encryption.conf.dmcrypt_no_workqueue is None
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=([''], ['fake error'], 1)))
+    def test_set_dmcrypt_no_workqueue_cryptsetup_version_fails(self):
+        with pytest.raises(RuntimeError):
+            encryption.set_dmcrypt_no_workqueue()
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=(['unexpected output'], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_pattern_not_found(self):
+        with pytest.raises(RuntimeError):
+            encryption.set_dmcrypt_no_workqueue()
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=([], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_index_error(self):
+        with pytest.raises(RuntimeError):
+            encryption.set_dmcrypt_no_workqueue()
+
 
 class TestGetKeySize(object):
     def test_get_size_from_conf_default(self, conf_ceph_stub):

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -41,13 +41,13 @@ def set_dmcrypt_no_workqueue(target_version: str = '2.3.4') -> None:
 
     # This regex extracts the version number from
     # the `cryptsetup --version` output
-    pattern: str = r'\b\d+(\.\d+)*\b'
+    pattern: str = r'(\d+\.?)+'
 
     if rc:
         raise RuntimeError(f"Can't retrieve cryptsetup version: {err}")
 
     try:
-        cryptsetup_version = re.match(pattern, out[0])
+        cryptsetup_version = re.search(pattern, out[0])
 
         if cryptsetup_version is None:
             _output: str = "\n".join(out)


### PR DESCRIPTION
With 18.2.5, it seems we can't activate dmcrypt'd OSDs using the upstream containers, at least `quay.io/ceph/ceph:v18.2.5`.

Backports commit [here](https://github.com/ceph/ceph/commit/607eb34b2c278566c386efcbf3018629cf08ccfd), simply cherry-picked.

In the referenced mailing list post, I suggested a dirty workaround, and am posting it being used below:

```
[root@prod-storage-001 /]# ceph-volume lvm activate --no-systemd 60 44f6ec4e-c272-4f96-951c-c9604ffcedd9
-->  RuntimeError: ('Error while checking cryptsetup version.\n', '`cryptsetup --version` output:\n', 'cryptsetup 2.7.2 flags: UDEV BLKID KEYRING FIPS KERNEL_CAPI PWQUALITY ')
[root@prod-storage-001 /]# sed -i "s/pattern:.*/pattern: str = r'(\\\d+\\\.?)+'/g" /usr/lib/python3.9/site-packages/ceph_volume/util/encryption.py
[root@prod-storage-001 /]# sed -i "s/cryptsetup_version = re.*/cryptsetup_version = re.search(pattern, out[0])/g" /usr/lib/python3.9/site-packages/ceph_volume/util/encryption.py
[root@prod-storage-001 /]# ceph-volume lvm activate --no-systemd 60 44f6ec4e-c272-4f96-951c-c9604ffcedd9
Running command: /usr/bin/mount -t tmpfs tmpfs /var/lib/ceph/osd/ceph-60
--> Creating keyring file for client.osd-lockbox.44f6ec4e-c272-4f96-951c-c9604ffcedd9
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-60/lockbox.keyring
--> Running ceph config-key get dm-crypt/osd/44f6ec4e-c272-4f96-951c-c9604ffcedd9/luks
Running command: /usr/bin/ceph --cluster ceph --name client.osd-lockbox.44f6ec4e-c272-4f96-951c-c9604ffcedd9 --keyring /var/lib/ceph/osd/ceph-60/lockbox.keyring config-key get dm-crypt/osd/44f6ec4e-c272-4f96-951c-c9604ffcedd9/luks
Running command: /usr/sbin/cryptsetup --key-size 512 --key-file - --allow-discards luksOpen /dev/ceph-c5c43f24-7174-4305-a2da-58dc646f606f/osd-block-44f6ec4e-c272-4f96-951c-c9604ffcedd9 zpvX8O-VoZQ-4Und-S131-rwsu-0ptP-zy0YVY --perf-no_read_workqueue --perf-no_write_workqueue
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-60
Running command: /usr/bin/ceph-bluestore-tool --cluster=ceph prime-osd-dir --dev /dev/mapper/zpvX8O-VoZQ-4Und-S131-rwsu-0ptP-zy0YVY --path /var/lib/ceph/osd/ceph-60 --no-mon-config
Running command: /usr/bin/ln -snf /dev/mapper/zpvX8O-VoZQ-4Und-S131-rwsu-0ptP-zy0YVY /var/lib/ceph/osd/ceph-60/block
Running command: /usr/bin/chown -h ceph:ceph /var/lib/ceph/osd/ceph-60/block
Running command: /usr/bin/chown -R ceph:ceph /dev/mapper/zpvX8O-VoZQ-4Und-S131-rwsu-0ptP-zy0YVY
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-60
--> ceph-volume lvm activate successful for osd ID: 60
```

For my case, this is done before a call to `ceph-volumne lvm activate ...` in a script that runs just before the OSD is started.

Ref: https://lists.ceph.io/hyperkitty/list/dev@ceph.io/message/JHEGT3TB2KIFJBTT2BTEMCLRGF7L5VWJ/
Ref: https://github.com/ceph/ceph/commit/607eb34b2c278566c386efcbf3018629cf08ccfd
Ref: https://tracker.ceph.com/issues/66393

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
