### PR TITLE
rgw: metadata and data sync notification to retry upon any failure case

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -2404,8 +2404,7 @@ public:
         set_status("sync lock notification");
         yield call(sync_env->bid_manager->notify_cr());
         if (retcode < 0) {
-          tn->log(5, SSTR("ERROR: failed to notify bidding information" << retcode));
-          return set_cr_error(retcode);
+          tn->log(5, SSTR("ERROR: failed to notify bidding information retcode=" << retcode));
         }
 
         set_status("sleeping");

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -1996,8 +1996,7 @@ public:
         set_status("sync lock notification");
         yield call(sync_env->bid_manager->notify_cr());
         if (retcode < 0) {
-          tn->log(5, SSTR("ERROR: failed to notify bidding information" << retcode));
-          return set_cr_error(retcode);
+          tn->log(5, SSTR("ERROR: failed to notify bidding information retcode=" << retcode));
         }
 
         set_status("sleeping");


### PR DESCRIPTION
Addresses https://tracker.ceph.com/issues/70270.

This is another fix, along with the earlier fix https://github.com/ceph/ceph/pull/62156, to complete the fix for https://tracker.ceph.com/issues/70270. 

## Testing

Testing has been done manually in an mstart env. Some details at [slack](https://ceph-storage.slack.com/archives/C05LPHSKVPG/p1740001077034029). Below is a slice of the slack discussion.

For testing purpose, added a custom event before & after the [RGWRadosNotifyCR call](https://github.com/ceph/ceph/blob/0da914551cb031ecafd417b13a0055e09a6083d7/src/rgw/driver/rados/sync_fairness.cc#L330) and saw that when an instance restarts it sometimes get timeout, also added some custom events within [RGWDataSyncShardNotifyCR inifinite notification loop](https://github.com/ceph/ceph/blob/0da914551cb031ecafd417b13a0055e09a6083d7/src/rgw/driver/rados/rgw_data_sync.cc#L2404), it shows that loop exits and never runs again:

<pre>
2025-04-11T20:51:59.421+0000 7fa903e95700  1 RGW-SYNC:data:sync: test before the call sync_env->bid_manager->notify_cr()
# notifycr gets timeout
2025-04-11T20:51:59.421+0000 7fa903e95700  1 rgw rados thread: NotifyCR::operate call start zg1-1.rgw.control:data-sync-bids.40ae2f77-e43b-4e4f-93db-54834bfe0004 with timeout 15000
2025-04-11T20:52:14.421+0000 7fa903e95700  1 rgw rados thread: NotifyCR::operate call end zg1-1.rgw.control:data-sync-bids.40ae2f77-e43b-4e4f-93db-54834bfe0004 ret -110
# the for loop exits
2025-04-11T20:52:14.421+0000 7fa903e95700  1 RGW-SYNC:data:sync: ERROR: failed to notify bidding information -110
</pre>

With the proposed fix above, the retry eventually succeeds:

<pre>
2025-04-11T21:16:02.244+0000 7f6fb8beb700  1 RGW-SYNC:data:sync: test before the call sync_env->bid_manager->notify_cr()

# again at the very first attempt right after instance restart, it gets timeout
2025-04-11T21:16:02.244+0000 7f6fb8beb700  1 rgw rados thread: NotifyCR::operate call start zg1-1.rgw.control:data-sync-bids.40ae2f77-e43b-4e4f-93db-54834bfe0004 with timeout 15000
2025-04-11T21:16:17.244+0000 7f6fb8beb700  1 rgw rados thread: NotifyCR::operate call end zg1-1.rgw.control:data-sync-bids.40ae2f77-e43b-4e4f-93db-54834bfe0004 ret -110

# logs the error but doesn't exit loop this time
2025-04-11T21:16:17.244+0000 7f6fb8beb700  1 RGW-SYNC:data:sync: ERROR: failed to notify bidding information -110

# 2 mins later, the next retry succeeds and things go back to normal on this instance
2025-04-11T21:18:17.244+0000 7f6fb8beb700  1 RGW-SYNC:data:sync: test before the call sync_env->bid_manager->notify_cr()

# this time succeeds & for loop doesn't log any error and goes to sleep
2025-04-11T21:18:17.244+0000 7f6fb8beb700  1 rgw rados thread: NotifyCR::operate call start zg1-1.rgw.control:data-sync-bids.40ae2f77-e43b-4e4f-93db-54834bfe0004 with timeout 15000
2025-04-11T21:18:17.245+0000 7f6fb8beb700  1 rgw rados thread: NotifyCR::operate call endzg1-1.rgw.control:data-sync-bids.40ae2f77-e43b-4e4f-93db-54834bfe0004 ret 0
</pre>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
