### PR TITLE
squid: osd/scheduler/OpSchedulerItem: Fix calculation of recovery latency counters

### DIFF
--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -190,7 +190,7 @@ void PGRecovery::run(
 {
   osd->logger->tinc(
     l_osd_recovery_queue_lat,
-    time_queued - ceph_clock_now());
+    ceph_clock_now() - time_queued);
   osd->do_recovery(pg.get(), epoch_queued, reserved_pushes, priority, handle);
   pg->unlock();
 }
@@ -203,7 +203,7 @@ void PGRecoveryContext::run(
 {
   osd->logger->tinc(
     l_osd_recovery_context_queue_lat,
-    time_queued - ceph_clock_now());
+    ceph_clock_now() - time_queued);
   c.release()->complete(handle);
   pg->unlock();
 }
@@ -223,7 +223,7 @@ void PGRecoveryMsg::run(
   PGRef& pg,
   ThreadPool::TPHandle &handle)
 {
-  auto latency = time_queued - ceph_clock_now();
+  auto latency = ceph_clock_now() - time_queued;
   switch (op->get_req()->get_type()) {
   case MSG_OSD_PG_PUSH:
     osd->logger->tinc(l_osd_recovery_push_queue_lat, latency);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70904

---

backport of https://github.com/ceph/ceph/pull/62704
parent tracker: https://tracker.ceph.com/issues/70811

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh