### PR TITLE
rgw/multisite: sync object tagging deletion

### DIFF
--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -3426,6 +3426,11 @@ RadosObject::RadosReadOp::RadosReadOp(RadosObject *_source, RGWObjectCtx *_octx)
 int RadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider* dpp)
 {
   uint64_t obj_size;
+  ceph::real_time mtime;
+
+  if (!params.lastmod) {
+    params.lastmod = &mtime;
+  }
 
   parent_op.conds.mod_ptr = params.mod_ptr;
   parent_op.conds.unmod_ptr = params.unmod_ptr;
@@ -3446,6 +3451,7 @@ int RadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider
 
   source->set_instance(parent_op.state.obj.key.instance);
   source->set_obj_size(obj_size);
+  source->set_mtime(*params.lastmod);
   params.parts_count = parent_op.params.parts_count;
 
   return ret;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -309,6 +309,11 @@ static int get_obj_policy_from_attr(const DoutPrefixProvider *dpp,
 
   std::unique_ptr<rgw::sal::Object::ReadOp> rop = obj->get_read_op();
 
+  ret = rop->prepare(y, dpp);
+  if (ret < 0) {
+    return ret;
+  }
+
   ret = rop->get_attr(dpp, RGW_ATTR_ACL, bl, y);
   if (ret >= 0) {
     ret = decode_policy(dpp, cct, bl, policy);

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -5865,3 +5865,115 @@ def test_copy_obj_perm_check_between_zonegroups(zonegroup):
                           CopySource={'Bucket': source_bucket.name, 'Key': objname},
                           Key=objname)
         assert e.response['Error']['Code'] == 'AccessDenied'
+        
+
+@attr('object_tagging')
+def test_create_delete_obj_tagging():
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    primary = zonegroup_conns.rw_zones[0]
+    secondary = zonegroup_conns.rw_zones[1]
+
+    bucket = primary.create_bucket(gen_bucket_name())
+    log.debug('created bucket=%s', bucket.name)
+
+    objname = 'dummy'
+
+    # upload a dummy object and wait for sync.
+    k = new_key(primary, bucket, objname)
+    k.set_contents_from_string('foo')
+    zonegroup_meta_checkpoint(zonegroup)
+
+    zonegroup_data_checkpoint(zonegroup_conns)
+    log.debug('created object=%s', objname)
+
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+
+    # put object tagging on primary zone
+    primary.s3_client.put_object_tagging(Bucket=bucket.name,
+                                Key= objname,
+                                Tagging={
+                                    'TagSet': [
+                                        {
+                                            'Key': 'key1',
+                                            'Value': 'value1'
+                                        },
+                                        ]})
+
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+
+    response = secondary.s3_client.get_object_tagging(Bucket=bucket.name,
+                                                      Key = objname)
+    assert(response['TagSet'][0]['Key'] == 'key1')
+    assert(response['TagSet'][0]['Value'] == 'value1')
+
+    primary.s3_client.delete_object_tagging(Bucket=bucket.name,
+                                Key= objname)
+
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+
+    response = secondary.s3_client.get_object_tagging(Bucket=bucket.name,
+                                                      Key = objname)
+
+    assert(response['TagSet'] == [])
+
+@attr('object_tagging')
+def test_create_delete_versioned_obj_tagging():
+
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+
+    primary = zonegroup_conns.rw_zones[0]
+    secondary = zonegroup_conns.rw_zones[1]
+
+    bucket = primary.create_bucket(gen_bucket_name())
+    log.debug('created bucket=%s', bucket.name)
+    zonegroup_meta_checkpoint(zonegroup)
+    
+    # upload an initial object
+    objname = 'dummy'
+    key = new_key(primary, bucket, objname)
+    key.set_contents_from_string('bar')
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+
+    # enable versioning
+    bucket.configure_versioning(True)
+    zonegroup_meta_checkpoint(zonegroup)
+
+    # upload object
+    k = new_key(primary, bucket, objname)
+    k.set_contents_from_string('foo')
+    log.debug('created new version id=%s', k.version_id)
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+    
+    # put object tagging on primary zone
+    primary.s3_client.put_object_tagging(Bucket=bucket.name,
+                                Key= objname,
+                                VersionId = k.version_id,
+                                Tagging={
+                                    'TagSet': [
+                                        {
+                                            'Key': 'key1',
+                                            'Value': 'value1'
+                                        },
+                                        ]})
+  
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+
+    response = secondary.s3_client.get_object_tagging(Bucket=bucket.name,
+                                                      Key = objname,
+                                                      VersionId = k.version_id)
+    assert(response['TagSet'][0]['Key'] == 'key1')
+    assert(response['TagSet'][0]['Value'] == 'value1')
+
+    primary.s3_client.delete_object_tagging(Bucket=bucket.name,
+                                Key= objname,
+                                VersionId = k.version_id)
+
+    zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
+ 
+    response = secondary.s3_client.get_object_tagging(Bucket=bucket.name,
+                                                      Key = objname,
+                                                      VersionId = k.version_id)
+
+    assert(response['TagSet'] == [])


### PR DESCRIPTION

https://tracker.ceph.com/issues/70920




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
