### PR TITLE
osd/scrub: performance counters: count I/Os, use unlabeled counters

### DIFF
--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -369,27 +369,109 @@ PerfCounters *build_osd_logger(CephContext *cct) {
   osd_plb.add_u64_counter(l_osd_scrub_rppool_read_cnt, "scrub_replicated_read_cnt", "scrub replicated pool read calls count");
   osd_plb.add_u64_counter(l_osd_scrub_rppool_read_bytes, "scrub_replicated_read_bytes", "scrub replicated pool read bytes read");
   // scrub I/O performed for EC pools
-  osd_plb.add_u64_counter(l_osd_scrub_ec_getattr_cnt, "scrub_ec_getattr_cnt", "scrub ec getattr calls count");
-  osd_plb.add_u64_counter(l_osd_scrub_ec_stats_cnt, "scrub_ec_stats_cnt", "scrub ec stats calls count");
-  osd_plb.add_u64_counter(l_osd_scrub_ec_read_cnt, "scrub_ec_read_cnt", "scrub ec read calls count");
-  osd_plb.add_u64_counter(l_osd_scrub_ec_read_bytes, "scrub_ec_read_bytes", "scrub ec read bytes read");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_getattr_cnt, "scrub_ec_getattr_cnt", "scrub EC getattr calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_stats_cnt, "scrub_ec_stats_cnt", "scrub EC stats calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_read_cnt, "scrub_ec_read_cnt", "scrub EC read calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_read_bytes, "scrub_ec_read_bytes", "scrub EC read bytes read");
 
-  // scrub (no EC vs. replicated differentiation)
   // scrub - replicated pools
-  osd_plb.add_u64_counter(l_osd_scrub_rppool_started, "num_scrubs_started_replicated", "replicated scrubs attempted count");
-  osd_plb.add_u64_counter(l_osd_scrub_rppool_active_started, "num_scrubs_past_reservation_replicated", "replicated scrubs count");
-  osd_plb.add_u64_counter(l_osd_scrub_rppool_successful, "successful_scrubs_replicated", "successful replicated scrubs count");
-  osd_plb.add_time_avg(l_osd_scrub_rppool_successful_elapsed, "successful_scrubs_replicated_elapsed", "time to complete a successful replicated scrub");
-  osd_plb.add_u64_counter(l_osd_scrub_rppool_failed, "failed_scrubs_replicated", "failed replicated scrubs count");
-  osd_plb.add_time_avg(l_osd_scrub_rppool_failed_elapsed, "failed_scrubs_replicated_elapsed", "time to scrub failure replicated");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_started,
+      "num_scrubs_started_replicated",
+      "replicated scrubs attempted count");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_active_started,
+      "num_scrubs_past_reservation_replicated",
+      "replicated scrubs count");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_successful,
+      "successful_scrubs_replicated",
+      "successful replicated scrubs count");
+  osd_plb.add_time_avg(
+      l_osd_scrub_rppool_successful_elapsed,
+      "successful_scrubs_replicated_elapsed",
+      "time to complete a successful replicated scrub");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_failed, "failed_scrubs_replicated",
+      "failed replicated scrubs count");
+  osd_plb.add_time_avg(
+      l_osd_scrub_rppool_failed_elapsed,
+      "failed_scrubs_replicated_elapsed",
+      "time to scrub failure replicated");
+
+  // the replica reservation process - replicated pool
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_reserv_success,
+      "scrub_replicated_scrub_reservations_completed",
+      "successfully completed reservation processes");
+  osd_plb.add_time_avg(
+      l_osd_scrub_rppool_reserv_successful_elapsed,
+      "scrub_replicated_successful_reservations_elapsed",
+      "time to scrub reservation completion");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_reserv_aborted,
+      "scrub_replicated_reservation_process_aborted",
+      "scrub replicated pool reservation was aborted");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_reserv_rejected,
+      "scrub_replicated_reservation_process_failure",
+      "scrub replicated pool reservation failed due to replica denial");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_rppool_reserv_skipped,
+      "scrub_replicated_reservation_process_skipped",
+      "scrub replicated pool reservation skipped for high priority scrub");
+  osd_plb.add_time_avg(
+      l_osd_scrub_rppool_reserv_failed_elapsed,
+      "scrub_replicated_failed_reservations_elapsed",
+      "scrub replicated pool time for scrub reservation to fail");
+  osd_plb.add_u64(
+      l_osd_scrub_rppool_reserv_secondaries_num,
+      "scrub_replicated_replicas_in_reservation",
+      "scrub replicated pool number of replicas to reserve");
 
   // scrub - EC
-  osd_plb.add_u64_counter(l_osd_scrub_ec_started, "num_scrubs_started_ec", "scrubs attempted count ec");
-  osd_plb.add_u64_counter(l_osd_scrub_ec_active_started, "num_scrubs_past_reservation_ec", "scrubs count ec");
-  osd_plb.add_u64_counter(l_osd_scrub_ec_successful, "successful_scrubs_ec", "successful scrubs count ec");
-  osd_plb.add_time_avg(l_osd_scrub_ec_successful_elapsed, "successful_scrubs_ec_elapsed", "time to complete a successful ec scrub");
-  osd_plb.add_u64_counter(l_osd_scrub_ec_failed, "failed_scrubs_ec", "failed scrubs count ec");
-  osd_plb.add_time_avg(l_osd_scrub_ec_failed_elapsed, "failed_scrubs_ec_elapsed", "time to scrub failure ec");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_started, "num_scrubs_started_ec",
+      "EC scrubs attempted count");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_active_started, "num_scrubs_past_reservation_ec",
+      "EC scrubs count");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_successful, "successful_scrubs_ec",
+      "successful EC scrubs count");
+  osd_plb.add_time_avg(
+      l_osd_scrub_ec_successful_elapsed, "successful_scrubs_ec_elapsed",
+      "time to complete a successful EC scrub");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_failed, "failed_scrubs_ec", "failed scrubs count EC");
+  osd_plb.add_time_avg(
+      l_osd_scrub_ec_failed_elapsed, "failed_scrubs_ec_elapsed",
+      "time to scrub failure ec");
+
+  // the replica reservation process - EC
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_reserv_success, "scrub_ec_reservations_completed",
+      "successfully completed reservation processes EC");
+  osd_plb.add_time_avg(
+      l_osd_scrub_ec_reserv_successful_elapsed,
+      "scrub_ec_successful_reservations_elapsed",
+      "time to EC scrub reservation completion");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_reserv_aborted, "scrub_ec_reservation_process_aborted",
+      "scrub reservation was aborted EC");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_reserv_rejected, "scrub_ec_reservation_process_failure",
+      "scrub reservation failed due to replica denial EC");
+  osd_plb.add_u64_counter(
+      l_osd_scrub_ec_reserv_skipped, "scrub_ec_reservation_process_skipped",
+      "scrub reservation skipped for high priority scrub EC");
+  osd_plb.add_time_avg(
+      l_osd_scrub_ec_reserv_failed_elapsed,
+      "scrub_ec_failed_reservations_elapsed",
+      "time for scrub reservation to fail EC");
+  osd_plb.add_u64(
+      l_osd_scrub_ec_reserv_secondaries_num, "scrub_ec_replicas_in_reservation",
+      "number of replicas to reserve EC");
 
   return osd_plb.create_perf_counters();
 }
@@ -448,14 +530,6 @@ PerfCounters *build_scrub_labeled_perf(CephContext *cct, std::string label)
   scrub_perf.add_u64_counter(scrbcnt_blocked, "locked_object", "waiting on locked object events");
   scrub_perf.add_u64_counter(scrbcnt_write_blocked, "write_blocked_by_scrub", "write blocked by scrub");
 
-  // the replica reservation process
-  scrub_perf.add_u64_counter(scrbcnt_resrv_success, "scrub_reservations_completed", "successfully completed reservation processes");
-  scrub_perf.add_time_avg(scrbcnt_resrv_successful_elapsed, "successful_reservations_elapsed", "time to scrub reservation completion");
-  scrub_perf.add_u64_counter(scrbcnt_resrv_aborted, "reservation_process_aborted", "scrub reservation was aborted");
-  scrub_perf.add_u64_counter(scrbcnt_resrv_rejected, "reservation_process_failure", "scrub reservation failed due to replica denial");
-  scrub_perf.add_u64_counter(scrbcnt_resrv_skipped, "reservation_process_skipped", "scrub reservation skipped for high priority scrub");
-  scrub_perf.add_time_avg(scrbcnt_resrv_failed_elapsed, "failed_reservations_elapsed", "time for scrub reservation to fail");
-  scrub_perf.add_u64(scrbcnt_resrv_replicas_num, "replicas_in_reservation", "number of replicas in reservation");
 
   return scrub_perf.create_perf_counters();
 }

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -374,7 +374,11 @@ PerfCounters *build_osd_logger(CephContext *cct) {
   osd_plb.add_u64_counter(l_osd_scrub_ec_read_cnt, "scrub_ec_read_cnt", "scrub ec read calls count");
   osd_plb.add_u64_counter(l_osd_scrub_ec_read_bytes, "scrub_ec_read_bytes", "scrub ec read bytes read");
 
-  // scrub I/O performed for replicated pools
+  // scrub (no EC vs. replicated differentiation)
+  // scrub - replicated pools
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_active_started, "num_scrubs_past_reservation_replicated", "scrubs count replicated");
+  // scrub - EC
+  osd_plb.add_u64_counter(l_osd_scrub_ec_active_started, "num_scrubs_past_reservation_ec", "scrubs count ec");
 
   return osd_plb.create_perf_counters();
 }
@@ -428,7 +432,6 @@ PerfCounters *build_scrub_labeled_perf(CephContext *cct, std::string label)
   scrub_perf.set_prio_default(PerfCountersBuilder::PRIO_INTERESTING);
 
   scrub_perf.add_u64_counter(scrbcnt_started, "num_scrubs_started", "scrubs attempted count");
-  scrub_perf.add_u64_counter(scrbcnt_active_started, "num_scrubs_past_reservation", "scrubs count");
   scrub_perf.add_u64_counter(scrbcnt_failed, "failed_scrubs", "failed scrubs count");
   scrub_perf.add_u64_counter(scrbcnt_successful, "successful_scrubs", "successful scrubs count");
   scrub_perf.add_time_avg(scrbcnt_failed_elapsed, "failed_scrubs_elapsed", "time to scrub failure");

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -376,9 +376,20 @@ PerfCounters *build_osd_logger(CephContext *cct) {
 
   // scrub (no EC vs. replicated differentiation)
   // scrub - replicated pools
-  osd_plb.add_u64_counter(l_osd_scrub_rppool_active_started, "num_scrubs_past_reservation_replicated", "scrubs count replicated");
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_started, "num_scrubs_started_replicated", "replicated scrubs attempted count");
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_active_started, "num_scrubs_past_reservation_replicated", "replicated scrubs count");
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_successful, "successful_scrubs_replicated", "successful replicated scrubs count");
+  osd_plb.add_time_avg(l_osd_scrub_rppool_successful_elapsed, "successful_scrubs_replicated_elapsed", "time to complete a successful replicated scrub");
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_failed, "failed_scrubs_replicated", "failed replicated scrubs count");
+  osd_plb.add_time_avg(l_osd_scrub_rppool_failed_elapsed, "failed_scrubs_replicated_elapsed", "time to scrub failure replicated");
+
   // scrub - EC
+  osd_plb.add_u64_counter(l_osd_scrub_ec_started, "num_scrubs_started_ec", "scrubs attempted count ec");
   osd_plb.add_u64_counter(l_osd_scrub_ec_active_started, "num_scrubs_past_reservation_ec", "scrubs count ec");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_successful, "successful_scrubs_ec", "successful scrubs count ec");
+  osd_plb.add_time_avg(l_osd_scrub_ec_successful_elapsed, "successful_scrubs_ec_elapsed", "time to complete a successful ec scrub");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_failed, "failed_scrubs_ec", "failed scrubs count ec");
+  osd_plb.add_time_avg(l_osd_scrub_ec_failed_elapsed, "failed_scrubs_ec_elapsed", "time to scrub failure ec");
 
   return osd_plb.create_perf_counters();
 }
@@ -430,12 +441,6 @@ PerfCounters *build_scrub_labeled_perf(CephContext *cct, std::string label)
   PerfCountersBuilder scrub_perf(cct, label, scrbcnt_first, scrbcnt_last);
 
   scrub_perf.set_prio_default(PerfCountersBuilder::PRIO_INTERESTING);
-
-  scrub_perf.add_u64_counter(scrbcnt_started, "num_scrubs_started", "scrubs attempted count");
-  scrub_perf.add_u64_counter(scrbcnt_failed, "failed_scrubs", "failed scrubs count");
-  scrub_perf.add_u64_counter(scrbcnt_successful, "successful_scrubs", "successful scrubs count");
-  scrub_perf.add_time_avg(scrbcnt_failed_elapsed, "failed_scrubs_elapsed", "time to scrub failure");
-  scrub_perf.add_time_avg(scrbcnt_successful_elapsed, "successful_scrubs_elapsed", "time to scrub completion");
 
   scrub_perf.add_u64_counter(scrbcnt_preempted, "preemptions", "preemptions on scrubs");
   scrub_perf.add_u64_counter(scrbcnt_chunks_selected, "chunk_selected", "chunk selection during scrubs");

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -356,7 +356,25 @@ PerfCounters *build_osd_logger(CephContext *cct) {
   osd_plb.add_u64_counter(
   l_osd_watch_timeouts, "watch_timeouts",
   "Number of watches that timed out or were blocklisted",
-  NULL, PerfCountersBuilder::PRIO_USEFUL);
+  nullptr, PerfCountersBuilder::PRIO_USEFUL);
+
+  // scrub I/O (no EC vs. replicated differentiation)
+  osd_plb.add_u64_counter(l_osd_scrub_omapgetheader_cnt, "scrub_omapgetheader_cnt", "scrub omap get header calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_omapgetheader_bytes, "scrub_omapgetheader_bytes", "scrub omap get header bytes read");
+  osd_plb.add_u64_counter(l_osd_scrub_omapget_cnt, "scrub_omapget_cnt", "scrub omap get calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_omapget_bytes, "scrub_omapget_bytes", "scrub omap get bytes read");
+  // scrub I/O performed for replicated pools
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_getattr_cnt, "scrub_replicated_getattr_cnt", "scrub replicated pool getattr calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_stats_cnt, "scrub_replicated_stats_cnt", "scrub replicated pool stats calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_read_cnt, "scrub_replicated_read_cnt", "scrub replicated pool read calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_rppool_read_bytes, "scrub_replicated_read_bytes", "scrub replicated pool read bytes read");
+  // scrub I/O performed for EC pools
+  osd_plb.add_u64_counter(l_osd_scrub_ec_getattr_cnt, "scrub_ec_getattr_cnt", "scrub ec getattr calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_stats_cnt, "scrub_ec_stats_cnt", "scrub ec stats calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_read_cnt, "scrub_ec_read_cnt", "scrub ec read calls count");
+  osd_plb.add_u64_counter(l_osd_scrub_ec_read_bytes, "scrub_ec_read_bytes", "scrub ec read bytes read");
+
+  // scrub I/O performed for replicated pools
 
   return osd_plb.create_perf_counters();
 }

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -159,6 +159,12 @@ enum osd_counter_idx_t {
   l_osd_scrub_ec_read_cnt, ///< read calls count
   l_osd_scrub_ec_read_bytes, ///< total bytes read
 
+  // scrub (no EC vs. replicated differentiation)
+  // scrub - replicated pools
+  l_osd_scrub_rppool_active_started, ///< scrubs that got past replicas reservation
+  // scrub - EC
+  l_osd_scrub_ec_active_started, /// scrubs that got past secondaries reservation
+
   l_osd_last,
 };
 
@@ -211,8 +217,6 @@ enum {
   // -- basic statistics --
   /// The number of times we started a scrub
   scrbcnt_started,
-  /// # scrubs that got past replicas reservation
-  scrbcnt_active_started,
   /// # successful scrubs
   scrbcnt_successful,
   /// time to complete a successful scrub

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -169,13 +169,48 @@ enum osd_counter_idx_t {
   l_osd_scrub_rppool_failed, ///< failed scrubs count
   l_osd_scrub_rppool_failed_elapsed, ///< time from start to failure
 
-  // scrub - EC
+  // ----   scrub reservation process - replicated pools
+
+  /// successful replicas reservation count
+  l_osd_scrub_rppool_reserv_success,
+  /// time to complete a successful replicas reservation
+  l_osd_scrub_rppool_reserv_successful_elapsed,
+  /// failed attempt to reserve replicas due to an abort
+  l_osd_scrub_rppool_reserv_aborted,
+  /// reservation failed due to a 'rejected' response
+  l_osd_scrub_rppool_reserv_rejected,
+  /// reservation skipped for high-priority scrubs
+  l_osd_scrub_rppool_reserv_skipped,
+  /// time for a replicas reservation process to fail
+  l_osd_scrub_rppool_reserv_failed_elapsed,
+  /// number of replicas
+  l_osd_scrub_rppool_reserv_secondaries_num,
+
+
+  // ----   scrub - EC
   l_osd_scrub_ec_started, ///< scrubs that got started
   l_osd_scrub_ec_active_started, /// scrubs that got past secondaries reservation
   l_osd_scrub_ec_successful, ///< successful scrubs count
   l_osd_scrub_ec_successful_elapsed, ///< time to complete a successful scrub
   l_osd_scrub_ec_failed, ///< failed scrubs count
   l_osd_scrub_ec_failed_elapsed, ///< time from start to failure
+
+  // ----   scrub reservation process - EC
+
+  /// successful replicas reservation count
+  l_osd_scrub_ec_reserv_success,
+  /// time to complete a successful replicas reservation
+  l_osd_scrub_ec_reserv_successful_elapsed,
+  /// failed attempt to reserve replicas due to an abort
+  l_osd_scrub_ec_reserv_aborted,
+  /// reservation failed due to a 'rejected' response
+  l_osd_scrub_ec_reserv_rejected,
+  /// reservation skipped for high-priority scrubs
+  l_osd_scrub_ec_reserv_skipped,
+  /// time for a replicas reservation process to fail
+  l_osd_scrub_ec_reserv_failed_elapsed,
+  /// number of replicas
+  l_osd_scrub_ec_reserv_secondaries_num,
 
   l_osd_last,
 };
@@ -237,22 +272,6 @@ enum {
   scrbcnt_blocked,
   /// # write blocked by the scrub
   scrbcnt_write_blocked,
-
-  // -- replicas reservation
-  /// # successfully completed reservation steps
-  scrbcnt_resrv_success,
-  /// time to complete a successful replicas reservation
-  scrbcnt_resrv_successful_elapsed,
-  /// # failed attempt to reserve replicas due to an abort
-  scrbcnt_resrv_aborted,
-  /// # reservation failed due to a 'rejected' response
-  scrbcnt_resrv_rejected,
-  /// # reservation skipped for high-priority scrubs
-  scrbcnt_resrv_skipped,
-  /// time for a replicas reservation process to fail
-  scrbcnt_resrv_failed_elapsed,
-  /// # number of replicas
-  scrbcnt_resrv_replicas_num,
 
   scrbcnt_last,
 };

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -148,22 +148,34 @@ enum osd_counter_idx_t {
   l_osd_scrub_omapgetheader_bytes,  ///< bytes read by omap get header
   l_osd_scrub_omapget_cnt,      ///< omap get calls count
   l_osd_scrub_omapget_bytes,    ///< total bytes read by omap get
-  // scrub I/O - replicated pools
+
+  // ----   scrub I/O - replicated pools
   l_osd_scrub_rppool_getattr_cnt, ///< get_attr calls count
   l_osd_scrub_rppool_stats_cnt, ///< stats calls count
   l_osd_scrub_rppool_read_cnt, ///< read calls count
   l_osd_scrub_rppool_read_bytes, ///< total bytes read
-  // scrub I/O - EC
+
+  // ----   scrub I/O - EC
   l_osd_scrub_ec_getattr_cnt, ///< get_attr calls count
   l_osd_scrub_ec_stats_cnt, ///< stats calls count
   l_osd_scrub_ec_read_cnt, ///< read calls count
   l_osd_scrub_ec_read_bytes, ///< total bytes read
 
-  // scrub (no EC vs. replicated differentiation)
-  // scrub - replicated pools
+  // ----   scrub - replicated pools
+  l_osd_scrub_rppool_started, ///< scrubs that got started
   l_osd_scrub_rppool_active_started, ///< scrubs that got past replicas reservation
+  l_osd_scrub_rppool_successful, ///< successful scrubs count
+  l_osd_scrub_rppool_successful_elapsed, ///< time to complete a successful scrub
+  l_osd_scrub_rppool_failed, ///< failed scrubs count
+  l_osd_scrub_rppool_failed_elapsed, ///< time from start to failure
+
   // scrub - EC
+  l_osd_scrub_ec_started, ///< scrubs that got started
   l_osd_scrub_ec_active_started, /// scrubs that got past secondaries reservation
+  l_osd_scrub_ec_successful, ///< successful scrubs count
+  l_osd_scrub_ec_successful_elapsed, ///< time to complete a successful scrub
+  l_osd_scrub_ec_failed, ///< failed scrubs count
+  l_osd_scrub_ec_failed_elapsed, ///< time from start to failure
 
   l_osd_last,
 };
@@ -213,18 +225,6 @@ PerfCounters *build_recoverystate_perf(CephContext *cct);
 // EC vs. replicated) of these counters:
 enum {
   scrbcnt_first = 20500,
-
-  // -- basic statistics --
-  /// The number of times we started a scrub
-  scrbcnt_started,
-  /// # successful scrubs
-  scrbcnt_successful,
-  /// time to complete a successful scrub
-  scrbcnt_successful_elapsed,
-  /// # failed scrubs
-  scrbcnt_failed,
-  /// time for a scrub to fail
-  scrbcnt_failed_elapsed,
 
   // -- interruptions of various types
   /// # preemptions

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -7,7 +7,7 @@
 #include "common/perf_counters.h"
 #include "common/perf_counters_key.h"
 
-enum {
+enum osd_counter_idx_t {
   l_osd_first = 10000,
   l_osd_op_wip,
   l_osd_op,
@@ -142,6 +142,22 @@ enum {
   l_osd_scrub_reservation_dur_hist,
 
   l_osd_watch_timeouts,
+
+  // scrub I/O (no EC vs. replicated differentiation)
+  l_osd_scrub_omapgetheader_cnt,  ///< omap get header calls count
+  l_osd_scrub_omapgetheader_bytes,  ///< bytes read by omap get header
+  l_osd_scrub_omapget_cnt,      ///< omap get calls count
+  l_osd_scrub_omapget_bytes,    ///< total bytes read by omap get
+  // scrub I/O - replicated pools
+  l_osd_scrub_rppool_getattr_cnt, ///< get_attr calls count
+  l_osd_scrub_rppool_stats_cnt, ///< stats calls count
+  l_osd_scrub_rppool_read_cnt, ///< read calls count
+  l_osd_scrub_rppool_read_bytes, ///< total bytes read
+  // scrub I/O - EC
+  l_osd_scrub_ec_getattr_cnt, ///< get_attr calls count
+  l_osd_scrub_ec_stats_cnt, ///< stats calls count
+  l_osd_scrub_ec_read_cnt, ///< read calls count
+  l_osd_scrub_ec_read_bytes, ///< total bytes read
 
   l_osd_last,
 };

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -143,7 +143,8 @@ static inline constexpr ScrubCounterSet io_counters_replicated{
   .omapgetheader_cnt = l_osd_scrub_omapgetheader_cnt,
   .omapgetheader_bytes = l_osd_scrub_omapgetheader_bytes,
   .omapget_cnt = l_osd_scrub_omapget_cnt,
-  .omapget_bytes = l_osd_scrub_omapget_bytes
+  .omapget_bytes = l_osd_scrub_omapget_bytes,
+  .active_started_cnt = l_osd_scrub_rppool_active_started
 };
 
 static inline constexpr ScrubCounterSet io_counters_ec{
@@ -154,7 +155,8 @@ static inline constexpr ScrubCounterSet io_counters_ec{
   .omapgetheader_cnt = l_osd_scrub_omapgetheader_cnt,
   .omapgetheader_bytes = l_osd_scrub_omapgetheader_bytes,
   .omapget_cnt = l_osd_scrub_omapget_cnt,
-  .omapget_bytes = l_osd_scrub_omapget_bytes
+  .omapget_bytes = l_osd_scrub_omapget_bytes,
+  .active_started_cnt = l_osd_scrub_ec_active_started
 };
 }  // namespace Scrub
 
@@ -414,7 +416,9 @@ class PgScrubber : public ScrubPgIF,
   int get_whoami() const final;
   spg_t get_spgid() const final { return m_pg->get_pgid(); }
   PG* get_pg() const final { return m_pg; }
-  PerfCounters& get_counters_set() const final;
+  PerfCounters* get_osd_perf_counters() const final;
+  const Scrub::ScrubCounterSet& get_unlabeled_counters() const final;
+  PerfCounters* get_labeled_counters() const final;
 
   /// delay next retry of this PG after a replica reservation failure
   void flag_reservations_failure();

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -144,7 +144,12 @@ static inline constexpr ScrubCounterSet io_counters_replicated{
   .omapgetheader_bytes = l_osd_scrub_omapgetheader_bytes,
   .omapget_cnt = l_osd_scrub_omapget_cnt,
   .omapget_bytes = l_osd_scrub_omapget_bytes,
-  .active_started_cnt = l_osd_scrub_rppool_active_started
+  .started_cnt = l_osd_scrub_rppool_started,
+  .active_started_cnt = l_osd_scrub_rppool_active_started,
+  .successful_cnt = l_osd_scrub_rppool_successful,
+  .successful_elapsed = l_osd_scrub_rppool_successful_elapsed,
+  .failed_cnt = l_osd_scrub_rppool_failed,
+  .failed_elapsed = l_osd_scrub_rppool_failed_elapsed
 };
 
 static inline constexpr ScrubCounterSet io_counters_ec{
@@ -156,7 +161,12 @@ static inline constexpr ScrubCounterSet io_counters_ec{
   .omapgetheader_bytes = l_osd_scrub_omapgetheader_bytes,
   .omapget_cnt = l_osd_scrub_omapget_cnt,
   .omapget_bytes = l_osd_scrub_omapget_bytes,
-  .active_started_cnt = l_osd_scrub_ec_active_started
+  .started_cnt = l_osd_scrub_ec_started,
+  .active_started_cnt = l_osd_scrub_ec_active_started,
+  .successful_cnt = l_osd_scrub_ec_successful,
+  .successful_elapsed = l_osd_scrub_ec_successful_elapsed,
+  .failed_cnt = l_osd_scrub_ec_failed,
+  .failed_elapsed = l_osd_scrub_ec_failed_elapsed
 };
 }  // namespace Scrub
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -149,7 +149,15 @@ static inline constexpr ScrubCounterSet io_counters_replicated{
   .successful_cnt = l_osd_scrub_rppool_successful,
   .successful_elapsed = l_osd_scrub_rppool_successful_elapsed,
   .failed_cnt = l_osd_scrub_rppool_failed,
-  .failed_elapsed = l_osd_scrub_rppool_failed_elapsed
+  .failed_elapsed = l_osd_scrub_rppool_failed_elapsed,
+  // replica-reservation-related:
+  .rsv_successful_cnt = l_osd_scrub_rppool_reserv_success,
+  .rsv_successful_elapsed = l_osd_scrub_rppool_reserv_successful_elapsed,
+  .rsv_aborted_cnt = l_osd_scrub_rppool_reserv_aborted,
+  .rsv_rejected_cnt = l_osd_scrub_rppool_reserv_rejected,
+  .rsv_skipped_cnt = l_osd_scrub_rppool_reserv_skipped,
+  .rsv_failed_elapsed = l_osd_scrub_rppool_reserv_failed_elapsed,
+  .rsv_secondaries_num = l_osd_scrub_rppool_reserv_secondaries_num
 };
 
 static inline constexpr ScrubCounterSet io_counters_ec{
@@ -166,7 +174,15 @@ static inline constexpr ScrubCounterSet io_counters_ec{
   .successful_cnt = l_osd_scrub_ec_successful,
   .successful_elapsed = l_osd_scrub_ec_successful_elapsed,
   .failed_cnt = l_osd_scrub_ec_failed,
-  .failed_elapsed = l_osd_scrub_ec_failed_elapsed
+  .failed_elapsed = l_osd_scrub_ec_failed_elapsed,
+  // replica-reservation-related:
+  .rsv_successful_cnt = l_osd_scrub_ec_reserv_success,
+  .rsv_successful_elapsed = l_osd_scrub_ec_reserv_successful_elapsed,
+  .rsv_aborted_cnt = l_osd_scrub_ec_reserv_aborted,
+  .rsv_rejected_cnt = l_osd_scrub_ec_reserv_rejected,
+  .rsv_skipped_cnt = l_osd_scrub_ec_reserv_skipped,
+  .rsv_failed_elapsed = l_osd_scrub_ec_reserv_failed_elapsed,
+  .rsv_secondaries_num = l_osd_scrub_ec_reserv_secondaries_num
 };
 }  // namespace Scrub
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -133,6 +133,29 @@ class MapsCollectionStatus {
 };
 
 
+// links to the two sets of I/O performance counters used by PgScrubber
+// (one to be used when in a replicated pool, and one for EC))
+static inline constexpr ScrubCounterSet io_counters_replicated{
+  .getattr_cnt = l_osd_scrub_rppool_getattr_cnt,
+  .stats_cnt = l_osd_scrub_rppool_stats_cnt,
+  .read_cnt = l_osd_scrub_rppool_read_cnt,
+  .read_bytes = l_osd_scrub_rppool_read_bytes,
+  .omapgetheader_cnt = l_osd_scrub_omapgetheader_cnt,
+  .omapgetheader_bytes = l_osd_scrub_omapgetheader_bytes,
+  .omapget_cnt = l_osd_scrub_omapget_cnt,
+  .omapget_bytes = l_osd_scrub_omapget_bytes
+};
+
+static inline constexpr ScrubCounterSet io_counters_ec{
+  .getattr_cnt = l_osd_scrub_ec_getattr_cnt,
+  .stats_cnt = l_osd_scrub_ec_stats_cnt,
+  .read_cnt = l_osd_scrub_ec_read_cnt,
+  .read_bytes = l_osd_scrub_ec_read_bytes,
+  .omapgetheader_cnt = l_osd_scrub_omapgetheader_cnt,
+  .omapgetheader_bytes = l_osd_scrub_omapgetheader_bytes,
+  .omapget_cnt = l_osd_scrub_omapget_cnt,
+  .omapget_bytes = l_osd_scrub_omapget_bytes
+};
 }  // namespace Scrub
 
 

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -257,7 +257,7 @@ ReservingReplicas::ReservingReplicas(my_context ctx)
   // initiate the reservation process
   session.m_reservations.emplace(
       *scrbr, context<PrimaryActive>().last_request_sent_nonce,
-      *session.m_perf_set);
+      *session.m_counters_idx);
 
   if (!session.m_reservations->get_last_sent()) {
     // no replicas to reserve

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -199,7 +199,7 @@ Session::Session(my_context ctx)
   m_perf_set = scrbr->get_labeled_counters();
   m_osd_counters = scrbr->get_osd_perf_counters();
   m_counters_idx = &scrbr->get_unlabeled_counters();
-  m_perf_set->inc(scrbcnt_started);
+  m_osd_counters->inc(m_counters_idx->started_cnt);
 }
 
 Session::~Session()

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -562,9 +562,16 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
   /// it's an RAII wrapper around the state of 'holding reservations')
   std::optional<ReplicaReservations> m_reservations{std::nullopt};
 
-  /// the relevant set of performance counters for this session
+  /// the relevant set of labeled performance counters for this session
   /// (relevant, i.e. for this pool type X scrub level)
   PerfCounters* m_perf_set{nullptr};
+
+  /// the OSD's unlabeled performance counters access point
+  PerfCounters* m_osd_counters{nullptr};
+
+  /// the set of performance counters for this session (relevant, i.e. for
+  /// this pool type)
+  const ScrubCounterSet* m_counters_idx{nullptr};
 
   /// the time when the session was initiated
   ScrubTimePoint m_session_started_at{ScrubClock::now()};

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -57,10 +57,17 @@ struct ScrubMachineListener {
   virtual PG* get_pg() const = 0;
 
   /**
-   * access the set of performance counters relevant to this scrub
+   * the OSD's performance counters interface ("logger")
+   */
+  virtual PerfCounters* get_osd_perf_counters() const = 0;
+
+  virtual const Scrub::ScrubCounterSet& get_unlabeled_counters() const = 0;
+
+  /**
+   * the set of labeled performance counters relevant to this scrub
    * (one of the four sets of counters maintained by the OSD)
    */
-  virtual PerfCounters& get_counters_set() const = 0;
+  virtual PerfCounters* get_labeled_counters() const = 0;
 
   using scrubber_callback_t = std::function<void(void)>;
   using scrubber_callback_cancel_token_t = Context*;

--- a/src/osd/scrubber/scrub_reservations.cc
+++ b/src/osd/scrubber/scrub_reservations.cc
@@ -32,13 +32,13 @@ namespace Scrub {
 ReplicaReservations::ReplicaReservations(
     ScrubMachineListener& scrbr,
     reservation_nonce_t& nonce,
-    PerfCounters& pc)
+    const ScrubCounterSet& pc)
     : m_scrubber{scrbr}
     , m_pg{m_scrubber.get_pg()}
     , m_pgid{m_scrubber.get_spgid().pgid}
     , m_osds{m_pg->get_pg_osd(ScrubberPasskey())}
     , m_last_request_sent_nonce{nonce}
-    , m_perf_set{pc}
+    , m_perf_indices{pc}
 {
   // the acting set is sorted by pg_shard_t. The reservations are to be issued
   // in this order, so that the OSDs will receive the requests in a consistent
@@ -52,7 +52,8 @@ ReplicaReservations::ReplicaReservations(
       [whoami = m_pg->pg_whoami](const pg_shard_t& shard) {
 	return shard != whoami;
       });
-  m_perf_set.set(scrbcnt_resrv_replicas_num, m_sorted_secondaries.size());
+  m_osds->logger->set(
+      m_perf_indices.rsv_secondaries_num, m_sorted_secondaries.size());
 
   m_next_to_request = m_sorted_secondaries.cbegin();
   if (m_scrubber.is_reservation_required()) {
@@ -63,7 +64,7 @@ ReplicaReservations::ReplicaReservations(
     // for high-priority scrubs (i.e. - user-initiated), no reservations are
     // needed. Note: not perf-counted as either success or failure.
     dout(10) << "high-priority scrub - no reservations needed" << dendl;
-    m_perf_set.inc(scrbcnt_resrv_skipped);
+    m_osds->logger->inc(m_perf_indices.rsv_skipped_cnt);
   }
 }
 
@@ -97,8 +98,8 @@ void ReplicaReservations::log_success_and_duration()
 {
   ceph_assert(m_process_started_at.has_value());
   auto logged_duration = ScrubClock::now() - m_process_started_at.value();
-  m_perf_set.tinc(scrbcnt_resrv_successful_elapsed, logged_duration);
-  m_perf_set.inc(scrbcnt_resrv_success);
+  m_osds->logger->tinc(m_perf_indices.rsv_successful_elapsed, logged_duration);
+  m_osds->logger->inc(m_perf_indices.rsv_successful_cnt);
   m_osds->logger->hinc(
       l_osd_scrub_reservation_dur_hist, std::ssize(m_sorted_secondaries),
       logged_duration.count());
@@ -112,16 +113,16 @@ void ReplicaReservations::log_failure_and_duration(int failure_cause_counter)
     return;
   }
   auto logged_duration = ScrubClock::now() - m_process_started_at.value();
-  m_perf_set.tinc(scrbcnt_resrv_failed_elapsed, logged_duration);
+  m_osds->logger->tinc(m_perf_indices.rsv_failed_elapsed, logged_duration);
   m_process_started_at.reset();
   // note: not counted into l_osd_scrub_reservation_dur_hist
-  m_perf_set.inc(failure_cause_counter);
+  m_osds->logger->inc(failure_cause_counter);
 }
 
 ReplicaReservations::~ReplicaReservations()
 {
   release_all();
-  log_failure_and_duration(scrbcnt_resrv_aborted);
+  log_failure_and_duration(m_perf_indices.rsv_aborted_cnt);
 }
 
 bool ReplicaReservations::is_reservation_response_relevant(
@@ -231,7 +232,7 @@ bool ReplicaReservations::handle_reserve_rejection(
     return false;
   }
 
-  log_failure_and_duration(scrbcnt_resrv_rejected);
+  log_failure_and_duration(m_perf_indices.rsv_rejected_cnt);
 
   // we should never see a rejection carrying a valid
   // reservation nonce - arriving while we have no pending requests

--- a/src/osd/scrubber/scrub_reservations.h
+++ b/src/osd/scrubber/scrub_reservations.h
@@ -90,9 +90,8 @@ class ReplicaReservations {
    */
   reservation_nonce_t& m_last_request_sent_nonce;
 
-  /// access to the performance counters container relevant to this scrub
-  /// parameters
-  PerfCounters& m_perf_set;
+  /// the performance counters relevant to this scrub
+  const ScrubCounterSet& m_perf_indices;
 
   /// used only for the 'duration of the reservation process' perf counter.
   /// discarded once the success or failure are recorded
@@ -102,7 +101,7 @@ class ReplicaReservations {
   ReplicaReservations(
       ScrubMachineListener& scrubber,
       reservation_nonce_t& nonce,
-      PerfCounters& pc);
+      const ScrubCounterSet& pc);
 
   ~ReplicaReservations();
 

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -292,7 +292,7 @@ struct PgScrubBeListener {
 // defining a specific subset of performance counters. Each of the members
 // is set to (the index of) the corresponding performance counter.
 // Separate sets are used for replicated and erasure-coded pools.
-struct ScrubIoCounterSet {
+struct ScrubCounterSet {
   osd_counter_idx_t getattr_cnt; ///< get_attr calls count
   osd_counter_idx_t stats_cnt;  ///< stats calls count
   osd_counter_idx_t read_cnt;   ///< read calls count
@@ -301,7 +301,9 @@ struct ScrubIoCounterSet {
   osd_counter_idx_t omapgetheader_bytes;  ///< bytes read by omap get header
   osd_counter_idx_t omapget_cnt;  ///< omap get calls count
   osd_counter_idx_t omapget_bytes;  ///< total bytes read by omap get
+  osd_counter_idx_t active_started_cnt; ///< scrubs that got past reservation
 };
+
 }  // namespace Scrub
 
 

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -301,7 +301,12 @@ struct ScrubCounterSet {
   osd_counter_idx_t omapgetheader_bytes;  ///< bytes read by omap get header
   osd_counter_idx_t omapget_cnt;  ///< omap get calls count
   osd_counter_idx_t omapget_bytes;  ///< total bytes read by omap get
+  osd_counter_idx_t started_cnt; ///< the number of times we started a scrub
   osd_counter_idx_t active_started_cnt; ///< scrubs that got past reservation
+  osd_counter_idx_t successful_cnt; ///< successful scrubs count
+  osd_counter_idx_t successful_elapsed; ///< time to complete a successful scrub
+  osd_counter_idx_t failed_cnt; ///< failed scrubs count
+  osd_counter_idx_t failed_elapsed; ///< time from start to failure
 };
 
 }  // namespace Scrub

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -307,6 +307,14 @@ struct ScrubCounterSet {
   osd_counter_idx_t successful_elapsed; ///< time to complete a successful scrub
   osd_counter_idx_t failed_cnt; ///< failed scrubs count
   osd_counter_idx_t failed_elapsed; ///< time from start to failure
+  // reservation process related:
+  osd_counter_idx_t rsv_successful_cnt; ///< completed reservation processes
+  osd_counter_idx_t rsv_successful_elapsed; ///< time to all-reserved
+  osd_counter_idx_t rsv_aborted_cnt; ///< failed due to an abort
+  osd_counter_idx_t rsv_rejected_cnt; ///< 'rejected' response
+  osd_counter_idx_t rsv_skipped_cnt; ///< high-priority. No reservation
+  osd_counter_idx_t rsv_failed_elapsed; ///< time for reservation to fail
+  osd_counter_idx_t rsv_secondaries_num; ///< number of replicas (EC or rep)
 };
 
 }  // namespace Scrub

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -15,6 +15,7 @@
 #include "include/types.h"
 #include "messages/MOSDScrubReserve.h"
 #include "os/ObjectStore.h"
+#include "osd/osd_perf_counters.h" // for osd_counter_idx_t
 
 #include "OpRequest.h"
 
@@ -288,6 +289,19 @@ struct PgScrubBeListener {
   virtual bool is_waiting_for_unreadable_object() const = 0;
 };
 
+// defining a specific subset of performance counters. Each of the members
+// is set to (the index of) the corresponding performance counter.
+// Separate sets are used for replicated and erasure-coded pools.
+struct ScrubIoCounterSet {
+  osd_counter_idx_t getattr_cnt; ///< get_attr calls count
+  osd_counter_idx_t stats_cnt;  ///< stats calls count
+  osd_counter_idx_t read_cnt;   ///< read calls count
+  osd_counter_idx_t read_bytes;  ///< total bytes read
+  osd_counter_idx_t omapgetheader_cnt; ///< omap get header calls count
+  osd_counter_idx_t omapgetheader_bytes;  ///< bytes read by omap get header
+  osd_counter_idx_t omapget_cnt;  ///< omap get calls count
+  osd_counter_idx_t omapget_bytes;  ///< total bytes read by omap get
+};
 }  // namespace Scrub
 
 


### PR DESCRIPTION
Change most performance counters used by the Scrubber to be the regular, unlabeled, ones.
For the unlabeled counters - use only two sets (EC vs. replicated), as there seems to be
little use for the Primary vs. replica distinction.

This is an extension of the original https://github.com/ceph/ceph/pull/62693 - counting
scrub I/O, but without the "counting I/Os" part (as that is pending EC changes merge).
