### PR TITLE
CMakeLists.txt: fix opentelemetry library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -330,7 +330,7 @@ if(WITH_JAEGER)
   include(BuildOpentelemetry)
   build_opentelemetry()
   add_library(jaeger_base INTERFACE)
-  target_link_libraries(jaeger_base INTERFACE opentelemetry::libopentelemetry
+  target_link_libraries(jaeger_base INTERFACE ${OPENTELEMETRY_CPP_LIBRARIES}
     thrift::libthrift)
 endif()
 


### PR DESCRIPTION
otherwise, cmake failed with:

> CMake Error at src/CMakeLists.txt:443 (target_link_libraries):
>   The link interface of target "jaeger_base" contains:
>
>     opentelemetry::libopentelemetry
>
>   but the target was not found.  Possible reasons include:
>
>     * There is a typo in the target name.
>     * A find_package call is missing for an IMPORTED target.
>     * An ALIAS target is missing.

See also: https://bugs.gentoo.org/930064