### PR TITLE
reef: doc/radosgw/cloud-transition: fix details

### DIFF
--- a/doc/radosgw/cloud-transition.rst
+++ b/doc/radosgw/cloud-transition.rst
@@ -3,7 +3,7 @@
 ==================
 
 This feature enables transitioning S3 objects to a remote cloud service as part
-of `<https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html>`
+of `object lifecycle <https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html>`_
 via :ref:`storage_classes`. The transition is unidirectional: data cannot be
 transitioned back from the remote zone. The goal of this feature is to enable
 data transition to multiple cloud providers. The currently supported cloud
@@ -35,26 +35,27 @@ The below tier types are supported:
 Cloud Storage Class Tier Configuration
 --------------------------------------
 
-```
-    {
-      "access_key": <access>,
-      "secret": <secret>,
-      "endpoint": <endpoint>,
-      "region": <region>,
-      "host_style": <path | virtual>,
-      "acls": [ { "type": <id | email | uri>,
-                  "source_id": <source_id>,
-                  "dest_id": <dest_id> } ... ],
-      "target_path": <target_path>,
-      "target_storage_class": <target-storage-class>,
-      "multipart_sync_threshold": {object_size},
-      "multipart_min_part_size": {part_size},
-      "retain_head_object": <true | false>
-    }
-```
+::
 
-Cloud Transition Specific Configurables:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  {
+    "access_key": <access>,
+    "secret": <secret>,
+    "endpoint": <endpoint>,
+    "region": <region>,
+    "host_style": <path | virtual>,
+    "acls": [ { "type": <id | email | uri>,
+                "source_id": <source_id>,
+                "dest_id": <dest_id> } ... ],
+    "target_path": <target_path>,
+    "target_storage_class": <target-storage-class>,
+    "multipart_sync_threshold": {object_size},
+    "multipart_min_part_size": {part_size},
+    "retain_head_object": <true | false>
+  }
+
+
+Cloud Transition Specific Configurables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * ``access_key`` (string)
 
@@ -120,19 +121,17 @@ This option is ignored for current-versioned objects. For more details,
 refer to the "Versioned Objects" section below.
 
 
-S3 Specific Configurables:
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+S3 Specific Configurables
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Currently, cloud transition will work only with backends that are compatible with
-AWS S3. There are a few configurables that can be used to tweak behavior
-when accessing cloud services:
+AWS S3 protocol. There are a few configurables that can be used to tweak behavior
+when accessing cloud services::
 
-```
-    {
-      "multipart_sync_threshold": {object_size},
-      "multipart_min_part_size": {part_size}
-    }
-```
+  {
+    "multipart_sync_threshold": {object_size},
+    "multipart_min_part_size": {part_size}
+  }
 
 * ``multipart_sync_threshold`` (integer)
 
@@ -155,165 +154,156 @@ See :ref:`adding_a_storage_class` for how to configure storage-class for a zoneg
           the zone/zonegroup changes will take effect once the changes are
           committed with ``radosgw-admin period update --commit``.
 
-```
-    # radosgw-admin zonegroup placement add --rgw-zonegroup={zone-group-name} \
-                                            --placement-id={placement-id} \
-                                            --storage-class={storage-class-name} \
-                                            --tier-type=cloud-s3 
-```
+::
 
-For example:
+  $ radosgw-admin zonegroup placement add --rgw-zonegroup={zone-group-name} \
+                                          --placement-id={placement-id} \
+                                          --storage-class={storage-class-name} \
+                                          --tier-type=cloud-s3 
 
-```
-    # radosgw-admin zonegroup placement add --rgw-zonegroup=default \
-                                            --placement-id=default-placement \
-                                            --storage-class=CLOUDTIER --tier-type=cloud-s3
-    [
-        {
-            "key": "default-placement",
-            "val": {
-                "name": "default-placement",
-                "tags": [],
-                "storage_classes": [
-                    "CLOUDTIER",
-                    "STANDARD"
-                ],
-                "tier_targets": [
-                    {
-                        "key": "CLOUDTIER",
-                        "val": {
-                            "tier_type": "cloud-s3",
-                            "storage_class": "CLOUDTIER",
-                            "retain_head_object": "false",
-                            "s3": {
-                                "endpoint": "",
-                                "access_key": "",
-                                "secret": "",
-                                "host_style": "path",
-                                "target_storage_class": "",
-                                "target_path": "",
-                                "acl_mappings": [],
-                                "multipart_sync_threshold": 33554432,
-                                "multipart_min_part_size": 33554432
-                            }
-                        }
-                    }
-                ]
-            }
-        }
-    ]
-```
+For example::
+
+  $ radosgw-admin zonegroup placement add --rgw-zonegroup=default \
+                                          --placement-id=default-placement \
+                                          --storage-class=CLOUDTIER --tier-type=cloud-s3
+  [
+      {
+          "key": "default-placement",
+          "val": {
+              "name": "default-placement",
+              "tags": [],
+              "storage_classes": [
+                  "CLOUDTIER",
+                  "STANDARD"
+              ],
+              "tier_targets": [
+                  {
+                      "key": "CLOUDTIER",
+                      "val": {
+                          "tier_type": "cloud-s3",
+                          "storage_class": "CLOUDTIER",
+                          "retain_head_object": "false",
+                          "s3": {
+                              "endpoint": "",
+                              "access_key": "",
+                              "secret": "",
+                              "host_style": "path",
+                              "target_storage_class": "",
+                              "target_path": "",
+                              "acl_mappings": [],
+                              "multipart_sync_threshold": 33554432,
+                              "multipart_min_part_size": 33554432
+                          }
+                      }
+                  }
+              ]
+          }
+      }
+  ]
 
 .. note:: Once a storage class
-	  of ``--tier-type=cloud-s3`` or ``--tier-type=cloud-s3-glacier``,
+          of ``--tier-type=cloud-s3`` or ``--tier-type=cloud-s3-glacier``
           is created it cannot be later modified to any other storage class type.
 
-The tier configuration can be then performed using the following command:
+The tier configuration can be then performed using the following command::
 
-```
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup={zone-group-name} \
-                                               --placement-id={placement-id} \
-                                               --storage-class={storage-class-name} \
-                                               --tier-config={key}={val}[,{key}={val}]
-```
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup={zone-group-name} \
+                                             --placement-id={placement-id} \
+                                             --storage-class={storage-class-name} \
+                                             --tier-config={key}={val}[,{key}={val}]
 
 The ``key`` in the configuration specifies the config variable to be updated, and
 the ``val`` specifies its new value.
 
-For example:
+For example::
 
-```
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup default \
-                                               --placement-id default-placement \
-                                               --storage-class CLOUDTIER \
-                                               --tier-config=endpoint=http://XX.XX.XX.XX:YY,\
-                                               access_key=<access_key>,secret=<secret>, \
-                                               multipart_sync_threshold=44432, \
-                                               multipart_min_part_size=44432, \
-                                               retain_head_object=true
-```
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup default \
+                                             --placement-id default-placement \
+                                             --storage-class CLOUDTIER \
+                                             --tier-config=endpoint=http://XX.XX.XX.XX:YY,\
+                                             access_key=<access_key>,secret=<secret>, \
+                                             multipart_sync_threshold=44432, \
+                                             multipart_min_part_size=44432, \
+                                             retain_head_object=true
 
-Nested values can be accessed using periods. For example:
+Nested tier configuration values can be accessed using periods. This notation
+works similarly to how nested fields are accessed in JSON with tools like ``jq``.
+Note that the use of period separators ``(.)`` is specific to key access within ``--tier-config``,
+and should not be confused with Ceph RGW patterns for realm/zonegroup/zone. 
+For example::
 
-```
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup={zone-group-name} \
-                                               --placement-id={placement-id} \
-                                               --storage-class={storage-class-name} \
-                                               --tier-config=acls.source_id=${source-id}, \
-                                               acls.dest_id=${dest-id}
-```
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup={zone-group-name} \
+                                             --placement-id={placement-id} \
+                                             --storage-class={storage-class-name} \
+                                             --tier-config=acls.source_id=${source-id}, \
+                                             acls.dest_id=${dest-id}
 
 Configuration array entries can be accessed by specifying the specific entry to
 be referenced enclosed in square brackets, and adding a new array entry can be
 performed with an empty array `[]`.
-For example, creating a new ``acl`` array entry:
+For example, creating a new ``acl`` array entry::
 
-```
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup={zone-group-name} \
-                                               --placement-id={placement-id} \
-                                               --storage-class={storage-class-name} \
-                                               --tier-config=acls[].source_id=${source-id}, \
-                                               acls[${source-id}].dest_id=${dest-id}, \
-                                               acls[${source-id}].type=email
-```
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup={zone-group-name} \
+                                             --placement-id={placement-id} \
+                                             --storage-class={storage-class-name} \
+                                             --tier-config=acls[].source_id=${source-id}, \
+                                             acls[${source-id}].dest_id=${dest-id}, \
+                                             acls[${source-id}].type=email
 
 An entry can be removed by supplying ``--tier-config-rm={key}``.
 
-For example:
+For example::
 
-```
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup default \
-                                               --placement-id default-placement \
-                                               --storage-class CLOUDTIER \
-                                               --tier-config-rm=acls.source_id=testid
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup default \
+                                             --placement-id default-placement \
+                                             --storage-class CLOUDTIER \
+                                             --tier-config-rm=acls.source_id=testid
 
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup default \
-                                               --placement-id default-placement \
-                                               --storage-class CLOUDTIER \
-                                               --tier-config-rm=target_path
-```
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup default \
+                                             --placement-id default-placement \
+                                             --storage-class CLOUDTIER \
+                                             --tier-config-rm=target_path
 
-The storage class can be removed using the following command:
+The storage class can be removed using the following command::
 
-```
-    # radosgw-admin zonegroup placement rm --rgw-zonegroup={zone-group-name} \
-                                           --placement-id={placement-id} \
-                                           --storage-class={storage-class-name}
-```
+  $ radosgw-admin zonegroup placement rm --rgw-zonegroup={zone-group-name} \
+                                         --placement-id={placement-id} \
+                                         --storage-class={storage-class-name}
 
-For example,
+For example::
 
-```
-    # radosgw-admin zonegroup placement rm --rgw-zonegroup default \
-                                           --placement-id default-placement \
-                                           --storage-class CLOUDTIER
-    [
-        {
-            "key": "default-placement",
-            "val": {
-                "name": "default-placement",
-                "tags": [],
-                "storage_classes": [
-                    "STANDARD"
-                ]
-            }
-        }
-    ]
-```
+  $ radosgw-admin zonegroup placement rm --rgw-zonegroup default \
+                                         --placement-id default-placement \
+                                         --storage-class CLOUDTIER
+  [
+      {
+          "key": "default-placement",
+          "val": {
+              "name": "default-placement",
+              "tags": [],
+              "storage_classes": [
+                  "STANDARD"
+              ]
+          }
+      }
+  ]
+
 
 Object Modification and Limitations
-----------------------------------
+-----------------------------------
 
 The cloud storage class, once configured, can be used like any other storage
-class when defining bucket lifecycle (LC) rules. For example,
+class when defining bucket lifecycle (LC) rules. For example::
 
-```
-    <Transition>
-      <StorageClass>CLOUDTIER</StorageClass>
+  <LifecycleConfiguration>
+    <Rule>
       ....
-      ....
-    </Transition>
-```
+      <Transition>
+        ....
+        <StorageClass>CLOUDTIER</StorageClass>
+      </Transition>
+    </Rule>
+  </LifecycleConfiguration>
 
 Since the transition is unidirectional, when configuring S3
 lifecycle rules, the cloud storage class should be specified
@@ -322,15 +312,13 @@ Subsequent rules (if any) do not apply post-transition to the cloud.
 
 Due to API limitations, there is no way to preserve the original object
 modification time and ETag, which are stored as metadata attributes
-on the destination objects, as shown below:
+on the destination objects, as shown below::
 
-```
-   x-amz-meta-rgwx-source: rgw
-   x-amz-meta-rgwx-source-etag: ed076287532e86365e841e92bfc50d8c
-   x-amz-meta-rgwx-source-key: lc.txt
-   x-amz-meta-rgwx-source-mtime: 1608546349.757100363
-   x-amz-meta-rgwx-versioned-epoch: 0
-```
+  x-amz-meta-rgwx-source: rgw
+  x-amz-meta-rgwx-source-etag: ed076287532e86365e841e92bfc50d8c
+  x-amz-meta-rgwx-source-key: lc.txt
+  x-amz-meta-rgwx-source-mtime: 1608546349.757100363
+  x-amz-meta-rgwx-versioned-epoch: 0
 
 In order to allow cloud services to detect the source and map
 user-defined ``x-amz-meta-`` attributes, two additional new
@@ -348,41 +336,40 @@ attributes are added to the objects being transitioned:
     just store the object data being sent.
 
 By default, post-transition, the source object gets deleted. But it is possible
-to retain its metadata but with updated values (including ``storage-class``
+to retain its metadata with updated values (including ``storage-class``
 and ``object-size``) by setting the config option ``retain_head_object``
 to true. However a ``GET`` operation on such an object will still fail
-with an ``InvalidObjectState`` error.
+with an ``InvalidObjectState`` error. Any other operations against original
+source objects will be for its metadata entries only keeping transitioned
+objects intact.
 
-For example:
+For example::
 
-```
-    # s3cmd info s3://bucket/lc.txt
-    s3://bucket/lc.txt (object):
-       File size: 12
-       Last mod:  Mon, 21 Dec 2020 10:25:56 GMT
-       MIME type: text/plain
-       Storage:   CLOUDTIER
-       MD5 sum:   ed076287532e86365e841e92bfc50d8c
-       SSE:       none
-       Policy:    none
-       CORS:      none
-       ACL:       M. Tester: FULL_CONTROL
-       x-amz-meta-s3cmd-attrs: atime:1608466266/ctime:1597606156/gid:0/gname:root/md5:ed076287532e86365e841e92bfc50d8c/mode:33188/mtime:1597605793/uid:0/uname:root
-
-    # s3cmd get s3://bucket/lc.txt lc_restore.txt
-    download: 's3://bucket/lc.txt' -> 'lc_restore.txt'  [1 of 1]
-    ERROR: S3 error: 403 (InvalidObjectState)
-```
+  # s3cmd info s3://bucket/lc.txt
+  s3://bucket/lc.txt (object):
+     File size: 12
+     Last mod:  Mon, 21 Dec 2020 10:25:56 GMT
+     MIME type: text/plain
+     Storage:   CLOUDTIER
+     MD5 sum:   ed076287532e86365e841e92bfc50d8c
+     SSE:       none
+     Policy:    none
+     CORS:      none
+     ACL:       M. Tester: FULL_CONTROL
+     x-amz-meta-s3cmd-attrs: atime:1608466266/ctime:1597606156/gid:0/gname:root/md5:ed076287532e86365e841e92bfc50d8c/mode:33188/mtime:1597605793/uid:0/uname:root
+  
+  # s3cmd get s3://bucket/lc.txt lc_restore.txt
+  download: 's3://bucket/lc.txt' -> 'lc_restore.txt'  [1 of 1]
+  ERROR: S3 error: 403 (InvalidObjectState)
 
 To avoid object name collisions across buckets, the source bucket name is
 prepended to the target object name. If the object is versioned, the object's
 ``versionid`` is appended.
 
-Below is the object name format:
+Below is the object name format::
 
-```
-    s3://<target_path>/<source_bucket_name>/<source_object_name>(-<source_object_version_id>)
-```
+  s3://<target_path>/<source_bucket_name>/<source_object_name>(-<source_object_version_id>)
+
 
 Versioned Objects
 ~~~~~~~~~~~~~~~~~
@@ -397,7 +384,7 @@ For versioned and locked objects, similar semantics as that of LifecycleExpirati
 Restoring Objects
 -----------------
 The objects transitioned to cloud can now be restored. For more information, refer to 
-[Restoring Objects from Cloud](https://docs.aws.amazon.com/AmazonS3/latest/dev/cloud-restore.html)
+`Restoring Objects from Cloud <https://docs.aws.amazon.com/AmazonS3/latest/dev/cloud-restore.html>`_.
 
 
 Future Work


### PR DESCRIPTION
Fix documentation on Ceph cloud storage transitions - broken link urls, returning back reStructuredText and some other details.

Signed-off-by: Laimis Juzeliunas <laimis.juzeliunas@oxylabs.io>
Co-authored-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>
(cherry picked from commit c47b559547326f837dde9dfed9eef526e275fa8e)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
