### PR TITLE
doc/radosgw/cloud-restore: use reStructuredText for code and details

### DIFF
--- a/doc/radosgw/cloud-restore.rst
+++ b/doc/radosgw/cloud-restore.rst
@@ -12,39 +12,37 @@ S3-compatible cloud services. In order to faciliate this,
 the ``retain_head_object`` option should be set to ``true``
 in the ``tier-config`` when configuring the storage class.
 
-Objects can be restored using the `S3 RestoreObject <https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html>`
-PI . The restored copies will be retained within RGW only for the number
+Objects can be restored using the `S3 RestoreObject <https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html>`_
+API. The restored copies will be retained within RGW only for the number
 of ``days`` specified. However if ``days`` is not provided, the restored copies
 are considered permanent and will be treated as regular objects.
 In addition, by enabling the ``allow_read_through`` option,
-the `S3 GetObject <https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html>`
+the `S3 GetObject <https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html>`_
 API can be used to restore the object temporarily.
 
 
 Cloud Storage Class Tier Configuration
 --------------------------------------
 
-The `tier configuration <https://docs.ceph.com/en/latest/radosgw/cloud-transition/#cloud-storage-class-configuration>`
+The `tier configuration <https://docs.ceph.com/en/latest/radosgw/cloud-transition/#cloud-storage-class-configuration>`_
 of the cloud storage class configured for data transition is used to restore
-objects as well:
+objects as well::
 
-```
-    {
-      "access_key": <access>,
-      "secret": <secret>,`
-      "endpoint": <endpoint>,
-      "region": <region>,
-      "host_style": <path | virtual>,
-      "acls": [ { "type": <id | email | uri>,
-                  "source_id": <source_id>,
-                  "dest_id": <dest_id> } ... ],
-      "target_path": <target_path>,
-      "target_storage_class": <target-storage-class>,
-      "multipart_sync_threshold": {object_size},
-      "multipart_min_part_size": {part_size},
-      "retain_head_object": <true | false>
-    }
-```
+  {
+    "access_key": <access>,
+    "secret": <secret>,`
+    "endpoint": <endpoint>,
+    "region": <region>,
+    "host_style": <path | virtual>,
+    "acls": [ { "type": <id | email | uri>,
+                "source_id": <source_id>,
+                "dest_id": <dest_id> } ... ],
+    "target_path": <target_path>,
+    "target_storage_class": <target-storage-class>,
+    "multipart_sync_threshold": {object_size},
+    "multipart_min_part_size": {part_size},
+    "retain_head_object": <true | false>
+  }
 
 The below options have been added to the tier configuration to facilitate object restoration.
 
@@ -53,7 +51,7 @@ The below options have been added to the tier configuration to facilitate object
 The storage class to which object data is to be restored. Default value is ``STANDARD``.
 
 
-read-through specific Configurables:
+read-through specific Configurables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * ``allow_read_through`` (``true`` | ``false``)
@@ -65,22 +63,20 @@ If true, enables ``read-through``. Objects can then be restored using the ``S3 G
 The duration for which objects restored via ``read-through`` are retained.
 Default value is 1 day.
 
-For example:
+For example::
 
-```
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup default \
-                                               --placement-id default-placement \
-                                               --storage-class CLOUDTIER \
-                                               --tier-config=endpoint=http://XX.XX.XX.XX:YY,\
-                                               access_key=<access_key>,secret=<secret>, \
-                                               retain_head_object=true, \
-                                               restore_storage_class=COLDTIER, \
-                                               allow_read_through=true, \
-                                               read_through_restore_days=10
-```
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup default \
+                                             --placement-id default-placement \
+                                             --storage-class CLOUDTIER \
+                                             --tier-config=endpoint=http://XX.XX.XX.XX:YY,\
+                                             access_key=<access_key>,secret=<secret>,\
+                                             retain_head_object=true,\
+                                             restore_storage_class=COLDTIER,\
+                                             allow_read_through=true,\
+                                             read_through_restore_days=10
 
 
-S3 Glacier specific Configurables:
+S3 Glacier specific Configurables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To restore objects archived in an S3 Glacier or Tape cloud storage class, the
@@ -98,80 +94,77 @@ The duration for which the objects are to be restored on the remote cloud servic
 The type of retrieval within the cloud service, which may represent different
 pricing. Supported options are ``Standard`` and ``Expedited``.
 
+For example::
 
-For example:
+  $ radosgw-admin zonegroup placement add --rgw-zonegroup=default \
+                                          --placement-id=default-placement \
+                                          --storage-class=CLOUDTIER-GLACIER \
+                                          --tier-type=cloud-s3-glacier
 
-```
-    # radosgw-admin zonegroup placement add --rgw-zonegroup=default \
-                                            --placement-id=default-placement \
-                                            --storage-class=CLOUDTIER-GLACIER --tier-type=cloud-s3-glacier
+  $ radosgw-admin zonegroup placement modify --rgw-zonegroup default \
+                                             --placement-id default-placement \
+                                             --storage-class CLOUDTIER \
+                                             --tier-config=endpoint=http://XX.XX.XX.XX:YY,\
+                                             access_key=XXXXX,secret=YYYYY,\
+                                             retain_head_object=true,\
+                                             target_storage_class=Glacier,\
+                                             ............
+                                             ............
+                                             restore_storage_class=COLDTIER,\
+                                             glacier_restore_days=2,\
+                                             glacier_restore_tier_type=Expedited
 
-    # radosgw-admin zonegroup placement modify --rgw-zonegroup default \
-                                               --placement-id default-placement \
-                                               --storage-class CLOUDTIER \
-                                               --tier-config=endpoint=http://XX.XX.XX.XX:YY,\
-                                               access_key=XXXXX,secret=YYYYY, \
-                                               retain_head_object=true, \
-                                               target_storage_class=Glacier, \
-                                               ............
-                                               ............
-                                               restore_storage_class=COLDTIER, \
-                                               glacier_restore_days=2, \
-                                               glacier_restore_tier_type=Expedited
-
-
-     [
-        {
-            "key": "default-placement",
+  [
+    {
+      "key": "default-placement",
+      "val": {
+        "name": "default-placement",
+        "tags": [],
+        "storage_classes": [
+          "CLOUDTIER-GLACIER",
+          "STANDARD"
+        ],
+        "tier_targets": [
+          {
+            "key": "CLOUDTIER-GLACIER",
             "val": {
-                "name": "default-placement",
-                "tags": [],
-                "storage_classes": [
-                    "CLOUDTIER-GLACIER",
-                    "STANDARD"
-                ],
-                "tier_targets": [
-                    {
-                        "key": "CLOUDTIER-GLACIER",
-                        "val": {
-                            "tier_type": "cloud-s3-glacier",
-                            "storage_class": "CLOUDTIER-GLACIER",
-                            "retain_head_object": "true",
-                            "s3": {
-                                "endpoint": http://XX.XX.XX.XX:YY,
-                                "access_key": "XXXXX",
-                                "secret": "YYYYY",
-                                "host_style": "path",
-                                "target_storage_class": "Glacier",
-                                .......
-                                .......
-                            }
-                            "allow_read_through": true,
-                            "read_through_restore_days": 10,
-                            "restore_storage_class": "COLDTIER",
-                            "s3-glacier": {
-                                "glacier_restore_days": 2
-                                "glacier_restore_tier_type": "Expedited"
-                            }
-                        }
-                    }
-                ]
+              "tier_type": "cloud-s3-glacier",
+              "storage_class": "CLOUDTIER-GLACIER",
+              "retain_head_object": "true",
+              "s3": {
+                "endpoint": "http://XX.XX.XX.XX:YY",
+                "access_key": "XXXXX",
+                "secret": "YYYYY",
+                "host_style": "path",
+                "target_storage_class": "Glacier"
+                .......
+                .......
+              },
+              "allow_read_through": true,
+              "read_through_restore_days": 10,
+              "restore_storage_class": "COLDTIER",
+              "s3-glacier": {
+                "glacier_restore_days": 2,
+                "glacier_restore_tier_type": "Expedited"
+              }
             }
-        }
-    ]
-```
+          }
+        ]
+      }
+    }
+  ]
 
 
-Examples of Restore Objects:
-----------------------------
+Examples of Restore Objects
+---------------------------
+
 
 Using the S3 RestoreObject CLI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Th `S3 restore-object <https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html>`
-CLI supports these options:
+The `S3 restore-object <https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html>`_
+CLI supports the following options::
 
-```
   $ aws s3api restore-object 
             --bucket <value>
             --key <value>
@@ -179,28 +172,22 @@ CLI supports these options:
             --restore-request (structure) {
               Days=<integer>
             }
-```
 
 Note: ``Days`` is optional and if not provided, the object is restored permanently.
 
-Example 1:
+Example 1::
 
-```
   $ aws s3api restore-object  --bucket bucket1 --key doc1.rtf 
                               [--version-id 3sL4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY+MTRCxf3vjVBH40Nr8X8gdRQBpUMLUo]
                               --restore-request Days=10 
                               ....
-```
 
 This will restore the object ``doc1.rtf`` at an optional version,
 for the duration of 10 days.
 
-Example 2:
+Example 2::
 
-```
   $ aws s3api restore-object  --bucket bucket1 --key doc2.rtf --restore-request {} ....
-```
-
 
 This will restore the object ``doc2.rtf`` permanently and it will be treated as regular object.
 
@@ -210,11 +197,9 @@ Using the S3 GetObject CLI
 
 Ensure that the ``allow_read_through`` tier-config option is enabled.
 
-Example 3:
+Example 3::
 
-```
   $ aws s3api get-object  --bucket bucket1 --key doc3.rtf ....
-```
 
 This will restore the object `doc3.rtf`` for ``read_through_restore_days`` days.
 
@@ -224,49 +209,50 @@ You can verify the restore status before reissuing the command.
 
 Verifying the restoration status
 --------------------------------
+
 Verify the status of the restoration by issuing
-an `S3 HeadObject <https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax>`
+an `S3 HeadObject <https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax>`_
 request. The response includes the ``x-amz-restore`` header if object restoration
 is in progress or a copy of it is already restored.
 
-Example:
+Example::
 
-```
   $ aws s3api head-object --key doc1.rtf --bucket bucket1 ....
-```
 
 The ``radosgw-admin`` CLI can be used to check restoration status and other
 details.
 
-Example:
+Example::
 
-```  
- $ radosgw-admin object stat --bucket bucket1 --object doc1.rtf
-```
+  $ radosgw-admin object stat --bucket bucket1 --object doc1.rtf
 
 
 Restored Object Properties
 --------------------------
 
+
 Storage
-~~~~~~
+~~~~~~~
+
 Objects are restored to the storage class configured via ``restore_storage_class``
 in the tier-config. However, as
-per `<https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html>`
+per `S3 restore-object <https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html>`_
 the storage class of restored objects should remain unchanged. Therefore, for
-temporary copies, the ```x-amz-storage-class``` will continue to reflect the
+temporary copies, the ``x-amz-storage-class`` will continue to reflect the
 original cloud-tier storage class.
 
 
 mtime
-~~~~
+~~~~~
+
 The ``mtime`` of the transitioned and restored objects should remain unchanged.
 
 
 Lifecycle
-~~~~~~~~
+~~~~~~~~~
+
 ``Temporary`` copies are not subject to transition to the cloud. However, as is the
-case with cloud-transitioned objects, they can be deleted via regular LC (Life Cycle)
+case with cloud-transitioned objects, they can be deleted via regular lifecycle
 expiration rules or an external S3 ``delete`` request.
 
 ``Permanent`` copies are treated as regular objects and are subject to applicable LC
@@ -274,7 +260,8 @@ policies.
 
 
 Replication
-~~~~~~~~~~
+~~~~~~~~~~~
+
 ``Temporary`` copies are not replicated and will be retained only by the zone
 on which the restore request is initiated.
 
@@ -282,11 +269,11 @@ on which the restore request is initiated.
 
 
 Versioned Objects
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
+
 For versioned objects, if an object has been cloud-transitioned, it is in a
 non-current state. After a restore, the same non-current object will be
 updated with the downloaded data, and its ``HEAD`` object will be modified accordingly.
-
 
 
 Future Work
@@ -295,4 +282,3 @@ Future Work
 * Admin Ops
 
 * Notifications
-


### PR DESCRIPTION
This PR is a continuation of the work for Ceph cloud-s3 module and targets the object restoration [documentation section](https://docs.ceph.com/en/latest/radosgw/cloud-restore/). Following [#62795](https://github.com/ceph/ceph/pull/62795) the main fix is using reStructuredText for code block elements as current layout is not rendering well on the webpage and is hard to follow through. Other fixes include url link fixes as well as other various details.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
