### PR TITLE
squid: common: CephContext::_refresh_perf_values() checks for null _mempool_perf

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -992,11 +992,13 @@ void CephContext::_refresh_perf_values()
     _cct_perf->set(l_cct_total_workers, _heartbeat_map->get_total_workers());
     _cct_perf->set(l_cct_unhealthy_workers, _heartbeat_map->get_unhealthy_workers());
   }
-  unsigned l = l_mempool_first + 1;
-  for (unsigned i = 0; i < mempool::num_pools; ++i) {
-    mempool::pool_t& p = mempool::get_pool(mempool::pool_index_t(i));
-    _mempool_perf->set(l++, p.allocated_bytes());
-    _mempool_perf->set(l++, p.allocated_items());
+  if (_mempool_perf) {
+    unsigned l = l_mempool_first + 1;
+    for (unsigned i = 0; i < mempool::num_pools; ++i) {
+      mempool::pool_t& p = mempool::get_pool(mempool::pool_index_t(i));
+      _mempool_perf->set(l++, p.allocated_bytes());
+      _mempool_perf->set(l++, p.allocated_items());
+    }
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70957

---

backport of https://github.com/ceph/ceph/pull/62754
parent tracker: https://tracker.ceph.com/issues/64895

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh