### PR TITLE
test/libcephfs: copy DT_NEEDED entries from input libraries

### DIFF
--- a/src/test/client/CMakeLists.txt
+++ b/src/test/client/CMakeLists.txt
@@ -12,7 +12,6 @@ if(${WITH_CEPHFS})
     client
     global
     ceph-common
-    cephfs
     ${UNITTEST_LIBS}
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}

--- a/src/test/fs/CMakeLists.txt
+++ b/src/test/fs/CMakeLists.txt
@@ -9,12 +9,16 @@ if(${WITH_CEPHFS})
   add_executable(ceph_test_trim_caps
     test_trim_caps.cc
   )
-  target_link_libraries(ceph_test_trim_caps ceph-common cephfs)
+  target_link_libraries(ceph_test_trim_caps
+      cephfs
+  )
   install(TARGETS ceph_test_trim_caps DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   add_executable(ceph_test_ino_release_cb
     test_ino_release_cb.cc
   )
-  target_link_libraries(ceph_test_ino_release_cb ceph-common cephfs)
+  target_link_libraries(ceph_test_ino_release_cb
+      cephfs
+  )
   install(TARGETS ceph_test_ino_release_cb DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(${WITH_CEPHFS})

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -1,3 +1,21 @@
+# Note:
+#
+#    target_link_options(ceph_test_libcephfs PRIVATE -Wl,--copy-dt-needed-entries)
+#
+# This is done due to this linker error:
+#
+#    FAILED: bin/ceph_test_libcephfs_newops
+#    : && /usr/bin/g++-11 -Og -g -rdynamic -pie src/test/libcephfs/CMakeFiles/ceph_test_libcephfs_newops.dir/main.cc.o src/test/libcephfs/CMakeFiles/ceph_test_libcephfs_newops.dir/newops.cc.o -o bin/ceph_test_libcephfs_newops  -Wl,-rpath,/home/ubuntu/ceph/build/lib:  lib/libcephfs.so.2.0.0  lib/libgmock_main.a  lib/libgmock.a  lib/libgtest.a  -ldl  -ldl  /usr/lib/x86_64-linux-gnu/librt.a  -lresolv  -ldl  lib/libceph-common.so.2  lib/libjson_spirit.a  lib/libcommon_utf8.a  lib/liberasure_code.a  lib/libextblkdev.a  -lcap  boost/lib/libboost_thread.a  boost/lib/libboost_chrono.a  boost/lib/libboost_atomic.a  boost/lib/libboost_system.a  boost/lib/libboost_random.a  boost/lib/libboost_program_options.a  boost/lib/libboost_date_time.a  boost/lib/libboost_iostreams.a  boost/lib/libboost_regex.a  lib/libfmtd.a  /usr/lib/x86_64-linux-gnu/libblkid.so  /usr/lib/x86_64-linux-gnu/libcrypto.so  /usr/lib/x86_64-linux-gnu/libudev.so  /usr/lib/x86_64-linux-gnu/libz.so  src/opentelemetry-cpp/sdk/src/trace/libopentelemetry_trace.a  src/opentelemetry-cpp/sdk/src/resource/libopentelemetry_resources.a  src/opentelemetry-cpp/sdk/src/common/libopentelemetry_common.a  src/opentelemetry-cpp/exporters/jaeger/libopentelemetry_exporter_jaeger_trace.a  src/opentelemetry-cpp/ext/src/http/client/curl/libopentelemetry_http_client_curl.a  /usr/lib/x86_64-linux-gnu/libcurl.so  /usr/lib/x86_64-linux-gnu/libthrift.so  -lresolv  -ldl   -Wl,--as-needed -latomic && :
+#    /usr/bin/ld: lib/libcephfs.so.2.0.0: undefined reference to symbol '_ZN4ceph18__ceph_assert_failERKNS_11assert_dataE'
+#    /usr/bin/ld: lib/libceph-common.so.2: error adding symbols: DSO missing from command line
+#    collect2: error: ld returned 1 exit status
+#
+# Despite the presence of libceph-common.so.2 on the linker invocation, this
+# error persists. I (Patrick) have not found a resolution for this except to
+# make the linker behave in traditional manner where library dependencies are
+# assumed to be available. It seems like a linker bug and I have no explanation
+# for why it only affects a few test executables.
+
 if(WITH_LIBCEPHFS)
   add_executable(ceph_test_libcephfs
     test.cc
@@ -19,6 +37,9 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
   install(TARGETS ceph_test_libcephfs
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -33,6 +54,9 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs_snapdiff PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
   install(TARGETS ceph_test_libcephfs_snapdiff
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -47,6 +71,9 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs_suidsgid PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
   install(TARGETS ceph_test_libcephfs_suidsgid
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -57,11 +84,13 @@ if(WITH_LIBCEPHFS)
   target_link_libraries(ceph_test_libcephfs_vxattr
     ceph-common
     cephfs
-    librados
     ${UNITTEST_LIBS}
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs_vxattr PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
   install(TARGETS ceph_test_libcephfs_vxattr
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -76,6 +105,9 @@ if(WITH_LIBCEPHFS)
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs_newops PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
   install(TARGETS ceph_test_libcephfs_newops
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -84,13 +116,16 @@ if(WITH_LIBCEPHFS)
     add_executable(ceph_test_libcephfs_reclaim
       reclaim.cc
     )
-  target_link_libraries(ceph_test_libcephfs_reclaim
+    target_link_libraries(ceph_test_libcephfs_reclaim
       ceph-common
       cephfs
       ${UNITTEST_LIBS}
       ${EXTRALIBS}
       ${CMAKE_DL_LIBS}
-      )
+    )
+    if(NOT WIN32)
+      target_link_options(ceph_test_libcephfs_reclaim PRIVATE -Wl,--copy-dt-needed-entries)
+    endif()
     install(TARGETS ceph_test_libcephfs_reclaim
       DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif(NOT WIN32)
@@ -98,14 +133,16 @@ if(WITH_LIBCEPHFS)
   add_executable(ceph_test_libcephfs_lazyio
     lazyio.cc
   )
-target_link_libraries(ceph_test_libcephfs_lazyio
-    ceph-common
+  target_link_libraries(ceph_test_libcephfs_lazyio
     cephfs
     librados
     ${UNITTEST_LIBS}
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
-    )   
+  )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs_lazyio PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
   install(TARGETS ceph_test_libcephfs_lazyio
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -119,7 +156,10 @@ target_link_libraries(ceph_test_libcephfs_lazyio
     ${UNITTEST_LIBS}
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
-    )
+  )
+  if(NOT WIN32)
+    target_link_options(ceph_test_libcephfs_access PRIVATE -Wl,--copy-dt-needed-entries)
+  endif()
   install(TARGETS ceph_test_libcephfs_access
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(WITH_LIBCEPHFS)


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
