### PR TITLE
neorados: relax fifo trim error for ENODATA

### DIFF
--- a/src/neorados/cls/fifo.h
+++ b/src/neorados/cls/fifo.h
@@ -1734,8 +1734,10 @@ public:
 		      sys::error_code{});
 	   co_return sys::error_code{};
 	 } catch (const sys::system_error& e) {
-	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
-			      << " trim failed: " << e.what() << dendl;
+	   if (ceph::from_error_code(e.code()) != -ENODATA) {
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	                        << " trim failed: " << e.what() << dendl;
+	   }
 	   co_return e.code();
 	 }
        }, rados.get_executor()),


### PR DESCRIPTION
Don't log failure if no data is there to be trimmed. This can be seen by running `radosgw-admin datalog autotrim` as well as normal auto trimming in radosgw logs.
```
2025-04-19T21:11:48.142+0000 7f46997cb640 -1 neorados::cls::fifo::FIFO::trim<const boost::asio::use_awaitable_t<>&>(const DoutPrefixProvider*, std::string, bool, const boost::asio::use_awaitable_t<>&)::<lambda(auto:318, const DoutPrefixProvider*, std::string, bool, neorados::cls::fifo::FIFO*)> [with auto:318 = boost::asio::detail::co_composed_state<void(boost::asio::io_context::basic_executor_type<std::allocator<void>, 0>), boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code>, boost::asio::detail::co_composed_returns<void(boost::system::error_code)> >; std::string = std::__cxx11::basic_string<char>]:1737 trim failed: No data available [generic:61]
```


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
