### PR TITLE
squid: rgw/iam: correcting the caps for OIDC Provider for a user.

### DIFF
--- a/src/rgw/rgw_rest_oidc_provider.cc
+++ b/src/rgw/rgw_rest_oidc_provider.cc
@@ -33,7 +33,7 @@ int RGWRestOIDCProvider::verify_permission(optional_yield y)
 
 int RGWRestOIDCProvider::check_caps(const RGWUserCaps& caps)
 {
-  return caps.check_cap("roles", perm);
+  return caps.check_cap("oidc-provider", perm);
 }
 
 void RGWRestOIDCProvider::send_response()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70969

---

backport of https://github.com/ceph/ceph/pull/62819
parent tracker: https://tracker.ceph.com/issues/70926

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh