### PR TITLE
qa: Add Teuthology test for BlueStore ESB assertion failure

### DIFF
--- a/qa/standalone/ec-esb-fio.sh
+++ b/qa/standalone/ec-esb-fio.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -ex
+
+# Install FIO
+if [[ -f /etc/debian_version ]]; then
+    sudo apt-get update
+    sudo apt-get install -y fio
+elif [[ -f /etc/redhat-release ]]; then
+    sudo yum install -y fio
+else
+    echo "Unsupported OS"
+    exit 1
+fi
+
+# Configure EC pool
+ceph osd erasure-code-profile set myecprofile k=2 m=1
+ceph osd pool create ecpool 16 16 erasure myecprofile
+ceph osd pool set ecpool allow_ec_overwrites true
+
+# FIO configuration
+fio_file=$(mktemp -t ec-esb-fio-XXXX)
+cat > $fio_file <<EOF
+[global]
+ioengine=rados
+pool=ecpool
+clientname=admin
+conf=/etc/ceph/ceph.conf
+time_based=1
+runtime=3600
+invalidate=0
+direct=1
+iodepth=64
+numjobs=8
+group_reporting=1
+rw=randwrite
+file_service_type=pareto:0.20:0
+
+[variable-writes]
+bssplit=4k/16:8k/10:12k/9:16k/8:20k/7:24k/7:28k/6:32k/6:36k/5:40k/5:44k/4:48k/4:52k/4:56k/3:60k/3:64k/3
+size=50G
+nrfiles=12500
+filename_format=stress_obj.\$jobnum.\$filenum
+EOF
+
+status_log() {
+    echo "Cluster status on failure:"
+    ceph -s
+    ceph health detail
+    ceph osd tree
+    ceph osd df
+}
+
+echo "[ec-esb-fio] Starting FIO test..."
+
+# Run FIO in background
+fio $fio_file  &
+FIO_PID=$!
+
+# Monitor ceph health for OSD down states
+TIMEOUT=3600
+START_TIME=$(date +%s)
+while true; do
+    if ! ps -p $FIO_PID > /dev/null; then
+        echo "FIO process terminated early, checking cluster status"
+        status_log
+        exit 1
+    fi
+    CURRENT_TIME=$(date +%s)
+    ELAPSED=$((CURRENT_TIME - START_TIME))
+    if [ $ELAPSED -ge $TIMEOUT ]; then
+        echo "Reached 1-hour timeout, stopping FIO"
+        kill -9 $FIO_PID
+        wait $FIO_PID 2>/dev/null
+        break
+    fi
+    if ceph health detail | grep -i "osd.*down"; then
+        echo "Detected OSD down state:"
+        ceph health detail | grep -i "osd.*down"
+        kill -9 $FIO_PID
+        wait $FIO_PID 2>/dev/null
+        status_log
+        exit 1
+    fi
+    sleep 10
+done
+
+echo "[ec-esb-fio] FIO test completed, log checks to follow"

--- a/qa/suites/rados/singleton/all/ec-esb-fio.yaml
+++ b/qa/suites/rados/singleton/all/ec-esb-fio.yaml
@@ -1,0 +1,40 @@
+roles:
+- - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - osd.4
+  - osd.5
+  - client.0
+openstack:
+  - volumes: # attached to each instance
+      count: 6
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    conf:
+      osd:
+        bluestore_elastic_shared_blobs: true
+        osd_memory_target: 939524096
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(OBJECT_
+      - \(PG_
+      - \(SLOW_OPS\)
+      - overall HEALTH
+      - slow request
+
+- workunit:
+    basedir: qa/standalone
+    clients:
+      client.0:
+        - ec-esb-fio.sh
+
+- exec:
+      all:
+        - if egrep -i 'assert|crash|abort' /var/log/ceph/ceph-osd.*.log; then exit 1; fi


### PR DESCRIPTION
Adds a test to reproduce the `!ito->is_valid()` assertion in BlueStore
with `bluestore_elastic_shared_blobs=true` using a
FIO randwrite workload (512 concurrent ops, 50G, 12,500 objects).

The test deploys a 6-OSD cluster and runs FIO for 1 hour via workunit,
failing if an OSD crashes. Validating PR : #62817.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
