### PR TITLE
mgr/dashboard: Replace data-cy with data-testid for cypress IDs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/images.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/images.po.ts
@@ -22,7 +22,7 @@ export class ImagesPageHelper extends PageHelper {
     cy.get('#size').type(size);
 
     // Click the create button and wait for image to be made
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
     this.getFirstTableCell(name).should('exist');
   }
 
@@ -35,7 +35,7 @@ export class ImagesPageHelper extends PageHelper {
     cy.get('#name').clear().type(newName);
     cy.get('#size').clear().type(newSize); // click the size box and send new size
 
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
 
     this.getExpandCollapseElement(newName).click();
     cy.get('[data-testid=rbd-details-table]').contains('td', newSize);
@@ -53,7 +53,7 @@ export class ImagesPageHelper extends PageHelper {
     cy.get('[data-testid="table-action-btn"]').click({ multiple: true });
     cy.get('button.move-to-trash').click({ force: true });
 
-    cy.get('[data-cy=submitBtn] button').should('be.visible').click({ force: true });
+    cy.get('[data-testid=submitBtn] button').should('be.visible').click({ force: true });
 
     // Clicks trash tab
     cy.contains('.nav-link', 'Trash').click();
@@ -80,7 +80,7 @@ export class ImagesPageHelper extends PageHelper {
       cy.get('cds-modal #name').clear().type(newName);
     }
 
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
 
     // clicks images tab
     cy.contains('.nav-link', 'Images').click();
@@ -103,7 +103,7 @@ export class ImagesPageHelper extends PageHelper {
       this.selectOption('poolName', pool);
       cy.get('#poolName').should('have.class', 'ng-valid'); // check if pool is selected
     }
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
     // Wait for image to delete and check it is not present
 
     this.getFirstTableCell(name).should('not.exist');

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/configuration.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/configuration.po.ts
@@ -21,7 +21,7 @@ export class ConfigurationPageHelper extends PageHelper {
       cy.get(`#${i}`).clear();
     }
     // Clicks save button and checks that values are not present for the selected config
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
 
     cy.wait(3 * 1000);
 
@@ -64,7 +64,7 @@ export class ConfigurationPageHelper extends PageHelper {
 
     // Clicks save button then waits until the desired config is visible, clicks it,
     // then checks that each desired value appears with the desired number
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
     cy.wait(3 * 1000);
 
     // Enter config setting name into filter box

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
@@ -67,7 +67,7 @@ And('{string} option {string}', (action: string, labels: string) => {
 });
 
 And('I click on submit button', () => {
-  cy.get('[data-cy=submitBtn]').click();
+  cy.get('[data-testid=submitBtn]').click();
 });
 
 /**

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/role-mgmt.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/role-mgmt.po.ts
@@ -16,7 +16,7 @@ export class RoleMgmtPageHelper extends PageHelper {
     cy.get('#description').type(description);
 
     // Click the create button and wait for role to be made
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
     cy.get('[data-testid="active-breadcrumb-item"]').should('not.have.text', 'Create');
 
     this.getFirstTableCell(name).should('exist');
@@ -31,7 +31,7 @@ export class RoleMgmtPageHelper extends PageHelper {
     cy.get('#description').clear().type(description);
 
     // Click the edit button and check new values are present in table
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
     cy.get('[data-testid="active-breadcrumb-item"]').should('not.have.text', 'Edit');
 
     this.getFirstTableCell(name).should('exist');

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/user-mgmt.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/user-mgmt.po.ts
@@ -17,7 +17,7 @@ export class UserMgmtPageHelper extends PageHelper {
     cy.get('#email').type(email);
 
     // Click the create button and wait for user to be made
-    cy.get('[data-cy=submitBtn]').click();
+    cy.get('[data-testid=submitBtn]').click();
     this.getFirstTableCell(username).should('exist');
   }
 
@@ -31,7 +31,7 @@ export class UserMgmtPageHelper extends PageHelper {
     cy.get('#email').clear().type(email);
 
     // Click the edit button and check new values are present in table
-    const editButton = cy.get('[data-cy=submitBtn]');
+    const editButton = cy.get('[data-testid=submitBtn]');
     editButton.click();
     this.getFirstTableCell(email).should('exist');
     this.getFirstTableCell(name).should('exist');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.html
@@ -8,7 +8,7 @@
                       [disabled]="disabled"
                       [form]="form"
                       [ariaLabel]="submitText"
-                      data-cy="submitBtn"
+                      data-testid="submitBtn"
                       [buttonType]="submitBtnType">{{ submitText }}</cd-submit-button>
   </div>
 </ng-container>
@@ -26,7 +26,7 @@
                       [disabled]="disabled"
                       [form]="form"
                       [ariaLabel]="submitText"
-                      data-cy="submitBtn"
+                      data-testid="submitBtn"
                       [modalForm]="modalForm"
                       [buttonType]="submitBtnType"
                       class="w-100">{{ submitText }}</cd-submit-button>


### PR DESCRIPTION


  This commit fixes inconsistencies in Cypress test IDs.
  Both data-testid and data-cy were being used — this change replaces all data-cy attributes with data-testid to keep it 
  consistent across the codebase.


 Fixes: https://tracker.ceph.com/issues/70986
     

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
