### PR TITLE
crimson/os/seastore: improve checks to the paddr types

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1521,7 +1521,7 @@ bool SegmentCleaner::check_usage()
         extent_types_t type,
         laddr_t laddr)
     {
-      if (paddr.get_addr_type() == paddr_types_t::SEGMENT) {
+      if (paddr.is_absolute_segmented()) {
         if (is_backref_node(type)) {
 	  assert(laddr == L_ADDR_NULL);
 	  assert(backref_key.is_absolute_segmented()
@@ -1557,7 +1557,7 @@ void SegmentCleaner::mark_space_used(
   assert(background_callback->get_state() >= state_t::SCAN_SPACE);
   assert(len);
   // TODO: drop
-  if (addr.get_addr_type() != paddr_types_t::SEGMENT) {
+  if (!addr.is_absolute_segmented()) {
     return;
   }
 
@@ -1588,7 +1588,7 @@ void SegmentCleaner::mark_space_free(
   assert(background_callback->get_state() >= state_t::SCAN_SPACE);
   assert(len);
   // TODO: drop
-  if (addr.get_addr_type() != paddr_types_t::SEGMENT) {
+  if (!addr.is_absolute_segmented()) {
     return;
   }
 
@@ -1722,7 +1722,7 @@ void RBMCleaner::mark_space_used(
   extent_len_t len)
 {
   LOG_PREFIX(RBMCleaner::mark_space_used);
-  assert(addr.get_addr_type() == paddr_types_t::RANDOM_BLOCK);
+  assert(addr.is_absolute_random_block());
   auto rbms = rb_group->get_rb_managers();
   for (auto rbm : rbms) {
     if (addr.get_device_id() == rbm->get_device_id()) {
@@ -1741,7 +1741,7 @@ void RBMCleaner::mark_space_free(
   extent_len_t len)
 {
   LOG_PREFIX(RBMCleaner::mark_space_free);
-  assert(addr.get_addr_type() == paddr_types_t::RANDOM_BLOCK);
+  assert(addr.is_absolute_random_block());
   auto rbms = rb_group->get_rb_managers();
   for (auto rbm : rbms) {
     if (addr.get_device_id() == rbm->get_device_id()) {

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1524,7 +1524,8 @@ bool SegmentCleaner::check_usage()
       if (paddr.get_addr_type() == paddr_types_t::SEGMENT) {
         if (is_backref_node(type)) {
 	  assert(laddr == L_ADDR_NULL);
-	  assert(backref_key != P_ADDR_NULL);
+	  assert(backref_key.is_absolute_segmented()
+                 || backref_key == P_ADDR_MIN);
           tracker->allocate(
             paddr.as_seg_paddr().get_segment_id(),
             paddr.as_seg_paddr().get_segment_off(),
@@ -1832,7 +1833,8 @@ bool RBMCleaner::check_usage()
 	if (rbm->get_device_id() == paddr.get_device_id()) {
 	  if (is_backref_node(type)) {
 	    assert(laddr == L_ADDR_NULL);
-	    assert(backref_key != P_ADDR_NULL);
+	    assert(backref_key.is_absolute_random_block()
+	           || backref_key == P_ADDR_MIN);
 	    tracker.allocate(
 	      paddr,
 	      len);

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -161,7 +161,7 @@ BtreeBackrefManager::new_mapping(
 {
   ceph_assert(
     is_aligned(
-      key.get_addr_type() == paddr_types_t::SEGMENT ?
+      key.is_absolute_segmented() ?
 	key.as_seg_paddr().get_segment_off() :
 	key.as_blk_paddr().get_device_off(),
       cache.get_block_size()));

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -68,12 +68,14 @@ struct FixedKVNode : CachedExtent {
      * Upon commit, these now block relative addresses will be interpretted
      * against the real final address.
      */
-    if (!get_paddr().is_absolute()) {
+    if (get_paddr().is_record_relative()) {
       // backend_type_t::SEGMENTED
-      assert(get_paddr().is_record_relative());
       resolve_relative_addrs(
 	make_record_relative_paddr(0).block_relative_to(get_paddr()));
-    } // else: backend_type_t::RANDOM_BLOCK
+    } else {
+      // backend_type_t::RANDOM_BLOCK
+      assert(get_paddr().is_absolute());
+    }
   }
 
   void on_delta_write(paddr_t record_block_offset) final {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -56,7 +56,7 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
   LOG_PREFIX(Cache::retire_extent_addr);
   TRACET("retire {}~0x{:x}", t, paddr, length);
 
-  assert(paddr.is_real() && !paddr.is_block_relative());
+  assert(paddr.is_real_location());
 
   CachedExtentRef ext;
   auto result = t.get_extent(paddr, &ext);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1937,8 +1937,7 @@ Cache::replay_delta(
    * safetly skip these deltas because the extent must already
    * have been rewritten.
    */
-  if (delta.paddr != P_ADDR_NULL &&
-      delta.paddr.get_addr_type() == paddr_types_t::SEGMENT) {
+  if (delta.paddr.is_absolute_segmented()) {
     auto& seg_addr = delta.paddr.as_seg_paddr();
     auto seg_info = get_segment_info(seg_addr.get_segment_id());
     if (seg_info) {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1408,7 +1408,11 @@ record_t Cache::prepare_record(
     fresh_stat.increment(i->get_length());
     get_by_ext(efforts.fresh_inline_by_ext,
                i->get_type()).increment(i->get_length());
+#ifdef UNIT_TESTS_BUILT
     assert(i->is_inline() || i->get_paddr().is_fake());
+#else
+    assert(i->is_inline());
+#endif
 
     bufferlist bl;
     i->prepare_write();

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1520,7 +1520,7 @@ private:
     paddr_t paddr,
     paddr_t key,
     extent_types_t type) {
-    assert(!paddr.is_relative());
+    assert(paddr.is_absolute());
     auto [iter, inserted] = backref_extents.emplace(paddr, key, type);
     boost::ignore_unused(inserted);
     assert(inserted);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -255,6 +255,7 @@ public:
       });
     }
 
+    assert(paddr.is_absolute());
     // get_extent_ret::ABSENT from transaction
     ret = query_cache(paddr);
     if (!ret) {
@@ -590,6 +591,7 @@ public:
 // Interfaces only for tests.
 public:
   CachedExtentRef test_query_cache(paddr_t offset) {
+    assert(offset.is_absolute());
     return query_cache(offset);
   }
 
@@ -678,6 +680,7 @@ private:
     const Transaction::src_t* p_src
   ) {
     LOG_PREFIX(Cache::do_get_caching_extent);
+    assert(offset.is_absolute());
     auto cached = query_cache(offset);
     if (!cached) {
       // partial read
@@ -1484,6 +1487,7 @@ private:
       const Transaction::src_t* p_src,
       cache_hint_t hint)
   {
+    assert(ext.get_paddr().is_absolute());
     if (hint == CACHE_HINT_NOCACHE && is_logical_type(ext.get_type())) {
       return;
     }
@@ -1919,6 +1923,7 @@ private:
     assert(!extent->is_range_loaded(offset, length));
     assert(is_aligned(offset, get_block_size()));
     assert(is_aligned(length, get_block_size()));
+    assert(extent->get_paddr().is_absolute());
     extent->set_io_wait();
     auto old_length = extent->get_loaded_length();
     load_ranges_t to_read = extent->load_ranges(offset, length);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -760,7 +760,7 @@ public:
   }
 
   bool is_inline() const {
-    return poffset.is_relative();
+    return poffset.is_record_relative();
   }
 
   paddr_t get_prior_paddr_and_reset() {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -558,9 +558,11 @@ public:
 
   bool get_checksum_needed(paddr_t addr) {
     // checksum offloading only for blocks physically stored in the device
+#ifdef UNIT_TESTS_BUILT
     if (addr.is_fake()) {
       return true;
     }
+#endif
     assert(addr.is_absolute());
     return !devices_by_id[addr.get_device_id()]->is_end_to_end_data_protection();
   }

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -111,7 +111,7 @@ SegmentedJournal::prep_replay_segments(
     auto journal_tail = trimmer.get_journal_tail();
     auto journal_tail_paddr = journal_tail.offset;
     ceph_assert(journal_tail != JOURNAL_SEQ_NULL);
-    ceph_assert(journal_tail_paddr != P_ADDR_NULL);
+    ceph_assert(journal_tail_paddr.is_absolute_segmented());
     auto from = std::find_if(
       segments.begin(),
       segments.end(),

--- a/src/crimson/os/seastore/lba_mapping.h
+++ b/src/crimson/os/seastore/lba_mapping.h
@@ -47,7 +47,7 @@ public:
   virtual bool is_data_stable() const = 0;
   virtual bool is_clone() const = 0;
   bool is_zero_reserved() const {
-    return !get_val().is_real();
+    return get_val().is_zero();
   }
 
   LBAMappingRef duplicate() const;

--- a/src/crimson/os/seastore/record_scanner.h
+++ b/src/crimson/os/seastore/record_scanner.h
@@ -30,11 +30,11 @@ public:
   ); ///< @return used budget
 
   device_off_t get_segment_off(paddr_t addr) const {
-    if (addr.get_addr_type() == paddr_types_t::SEGMENT) {
+    if (addr.is_absolute_segmented()) {
       auto& seg_addr = addr.as_seg_paddr();
       return seg_addr.get_segment_off();
     }
-    assert(addr.get_addr_type() == paddr_types_t::RANDOM_BLOCK);
+    assert(addr.is_absolute_random_block());
     auto& blk_addr = addr.as_blk_paddr();
     return blk_addr.get_device_off();
   }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -127,12 +127,12 @@ std::ostream &operator<<(std::ostream &out, const paddr_t &rhs)
     out << device_id_printer_t{id}
         << ",0x"
         << std::hex << s.get_device_off() << std::dec;
-  } else if (rhs.get_addr_type() == paddr_types_t::SEGMENT) {
+  } else if (rhs.is_absolute_segmented()) {
     auto &s = rhs.as_seg_paddr();
     out << s.get_segment_id()
         << ",0x"
         << std::hex << s.get_segment_off() << std::dec;
-  } else if (rhs.get_addr_type() == paddr_types_t::RANDOM_BLOCK) {
+  } else if (rhs.is_absolute_random_block()) {
     auto &s = rhs.as_blk_paddr();
     out << device_id_printer_t{s.get_device_id()}
         << ",0x"

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -651,6 +651,14 @@ public:
     return get_addr_type() != paddr_types_t::RESERVED;
   }
 
+  bool is_absolute_random_block() const {
+    return get_addr_type() == paddr_types_t::RANDOM_BLOCK;
+  }
+
+  bool is_absolute_segmented() const {
+    return get_addr_type() == paddr_types_t::SEGMENT;
+  }
+
   bool is_fake() const {
     return get_device_id() == DEVICE_ID_FAKE;
   }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -643,8 +643,21 @@ public:
     return get_device_id() == DEVICE_ID_ROOT;
   }
 
+  /**
+   * is_absolute()
+   *
+   * indicates whether addr reflects an absolute location
+   * which can be found on disk.
+   *
+   * Note, fake paddrs should work like the absolute ones.
+   */
   bool is_absolute() const {
+#ifdef UNIT_TESTS_BUILT
+    return get_addr_type() != paddr_types_t::RESERVED ||
+           is_fake();
+#else
     return get_addr_type() != paddr_types_t::RESERVED;
+#endif
   }
 
   bool is_absolute_random_block() const {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -565,10 +565,6 @@ public:
     return static_cast<device_id_t>(internal_paddr >> DEVICE_OFF_BITS);
   }
 
-  paddr_types_t get_addr_type() const {
-    return device_id_to_paddr_type(get_device_id());
-  }
-
   paddr_t add_offset(device_off_t o) const;
 
   paddr_t add_relative(paddr_t o) const;
@@ -701,7 +697,7 @@ private:
               encode_device_off(offset)) {
     assert(offset >= DEVICE_OFF_MIN);
     assert(offset <= DEVICE_OFF_MAX);
-    assert(get_addr_type() != paddr_types_t::SEGMENT);
+    assert(!is_absolute_segmented());
   }
 
   paddr_t(internal_paddr_t val);
@@ -710,6 +706,10 @@ private:
   constexpr paddr_t(device_id_t d_id, device_off_t offset, const_construct_t)
     : internal_paddr((static_cast<internal_paddr_t>(d_id) << DEVICE_OFF_BITS) |
                      static_cast<u_device_off_t>(offset)) {}
+
+  paddr_types_t get_addr_type() const {
+    return device_id_to_paddr_type(get_device_id());
+  }
 
   friend struct paddr_le_t;
   friend struct pladdr_le_t;
@@ -827,22 +827,22 @@ inline paddr_t make_delayed_temp_paddr(device_off_t off) {
 }
 
 inline const seg_paddr_t& paddr_t::as_seg_paddr() const {
-  assert(get_addr_type() == paddr_types_t::SEGMENT);
+  assert(is_absolute_segmented());
   return *static_cast<const seg_paddr_t*>(this);
 }
 
 inline seg_paddr_t& paddr_t::as_seg_paddr() {
-  assert(get_addr_type() == paddr_types_t::SEGMENT);
+  assert(is_absolute_segmented());
   return *static_cast<seg_paddr_t*>(this);
 }
 
 inline const blk_paddr_t& paddr_t::as_blk_paddr() const {
-  assert(get_addr_type() == paddr_types_t::RANDOM_BLOCK);
+  assert(is_absolute_random_block());
   return *static_cast<const blk_paddr_t*>(this);
 }
 
 inline blk_paddr_t& paddr_t::as_blk_paddr() {
-  assert(get_addr_type() == paddr_types_t::RANDOM_BLOCK);
+  assert(is_absolute_random_block());
   return *static_cast<blk_paddr_t*>(this);
 }
 
@@ -1009,18 +1009,15 @@ private:
     }
     using ret_t = std::pair<device_off_t, segment_id_t>;
     auto to_pair = [](const paddr_t &addr) -> ret_t {
-      if (addr.get_addr_type() == paddr_types_t::SEGMENT) {
+      if (addr.is_absolute_segmented()) {
 	auto &seg_addr = addr.as_seg_paddr();
 	return ret_t(seg_addr.get_segment_off(), seg_addr.get_segment_id());
-      } else if (addr.get_addr_type() == paddr_types_t::RANDOM_BLOCK) {
+      } else if (addr.is_absolute_random_block()) {
 	auto &blk_addr = addr.as_blk_paddr();
 	return ret_t(blk_addr.get_device_off(), MAX_SEG_ID);
-      } else if (addr.get_addr_type() == paddr_types_t::RESERVED) {
+      } else {
         auto &res_addr = addr.as_res_paddr();
         return ret_t(res_addr.get_device_off(), MAX_SEG_ID);
-      } else {
-	assert(0 == "impossible");
-	return ret_t(0, MAX_SEG_ID);
       }
     };
     auto left = to_pair(offset);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -647,23 +647,22 @@ public:
     return get_device_id() == DEVICE_ID_ROOT;
   }
 
-  /**
-   * is_real
-   *
-   * indicates whether addr reflects a physical location, absolute, relative,
-   * or delayed.  FAKE segments also count as real so as to reflect the way in
-   * which unit tests use them.
-   */
-  bool is_real() const {
-    return !is_zero() && !is_null() && !is_root();
-  }
-
   bool is_absolute() const {
     return get_addr_type() != paddr_types_t::RESERVED;
   }
 
   bool is_fake() const {
     return get_device_id() == DEVICE_ID_FAKE;
+  }
+
+  /**
+   * is_real_location
+   *
+   * indicates whether addr reflects a real location (valid in lba) --
+   * absolute, record-relative, or delayed.
+   */
+  bool is_real_location() const {
+    return is_absolute() || is_delayed() || is_record_relative();
   }
 
   auto operator<=>(const paddr_t &) const = default;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -217,28 +217,26 @@ public:
   }
 
   void mark_delayed_extent_ool(CachedExtentRef& ref) {
+    assert(ref->get_paddr().is_delayed());
     ool_block_list.push_back(ref);
   }
 
   void update_delayed_ool_extent_addr(LogicalCachedExtentRef& ref,
                                       paddr_t final_addr) {
-    write_set.erase(*ref);
     assert(ref->get_paddr().is_delayed());
+    assert(final_addr.is_absolute());
+    write_set.erase(*ref);
     ref->set_paddr(final_addr, /* need_update_mapping: */ true);
-    assert(!ref->get_paddr().is_null());
-    assert(!ref->is_inline());
     write_set.insert(*ref);
   }
 
   void mark_allocated_extent_ool(CachedExtentRef& ref) {
     assert(ref->get_paddr().is_absolute());
-    assert(!ref->is_inline());
     ool_block_list.push_back(ref);
   }
 
   void mark_inplace_rewrite_extent_ool(LogicalCachedExtentRef ref) {
     assert(ref->get_paddr().is_absolute_random_block());
-    assert(!ref->is_inline());
     inplace_ool_block_list.push_back(ref);
   }
 

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -188,11 +188,16 @@ public:
       pre_alloc_list.emplace_back(ref);
       fresh_block_stats.increment(ref->get_length());
     } else {
+#ifdef UNIT_TESTS_BUILT
       if (likely(ref->get_paddr() == make_record_relative_paddr(0))) {
 	ref->set_paddr(make_record_relative_paddr(offset));
       } else {
 	ceph_assert(ref->get_paddr().is_fake());
       }
+#else
+      assert(ref->get_paddr() == make_record_relative_paddr(0));
+      ref->set_paddr(make_record_relative_paddr(offset));
+#endif
       offset += ref->get_length();
       inline_block_list.push_back(ref);
       fresh_block_stats.increment(ref->get_length());

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -184,7 +184,7 @@ public:
       delayed_temp_offset += ref->get_length();
       delayed_alloc_list.emplace_back(ref);
       fresh_block_stats.increment(ref->get_length());
-    } else if (ref->get_paddr().is_absolute()) {
+    } else if (ref->get_paddr().is_absolute_random_block()) {
       pre_alloc_list.emplace_back(ref);
       fresh_block_stats.increment(ref->get_length());
     } else {
@@ -237,7 +237,7 @@ public:
   }
 
   void mark_inplace_rewrite_extent_ool(LogicalCachedExtentRef ref) {
-    assert(ref->get_paddr().is_absolute());
+    assert(ref->get_paddr().is_absolute_random_block());
     assert(!ref->is_inline());
     inplace_ool_block_list.push_back(ref);
   }
@@ -245,7 +245,7 @@ public:
   void add_inplace_rewrite_extent(CachedExtentRef ref) {
    ceph_assert(!is_weak());
    ceph_assert(ref);
-   ceph_assert(ref->get_paddr().is_absolute());
+   ceph_assert(ref->get_paddr().is_absolute_random_block());
    assert(ref->state == CachedExtent::extent_state_t::DIRTY);
    pre_inplace_rewrite_list.emplace_back(ref->cast<LogicalCachedExtent>());
   }

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -107,6 +107,7 @@ public:
     RETIRED
   };
   get_extent_ret get_extent(paddr_t addr, CachedExtentRef *out) {
+    assert(addr.is_real_location() || addr.is_root());
     auto [result, ext] = do_get_extent(addr);
     // placeholder in read-set must be in the retired-set
     // at the same time, user should not see a placeholder.
@@ -119,12 +120,14 @@ public:
   }
 
   void add_absent_to_retired_set(CachedExtentRef ref) {
+    assert(ref->get_paddr().is_absolute());
     bool added = do_add_to_read_set(ref);
     ceph_assert(added);
     add_present_to_retired_set(ref);
   }
 
   void add_present_to_retired_set(CachedExtentRef ref) {
+    assert(ref->get_paddr().is_real_location());
     assert(!is_weak());
 #ifndef NDEBUG
     auto [result, ext] = do_get_extent(ref->get_paddr());
@@ -156,6 +159,7 @@ public:
 
   // Returns true if added, false if already added or weak
   bool maybe_add_to_read_set(CachedExtentRef ref) {
+    assert(ref->get_paddr().is_absolute());
     if (is_weak()) {
       return false;
     }
@@ -163,6 +167,8 @@ public:
   }
 
   void add_to_read_set(CachedExtentRef ref) {
+    assert(ref->get_paddr().is_absolute()
+           || ref->get_paddr().is_root());
     if (is_weak()) {
       return;
     }
@@ -173,6 +179,7 @@ public:
 
   void add_fresh_extent(
     CachedExtentRef ref) {
+    assert(ref->get_paddr().is_real_location());
     ceph_assert(!is_weak());
     if (ref->is_exist_clean()) {
       existing_block_stats.inc(ref);
@@ -255,6 +262,8 @@ public:
 
   void add_mutated_extent(CachedExtentRef ref) {
     ceph_assert(!is_weak());
+    assert(ref->get_paddr().is_absolute() ||
+           ref->get_paddr().is_root());
     assert(ref->is_exist_mutation_pending() ||
 	   read_set.count(ref->prior_instance->get_paddr()));
     mutated_block_list.push_back(ref);
@@ -273,6 +282,7 @@ public:
     assert(!is_retired_placeholder_type(extent.get_type()));
     assert(!is_root_type(extent.get_type()));
     assert(extent.get_paddr() == placeholder.get_paddr());
+    assert(extent.get_paddr().is_absolute());
     {
       auto where = read_set.find(placeholder.get_paddr());
       assert(where != read_set.end());
@@ -327,6 +337,7 @@ public:
   }
 
   bool is_stable_extent_retired(paddr_t paddr, extent_len_t len) {
+    assert(paddr.is_absolute());
     auto iter = retired_set.lower_bound(paddr);
     if (iter == retired_set.end()) {
       return false;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -151,9 +151,10 @@ TransactionManager::mount()
             extent_len_t len,
             extent_types_t type,
             laddr_t laddr) {
+          assert(paddr.is_absolute());
           if (is_backref_node(type)) {
             assert(laddr == L_ADDR_NULL);
-	    assert(backref_key != P_ADDR_NULL);
+	    assert(backref_key.is_absolute() || backref_key == P_ADDR_MIN);
             backref_manager->cache_new_backref_extent(paddr, backref_key, type);
             cache->update_tree_extents_num(type, 1);
             epm->mark_space_used(paddr, len);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -691,7 +691,7 @@ TransactionManager::get_extents_if_live(
 
   // This only works with segments to check if alive,
   // as parallel transactions may split the extent at the same time.
-  ceph_assert(paddr.get_addr_type() == paddr_types_t::SEGMENT);
+  ceph_assert(paddr.is_absolute_segmented());
 
   return cache->get_extent_if_cached(t, paddr, len, type
   ).si_then([this, FNAME, type, paddr, laddr, len, &t](auto extent)
@@ -727,7 +727,7 @@ TransactionManager::get_extents_if_live(
           {
             DEBUGT("got pin, try read in parallel ... -- {}", t, *pin);
             auto pin_paddr = pin->get_val();
-            if (pin_paddr.get_addr_type() != paddr_types_t::SEGMENT) {
+            if (!pin_paddr.is_absolute_segmented()) {
               return seastar::now();
             }
             auto &pin_seg_paddr = pin_paddr.as_seg_paddr();

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -213,7 +213,7 @@ public:
     ).si_then([this, FNAME, &t, offset, length,
 	      maybe_init=std::move(maybe_init)] (auto pin) mutable
       -> read_extent_ret<T> {
-      if (length != pin->get_length() || !pin->get_val().is_real()) {
+      if (length != pin->get_length() || !pin->get_val().is_real_location()) {
         SUBERRORT(seastore_tm, "{}~0x{:x} {} got wrong pin {}",
                   t, offset, length, T::TYPE, *pin);
         ceph_abort("Impossible");
@@ -240,7 +240,7 @@ public:
     ).si_then([this, FNAME, &t, offset,
 	      maybe_init=std::move(maybe_init)] (auto pin) mutable
       -> read_extent_ret<T> {
-      if (!pin->get_val().is_real()) {
+      if (!pin->get_val().is_real_location()) {
         SUBERRORT(seastore_tm, "{} {} got wrong pin {}",
                   t, offset, T::TYPE, *pin);
         ceph_abort("Impossible");


### PR DESCRIPTION
In short:
* Refine the paddr type categories.
* Fix or improve the existing paddr type checks.
* Add checks related to cache(lru, dirty, extent-index) and transaction.
* Refine fake paddr related logic.
* Make sure root is always dirty.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
