### PR TITLE
mgr/dashboard: Tieiring - allow read through

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-storage-class.model.ts
@@ -20,19 +20,7 @@ export interface StorageClassDetails {
   multipart_sync_threshold: number;
   host_style: string;
   retain_head_object: boolean;
-}
-
-export interface S3Details {
-  endpoint: string;
-  access_key: string;
-  storage_class: string;
-  target_path: string;
-  target_storage_class: string;
-  region: string;
-  secret: string;
-  multipart_min_part_size: number;
-  multipart_sync_threshold: number;
-  host_style: boolean;
+  allow_read_through: boolean;
 }
 
 export interface TierTarget {
@@ -40,6 +28,7 @@ export interface TierTarget {
     storage_class: string;
     tier_type: string;
     retain_head_object: boolean;
+    allow_read_through: boolean;
     s3: S3Details;
   };
 }
@@ -47,15 +36,6 @@ export interface TierTarget {
 export interface Target {
   name: string;
   tier_targets: TierTarget[];
-}
-
-export interface StorageClassDetails {
-  target_path: string;
-  access_key: string;
-  secret: string;
-  multipart_min_part_size: number;
-  multipart_sync_threshold: number;
-  host_style: string;
 }
 
 export interface ZoneGroup {
@@ -76,6 +56,7 @@ export interface S3Details {
   multipart_sync_threshold: number;
   host_style: boolean;
   retain_head_object?: boolean;
+  allow_read_through?: boolean;
 }
 export interface RequestModel {
   zone_group: string;
@@ -92,6 +73,7 @@ export interface PlacementTarget {
     secret: string;
     target_path: string;
     retain_head_object: boolean;
+    allow_read_through: boolean;
     region: string;
     multipart_sync_threshold: number;
     multipart_min_part_size: number;
@@ -104,3 +86,33 @@ export interface PlacementTarget {
 export const CLOUD_TIER = 'cloud-s3';
 
 export const DEFAULT_PLACEMENT = 'default-placement';
+
+export const ALLOW_READ_THROUGH_TEXT =
+  'Enables fetching objects from remote cloud S3 if not found locally.';
+
+export const MULTIPART_MIN_PART_TEXT =
+  'It specifies that objects this size or larger are transitioned to the cloud using multipart upload.';
+
+export const MULTIPART_SYNC_THRESHOLD_TEXT =
+  'It specifies the minimum part size to use when transitioning objects using multipart upload.';
+
+export const TARGET_PATH_TEXT =
+  'Target Path refers to the storage location (e.g., bucket or container) in the cloud where data will be stored.';
+
+export const TARGET_REGION_TEXT =
+  'The region of the remote cloud service where storage is located.';
+
+export const TARGET_ENDPOINT_TEXT =
+  'The URL endpoint of the remote cloud service for accessing storage.';
+
+export const TARGET_ACCESS_KEY_TEXT =
+  "To view or copy your access key, go to your cloud service's user management or credentials section, find your user profile, and locate the access key. You can view and copy the key by following the instructions provided.";
+
+export const TARGET_SECRET_KEY_TEXT =
+  "To view or copy your secret key, go to your cloud service's user management or credentials section, find your user profile, and locate the secret key. You can view and copy the key by following the instructions provided.";
+
+export const RETAIN_HEAD_OBJECT_TEXT = 'Retain object metadata after transition to the cloud.';
+
+export const HOST_STYLE = `The URL format for accessing the remote S3 endpoint:
+  - 'Path': Use for a path-based URL
+  - 'Virtual': Use for a domain-based URL`;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.html
@@ -12,8 +12,7 @@
               Target Path
               <cd-helper class="text-pre-wrap">
                 <span i18n>
-                  The target path specifies a prefix to which the source bucket-name/object-name is
-                  appended.
+                 {{ targetPathText }}
                 </span>
               </cd-helper>
             </td>
@@ -24,7 +23,7 @@
               Access key
               <cd-helper class="text-pre-wrap">
                 <span i18n>
-                  Access key is the remote cloud S3 access key used for a specific connection.
+                  {{ targetAccessKeyText }}
                 </span>
               </cd-helper>
             </td>
@@ -50,7 +49,7 @@
             <td class="bold">
               Secret key
               <cd-helper class="text-pre-wrap">
-                <span i18n> Secret is the secret key for the remote cloud S3 service. </span>
+                <span i18n> {{ targetSecretKeyText }} </span>
               </cd-helper>
             </td>
             <td>
@@ -72,48 +71,54 @@
             </td>
           </tr>
           <tr>
-            <td
-                class="bold">
+            <td class="bold">
               Host Style
               <cd-helper class="text-pre-wrap">
-                <span i18n>The URL format for accessing the remote S3 endpoint: 'Path' for a path-based URL
-                  or 'Virtual' for a domain-based URL.</span>
+                <span i18n>{{ hostStyleText }}</span
+                >
               </cd-helper>
             </td>
             <td>{{ selection?.host_style }}</td>
           </tr>
           <tr>
-            <td
-                class="bold">
+            <td class="bold">
               Multipart Minimum Part Size
               <cd-helper class="text-pre-wrap">
                 <span i18n>
-                  Minimum parts size to use when transitioning objects using multipart upload.
+                  {{ multipartMinPartText }}
                 </span>
               </cd-helper>
             </td>
             <td>{{ selection?.multipart_min_part_size }}</td>
           </tr>
           <tr>
-            <td
-                class="bold">
+            <td class="bold">
               Multipart Sync Threshold
               <cd-helper class="text-pre-wrap">
                 <span i18n>
-                  Objects this size or larger will be transitioned to the cloud using multipart
-                  upload.
+                 {{ multipartSyncThreholdText }}
                 </span>
               </cd-helper>
             </td>
             <td>{{ selection?.multipart_sync_threshold }}</td>
           </tr>
           <tr>
-            <td
-                class="bold">
-              Retain Head Object
+            <td class="bold">
+              <span i18n>Allow Read Through </span>
               <cd-helper class="text-pre-wrap">
                 <span i18n>
-                  Retain object metadata after transition to the cloud (default: false).
+                  {{ allowReadThroughText }}
+                </span>
+              </cd-helper>
+            </td>
+            <td>{{ selection?.allow_read_through }}</td>
+          </tr>
+          <tr>
+            <td class="bold">
+              Head Object (Stub File)
+              <cd-helper class="text-pre-wrap">
+                <span i18n>
+                  {{ retainHeadObjectText }}
                 </span>
               </cd-helper>
             </td>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.spec.ts
@@ -39,7 +39,8 @@ describe('RgwStorageClassDetailsComponent', () => {
       multipart_min_part_size: 100,
       multipart_sync_threshold: 200,
       host_style: 'path',
-      retain_head_object: true
+      retain_head_object: true,
+      allow_read_through: true
     };
     component.selection = mockSelection;
     component.ngOnChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-details/rgw-storage-class-details.component.ts
@@ -1,6 +1,16 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { CdTableColumn } from '~/app/shared/models/cd-table-column';
-import { StorageClassDetails } from '../models/rgw-storage-class.model';
+import {
+  ALLOW_READ_THROUGH_TEXT,
+  HOST_STYLE,
+  MULTIPART_MIN_PART_TEXT,
+  MULTIPART_SYNC_THRESHOLD_TEXT,
+  RETAIN_HEAD_OBJECT_TEXT,
+  StorageClassDetails,
+  TARGET_ACCESS_KEY_TEXT,
+  TARGET_PATH_TEXT,
+  TARGET_SECRET_KEY_TEXT
+} from '../models/rgw-storage-class.model';
 
 @Component({
   selector: 'cd-rgw-storage-class-details',
@@ -12,6 +22,14 @@ export class RgwStorageClassDetailsComponent implements OnChanges {
   selection: StorageClassDetails;
   columns: CdTableColumn[] = [];
   storageDetails: StorageClassDetails;
+  allowReadThroughText = ALLOW_READ_THROUGH_TEXT;
+  retainHeadObjectText = RETAIN_HEAD_OBJECT_TEXT;
+  multipartMinPartText = MULTIPART_MIN_PART_TEXT;
+  multipartSyncThreholdText = MULTIPART_SYNC_THRESHOLD_TEXT;
+  targetAccessKeyText = TARGET_ACCESS_KEY_TEXT;
+  targetSecretKeyText = TARGET_SECRET_KEY_TEXT;
+  targetPathText = TARGET_PATH_TEXT;
+  hostStyleText = HOST_STYLE;
 
   ngOnChanges() {
     if (this.selection) {
@@ -22,7 +40,8 @@ export class RgwStorageClassDetailsComponent implements OnChanges {
         multipart_min_part_size: this.selection.multipart_min_part_size,
         multipart_sync_threshold: this.selection.multipart_sync_threshold,
         host_style: this.selection.host_style,
-        retain_head_object: this.selection.retain_head_object
+        retain_head_object: this.selection.retain_head_object,
+        allow_read_through: this.selection.allow_read_through
       };
     }
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.html
@@ -125,9 +125,7 @@
               placeholder="e.g, us-east-1"
               i18n-placeholder
               [invalid]="
-              storageClassForm.showError('region', formDir, 'required')
-              "
-            />
+              storageClassForm.showError('region', formDir, 'required')"/>
           </cds-text-label>
           <ng-template #regionError>
             <span
@@ -274,6 +272,27 @@
           >
         </ng-template>
       </div>
+      <div class="form-item">
+        <cds-checkbox
+          id="allow_read_through"
+          formControlName="allow_read_through"
+          cdOptionalField="Allow Read Through"
+          i18n
+          (change)="onAllowReadThroughChange($event)"
+          >Allow Read Through
+          <cd-help-text>{{ allowReadThroughText }}</cd-help-text>
+        </cds-checkbox>
+      </div>
+      <div class="form-item">
+        <cds-checkbox
+          id="retain_head_object"
+          formControlName="retain_head_object"
+          cdOptionalField="Head Object (Stub File)"
+          i18n
+          >Head Object (Stub File)
+          <cd-help-text>{{ retainHeadObjectText }}</cd-help-text>
+        </cds-checkbox>
+      </div>
 
       <fieldset>
         <cds-accordion size="lg"
@@ -316,16 +335,6 @@
                   />
                 </cds-text-label>
               </div>
-            </div>
-            <div class="form-item">
-              <cds-checkbox
-                id="retain_head_object"
-                formControlName="retain_head_object"
-                cdOptionalField="Retain Head Object"
-                i18n-label
-                >Retain Head Object
-                <cd-help-text>{{ retainHeadObjectText }}</cd-help-text>
-              </cds-checkbox>
             </div>
           </cds-accordion-item>
         </cds-accordion>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-storage-class-form/rgw-storage-class-form.component.spec.ts
@@ -72,6 +72,7 @@ describe('RgwStorageClassFormComponent', () => {
                     storage_class: 'CLOUDIBM',
                     tier_type: 'cloud-s3',
                     retain_head_object: true,
+                    allow_read_through: true,
                     s3: {
                       endpoint: 'https://s3.amazonaws.com',
                       access_key: 'ACCESSKEY',
@@ -96,6 +97,7 @@ describe('RgwStorageClassFormComponent', () => {
                     storage_class: 'CloudIBM',
                     tier_type: 'cloud-s3',
                     retain_head_object: true,
+                    allow_read_through: true,
                     s3: {
                       endpoint: 'https://s3.amazonaws.com',
                       access_key: 'ACCESSKEY',
@@ -132,6 +134,7 @@ describe('RgwStorageClassFormComponent', () => {
     component.storageClassForm.get('secret_key').setValue('secretkey');
     component.storageClassForm.get('target_path').setValue('/target');
     component.storageClassForm.get('retain_head_object').setValue(true);
+    component.storageClassForm.get('allow_read_through').setValue(true);
     component.storageClassForm.get('region').setValue('useast1');
     component.storageClassForm.get('multipart_sync_threshold').setValue(1024);
     component.storageClassForm.get('multipart_min_part_size').setValue(256);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/rgw-bucket-tiering.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/utils/rgw-bucket-tiering.ts
@@ -28,6 +28,7 @@ export class BucketTieringUtils {
       placement_target: targetName,
       storage_class: tierTarget.val.storage_class,
       retain_head_object: tierTarget.val.retain_head_object,
+      allow_read_through: tierTarget.val.allow_read_through,
       ...tierTarget.val.s3
     };
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-storage-class.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-storage-class.service.spec.ts
@@ -47,6 +47,7 @@ describe('RgwStorageClassService', () => {
             secret: 'test56',
             target_path: 'tsest-dnyanee',
             retain_head_object: false,
+            allow_read_through: true,
             region: 'ams3d',
             multipart_sync_threshold: 33554432,
             multipart_min_part_size: 33554432


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/71053

Signed-off-by: Dnyaneshwari Talwekar <dtalwekar@redhat.com>

Description:
1.Moved "Allow Read Through" and "Head Object" to general section from Advanced section.
2.Enable Head Object checkbox by default
3.When Allow Read through is enabled, enable Head Object checkbox and disable the checkbox so user doesn't change it.
4.Added description to Head Object to mention about Stub File.


https://github.com/user-attachments/assets/f376ebfe-d992-4b63-83a8-a9108259f7d7

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
