### PR TITLE
reef: qa/rgw: run verify tests with garbage collection disabled

### DIFF
--- a/qa/suites/rgw/verify/inline-data$/off-no-gc.yaml
+++ b/qa/suites/rgw/verify/inline-data$/off-no-gc.yaml
@@ -1,0 +1,10 @@
+overrides:
+  rgw:
+    inline data: false
+  ceph:
+    conf:
+      osd:
+        # causes all cls_rgw_gc_queue_enqueue() requests to fail with ENOSPC.
+        # this tests that error path, and effectively disables garbage
+        # collection which has masked some data loss bugs in the past
+        rgw gc max queue size: 0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71062

---

backport of https://github.com/ceph/ceph/pull/62715
parent tracker: https://tracker.ceph.com/issues/70823

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh