### PR TITLE
squid: librbd: respect rbd_default_snapshot_quiesce_mode in group_snap_create()

### DIFF
--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -268,6 +268,7 @@ int snap_create_flags_api_to_internal(CephContext *cct, uint32_t api_flags,
                                       uint64_t *internal_flags);
 
 uint32_t get_default_snap_create_flags(ImageCtx *ictx);
+uint32_t get_default_snap_create_flags(librados::IoCtx& group_ioctx);
 
 SnapContext get_snap_context(
     const std::optional<

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -885,8 +885,6 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
   if (r < 0) {
     return r;
   }
-  internal_flags &= ~(SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE |
-                      SNAP_CREATE_FLAG_IGNORE_NOTIFY_QUIESCE_ERROR);
 
   r = cls_client::dir_get_id(&group_ioctx, RBD_GROUP_DIRECTORY, group_name,
                              &group_id);
@@ -975,10 +973,11 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
     goto remove_record;
   }
 
-  if ((flags & RBD_SNAP_CREATE_SKIP_QUIESCE) == 0) {
+  if ((internal_flags & SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE) == 0) {
     ldout(cct, 20) << "Sending quiesce notification" << dendl;
     ret_code = notify_quiesce(ictxs, prog_ctx, &quiesce_requests);
-    if (ret_code != 0 && (flags & RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR) == 0) {
+    if (ret_code != 0 &&
+        (internal_flags & SNAP_CREATE_FLAG_IGNORE_NOTIFY_QUIESCE_ERROR) == 0) {
       goto remove_record;
     }
   }

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1386,8 +1386,9 @@ namespace librbd {
     tracepoint(librbd, group_snap_create_enter,
                group_ioctx.get_pool_name().c_str(),
 	       group_ioctx.get_id(), group_name, snap_name);
+    auto flags = librbd::util::get_default_snap_create_flags(group_ioctx);
     int r = librbd::api::Group<>::snap_create(group_ioctx, group_name,
-                                              snap_name, 0);
+                                              snap_name, flags);
     tracepoint(librbd, group_snap_create_exit, r);
     return r;
   }
@@ -7173,8 +7174,9 @@ extern "C" int rbd_group_snap_create(rados_ioctx_t group_p,
              group_ioctx.get_pool_name().c_str(),
 	     group_ioctx.get_id(), group_name, snap_name);
 
+  auto flags = librbd::util::get_default_snap_create_flags(group_ioctx);
   int r = librbd::api::Group<>::snap_create(group_ioctx, group_name,
-                                            snap_name, 0);
+                                            snap_name, flags);
   tracepoint(librbd, group_snap_create_exit, r);
 
   return r;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70641

---

backport of https://github.com/ceph/ceph/pull/62464
parent tracker: https://tracker.ceph.com/issues/70632