### PR TITLE
mgr: migrate from boost::variant to std::variant

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -192,7 +192,7 @@ seastar::future<> OSD::open_meta_coll()
 seastar::future<> OSD::set_perf_queries(const ConfigPayload &config_payload) {
   LOG_PREFIX(OSD::set_perf_queries);
   const OSDConfigPayload &osd_config_payload =
-    boost::get<OSDConfigPayload>(config_payload);
+    std::get<OSDConfigPayload>(config_payload);
   const std::map<OSDPerfMetricQuery, OSDPerfMetricLimits> &queries =
     osd_config_payload.config;
   DEBUG("setting {} queries", queries.size());

--- a/src/mds/MetricAggregator.cc
+++ b/src/mds/MetricAggregator.cc
@@ -551,7 +551,7 @@ void MetricAggregator::notify_mdsmap(const MDSMap &mdsmap) {
 }
 
 void MetricAggregator::set_perf_queries(const ConfigPayload &config_payload) {
-  const MDSConfigPayload &mds_config_payload = boost::get<MDSConfigPayload>(config_payload);
+  const MDSConfigPayload &mds_config_payload = std::get<MDSConfigPayload>(config_payload);
   const std::map<MDSPerfMetricQuery, MDSPerfMetricLimits> &queries = mds_config_payload.config;
 
   dout(10) << ": setting " << queries.size() << " queries" << dendl;

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -812,7 +812,7 @@ bool DaemonServer::handle_report(const ref_t<MMgrReport>& m)
 
   if (m->metric_report_message) {
     const MetricReportMessage &message = *m->metric_report_message;
-    boost::apply_visitor(HandlePayloadVisitor(this), message.payload);
+    std::visit(HandlePayloadVisitor(this), message.payload);
   }
 
   return true;

--- a/src/mgr/MDSPerfMetricCollector.cc
+++ b/src/mgr/MDSPerfMetricCollector.cc
@@ -21,7 +21,7 @@ MDSPerfMetricCollector::MDSPerfMetricCollector(MetricListener &listener)
 }
 
 void MDSPerfMetricCollector::process_reports(const MetricPayload &payload) {
-  const MDSPerfMetricReport &metric_report = boost::get<MDSMetricPayload>(payload).metric_report;
+  const MDSPerfMetricReport &metric_report = std::get<MDSMetricPayload>(payload).metric_report;
 
   std::lock_guard locker(lock);
   process_reports_generic(

--- a/src/mgr/MetricTypes.h
+++ b/src/mgr/MetricTypes.h
@@ -4,7 +4,7 @@
 #ifndef CEPH_MGR_METRIC_TYPES_H
 #define CEPH_MGR_METRIC_TYPES_H
 
-#include <boost/variant.hpp>
+#include <variant>
 #include "include/denc.h"
 #include "include/ceph_features.h"
 #include "mgr/OSDPerfMetricTypes.h"
@@ -89,9 +89,9 @@ WRITE_CLASS_DENC(OSDMetricPayload)
 WRITE_CLASS_DENC(MDSMetricPayload)
 WRITE_CLASS_DENC(UnknownMetricPayload)
 
-typedef boost::variant<OSDMetricPayload,
-                       MDSMetricPayload,
-                       UnknownMetricPayload> MetricPayload;
+typedef std::variant<OSDMetricPayload,
+		     MDSMetricPayload,
+		     UnknownMetricPayload> MetricPayload;
 
 class EncodeMetricPayloadVisitor : public boost::static_visitor<void> {
 public:
@@ -133,14 +133,14 @@ struct MetricReportMessage {
 
   bool should_encode(uint64_t features) const {
     if (!HAVE_FEATURE(features, SERVER_PACIFIC) &&
-	boost::get<MDSMetricPayload>(&payload)) {
+	std::get_if<MDSMetricPayload>(&payload)) {
       return false;
     }
     return true;
   }
 
   void encode(ceph::buffer::list &bl) const {
-    boost::apply_visitor(EncodeMetricPayloadVisitor(bl), payload);
+    std::visit(EncodeMetricPayloadVisitor(bl), payload);
   }
 
   void decode(ceph::buffer::list::const_iterator &iter) {
@@ -161,15 +161,15 @@ struct MetricReportMessage {
       break;
   }
 
-  boost::apply_visitor(DecodeMetricPayloadVisitor(iter), payload);
+  std::visit(DecodeMetricPayloadVisitor(iter), payload);
   }
   void dump(ceph::Formatter *f) const {
     f->open_object_section("payload");
-    if (const OSDMetricPayload* osdPayload = boost::get<OSDMetricPayload>(&payload)) {
+    if (const OSDMetricPayload* osdPayload = std::get_if<OSDMetricPayload>(&payload)) {
       osdPayload->dump(f);
-    } else if (const MDSMetricPayload* mdsPayload = boost::get<MDSMetricPayload>(&payload)) {
+    } else if (const MDSMetricPayload* mdsPayload = std::get_if<MDSMetricPayload>(&payload)) {
       mdsPayload->dump(f);
-    } else if (const UnknownMetricPayload* unknownPayload = boost::get<UnknownMetricPayload>(&payload)) {
+    } else if (const UnknownMetricPayload* unknownPayload = std::get_if<UnknownMetricPayload>(&payload)) {
       unknownPayload->dump(f);
     } else {
       ceph_abort();
@@ -255,9 +255,9 @@ WRITE_CLASS_DENC(OSDConfigPayload)
 WRITE_CLASS_DENC(MDSConfigPayload)
 WRITE_CLASS_DENC(UnknownConfigPayload)
 
-typedef boost::variant<OSDConfigPayload,
-                       MDSConfigPayload,
-                       UnknownConfigPayload> ConfigPayload;
+typedef std::variant<OSDConfigPayload,
+		     MDSConfigPayload,
+		     UnknownConfigPayload> ConfigPayload;
 
 class EncodeConfigPayloadVisitor : public boost::static_visitor<void> {
 public:
@@ -299,14 +299,14 @@ struct MetricConfigMessage {
 
   bool should_encode(uint64_t features) const {
     if (!HAVE_FEATURE(features, SERVER_PACIFIC) &&
-	boost::get<MDSConfigPayload>(&payload)) {
+	std::get_if<MDSConfigPayload>(&payload)) {
       return false;
     }
     return true;
   }
 
   void encode(ceph::buffer::list &bl) const {
-    boost::apply_visitor(EncodeConfigPayloadVisitor(bl), payload);
+    std::visit(EncodeConfigPayloadVisitor(bl), payload);
   }
 
   void decode(ceph::buffer::list::const_iterator &iter) {
@@ -327,7 +327,7 @@ struct MetricConfigMessage {
       break;
   }
 
-  boost::apply_visitor(DecodeConfigPayloadVisitor(iter), payload);
+  std::visit(DecodeConfigPayloadVisitor(iter), payload);
   }
 };
 

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -465,7 +465,7 @@ bool MgrClient::handle_mgr_configure(ref_t<MMgrConfigure> m)
     handle_config_payload(m->osd_perf_metric_queries);
   } else if (m->metric_config_message) {
     const MetricConfigMessage &message = *m->metric_config_message;
-    boost::apply_visitor(HandlePayloadVisitor(this), message.payload);
+    std::visit(HandlePayloadVisitor(this), message.payload);
   }
 
   bool starting = (stats_period == 0) && (m->stats_period != 0);

--- a/src/mgr/OSDPerfMetricCollector.cc
+++ b/src/mgr/OSDPerfMetricCollector.cc
@@ -21,7 +21,7 @@ OSDPerfMetricCollector::OSDPerfMetricCollector(MetricListener &listener)
 
 void OSDPerfMetricCollector::process_reports(const MetricPayload &payload) {
   const std::map<OSDPerfMetricQuery, OSDPerfMetricReport> &reports =
-    boost::get<OSDMetricPayload>(payload).report;
+    std::get<OSDMetricPayload>(payload).report;
 
   std::lock_guard locker(lock);
   process_reports_generic(

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10586,7 +10586,7 @@ void OSD::get_latest_osdmap()
 // --------------------------------
 
 void OSD::set_perf_queries(const ConfigPayload &config_payload) {
-  const OSDConfigPayload &osd_config_payload = boost::get<OSDConfigPayload>(config_payload);
+  const OSDConfigPayload &osd_config_payload = std::get<OSDConfigPayload>(config_payload);
   const std::map<OSDPerfMetricQuery, OSDPerfMetricLimits> &queries = osd_config_payload.config;
   dout(10) << "setting " << queries.size() << " queries" << dendl;
 


### PR DESCRIPTION
Replace `boost::variant` with `std::variant` as part of our effort to reduce third-party dependencies in favor of C++ standard library alternatives.

Benefits include:
- Improved code readability and maintainability
- Reduced external dependency surface
- More consistent API usage with other components





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
