### PR TITLE
D4N Test Updates

### DIFF
--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -37,7 +37,8 @@ static inline Object* nextObject(Object* t)
 }
 
 D4NFilterDriver::D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context) : FilterDriver(_next),
-                                                                                       io_context(io_context) 
+                                                                                       io_context(io_context),
+										       y(null_yield)
 {
   rgw::cache::Partition partition_info;
   partition_info.location = g_conf()->rgw_d4n_l1_datacache_persistent_path;
@@ -60,7 +61,8 @@ int D4NFilterDriver::initialize(CephContext *cct, const DoutPrefixProvider *dpp)
   bucketDir = std::make_unique<rgw::d4n::BucketDirectory>(conn);
   policyDriver = std::make_unique<rgw::d4n::PolicyDriver>(conn,
 							  cacheDriver.get(),
-							  "lfuda");
+							  "lfuda",
+                                                          this->y);
 
   std::string address = cct->_conf->rgw_d4n_address;
   config cfg;

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -60,6 +60,7 @@ class D4NFilterDriver : public FilterDriver {
     std::unique_ptr<rgw::d4n::BucketDirectory> bucketDir;
     std::unique_ptr<rgw::d4n::PolicyDriver> policyDriver;
     boost::asio::io_context& io_context;
+    optional_yield y;
 
   public:
     D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context);
@@ -84,6 +85,7 @@ class D4NFilterDriver : public FilterDriver {
     rgw::d4n::BlockDirectory* get_block_dir() { return blockDir.get(); }
     rgw::d4n::BucketDirectory* get_bucket_dir() { return bucketDir.get(); }
     rgw::d4n::PolicyDriver* get_policy_driver() { return policyDriver.get(); }
+    void save_y(optional_yield y) { this->y = y; }
     void shutdown() override;
 };
 

--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -141,7 +141,7 @@ class D4NFilterFixture: public ::testing::Test {
     }
 
     void init_driver(net::yield_context yield) {
-      dynamic_cast<rgw::d4n::LFUDAPolicy*>(d4nFilter->get_policy_driver()->get_cache_policy())->save_y(optional_yield{yield});
+      d4nFilter->save_y(optional_yield{yield});
       driver->initialize(env->cct.get(), env->dpp);
 
       ASSERT_NE(driver, nullptr);
@@ -342,6 +342,7 @@ TEST_F(D4NFilterFixture, PutObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -410,6 +411,7 @@ TEST_F(D4NFilterFixture, GetObjectRead)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver)); 
   }, rethrow);
 
@@ -520,6 +522,7 @@ TEST_F(D4NFilterFixture, CopyNoneObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -606,6 +609,7 @@ TEST_F(D4NFilterFixture, CopyMergeObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -692,6 +696,7 @@ TEST_F(D4NFilterFixture, CopyReplaceObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -762,6 +767,7 @@ TEST_F(D4NFilterFixture, DeleteObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -801,6 +807,7 @@ TEST_F(D4NFilterFixture, PutVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -886,6 +893,7 @@ TEST_F(D4NFilterFixture, GetVersionedObjectRead)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1024,6 +1032,7 @@ TEST_F(D4NFilterFixture, CopyNoneVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1162,6 +1171,7 @@ TEST_F(D4NFilterFixture, CopyMergeVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1300,6 +1310,7 @@ TEST_F(D4NFilterFixture, CopyReplaceVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1390,6 +1401,7 @@ TEST_F(D4NFilterFixture, DeleteVersionedObjectRead)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1504,9 +1516,10 @@ TEST_F(D4NFilterFixture, PutObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
- 
+
   io.run();
 }
 
@@ -1576,6 +1589,7 @@ TEST_F(D4NFilterFixture, GetObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1697,6 +1711,7 @@ TEST_F(D4NFilterFixture, CopyNoneObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1818,6 +1833,7 @@ TEST_F(D4NFilterFixture, CopyMergeObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -1939,6 +1955,7 @@ TEST_F(D4NFilterFixture, CopyReplaceObjectWrite)
     testFile.close();
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2019,6 +2036,7 @@ TEST_F(D4NFilterFixture, DeleteObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2175,6 +2193,7 @@ TEST_F(D4NFilterFixture, PutVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
  
@@ -2325,6 +2344,7 @@ TEST_F(D4NFilterFixture, GetVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2545,6 +2565,7 @@ TEST_F(D4NFilterFixture, CopyNoneVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2765,6 +2786,7 @@ TEST_F(D4NFilterFixture, CopyMergeVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -2985,6 +3007,7 @@ TEST_F(D4NFilterFixture, CopyReplaceVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3089,6 +3112,7 @@ TEST_F(D4NFilterFixture, DeleteVersionedObjectWrite)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3174,6 +3198,7 @@ TEST_F(D4NFilterFixture, SimpleDeleteBeforeCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3285,6 +3310,7 @@ TEST_F(D4NFilterFixture, VersionedDeleteBeforeCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3337,6 +3363,7 @@ TEST_F(D4NFilterFixture, SimpleDeleteAfterCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3433,6 +3460,7 @@ TEST_F(D4NFilterFixture, VersionedDeleteAfterCleaning)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 
@@ -3475,6 +3503,7 @@ TEST_F(D4NFilterFixture, ListObjectVersions)
 
     conn->cancel();
     testBucket->remove(env->dpp, true, optional_yield{yield});
+    driver->shutdown();
     DriverDestructor driver_destructor(static_cast<rgw::sal::D4NFilterDriver*>(driver));
   }, rethrow);
 

--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -116,7 +116,7 @@ class D4NFilterFixture: public ::testing::Test {
       DriverManager::Config cfg = DriverManager::get_config(true, g_ceph_context);
       cfg.store_name = "dbstore";
       cfg.filter_name = "d4n";
-      auto config_store_type = g_conf().get_val<std::string>("rgw_config_store");
+      auto config_store_type = "dbstore";
       auto cfgstore = DriverManager::create_config_store(env->dpp, config_store_type);
 
       auto filterDriver = DriverManager::get_raw_storage(env->dpp, g_ceph_context,

--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -188,7 +188,7 @@ class D4NFilterFixture: public ::testing::Test {
       /* DBStore does not provide the RGW_ATTR_ID_TAG attr, so it is being manually written
          here since D4N cache backend versioning relies on it. */
       rgw::sal::Attrs attrs{{RGW_ATTR_ID_TAG, std::move(bl)}};
-      bl.append("test_etag");
+      bl.append("test_etag\0", 10);
       attrs.insert({RGW_ATTR_ETAG, std::move(bl)});
 
       bl.append("test data", 9);
@@ -225,7 +225,7 @@ class D4NFilterFixture: public ::testing::Test {
       buffer::list bl;
       bl.append("test_version\0", 13);
       rgw::sal::Attrs attrs{{RGW_ATTR_ID_TAG, std::move(bl)}};
-      bl.append("test_etag");
+      bl.append("test_etag\0", 10);
       attrs.insert({RGW_ATTR_ETAG, std::move(bl)});
 
       bl.append("test data", 9);
@@ -260,7 +260,7 @@ class D4NFilterFixture: public ::testing::Test {
       buffer::list bl;
       bl.append("test_version\0", 13);
       rgw::sal::Attrs attrs{{RGW_ATTR_ID_TAG, std::move(bl)}};
-      bl.append("test_etag");
+      bl.append("test_etag\0", 10);
       attrs.insert({RGW_ATTR_ETAG, std::move(bl)});
 
       bl.append("test data", 9);

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -72,7 +72,7 @@ class LFUDAPolicyFixture : public ::testing::Test {
       conn = std::make_shared<connection>(net::make_strand(io));
       rgw::cache::Partition partition_info{ .location = "RedisCache", .size = 1000 };
       cacheDriver = new rgw::cache::RedisDriver{io, partition_info};
-      policyDriver = new rgw::d4n::PolicyDriver(conn, cacheDriver, "lfuda");
+      policyDriver = new rgw::d4n::PolicyDriver(conn, cacheDriver, "lfuda", null_yield);
       dir = new rgw::d4n::BlockDirectory{conn};
 
       ASSERT_NE(dir, nullptr);

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -27,14 +27,13 @@ class Environment : public ::testing::Environment {
 
     void SetUp() override {
       std::vector<const char*> args;
-      std::string conf_file_list;
-      std::string cluster = "";
-      CephInitParameters iparams = ceph_argparse_early_args(
-	args, CEPH_ENTITY_TYPE_CLIENT,
-	&cluster, &conf_file_list);
+      auto _cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+			      CODE_ENVIRONMENT_UTILITY,
+			      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
 
-      cct = common_preinit(iparams, CODE_ENVIRONMENT_UTILITY, {}); 
+      cct = _cct.get();
       dpp = new DoutPrefix(cct->get(), dout_subsys, "D4N Object Directory Test: ");
+      common_init_finish(g_ceph_context);
       
       redisHost = cct->_conf->rgw_d4n_address; 
     }

--- a/src/test/rgw/test_ssd_driver.cc
+++ b/src/test/rgw/test_ssd_driver.cc
@@ -70,14 +70,13 @@ class Environment : public ::testing::Environment {
 
     void SetUp() override {
       std::vector<const char*> args;
-      std::string conf_file_list;
-      std::string cluster = "";
-      CephInitParameters iparams = ceph_argparse_early_args(
-        args, CEPH_ENTITY_TYPE_CLIENT,
-        &cluster, &conf_file_list);
+      auto _cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+			      CODE_ENVIRONMENT_UTILITY,
+			      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
 
-      cct = common_preinit(iparams, CODE_ENVIRONMENT_UTILITY, {});
+      cct = _cct.get();
       dpp = new DoutPrefix(cct->get(), dout_subsys, "SSD backed Cache backend Test: ");
+      common_init_finish(g_ceph_context);
     }
 
     CephContext* cct;


### PR DESCRIPTION
These fixes allow the D4N suite and unit test programs to pass. Note: removal of D4N subsuite from RGW suite must be reversed in Tentacle branch. Backports to the Tentacle branch are necessary.

The most recent commit addresses the following tracker issue: https://tracker.ceph.com/issues/71088

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
