### PR TITLE
common/io_exerciser: Add consistency checking functionality to IO exerciser

### DIFF
--- a/src/common/io_exerciser/EcIoSequence.h
+++ b/src/common/io_exerciser/EcIoSequence.h
@@ -12,7 +12,8 @@ class EcIoSequence : public IoSequence {
       std::optional<std::pair<int, int>> km,
       std::optional<std::pair<std::string_view, std::string_view>>
           mappinglayers,
-      int seed);
+      int seed,
+      bool check_consistency);
 
  protected:
   bool setup_inject;
@@ -20,7 +21,7 @@ class EcIoSequence : public IoSequence {
   std::optional<uint64_t> shard_to_inject;
   InjectOpType inject_op_type;
 
-  EcIoSequence(std::pair<int, int> obj_size_range, int seed);
+  EcIoSequence(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   // Writes cannot be sent to injected on shard zero, so selections seperated
   // out
@@ -50,7 +51,8 @@ class ReadInjectSequence : public EcIoSequence {
       std::pair<int, int> obj_size_range, int seed, Sequence s,
       std::optional<std::pair<int, int>> km,
       std::optional<std::pair<std::string_view, std::string_view>>
-          mappinglayers);
+          mappinglayers,
+      bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -67,7 +69,8 @@ class Seq10 : public EcIoSequence {
   Seq10(std::pair<int, int> obj_size_range, int seed,
         std::optional<std::pair<int, int>> km,
         std::optional<std::pair<std::string_view, std::string_view>>
-            mappinglayers);
+            mappinglayers,
+        bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;

--- a/src/common/io_exerciser/IoOp.cc
+++ b/src/common/io_exerciser/IoOp.cc
@@ -10,6 +10,7 @@ using DoneOp = ceph::io_exerciser::DoneOp;
 using BarrierOp = ceph::io_exerciser::BarrierOp;
 using CreateOp = ceph::io_exerciser::CreateOp;
 using RemoveOp = ceph::io_exerciser::RemoveOp;
+using ConsistencyOp = ceph::io_exerciser::ConsistencyOp;
 using SingleReadOp = ceph::io_exerciser::SingleReadOp;
 using DoubleReadOp = ceph::io_exerciser::DoubleReadOp;
 using TripleReadOp = ceph::io_exerciser::TripleReadOp;
@@ -96,6 +97,16 @@ ceph::io_exerciser::ReadWriteOp<opType, numIOs>::ReadWriteOp(
       }
     }
   }
+}
+
+ConsistencyOp::ConsistencyOp() : TestOp<OpType::Consistency>() {}
+
+std::unique_ptr<ConsistencyOp> ConsistencyOp::generate() {
+  return std::make_unique<ConsistencyOp>();
+}
+
+std::string ConsistencyOp::to_string(uint64_t block_size) const {
+  return "Consistency";
 }
 
 template <OpType opType, int numIOs>

--- a/src/common/io_exerciser/IoOp.h
+++ b/src/common/io_exerciser/IoOp.h
@@ -61,6 +61,13 @@ class RemoveOp : public TestOp<OpType::Remove> {
   std::string to_string(uint64_t block_size) const override;
 };
 
+class ConsistencyOp : public TestOp<OpType::Consistency> {
+  public:
+   ConsistencyOp();
+   static std::unique_ptr<ConsistencyOp> generate();
+   std::string to_string(uint64_t block_size) const override;
+ };
+
 template <OpType opType, int numIOs>
 class ReadWriteOp : public TestOp<opType> {
  public:

--- a/src/common/io_exerciser/IoSequence.cc
+++ b/src/common/io_exerciser/IoSequence.cc
@@ -65,57 +65,60 @@ bool IoSequence::is_supported(Sequence sequence) const {
 }
 
 std::unique_ptr<IoSequence> IoSequence::generate_sequence(
-    Sequence s, std::pair<int, int> obj_size_range, int seed) {
+    Sequence s, std::pair<int, int> obj_size_range, int seed, bool check_consistency) {
   switch (s) {
     case Sequence::SEQUENCE_SEQ0:
-      return std::make_unique<Seq0>(obj_size_range, seed);
+      return std::make_unique<Seq0>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ1:
-      return std::make_unique<Seq1>(obj_size_range, seed);
+      return std::make_unique<Seq1>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ2:
-      return std::make_unique<Seq2>(obj_size_range, seed);
+      return std::make_unique<Seq2>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ3:
-      return std::make_unique<Seq3>(obj_size_range, seed);
+      return std::make_unique<Seq3>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ4:
-      return std::make_unique<Seq4>(obj_size_range, seed);
+      return std::make_unique<Seq4>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ5:
-      return std::make_unique<Seq5>(obj_size_range, seed);
+      return std::make_unique<Seq5>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ6:
-      return std::make_unique<Seq6>(obj_size_range, seed);
+      return std::make_unique<Seq6>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ7:
-      return std::make_unique<Seq7>(obj_size_range, seed);
+      return std::make_unique<Seq7>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ8:
-      return std::make_unique<Seq8>(obj_size_range, seed);
+      return std::make_unique<Seq8>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ9:
-      return std::make_unique<Seq9>(obj_size_range, seed);
+      return std::make_unique<Seq9>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ10:
       ceph_abort_msg(
           "Sequence 10 only supported for erasure coded pools "
           "through the EcIoSequence interface");
       return nullptr;
     case Sequence::SEQUENCE_SEQ11:
-      return std::make_unique<Seq11>(obj_size_range, seed);
+      return std::make_unique<Seq11>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ12:
-      return std::make_unique<Seq12>(obj_size_range, seed);
+      return std::make_unique<Seq12>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ13:
-      return std::make_unique<Seq13>(obj_size_range, seed);
+      return std::make_unique<Seq13>(obj_size_range, seed, check_consistency);
     case Sequence::SEQUENCE_SEQ14:
-      return std::make_unique<Seq14>(obj_size_range, seed);
+      return std::make_unique<Seq14>(obj_size_range, seed, check_consistency);
     default:
       break;
   }
   return nullptr;
 }
 
-IoSequence::IoSequence(std::pair<int, int> obj_size_range, int seed)
+IoSequence::IoSequence(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
     : min_obj_size(obj_size_range.first),
       max_obj_size(obj_size_range.second),
       create(true),
       barrier(false),
       done(false),
       remove(false),
+      consistency(false),
+      doneconsistency(false),
       obj_size(min_obj_size),
       step(-1),
-      seed(seed) {
+      seed(seed),
+      check_consistency(check_consistency) {
   rng.seed(seed);
 }
 
@@ -158,6 +161,7 @@ std::unique_ptr<IoOp> IoSequence::increment_object_size() {
   create = true;
   barrier = true;
   remove = true;
+  consistency = check_consistency;
   return BarrierOp::generate();
 }
 
@@ -175,6 +179,15 @@ Sequence IoSequence::getNextSupportedSequenceId() const {
 
 std::unique_ptr<IoOp> IoSequence::next() {
   step++;
+  if (consistency) {
+    if (doneconsistency) {
+      doneconsistency = false;
+      consistency = false;
+      return BarrierOp::generate();
+    }
+    doneconsistency = true;
+    return ConsistencyOp::generate();
+  }
   if (remove) {
     remove = false;
     return RemoveOp::generate();
@@ -194,8 +207,8 @@ std::unique_ptr<IoOp> IoSequence::next() {
   return _next();
 }
 
-ceph::io_exerciser::Seq0::Seq0(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), offset(0) {
+ceph::io_exerciser::Seq0::Seq0(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency), offset(0) {
   select_random_object_size();
   length = 1 + rng(obj_size - 1);
 }
@@ -215,6 +228,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq0::_next() {
     done = true;
     barrier = true;
     remove = true;
+    consistency = check_consistency;
     return BarrierOp::generate();
   }
   if (offset + length > obj_size) {
@@ -226,8 +240,9 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq0::_next() {
   return r;
 }
 
-ceph::io_exerciser::Seq1::Seq1(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed) {
+ceph::io_exerciser::Seq1::Seq1(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency),
+      donewrite(false) {
   select_random_object_size();
   count = 3 * obj_size;
 }
@@ -242,6 +257,12 @@ std::string ceph::io_exerciser::Seq1::get_name() const {
 
 std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq1::_next() {
   barrier = true;
+  if (check_consistency) {
+    if (donewrite) {
+      donewrite = false;
+      return ConsistencyOp::generate();
+    }
+  }
   if (count-- == 0) {
     done = true;
     remove = true;
@@ -252,14 +273,15 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq1::_next() {
   uint64_t length = 1 + rng(obj_size - 1 - offset);
 
   if (rng(2) != 0) {
+    donewrite = true;
     return SingleWriteOp::generate(offset, length);
   } else {
     return SingleReadOp::generate(offset, length);
   }
 }
 
-ceph::io_exerciser::Seq2::Seq2(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), offset(0), length(0) {}
+ceph::io_exerciser::Seq2::Seq2(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency), offset(0), length(0) {}
 
 Sequence ceph::io_exerciser::Seq2::get_id() const {
   return Sequence::SEQUENCE_SEQ2;
@@ -283,8 +305,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq2::_next() {
   return SingleReadOp::generate(offset, length);
 }
 
-ceph::io_exerciser::Seq3::Seq3(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), offset1(0), offset2(0) {
+ceph::io_exerciser::Seq3::Seq3(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency), offset1(0), offset2(0) {
   set_min_object_size(2);
 }
 
@@ -310,8 +332,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq3::_next() {
   return DoubleReadOp::generate(offset1, 1, offset1 + offset2, 1);
 }
 
-ceph::io_exerciser::Seq4::Seq4(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), offset1(0), offset2(1) {
+ceph::io_exerciser::Seq4::Seq4(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency), offset1(0), offset2(1) {
   set_min_object_size(3);
 }
 
@@ -338,8 +360,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq4::_next() {
                                 (offset1 * 2 + offset2) / 2, 1);
 }
 
-ceph::io_exerciser::Seq5::Seq5(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed),
+ceph::io_exerciser::Seq5::Seq5(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency),
       offset(0),
       length(1),
       doneread(false),
@@ -358,6 +380,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq5::_next() {
     if (!doneread) {
       if (!donebarrier) {
         donebarrier = true;
+        consistency = check_consistency;
         return BarrierOp::generate();
       }
       doneread = true;
@@ -379,8 +402,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq5::_next() {
   return r;
 }
 
-ceph::io_exerciser::Seq6::Seq6(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed),
+ceph::io_exerciser::Seq6::Seq6(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency),
       offset(0),
       length(1),
       doneread(false),
@@ -399,6 +422,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq6::_next() {
     if (!doneread) {
       if (!donebarrier) {
         donebarrier = true;
+        consistency = check_consistency;
         return BarrierOp::generate();
       }
       doneread = true;
@@ -423,8 +447,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq6::_next() {
   return r;
 }
 
-ceph::io_exerciser::Seq7::Seq7(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed) {
+ceph::io_exerciser::Seq7::Seq7(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency) {
   set_min_object_size(2);
   offset = obj_size;
 }
@@ -441,6 +465,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq7::_next() {
   if (!doneread) {
     if (!donebarrier) {
       donebarrier = true;
+      consistency = check_consistency;
       return BarrierOp::generate();
     }
     doneread = true;
@@ -462,8 +487,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq7::_next() {
   return DoubleReadOp::generate(offset, 1, obj_size / 2, 1);
 }
 
-ceph::io_exerciser::Seq8::Seq8(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), offset1(0), offset2(1) {
+ceph::io_exerciser::Seq8::Seq8(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency), offset1(0), offset2(1) {
   set_min_object_size(3);
 }
 
@@ -479,6 +504,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq8::_next() {
   if (!doneread) {
     if (!donebarrier) {
       donebarrier = true;
+      consistency = check_consistency;
       return BarrierOp::generate();
     }
     doneread = true;
@@ -501,8 +527,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq8::_next() {
                                  (offset1 * 2 + offset2) / 2, 1);
 }
 
-ceph::io_exerciser::Seq9::Seq9(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), offset(0), length(0) {}
+ceph::io_exerciser::Seq9::Seq9(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency), offset(0), length(0) {}
 
 Sequence ceph::io_exerciser::Seq9::get_id() const {
   return Sequence::SEQUENCE_SEQ9;
@@ -516,6 +542,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq9::_next() {
   if (!doneread) {
     if (!donebarrier) {
       donebarrier = true;
+      consistency = check_consistency;
       return BarrierOp::generate();
     }
     doneread = true;
@@ -537,8 +564,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq9::_next() {
   return SingleWriteOp::generate(offset, length);
 }
 
-ceph::io_exerciser::Seq11::Seq11(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed),
+ceph::io_exerciser::Seq11::Seq11(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency),
       count(0),
       doneread(false),
       donebarrier(false) {}
@@ -570,8 +597,9 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq11::_next() {
   return SingleAppendOp::generate(obj_size);
 }
 
-ceph::io_exerciser::Seq12::Seq12(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), count(0), overlap(1), doneread(false) {}
+ceph::io_exerciser::Seq12::Seq12(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency 
+    ), count(0), overlap(1), doneread(false) {}
 
 Sequence ceph::io_exerciser::Seq12::get_id() const {
   return Sequence::SEQUENCE_SEQ12;
@@ -597,6 +625,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq12::_next() {
       create = true;
       barrier = true;
       remove = true;
+      consistency = check_consistency;
       return BarrierOp::generate();
     }
   }
@@ -606,8 +635,8 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq12::_next() {
                                  obj_size + overlap);
 }
 
-ceph::io_exerciser::Seq13::Seq13(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(obj_size_range, seed), count(0), gap(1), doneread(false) {
+ceph::io_exerciser::Seq13::Seq13(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(obj_size_range, seed, check_consistency), count(0), gap(1), doneread(false) {
   set_min_object_size(2);
 }
 
@@ -635,6 +664,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq13::_next() {
       create = true;
       barrier = true;
       remove = true;
+      consistency = check_consistency;
       return BarrierOp::generate();
     }
   }
@@ -643,10 +673,11 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq13::_next() {
   return SingleWriteOp::generate((count * obj_size) + gap, obj_size - gap);
 }
 
-ceph::io_exerciser::Seq14::Seq14(std::pair<int, int> obj_size_range, int seed)
-    : IoSequence(std::make_pair(0, obj_size_range.second), seed),
+ceph::io_exerciser::Seq14::Seq14(std::pair<int, int> obj_size_range, int seed, bool check_consistency)
+    : IoSequence(std::make_pair(0, obj_size_range.second), seed, check_consistency),
       offset(0),
-      step(1) {
+      step(1),
+      doneconsistency(true) {
   startrng = std::default_random_engine(seed);
   target_obj_size = std::max(obj_size_range.first, 3);
   if (target_obj_size > max_obj_size) {
@@ -676,10 +707,18 @@ std::string ceph::io_exerciser::Seq14::get_name() const {
 std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq14::_next() {
   if (offset >= target_obj_size) {
     if (!doneread) {
+      if (check_consistency) {
+        if (!doneconsistency) {
+          consistency = true;
+          doneconsistency = true;
+          return BarrierOp::generate();
+        }
+      }
       doneread = true;
       return SingleReadOp::generate(0, current_size);
     }
     doneread = false;
+    doneconsistency = false;
     startidx++;
     if (startidx >= starts.size()) {
       step++;
@@ -687,6 +726,7 @@ std::unique_ptr<ceph::io_exerciser::IoOp> ceph::io_exerciser::Seq14::_next() {
       create = true;
       barrier = true;
       remove = true;
+      consistency = check_consistency;
       if (step >= target_obj_size) {
         step = 1;
         target_obj_size++;

--- a/src/common/io_exerciser/IoSequence.h
+++ b/src/common/io_exerciser/IoSequence.h
@@ -74,7 +74,7 @@ class IoSequence {
 
   virtual bool is_supported(Sequence sequence) const;
   static std::unique_ptr<IoSequence> generate_sequence(
-      Sequence s, std::pair<int, int> obj_size_range, int seed);
+      Sequence s, std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
  protected:
   uint64_t min_obj_size;
@@ -83,13 +83,16 @@ class IoSequence {
   bool barrier;
   bool done;
   bool remove;
+  bool consistency;
+  bool doneconsistency;
   uint64_t obj_size;
   int step;
   int seed;
+  bool check_consistency;
   ceph::util::random_number_generator<int> rng =
       ceph::util::random_number_generator<int>();
 
-  IoSequence(std::pair<int, int> obj_size_range, int seed);
+  IoSequence(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   virtual std::unique_ptr<IoOp> _next() = 0;
 
@@ -101,7 +104,7 @@ class IoSequence {
 
 class Seq0 : public IoSequence {
  public:
-  Seq0(std::pair<int, int> obj_size_range, int seed);
+  Seq0(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -114,7 +117,7 @@ class Seq0 : public IoSequence {
 
 class Seq1 : public IoSequence {
  public:
-  Seq1(std::pair<int, int> obj_size_range, int seed);
+  Seq1(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -122,11 +125,12 @@ class Seq1 : public IoSequence {
 
  private:
   int count;
+  bool donewrite;
 };
 
 class Seq2 : public IoSequence {
  public:
-  Seq2(std::pair<int, int> obj_size_range, int seed);
+  Seq2(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -139,7 +143,7 @@ class Seq2 : public IoSequence {
 
 class Seq3 : public IoSequence {
  public:
-  Seq3(std::pair<int, int> obj_size_range, int seed);
+  Seq3(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -152,7 +156,7 @@ class Seq3 : public IoSequence {
 
 class Seq4 : public IoSequence {
  public:
-  Seq4(std::pair<int, int> obj_size_range, int seed);
+  Seq4(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -165,7 +169,7 @@ class Seq4 : public IoSequence {
 
 class Seq5 : public IoSequence {
  public:
-  Seq5(std::pair<int, int> obj_size_range, int seed);
+  Seq5(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -180,7 +184,7 @@ class Seq5 : public IoSequence {
 
 class Seq6 : public IoSequence {
  public:
-  Seq6(std::pair<int, int> obj_size_range, int seed);
+  Seq6(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -195,7 +199,7 @@ class Seq6 : public IoSequence {
 
 class Seq7 : public IoSequence {
  public:
-  Seq7(std::pair<int, int> obj_size_range, int seed);
+  Seq7(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -209,7 +213,7 @@ class Seq7 : public IoSequence {
 
 class Seq8 : public IoSequence {
  public:
-  Seq8(std::pair<int, int> obj_size_range, int seed);
+  Seq8(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -230,7 +234,7 @@ class Seq9 : public IoSequence {
   bool donebarrier = false;
 
  public:
-  Seq9(std::pair<int, int> obj_size_range, int seed);
+  Seq9(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
       Sequence get_id() const override;
       std::string get_name() const override;
@@ -244,7 +248,7 @@ class Seq11 : public IoSequence {
   bool donebarrier = false;
 
  public:
-  Seq11(std::pair<int, int> obj_size_range, int seed);
+  Seq11(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -259,7 +263,7 @@ class Seq12 : public IoSequence {
   bool donebarrier = false;
 
  public:
-  Seq12(std::pair<int, int> obj_size_range, int seed);
+  Seq12(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -274,7 +278,7 @@ class Seq13 : public IoSequence {
   bool donebarrier = false;
 
  public:
-  Seq13(std::pair<int, int> obj_size_range, int seed);
+  Seq13(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   Sequence get_id() const override;
   std::string get_name() const override;
@@ -291,9 +295,10 @@ class Seq14 : public IoSequence {
   std::vector<uint64_t> starts;
   size_t startidx;
   bool doneread = false;
+  bool doneconsistency = true;
 
  public:
-  Seq14(std::pair<int, int> obj_size_range, int seed);
+  Seq14(std::pair<int, int> obj_size_range, int seed, bool check_consistency);
 
   void setup_starts();
   Sequence get_id() const override;

--- a/src/common/io_exerciser/OpType.h
+++ b/src/common/io_exerciser/OpType.h
@@ -17,6 +17,7 @@ enum class OpType {
   Barrier,               // Barrier - all prior I/Os must complete
   Create,                // Create object and pattern with data
   Remove,                // Remove object
+  Consistency,           // Check consistency of an object
   Read,                  // Read
   Read2,                 // Two reads in a single op
   Read3,                 // Three reads in a single op

--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -10,6 +10,7 @@
 #include "common/json/OSDStructures.h"
 
 using RadosIo = ceph::io_exerciser::RadosIo;
+using ConsistencyChecker = ceph::consistency::ConsistencyChecker;
 
 namespace {
 template <typename S>
@@ -40,7 +41,7 @@ int send_mon_command(S& s, librados::Rados& rados, const char* name,
 RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
                  const std::string& pool, const std::string& oid,
                  const std::optional<std::vector<int>>& cached_shard_order,
-                 uint64_t block_size, int seed, int threads, ceph::mutex& lock,
+                 uint64_t block_size, uint64_t chunk_size, int seed, int threads, ceph::mutex& lock,
                  ceph::condition_variable& cond, bool ec_optimizations)
     : Model(oid, block_size),
       rados(rados),
@@ -48,12 +49,14 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
       om(std::make_unique<ObjectModel>(oid, block_size, seed)),
       db(data_generation::DataGenerator::create_generator(
           data_generation::GenerationType::HeaderedSeededRandom, *om)),
+      cc(std::make_unique<ConsistencyChecker>(rados, asio, pool)),
       pool(pool),
       cached_shard_order(cached_shard_order),
       threads(threads),
       lock(lock),
       cond(cond),
-      outstanding_io(0) {
+      outstanding_io(0),
+      chunk_size(chunk_size) {
   int rc;
   rc = rados.ioctx_create(pool.c_str(), io);
   ceph_assert(rc == 0);
@@ -188,6 +191,16 @@ void RadosIo::applyIoOp(IoOp& op) {
                               std::move(wop), 0, nullptr, remove_cb);
       break;
     }
+
+    case OpType::Consistency: {
+      start_io();
+      bool is_consistent =
+          cc->single_read_and_check_consistency(oid, block_size, 0, 0, chunk_size);
+      ceph_assert(is_consistent);
+      finish_io();
+      break;
+    }
+
     case OpType::Read:
       [[fallthrough]];
     case OpType::Read2:

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ObjectModel.h"
+#include "erasure-code/consistency/ConsistencyChecker.h"
 
 /* Overview
  *
@@ -25,6 +26,7 @@ class RadosIo : public Model {
   boost::asio::io_context& asio;
   std::unique_ptr<ObjectModel> om;
   std::unique_ptr<ceph::io_exerciser::data_generation::DataGenerator> db;
+  std::unique_ptr<ceph::consistency::ConsistencyChecker> cc;
   std::string pool;
   std::optional<std::vector<int>> cached_shard_order;
   int threads;
@@ -32,6 +34,7 @@ class RadosIo : public Model {
   ceph::condition_variable& cond;
   librados::IoCtx io;
   int outstanding_io;
+  uint64_t chunk_size;
 
   void start_io();
   void finish_io();
@@ -41,7 +44,7 @@ class RadosIo : public Model {
   RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
           const std::string& pool, const std::string& oid,
           const std::optional<std::vector<int>>& cached_shard_order,
-          uint64_t block_size, int seed, int threads, ceph::mutex& lock,
+          uint64_t block_size, uint64_t chunk_size, int seed, int threads, ceph::mutex& lock,
           ceph::condition_variable& cond, bool ec_optimizations);
 
   ~RadosIo();

--- a/src/common/json/OSDStructures.cc
+++ b/src/common/json/OSDStructures.cc
@@ -173,7 +173,7 @@ void InjectECParityRead::decode_json(JSONObj* obj) {
 }
 
 void InjectECClearParityRead::dump(Formatter* f) const {
-  encode_json("prefix", "injectparityread", f);
+  encode_json("prefix", "injectclearparityread", f);
   encode_json("pool", pool, f);
   encode_json("objname", objname, f);
 }

--- a/src/common/json/OSDStructures.cc
+++ b/src/common/json/OSDStructures.cc
@@ -160,3 +160,25 @@ void OSDSetRequest::decode_json(JSONObj* obj) {
   JSONDecoder::decode_json("key", key, obj);
   JSONDecoder::decode_json("yes_i_really_mean_it", yes_i_really_mean_it, obj);
 }
+
+void InjectECParityRead::dump(Formatter* f) const {
+  encode_json("prefix", "injectparityread", f);
+  encode_json("pool", pool, f);
+  encode_json("objname", objname, f);
+}
+
+void InjectECParityRead::decode_json(JSONObj* obj) {
+  JSONDecoder::decode_json("pool", pool, obj);
+  JSONDecoder::decode_json("objname", objname, obj);
+}
+
+void InjectECClearParityRead::dump(Formatter* f) const {
+  encode_json("prefix", "injectparityread", f);
+  encode_json("pool", pool, f);
+  encode_json("objname", objname, f);
+}
+
+void InjectECClearParityRead::decode_json(JSONObj* obj) {
+  JSONDecoder::decode_json("pool", pool, obj);
+  JSONDecoder::decode_json("objname", objname, obj);
+}

--- a/src/common/json/OSDStructures.cc
+++ b/src/common/json/OSDStructures.cc
@@ -68,7 +68,7 @@ void OSDPoolGetReply::decode_json(JSONObj* obj) {
 }
 
 void OSDECProfileGetRequest::dump(Formatter* f) const {
-  encode_json("prefix", "osd pool get", f);
+  encode_json("prefix", "osd erasure-code-profile get", f);
   encode_json("name", name, f);
   encode_json("format", format, f);
 }

--- a/src/common/json/OSDStructures.h
+++ b/src/common/json/OSDStructures.h
@@ -190,6 +190,20 @@ struct InjectECClearErrorRequest {
     JSONDecoder::decode_json("type", type, obj);
   }
 };
+struct InjectECParityRead {
+  std::string pool;
+  std::string objname;
+
+  void dump(Formatter* f) const;
+  void decode_json(JSONObj* obj);
+};
+struct InjectECClearParityRead {
+  std::string pool;
+  std::string objname;
+
+  void dump(Formatter* f) const;
+  void decode_json(JSONObj* obj);
+};
 }  // namespace osd
 }  // namespace messaging
 }  // namespace ceph

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5510,6 +5510,11 @@ options:
     repair are applied.
   default: false
   with_legacy: true
+- name: bluestore_debug_inject_parity_read
+  type: bool
+  level: dev
+  default: false
+  with_legacy: true
 - name: bluestore_fsck_error_on_no_per_pool_stats
   type: bool
   level: advanced

--- a/src/erasure-code/CMakeLists.txt
+++ b/src/erasure-code/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(jerasure)
 add_subdirectory(lrc)
 add_subdirectory(shec)
 add_subdirectory(clay)
+add_subdirectory(consistency)
 
 if(HAVE_NASM_X64_AVX2 OR HAVE_ARMV8_SIMD)
   set(WITH_EC_ISA_PLUGIN TRUE CACHE BOOL "")

--- a/src/erasure-code/consistency/CMakeLists.txt
+++ b/src/erasure-code/consistency/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ec_consistency STATIC
   ECReader.cc
   ECEncoder.cc
   Pool.cc
+  ConsistencyChecker.cc
   RadosCommands.cc
   ${PROJECT_SOURCE_DIR}/src/osd/ECUtilL.cc
 )

--- a/src/erasure-code/consistency/CMakeLists.txt
+++ b/src/erasure-code/consistency/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_library(ec_consistency STATIC
+  ECReader.cc
+  ECEncoder.cc
+  Pool.cc
   RadosCommands.cc
+  ${PROJECT_SOURCE_DIR}/src/osd/ECUtilL.cc
 )
 
 target_link_libraries(ec_consistency
@@ -10,7 +14,7 @@ target_link_libraries(ec_consistency
 
 add_executable(ceph_ec_consistency_checker
   ${CMAKE_CURRENT_SOURCE_DIR}/ceph_ec_consistency_checker.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/ECUtil.cc)
+  ${PROJECT_SOURCE_DIR}/src/osd/ECUtilL.cc)
 target_link_libraries(ceph_ec_consistency_checker
   librados global ec_consistency)
 install(TARGETS

--- a/src/erasure-code/consistency/CMakeLists.txt
+++ b/src/erasure-code/consistency/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(ec_consistency STATIC
+  RadosCommands.cc
+)
+
+target_link_libraries(ec_consistency
+  librados
+  global
+  json_structures
+)
+
+add_executable(ceph_ec_consistency_checker
+  ${CMAKE_CURRENT_SOURCE_DIR}/ceph_ec_consistency_checker.cc
+  ${PROJECT_SOURCE_DIR}/src/osd/ECUtil.cc)
+target_link_libraries(ceph_ec_consistency_checker
+  librados global ec_consistency)
+install(TARGETS
+ceph_ec_consistency_checker
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/erasure-code/consistency/ConsistencyChecker.cc
+++ b/src/erasure-code/consistency/ConsistencyChecker.cc
@@ -1,0 +1,127 @@
+#include "ConsistencyChecker.h"
+
+#include "RadosCommands.h"
+#include "Pool.h"
+#include "ECReader.h"
+#include "ECEncoder.h"
+
+using ConsistencyChecker = ceph::consistency::ConsistencyChecker;
+
+using Read = ceph::consistency::Read;
+using ReadResult = ceph::consistency::ReadResult;
+using bufferlist = ceph::bufferlist;
+
+
+ConsistencyChecker::ConsistencyChecker(librados::Rados &rados,
+                                       boost::asio::io_context& asio,
+                                       const std::string& pool_name) :
+  rados(rados),
+  asio(asio),
+  reader(ceph::consistency::ECReader(rados, asio, pool_name)),
+  commands(ceph::consistency::RadosCommands(rados)),
+  pool(pool_name, commands.get_ec_profile_for_pool(pool_name))
+{
+}
+
+/**
+ * Perform an end-to-end read and consistency check on a single object.
+ * Current implementation only supports reading the entire object, so length and
+ * offset should normally be 0.
+ *
+ * @param oid string Name of the pool to perform inject on
+ * @param block_size int Block size for the data being read
+ * @param offset int Which offset to read from
+ * @param length int How much data of each shard to read
+ * @param stripe_unit int Size of each chunk of the object
+ */
+void ConsistencyChecker::single_read_and_check_consistency(const std::string& oid,
+                                                           int block_size,
+                                                           int offset,
+                                                           int length,
+                                                           int stripe_unit)
+{
+  auto read = Read(oid, block_size, offset, length);
+  queue_ec_read(read);
+
+  auto read_results = get_read_results();
+  std::vector<ConsistencyCheckResult> consistency_results;
+
+  for (auto r : *read_results) {
+    std::string oid = r.first;
+    bool is_consistent = check_object_consistency(r.second, stripe_unit);
+    consistency_results.push_back(ConsistencyCheckResult(oid, is_consistent));
+    commands.inject_clear_parity_read_on_primary_osd(pool.get_pool_name(),
+                                                     oid);
+  }
+
+  print_results(consistency_results, std::cout);
+}
+
+/**
+ * Queue up an EC read with the parity read inject set
+ *
+ * @param read Object containing information about the read
+ */
+void ConsistencyChecker::queue_ec_read(Read read)
+{
+  commands.inject_parity_read_on_primary_osd(pool.get_pool_name(),
+                                             read.get_oid());
+  reader.do_read(read);
+}
+
+/**
+ * Generate parities from the data and compare to the parity shards
+ *
+ * @param inbl bufferlist The entire contents of the object, including parities
+ * @param stripe_unit int The chunk size for the object
+ */
+bool ConsistencyChecker::check_object_consistency(const bufferlist& inbl, int stripe_unit)
+{
+  std::pair<bufferlist, bufferlist> data_and_parity;
+  data_and_parity = split_data_and_parity(inbl, pool.get_ec_profile());
+
+  bufferlist outbl;
+  auto encoder = ceph::consistency::ECEncoder(pool.get_ec_profile(), stripe_unit);
+  encoder.do_encode(data_and_parity.first, outbl);
+
+  return buffers_match(outbl, data_and_parity.second);
+}
+
+void ConsistencyChecker::print_results(std::vector<ConsistencyCheckResult> results, 
+                                       std::ostream& out)
+{
+  out << "Results:" << std::endl;
+  for (auto r : results) {
+    std::string result_str = (r.second) ? "Passed" : "Failed";
+    out << "Object ID " << r.first << ": " << result_str << std::endl;
+  }
+  int count = results.size();
+  out << "Total: " << count << " objects checked." << std::endl;
+}
+
+std::pair<bufferlist, bufferlist>
+  ConsistencyChecker::split_data_and_parity(const bufferlist& read,
+                                            ErasureCodeProfile profile)
+{
+  uint8_t k = atoi(profile["k"].c_str());
+  uint8_t m = atoi(profile["m"].c_str());
+  uint64_t parity_index = (read.length() / (k + m)) * k;
+  uint64_t parity_size = read.length() - parity_index;
+
+  bufferlist data, parity;
+  auto it = read.begin();
+  it.copy(read.length() - parity_size, data);
+  it.copy(parity_size, parity);
+  return std::pair<bufferlist, bufferlist>(data, parity);
+}
+
+bool ConsistencyChecker::buffers_match(const bufferlist& b1,
+                                       const bufferlist& b2)
+{
+  return (b1.contents_equal(b2));
+}
+
+std::vector<ReadResult>* ConsistencyChecker::get_read_results()
+{
+  return reader.get_results();
+}

--- a/src/erasure-code/consistency/ConsistencyChecker.h
+++ b/src/erasure-code/consistency/ConsistencyChecker.h
@@ -25,8 +25,8 @@ namespace ceph {
         ceph::consistency::ECReader reader;
         ceph::consistency::RadosCommands commands;
         ceph::consistency::Pool pool;
+        std::vector<ConsistencyCheckResult> results;
         bool buffers_match(const bufferlist& b1, const bufferlist& b2);
-        std::vector<ReadResult>* get_read_results();
         std::pair<bufferlist, bufferlist> split_data_and_parity(const bufferlist& read, 
                                                                 ErasureCodeProfile profile);
 
@@ -36,8 +36,9 @@ namespace ceph {
                            const std::string& pool_name);
         void queue_ec_read(Read read);
         bool check_object_consistency(const bufferlist& inbl, int stripe_unit);
-        void print_results(std::vector<ConsistencyCheckResult> results, std::ostream& out);
-        void single_read_and_check_consistency(const std::string& oid,
+        void print_results(std::ostream& out);
+        void clear_results();
+        bool single_read_and_check_consistency(const std::string& oid,
                                                int block_size,
                                                int offset,
                                                int length,

--- a/src/erasure-code/consistency/ConsistencyChecker.h
+++ b/src/erasure-code/consistency/ConsistencyChecker.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+#include <boost/program_options.hpp>
+
+#include "librados/librados_asio.h"
+
+#include "global/global_init.h"
+#include "global/global_context.h"
+
+#include "Pool.h"
+#include "ECReader.h"
+#include "RadosCommands.h"
+#include "ECEncoder.h"
+
+#define dout_context g_ceph_context
+
+namespace ceph {
+  namespace consistency {
+    typedef std::pair<std::string, bool> ConsistencyCheckResult;
+    class ConsistencyChecker {
+      protected:
+        librados::Rados& rados;
+        boost::asio::io_context& asio;
+        ceph::consistency::ECReader reader;
+        ceph::consistency::RadosCommands commands;
+        ceph::consistency::Pool pool;
+        bool buffers_match(const bufferlist& b1, const bufferlist& b2);
+        std::vector<ReadResult>* get_read_results();
+        std::pair<bufferlist, bufferlist> split_data_and_parity(const bufferlist& read, 
+                                                                ErasureCodeProfile profile);
+
+      public:
+        ConsistencyChecker(librados::Rados& rados,
+                           boost::asio::io_context& asio,
+                           const std::string& pool_name);
+        void queue_ec_read(Read read);
+        bool check_object_consistency(const bufferlist& inbl, int stripe_unit);
+        void print_results(std::vector<ConsistencyCheckResult> results, std::ostream& out);
+        void single_read_and_check_consistency(const std::string& oid,
+                                               int block_size,
+                                               int offset,
+                                               int length,
+                                               int stripe_unit);
+    };
+  }
+}

--- a/src/erasure-code/consistency/ECEncoder.cc
+++ b/src/erasure-code/consistency/ECEncoder.cc
@@ -1,0 +1,92 @@
+#include "ECEncoder.h"
+#include "osd/ECUtilL.h"
+
+using ECEncoder = ceph::consistency::ECEncoder;
+
+ECEncoder::ECEncoder(ceph::ErasureCodeProfile profile, int stripe_unit) :
+profile(profile),
+stripe_unit(stripe_unit)
+{
+}
+
+/**
+ * Initialize the ErasureCodeInterfaceRef and stripe_info_t needed to perform encode.
+ * for the specified object and pool. Assert on failure.
+ *
+ * @param stripe_unit Size of each shard in the stripe
+ * @param ec_impl Pointer to plugin being initialized
+ * @param sinfo Pointer to the stripe info object associated with the EC profile
+ * @returns int 0 if successful, otherwise 1
+ */
+int ECEncoder::ec_init(int stripe_unit,
+                       ceph::ErasureCodeInterfaceRef *ec_impl,
+                       std::unique_ptr<ECLegacy::ECUtilL::stripe_info_t> *sinfo)
+{
+  auto plugin = profile.find("plugin");
+  if (plugin == profile.end()) {
+    std::cerr << "Invalid profile: plugin not specified." << std::endl;
+    return 1;
+  }
+
+  std::stringstream ss;
+  std::string dir = g_conf().get_val<std::string>("erasure_code_dir");
+  ceph::ErasureCodePluginRegistry::instance().factory(plugin->second, dir, profile, ec_impl, &ss);
+  if (!*ec_impl) {
+    std::cerr << "Invalid profile: " << ss.str() << std::endl;
+    return 1;
+  }
+
+  if (sinfo == nullptr) {
+    return 0;
+  }
+
+  uint64_t stripe_size = atoi(profile["k"].c_str());
+  ceph_assert(stripe_size > 0);
+  uint64_t stripe_width = stripe_size * stripe_unit;
+  sinfo->reset(new ECLegacy::ECUtilL::stripe_info_t(*ec_impl, stripe_width));
+
+  return 0;
+  }
+
+/**
+ * Perform encode on the input buffer.
+ *
+ * @param inbl Buffer to be encoded
+ * @param outbl Buffer for the encode output
+ * @returns int 0 if successful, otherwise 1
+ */
+int ECEncoder::do_encode(ceph::bufferlist inbl,
+                         ceph::bufferlist &outbl)
+{
+  std::unique_ptr<ECLegacy::ECUtilL::stripe_info_t> sinfo;
+  ceph::ErasureCodeInterfaceRef ec_impl;
+  ec_init(stripe_unit, &ec_impl, &sinfo);
+
+  uint64_t stripe_width = (*sinfo).get_stripe_width();
+  if (inbl.length() % stripe_width != 0) {
+    uint64_t pad = stripe_width - inbl.length() % stripe_width;
+    inbl.append_zero(pad);
+  }
+
+  std::set<int> want;
+  int shard_count = atoi(profile["k"].c_str()) + atoi(profile["m"].c_str());
+  for (int i=0; i<shard_count; i++)
+    want.insert(i);
+
+  std::map<int, ceph::bufferlist> encoded_data;
+  int rc = ECLegacy::ECUtilL::encode(*sinfo, ec_impl, inbl, want, &encoded_data);
+  if (rc < 0) {
+    std::cerr << "Failed to encode, rc: " << rc << std::endl;
+    return 1;
+  }
+
+  for (auto &[shard, bl] : encoded_data) {
+    if (shard >= atoi(profile["k"].c_str()))
+    {
+      bufferlist::iterator it = bl.begin();
+      it.copy_all(outbl);
+    }
+  }
+
+  return 0;
+}

--- a/src/erasure-code/consistency/ECEncoder.h
+++ b/src/erasure-code/consistency/ECEncoder.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "include/buffer.h"
+#include "erasure-code/ErasureCode.h"
+#include "erasure-code/ErasureCodePlugin.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
+#include "osd/ECUtilL.h"
+
+namespace ceph {
+  namespace consistency {
+    class ECEncoder {
+      protected:
+        ceph::ErasureCodeProfile profile;
+        int stripe_unit;
+      public:
+        ECEncoder(ceph::ErasureCodeProfile profile, int stripe_unit);
+        int ec_init(int stripe_unit,
+                     ceph::ErasureCodeInterfaceRef *ec_impl,
+                     std::unique_ptr<ECLegacy::ECUtilL::stripe_info_t> *sinfo);
+        int do_encode(ceph::bufferlist inbl,
+                      ceph::bufferlist &outbl);
+
+    };
+  }
+}

--- a/src/erasure-code/consistency/ECReader.cc
+++ b/src/erasure-code/consistency/ECReader.cc
@@ -99,3 +99,11 @@ std::vector<ReadResult>* ECReader::get_results()
   wait_for_io();
   return &results;
 }
+
+/**
+ * Clear the results vector.
+ */
+void ECReader::clear_results()
+{
+  results.clear();
+}

--- a/src/erasure-code/consistency/ECReader.cc
+++ b/src/erasure-code/consistency/ECReader.cc
@@ -1,0 +1,100 @@
+#include "ECReader.h"
+
+#include <boost/program_options.hpp>
+
+
+using ECReader = ceph::consistency::ECReader;
+using ReadResult = ceph::consistency::ReadResult;
+using Read = ceph::consistency::Read;
+
+Read::Read(const std::string& oid,
+           uint64_t block_size,
+           uint64_t offset,
+           uint64_t length) :
+oid(oid),
+block_size(block_size),
+offset(offset),
+length(length)
+{
+}
+
+std::string Read::get_oid() { return oid; }
+uint64_t Read::get_block_size()  { return block_size; }
+uint64_t Read::get_offset() { return offset; }
+uint64_t Read::get_length() { return length; }
+
+
+ECReader::ECReader(librados::Rados& rados,
+                   boost::asio::io_context& asio,
+                   const std::string& pool_name) :
+  rados(rados),
+  asio(asio),
+  pool_name(pool_name),
+  lock(ceph::make_mutex("ECReader::lock")),
+  outstanding_io(0)
+{
+  int rc;
+  rc = rados.ioctx_create(pool_name.c_str(), io);
+  ceph_assert(rc == 0);
+  results = std::vector<ReadResult>();
+}
+
+void ECReader::start_io()
+{
+  std::lock_guard l(lock);
+  outstanding_io++;
+}
+
+void ECReader::finish_io()
+{
+  std::lock_guard l(lock);
+  ceph_assert(outstanding_io > 0);
+  outstanding_io--;
+  cond.notify_all();
+}
+
+void ECReader::wait_for_io()
+{
+  std::unique_lock l(lock);
+  while (outstanding_io > 0) {
+    cond.wait(l);
+  }
+}
+
+/**
+ * Send an async read request to librados. Push the returned data
+ * and oid into the results vector. 
+ *
+ * @param read Read object containing oid, length, offset and block size
+ */
+void ECReader::do_read(Read read)
+{
+  start_io();
+  op.read(read.get_offset() * read.get_block_size(),
+          read.get_length() * read.get_block_size(),
+          nullptr, nullptr);
+
+  std::string oid = read.get_oid();
+  auto read_cb = [&, oid](boost::system::error_code ec,
+                         version_t ver,
+                         bufferlist outbl) {
+    ceph_assert(ec == boost::system::errc::success);
+    ceph_assert(outbl.length() > 0);
+
+    results.push_back({oid, outbl});
+    finish_io();
+  };
+
+  librados::async_operate(asio.get_executor(), io, read.get_oid(),
+                          std::move(op), 0, nullptr, read_cb);
+}
+
+/**
+ * Wait for all outstanding reads to complete then return the results vector.
+ * @returns Vector containing the results of all reads
+ */
+std::vector<ReadResult>* ECReader::get_results()
+{
+  wait_for_io();
+  return &results;
+}

--- a/src/erasure-code/consistency/ECReader.cc
+++ b/src/erasure-code/consistency/ECReader.cc
@@ -70,6 +70,7 @@ void ECReader::wait_for_io()
 void ECReader::do_read(Read read)
 {
   start_io();
+  librados::ObjectReadOperation op;
   op.read(read.get_offset() * read.get_block_size(),
           read.get_length() * read.get_block_size(),
           nullptr, nullptr);

--- a/src/erasure-code/consistency/ECReader.h
+++ b/src/erasure-code/consistency/ECReader.h
@@ -47,6 +47,7 @@ namespace ceph {
         void finish_io(void);
         void wait_for_io(void);
         std::vector<ReadResult>* get_results(void);
+        void clear_results(void);
     };
   }
 }

--- a/src/erasure-code/consistency/ECReader.h
+++ b/src/erasure-code/consistency/ECReader.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+#include <boost/program_options.hpp>
+#include "librados/librados_asio.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+
+#define dout_context g_ceph_context
+
+namespace ceph {
+  namespace consistency {
+    typedef std::pair<std::string, ceph::bufferlist> ReadResult;
+    class Read {
+      protected:
+        std::string oid;
+        uint64_t block_size;
+        uint64_t offset;
+        uint64_t length;
+      
+      public:
+        Read(const std::string& oid,
+             uint64_t block_size,
+             uint64_t offset,
+             uint64_t length);
+        std::string get_oid(void);
+        uint64_t get_block_size(void);
+        uint64_t get_offset(void);
+        uint64_t get_length(void);
+    };
+    class ECReader {
+      protected:
+        librados::Rados& rados;
+        boost::asio::io_context& asio;
+        std::string pool_name;
+        std::string oid;
+        librados::IoCtx io;
+        librados::ObjectReadOperation op;
+        ceph::condition_variable cond;
+        std::vector<ReadResult> results;
+        ceph::mutex lock;
+        int outstanding_io;
+
+      public:
+        ECReader(librados::Rados& rados, boost::asio::io_context& asio, const std::string& pool);
+        void do_read(Read read);
+        void start_io(void);
+        void finish_io(void);
+        void wait_for_io(void);
+        std::vector<ReadResult>* get_results(void);
+    };
+  }
+}

--- a/src/erasure-code/consistency/ECReader.h
+++ b/src/erasure-code/consistency/ECReader.h
@@ -35,7 +35,6 @@ namespace ceph {
         std::string pool_name;
         std::string oid;
         librados::IoCtx io;
-        librados::ObjectReadOperation op;
         ceph::condition_variable cond;
         std::vector<ReadResult> results;
         ceph::mutex lock;

--- a/src/erasure-code/consistency/Pool.cc
+++ b/src/erasure-code/consistency/Pool.cc
@@ -1,0 +1,12 @@
+#include "Pool.h"
+
+using Pool = ceph::consistency::Pool;
+
+Pool::Pool(const std::string& pool_name, const ceph::ErasureCodeProfile& profile) :
+  pool_name(pool_name),
+  profile(profile)
+{
+}
+
+ceph::ErasureCodeProfile Pool::get_ec_profile() { return profile; }
+std::string Pool::get_pool_name() { return pool_name; }

--- a/src/erasure-code/consistency/Pool.h
+++ b/src/erasure-code/consistency/Pool.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "erasure-code/ErasureCodePlugin.h"
+
+namespace ceph {
+  namespace consistency {
+    class Pool {
+      protected:
+        std::string pool_name;
+        ceph::ErasureCodeProfile profile;
+
+      public:
+        Pool(const std::string& pool_name, const ceph::ErasureCodeProfile& profile);
+        ceph::ErasureCodeProfile get_ec_profile(void);
+        std::string get_pool_name(void); 
+    };
+  }
+}

--- a/src/erasure-code/consistency/RadosCommands.cc
+++ b/src/erasure-code/consistency/RadosCommands.cc
@@ -54,7 +54,7 @@ int RadosCommands::get_primary_osd(const std::string& pool_name,
 /**
  * Send a mon command to fetch the name of the erasure code profile for the
  * specified pool and return it.
- * 
+ *
  * @param pool_name string Name of the pool to get the erasure code profile for
  * @returns string The erasure code profile for the specified pool
  */
@@ -82,7 +82,7 @@ std::string RadosCommands::get_pool_ec_profile_name(const std::string& pool_name
 
 /**
  * Fetch the erasure code profile for the specified pool and return it.
- * 
+ *
  * @param pool_name string Name of the pool to get the EC profile for
  * @returns ErasureCodeProfile The EC profile for the specified pool
  */

--- a/src/erasure-code/consistency/RadosCommands.cc
+++ b/src/erasure-code/consistency/RadosCommands.cc
@@ -1,0 +1,158 @@
+#include "RadosCommands.h"
+#include "common/ceph_json.h"
+#include "common/json/OSDStructures.h"
+#include "erasure-code/ErasureCodePlugin.h"
+#include <boost/algorithm/string.hpp>
+
+using RadosCommands = ceph::consistency::RadosCommands;
+
+RadosCommands::RadosCommands(librados::Rados& rados) :
+  rados(rados),
+  formatter(new JSONFormatter(true))
+{
+}
+
+RadosCommands::~RadosCommands()
+{
+  delete formatter;
+}
+
+/**
+ * Return the index of the acting primary OSD for the given pool
+ * and object name. Assert on failure.
+ *
+ * @param pool_name string Name of the pool to find acting primary of
+ * @param oid string OID of the object to find acting primary of
+ * @returns int ID of the acting primary OSD
+ */
+int RadosCommands::get_primary_osd(const std::string& pool_name,
+                              const std::string& oid)
+{
+  ceph::messaging::osd::OSDMapRequest osd_map_request{pool_name, oid, ""};
+  encode_json("OSDMapRequest", osd_map_request, formatter);
+
+  std::ostringstream oss;
+  formatter->flush(oss);
+  int osd = -1;
+
+  ceph::bufferlist inbl, outbl;
+  int rc = rados.mon_command(oss.str(), inbl, &outbl, nullptr);
+  ceph_assert(rc == 0);
+
+  JSONParser p;
+  bool success = p.parse(outbl.c_str(), outbl.length());
+  ceph_assert(success);
+
+  ceph::messaging::osd::OSDMapReply reply;
+  reply.decode_json(&p);
+  osd = reply.acting_primary;
+  ceph_assert(osd >= 0);
+
+  return osd;
+}
+
+/**
+ * Send a mon command to fetch the name of the erasure code profile for the
+ * specified pool and return it.
+ * 
+ * @param pool_name string Name of the pool to get the erasure code profile for
+ * @returns string The erasure code profile for the specified pool
+ */
+std::string RadosCommands::get_pool_ec_profile_name(const std::string& pool_name)
+{
+  ceph::messaging::osd::OSDPoolGetRequest osd_pool_get_request{pool_name};
+  encode_json("OSDPoolGetRequest", osd_pool_get_request, formatter);
+
+  std::ostringstream oss;
+  formatter->flush(oss);
+
+  ceph::bufferlist inbl, outbl;
+  int rc = rados.mon_command(oss.str(), inbl, &outbl, nullptr);
+  ceph_assert(rc == 0);
+
+  JSONParser p;
+  bool success = p.parse(outbl.c_str(), outbl.length());
+  ceph_assert(success);
+
+  ceph::messaging::osd::OSDPoolGetReply osd_pool_get_reply;
+  osd_pool_get_reply.decode_json(&p);
+
+  return osd_pool_get_reply.erasure_code_profile;
+}
+
+/**
+ * Fetch the erasure code profile for the specified pool and return it.
+ * 
+ * @param pool_name string Name of the pool to get the EC profile for
+ * @returns ErasureCodeProfile The EC profile for the specified pool
+ */
+ceph::ErasureCodeProfile RadosCommands::get_ec_profile_for_pool(const std::string& pool_name)
+{
+  ceph::messaging::osd::OSDECProfileGetRequest osd_ec_profile_get_req{
+      get_pool_ec_profile_name(pool_name), "plain"};
+  encode_json("OSDECProfileGetRequest", osd_ec_profile_get_req, formatter);
+
+  std::ostringstream oss;
+  formatter->flush(oss);
+
+  ceph::bufferlist inbl, outbl;
+  int rc = rados.mon_command(oss.str(), inbl, &outbl, nullptr);
+  ceph_assert(rc == 0);
+
+  // Parse the string output into an ErasureCodeProfile
+  ceph::ErasureCodeProfile profile;
+  std::string line, key, val, out(outbl.c_str(), outbl.length());
+  std::stringstream ss(out);
+
+  while (std::getline(ss, line)) {
+    key = line.substr(0, line.find("="));
+    val = line.substr(line.find("=") + 1, line.length() - 1);
+    profile.emplace(key, val);
+  }
+
+  return profile;
+}
+
+/**
+ * RadosCommands the parity read inject on the acting primary
+ * for the specified object and pool. Assert on failure.
+ *
+ * @param pool_name string Name of the pool to perform inject on
+ * @param oid string OID of the object to perform inject on
+ */
+void RadosCommands::inject_parity_read_on_primary_osd(const std::string& pool_name,
+                                                 const std::string& oid)
+{
+  int primary_osd = get_primary_osd(pool_name, oid);
+  ceph::messaging::osd::InjectECParityRead parity_read_req{pool_name, oid};
+  encode_json("InjectECParityRead", parity_read_req, formatter);
+
+  std::ostringstream oss;
+  formatter->flush(oss);
+
+  ceph::bufferlist inbl, outbl;
+  int rc = rados.osd_command(primary_osd, oss.str(), inbl, &outbl, nullptr);
+  ceph_assert(rc == 0);
+}
+
+/**
+ * RadosCommands the clear parity read inject on the acting primary
+ * for the specified object and pool. Assert on failure.
+ *
+ * @param pool_name string Name of the pool to perform inject on
+ * @param oid string OID of the object to perform inject on
+ */
+void RadosCommands::inject_clear_parity_read_on_primary_osd(const std::string& pool_name,
+                                                       const std::string& oid)
+{
+  int primary_osd = get_primary_osd(pool_name, oid);
+  ceph::messaging::osd::InjectECClearParityRead clear_parity_read_req{pool_name, oid};
+  encode_json("InjectECClearParityRead", clear_parity_read_req, formatter);
+
+  std::ostringstream oss;
+  formatter->flush(oss);
+
+  ceph::bufferlist inbl, outbl;
+  int rc = rados.osd_command(primary_osd, oss.str(), inbl, &outbl, nullptr);
+  ceph_assert(rc == 0);
+}

--- a/src/erasure-code/consistency/RadosCommands.h
+++ b/src/erasure-code/consistency/RadosCommands.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+#include <boost/program_options.hpp>
+#include "common/ceph_json.h"
+#include "librados/librados_asio.h"
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "erasure-code/ErasureCodePlugin.h"
+
+#define dout_context g_ceph_context
+
+namespace ceph {
+  namespace consistency {
+    class RadosCommands {
+      private:
+        librados::Rados& rados;
+        JSONFormatter* formatter;
+
+      public:
+        RadosCommands(librados::Rados& rados);
+        ~RadosCommands();
+        int get_primary_osd(const std::string& pool_name,
+                            const std::string& oid);
+        std::string get_pool_ec_profile_name(const std::string& pool_name);
+        ceph::ErasureCodeProfile get_ec_profile_for_pool(const std::string& pool_name);
+        void inject_parity_read_on_primary_osd(const std::string& pool_name,
+                                               const std::string& oid);
+        void inject_clear_parity_read_on_primary_osd(const std::string& pool_name,
+                                                     const std::string& oid);
+    };
+  }
+}

--- a/src/erasure-code/consistency/ceph_ec_consistency_checker.cc
+++ b/src/erasure-code/consistency/ceph_ec_consistency_checker.cc
@@ -1,0 +1,80 @@
+#include <boost/asio/io_context.hpp>
+#include <boost/program_options.hpp>
+
+#include "global/global_init.h"
+#include "global/global_context.h"
+#include "librados/librados_asio.h"
+#include "common/ceph_argparse.h"
+
+#include "ConsistencyChecker.h"
+
+#define dout_context g_ceph_context
+
+namespace po = boost::program_options;
+using bufferlist = ceph::bufferlist;
+
+int main(int argc, char **argv)
+{
+  auto args = argv_to_vec(argc, argv);
+  env_to_vec(args);
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(cct.get());
+
+  librados::Rados rados;
+  boost::asio::io_context asio;
+  std::thread thread;
+  std::optional<boost::asio::executor_work_guard<
+                  boost::asio::io_context::executor_type>> guard;
+
+  po::options_description desc("ceph_ec_consistency_checker options");
+
+  desc.add_options()
+    ("help,h", "show help message")
+    ("pool,p", po::value<std::string>(), "pool name")
+    ("oid,i", po::value<std::string>(), "object io")
+    ("blocksize,b", po::value<int>(), "block size")
+    ("offset,o", po::value<int>(), "offset")
+    ("length,l", po::value<int>(), "length")
+    ("stripeunit,s", po::value<int>(), "stripe unit");
+
+  po::variables_map vm;
+  std::vector<std::string> unrecognized_options;
+  try {
+      auto parsed = po::command_line_parser(argc, argv)
+      .options(desc)
+      .allow_unregistered()
+      .run();
+      po::store(parsed, vm);
+      if (vm.count("help")) {
+      std::cout << desc << std::endl;
+      return 0;
+      }
+      po::notify(vm);
+      unrecognized_options = po::collect_unrecognized(parsed.options, po::include_positional);
+  } catch(const po::error& e) {
+      std::cerr << "error: " << e.what() << std::endl;
+      return 1;
+  }
+
+  auto pool = vm["pool"].as<std::string>();
+  auto oid = vm["oid"].as<std::string>();
+  auto blocksize = vm["blocksize"].as<int>();
+  auto offset = vm["offset"].as<int>();
+  auto length = vm["length"].as<int>();
+  auto stripe_unit = vm["stripeunit"].as<int>();
+
+  int rc;
+  rc = rados.init_with_context(g_ceph_context);
+  ceph_assert(rc == 0);
+  rc = rados.connect();
+  ceph_assert(rc == 0);
+
+  guard.emplace(boost::asio::make_work_guard(asio));
+  thread = make_named_thread("io_thread",[&asio] { asio.run(); });
+
+  auto checker = ceph::consistency::ConsistencyChecker(rados, asio, pool);
+  checker.single_read_and_check_consistency(oid, blocksize, offset, length, stripe_unit);
+
+  exit(0);
+}

--- a/src/erasure-code/consistency/ceph_ec_consistency_checker.cc
+++ b/src/erasure-code/consistency/ceph_ec_consistency_checker.cc
@@ -75,6 +75,7 @@ int main(int argc, char **argv)
 
   auto checker = ceph::consistency::ConsistencyChecker(rados, asio, pool);
   checker.single_read_and_check_consistency(oid, blocksize, offset, length, stripe_unit);
+  checker.print_results(std::cout);
 
   exit(0);
 }

--- a/src/osd/ECBackendL.cc
+++ b/src/osd/ECBackendL.cc
@@ -1609,17 +1609,20 @@ void ECBackendL::objects_read_async(
     list<pair<ec_align_t,
 	      pair<bufferlist*, Context*> > > to_read;
     unique_ptr<Context> on_complete;
+    CephContext *cct;
     cb(const cb&) = delete;
     cb(cb &&) = default;
     cb(ECBackendL *ec,
        const hobject_t &hoid,
        const list<pair<ec_align_t,
                   pair<bufferlist*, Context*> > > &to_read,
-       Context *on_complete)
+       Context *on_complete,
+       CephContext *cct)
       : ec(ec),
 	hoid(hoid),
 	to_read(to_read),
-	on_complete(on_complete) {}
+	on_complete(on_complete),
+        cct(cct) {}
     void operator()(ECCommonL::ec_extents_t &&results) {
       auto dpp = ec->get_parent()->get_dpp();
       ldpp_dout(dpp, 20) << "objects_read_async_cb: got: " << results
@@ -1652,6 +1655,10 @@ void ECBackendL::objects_read_async(
           ldpp_dout(dpp, 20) << "length: " << length << dendl;
           ldpp_dout(dpp, 20) << "range length: " << range_length << dendl;
 	  ceph_assert(offset + length <= range_offset + range_length);
+          if (cct->_conf->bluestore_debug_inject_parity_read &&
+            ECInject::test_parity_read(hoid)) {
+            length = range_length;
+          }
 	  read.second.first->substr_of(
 	    range.first.get_val(),
 	    offset - range_offset,
@@ -1682,7 +1689,8 @@ void ECBackendL::objects_read_async(
 	cb(this,
 	   hoid,
 	   to_read,
-	   on_complete)));
+	   on_complete,
+           cct)));
 }
 
 void ECBackendL::objects_read_and_reconstruct(

--- a/src/osd/ECCommonL.cc
+++ b/src/osd/ECCommonL.cc
@@ -505,6 +505,54 @@ void ECCommonL::ReadPipeline::get_want_to_read_shards(
   }
 }
 
+void ECCommonL::ReadPipeline::get_want_to_read_all_shards(
+  std::set<int> *want_to_read) const
+{
+  for (int i = 0; i < (int)sinfo.get_k_plus_m(); ++i) {
+    want_to_read->insert(sinfo.get_shard(i));
+  }
+}
+
+/**
+ * Create a buffer containing both the ordered data and parity shards
+ *
+ * @param to_decode Map of shard indexes and their corresponding data buffers
+ * @param wanted_to_read Set of shard indexes to be read
+ * @param outbl Pointer to output buffer
+ */
+void ECCommonL::ReadPipeline::create_parity_read_buffer(
+  std::map<int, bufferlist> to_decode,
+  std::set<int> wanted_to_read,
+  bufferlist *outbl)
+{
+  int stripe_size = (int)sinfo.get_k_plus_m();
+  int k = (int)sinfo.get_k();
+  bufferlist parity;
+
+  ceph_assert((int)to_decode.size() == stripe_size);
+  ceph_assert((int)wanted_to_read.size() == stripe_size);
+
+  for (int i = k; i < stripe_size; i++) {
+    parity.append(to_decode[i]);
+    wanted_to_read.erase(i);
+    to_decode.erase(i);
+  }
+
+  dout(20) << __func__ << " going to decode: "
+            << " wanted_to_read=" << wanted_to_read
+            << " to_decode=" << to_decode
+            << dendl;
+  int r = ECUtilL::decode(
+    sinfo,
+    ec_impl,
+    wanted_to_read,
+    to_decode,
+    outbl);
+
+  ceph_assert(r == 0);
+  outbl->append(parity);
+}
+
 struct ClientReadCompleter : ECCommonL::ReadCompleter {
   ClientReadCompleter(ECCommonL::ReadPipeline &read_pipeline,
                       ECCommonL::ClientAsyncReadStatus *status)
@@ -539,6 +587,18 @@ struct ClientReadCompleter : ECCommonL::ReadCompleter {
 	   ++j) {
 	to_decode[static_cast<int>(j->first.shard)] = std::move(j->second);
       }
+
+      if (cct->_conf->bluestore_debug_inject_parity_read &&
+          ECInject::test_parity_read(hoid)) {
+        bufferlist outbl;
+        read_pipeline.create_parity_read_buffer(to_decode, wanted_to_read, &outbl);
+
+        result.insert(
+          read.offset, outbl.length(), std::move(outbl));
+        res.returned.pop_front();
+        goto out;
+      }
+
       dout(20) << __func__ << " going to decode: "
                << " wanted_to_read=" << wanted_to_read
                << " to_decode=" << to_decode
@@ -619,7 +679,10 @@ void ECCommonL::ReadPipeline::objects_read_and_reconstruct(
   map<hobject_t, read_request_t> for_read_op;
   for (auto &&to_read: reads) {
     set<int> want_to_read;
-    if (cct->_conf->osd_ec_partial_reads) {
+    if (cct->_conf->bluestore_debug_inject_parity_read &&
+        ECInject::test_parity_read(to_read.first)) {
+      get_want_to_read_all_shards(&want_to_read);
+    } else if (cct->_conf->osd_ec_partial_reads) {
       for (const auto& single_region : to_read.second) {
         get_min_want_to_read_shards(single_region.offset,
 				    single_region.size,

--- a/src/osd/ECCommonL.h
+++ b/src/osd/ECCommonL.h
@@ -322,6 +322,12 @@ struct ECCommonL {
     friend struct FinishReadOp;
 
     void get_want_to_read_shards(std::set<int> *want_to_read) const;
+    void get_want_to_read_all_shards(std::set<int> *want_to_read) const;
+    void create_parity_read_buffer(
+      std::map<int, bufferlist> to_decode,
+      std::set<int> wanted_to_read,
+      bufferlist *outbl
+      );
 
     /// Returns to_read replicas sufficient to reconstruct want
     int get_min_avail_to_read_shards(

--- a/src/osd/ECInject.cc
+++ b/src/osd/ECInject.cc
@@ -29,7 +29,7 @@ namespace ECInject {
   static std::map<ghobject_t,std::pair<int64_t,int64_t>> write_failures3;
   static std::map<ghobject_t,shard_id_t> write_failures0_shard;
   static std::set<osd_reqid_t> write_failures0_reqid;
-
+  static std::vector<hobject_t> parity_reads;
   /**
    * Configure a read error inject that typically forces additional reads of
    * shards in an EC pool to recover data using the redundancy. With multiple
@@ -141,6 +141,20 @@ namespace ECInject {
   }
 
   /**
+   * Configure a parity read inject that typically forces parity shards in an
+   * EC pool to be returned along with the data shards.
+   *
+   * @brief Set up a parity read inject for an object in an EC pool.
+   * @param o Target object for the parity read inject.
+   * @return string Result of configuring the inject.
+   */
+  std::string parity_read(const hobject_t& o) {
+    std::lock_guard<ceph::recursive_mutex> l(lock);
+    parity_reads.push_back(o);
+    return "ok - parity read inject set";
+  }
+
+  /**
    * @brief Clear a previously configured read error inject.
    * @param o Target object for the error inject.
    * @param type Type of error inject 0 = EIO, 1 = missing shard.
@@ -228,6 +242,23 @@ namespace ECInject {
       return "ok - 1 inject cleared";
     }
     return "ok - " + std::to_string(remaining) + " injects cleared";
+  }
+
+  /**
+   * @brief Clear a previously configured parity read inject.
+   * @param o Target object for the clear parity read inject.
+   * @return string Indication of whether the inject was cleared.
+   */
+  std::string clear_parity_read(const hobject_t& o) {
+    std::lock_guard<ceph::recursive_mutex> l(lock);
+
+    auto it = std::find(parity_reads.begin(), parity_reads.end(), o);
+    if (it != parity_reads.end()) {
+      parity_reads.erase(it);
+      return "ok - parity read inject cleared";
+    }
+
+    return "no outstanding parity read inject";
   }
 
   static bool test_error(const ghobject_t& o,
@@ -320,4 +351,15 @@ namespace ECInject {
       &write_failures3);
   }
 
+  /**
+   * @brief Test whether parity read inject is set for a particular object.
+   * @param o Target object for the parity read inject.
+   * @return bool true if set, otherwise false.
+   */
+  bool test_parity_read(const hobject_t& o)
+  {
+    std::lock_guard<ceph::recursive_mutex> l(lock);
+    auto it = std::find(parity_reads.begin(), parity_reads.end(), o);
+    return (it != parity_reads.end());
+  }
 } // ECInject

--- a/src/osd/ECInject.h
+++ b/src/osd/ECInject.h
@@ -23,13 +23,16 @@ namespace ECInject {
   // Error inject interfaces
   std::string read_error(const ghobject_t& o, const int64_t type, const int64_t when, const int64_t duration);
   std::string write_error(const ghobject_t& o, const int64_t type, const int64_t when, const int64_t duration);
+  std::string parity_read(const hobject_t& o);
   std::string clear_read_error(const ghobject_t& o, const int64_t type);
   std::string clear_write_error(const ghobject_t& o, const int64_t type);
+  std::string clear_parity_read(const hobject_t& o);
   bool test_read_error0(const ghobject_t& o);
   bool test_read_error1(const ghobject_t& o);
   bool test_write_error0(const hobject_t& o,const osd_reqid_t& reqid);
   bool test_write_error1(const ghobject_t& o);
   bool test_write_error2(const hobject_t& o);
   bool test_write_error3(const hobject_t& o);
+  bool test_parity_read(const hobject_t& o);
 
 } // ECInject

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4420,6 +4420,21 @@ void OSD::final_init()
    "Inject a full disk (optional count times)");
   ceph_assert(r == 0);
   r = admin_socket->register_command(
+    "injectparityread " \
+    "name=pool,type=CephString " \
+    "name=objname,type=CephObjectname ",
+    test_ops_hook,
+    "Tell the OSD to return the parity chunks along with the next read");
+  ceph_assert(r == 0);
+  r = admin_socket->register_command(
+    "injectclearparityread " \
+    "name=pool,type=CephString " \
+    "name=objname,type=CephObjectname ",
+    test_ops_hook,
+    "Clear a parity read inject");
+  ceph_assert(r == 0);
+
+  r = admin_socket->register_command(
     "bench " \
     "name=count,type=CephInt,req=false "    \
     "name=size,type=CephInt,req=false "		   \
@@ -6559,7 +6574,8 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       command == "truncobj" ||
       command == "injectmdataerr" || command == "injectdataerr" ||
       command == "injectecreaderr" || command == "injectecclearreaderr" ||
-      command == "injectecwriteerr" || command == "injectecclearwriteerr"
+      command == "injectecwriteerr" || command == "injectecclearwriteerr" ||
+      command == "injectparityread" || command == "injectclearparityread"
     ) {
     pg_t rawpg;
     int64_t pool;
@@ -6605,7 +6621,9 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
 	    (command != "injectecreaderr") &&
 	    (command != "injectecclearreaderr") &&
 	    (command != "injectecwriteerr") &&
-	    (command != "injectecclearwriteerr")) {
+	    (command != "injectecclearwriteerr") &&
+            (command != "injectparityread") &&
+            (command != "injectclearparityread")) {
             ss << "Must not call on ec pool";
             return;
         }
@@ -6613,7 +6631,9 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
         if ((command == "injectecreaderr") ||
 	    (command == "injecteclearreaderr") ||
 	    (command == "injectecwriteerr") ||
-	    (command == "injecteclearwriteerr")) {
+	    (command == "injecteclearwriteerr") ||
+            (command == "injectparityread") ||
+            (command == "injectclearparityread")) {
             ss << "Only supported on ec pool";
             return;
         }
@@ -6725,6 +6745,18 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       } else {
 	ss << "bluestore_debug_inject_read_err not enabled";
       }
+    } else if (command == "injectparityread") {
+      if (service->cct->_conf->bluestore_debug_inject_parity_read) {
+        ss << "injectparityread: " << ECInject::parity_read(obj);
+      } else {
+        ss << "bluestore_debug_inject_parity_read not enabled";
+      }
+    } else if (command == "injectclearparityread") {
+      if (service->cct->_conf->bluestore_debug_inject_parity_read) {
+        ss << "injectclearparityread: " << ECInject::clear_parity_read(obj);
+      } else {
+        ss << "bluestore_debug_inject_parity_read not enabled";
+      }
     }
     return;
   }
@@ -6762,6 +6794,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
     service->set_injectfull(state, count);
     return;
   }
+
   ss << "Internal error - command=" << command;
 }
 

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -22,7 +22,7 @@ install(TARGETS
 add_executable(ceph_test_rados_io_sequence
   ${CMAKE_CURRENT_SOURCE_DIR}/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc)
 target_link_libraries(ceph_test_rados_io_sequence
-  librados global object_io_exerciser json_structures)
+  librados global object_io_exerciser json_structures ec_consistency)
 install(TARGETS
   ceph_test_rados_io_sequence
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -25,6 +25,10 @@
 #include "common/json/BalancerStructures.h"
 #include "common/json/ConfigStructures.h"
 #include "common/json/OSDStructures.h"
+// #include "common/split.h"
+// #include "common/strtol.h"  // for strict_iecstrtoll()
+// #include "erasure-code/ErasureCodePlugin.h"
+#include "erasure-code/consistency/ConsistencyChecker.h"
 #include "fmt/format.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
@@ -53,6 +57,7 @@ using TruncateOp = ceph::io_exerciser::TruncateOp;
 using SingleFailedWriteOp = ceph::io_exerciser::SingleFailedWriteOp;
 using DoubleFailedWriteOp = ceph::io_exerciser::DoubleFailedWriteOp;
 using TripleFailedWriteOp = ceph::io_exerciser::TripleFailedWriteOp;
+using ConsistencyChecker = ceph::consistency::ConsistencyChecker;
 
 namespace {
 struct Size {};
@@ -179,6 +184,8 @@ po::options_description get_options_description() {
       "number of objects to exercise in parallel")(
       "testrecovery",
       "Inject errors during sequences to test recovery processes of OSDs")(
+      "checkconsistency",
+      "Test objects for consistency during IO sequences. Disabled by default.")(
       "interactive", "interactive mode, execute IO commands from stdin")(
       "allow_pool_autoscaling",
       "Allows pool autoscaling. Disabled by default.")(
@@ -924,8 +931,9 @@ ceph::io_sequence::tester::TestObject::TestObject(
     SelectObjectSize& sos, SelectNumThreads& snt, SelectSeqRange& ssr,
     ceph::util::random_number_generator<int>& rng, ceph::mutex& lock,
     ceph::condition_variable& cond, bool dryrun, bool verbose,
-    std::optional<int> seqseed, bool testrecovery)
-    : rng(rng), verbose(verbose), seqseed(seqseed), testrecovery(testrecovery) {
+    std::optional<int> seqseed, bool testrecovery, bool checkconsistency)
+    : rng(rng), verbose(verbose), seqseed(seqseed),
+      testrecovery(testrecovery), checkconsistency(checkconsistency) {
   if (dryrun) {
     exerciser_model = std::make_unique<ceph::io_exerciser::ObjectModel>(
         oid, sbs.select(), rng());
@@ -964,8 +972,9 @@ ceph::io_sequence::tester::TestObject::TestObject(
       cached_shard_order = reply.acting;
     }
 
+    int chunk_size = spo.getProfile()->chunk_size.value_or(0);
     exerciser_model = std::make_unique<ceph::io_exerciser::RadosIo>(
-        rados, asio, pool, oid, cached_shard_order, sbs.select(), rng(),
+        rados, asio, pool, oid, cached_shard_order, sbs.select(), chunk_size, rng(),
         threads, lock, cond, spo.get_allow_pool_ec_optimizations());
     dout(0) << "= " << oid << " pool=" << pool << " threads=" << threads
             << " blocksize=" << exerciser_model->get_block_size() << " ="
@@ -978,10 +987,10 @@ ceph::io_sequence::tester::TestObject::TestObject(
   if (testrecovery) {
     seq = ceph::io_exerciser::EcIoSequence::generate_sequence(
         curseq, obj_size_range, pool_km, pool_mappinglayers,
-        seqseed.value_or(rng()));
+        seqseed.value_or(rng()), checkconsistency);
   } else {
     seq = ceph::io_exerciser::IoSequence::generate_sequence(
-        curseq, obj_size_range, seqseed.value_or(rng()));
+        curseq, obj_size_range, seqseed.value_or(rng()), checkconsistency);
   }
 
   op = seq->next();
@@ -1017,10 +1026,10 @@ bool ceph::io_sequence::tester::TestObject::next() {
         if (testrecovery) {
           seq = ceph::io_exerciser::EcIoSequence::generate_sequence(
               curseq, obj_size_range, pool_km, pool_mappinglayers,
-              seqseed.value_or(rng()));
+              seqseed.value_or(rng()), checkconsistency);
         } else {
           seq = ceph::io_exerciser::IoSequence::generate_sequence(
-              curseq, obj_size_range, seqseed.value_or(rng()));
+              curseq, obj_size_range, seqseed.value_or(rng()), checkconsistency);
         }
 
         dout(0) << "== " << exerciser_model->get_oid() << " " << curseq << " "
@@ -1075,6 +1084,7 @@ ceph::io_sequence::tester::TestRunner::TestRunner(
   object_name = vm["object"].as<std::string>();
   interactive = vm.contains("interactive");
   testrecovery = vm.contains("testrecovery");
+  checkconsistency = vm.contains("checkconsistency");
 
   allow_pool_autoscaling = vm.contains("allow_pool_autoscaling");
   allow_pool_balancer = vm.contains("allow_pool_balancer");
@@ -1108,7 +1118,7 @@ void ceph::io_sequence::tester::TestRunner::help() {
 }
 
 void ceph::io_sequence::tester::TestRunner::list_sequence(bool testrecovery) {
-  // List seqeunces
+  // List sequences
   std::pair<int, int> obj_size_range = sos.select();
   ceph::io_exerciser::Sequence s = ceph::io_exerciser::Sequence::SEQUENCE_BEGIN;
   std::unique_ptr<ceph::io_exerciser::IoSequence> seq;
@@ -1124,10 +1134,10 @@ void ceph::io_sequence::tester::TestRunner::list_sequence(bool testrecovery) {
       }
     }
     seq = ceph::io_exerciser::EcIoSequence::generate_sequence(
-        s, obj_size_range, km, mappinglayers, seqseed.value_or(rng()));
+        s, obj_size_range, km, mappinglayers, seqseed.value_or(rng()), checkconsistency);
   } else {
     seq = ceph::io_exerciser::IoSequence::generate_sequence(
-        s, obj_size_range, seqseed.value_or(rng()));
+        s, obj_size_range, seqseed.value_or(rng()), checkconsistency);
   }
 
   do {
@@ -1232,8 +1242,9 @@ bool ceph::io_sequence::tester::TestRunner::run_interactive_test() {
     ceph::messaging::osd::OSDMapReply osd_map_reply{};
     osd_map_reply.decode_json(&p);
 
+    int chunk_size = spo.getProfile()->chunk_size.value_or(0);
     model = std::make_unique<ceph::io_exerciser::RadosIo>(
-        rados, asio, pool, object_name, osd_map_reply.acting, sbs.select(), rng(),
+        rados, asio, pool, object_name, osd_map_reply.acting, sbs.select(), chunk_size, rng(),
         1,  // 1 thread
         lock, cond,
         spo.get_allow_pool_ec_optimizations());
@@ -1384,7 +1395,7 @@ bool ceph::io_sequence::tester::TestRunner::run_automated_test() {
     test_objects.push_back(
         std::make_shared<ceph::io_sequence::tester::TestObject>(
             name, rados, asio, sbs, spo, sos, snt, ssr, rng, lock, cond, dryrun,
-            verbose, seqseed, testrecovery));
+            verbose, seqseed, testrecovery, checkconsistency));
   }
   if (!dryrun) {
     rados.wait_for_latest_osdmap();

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -10,6 +10,7 @@
 #include "common/io_exerciser/Model.h"
 #include "common/split.h"
 #include "erasure-code/ErasureCodePlugin.h"
+#include "erasure-code/consistency/ConsistencyChecker.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
 #include "include/random.h"
@@ -443,7 +444,8 @@ class TestObject {
              bool dryrun,
              bool verbose,
              std::optional<int> seqseed,
-             bool testRecovery);
+             bool testRecovery,
+             bool checkConsistency);
 
   int get_num_io();
   bool readyForIo();
@@ -466,6 +468,7 @@ class TestObject {
   std::optional<std::pair<std::string_view, std::string_view>>
       pool_mappinglayers;
   bool testrecovery;
+  bool checkconsistency;
 };
 
 class TestRunner {
@@ -504,6 +507,7 @@ class TestRunner {
   bool interactive;
 
   bool testrecovery;
+  bool checkconsistency;
 
   bool allow_pool_autoscaling;
   bool allow_pool_balancer;


### PR DESCRIPTION
Depends on: #62170 

This PR integrates the consistency checker with the IO exerciser to allow live consistency checking of objects as IO is being performed. A new op type ‘consistency’ has been added and the existing sequences have been updated to perform a consistency check at appropriate times, mainly when a read is done after a write or series of writes, or just before an object is deleted. This new behaviour is guarded behind a flag (—checkconsistency), the default behaviour is unchanged and the exerciser behaviour should not be changed when the flag is not specified.

Only the latest commit (e4f0a02fe0ba91166e68a210ea69d0329833fa50) is part of this PR, previous commits will go in as part of 62170.

Signed-off-by: Connor Fawcett <connorfa@uk.ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
