### PR TITLE
squid: doc/radosgw: Fix RST syntax rendeded as text in oidc.rst

### DIFF
--- a/doc/radosgw/oidc.rst
+++ b/doc/radosgw/oidc.rst
@@ -11,10 +11,10 @@ The following REST APIs can be used for creating and managing an OpenID Connect 
 
 In order to invoke the REST admin APIs, a user with admin caps needs to be created.
 
-.. code-block:: javascript
+.. prompt:: bash #
 
-  radosgw-admin --uid TESTER --display-name "TestUser" --access_key TESTER --secret test123 user create
-  radosgw-admin caps add --uid="TESTER" --caps="oidc-provider=*"
+   radosgw-admin --uid TESTER --display-name "TestUser" --access_key TESTER --secret test123 user create
+   radosgw-admin caps add --uid="TESTER" --caps="oidc-provider=*"
 
 
 CreateOpenIDConnectProvider
@@ -42,6 +42,7 @@ Request Parameters
 
 
 Example::
+
   POST "<hostname>?Action=Action=CreateOpenIDConnectProvider
     &ThumbprintList.list.1=F7D7B3515DD0D319DD219A43A9EA727AD6065287
     &ClientIDList.list.1=app-profile-jsp
@@ -62,6 +63,7 @@ Request Parameters
 :Type: String
 
 Example::
+
   POST "<hostname>?Action=Action=DeleteOpenIDConnectProvider
     &OpenIDConnectProviderArn=arn:aws:iam:::oidc-provider/localhost:8080/auth/realms/quickstart
 
@@ -80,6 +82,7 @@ Request Parameters
 :Type: String
 
 Example::
+
   POST "<hostname>?Action=Action=GetOpenIDConnectProvider
     &OpenIDConnectProviderArn=arn:aws:iam:::oidc-provider/localhost:8080/auth/realms/quickstart
 
@@ -94,4 +97,78 @@ Request Parameters
 None
 
 Example::
+
   POST "<hostname>?Action=Action=ListOpenIDConnectProviders
+
+AddClientIDToOpenIDConnectProvider
+----------------------------------
+
+Add a client id to the list of existing client ids registered while creating an OpenIDConnectProvider.
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``OpenIDConnectProviderArn``
+
+:Description: ARN of the IDP which is returned by the Create API.
+:Type: String
+
+``ClientID``
+
+:Description: Client Id to add to the existing OpenIDConnectProvider.
+:Type: String
+
+Example::
+
+  POST "<hostname>?Action=Action=AddClientIDToOpenIDConnectProvider
+    &OpenIDConnectProviderArn=arn:aws:iam:::oidc-provider/localhost:8080/auth/realms/quickstart
+    &ClientID=app-jee-jsp"
+
+RemoveClientIDFromOpenIDConnectProvider
+----------------------------------
+
+Remove a client id from the list of existing client ids registered while creating an OpenIDConnectProvider.
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``OpenIDConnectProviderArn``
+
+:Description: ARN of the IDP which is returned by the Create API.
+:Type: String
+
+``ClientID``
+
+:Description: Client ID to remove from the existing OpenIDConnectProvider.
+:Type: String
+
+Example::
+
+  POST "<hostname>?Action=Action=RemoveClientIDFromOpenIDConnectProvider
+    &OpenIDConnectProviderArn=arn:aws:iam:::oidc-provider/localhost:8080/auth/realms/quickstart
+    &ClientID=app-jee-jsp"
+
+UpdateOpenIDConnectProviderThumbprint
+-------------------------------------
+
+Update the existing thumbprint list of an OpenIDConnectProvider with the given list.
+This API removes the existing thumbprint list and replaces that with the input thumbprint list.
+
+Request Parameters
+~~~~~~~~~~~~~~~~~~
+
+``OpenIDConnectProviderArn``
+
+:Description: ARN of the IDP which is returned by the Create API.
+:Type: String
+
+``ThumbprintList.member.N``
+
+:Description: List of OpenID Connect IDP's server certificates' thumbprints. A maximum of 5 thumbprints are allowed.
+:Type: Array of Strings
+
+Example::
+
+  POST "<hostname>?Action=Action=UpdateOpenIDConnectProviderThumbprint
+    &OpenIDConnectProviderArn=arn:aws:iam:::oidc-provider/localhost:8080/auth/realms/quickstart
+    &&ThumbprintList.list.1=ABCDB3515DD0D319DD219A43A9EA727AD6061234"


### PR DESCRIPTION
Empty line after starting a pre-formatted block with the double-colon syntax is required, otherwise the double-colon does nothing and is just rendered as-is as "::" and there would be no following pre-formatted block.

Add empty lines after the double-colon syntax so that the following block is rendered pre-formatted.

Also add bash privileged prompts to a block with 2 example CLI commands.


(cherry picked from commit b4fb5dc4030b4de477942630ebe3b98b882ae978)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
