### PR TITLE
rgw/multisite: rgw_forward_request_to_master() preserves Error responses

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1476,8 +1476,9 @@ int RGWBucketAdminOp::remove_bucket(rgw::sal::Driver* driver, const rgw::SiteCon
   env.set("REQUEST_URI", delpath);
   env.set("QUERY_STRING", fmt::format("bucket={}&tenant={}", bucket->get_name(), bucket->get_tenant()));
   req_info req(dpp->get_cct(), &env);
+  rgw_err err; // unused
 
-  ret = rgw_forward_request_to_master(dpp, site, bucket->get_owner(), nullptr, nullptr, req, y);
+  ret = rgw_forward_request_to_master(dpp, site, bucket->get_owner(), nullptr, nullptr, req, err, y);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to forward request to master zonegroup: "
                       << ret << dendl;

--- a/src/rgw/driver/rados/rgw_rest_bucket.cc
+++ b/src/rgw/driver/rados/rgw_rest_bucket.cc
@@ -153,7 +153,7 @@ void RGWOp_Bucket_Link::execute(optional_yield y)
   op_state.set_new_bucket_name(new_bucket_name);
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -192,7 +192,7 @@ void RGWOp_Bucket_Unlink::execute(optional_yield y)
   op_state.set_bucket_name(bucket);
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;

--- a/src/rgw/driver/rados/rgw_rest_user.cc
+++ b/src/rgw/driver/rados/rgw_rest_user.cc
@@ -28,7 +28,7 @@ int fetch_access_keys_from_master(const DoutPrefixProvider* dpp, req_state* s,
   bufferlist data;
   JSONParser jp;
   int ret = rgw_forward_request_to_master(dpp, *s->penv.site, s->user->get_id(),
-                                          &data, &jp, s->info, y);
+                                          &data, &jp, s->info, s->err, y);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "forward_request_to_master returned ret=" << ret << dendl;
     return ret;
@@ -480,7 +480,7 @@ void RGWOp_User_Remove::execute(optional_yield y)
   op_state.set_purge_data(purge_data);
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -555,7 +555,7 @@ void RGWOp_Subuser_Create::execute(optional_yield y)
   op_state.set_key_type(key_type);
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -622,7 +622,7 @@ void RGWOp_Subuser_Modify::execute(optional_yield y)
   op_state.set_key_type(key_type);
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -665,7 +665,7 @@ void RGWOp_Subuser_Remove::execute(optional_yield y)
     op_state.set_purge_keys();
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -812,7 +812,7 @@ void RGWOp_Caps_Add::execute(optional_yield y)
   op_state.set_caps(caps);
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -850,7 +850,7 @@ void RGWOp_Caps_Remove::execute(optional_yield y)
   op_state.set_caps(caps);
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -1902,7 +1902,7 @@ static int send_to_remote_gateway(RGWRESTConn* conn, req_info& info,
 
   ceph::bufferlist response;
   rgw_user user;
-  int ret = conn->forward(dpp(), user, info, nullptr, MAX_REST_RESPONSE, &in_data, &response, null_yield);
+  int ret = conn->forward(dpp(), user, info, MAX_REST_RESPONSE, &in_data, &response, null_yield);
 
   int parse_ret = parser.parse(response.c_str(), response.length());
   if (parse_ret < 0) {

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -337,6 +337,9 @@ void set_req_state_err(struct rgw_err& err,	/* out */
     err_no = -err_no;
 
   err.ret = -err_no;
+  if (!err.err_code.empty()) { // request already set the error
+    return;
+  }
 
   if (prot_flags & RGW_REST_SWIFT) {
     if (search_err(rgw_http_swift_errors, err_no, err.http_ret, err.err_code))

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -155,8 +155,12 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
                           creds, site.get_zonegroup().id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
-  int ret = conn.forward(dpp, effective_owner, req,
-                         max_response_size, indata, &outdata, y);
+  auto result = conn.forward(dpp, effective_owner, req,
+                             max_response_size, indata, &outdata, y);
+  if (!result) {
+    return result.error();
+  }
+  int ret = rgw_http_error_to_errno(*result);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3847,25 +3847,6 @@ void RGWDeleteBucket::execute(optional_yield y)
     op_ret = -ERR_NO_SUCH_BUCKET;
     return;
   }
-  RGWObjVersionTracker ot;
-  ot.read_version = s->bucket->get_version();
-
-  if (s->system_request) {
-    string tag = s->info.args.get(RGW_SYS_PARAM_PREFIX "tag");
-    string ver_str = s->info.args.get(RGW_SYS_PARAM_PREFIX "ver");
-    if (!tag.empty()) {
-      ot.read_version.tag = tag;
-      uint64_t ver;
-      string err;
-      ver = strict_strtol(ver_str.c_str(), 10, &err);
-      if (!err.empty()) {
-        ldpp_dout(this, 0) << "failed to parse ver param" << dendl;
-        op_ret = -EINVAL;
-        return;
-      }
-      ot.read_version.ver = ver;
-    }
-  }
 
   const bool own_bucket = s->penv.site->get_zonegroup().get_id() == s->bucket->get_info().zonegroup;
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -155,7 +155,7 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
                           creds, site.get_zonegroup().id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
-  int ret = conn.forward(dpp, effective_owner, req, nullptr,
+  int ret = conn.forward(dpp, effective_owner, req,
                          max_response_size, indata, &outdata, y);
   if (ret < 0) {
     return ret;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -120,11 +120,35 @@ static constexpr auto S3_EXISTING_OBJTAG = "s3:ExistingObjectTag";
 static constexpr auto S3_RESOURCE_TAG = "s3:ResourceTag";
 static constexpr auto S3_RUNTIME_RESOURCE_VAL = "${s3:ResourceTag";
 
+// try to parse the xml <Error> response body
+bool parse_aws_s3_error(const std::string& input, rgw_err& err)
+{
+  RGWXMLParser parser;
+  if (!parser.init()) {
+    return false;
+  }
+  if (!parser.parse(input.c_str(), input.length(), 1)) {
+    return false;
+  }
+  auto error = parser.find_first("Error");
+  if (!error) {
+    return false;
+  }
+  if (auto code = error->find_first("Code"); code) {
+    err.err_code = code->get_data();
+  }
+  if (auto message = error->find_first("Message"); message) {
+    err.message = message->get_data();
+  }
+  return true;
+}
+
 int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
                                   const rgw::SiteConfig& site,
                                   const rgw_owner& effective_owner,
                                   bufferlist* indata, JSONParser* jp,
-                                  req_info& req, optional_yield y)
+                                  const req_info& req, rgw_err& err,
+                                  optional_yield y)
 {
   const auto& period = site.get_period();
   if (!period) {
@@ -160,7 +184,11 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
   if (!result) {
     return result.error();
   }
-  int ret = rgw_http_error_to_errno(*result);
+  err.http_ret = *result;
+  if (err.is_err() && outdata.length()) { // 4xx or 5xx
+    std::ignore = parse_aws_s3_error(rgw_bl_str(outdata), err);
+  }
+  int ret = rgw_http_error_to_errno(err.http_ret);
   if (ret < 0) {
     return ret;
   }
@@ -1309,7 +1337,7 @@ void RGWPutBucketTags::execute(optional_yield y)
     return;
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &in_data, nullptr, s->info, y);
+                                         &in_data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -1344,7 +1372,7 @@ int RGWDeleteBucketTags::verify_permission(optional_yield y)
 void RGWDeleteBucketTags::execute(optional_yield y)
 {
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -1405,7 +1433,7 @@ void RGWPutBucketReplication::execute(optional_yield y) {
     return;
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &in_data, nullptr, s->info, y);
+                                         &in_data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -1451,7 +1479,7 @@ int RGWDeleteBucketReplication::verify_permission(optional_yield y)
 void RGWDeleteBucketReplication::execute(optional_yield y)
 {
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -2936,7 +2964,7 @@ void RGWSetBucketVersioning::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &in_data, nullptr, s->info, y);
+                                         &in_data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -3034,7 +3062,7 @@ void RGWSetBucketWebsite::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &in_data, nullptr, s->info, y);
+                                         &in_data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << " forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -3080,7 +3108,7 @@ void RGWDeleteBucketWebsite::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "NOTICE: forward_to_master failed on bucket=" << s->bucket->get_name()
       << "returned err=" << op_ret << dendl;
@@ -3734,7 +3762,7 @@ void RGWCreateBucket::execute(optional_yield y)
     // apply bucket creation on the master zone first
     JSONParser jp;
     op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                           &in_data, &jp, s->info, y);
+                                           &in_data, &jp, s->info, s->err, y);
     if (op_ret < 0) {
       return;
     }
@@ -3868,7 +3896,7 @@ void RGWDeleteBucket::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     if (op_ret == -ENOENT) {
       /* adjust error, we want to return with NoSuchBucket and not
@@ -6222,7 +6250,7 @@ void RGWPutACLs::execute(optional_yield y)
   // forward bucket acl requests to meta master zone
   if ((rgw::sal::Object::empty(s->object.get()))) {
     op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                           &data, nullptr, s->info, y);
+                                           &data, nullptr, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
       return;
@@ -6355,7 +6383,7 @@ void RGWPutLC::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &data, nullptr, s->info, y);
+                                         &data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -6372,7 +6400,7 @@ void RGWPutLC::execute(optional_yield y)
 void RGWDeleteLC::execute(optional_yield y)
 {
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -6434,7 +6462,7 @@ void RGWPutCORS::execute(optional_yield y)
     return;
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &in_data, nullptr, s->info, y);
+                                         &in_data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -6464,7 +6492,7 @@ int RGWDeleteCORS::verify_permission(optional_yield y)
 void RGWDeleteCORS::execute(optional_yield y)
 {
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -6595,7 +6623,7 @@ void RGWSetRequestPayment::execute(optional_yield y)
     return;
   
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &in_data, nullptr, s->info, y);
+                                         &in_data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -7634,8 +7662,9 @@ bool RGWBulkDelete::Deleter::delete_single(const acct_path_t& path, optional_yie
       req_info req = s->info;
       forward_req_info(dpp, s->cct, req, path.bucket_name);
 
+      rgw_err err; // unused
       ret = rgw_forward_request_to_master(dpp, *s->penv.site, s->owner.id,
-                                          nullptr, nullptr, req, y);
+                                          nullptr, nullptr, req, err, y);
       if (ret < 0) {
         goto delop_fail;
       }
@@ -7891,7 +7920,7 @@ int RGWBulkUploadOp::handle_dir(const std::string_view path, optional_yield y)
     forward_req_info(this, s->cct, req, bucket_name);
 
     ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                        &in_data, &jp, req, y);
+                                        &in_data, &jp, req, s->err, y);
     if (ret < 0) {
       return ret;
     }
@@ -8568,7 +8597,7 @@ void RGWPutBucketPolicy::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &data, nullptr, s->info, y);
+                                         &data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -8695,7 +8724,7 @@ int RGWDeleteBucketPolicy::verify_permission(optional_yield y)
 void RGWDeleteBucketPolicy::execute(optional_yield y)
 {
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -8768,7 +8797,7 @@ void RGWPutBucketObjectLock::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &data, nullptr, s->info, y);
+                                         &data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << __func__ << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -9146,7 +9175,7 @@ void RGWPutBucketPublicAccessBlock::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &data, nullptr, s->info, y);
+                                         &data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -9228,7 +9257,7 @@ int RGWDeleteBucketPublicAccessBlock::verify_permission(optional_yield y)
 void RGWDeleteBucketPublicAccessBlock::execute(optional_yield y)
 {
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -9284,7 +9313,7 @@ void RGWPutBucketEncryption::execute(optional_yield y)
   }
 
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         &data, nullptr, s->info, y);
+                                         &data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -9339,7 +9368,7 @@ int RGWDeleteBucketEncryption::verify_permission(optional_yield y)
 void RGWDeleteBucketEncryption::execute(optional_yield y)
 {
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->owner.id,
-                                         nullptr, nullptr, s->info, y);
+                                         nullptr, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -74,7 +74,8 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
                                   const rgw::SiteConfig& site,
                                   const rgw_owner& effective_owner,
                                   bufferlist* indata, JSONParser* jp,
-                                  req_info& req, optional_yield y);
+                                  const req_info& req, rgw_err& err,
+                                  optional_yield y);
 
 int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
                                        CephContext *cct,

--- a/src/rgw/rgw_period_puller.cc
+++ b/src/rgw/rgw_period_puller.cc
@@ -40,7 +40,7 @@ int pull_period(const DoutPrefixProvider *dpp, RGWRESTConn* conn, const std::str
 
   bufferlist data;
 #define MAX_REST_RESPONSE (128 * 1024)
-  int r = conn->forward(dpp, user, info, nullptr, MAX_REST_RESPONSE, nullptr, &data, y);
+  int r = conn->forward(dpp, user, info, MAX_REST_RESPONSE, nullptr, &data, y);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_period_puller.cc
+++ b/src/rgw/rgw_period_puller.cc
@@ -4,6 +4,7 @@
 #include "rgw_rados.h"
 #include "rgw_zone.h"
 #include "rgw_rest_conn.h"
+#include "rgw_http_errors.h"
 #include "common/ceph_json.h"
 #include "common/errno.h"
 
@@ -40,7 +41,11 @@ int pull_period(const DoutPrefixProvider *dpp, RGWRESTConn* conn, const std::str
 
   bufferlist data;
 #define MAX_REST_RESPONSE (128 * 1024)
-  int r = conn->forward(dpp, user, info, MAX_REST_RESPONSE, nullptr, &data, y);
+  auto result = conn->forward(dpp, user, info, MAX_REST_RESPONSE, nullptr, &data, y);
+  if (!result) {
+    return result.error();
+  }
+  int r = rgw_http_error_to_errno(*result);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_rest_account.cc
+++ b/src/rgw/rgw_rest_account.cc
@@ -75,7 +75,7 @@ void RGWOp_Account_Create::execute(optional_yield y)
     bufferlist data;
     JSONParser parser;
     op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                           &data, &parser, s->info, y);
+                                           &data, &parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
       return;
@@ -116,7 +116,7 @@ void RGWOp_Account_Modify::execute(optional_yield y)
 {
   bufferlist data;
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         &data, nullptr, s->info, y);
+                                         &data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -205,7 +205,7 @@ void RGWOp_Account_Delete::execute(optional_yield y)
 {
   bufferlist data;
   op_ret = rgw_forward_request_to_master(this, *s->penv.site, s->user->get_id(),
-                                         &data, nullptr, s->info, y);
+                                         &data, nullptr, s->info, s->err, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "include/expected.hpp"
 #include "rgw_http_client.h"
 
 class RGWGetDataCB;
@@ -65,7 +66,9 @@ public:
                        param_vec_t *_headers, param_vec_t *_params,
                        std::optional<std::string> _api_name) : RGWHTTPSimpleRequest(_cct, _method, _url, _headers, _params), api_name(_api_name) {}
 
-  int forward_request(const DoutPrefixProvider *dpp, const RGWAccessKey& key, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y, std::string service="");
+  // return the http status of the response or an error code from the transport
+  auto forward_request(const DoutPrefixProvider *dpp, const RGWAccessKey& key, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y, std::string service="")
+    -> tl::expected<int, int>;
 };
 
 class RGWWriteDrainCB {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -153,7 +153,7 @@ void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, con
   populate_zonegroup(params, zonegroup);
 }
 
-int RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
+int RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
 {
   int ret = 0;
 
@@ -165,12 +165,6 @@ int RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, co
       return ret;
     param_vec_t params;
     populate_params(params, &uid, self_zone_group);
-    if (objv) {
-      params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "tag", objv->tag));
-      char buf[16];
-      snprintf(buf, sizeof(buf), "%lld", (long long)objv->ver);
-      params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "ver", buf));
-    }
     RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params, api_name);
     ret = req.forward_request(dpp, key, info, max_response, inbl, outbl, y);
     if (ret == -EIO) {
@@ -185,7 +179,7 @@ int RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, co
   return ret;
 }
 
-int RGWRESTConn::forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
+int RGWRESTConn::forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
 {
   int ret = 0;
 
@@ -196,12 +190,6 @@ int RGWRESTConn::forward_iam_request(const DoutPrefixProvider *dpp, const req_in
     if (ret < 0)
       return ret;
     param_vec_t params;
-    if (objv) {
-      params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "tag", objv->tag));
-      char buf[16];
-      snprintf(buf, sizeof(buf), "%lld", (long long)objv->ver);
-      params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "ver", buf));
-    }
     std::string service = "iam";
     RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params, api_name);
     // coverity[uninit_use_in_call:SUPPRESS]

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -3,6 +3,7 @@
 
 #include "rgw_zone.h"
 #include "rgw_rest_conn.h"
+#include "rgw_http_errors.h"
 #include "rgw_sal.h"
 #include "rgw_rados.h"
 
@@ -153,57 +154,63 @@ void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, con
   populate_zonegroup(params, zonegroup);
 }
 
-int RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
+auto RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
+                          const req_info& info, size_t max_response,
+                          bufferlist *inbl, bufferlist *outbl, optional_yield y)
+  -> tl::expected<int, int>
 {
-  int ret = 0;
-
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
     string url;
-    ret = get_url(url);
-    if (ret < 0)
-      return ret;
+    int ret = get_url(url);
+    if (ret < 0) {
+      return tl::unexpected(ret);
+    }
     param_vec_t params;
     populate_params(params, &uid, self_zone_group);
     RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params, api_name);
-    ret = req.forward_request(dpp, key, info, max_response, inbl, outbl, y);
-    if (ret == -EIO) {
-      set_url_unconnectable(url);
-      if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
-        ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
-        continue;
-      }
+    auto result = req.forward_request(dpp, key, info, max_response, inbl, outbl, y);
+    if (result) {
+      return result;
+    } else if (result.error() != -EIO) {
+      return result;
     }
-    break;
+    set_url_unconnectable(url);
+    if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+      ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
+    }
   }
-  return ret;
+  return tl::unexpected(-EIO);
 }
 
-int RGWRESTConn::forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
+auto RGWRESTConn::forward_iam(const DoutPrefixProvider *dpp, const req_info& info,
+                              size_t max_response, bufferlist *inbl,
+                              bufferlist *outbl, optional_yield y)
+  -> tl::expected<int, int>
 {
-  int ret = 0;
-
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
     string url;
-    ret = get_url(url);
-    if (ret < 0)
-      return ret;
+    int ret = get_url(url);
+    if (ret < 0) {
+      return tl::unexpected(ret);
+    }
     param_vec_t params;
     std::string service = "iam";
     RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params, api_name);
     // coverity[uninit_use_in_call:SUPPRESS]
-    ret = req.forward_request(dpp, key, info, max_response, inbl, outbl, y, service);
-    if (ret == -EIO) {
-      set_url_unconnectable(url);
-      if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
-        ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
-        continue;
-      }
+    auto result = req.forward_request(dpp, key, info, max_response, inbl, outbl, y, service);
+    if (result) {
+      return result;
+    } else if (result.error() != -EIO) {
+      return result;
     }
-    break;
+    set_url_unconnectable(url);
+    if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+      ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
+    }
   }
-  return ret;
+  return tl::unexpected(-EIO);
 }
 
 int RGWRESTConn::put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req)

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -130,10 +130,10 @@ public:
   virtual void populate_params(param_vec_t& params, const rgw_owner* uid, const std::string& zonegroup);
 
   /* sync request */
-  int forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
+  int forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
 
   /* sync request */
-  int forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
+  int forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
 
 
   /* async requests */

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -130,11 +130,16 @@ public:
   virtual void populate_params(param_vec_t& params, const rgw_owner* uid, const std::string& zonegroup);
 
   /* sync request */
-  int forward(const DoutPrefixProvider *dpp, const rgw_owner& uid, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
+  auto forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
+               const req_info& info, size_t max_response,
+               bufferlist *inbl, bufferlist *outbl, optional_yield y)
+    -> tl::expected<int, int>;
 
   /* sync request */
-  int forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
-
+  auto forward_iam(const DoutPrefixProvider *dpp, const req_info& info,
+                   size_t max_response, bufferlist *inbl,
+                   bufferlist *outbl, optional_yield y)
+    -> tl::expected<int, int>;
 
   /* async requests */
   int put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -304,8 +304,12 @@ int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
                           std::move(creds), zg->second.id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
-  int ret = conn.forward_iam_request(dpp, req, max_response_size,
-                                     &indata, &outdata, y);
+  auto result = conn.forward_iam(dpp, req, max_response_size,
+                                 &indata, &outdata, y);
+  if (!result) {
+    return result.error();
+  }
+  int ret = rgw_http_error_to_errno(*result);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -304,7 +304,7 @@ int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
                           std::move(creds), zg->second.id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
-  int ret = conn.forward_iam_request(dpp, req, nullptr, max_response_size,
+  int ret = conn.forward_iam_request(dpp, req, max_response_size,
                                      &indata, &outdata, y);
   if (ret < 0) {
     return ret;

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -269,12 +269,39 @@ std::string iam_group_arn(const RGWGroupInfo& info)
                      info.account_id, path, info.name);
 }
 
+// try to parse the xml <ErrorResponse> response body
+bool parse_aws_error_response(const std::string& input, rgw_err& err)
+{
+  RGWXMLParser parser;
+  if (!parser.init()) {
+    return false;
+  }
+  if (!parser.parse(input.c_str(), input.length(), 1)) {
+    return false;
+  }
+  auto error_response = parser.find_first("ErrorResponse");
+  if (!error_response) {
+    return false;
+  }
+  auto error = error_response->find_first("Error");
+  if (!error) {
+    return false;
+  }
+  if (auto code = error->find_first("Code"); code) {
+    err.err_code = code->get_data();
+  }
+  if (auto message = error->find_first("Message"); message) {
+    err.message = message->get_data();
+  }
+  return true;
+}
+
 int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
                                   const rgw::SiteConfig& site,
                                   const RGWUserInfo& user,
-                                  bufferlist& indata,
-                                  RGWXMLDecoder::XMLParser& parser,
-                                  req_info& req, optional_yield y)
+                                  bufferlist& indata, RGWXMLParser& parser,
+                                  const req_info& req, rgw_err& err,
+                                  optional_yield y)
 {
   const auto& period = site.get_period();
   if (!period) {
@@ -309,7 +336,11 @@ int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
   if (!result) {
     return result.error();
   }
-  int ret = rgw_http_error_to_errno(*result);
+  err.http_ret = *result;
+  if (err.is_err() && outdata.length()) { // 4xx or 5xx
+    std::ignore = parse_aws_error_response(rgw_bl_str(outdata), err);
+  }
+  int ret = rgw_http_error_to_errno(err.http_ret);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_rest_iam.h
+++ b/src/rgw/rgw_rest_iam.h
@@ -31,9 +31,9 @@ std::string iam_group_arn(const RGWGroupInfo& info);
 int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
                                   const rgw::SiteConfig& site,
                                   const RGWUserInfo& user,
-                                  bufferlist& indata,
-                                  RGWXMLDecoder::XMLParser& parser,
-                                  req_info& req, optional_yield y);
+                                  bufferlist& indata, RGWXMLParser& parser,
+                                  const req_info& req, rgw_err& err,
+                                  optional_yield y);
 
 /// Perform an atomic read-modify-write operation on the given user metadata.
 /// Racing writes are detected here as ECANCELED errors, where we reload the

--- a/src/rgw/rgw_rest_iam_group.cc
+++ b/src/rgw/rgw_rest_iam_group.cc
@@ -123,7 +123,7 @@ int RGWCreateGroup_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -422,7 +422,7 @@ int RGWUpdateGroup_IAM::forward_to_master(optional_yield y, const rgw::SiteConfi
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -556,7 +556,7 @@ int RGWDeleteGroup_IAM::forward_to_master(optional_yield y, const rgw::SiteConfi
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -885,7 +885,7 @@ int RGWAddUserToGroup_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -1022,7 +1022,7 @@ int RGWRemoveUserFromGroup_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -1261,7 +1261,7 @@ int RGWPutGroupPolicy_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -1508,7 +1508,7 @@ int RGWDeleteGroupPolicy_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -1749,7 +1749,7 @@ int RGWAttachGroupPolicy_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -1898,7 +1898,7 @@ int RGWDetachGroupPolicy_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;

--- a/src/rgw/rgw_rest_iam_user.cc
+++ b/src/rgw/rgw_rest_iam_user.cc
@@ -123,7 +123,7 @@ int RGWCreateUser_IAM::forward_to_master(optional_yield y,
   }
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -412,7 +412,7 @@ int RGWUpdateUser_IAM::forward_to_master(optional_yield y, const rgw::SiteConfig
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -551,7 +551,7 @@ int RGWDeleteUser_IAM::forward_to_master(optional_yield y, const rgw::SiteConfig
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -882,7 +882,7 @@ int RGWCreateAccessKey_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -1106,7 +1106,7 @@ int RGWUpdateAccessKey_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -1253,7 +1253,7 @@ int RGWDeleteAccessKey_IAM::forward_to_master(optional_yield y,
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -404,7 +404,7 @@ void RGWPSCreateTopicOp::execute(optional_yield y) {
   // master request will replicate the topic creation.
   if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
+        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 4)
           << "CreateTopic forward_request_to_master returned ret = " << op_ret
@@ -871,7 +871,7 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
 void RGWPSSetTopicAttributesOp::execute(optional_yield y) {
   if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
+        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 4)
           << "SetTopicAttributes forward_request_to_master returned ret = "
@@ -1015,7 +1015,7 @@ class RGWPSDeleteTopicOp : public RGWOp {
 void RGWPSDeleteTopicOp::execute(optional_yield y) {
   if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
+        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, s->err, y);
 
     if (op_ret < 0) {
       ldpp_dout(this, 1)
@@ -1268,7 +1268,7 @@ int RGWPSCreateNotifOp::verify_permission(optional_yield y) {
 void RGWPSCreateNotifOp::execute(optional_yield y) {
   if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->owner.id, &data, nullptr, s->info, y);
+        this, *s->penv.site, s->owner.id, &data, nullptr, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 4) << "CreateBucketNotification "
                             "forward_request_to_master returned ret = "
@@ -1471,7 +1471,7 @@ void RGWPSDeleteNotifOp::execute(optional_yield y) {
   if (should_forward_request_to_master(s, driver)) {
     bufferlist indata;
     op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->owner.id, &indata, nullptr, s->info, y);
+        this, *s->penv.site, s->owner.id, &indata, nullptr, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 4) << "DeleteBucketNotification "
                             "forward_request_to_master returned error ret= "

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -269,7 +269,7 @@ void RGWCreateRole::execute(optional_yield y)
     }
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -368,7 +368,7 @@ void RGWDeleteRole::execute(optional_yield y)
     s->info.args.remove("Version");
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 0) << "forward_iam_request_to_master returned ret=" << op_ret << dendl;
       return;
@@ -479,7 +479,7 @@ void RGWModifyRoleTrustPolicy::execute(optional_yield y)
     s->info.args.remove("Version");
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -616,7 +616,7 @@ void RGWPutRolePolicy::execute(optional_yield y)
     s->info.args.remove("Version");
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -750,7 +750,7 @@ void RGWDeleteRolePolicy::execute(optional_yield y)
     s->info.args.remove("Version");
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -825,7 +825,7 @@ void RGWTagRole::execute(optional_yield y)
     }
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -934,7 +934,7 @@ void RGWUntagRole::execute(optional_yield y)
     }
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -997,7 +997,7 @@ void RGWUpdateRole::execute(optional_yield y)
     s->info.args.remove("Version");
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -1107,7 +1107,7 @@ void RGWAttachRolePolicy_IAM::execute(optional_yield y)
     s->info.args.remove("Version");
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;
@@ -1207,7 +1207,7 @@ void RGWDetachRolePolicy_IAM::execute(optional_yield y)
     s->info.args.remove("Version");
 
     op_ret = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                           bl_post_body, parser, s->info, y);
+                                           bl_post_body, parser, s->info, s->err, y);
     if (op_ret < 0) {
       ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << op_ret << dendl;
       return;

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -148,7 +148,7 @@ int RGWPutUserPolicy::forward_to_master(optional_yield y, const rgw::SiteConfig&
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -355,7 +355,7 @@ int RGWDeleteUserPolicy::forward_to_master(optional_yield y, const rgw::SiteConf
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -453,7 +453,7 @@ int RGWAttachUserPolicy_IAM::forward_to_master(optional_yield y, const rgw::Site
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;
@@ -573,7 +573,7 @@ int RGWDetachUserPolicy_IAM::forward_to_master(optional_yield y, const rgw::Site
   s->info.args.remove("Version");
 
   int r = forward_iam_request_to_master(this, site, s->user->get_info(),
-                                        post_body, parser, s->info, y);
+                                        post_body, parser, s->info, s->err, y);
   if (r < 0) {
     ldpp_dout(this, 20) << "ERROR: forward_iam_request_to_master failed with error code: " << r << dendl;
     return r;


### PR DESCRIPTION
when a forwarded request fails on the master zone, the local zone should return that same error response back to the client. this means reproducing both the http error and the aws xml `<Error>` response
    
`rgw_forward_request_to_master()` stores these errors in `s->err`, and `set_req_state_err()` now avoids overwriting existing an error

Fixes: https://tracker.ceph.com/issues/71098

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
