### PR TITLE
squid: osd/scrub: always round up reported scrub duration

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2123,7 +2123,7 @@ pg_scrubbing_status_t PgScrubber::get_schedule() const
 
     } else {
       int32_t dur_seconds =
-	  duration_cast<seconds>(m_fsm->get_time_scrubbing()).count();
+	  ceil<seconds>(m_fsm->get_time_scrubbing()).count();
       return pg_scrubbing_status_t{
 	  utime_t{},
 	  dur_seconds,


### PR DESCRIPTION
... as expected by some tests, and clearer for the user.

Fixes: https://tracker.ceph.com/issues/71099
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
