### PR TITLE
OSD: use the prev_trim_key when calling SnapMapper::get_next_objects_to_trim

### DIFF
--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -57,7 +57,8 @@ public:
   /// Returns next key
   virtual int get_next(
     const K &key,       ///< [in] key after which to get next
-    pair<K, V> *next    ///< [out] first key after key
+    pair<K, V> *next,    ///< [out] first key after key
+    bool with_lower_bound = true ///< [in] whether to call lower_bound to seek in bluestore get_omap_iterator function
     ) = 0; ///< @return 0 on success, -ENOENT if there is no next
 
   virtual ~StoreDriver() {}
@@ -83,7 +84,8 @@ public:
   /// Fetch first key/value pair after specified key
   int get_next(
     K key,               ///< [in] key after which to get next
-    pair<K, V> *next     ///< [out] next key
+    pair<K, V> *next,     ///< [out] next key
+    bool with_lower_bound = true ///< [in] whether to call lower_boundto seek in get_omap_iterator
     ) {
     while (true) {
       pair<K, boost::optional<V> > cached;
@@ -91,7 +93,7 @@ public:
       bool got_cached = in_progress.get_next(key, &cached);
 
       bool got_store = false;
-      int r = driver->get_next(key, &store);
+      int r = driver->get_next(key, &store, with_lower_bound);
       if (r < 0 && r != -ENOENT) {
 	return r;
       } else if (r == 0) {

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1888,6 +1888,14 @@ public:
     CollectionHandle &c,   ///< [in] collection
     const ghobject_t &oid  ///< [in] object
     ) = 0;
+  
+  virtual ObjectMap::ObjectMapIterator get_omap_iterator(
+    CollectionHandle &c,   ///< [in] collection
+    const ghobject_t &oid,  ///< [in] object
+    bool with_lower_bound  ///< [in] if invoke lower_bound to rocksdb's seek
+    ) {
+    return get_omap_iterator(c, oid);
+  };
 
   virtual int flush_journal() { return -EOPNOTSUPP; }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1485,7 +1485,7 @@ public:
     string _stringify() const;
 
   public:
-    OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it);
+    OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it, bool with_lower_bound);
     int seek_to_first() override;
     int upper_bound(const string &after) override;
     int lower_bound(const string &to) override;
@@ -2672,6 +2672,11 @@ public:
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle &c,   ///< [in] collection
     const ghobject_t &oid  ///< [in] object
+    ) override;
+  ObjectMap::ObjectMapIterator get_omap_iterator(
+    CollectionHandle &c,   ///< [in] collection
+    const ghobject_t &oid,  ///< [in] object
+    bool with_lower_bound   ///< [in] if invoke lower_bound to rocksdb's seek
     ) override;
 
   void set_fsid(uuid_d u) override {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15381,6 +15381,8 @@ boost::statechart::result PrimaryLogPG::AwaitAsyncWork::react(const DoSnapWork&)
   snapid_t snap_to_trim = context<Trimming>().snap_to_trim;
   auto &in_flight = context<Trimming>().in_flight;
   ceph_assert(in_flight.empty());
+  auto &prev_trim_key = context<Trimming>().prev_trim_key;
+  auto &prev_pg_prefixes = context<Trimming>().prev_pg_prefixes;
 
   ceph_assert(pg->is_primary() && pg->is_active());
   if (!context< SnapTrimmer >().can_trim()) {
@@ -15397,7 +15399,9 @@ boost::statechart::result PrimaryLogPG::AwaitAsyncWork::react(const DoSnapWork&)
   int r = pg->snap_mapper.get_next_objects_to_trim(
     snap_to_trim,
     max,
-    &to_trim);
+    &to_trim,
+    prev_trim_key,
+    prev_pg_prefixes);
   if (r != 0 && r != -ENOENT) {
     lderr(pg->cct) << "get_next_objects_to_trim returned "
 		   << cpp_strerror(r) << dendl;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1611,6 +1611,8 @@ private:
 
     set<hobject_t> in_flight;
     snapid_t snap_to_trim;
+    string prev_trim_key;
+    set<string> prev_pg_prefixes;
 
     explicit Trimming(my_context ctx)
       : my_base(ctx),

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -33,10 +33,11 @@ int OSDriver::get_keys(
 
 int OSDriver::get_next(
   const std::string &key,
-  pair<std::string, bufferlist> *next)
+  pair<std::string, bufferlist> *next,
+  bool with_lower_bound)
 {
   ObjectMap::ObjectMapIterator iter =
-    os->get_omap_iterator(ch, hoid);
+    os->get_omap_iterator(ch, hoid, with_lower_bound);
   if (!iter) {
     ceph_abort();
     return -EINVAL;
@@ -291,19 +292,30 @@ void SnapMapper::add_oid(
 int SnapMapper::get_next_objects_to_trim(
   snapid_t snap,
   unsigned max,
-  vector<hobject_t> *out)
+  vector<hobject_t> *out,
+  string &prev_trim_key,
+  std::set<string>& prev_pg_prefixes)
 {
   ceph_assert(out);
   ceph_assert(out->empty());
   int r = 0;
-  for (set<string>::iterator i = prefixes.begin();
-       i != prefixes.end() && out->size() < max && r == 0;
+  size_t prefix_snap = get_prefix(snap).size();
+  size_t prefix_pg = (*prefixes.begin()).size();
+  if(prev_pg_prefixes != prefixes) {
+    prev_trim_key = string();
+    prev_pg_prefixes = prefixes;
+  }
+  string target = (prefix_snap + prefix_pg ) < prev_trim_key.size() ? prev_trim_key.substr(prefix_snap, prefix_pg) : "";
+  auto i = prefixes.lower_bound(target);
+
+  for (; i != prefixes.end() && out->size() < max && r == 0;
        ++i) {
     string prefix(get_prefix(snap) + *i);
-    string pos = prefix;
+    string pos = prev_trim_key.size() > 0 ? prev_trim_key : prefix;
     while (out->size() < max) {
       pair<string, bufferlist> next;
-      r = backend.get_next(pos, &next);
+      r = backend.get_next(pos, &next, false);
+      prev_trim_key = string();
       dout(20) << __func__ << " get_next(" << pos << ") returns " << r
 	       << " " << next << dendl;
       if (r != 0) {
@@ -323,7 +335,7 @@ int SnapMapper::get_next_objects_to_trim(
       ceph_assert(check(next_decoded.second));
 
       out->push_back(next_decoded.second);
-      pos = next.first;
+      prev_trim_key = pos = next.first;
     }
   }
   if (out->size() == 0) {

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -73,7 +73,8 @@ public:
     std::map<std::string, bufferlist> *out) override;
   int get_next(
     const std::string &key,
-    pair<std::string, bufferlist> *next) override;
+    pair<std::string, bufferlist> *next,
+    bool with_lower_bound) override;
 };
 
 /**
@@ -216,8 +217,10 @@ public:
   int get_next_objects_to_trim(
     snapid_t snap,              ///< [in] snap to check
     unsigned max,               ///< [in] max to get
-    vector<hobject_t> *out      ///< [out] next objects to trim (must be empty)
-    );  ///< @return error, -ENOENT if no more objects
+    vector<hobject_t> *out,     ///< [out] next objects to trim (must be empty)
+    std::string &prev_trim_key,       ///< [out] previous trim key
+    std::set<string>& prev_pg_prefixes      ///< [out] previous pg prefixes
+  );  ///< @return error, -ENOENT if no more objects
 
   /// Remove mapping for oid
   int remove_oid(


### PR DESCRIPTION
pass the last queried key to subsequent queries in get_next_objects_to_trim instead of scanning the entire database from the beginning(pg prefix)

1. Improve RocksDB key lookup efficiency:
   - Pass the last queried key to subsequent queries in snaptrim operations.
   - This reduces CPU overhead and query duration caused by tombstone accumulation, thereby minimizing the time spent on tp_osd_tp threads and avoiding slow requests.

2. pass a Boolean variable to determine whether invoke it->lower_bound(head) call in BlueStore's get_omap_iterator -> BlueStore::OmapIteratorImpl::OmapIteratorImpl :
   - The lower_bound(head) call was deemed redundant and could also lead to long query times due to tombstone accumulation.
   - Removing this call improves performance and avoids unnecessary overhead.

https://tracker.ceph.com/issues/71100



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
