### PR TITLE
doc/radosgw: Promptify commands and improve formatting in keystone.rst

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -54,15 +54,20 @@ only use implicit tenants, and the other protocol will
 never use implicit tenants.  Some older versions of ceph
 only supported implicit tenants with swift.
 
-Ocata (and later)
+Ocata (and Later)
 -----------------
 
 Keystone itself needs to be configured to point to the Ceph Object Gateway as an
-object-storage endpoint::
+object-storage endpoint:
 
-  openstack service create --name=swift \
-                           --description="Swift Service" \
-                           object-store
+.. prompt:: bash #
+
+   openstack service create --name=swift \
+                              --description="Swift Service" \
+                              object-store
+
+::
+
   +-------------+----------------------------------+
   | Field       | Value                            |
   +-------------+----------------------------------+
@@ -73,11 +78,16 @@ object-storage endpoint::
   | type        | object-store                     |
   +-------------+----------------------------------+
 
-  openstack endpoint create --region RegionOne \
-       --publicurl   "http://radosgw.example.com:8080/swift/v1" \
-       --adminurl    "http://radosgw.example.com:8080/swift/v1" \
-       --internalurl "http://radosgw.example.com:8080/swift/v1" \
-       swift
+.. prompt:: bash #
+
+   openstack endpoint create --region RegionOne \
+                               --publicurl   "http://radosgw.example.com:8080/swift/v1" \
+                               --adminurl    "http://radosgw.example.com:8080/swift/v1" \
+                               --internalurl "http://radosgw.example.com:8080/swift/v1" \
+                               swift
+
+::
+
   +--------------+------------------------------------------+
   | Field        | Value                                    |
   +--------------+------------------------------------------+
@@ -91,7 +101,12 @@ object-storage endpoint::
   | service_type | object-store                             |
   +--------------+------------------------------------------+
 
-  $ openstack endpoint show object-store
+.. prompt:: bash #
+
+   openstack endpoint show object-store
+
+::
+
   +--------------+------------------------------------------+
   | Field        | Value                                    |
   +--------------+------------------------------------------+
@@ -131,13 +146,18 @@ In order to let a project (earlier called a 'tenant') access buckets belonging t
 
    rgw swift account in url = true
 
-The Keystone object-store endpoint must accordingly be configured to include the AUTH_%(project_id)s suffix::
+The Keystone object-store endpoint must accordingly be configured to include the ``AUTH_%(project_id)s`` suffix:
+
+.. prompt:: bash #
 
    openstack endpoint create --region RegionOne \
-       --publicurl   "http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s" \
-       --adminurl    "http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s" \
-       --internalurl "http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s" \
-       swift
+                               --publicurl   "http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s" \
+                               --adminurl    "http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s" \
+                               --internalurl "http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s" \
+                               swift
+
+::
+
   +--------------+--------------------------------------------------------------+
   | Field        | Value                                                        |
   +--------------+--------------------------------------------------------------+
@@ -151,7 +171,7 @@ The Keystone object-store endpoint must accordingly be configured to include the
   | service_type | object-store                                                 |
   +--------------+--------------------------------------------------------------+
 
-Keystone integration with the S3 API
+Keystone Integration with the S3 API
 ------------------------------------
 
 It is possible to use Keystone for authentication even when using the
@@ -159,7 +179,7 @@ S3 API (with AWS-like access and secret keys), if the ``rgw s3 auth
 use keystone`` option is set. For details, see
 :doc:`s3/authentication`.
 
-Service token support
+Service Token Support
 ---------------------
 
 Service tokens can be enabled to support RadosGW Keystone integration
@@ -173,7 +193,7 @@ The ``rgw keystone expired token cache expiration`` option can be used to tune t
 expiration for an expired token allowed with a service token, please note that this must
 be lower than the ``[token]/allow_expired_window`` option in the Keystone configuration.
 
-Enabling this will cause an expired token given in the X-Auth-Token header to be allowed
-if coupled with a X-Service-Token header that contains a valid token with the accepted
-roles. This can allow long running processes using a user token in X-Auth-Token to function
+Enabling this will cause an expired token given in the ``X-Auth-Token`` header to be allowed
+if coupled with a ``X-Service-Token`` header that contains a valid token with the accepted
+roles. This can allow long running processes using a user token in ``X-Auth-Token`` to function
 beyond the expiration of the token.


### PR DESCRIPTION
Use blocks with bash privileged command prompt for CLI command examples.  
Separate example command output to a preformatted block.  
Previously a hard-coded prompt in some place inconsistently while no prompts in others.

Indent multi-line CLI command examples consistently.

Use Title Case consistency in section titles, instead of some capitalized only first letter of title text.

Use double-backtick inline code for syntax strings, HTTP header names etc as seems common.

- Before: https://docs.ceph.com/en/latest/radosgw/keystone/
- Rendered PR: https://ceph--63007.org.readthedocs.build/en/63007/radosgw/keystone/


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
