### PR TITLE
squid: ceph-volume: Fix splitting with too many parts

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -682,6 +682,7 @@ E:DM_LV_NAME=fake-lv1
 E:DM_LV_LAYER=
 E:NVME_HOST_IFACE=none
 E:SYSTEMD_READY=1
+E:ENV_WITH_EQUALS_SIGN=test=abc
 G:systemd
 Q:systemd
 V:1"""

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -1397,7 +1397,7 @@ class UdevData:
             if data_type == 'I':
                 self.id = data
             if data_type == 'E':
-                key, value = data.split('=')
+                key, value = data.split('=', maxsplit=1)
                 self.environment[key] = value
             if data_type == 'G':
                 self.group = data


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71105

---

backport of https://github.com/ceph/ceph/pull/63004
parent tracker: https://tracker.ceph.com/issues/71101

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh