### PR TITLE
squid: qa/workunits/fs/misc: remove data pool cleanup

### DIFF
--- a/qa/workunits/fs/misc/mkpool_layout_vxattrs.sh
+++ b/qa/workunits/fs/misc/mkpool_layout_vxattrs.sh
@@ -9,7 +9,5 @@ setfattr -n ceph.file.layout.pool -v foo.$$ foo.$$
 
 # cleanup
 rm foo.$$
-ceph fs rm_data_pool cephfs foo.$$
-ceph osd pool rm foo.$$ foo.$$ --yes-i-really-really-mean-it
 
 echo OK


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71093

---

backport of https://github.com/ceph/ceph/pull/62901
parent tracker: https://tracker.ceph.com/issues/70919

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh