### PR TITLE
squid: pybind/mgr/volumes: fix typo in casesensitive vxattr

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -276,7 +276,7 @@ Use a command of the following form to create a subvolume:
 
 .. prompt:: bash #
 
-   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated] [--earmark <earmark>]
+   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated] [--earmark <earmark>] [--normalization <form>] [--case-insensitive]
 
 
 The command succeeds even if the subvolume already exists.
@@ -316,6 +316,29 @@ Valid Earmarks
    be aware that user permissions and ACLs associated with the previous scope might still apply. Ensure that
    any necessary permissions are updated as needed to maintain proper access control.
 
+When creating a subvolume you can also specify an unicode normalization form by
+using the ``--normalization`` option. This will be used to internally mangle
+file names so that unicode characters that can be represented by different
+unicode code point sequences are all mapped to the representation, which means
+that they will all access the same file. However, users will continue to see
+the same name that they used when the file was created.
+
+The valid values for the unicode normalization form are:
+
+    - nfd: canonical decomposition (default)
+    - nfc: canonical decomposition, followed by canonical composition
+    - nfkd: compatibility decomposition
+    - nfkc: compatibility decomposition, followed by canonical composition
+
+To learn more about unicode normalization forms see https://unicode.org/reports/tr15
+
+It's also possible to configure a subvolume for case insensitive access when
+the ``--case-insensitive`` option is used. When this option is added, file
+names that only differ in the case of its characters will be mapped to the same
+file. The case of the file name used when the file was created is preserved.
+
+.. note:: Setting ``--case-insensitive`` option implicitly enables
+   unicode normalization on the subvolume.
 
 Removing a subvolume
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -276,7 +276,7 @@ Use a command of the following form to create a subvolume:
 
 .. prompt:: bash #
 
-   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated] [--earmark <earmark>] [--normalization <form>] [--case-insensitive]
+   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated] [--earmark <earmark>] [--normalization <form>] [--casesensitive <bool>]
 
 
 The command succeeds even if the subvolume already exists.
@@ -333,11 +333,11 @@ The valid values for the unicode normalization form are:
 To learn more about unicode normalization forms see https://unicode.org/reports/tr15
 
 It's also possible to configure a subvolume for case insensitive access when
-the ``--case-insensitive`` option is used. When this option is added, file
+the ``--casesensitive=0`` option is used. When this option is added, file
 names that only differ in the case of its characters will be mapped to the same
 file. The case of the file name used when the file was created is preserved.
 
-.. note:: Setting ``--case-insensitive`` option implicitly enables
+.. note:: Setting ``--casesensitive=0`` option implicitly enables
    unicode normalization on the subvolume.
 
 Removing a subvolume

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -2064,6 +2064,29 @@ class TestSubvolumes(TestVolumesHelper):
         v = json.loads(v)
         self.assertEqual(v, attrs)
 
+    def test_subvolume_clone_charmap(self):
+        subvolume = self._gen_subvol_name()
+        attrs = {
+          "normalization": "nfkd",
+          "encoding": "utf8",
+          "casesensitive": False,
+        }
+        self._fs_cmd("subvolume", "create", self.volname, subvolume)
+        for setting, value in attrs.items():
+            self._fs_cmd("subvolume", "charmap", "set", self.volname, subvolume, setting, str(value))
+
+        snapshot = "snap1"
+        self._fs_cmd("subvolume", "snapshot", "create", self.volname, subvolume, snapshot)
+        clone = "clone"
+        self._fs_cmd("subvolume", "snapshot", "clone", self.volname, subvolume, snapshot, clone)
+
+        # wait for clone to complete
+        self._wait_for_clone_to_complete(clone)
+
+        v = self._fs_cmd("subvolume", "charmap", "get", self.volname, clone)
+        v = json.loads(v)
+        self.assertEqual(v, attrs)
+
     def test_subvolume_charmap_rm(self):
         subvolume = self._gen_subvol_name()
         self._fs_cmd("subvolume", "create", self.volname, subvolume)

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -2605,7 +2605,7 @@ class TestSubvolumes(TestVolumesHelper):
     def test_subvolume_create_with_case_insensitive(self):
         # create subvolume
         subvolume = self._gen_subvol_name()
-        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--case-insensitive")
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--casesensitive=0")
 
         # make sure it exists
         subvolpath = self._get_subvolume_path(self.volname, subvolume)

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -2562,6 +2562,40 @@ class TestSubvolumes(TestVolumesHelper):
         normalization = self._fs_cmd("subvolume", "charmap", "get", self.volname, subvolume, "normalization")
         self.assertEqual(normalization.strip(), "nfc")
 
+    def test_subvolume_create_without_case_sensitivity(self):
+        # create subvolume
+        subvolume = self._gen_subvol_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolume)
+
+        # make sure it exists
+        subvolpath = self._get_subvolume_path(self.volname, subvolume)
+        self.assertNotEqual(subvolpath, None)
+
+        # check case sensitivity
+        try:
+            self._fs_cmd("subvolume", "charmap", "get", self.volname, subvolume, "casesensitive")
+        except CommandFailedError as ce:
+            self.assertEqual(ce.exitstatus, errno.ENODATA)
+        else:
+            self.fail("expected the 'fs subvolume charmap' command to fail")
+
+    def test_subvolume_create_with_case_insensitive(self):
+        # create subvolume
+        subvolume = self._gen_subvol_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--case-insensitive")
+
+        # make sure it exists
+        subvolpath = self._get_subvolume_path(self.volname, subvolume)
+        self.assertNotEqual(subvolpath, None)
+
+        # check case sensitivity
+        case_sensitive = self._fs_cmd("subvolume", "charmap", "get", self.volname, subvolume, "casesensitive")
+        self.assertEqual(case_sensitive.strip(), "0")
+
+        # check normalization (it's implicitly enabled by --case-insensitive, with default value 'nfd')
+        normalization = self._fs_cmd("subvolume", "charmap", "get", self.volname, subvolume, "normalization")
+        self.assertEqual(normalization.strip(), "nfd")
+
     def test_subvolume_expand(self):
         """
         That a subvolume can be expanded in size and its quota matches the expected size.

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -2532,6 +2532,36 @@ class TestSubvolumes(TestVolumesHelper):
             except CommandFailedError as ce:
                 self.assertEqual(ce.exitstatus, errno.ENOENT, error_message)
 
+    def test_subvolume_create_without_normalization(self):
+        # create subvolume
+        subvolume = self._gen_subvol_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolume)
+
+        # make sure it exists
+        subvolpath = self._get_subvolume_path(self.volname, subvolume)
+        self.assertNotEqual(subvolpath, None)
+
+        # check normalization
+        try:
+            self._fs_cmd("subvolume", "charmap", "get", self.volname, subvolume, "normalization")
+        except CommandFailedError as ce:
+            self.assertEqual(ce.exitstatus, errno.ENODATA)
+        else:
+            self.fail("expected the 'fs subvolume charmap' command to fail")
+
+    def test_subvolume_create_with_normalization(self):
+        # create subvolume
+        subvolume = self._gen_subvol_name()
+        self._fs_cmd("subvolume", "create", self.volname, subvolume, "--normalization", "nfc")
+
+        # make sure it exists
+        subvolpath = self._get_subvolume_path(self.volname, subvolume)
+        self.assertNotEqual(subvolpath, None)
+
+        # check normalization
+        normalization = self._fs_cmd("subvolume", "charmap", "get", self.volname, subvolume, "normalization")
+        self.assertEqual(normalization.strip(), "nfc")
+
     def test_subvolume_expand(self):
         """
         That a subvolume can be expanded in size and its quota matches the expected size.

--- a/src/pybind/mgr/volumes/fs/operations/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/operations/subvolume.py
@@ -5,7 +5,7 @@ from .group import open_group
 from .template import SubvolumeOpType
 from .versions import loaded_subvolumes
 
-def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive):
+def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, casesensitive):
     """
     create a subvolume (create a subvolume with the max known version).
 
@@ -20,11 +20,11 @@ def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, po
     :param gid: the group identifier
     :param earmark: metadata string to identify if subvolume is associated with nfs/smb
     :param normalization: the unicode normalization form to use (nfd, nfc, nfkd or nfkc)
-    :param case_insensitive: whether to make the subvolume case insensitive or not
+    :param casesensitive: whether to make the subvolume case insensitive or not
     :return: None
     """
     subvolume = loaded_subvolumes.get_subvolume_object_max(mgr, fs, vol_spec, group, subvolname)
-    subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive)
+    subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, casesensitive)
 
 
 def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, source_subvolume, snapname):

--- a/src/pybind/mgr/volumes/fs/operations/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/operations/subvolume.py
@@ -5,7 +5,7 @@ from .group import open_group
 from .template import SubvolumeOpType
 from .versions import loaded_subvolumes
 
-def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid, earmark):
+def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization):
     """
     create a subvolume (create a subvolume with the max known version).
 
@@ -19,10 +19,11 @@ def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, po
     :param uid: the user identifier
     :param gid: the group identifier
     :param earmark: metadata string to identify if subvolume is associated with nfs/smb
+    :param normalization: the unicode normalization form to use (nfd, nfc, nfkd or nfkc)
     :return: None
     """
     subvolume = loaded_subvolumes.get_subvolume_object_max(mgr, fs, vol_spec, group, subvolname)
-    subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark)
+    subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark, normalization)
 
 
 def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, source_subvolume, snapname):

--- a/src/pybind/mgr/volumes/fs/operations/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/operations/subvolume.py
@@ -5,7 +5,7 @@ from .group import open_group
 from .template import SubvolumeOpType
 from .versions import loaded_subvolumes
 
-def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization):
+def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive):
     """
     create a subvolume (create a subvolume with the max known version).
 
@@ -20,10 +20,11 @@ def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, po
     :param gid: the group identifier
     :param earmark: metadata string to identify if subvolume is associated with nfs/smb
     :param normalization: the unicode normalization form to use (nfd, nfc, nfkd or nfkc)
+    :param case_insensitive: whether to make the subvolume case insensitive or not
     :return: None
     """
     subvolume = loaded_subvolumes.get_subvolume_object_max(mgr, fs, vol_spec, group, subvolname)
-    subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark, normalization)
+    subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive)
 
 
 def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, source_subvolume, snapname):

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -203,6 +203,13 @@ class SubvolumeBase(object):
         except EarmarkException:
             attrs["earmark"] = ''
 
+        try:
+            attrs["normalization"] = self.fs.getxattr(pathname,
+                                                      'ceph.dir.normalization'
+                                                      ).decode('utf-8')
+        except cephfs.NoData:
+            attrs["normalization"] = None
+
         return attrs
 
     def set_attrs(self, path, attrs):
@@ -293,6 +300,13 @@ class SubvolumeBase(object):
         if earmark is not None:
             fs_earmark = CephFSVolumeEarmarking(self.fs, path)
             fs_earmark.set_earmark(earmark)
+
+        normalization = attrs.get("normalization")
+        if normalization is not None:
+            try:
+                self.fs.setxattr(path, "ceph.dir.normalization", normalization.encode('utf-8'), 0)
+            except cephfs.Error as e:
+                raise VolumeException(-e.args[0], e.args[1])
 
     def _resize(self, path, newsize, noshrink):
         try:
@@ -480,6 +494,13 @@ class SubvolumeBase(object):
         except EarmarkException:
             earmark = ''
 
+        try:
+            normalization = self.fs.getxattr(subvolpath,
+                                             'ceph.dir.normalization'
+                                             ).decode('utf-8')
+        except cephfs.NoData:
+            normalization = "none"
+
         subvol_info = {
                 'path': subvolpath,
                 'type': etype.value,
@@ -499,7 +520,9 @@ class SubvolumeBase(object):
                 'pool_namespace': pool_namespace,
                 'features': self.features,
                 'state': self.state.value,
-                'earmark': earmark}
+                'earmark': earmark,
+                'normalization': normalization,
+        }
 
         subvol_src_info = self._get_clone_source()
         if subvol_src_info:

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -212,9 +212,9 @@ class SubvolumeBase(object):
 
         try:
             casesensitive = self.fs.getxattr(pathname, 'ceph.dir.casesensitive').decode('utf-8')
-            attrs["case_insensitive"] = casesensitive == "0"
+            attrs["casesensitive"] = casesensitive == "1"
         except cephfs.NoData:
-            attrs["case_insensitive"] = False
+            attrs["casesensitive"] = True
 
         return attrs
 
@@ -314,8 +314,8 @@ class SubvolumeBase(object):
             except cephfs.Error as e:
                 raise VolumeException(-e.args[0], e.args[1])
 
-        case_insensitive = attrs.get("case_insensitive")
-        if case_insensitive:
+        casesensitive = attrs.get("casesensitive")
+        if casesensitive is False:
             try:
                 self.fs.setxattr(path, "ceph.dir.casesensitive", "0".encode('utf-8'), 0)
             except cephfs.Error as e:
@@ -515,12 +515,12 @@ class SubvolumeBase(object):
             normalization = "none"
 
         try:
-            case_insensitive = self.fs.getxattr(subvolpath,
+            casesensitive = self.fs.getxattr(subvolpath,
                                                 'ceph.dir.casesensitive'
                                                 ).decode('utf-8')
-            case_insensitive = case_insensitive == "0"
+            casesensitive = casesensitive == "1"
         except cephfs.NoData:
-            case_insensitive = False
+            casesensitive = True
 
         subvol_info = {
                 'path': subvolpath,
@@ -543,7 +543,7 @@ class SubvolumeBase(object):
                 'state': self.state.value,
                 'earmark': earmark,
                 'normalization': normalization,
-                'case_insensitive': case_insensitive,
+                'casesensitive': casesensitive,
         }
 
         subvol_src_info = self._get_clone_source()

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -210,6 +210,12 @@ class SubvolumeBase(object):
         except cephfs.NoData:
             attrs["normalization"] = None
 
+        try:
+            case_insensitive = self.fs.getxattr(pathname, 'ceph.dir.caseinsensitive').decode('utf-8')
+            attrs["case_insensitive"] = case_insensitive == "0"
+        except cephfs.NoData:
+            attrs["case_insensitive"] = False
+
         return attrs
 
     def set_attrs(self, path, attrs):
@@ -305,6 +311,13 @@ class SubvolumeBase(object):
         if normalization is not None:
             try:
                 self.fs.setxattr(path, "ceph.dir.normalization", normalization.encode('utf-8'), 0)
+            except cephfs.Error as e:
+                raise VolumeException(-e.args[0], e.args[1])
+
+        case_insensitive = attrs.get("case_insensitive")
+        if case_insensitive:
+            try:
+                self.fs.setxattr(path, "ceph.dir.casesensitive", "0".encode('utf-8'), 0)
             except cephfs.Error as e:
                 raise VolumeException(-e.args[0], e.args[1])
 
@@ -501,6 +514,14 @@ class SubvolumeBase(object):
         except cephfs.NoData:
             normalization = "none"
 
+        try:
+            case_insensitive = self.fs.getxattr(subvolpath,
+                                                'ceph.dir.casesensitive'
+                                                ).decode('utf-8')
+            case_insensitive = case_insensitive == "0"
+        except cephfs.NoData:
+            case_insensitive = False
+
         subvol_info = {
                 'path': subvolpath,
                 'type': etype.value,
@@ -522,6 +543,7 @@ class SubvolumeBase(object):
                 'state': self.state.value,
                 'earmark': earmark,
                 'normalization': normalization,
+                'case_insensitive': case_insensitive,
         }
 
         subvol_src_info = self._get_clone_source()

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -211,8 +211,8 @@ class SubvolumeBase(object):
             attrs["normalization"] = None
 
         try:
-            case_insensitive = self.fs.getxattr(pathname, 'ceph.dir.caseinsensitive').decode('utf-8')
-            attrs["case_insensitive"] = case_insensitive == "0"
+            casesensitive = self.fs.getxattr(pathname, 'ceph.dir.casesensitive').decode('utf-8')
+            attrs["case_insensitive"] = casesensitive == "0"
         except cephfs.NoData:
             attrs["case_insensitive"] = False
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -85,7 +85,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
         """ Path to user data directory within a subvolume snapshot named 'snapname' """
         return self.snapshot_path(snapname)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -106,6 +106,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                 'quota': size,
                 'earmark': earmark,
                 'normalization': normalization,
+                'case_insensitive': case_insensitive,
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -85,7 +85,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
         """ Path to user data directory within a subvolume snapshot named 'snapname' """
         return self.snapshot_path(snapname)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, casesensitive):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -106,7 +106,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                 'quota': size,
                 'earmark': earmark,
                 'normalization': normalization,
-                'case_insensitive': case_insensitive,
+                'casesensitive': casesensitive,
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -85,7 +85,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
         """ Path to user data directory within a subvolume snapshot named 'snapname' """
         return self.snapshot_path(snapname)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -104,7 +104,8 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                 'data_pool': pool,
                 'pool_namespace': self.namespace if isolate_nspace else None,
                 'quota': size,
-                'earmark': earmark
+                'earmark': earmark,
+                'normalization': normalization,
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -154,7 +154,7 @@ class SubvolumeV2(SubvolumeV1):
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_PATH, qpath)
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_STATE, initial_state.value)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -178,6 +178,7 @@ class SubvolumeV2(SubvolumeV1):
                 'quota': size,
                 'earmark': earmark,
                 'normalization': normalization,
+                'case_insensitive': case_insensitive,
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -154,7 +154,7 @@ class SubvolumeV2(SubvolumeV1):
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_PATH, qpath)
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_STATE, initial_state.value)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, case_insensitive):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, casesensitive):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -178,7 +178,7 @@ class SubvolumeV2(SubvolumeV1):
                 'quota': size,
                 'earmark': earmark,
                 'normalization': normalization,
-                'case_insensitive': case_insensitive,
+                'casesensitive': casesensitive,
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -154,7 +154,7 @@ class SubvolumeV2(SubvolumeV1):
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_PATH, qpath)
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_STATE, initial_state.value)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark, normalization):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -176,7 +176,8 @@ class SubvolumeV2(SubvolumeV1):
                 'data_pool': pool,
                 'pool_namespace': self.namespace if isolate_nspace else None,
                 'quota': size,
-                'earmark': earmark
+                'earmark': earmark,
+                'normalization': normalization,
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -226,12 +226,13 @@ class VolumeClient(CephfsClient["Module"]):
         mode       = kwargs['mode']
         isolate_nspace = kwargs['namespace_isolated']
         earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
+        normalization = kwargs['normalization']
 
         oct_mode = octal_str_to_decimal_int(mode)
 
         try:
             create_subvol(
-                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid, earmark)
+                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid, earmark, normalization)
         except VolumeException as ve:
             # kick the purge threads for async removal -- note that this
             # assumes that the subvolume is moved to trashcan for cleanup on error.
@@ -250,6 +251,7 @@ class VolumeClient(CephfsClient["Module"]):
         mode       = kwargs['mode']
         isolate_nspace = kwargs['namespace_isolated']
         earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
+        normalization = kwargs['normalization']
 
         try:
             with open_volume(self, volname) as fs_handle:
@@ -264,7 +266,8 @@ class VolumeClient(CephfsClient["Module"]):
                                 'data_pool': pool,
                                 'pool_namespace': subvolume.namespace if isolate_nspace else None,
                                 'quota': size,
-                                'earmark': earmark
+                                'earmark': earmark,
+                                'normalization': normalization,
                             }
                             subvolume.set_attrs(subvolume.path, attrs)
                     except VolumeException as ve:

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -227,12 +227,13 @@ class VolumeClient(CephfsClient["Module"]):
         isolate_nspace = kwargs['namespace_isolated']
         earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
         normalization = kwargs['normalization']
+        case_insensitive = kwargs['case_insensitive']
 
         oct_mode = octal_str_to_decimal_int(mode)
 
         try:
             create_subvol(
-                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid, earmark, normalization)
+                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid, earmark, normalization, case_insensitive)
         except VolumeException as ve:
             # kick the purge threads for async removal -- note that this
             # assumes that the subvolume is moved to trashcan for cleanup on error.
@@ -252,6 +253,7 @@ class VolumeClient(CephfsClient["Module"]):
         isolate_nspace = kwargs['namespace_isolated']
         earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
         normalization = kwargs['normalization']
+        case_insensitive = kwargs['case_insensitive']
 
         try:
             with open_volume(self, volname) as fs_handle:
@@ -268,6 +270,7 @@ class VolumeClient(CephfsClient["Module"]):
                                 'quota': size,
                                 'earmark': earmark,
                                 'normalization': normalization,
+                                'case_insensitive': case_insensitive,
                             }
                             subvolume.set_attrs(subvolume.path, attrs)
                     except VolumeException as ve:

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -227,13 +227,13 @@ class VolumeClient(CephfsClient["Module"]):
         isolate_nspace = kwargs['namespace_isolated']
         earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
         normalization = kwargs['normalization']
-        case_insensitive = kwargs['case_insensitive']
+        casesensitive = kwargs['casesensitive']
 
         oct_mode = octal_str_to_decimal_int(mode)
 
         try:
             create_subvol(
-                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid, earmark, normalization, case_insensitive)
+                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid, earmark, normalization, casesensitive)
         except VolumeException as ve:
             # kick the purge threads for async removal -- note that this
             # assumes that the subvolume is moved to trashcan for cleanup on error.
@@ -253,7 +253,7 @@ class VolumeClient(CephfsClient["Module"]):
         isolate_nspace = kwargs['namespace_isolated']
         earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
         normalization = kwargs['normalization']
-        case_insensitive = kwargs['case_insensitive']
+        casesensitive = kwargs['casesensitive']
 
         try:
             with open_volume(self, volname) as fs_handle:
@@ -270,7 +270,7 @@ class VolumeClient(CephfsClient["Module"]):
                                 'quota': size,
                                 'earmark': earmark,
                                 'normalization': normalization,
-                                'case_insensitive': case_insensitive,
+                                'casesensitive': casesensitive,
                             }
                             subvolume.set_attrs(subvolume.path, attrs)
                     except VolumeException as ve:

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -142,7 +142,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=gid,type=CephInt,req=false '
                    'name=mode,type=CephString,req=false '
                    'name=namespace_isolated,type=CephBool,req=false '
-                   'name=earmark,type=CephString,req=false ',
+                   'name=earmark,type=CephString,req=false '
+                   'name=normalization,type=CephChoices,strings=nfd|nfc|nfkd|nfkc,req=false ',
             'desc': "Create a CephFS subvolume in a volume, and optionally, "
                     "with a specific size (in bytes), a specific data pool layout, "
                     "a specific mode, in a specific subvolume group and in separate "
@@ -743,7 +744,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                         gid=cmd.get('gid', None),
                                         mode=cmd.get('mode', '755'),
                                         namespace_isolated=cmd.get('namespace_isolated', False),
-                                        earmark=cmd.get('earmark', None))
+                                        earmark=cmd.get('earmark', None),
+                                        normalization=cmd.get('normalization', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_rm(self, inbuf, cmd):

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -144,7 +144,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=namespace_isolated,type=CephBool,req=false '
                    'name=earmark,type=CephString,req=false '
                    'name=normalization,type=CephChoices,strings=nfd|nfc|nfkd|nfkc,req=false '
-                   'name=case_insensitive,type=CephBool,req=false ',
+                   'name=casesensitive,type=CephBool,req=false ',
             'desc': "Create a CephFS subvolume in a volume, and optionally, "
                     "with a specific size (in bytes), a specific data pool layout, "
                     "a specific mode, in a specific subvolume group and in separate "
@@ -747,7 +747,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                         namespace_isolated=cmd.get('namespace_isolated', False),
                                         earmark=cmd.get('earmark', None),
                                         normalization=cmd.get('normalization', None),
-                                        case_insensitive=cmd.get('case_insensitive', False))
+                                        casesensitive=cmd.get('casesensitive', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_rm(self, inbuf, cmd):

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -143,7 +143,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=mode,type=CephString,req=false '
                    'name=namespace_isolated,type=CephBool,req=false '
                    'name=earmark,type=CephString,req=false '
-                   'name=normalization,type=CephChoices,strings=nfd|nfc|nfkd|nfkc,req=false ',
+                   'name=normalization,type=CephChoices,strings=nfd|nfc|nfkd|nfkc,req=false '
+                   'name=case_insensitive,type=CephBool,req=false ',
             'desc': "Create a CephFS subvolume in a volume, and optionally, "
                     "with a specific size (in bytes), a specific data pool layout, "
                     "a specific mode, in a specific subvolume group and in separate "
@@ -745,7 +746,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                         mode=cmd.get('mode', '755'),
                                         namespace_isolated=cmd.get('namespace_isolated', False),
                                         earmark=cmd.get('earmark', None),
-                                        normalization=cmd.get('normalization', None))
+                                        normalization=cmd.get('normalization', None),
+                                        case_insensitive=cmd.get('case_insensitive', False))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_rm(self, inbuf, cmd):


### PR DESCRIPTION
backport tracker:

- https://tracker.ceph.com/issues/71117
- https://tracker.ceph.com/issues/71130
- #62105

---

backport of https://github.com/ceph/ceph/pull/62872
parent tracker: https://tracker.ceph.com/issues/70974

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh