### PR TITLE
squid: qa/workunits/cephtool: add extra privileges to cephtool script

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -868,7 +868,7 @@ function test_tell_output_file()
   # only one line of json
   expect_true sed '2q1' < /tmp/foo > /dev/null
   expect_true jq -e '.version | length > 0' < /tmp/foo
-  rm -f /tmp/foo
+  sudo rm -f /tmp/foo
 
   J=$(ceph tell --format=json-pretty --daemon-output-file=/tmp/foo "$name" version)
   expect_true jq -e '.path == "/tmp/foo"' <<<"$J"
@@ -876,24 +876,24 @@ function test_tell_output_file()
   # more than one line of json
   expect_false sed '2q1' < /tmp/foo > /dev/null
   expect_true jq -e '.version | length > 0' < /tmp/foo
-  rm -f /tmp/foo
+  sudo rm -f /tmp/foo
 
   # Test --daemon-output-file=:tmp:
   J=$(ceph tell --format=json --daemon-output-file=":tmp:" "$name" version)
   path=$(jq -r .path <<<"$J")
   expect_true test -e "$path"
   # only one line of json
-  expect_true sed '2q1' < "$path" > /dev/null
-  expect_true jq -e '.version | length > 0' < "$path"
-  rm -f "$path"
+  expect_true sudo sh -c "sed '2q1' < \"$path\" > /dev/null"
+  expect_true sudo sudo sh -c "jq -e '.version | length > 0' < \"$path\""
+  sudo rm -f "$path"
 
   J=$(ceph tell --format=json-pretty --daemon-output-file=":tmp:" "$name" version)
   path=$(jq -r .path <<<"$J")
   expect_true test -e "$path"
   # only one line of json
-  expect_false sed '2q1' < "$path" > /dev/null
-  expect_true jq -e '.version | length > 0' < "$path"
-  rm -f "$path"
+  expect_false sudo sh -c "sed '2q1' < \"$path\" > /dev/null"
+  expect_true sudo sh -c "jq -e '.version | length > 0' < \"$path\""
+  sudo rm -f "$path"
 }
 
 function test_mds_tell()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70370

---

backport of https://github.com/ceph/ceph/pull/58566
parent tracker: https://tracker.ceph.com/issues/66881

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh