### PR TITLE
doc/radosgw: Improve formatting in d3n_datacache.rst

### DIFF
--- a/doc/radosgw/d3n_datacache.rst
+++ b/doc/radosgw/d3n_datacache.rst
@@ -26,7 +26,7 @@ D3N improves the performance of big-data jobs by speeding up repeatedly accessed
 Cache servers are located in the datacenter on the access side of potential network and storage bottlenecks.
 D3Ns two-layer logical cache forms a traditional caching hierarchy :sup:`*`
 where caches nearer the client have the lowest access latency and overhead,
-while caches in higher levels in the hierarchy are slower (requiring multiple hops to access),
+while caches in higher levels in the hierarchy are slower (requiring multiple hops to access).
 The layer 1 cache server nearest to the client handles object requests by breaking them into blocks,
 returning any blocks which are cached locally, and forwarding missed requests to the block home location
 (as determined by consistent hashing) in the next layer.
@@ -48,7 +48,7 @@ Implementation
 Requirements
 ------------
 
-- An SSD (/dev/nvme,/dev/pmem,/dev/shm) or similar block storage device, formatted
+- An SSD (``/dev/nvme``, ``/dev/pmem``, ``/dev/shm``) or similar block storage device, formatted
   (filesystems other than XFS were not tested) and mounted.
   It will be used as the cache backing store.
   (depending on device performance, multiple RGWs may share a single device but each requires
@@ -77,7 +77,7 @@ in each Rados Gateways ceph.conf client section, for example for ``[client.rgw.8
       rgw_d3n_l1_datacache_size = 10737418240
 
 The above example assumes that the cache backing-store solid state device
-is mounted at `/mnt/nvme0` and has `10 GB` of free space available for the cache.
+is mounted at ``/mnt/nvme0`` and has 10 GB of free space available for the cache.
 
 The persistent path directory has to be created before starting the Gateway.
 (``mkdir -p /mnt/nvme0/rgw_datacache/client.rgw.8000/``)
@@ -91,25 +91,25 @@ In containerized deployments the cache directory should be mounted as a volume::
 (Reference: `Service Management - Mounting Files with Extra Container Arguments`_)
 
 If another Gateway is co-located on the same machine, configure it's persistent path to a discrete directory,
-for example in the case of `[client.rgw.8001]` configure
+for example in the case of ``[client.rgw.8001]`` configure
 ``rgw_d3n_l1_datacache_persistent_path = "/mnt/nvme0/rgw_datacache/client.rgw.8001/"``
-in the ``[client.rgw.8001]`` ceph.conf client section.
+in the ``[client.rgw.8001]`` ``ceph.conf`` client section.
 
 In a multiple co-located Gateways configuration consider assigning clients with different workloads
 to each Gateway without a balancer in order to avoid cached data duplication.
 
-    NOTE: each time the Rados Gateway is restarted the content of the cache directory is purged.
+.. note:: Each time the Rados Gateway is restarted the content of the cache directory is purged.
 
 Logs
 ----
-- D3N related log lines in `radosgw.*.log` contain the string ``d3n`` (case insensitive).
-- low level D3N logs can be enabled by the ``debug_rgw_datacache`` subsystem (up to ``debug_rgw_datacache=30``)
+- D3N related log lines in ``radosgw.*.log`` contain the string ``d3n`` (case insensitive).
+- Low level D3N logs can be enabled by the ``debug_rgw_datacache`` subsystem (up to ``debug_rgw_datacache=30``).
 
 
-CONFIG REFERENCE
+Config Reference
 ================
 The following D3N related settings can be added to the Ceph configuration file
-(i.e., usually `ceph.conf`) under the ``[client.rgw.{instance-name}]`` section.
+(i.e., usually ``ceph.conf``) under the ``[client.rgw.{instance-name}]`` section.
 
 .. confval:: rgw_d3n_l1_local_datacache_enabled
 .. confval:: rgw_d3n_l1_datacache_persistent_path


### PR DESCRIPTION
Change to a full stop one comma that is followed by capital case and looks like a separate sentence otherwise too.

Add missing inline code formatting consistently for file names, config data, etc.

Use a boxed "note" RST admonition instead of spelling out "NOTE" in the beginning of the paragraph.

For one sentence capitalize first letter & add full stop at the end.

Use Title Case instead of ALL CAPS in a section title text.  
The TOC shows this the same way as it is capitalized in the source even if the rendered section titles are always all caps.

- Before: https://docs.ceph.com/en/latest/radosgw/d3n_datacache/
- Rendered PR: https://ceph--63028.org.readthedocs.build/en/63028/radosgw/d3n_datacache/



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
