### PR TITLE
doc/radosgw: Promptify cmds and improve formatting in placement.rst

### DIFF
--- a/doc/radosgw/placement.rst
+++ b/doc/radosgw/placement.rst
@@ -44,9 +44,12 @@ the zonegroups and zones.
 
 The zonegroup placement configuration can be queried with:
 
+.. prompt:: bash #
+
+   radosgw-admin zonegroup get
+
 ::
 
-  $ radosgw-admin zonegroup get
   {
       "id": "ab01123f-e0df-4f29-9d71-b44888d67cd5",
       "name": "default",
@@ -67,9 +70,12 @@ The zonegroup placement configuration can be queried with:
 
 The zone placement configuration can be queried with:
 
+.. prompt:: bash #
+
+   radosgw-admin zone get
+
 ::
 
-  $ radosgw-admin zone get
   {
       "id": "557cdcee-3aae-4e9e-85c7-2f86f5eddb1f",
       "name": "default",
@@ -107,26 +113,24 @@ Adding a Placement Target
 To create a new placement target named ``temporary``, add it to
 the zonegroup:
 
-::
+.. prompt:: bash #
 
-  $ radosgw-admin zonegroup placement add \
-        --rgw-zonegroup default \
-        --placement-id temporary
+   radosgw-admin zonegroup placement add --rgw-zonegroup default \
+                                           --placement-id temporary
 
 Then provide the zone placement info for that target:
 
-::
+.. prompt:: bash #
 
-  $ radosgw-admin zone placement add \
-        --rgw-zone default \
-        --placement-id temporary \
-        --data-pool default.rgw.temporary.data \
-        --index-pool default.rgw.temporary.index \
-        --data-extra-pool default.rgw.temporary.non-ec
+   radosgw-admin zone placement add --rgw-zone default \
+                                      --placement-id temporary \
+                                      --data-pool default.rgw.temporary.data \
+                                      --index-pool default.rgw.temporary.index \
+                                      --data-extra-pool default.rgw.temporary.non-ec
 
-.. note:: With default placement target settings, RGW stores an object's first data chunk in the RADOS `HEAD` object along
-          with XATTR metadata. The `--placement-inline-data=false` flag may be passed with the `zone placement add` or
-          `zone placement modify` commands to change this behavior for new objects stored on the target.
+.. note:: With default placement target settings, RGW stores an object's first data chunk in the RADOS ``HEAD`` object along
+          with XATTR metadata. The ``--placement-inline-data=false`` flag may be passed with the ``zone placement add`` or
+          ``zone placement modify`` commands to change this behavior for new objects stored on the target.
           When data is stored inline (default), it may provide an advantage for read/write workloads since the first chunk of
           an object's data can be retrieved/stored in a single librados call along with object metadata. On the other hand, a
           target that does not store data inline can provide a performance benefit for RGW client delete requests when
@@ -134,7 +138,7 @@ Then provide the zone placement info for that target:
           slower devices synchronously while processing the client request. In that case, data associated with the deleted
           objects is removed asynchronously in the background by garbage collection. Note that inlining is only ever performed
           when writing to the default storage class.  Inlining is *never* performed when writing to a non-default
-	  storage class.
+          storage class.
 
 .. _adding_a_storage_class:
 
@@ -144,23 +148,21 @@ Adding a Storage Class
 To add a new storage class named ``STANDARD_IA`` to the ``default-placement`` target,
 start by adding it to the zonegroup:
 
-::
+.. prompt:: bash #
 
-  $ radosgw-admin zonegroup placement add \
-        --rgw-zonegroup default \
-        --placement-id default-placement \
-        --storage-class STANDARD_IA
+   radosgw-admin zonegroup placement add --rgw-zonegroup default \
+                                           --placement-id default-placement \
+                                           --storage-class STANDARD_IA
 
 Then provide the zone placement info for that storage class:
 
-::
+.. prompt:: bash #
 
-  $ radosgw-admin zone placement add \
-        --rgw-zone default \
-        --placement-id default-placement \
-        --storage-class STANDARD_IA \
-        --data-pool default.rgw.glacier.data \
-        --compression lz4
+   radosgw-admin zone placement add --rgw-zone default \
+                                      --placement-id default-placement \
+                                      --storage-class STANDARD_IA \
+                                      --data-pool default.rgw.glacier.data \
+                                      --compression lz4
 
 Customizing Placement
 =====================
@@ -171,11 +173,10 @@ Default Placement
 By default, new buckets will use the zonegroup's ``default_placement`` target.
 This zonegroup setting can be changed with:
 
-::
+.. prompt:: bash #
 
-  $ radosgw-admin zonegroup placement default \
-        --rgw-zonegroup default \
-        --placement-id new-placement
+   radosgw-admin zonegroup placement default --rgw-zonegroup default \
+                                               --placement-id new-placement
 
 User Placement
 --------------
@@ -185,9 +186,12 @@ target by setting a non-empty ``default_placement`` field in the user info.
 Similarly, the ``default_storage_class`` can override the ``STANDARD``
 storage class applied to objects by default.
 
+.. prompt:: bash #
+
+   radosgw-admin user info --uid testid
+
 ::
 
-  $ radosgw-admin user info --uid testid
   {
       ...
       "default_placement": "",
@@ -203,13 +207,12 @@ to restrict access to certain types of storage.
 
 The ``radosgw-admin`` command can modify these fields directly with:
 
-::
+.. prompt:: bash #
 
-  $ radosgw-admin user modify \
-        --uid <user-id> \
-        --placement-id <default-placement-id> \
-        --storage-class <default-storage-class> \
-        --tags <tag1,tag2>
+   radosgw-admin user modify --uid <user-id> \
+                               --placement-id <default-placement-id> \
+                               --storage-class <default-storage-class> \
+                               --tags <tag1,tag2>
 
 .. _s3_bucket_placement:
 
@@ -217,10 +220,10 @@ S3 Bucket Placement
 -------------------
 
 When creating a bucket with the S3 protocol, a placement target can be
-provided as part of the LocationConstraint to override the default placement
+provided as part of the ``LocationConstraint`` to override the default placement
 targets from the user and zonegroup.
 
-Normally, the LocationConstraint must match the zonegroup's ``api_name``:
+Normally, the ``LocationConstraint`` must match the zonegroup's ``api_name``:
 
 ::
 


### PR DESCRIPTION
Use preformatted blocks with a privileged bash prompt instead of hardcoding prompts in the beginning of each line for CLI commands.

Indent continuation lines of multi-line CLI example commands the same way they are indented elsewhere.

Indent for one line included a tab character, changed it to spaces instead.

Use inline code formatting consistently, add double-backticks for inside text references to CLI commands, configuration data, etc.

- Before: https://docs.ceph.com/en/latest/radosgw/placement/
- Rendered PR: https://ceph--63033.org.readthedocs.build/en/63033/radosgw/placement/



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
