### PR TITLE
.github: add Github CI checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,119 @@
+name: CI Build and Test
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes
+permissions: {}
+
+jobs:
+    create-build-container:
+      runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - distro-name: centos
+              distro-release: stream9
+              distro-image: quay.io/centos/centos:stream9
+              git-install: dnf install -y git-core
+              # cache_package_path: |
+              #   /var/lib/dnf
+              #   /var/cache/dnf
+              # cache_package_hashfiles: |
+              #   ceph.spec.in
+            - distro-name: ubuntu
+              distro-release: 22.04
+              distro-image: ubuntu:22.04
+              git-install: apt-get update && apt-get install -y git
+      container:
+        image: ${{ matrix.distro-image }}
+        # options: --user root
+        # env:
+        #   BASH_ENV: ./run-make-check.sh
+        #   SHELLOPTS: xtrace
+        #   FOR_MAKE_CHECK: 1
+        #   DNF_INSTALL_OPTIONS: >-
+        #     --setopt=install_weak_deps=False
+        #     --setopt=keepcache=True
+        #     --setopt=fastestmirror=True
+        #     --nodocs
+      # defaults:
+      #   run:
+      #     shell: bash
+      # env:
+      #   CACHE_PACKAGE_HASHFILES: |
+      #     install-deps.sh
+      #     run-make-check.sh
+      #     do_cmake.sh
+      #     src/script/run-make.sh
+      #     src/script/lib-build.sh
+      name: "${{ matrix.distro-name }}:${{ matrix.distro-release }}"
+      timeout-minutes: 120
+      steps:
+        - run: export
+        - name: Install git
+          run: "${{ matrix.git-install }}"
+        - name: Git check-out
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          with:
+            set-safe-directory: '/__w/ceph/ceph'
+        - name: Install Dependencies
+          run: ./install-deps.sh
+        - name: Configure Build Environment
+          run: ./do_cmake.sh
+        # - name: Build
+        #  run: cd build && ninja -j $(nproc) ceph-mon
+        # - run: |
+        #     dnf install -y $DNF_INSTALL_OPTIONS git-core
+        # - run: export
+        # - run: set
+        # - name: Restore package cache
+        #   uses: actions/checkout@v3
+        #   with:
+        #     submodules: true
+        # - run: git config --global --add safe.directory $GITHUB_WORKSPACE
+        # - name: Restore ccache
+        #   uses: actions/cache@v3
+        #   with:
+        #     path: ~/.ccache
+        #     key: ccache-${{ matrix.distro-name }}-${{ matrix.distro-release }}-${{ github.ref_name }}
+        #     restore-keys: |
+        #       packages-${{ matrix.distro-name }}-${{ matrix.distro-release }}-
+        # - uses: actions/cache@v3
+        #   with:
+        #     path: ${{ matrix.cache_package_path }}
+        #     key: packages-${{ matrix.distro-name }}-${{ matrix.distro-release }}-${{ hashFiles(env.CACHE_PACKAGE_HASHFILES, matrix.cache_package_hashfiles) }}
+        #     restore-keys: |
+        #       packages-${{ matrix.distro-name }}-${{ matrix.distro-release }}-
+        # - run: prepare
+        # - run: ccache -s
+        # - run: configure
+        # - run: build vstart
+        # - name: Test
+        #   run: |
+        #     build tests
+        #     cd build
+        #     run
+
+
+    # build-and-test:
+    #     runs-on: ubuntu-latest
+
+    #     steps:
+    #     - name: Checkout code
+    #       uses: actions/checkout@v4.2.2
+
+    #     - name: Install dependencies
+    #       run: ./install-deps.sh
+
+    #     - name: Configure
+    #       run: ./do_cmake.sh $CMAKE_ARGS
+
+    #     - name: Build
+    #       run: cd build && ninja -j$(nproc)


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
