### PR TITLE
qa/crontab: add tentacle nightlies

### DIFF
--- a/qa/crontab/teuthology-cronjobs
+++ b/qa/crontab/teuthology-cronjobs
@@ -50,8 +50,8 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 
 ## ********** smoke tests on main and release branches
 00 05  * * 0,2,4   $CW $SS      1 --ceph main    --suite smoke -p 100 --force-priority
+16 05  * * 0       $CW $SS      1 --ceph tentacle --suite smoke -p 100 --force-priority
 08 05  * * 0       $CW $SS      1 --ceph squid   --suite smoke -p 100 --force-priority
-16 05  * * 0       $CW $SS      1 --ceph reef    --suite smoke -p 100 --force-priority
 
 ## ********** windows tests on main branch - weekly
 # 00 03 * * 1 CEPH_BRANCH=main; MACHINE_NAME=smithi; $CW teuthology-suite -v -c $CEPH_BRANCH -n 100 -m $MACHINE_NAME -s windows -k distro -e $CEPH_QA_EMAIL
@@ -72,6 +72,15 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 48 20 * * 6        $CW $SS      4 --ceph main --suite       krbd -p 950 --kernel testing
 56 20 * * 2,6      $CW $SS      1 --ceph main --suite crimson-rados -p 101 --force-priority --flavor crimson
 
+## tentacle branch runs - weekly
+# rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
+00 22 * * 0        $CW $SS 100000 --ceph tentacle --suite      rados -p 831
+08 22 * * 1        $CW $SS     64 --ceph tentacle --suite       orch -p 830
+16 22 * * 2        $CW $SS    128 --ceph tentacle --suite        rbd -p 830
+24 22 * * 3        $CW $SS    512 --ceph tentacle --suite         fs -p 830
+32 22 * * 4        $CW $SS      4 --ceph tentacle --suite powercycle -p 830
+40 22 * * 5        $CW $SS      1 --ceph tentacle --suite        rgw -p 830
+48 22 * * 6        $CW $SS      4 --ceph tentacle --suite       krbd -p 830 --kernel testing
 
 ## squid branch runs - weekly
 # rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
@@ -82,16 +91,6 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 32 21 * * 4        $CW $SS      4 --ceph squid --suite powercycle -p 920
 40 21 * * 5        $CW $SS      1 --ceph squid --suite        rgw -p 920
 48 21 * * 6        $CW $SS      4 --ceph squid --suite       krbd -p 920 --kernel testing
-
-## reef branch runs - weekly
-# rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
-00 22 * * 0        $CW $SS 100000 --ceph reef --suite      rados -p 931
-08 22 * * 1        $CW $SS     64 --ceph reef --suite       orch -p 930
-16 22 * * 2        $CW $SS    128 --ceph reef --suite        rbd -p 930
-24 22 * * 3        $CW $SS    512 --ceph reef --suite         fs -p 930
-32 22 * * 4        $CW $SS      4 --ceph reef --suite powercycle -p 930
-40 22 * * 5        $CW $SS      1 --ceph reef --suite        rgw -p 930
-48 22 * * 6        $CW $SS      4 --ceph reef --suite       krbd -p 930 --kernel testing
 
 
 ###  The suite below must run on bare-metal because it's performance suite and run 3 times to produce more data points
@@ -111,17 +110,15 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 24 00 * * 1        $CW $SS 120000 --ceph quincy --suite upgrade:octopus-x -p 820
 32 00 * * 1        $CW $SS 120000 --ceph quincy --suite upgrade:pacific-x -p 820
 
-### upgrade runs for reef release
+### upgrade runs for tentacle release
 ###### on smithi
 
-08 01 * * 3        $CW $SS      1 --ceph reef --suite upgrade:pacific-x -p 830
-16 01 * * 3        $CW $SS      1 --ceph reef --suite upgrade:quincy-x  -p 830
+08 01 * * 3        $CW $SS      1 --ceph tentacle --suite upgrade -p 100
 
 ### upgrade runs for squid release
 ###### on smithi
 
-#                                                              -p 840
-08 02 * * 5        $CW $SS     32 --ceph squid --suite upgrade -p 100 --force-priority
+08 02 * * 5        $CW $SS     32 --ceph squid --suite upgrade -p 840 --force-priority
 
 ### upgrade runs for main
 ###### on smithi


### PR DESCRIPTION
And delete reef nightlies. This is primarily because we do not have capacity to also test reef.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
