### PR TITLE
nvmeof: add gateway groups in dashboard inventory

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
@@ -124,6 +124,13 @@
                      summaryType="iscsi"
                      id="iscsi-item"
                      *ngIf="enabledFeature.iscsi && healthData.iscsi_daemons"></cd-card-row>
+        <!-- Gateway Groups -->  
+        <cd-card-row [data]="healthData.gw_group"
+                     link="/nvmeof/gateways"
+                     title="Gateway Groups"
+                     summaryType="simplified"
+                     id="nvmeof-gateways-item"
+                     *ngIf="healthData.gw_group !== undefined"></cd-card-row>
       </cd-card>
     </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
@@ -127,7 +127,7 @@
         <!-- Gateway Groups -->  
         <cd-card-row [data]="healthData.nvmeof_gateway_groups"
                      link="/nvmeof/gateways"
-                     title="Gateway Groups"
+                     title="NVMe-oF Gateway Groups"
                      i18n-title
                      summaryType="iscsi"
                      id="nvmeof-gateways-item"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.html
@@ -125,12 +125,13 @@
                      id="iscsi-item"
                      *ngIf="enabledFeature.iscsi && healthData.iscsi_daemons"></cd-card-row>
         <!-- Gateway Groups -->  
-        <cd-card-row [data]="healthData.gw_group"
+        <cd-card-row [data]="healthData.nvmeof_gateway_groups"
                      link="/nvmeof/gateways"
                      title="Gateway Groups"
-                     summaryType="simplified"
+                     i18n-title
+                     summaryType="iscsi"
                      id="nvmeof-gateways-item"
-                     *ngIf="healthData.gw_group !== undefined"></cd-card-row>
+                     *ngIf="healthData.nvmeof_gateway_groups"></cd-card-row>
       </cd-card>
     </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
@@ -27,7 +27,6 @@ import { AlertClass } from '~/app/shared/enum/health-icon.enum';
 import { HardwareService } from '~/app/shared/api/hardware.service';
 import { SettingsService } from '~/app/shared/api/settings.service';
 import { OsdSettings } from '~/app/shared/models/osd-settings';
-import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 
 @Component({
   selector: 'cd-dashboard-v3',
@@ -94,8 +93,7 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
     private mgrModuleService: MgrModuleService,
     private refreshIntervalService: RefreshIntervalService,
     public prometheusAlertService: PrometheusAlertService,
-    private hardwareService: HardwareService,
-    private nvmeofService: NvmeofService 
+    private hardwareService: HardwareService
   ) {
     super(prometheusService);
     this.permissions = this.authStorageService.getPermissions();
@@ -146,17 +144,6 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
   getHealth() {
     this.healthService.getMinimalHealth().subscribe((data: any) => {
       this.healthData = data;
-
-      this.nvmeofService.listGatewayGroups().subscribe({
-        next: (groups: any) => {
-          this.healthData.gw_group = Array.isArray(groups) ? groups.length : 0;
-          console.log('gateway count:', this.healthData.gw_group);
-        },
-        error: (err) => {
-          console.error('Failed to fetch gateway groups', err);
-          this.healthData.gw_group = 0;
-        }
-      });
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
@@ -27,6 +27,7 @@ import { AlertClass } from '~/app/shared/enum/health-icon.enum';
 import { HardwareService } from '~/app/shared/api/hardware.service';
 import { SettingsService } from '~/app/shared/api/settings.service';
 import { OsdSettings } from '~/app/shared/models/osd-settings';
+import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 
 @Component({
   selector: 'cd-dashboard-v3',
@@ -93,7 +94,8 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
     private mgrModuleService: MgrModuleService,
     private refreshIntervalService: RefreshIntervalService,
     public prometheusAlertService: PrometheusAlertService,
-    private hardwareService: HardwareService
+    private hardwareService: HardwareService,
+    private nvmeofService: NvmeofService 
   ) {
     super(prometheusService);
     this.permissions = this.authStorageService.getPermissions();
@@ -144,6 +146,17 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
   getHealth() {
     this.healthService.getMinimalHealth().subscribe((data: any) => {
       this.healthData = data;
+
+      this.nvmeofService.listGatewayGroups().subscribe({
+        next: (groups: any) => {
+          this.healthData.gw_group = Array.isArray(groups) ? groups.length : 0;
+          console.log('gateway count:', this.healthData.gw_group);
+        },
+        error: (err) => {
+          console.error('Failed to fetch gateway groups', err);
+          this.healthData.gw_group = 0;
+        }
+      });
     });
   }
 

--- a/src/pybind/mgr/dashboard/security.py
+++ b/src/pybind/mgr/dashboard/security.py
@@ -13,6 +13,7 @@ class Scope(object):
     CONFIG_OPT = "config-opt"
     POOL = "pool"
     OSD = "osd"
+    NVMEOF = "nvmeof"
     MONITOR = "monitor"
     RBD_IMAGE = "rbd-image"
     ISCSI = "iscsi"

--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Generator, List, NamedTuple, Optional, T
 
 from ..exceptions import DashboardException
 from .nvmeof_conf import NvmeofGatewaysConfig
+from ..rest_client import RequestException
 
 logger = logging.getLogger("nvmeof_client")
 
@@ -127,6 +128,20 @@ else:
             return wrapper
 
         return decorator
+    
+    def get_gateway_groups(self) -> List[Dict]:
+        # GET /api/nvmeof/gateway/group
+        response = self.get("/api/nvmeof/gateway/group")
+        data = response.json()
+        if isinstance(data, dict):  
+            return data.get("groups", [])
+        else: 
+            return []
+
+    def check_group_health(self, group_name: str) -> bool:
+        # GET /api/nvmeof/gateway/group/{group_name}/health
+        response = self.get(f"/api/nvmeof/gateway/group/{group_name}/health")
+        return response.json().get("healthy", False)
 
     import errno
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

This PR adds Gateway Groups card to cluster inventory dashboard with the following changes:  

- [x] Frontend component for displaying gateway groups count  
- [x] Integration with `/api/nvmeof/gateway/group` API  
- [x] Route configuration for `/nvmeof/gateways`  

Signed-off-by: Stevie Hu [steviehu95@gmail.com](mailto:steviehu95@gmail.com)
<img width="306" alt="Screenshot 2025-04-29 at 7 57 53 PM" src="https://github.com/user-attachments/assets/30d1ff4a-3598-497a-a1f4-9bd2e5ba1a1a" />

## Related Issues
Fixes: https://tracker.ceph.com/issues/68703?tab=history 

## Checklist
- Tracker
  - [x] References tracker ticket
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new)
- Documentation
  - [x] Updates relevant documentation
- Tests
  - [ ] Includes unit test(s)
  - [ ] Includes integration test(s)
  - [x] No tests

Testing Suggestions
```bash
jenkins test dashboard
jenkins test make check
