### PR TITLE
osd/scrub: making Scrub's fadvide flags a constant

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1775,10 +1775,6 @@ int ECBackend::be_deep_scrub(
   dout(10) << __func__ << " " << poid << " pos " << pos << dendl;
   int r;
 
-  uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
-    CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
-    CEPH_OSD_OP_FLAG_BYPASS_CLEAN_CACHE;
-
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
   if (sleeptime != utime_t()) {
@@ -1803,7 +1799,7 @@ int ECBackend::be_deep_scrub(
       poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
     pos.data_pos,
     stride, bl,
-    fadvise_flags);
+    ECCommon::scrub_fadvise_flags);
   if (r < 0) {
     dout(20) << __func__ << "  " << poid << " got "
 	     << r << " on read, read_error" << dendl;

--- a/src/osd/ECBackendL.cc
+++ b/src/osd/ECBackendL.cc
@@ -1736,10 +1736,6 @@ int ECBackendL::be_deep_scrub(
   dout(10) << __func__ << " " << poid << " pos " << pos << dendl;
   int r;
 
-  uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
-                           CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
-                           CEPH_OSD_OP_FLAG_BYPASS_CLEAN_CACHE;
-
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
   if (sleeptime != utime_t()) {
@@ -1764,7 +1760,7 @@ int ECBackendL::be_deep_scrub(
       poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
     pos.data_pos,
     stride, bl,
-    fadvise_flags);
+    ECCommonL::scrub_fadvise_flags);
   if (r < 0) {
     dout(20) << __func__ << "  " << poid << " got "
 	     << r << " on read, read_error" << dendl;

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -65,6 +65,11 @@ struct ECCommon {
 
   using ec_extents_t = std::map<hobject_t, ec_extent_t>;
 
+  static inline const uint32_t scrub_fadvise_flags{
+      CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
+      CEPH_OSD_OP_FLAG_BYPASS_CLEAN_CACHE};
+
   virtual ~ECCommon() = default;
 
   virtual void handle_sub_write(

--- a/src/osd/ECCommonL.h
+++ b/src/osd/ECCommonL.h
@@ -64,6 +64,11 @@ struct ECCommonL {
   friend std::ostream &operator<<(std::ostream &lhs, const ec_extent_t &rhs);
   using ec_extents_t = std::map<hobject_t, ec_extent_t>;
 
+  static inline const uint32_t scrub_fadvise_flags{
+      CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
+      CEPH_OSD_OP_FLAG_BYPASS_CLEAN_CACHE};
+
   virtual ~ECCommonL() = default;
 
   virtual void handle_sub_write(

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -753,9 +753,6 @@ int ReplicatedBackend::be_deep_scrub(
 {
   dout(10) << __func__ << " " << poid << " pos " << pos << dendl;
   auto& perf_logger = *(get_parent()->get_logger());
-  const uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
-                                 CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
-                                 CEPH_OSD_OP_FLAG_BYPASS_CLEAN_CACHE;
 
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
@@ -781,7 +778,7 @@ int ReplicatedBackend::be_deep_scrub(
 	poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
       pos.data_pos,
       stride, bl,
-      fadvise_flags);
+      scrub_fadvise_flags);
     if (r < 0) {
       dout(20) << __func__ << "  " << poid << " got "
 	       << r << " on read, read_error" << dendl;

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -455,6 +455,10 @@ private:
   void repop_commit(RepModifyRef rm);
   bool auto_repair_supported() const override { return store->has_builtin_csum(); }
 
+  static inline const uint32_t scrub_fadvise_flags{
+      CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
+      CEPH_OSD_OP_FLAG_BYPASS_CLEAN_CACHE};
 
   int be_deep_scrub(
     const Scrub::ScrubCounterSet& io_counters,


### PR DESCRIPTION
Fixing the very minor irritation of having the constant fadvise flags declared as a function-scope variable.
