### PR TITLE
doc/radosgw: Improve language, capitalization and use config database

### DIFF
--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -862,7 +862,7 @@ all unauthenticated users:
 
 .. note:: In a multisite configuration where a realm and a period are present,
    any changes to the global rate limit must be committed using ``period update
-   --commit``. If no period is present, the rados gateway(s) must be restarted
+   --commit``. If no period is present, the RGW instances must be restarted
    for the changes to take effect.
 
 Usage

--- a/doc/radosgw/d3n_datacache.rst
+++ b/doc/radosgw/d3n_datacache.rst
@@ -7,7 +7,7 @@ D3N RGW Data Cache
 Datacenter-Data-Delivery Network (D3N) uses high-speed storage such as NVMe flash or DRAM to cache
 datasets on the access side.
 Such caching allows big data jobs to use the compute and fast storage resources available on each
-Rados Gateway node at the edge.
+RADOS Gateway (RGW) node at the edge.
 
 Many datacenters include low-cost, centralized storage repositories, called data lakes,
 to store and share terabyte and petabyte-scale datasets.
@@ -17,7 +17,7 @@ Even with a well-designed datacenter network, cluster-to-data lake bandwidth is 
 than the bandwidth of a solid-state storage located at an edge node.
 
 | D3N improves the performance of big-data jobs running in analysis clusters by speeding up recurring reads from the data lake.
-| The Rados Gateways act as cache servers for the back-end object store (OSDs), storing data locally for reuse.
+| The RADOS Gateways act as cache servers for the back-end object store (OSDs), storing data locally for reuse.
 
 Architecture
 ============
@@ -31,7 +31,7 @@ The layer 1 cache server nearest to the client handles object requests by breaki
 returning any blocks which are cached locally, and forwarding missed requests to the block home location
 (as determined by consistent hashing) in the next layer.
 Cache misses are forwarded to successive logical caching layers until a miss at the top layer is resolved
-by a request to the data lake (Rados)
+by a request to the data lake (RADOS)
 
 :sup:`*` currently only layer 1 cache has been upstreamed.
 
@@ -68,19 +68,23 @@ D3N Environment Setup
 Running
 -------
 
-To enable D3N on an existing RGWs the following configuration entries are required
-in each Rados Gateways ceph.conf client section, for example for ``[client.rgw.8000]``::
+To enable D3N on existing RGWs the following configuration entries are required
+in the :ref:`ceph-conf-database`, for example for ``client.rgw.8000``:
 
-    [client.rgw.8000]
-      rgw_d3n_l1_local_datacache_enabled = true
-      rgw_d3n_l1_datacache_persistent_path = "/mnt/nvme0/rgw_datacache/client.rgw.8000/"
-      rgw_d3n_l1_datacache_size = 10737418240
+.. prompt:: bash #
+
+   ceph config set client.rgw.8000 rgw_d3n_l1_local_datacache_enabled true
+   ceph config set client.rgw.8000 rgw_d3n_l1_datacache_persistent_path /mnt/nvme0/rgw_datacache/client.rgw.8000/
+   ceph config set client.rgw.8000 rgw_d3n_l1_datacache_size 10737418240
 
 The above example assumes that the cache backing-store solid state device
 is mounted at ``/mnt/nvme0`` and has 10 GB of free space available for the cache.
 
-The persistent path directory has to be created before starting the Gateway.
-(``mkdir -p /mnt/nvme0/rgw_datacache/client.rgw.8000/``)
+The directory must exist and be writable before starting the RGW daemon:
+
+.. prompt:: bash #
+
+   mkdir -p /mnt/nvme0/rgw_datacache/client.rgw.8000/
 
 In containerized deployments the cache directory should be mounted as a volume::
 
@@ -90,15 +94,17 @@ In containerized deployments the cache directory should be mounted as a volume::
 
 (Reference: `Service Management - Mounting Files with Extra Container Arguments`_)
 
-If another Gateway is co-located on the same machine, configure it's persistent path to a discrete directory,
-for example in the case of ``[client.rgw.8001]`` configure
-``rgw_d3n_l1_datacache_persistent_path = "/mnt/nvme0/rgw_datacache/client.rgw.8001/"``
-in the ``[client.rgw.8001]`` ``ceph.conf`` client section.
+If another RADOS Gateway is co-located on the same host, configure its persistent
+path to a discrete directory, for example in the case of ``client.rgw.8001``:
 
-In a multiple co-located Gateways configuration consider assigning clients with different workloads
-to each Gateway without a balancer in order to avoid cached data duplication.
+.. prompt:: bash #
 
-.. note:: Each time the Rados Gateway is restarted the content of the cache directory is purged.
+   ceph config set client.rgw.8001 rgw_d3n_l1_datacache_persistent_path /mnt/nvme0/rgw_datacache/client.rgw.8001/
+
+In a multiple co-located RADOS Gateways configuration consider assigning clients with different workloads
+to each RADOS Gateway without a balancer in order to avoid cached data duplication.
+
+.. note:: Each time the RGW daemon is restarted the content of the cache directory is purged.
 
 Logs
 ----

--- a/doc/radosgw/layout.rst
+++ b/doc/radosgw/layout.rst
@@ -1,5 +1,5 @@
 ===========================
- Rados Gateway Data Layout
+ RADOS Gateway Data Layout
 ===========================
 
 Although the source code is the ultimate guide, this document helps

--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -26,7 +26,7 @@ By default, the execution of a Lua script is limited to a maximum runtime of 100
 
 .. warning:: Be cautious when modifying the memory limit. If the current memory usage exceeds the newly set limit, all previously stored data in the background state will be lost.
 
-.. warning:: Disabling the runtime limit may result in unbounded script execution, which can lead to excessive resource consumption and potentially impact the RADOS gateway's availability.
+.. warning:: Disabling the runtime limit may result in unbounded script execution, which can lead to excessive resource consumption and potentially impact the RADOS Gateway's availability.
 
 By default, all Lua standard libraries are available in the script, however, in order to allow for additional Lua modules to be used in the script, we support adding packages to an allowlist:
 

--- a/doc/radosgw/rgw-cache.rst
+++ b/doc/radosgw/rgw-cache.rst
@@ -17,7 +17,7 @@ and caching-out on subsequent GET requests, passing thru transparently PUT,POST,
 
 The feature introduces 2 new APIs: Auth and Cache.
 
-    NOTE: The `D3N RGW Data Cache`_ is an alternative data caching mechanism implemented natively in the Rados Gateway.
+    NOTE: The `D3N RGW Data Cache`_ is an alternative data caching mechanism implemented natively in the RADOS Gateway.
 
 New APIs
 -------------------------


### PR DESCRIPTION
Use "RADOS Gateway" instead of "Rados Gateway", "rados gateway" etc.  
I am aware of the term "Ceph Object Gateway" but this change intends to be an uncontroversial low hanging fruit fix of obviously incorrectly capitalized terms.

Use "RGW daemon" instead of "Gateway", "Rados Gateway" etc.  
Use "RGW instance" instead of "rados gateway" for consistency with exactly similar other instance.
If referring obviously clearly to an instance of the daemon with an obviously not preferred term, change it to "RGW daemon"; for example when talking about restarting the RGW.  
Do not touch other instances that are not 100% clear.

The files touched mostly do not use "Ceph Object Gateway" so changing the term to it would create inconsistency, or several more changes would need to be done to update all instances to use this terminology.

Use configuration database instead of ceph.conf in d3n_datacache.rst.

Improve language in d3n_datacache.rst.

- Before: https://docs.ceph.com/en/latest/radosgw/
  - https://docs.ceph.com/en/latest/radosgw/admin/#reading-and-writing-global-rate-limit-configuration
  - https://docs.ceph.com/en/latest/radosgw/d3n_datacache/
  - https://docs.ceph.com/en/latest/radosgw/layout/
  - https://docs.ceph.com/en/latest/radosgw/lua-scripting/
  - https://docs.ceph.com/en/latest/radosgw/rgw-cache/
- Rendered PR: https://ceph--63057.org.readthedocs.build/en/63057/radosgw/
  - https://ceph--63057.org.readthedocs.build/en/63057/radosgw/admin/#reading-and-writing-global-rate-limit-configuration
  - https://ceph--63057.org.readthedocs.build/en/63057/radosgw/d3n_datacache/
  - https://ceph--63057.org.readthedocs.build/en/63057/radosgw/layout/
  - https://ceph--63057.org.readthedocs.build/en/63057/radosgw/lua-scripting/
  - https://ceph--63057.org.readthedocs.build/en/63057/radosgw/rgw-cache/



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
