### PR TITLE
squid: rgw/sts: correcting authentication in case s3 ops are directed to a primary from secondary after  assumerole.

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -20,5 +20,7 @@ overrides:
         rgw sync obj etag verify: true
         rgw sync meta inject err probability: 0
         rgw sync data inject err probability: 0
+        rgw s3 auth use sts: true
+        rgw sts key: abcdefghijklmnoq
   rgw:
     compression type: random

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -1259,6 +1259,9 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   for (auto& it : token_attrs.token_claims) {
     s->token_claims.emplace_back(it);
   }
+  if (is_system_request) {
+    s->system_request = true;
+  }
 }
 
 rgw::auth::Engine::result_t

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -781,14 +781,17 @@ public:
 protected:
   Role role;
   TokenAttrs token_attrs;
+  bool is_system_request;
 
 public:
 
   RoleApplier(CephContext* const cct,
                const Role& role,
-               const TokenAttrs& token_attrs)
+               const TokenAttrs& token_attrs,
+               bool is_system_request)
     : role(role),
-      token_attrs(token_attrs) {}
+      token_attrs(token_attrs),
+      is_system_request(is_system_request) {}
 
   ACLOwner get_aclowner() const override;
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
@@ -817,11 +820,12 @@ public:
 
   struct Factory {
     virtual ~Factory() {}
-    virtual aplptr_t create_apl_role(CephContext* cct,
-                                     const req_state* s,
-                                     Role role,
-                                     TokenAttrs token_attrs) const = 0;
-  };
+    virtual aplptr_t create_apl_role( CephContext* cct,
+                                      const req_state* s,
+                                      Role role,
+                                      TokenAttrs token_attrs,
+                                      bool is_system_request) const = 0;
+    };
 };
 
 /* The anonymous abstract engine. */

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -70,9 +70,10 @@ class STSAuthStrategy : public rgw::auth::Strategy,
   aplptr_t create_apl_role(CephContext* const cct,
                             const req_state* const s,
                             RoleApplier::Role role,
-                            RoleApplier::TokenAttrs token_attrs) const override {
+                            RoleApplier::TokenAttrs token_attrs,
+                            bool is_system_request) const override {
     auto apl = rgw::auth::add_sysreq(cct, driver, s,
-      rgw::auth::RoleApplier(cct, std::move(role), std::move(token_attrs)));
+      rgw::auth::RoleApplier(cct, std::move(role), std::move(token_attrs), is_system_request));
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -6416,6 +6416,7 @@ rgw::auth::s3::STSEngine::authenticate(
   const req_state* const s,
   optional_yield y) const
 {
+  bool is_system_request{false};
   if (! s->info.args.exists("x-amz-security-token") &&
       ! s->info.env->exists("HTTP_X_AMZ_SECURITY_TOKEN") &&
       s->auth.s3_postobj_creds.x_amz_security_token.empty()) {
@@ -6427,10 +6428,36 @@ rgw::auth::s3::STSEngine::authenticate(
     return result_t::reject(ret);
   }
   //Authentication
+  std::string secret_access_key;
   //Check if access key is not the same passed in by client
   if (token.access_key_id != _access_key_id) {
-    ldpp_dout(dpp, 0) << "Invalid access key" << dendl;
-    return result_t::reject(-EPERM);
+    /* In case the request is forwarded from secondary in case of multi-site,
+      we by-pass authentication using the session token credentials,
+      instead we use the system user's credentials that was used to sign
+      this request */
+    std::unique_ptr<rgw::sal::User> user;
+    const std::string access_key_id(_access_key_id);
+    if (driver->get_user_by_access_key(dpp, access_key_id, y, &user) < 0) {
+        ldpp_dout(dpp, 5) << "error reading user info, uid=" << access_key_id
+                << " can't authenticate" << dendl;
+        return result_t::reject(-ERR_INVALID_ACCESS_KEY);
+    }
+    // only allow system users as this could be a forwarded request from secondary
+    if (user->get_info().system && driver->is_meta_master()) {
+      const auto iter = user->get_info().access_keys.find(access_key_id);
+      if (iter == std::end(user->get_info().access_keys)) {
+        ldpp_dout(dpp, 0) << "ERROR: access key not encoded in user info" << dendl;
+        return result_t::reject(-EPERM);
+      }
+      const RGWAccessKey& k = iter->second;
+      secret_access_key = k.key;
+      is_system_request = true;
+    } else {
+      ldpp_dout(dpp, 0) << "Invalid access key" << dendl;
+      return result_t::reject(-EPERM);
+    }
+  } else {
+    secret_access_key = token.secret_access_key;
   }
   //Check if the token has expired
   if (! token.expiration.empty()) {
@@ -6451,7 +6478,7 @@ rgw::auth::s3::STSEngine::authenticate(
   }
   //Check for signature mismatch
   const VersionAbstractor::server_signature_t server_signature = \
-    signature_factory(cct, token.secret_access_key, string_to_sign);
+    signature_factory(cct, secret_access_key, string_to_sign);
   auto compare = signature.compare(server_signature);
 
   ldpp_dout(dpp, 15) << "string_to_sign="
@@ -6515,7 +6542,7 @@ rgw::auth::s3::STSEngine::authenticate(
     t_attrs.token_issued_at = std::move(token.issued_at);
     t_attrs.principal_tags = std::move(token.principal_tags);
     auto apl = role_apl_factory->create_apl_role(cct, s, std::move(r),
-                                                 std::move(t_attrs));
+                                                 std::move(t_attrs), is_system_request);
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   } else { // This is for all local users of type TYPE_RGW|ROOT|NONE
     if (token.user.empty()) {

--- a/src/test/rgw/rgw_multi/conn.py
+++ b/src/test/rgw/rgw_multi/conn.py
@@ -1,7 +1,9 @@
 import boto
 import boto.s3.connection
 import boto.iam.connection
+import boto.sts.connection
 import boto3
+from boto.regioninfo import RegionInfo
 
 def get_gateway_connection(gateway, credentials):
     """ connect to the given gateway """
@@ -44,6 +46,20 @@ def get_gateway_iam_connection(gateway, credentials, region):
                 use_ssl = False)
     return gateway.iam_connection
 
+def get_gateway_sts_connection(gateway, credentials, region):
+    """ connect to sts api of the given gateway """
+    if gateway.sts_connection is None:
+        endpoint = f'http://{gateway.host}:{gateway.port}'
+        print(endpoint)
+        gateway.sts_connection = boto3.client(
+                service_name = 'sts',
+                aws_access_key_id = credentials.access_key,
+                aws_secret_access_key = credentials.secret,
+                endpoint_url = endpoint,
+                region_name=region,
+                use_ssl = False)
+    return gateway.sts_connection
+
 
 def get_gateway_s3_client(gateway, credentials, region):
   """ connect to boto3 s3 client api of the given gateway """
@@ -65,3 +81,13 @@ def get_gateway_sns_client(gateway, credentials, region):
                                         aws_secret_access_key=credentials.secret,
                                         region_name=region)
   return gateway.sns_client
+
+def get_gateway_temp_s3_client(gateway, credentials, session_token, region):
+  """ connect to boto3 s3 client api using temporary credntials """
+  gateway.temp_s3_client = boto3.client('s3',
+                        endpoint_url='http://' + gateway.host + ':' + str(gateway.port),
+                        aws_access_key_id=credentials.access_key,
+                        aws_secret_access_key=credentials.secret,
+                        aws_session_token = session_token,
+                        region_name=region)
+  return gateway.temp_s3_client

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -2039,6 +2039,40 @@ def test_replication_status():
     bilog = bilog_list(zone.zone, bucket.name)
     assert(len(bilog) == 0)
 
+def test_assume_role_after_sync():
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    access_key = 'abcd'
+    secret_key = 'efgh'
+    tenant = 'testx'
+    uid = 'test'
+    cmd = ['user', 'create', '--tenant', tenant, '--uid', uid, '--access-key', access_key, '--secret-key', secret_key, '--display-name', 'tenanted-user']
+    zonegroup_conns.master_zone.zone.cluster.admin(cmd)
+    credentials = Credentials(access_key, secret_key)
+
+    role_name = gen_role_name()
+    log.info('create role zone=%s name=%s', zonegroup_conns.master_zone.name, role_name)
+    policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::testx:user/test\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+    role = zonegroup_conns.master_zone.create_role("/", role_name, policy_document, "")
+    policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Resource\":\"*\",\"Action\":\"s3:*\"}]}"
+    zonegroup_conns.master_zone.put_role_policy(role_name, "Policy1", policy_document)
+
+    zonegroup_meta_checkpoint(zonegroup)
+
+    for zone in zonegroup_conns.zones:
+        log.info(f'checking if zone: {zone.name} has role: {role_name}')
+        assert(zone.has_role(role_name))
+        log.info(f'success, zone: {zone.name} has role: {role_name}')
+    
+    for zone in zonegroup_conns.zones:
+        if zone == zonegroup_conns.master_zone:
+            log.info(f'creating bucket in primary zone')
+            bucket = "bucket1"
+            zone.assume_role_create_bucket(bucket, role['Role']['Arn'], "primary", credentials)
+        if zone != zonegroup_conns.master_zone:
+            log.info(f'creating bucket in secondary zone')
+            bucket = "bucket2"
+            zone.assume_role_create_bucket(bucket, role['Role']['Arn'], "secondary", credentials)
 
 @attr('fails_with_rgw')
 @attr('data_sync_init')

--- a/src/test/rgw/rgw_multi/zone_cloud.py
+++ b/src/test/rgw/rgw_multi/zone_cloud.py
@@ -310,6 +310,9 @@ class CloudZone(Zone):
         def has_role(self, role_name):
             assert False
 
+        def put_role_policy(self, rolename, policyname, policy_document):
+            assert False
+
         def create_topic(self, topicname, attributes):
             assert False
 
@@ -329,6 +332,9 @@ class CloudZone(Zone):
             assert False
 
         def list_notifications(self, bucket_name):
+            assert False
+
+        def assume_role(self, role_arn, session_name, policy, duration_seconds):
             assert False
 
     def get_conn(self, credentials):

--- a/src/test/rgw/rgw_multi/zone_es.py
+++ b/src/test/rgw/rgw_multi/zone_es.py
@@ -252,6 +252,9 @@ class ESZone(Zone):
         def has_role(self, role_name):
             assert False
 
+        def put_role_policy(self, rolename, policyname, policy_document):
+            assert False
+
         def create_topic(self, topicname, attributes):
             assert False
 
@@ -271,6 +274,9 @@ class ESZone(Zone):
             assert False
 
         def list_notifications(self, bucket_name):
+            assert False
+
+        def assume_role(self, role_arn, session_name, policy, duration_seconds):
             assert False
 
     def get_conn(self, credentials):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71113

---

backport of https://github.com/ceph/ceph/pull/56576
parent tracker: https://tracker.ceph.com/issues/71112

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh