### PR TITLE
tentacle: crimson: PG backfill is not showing any progress

### DIFF
--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -220,11 +220,9 @@ public:
     }
     void set_pushed(pg_shard_t shard) {
       auto it = pushes.find(shard);
-      if (it != pushes.end()) {
-	auto &push_promise = it->second;
-	push_promise.set_value();
-	pushes.erase(it);
-      }
+      ceph_assert(it != pushes.end());
+      it->second.set_value();
+      pushes.erase(it);
     }
     void set_pulled() {
       if (pulled) {

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -81,13 +81,14 @@ ReplicatedRecoveryBackend::maybe_push_shards(
         msg->min_epoch = pg.get_last_peering_reset();
         msg->pushes.push_back(std::move(push));
         msg->set_priority(pg.get_recovery_op_priority());
+        seastar::future<> push_future = get_recovering(soid).wait_for_pushes(shard);
         return interruptor::make_interruptible(
             shard_services.send_to_osd(shard.osd,
                                        std::move(msg),
                                        pg.get_osdmap_epoch()))
         .then_interruptible(
-          [this, soid, shard] {
-          return get_recovering(soid).wait_for_pushes(shard);
+          [push_future = std::move(push_future)]() mutable {
+          return std::move(push_future);
         });
       });
     });
@@ -184,11 +185,12 @@ ReplicatedRecoveryBackend::push_delete(
 	  pg.get_pg_whoami(), target_pg, pg.get_osdmap_epoch(), min_epoch);
       msg->set_priority(pg.get_recovery_op_priority());
       msg->objects.push_back(std::make_pair(soid, need));
+      seastar::future<> push_future = get_recovering(soid).wait_for_pushes(shard);
       return interruptor::make_interruptible(
 	  shard_services.send_to_osd(shard.osd, std::move(msg),
 				     pg.get_osdmap_epoch())).then_interruptible(
-	[this, soid, shard] {
-	return get_recovering(soid).wait_for_pushes(shard);
+        [push_future = std::move(push_future)]() mutable {
+        return std::move(push_future);
       });
     }
     return seastar::make_ready_future<>();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71145

---

backport of https://github.com/ceph/ceph/pull/62760
parent tracker: https://tracker.ceph.com/issues/70502

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh