### PR TITLE
tentacle: mgr/vol: don't delete user-created pool in "volume create" command

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -802,6 +802,28 @@ class TestVolumeCreate(TestVolumesHelper):
             self.run_ceph_cmd(f'osd pool rm {data} {data} '
                                '--yes-i-really-really-mean-it')
 
+    def test_user_created_pool_isnt_deleted(self):
+        '''
+        Test that the user created pool is not deleted by this commmand if it
+        has been passed to it along with a non-existent pool name.
+        '''
+        data_pool = 'cephfs.b.data'
+        non_existent_meta_pool = 'nonexistent-pool'
+
+        self.run_ceph_cmd(f'osd pool create {data_pool}')
+        o = self.get_ceph_cmd_stdout('osd pool ls')
+        self.assertIn(data_pool, o)
+        self.assertNotIn(non_existent_meta_pool, o)
+
+        self.negtest_ceph_cmd(
+            args=f'fs volume create b --data-pool {data_pool} --meta-pool '
+                  f'{non_existent_meta_pool}',
+            retval=errno.ENOENT,
+            errmsgs=f'pool \'{non_existent_meta_pool}\' does not exist')
+
+        o = self.get_ceph_cmd_stdout('osd pool ls')
+        self.assertIn(data_pool, o)
+        self.assertNotIn(non_existent_meta_pool, o)
 
 class TestRenameCmd(TestVolumesHelper):
 

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -107,6 +107,8 @@ def create_volume(mgr, volname, placement, data_pool, metadata_pool):
     # are passed by user they must exist already), leave it here so that some
     # future readers know that this case is already considered and not missed
     # by chance.
+    data_pool_was_created = False
+    metadata_pool_was_created = False
     if data_pool and metadata_pool:
         pass
     elif not data_pool and metadata_pool:
@@ -119,6 +121,8 @@ def create_volume(mgr, volname, placement, data_pool, metadata_pool):
         retval = create_fs_pools(mgr, volname, data_pool, metadata_pool)
         success = retval.pop(0)
         if success:
+            data_pool_was_created = True
+            metadata_pool_was_created = True
             data_pool, metadata_pool = retval
         else:
             return retval
@@ -128,8 +132,10 @@ def create_volume(mgr, volname, placement, data_pool, metadata_pool):
     if r != 0:
         log.error("Filesystem creation error: {0} {1} {2}".format(r, outb, outs))
         #cleanup
-        remove_pool(mgr, data_pool)
-        remove_pool(mgr, metadata_pool)
+        if data_pool_was_created:
+            remove_pool(mgr, data_pool)
+        if metadata_pool_was_created:
+            remove_pool(mgr, metadata_pool)
         return r, outb, outs
     return create_mds(mgr, volname, placement)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71148

---

backport of https://github.com/ceph/ceph/pull/62843
parent tracker: https://tracker.ceph.com/issues/70945

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh