### PR TITLE
tentacle: mgr/dashboard: Bump grafana version to 11.6.0 

### DIFF
--- a/src/python-common/ceph/cephadm/images.py
+++ b/src/python-common/ceph/cephadm/images.py
@@ -29,7 +29,7 @@ class DefaultImages(Enum):
     PROMTAIL = _create_image('docker.io/grafana/promtail:3.0.0', 'promtail')
     NODE_EXPORTER = _create_image('quay.io/prometheus/node-exporter:v1.7.0', 'node_exporter')
     ALERTMANAGER = _create_image('quay.io/prometheus/alertmanager:v0.27.0', 'alertmanager')
-    GRAFANA = _create_image('quay.io/ceph/grafana:10.4.16', 'grafana')
+    GRAFANA = _create_image('quay.io/ceph/grafana:11.6.0', 'grafana')
     HAPROXY = _create_image('quay.io/ceph/haproxy:2.3', 'haproxy')
     KEEPALIVED = _create_image('quay.io/ceph/keepalived:2.2.4', 'keepalived')
     NVMEOF = _create_image('quay.io/ceph/nvmeof:1.5', 'nvmeof')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71158

---

backport of https://github.com/ceph/ceph/pull/62827
parent tracker: https://tracker.ceph.com/issues/70929

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh