### PR TITLE
squid: qa/tasks/cephfs/mount: use 'ip route' instead 'route'

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -296,12 +296,11 @@ class CephFSMountBase(object):
         self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         
         # Setup the NAT
-        p = self.client_remote.run(args=['route'], stderr=StringIO(),
-                                   stdout=StringIO(), timeout=(5*60))
-        p = re.findall(r'default .*', p.stdout.getvalue())
-        if p == False:
+        routes = self.client_remote.sh('ip r', timeout=(5*60))
+        defaults = re.findall(r'^default .*', routes)
+        if defaults == False:
             raise RuntimeError("No default gw found")
-        gw = p[0].split()[7]
+        gw = defaults[0].split()[4]
 
         self.run_shell_payload(f"""
             set -e
@@ -441,12 +440,12 @@ class CephFSMountBase(object):
         ip = IP(self.ceph_brx_net)[-2]
         mask = self.ceph_brx_net.split('/')[1]
 
-        p = self.client_remote.run(args=['route'], stderr=StringIO(),
-                                   stdout=StringIO(), timeout=(5*60))
-        p = re.findall(r'default .*', p.stdout.getvalue())
-        if p == False:
+        routes = self.client_remote.sh('ip r', timeout=(5*60))
+        defaults = re.findall(r'^default .*', routes)
+        if defaults == False:
             raise RuntimeError("No default gw found")
-        gw = p[0].split()[7]
+        gw = defaults[0].split()[4]
+
         self.run_shell_payload(f"""
             set -e
             sudo iptables -D FORWARD -o {gw} -i ceph-brx -j ACCEPT

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -264,6 +264,13 @@ class CephFSMountBase(object):
             if 'permission denied' in stderr.getvalue().lower():
                 pass
 
+    def _default_gateway(self):
+        routes = self.client_remote.sh('ip r', timeout=(5*60))
+        defaults = re.findall(r'^default .*', routes)
+        if defaults == False:
+            raise RuntimeError("No default gw found")
+        return defaults[0].split()[4]
+
     def _setup_brx_and_nat(self):
         # The ip for ceph-brx should be
         ip = IP(self.ceph_brx_net)[-2]
@@ -296,11 +303,7 @@ class CephFSMountBase(object):
         self.client_remote.run(args=args, timeout=(5*60), omit_sudo=False)
         
         # Setup the NAT
-        routes = self.client_remote.sh('ip r', timeout=(5*60))
-        defaults = re.findall(r'^default .*', routes)
-        if defaults == False:
-            raise RuntimeError("No default gw found")
-        gw = defaults[0].split()[4]
+        gw = self._default_gateway()
 
         self.run_shell_payload(f"""
             set -e
@@ -440,11 +443,7 @@ class CephFSMountBase(object):
         ip = IP(self.ceph_brx_net)[-2]
         mask = self.ceph_brx_net.split('/')[1]
 
-        routes = self.client_remote.sh('ip r', timeout=(5*60))
-        defaults = re.findall(r'^default .*', routes)
-        if defaults == False:
-            raise RuntimeError("No default gw found")
-        gw = defaults[0].split()[4]
+        gw = self._default_gateway()
 
         self.run_shell_payload(f"""
             set -e


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71208

---

backport of https://github.com/ceph/ceph/pull/62259
parent tracker: https://tracker.ceph.com/issues/71206

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh