### PR TITLE
reef: tasks/cephfs/mount: use 192.168.144.0.0/20 for brxnet

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -81,7 +81,7 @@ class CephFSMount(object):
         self._netns_name = None
         self.nsid = -1
         if brxnet is None:
-            self.ceph_brx_net = '192.168.0.0/16'
+            self.ceph_brx_net = '192.168.144.0/20'
         else:
             self.ceph_brx_net = brxnet
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71215

---

backport of https://github.com/ceph/ceph/pull/62709
parent tracker: https://tracker.ceph.com/issues/70817

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh