### PR TITLE
tools/ceph_dedup: remove 'using namespace std'

### DIFF
--- a/src/tools/ceph_dedup/ceph_dedup_daemon.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_daemon.cc
@@ -34,16 +34,16 @@ po::options_description make_usage() {
   return desc;
 }
 
-using AioCompRef = unique_ptr<AioCompletion>;
+using AioCompRef = std::unique_ptr<AioCompletion>;
 
 class SampleDedupWorkerThread : public Thread
 {
 public:
   struct chunk_t {
-    string oid = "";
+    std::string oid = "";
     size_t start = 0;
     size_t size = 0;
-    string fingerprint = "";
+    std::string fingerprint = "";
     bufferlist data;
   };
 
@@ -187,7 +187,7 @@ public:
       }
     }
 
-    bool contains(string& fp) {
+    bool contains(std::string& fp) {
       std::shared_lock lock(fingerprint_lock);
       return fp_map.contains(fp);
     }
@@ -319,11 +319,11 @@ private:
   void try_dedup_and_accumulate_result(ObjectItem &object, snap_t snap = 0);
   int do_chunk_dedup(chunk_t &chunk, snap_t snap);
   bufferlist read_object(ObjectItem &object);
-  std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> do_cdc(
+  std::vector<std::tuple<bufferlist, std::pair<uint64_t, uint64_t>>> do_cdc(
     ObjectItem &object,
     bufferlist &data);
   std::string generate_fingerprint(bufferlist chunk_data);
-  AioCompRef do_async_evict(string oid);
+  AioCompRef do_async_evict(std::string oid);
 
   IoCtx io_ctx;
   IoCtx chunk_io_ctx;
@@ -362,7 +362,7 @@ void SampleDedupWorkerThread::crawl()
 	op.list_snaps(&snap_set, &snap_ret);
 	io_ctx.operate(target.oid, &op, NULL);
 
-	for (vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
+	for (std::vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
 	  r != snap_set.clones.end();
 	  ++r) {
 	  io_ctx.snap_set_read(r->cloneid);
@@ -378,7 +378,7 @@ void SampleDedupWorkerThread::crawl()
     }
   }
 
-  vector<AioCompRef> evict_completions(oid_for_evict.size());
+  std::vector<AioCompRef> evict_completions(oid_for_evict.size());
   int i = 0;
   for (auto &oid : oid_for_evict) {
     if (snap) {
@@ -392,7 +392,7 @@ void SampleDedupWorkerThread::crawl()
   }
 }
 
-AioCompRef SampleDedupWorkerThread::do_async_evict(string oid)
+AioCompRef SampleDedupWorkerThread::do_async_evict(std::string oid)
 {
   Rados rados;
   ObjectReadOperation op_tier;
@@ -432,7 +432,7 @@ std::vector<size_t> SampleDedupWorkerThread::sample_object(size_t count)
   for (size_t i = 0 ; i < count ; i++) {
     indexes[i] = i;
   }
-  default_random_engine generator;
+  std::default_random_engine generator;
   shuffle(indexes.begin(), indexes.end(), generator);
   size_t sampling_count = static_cast<double>(count) *
     sample_dedup_global.sampling_ratio;
@@ -466,7 +466,7 @@ void SampleDedupWorkerThread::try_dedup_and_accumulate_result(
   }
 
   size_t duplicated_size = 0;
-  list<chunk_t> redundant_chunks;
+  std::list<chunk_t> redundant_chunks;
   for (auto &chunk : chunks) {
     auto &chunk_data = std::get<0>(chunk);
     std::string fingerprint = generate_fingerprint(chunk_data);
@@ -525,14 +525,14 @@ bufferlist SampleDedupWorkerThread::read_object(ObjectItem &object)
   return whole_data;
 }
 
-std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> SampleDedupWorkerThread::do_cdc(
+std::vector<std::tuple<bufferlist, std::pair<uint64_t, uint64_t>>> SampleDedupWorkerThread::do_cdc(
   ObjectItem &object,
   bufferlist &data)
 {
-  std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> ret;
+  std::vector<std::tuple<bufferlist, std::pair<uint64_t, uint64_t>>> ret;
 
-  unique_ptr<CDC> cdc = CDC::create(chunk_algo, cbits(chunk_size) - 1);
-  vector<pair<uint64_t, uint64_t>> chunks;
+  std::unique_ptr<CDC> cdc = CDC::create(chunk_algo, cbits(chunk_size) - 1);
+  std::vector<std::pair<uint64_t, uint64_t>> chunks;
   cdc->calc_chunks(data, &chunks);
   for (auto &p : chunks) {
     bufferlist chunk;
@@ -545,7 +545,7 @@ std::vector<std::tuple<bufferlist, pair<uint64_t, uint64_t>>> SampleDedupWorkerT
 
 std::string SampleDedupWorkerThread::generate_fingerprint(bufferlist chunk_data)
 {
-  string ret;
+  std::string ret;
 
   switch (fp_type) {
     case pg_pool_t::TYPE_FINGERPRINT_SHA1:
@@ -598,8 +598,8 @@ int SampleDedupWorkerThread::do_chunk_dedup(chunk_t &chunk, snap_t snap)
 
 int run_crawling_daemon(const po::variables_map &opts)
 {
-  string base_pool_name = get_opts_pool_name(opts);
-  string chunk_pool_name = get_opts_chunk_pool(opts);
+  std::string base_pool_name = get_opts_pool_name(opts);
+  std::string chunk_pool_name = get_opts_chunk_pool(opts);
   unsigned max_thread = get_opts_max_thread(opts);
   uint32_t report_period = get_opts_report_period(opts);
   bool run_once = false; // for debug
@@ -612,7 +612,7 @@ int run_crawling_daemon(const po::variables_map &opts)
   if (opts.count("chunk-size")) {
     chunk_size = opts["chunk-size"].as<int>();
   } else {
-    cout << "8192 is set as chunk size by default" << std::endl;
+    std::cout << "8192 is set as chunk size by default" << std::endl;
   }
   bool snap = false;
   if (opts.count("snap")) {
@@ -641,14 +641,14 @@ int run_crawling_daemon(const po::variables_map &opts)
   if (opts.count("wakeup-period")) {
     wakeup_period = opts["wakeup-period"].as<int>();
   } else {
-    cout << "100 second is set as wakeup period by default" << std::endl;
+    std::cout << "100 second is set as wakeup period by default" << std::endl;
   }
 
   const size_t fp_threshold = opts["fpstore-threshold"].as<size_t>();
 
   std::string fp_algo = get_opts_fp_algo(opts);
 
-  list<string> pool_names;
+  std::list<std::string> pool_names;
   IoCtx io_ctx, chunk_io_ctx;
   pool_names.push_back(base_pool_name);
   ret = rados.ioctx_create(base_pool_name.c_str(), io_ctx);
@@ -731,7 +731,7 @@ int run_crawling_daemon(const po::variables_map &opts)
 
     sleep(wakeup_period);
 
-    map<string, librados::pool_stat_t> stats;
+    std::map<std::string, librados::pool_stat_t> stats;
     ret = rados.get_pool_stats(pool_names, stats);
     if (ret < 0) {
       derr << "error fetching pool stats: " << cpp_strerror(ret) << dendl;
@@ -756,7 +756,7 @@ int main(int argc, const char **argv)
 {
   auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
-    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    std::cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
   }
 
@@ -774,7 +774,7 @@ int main(int argc, const char **argv)
     return 1;
   }
   if (opts.count("help") || opts.count("h")) {
-    cout<< desc << std::endl;
+    std::cout<< desc << std::endl;
     exit(0);
   }
 
@@ -787,7 +787,7 @@ int main(int argc, const char **argv)
     std::string err;
     int r = forker.prefork(err);
     if (r < 0) {
-      cerr << err << std::endl;
+      std::cerr << err << std::endl;
       return r;
     }
     if (forker.is_parent()) {

--- a/src/tools/ceph_dedup/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_tool.cc
@@ -25,7 +25,7 @@ struct EstimateResult {
   ceph::mutex lock = ceph::make_mutex("EstimateResult::lock");
 
   // < key, <count, chunk_size> >
-  map< string, pair <uint64_t, uint64_t> > chunk_statistics;
+  std::map< std::string, std::pair <uint64_t, uint64_t> > chunk_statistics;
   uint64_t total_bytes = 0;
   std::atomic<uint64_t> total_objects = {0};
 
@@ -34,7 +34,7 @@ struct EstimateResult {
       chunk_size(1ull << chunk_size) {}
 
   void add_chunk(bufferlist& chunk, const std::string& fp_algo) {
-    string fp;
+    std::string fp;
     if (fp_algo == "sha1") {
       sha1_digest_t sha1_val = crypto::digest<crypto::SHA1>(chunk);
       fp = sha1_val.to_str();
@@ -53,12 +53,12 @@ struct EstimateResult {
     if (p != chunk_statistics.end()) {
       p->second.first++;
       if (p->second.second != chunk.length()) {
-	cerr << "warning: hash collision on " << fp
+	std::cerr << "warning: hash collision on " << fp
 	     << ": was " << p->second.second
 	     << " now " << chunk.length() << std::endl;
       }
     } else {
-      chunk_statistics[fp] = make_pair(1, chunk.length());
+      chunk_statistics[fp] = std::make_pair(1, chunk.length());
     }
     total_bytes += chunk.length();
   }
@@ -89,7 +89,7 @@ struct EstimateResult {
   }
 };
 
-map<uint64_t, EstimateResult> dedup_estimates;  // chunk size -> result
+std::map<uint64_t, EstimateResult> dedup_estimates;  // chunk size -> result
 ceph::mutex glock = ceph::make_mutex("glock");
 
 po::options_description make_usage() {
@@ -147,7 +147,7 @@ static int rados_sistrtoll(I &i, T *val) {
   std::string err;
   *val = strict_iecstrtoll(i->second, &err);
   if (err != "") {
-    cerr << "Invalid value for " << i->first << ": " << err << std::endl;
+    std::cerr << "Invalid value for " << i->first << ": " << err << std::endl;
     return -EINVAL;
   } else {
     return 0;
@@ -188,7 +188,7 @@ public:
     m_stop = true;
     m_cond.notify_all();
   }
-  virtual void print_status(Formatter *f, ostream &out) {}
+  virtual void print_status(Formatter *f, std::ostream &out) {}
   uint64_t get_examined_objects() { return examined_objects; }
   uint64_t get_examined_bytes() { return examined_bytes; }
   uint64_t get_total_bytes() { return total_bytes; }
@@ -200,15 +200,15 @@ public:
 
 class EstimateDedupRatio : public CrawlerThread
 {
-  string chunk_algo;
-  string fp_algo;
+  std::string chunk_algo;
+  std::string fp_algo;
   uint64_t chunk_size;
   uint64_t max_seconds;
 
 public:
   EstimateDedupRatio(
     IoCtx& io_ctx, int n, int m, ObjectCursor begin, ObjectCursor end,
-    string chunk_algo, string fp_algo, uint64_t chunk_size, int32_t report_period,
+    std::string chunk_algo, std::string fp_algo, uint64_t chunk_size, int32_t report_period,
     uint64_t num_objects, uint64_t max_read_size,
     uint64_t max_seconds):
     CrawlerThread(io_ctx, n, m, begin, end, report_period, num_objects,
@@ -242,10 +242,10 @@ public:
   }
   void chunk_scrub_common();
   int get_damaged_objects() { return damaged_objects; }
-  void print_status(Formatter *f, ostream &out);
+  void print_status(Formatter *f, std::ostream &out);
 };
 
-vector<std::unique_ptr<CrawlerThread>> estimate_threads;
+std::vector<std::unique_ptr<CrawlerThread>> estimate_threads;
 
 static void print_dedup_estimate(std::ostream& out, std::string chunk_algo)
 {
@@ -323,7 +323,7 @@ void EstimateDedupRatio::estimate_dedup_ratio()
     std::vector<ObjectItem> result;
     int r = io_ctx.object_list(c, shard_end, 12, {}, &result, &c);
     if (r < 0 ){
-      cerr << "error object_list : " << cpp_strerror(r) << std::endl;
+      std::cerr << "error object_list : " << cpp_strerror(r) << std::endl;
       return;
     }
 
@@ -342,10 +342,10 @@ void EstimateDedupRatio::estimate_dedup_ratio()
 
       if (n == 0 && // first thread only
 	  next_report != utime_t() && now > next_report) {
-	cerr << (int)(now - start) << "s : read "
+	std::cerr << (int)(now - start) << "s : read "
 	     << dedup_estimates.begin()->second.total_bytes << " bytes so far..."
 	     << std::endl;
-	print_dedup_estimate(cerr, chunk_algo);
+	print_dedup_estimate(std::cerr, chunk_algo);
 	next_report = now;
 	next_report += report_period;
       }
@@ -367,14 +367,14 @@ void EstimateDedupRatio::estimate_dedup_ratio()
 
       // do the chunking
       for (auto& i : dedup_estimates) {
-	vector<pair<uint64_t, uint64_t>> chunks;
+	std::vector<std::pair<uint64_t, uint64_t>> chunks;
 	i.second.cdc->calc_chunks(bl, &chunks);
 	for (auto& p : chunks) {
 	  bufferlist chunk;
 	  chunk.substr_of(bl, p.first, p.second);
 	  i.second.add_chunk(chunk, fp_algo);
 	  if (debug) {
-	    cout << " " << oid <<  " " << p.first << "~" << p.second << std::endl;
+	    std::cout << " " << oid <<  " " << p.first << "~" << p.second << std::endl;
 	  }
 	}
 	++i.second.total_objects;
@@ -393,12 +393,12 @@ void ChunkScrub::chunk_scrub_common()
 
   ret = rados.init_with_context(g_ceph_context);
   if (ret < 0) {
-     cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
      return;
   }
   ret = rados.connect();
   if (ret) {
-     cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
      return;
   }
 
@@ -423,7 +423,7 @@ void ChunkScrub::chunk_scrub_common()
     std::vector<ObjectItem> result;
     int r = chunk_io_ctx.object_list(c, shard_end, 12, {}, &result, &c);
     if (r < 0 ){
-      cerr << "error object_list : " << cpp_strerror(r) << std::endl;
+      std::cerr << "error object_list : " << cpp_strerror(r) << std::endl;
       return;
     }
 
@@ -431,7 +431,7 @@ void ChunkScrub::chunk_scrub_common()
       std::unique_lock l{m_lock};
       if (m_stop) {
 	Formatter *formatter = Formatter::create("json-pretty");
-	print_status(formatter, cout);
+	print_status(formatter, std::cout);
 	delete formatter;
 	return;
       }
@@ -439,7 +439,7 @@ void ChunkScrub::chunk_scrub_common()
       utime_t now = ceph_clock_now();
       if (n == 0 && // first thread only
 	  next_report != utime_t() && now > next_report) {
-	cerr << (int)(now - start) << "s, interim findings is : "
+	std::cerr << (int)(now - start) << "s, interim findings is : "
 	     << std::endl;
 	print_chunk_scrub();
 	next_report = now;
@@ -448,7 +448,7 @@ void ChunkScrub::chunk_scrub_common()
 
       auto oid = i.oid;
       if (debug) {
-	cout << oid << std::endl;
+	std::cout << oid << std::endl;
       }
       chunk_refs_t refs;
       {
@@ -470,7 +470,7 @@ void ChunkScrub::chunk_scrub_common()
       // check all objects
       chunk_refs_by_object_t *byo =
 	static_cast<chunk_refs_by_object_t*>(refs.r.get());
-      set<hobject_t> real_refs;
+      std::set<hobject_t> real_refs;
 
       uint64_t pool_missing = 0;
       uint64_t object_missing = 0;
@@ -479,7 +479,7 @@ void ChunkScrub::chunk_scrub_common()
 	IoCtx target_io_ctx;
 	ret = rados.ioctx_create2(pp.pool, target_io_ctx);
 	if (ret < 0) {
-	  cerr << oid << " ref " << pp
+	  std::cerr << oid << " ref " << pp
 	       << ": referencing pool does not exist" << std::endl;
 	  ++pool_missing;
 	  continue;
@@ -487,11 +487,11 @@ void ChunkScrub::chunk_scrub_common()
 
 	ret = cls_cas_references_chunk(target_io_ctx, pp.oid.name, oid);
 	if (ret == -ENOENT) {
-	  cerr << oid << " ref " << pp
+	  std::cerr << oid << " ref " << pp
 	       << ": referencing object missing" << std::endl;
 	  ++object_missing;
 	} else if (ret == -ENOLINK) {
-	  cerr << oid << " ref " << pp
+	  std::cerr << oid << " ref " << pp
 	       << ": referencing object does not reference chunk"
 	       << std::endl;
 	  ++does_not_ref;
@@ -502,10 +502,10 @@ void ChunkScrub::chunk_scrub_common()
       }
     }
   }
-  cout << "--done--" << std::endl;
+  std::cout << "--done--" << std::endl;
 }
 
-void ChunkScrub::print_status(Formatter *f, ostream &out)
+void ChunkScrub::print_status(Formatter *f, std::ostream &out)
 {
   if (f) {
     f->open_array_section("chunk_scrub");
@@ -516,7 +516,7 @@ void ChunkScrub::print_status(Formatter *f, ostream &out)
     f->dump_string("damaged objects", stringify(damaged_objects));
     f->close_section();
     f->flush(out);
-    cout << std::endl;
+    std::cout << std::endl;
   }
 }
 
@@ -525,8 +525,8 @@ int estimate_dedup_ratio(const po::variables_map &opts)
   Rados rados;
   IoCtx io_ctx;
   std::string chunk_algo = "fastcdc";
-  string fp_algo = "sha1";
-  string pool_name;
+  std::string fp_algo = "sha1";
+  std::string pool_name;
   uint64_t chunk_size = 8192;
   uint64_t min_chunk_size = 8192;
   uint64_t max_chunk_size = 4*1024*1024;
@@ -540,45 +540,45 @@ int estimate_dedup_ratio(const po::variables_map &opts)
   ObjectCursor begin;
   ObjectCursor end;
   librados::pool_stat_t s; 
-  list<string> pool_names;
-  map<string, librados::pool_stat_t> stats;
+  std::list<std::string> pool_names;
+  std::map<std::string, librados::pool_stat_t> stats;
 
   pool_name = get_opts_pool_name(opts);
   if (opts.count("chunk-algorithm")) {
-    chunk_algo = opts["chunk-algorithm"].as<string>();
+    chunk_algo = opts["chunk-algorithm"].as<std::string>();
     if (!CDC::create(chunk_algo, 12)) {
-      cerr << "unrecognized chunk-algorithm " << chunk_algo << std::endl;
+      std::cerr << "unrecognized chunk-algorithm " << chunk_algo << std::endl;
       exit(1);
     }
   } else {
-    cerr << "must specify chunk-algorithm" << std::endl;
+    std::cerr << "must specify chunk-algorithm" << std::endl;
     exit(1);
   }
   fp_algo = get_opts_fp_algo(opts);
   if (opts.count("chunk-size")) {
     chunk_size = opts["chunk-size"].as<int>();
   } else {
-    cout << "8192 is set as chunk size by default" << std::endl;
+    std::cout << "8192 is set as chunk size by default" << std::endl;
   }
   if (opts.count("min-chunk-size")) {
     chunk_size = opts["min-chunk-size"].as<int>();
   } else {
-    cout << "8192 is set as min chunk size by default" << std::endl;
+    std::cout << "8192 is set as min chunk size by default" << std::endl;
   }
   if (opts.count("max-chunk-size")) {
     chunk_size = opts["max-chunk-size"].as<int>();
   } else {
-    cout << "4MB is set as max chunk size by default" << std::endl;
+    std::cout << "4MB is set as max chunk size by default" << std::endl;
   }
   if (opts.count("max-seconds")) {
     max_seconds = opts["max-seconds"].as<int>();
   } else {
-    cout << "max seconds is not set" << std::endl;
+    std::cout << "max seconds is not set" << std::endl;
   }
   if (opts.count("max-read-size")) {
     max_read_size = opts["max-read-size"].as<int>();
   } else {
-    cout << default_op_size << " is set as max-read-size by default" << std::endl;
+    std::cout << default_op_size << " is set as max-read-size by default" << std::endl;
   }
   if (opts.count("debug")) {
     debug = true;
@@ -587,22 +587,22 @@ int estimate_dedup_ratio(const po::variables_map &opts)
 
   ret = rados.init_with_context(g_ceph_context);
   if (ret < 0) {
-     cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
      goto out;
   }
   ret = rados.connect();
   if (ret) {
-     cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
      ret = -1;
      goto out;
   }
   if (pool_name.empty()) {
-    cerr << "--create-pool requested but pool_name was not specified!" << std::endl;
+    std::cerr << "--create-pool requested but pool_name was not specified!" << std::endl;
     exit(1);
   }
   ret = rados.ioctx_create(pool_name.c_str(), io_ctx);
   if (ret < 0) {
-    cerr << "error opening pool "
+    std::cerr << "error opening pool "
 	 << pool_name << ": "
 	 << cpp_strerror(ret) << std::endl;
     goto out;
@@ -627,12 +627,12 @@ int estimate_dedup_ratio(const po::variables_map &opts)
   pool_names.push_back(pool_name);
   ret = rados.get_pool_stats(pool_names, stats);
   if (ret < 0) {
-    cerr << "error fetching pool stats: " << cpp_strerror(ret) << std::endl;
+    std::cerr << "error fetching pool stats: " << cpp_strerror(ret) << std::endl;
     glock.unlock();
     return ret;
   }
   if (stats.find(pool_name) == stats.end()) {
-    cerr << "stats can not find pool name: " << pool_name << std::endl;
+    std::cerr << "stats can not find pool name: " << pool_name << std::endl;
     glock.unlock();
     return ret;
   }
@@ -654,7 +654,7 @@ int estimate_dedup_ratio(const po::variables_map &opts)
     p->join();
   }
 
-  print_dedup_estimate(cout, chunk_algo);
+  print_dedup_estimate(std::cout, chunk_algo);
 
  out:
   return (ret < 0) ? 1 : 0;
@@ -675,9 +675,9 @@ static void print_chunk_scrub()
     damaged_objects += ptr->get_damaged_objects();
   }
 
-  cout << " Total object : " << total_objects << std::endl;
-  cout << " Examined object : " << examined_objects << std::endl;
-  cout << " Damaged object : " << damaged_objects << std::endl;
+  std::cout << " Total object : " << total_objects << std::endl;
+  std::cout << " Examined object : " << examined_objects << std::endl;
+  std::cout << " Damaged object : " << damaged_objects << std::endl;
 }
 
 int chunk_scrub_common(const po::variables_map &opts)
@@ -685,7 +685,7 @@ int chunk_scrub_common(const po::variables_map &opts)
   Rados rados;
   IoCtx io_ctx, chunk_io_ctx;
   std::string object_name, target_object_name;
-  string chunk_pool_name, op_name;
+  std::string chunk_pool_name, op_name;
   int ret;
   unsigned max_thread = get_opts_max_thread(opts);
   std::map<std::string, std::string>::const_iterator i;
@@ -693,8 +693,8 @@ int chunk_scrub_common(const po::variables_map &opts)
   ObjectCursor begin;
   ObjectCursor end;
   librados::pool_stat_t s; 
-  list<string> pool_names;
-  map<string, librados::pool_stat_t> stats;
+  std::list<std::string> pool_names;
+  std::map<std::string, librados::pool_stat_t> stats;
 
   op_name = get_opts_op_name(opts);
   chunk_pool_name = get_opts_chunk_pool(opts);
@@ -702,18 +702,18 @@ int chunk_scrub_common(const po::variables_map &opts)
 
   ret = rados.init_with_context(g_ceph_context);
   if (ret < 0) {
-     cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
      goto out;
   }
   ret = rados.connect();
   if (ret) {
-     cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
      ret = -1;
      goto out;
   }
   ret = rados.ioctx_create(chunk_pool_name.c_str(), chunk_io_ctx);
   if (ret < 0) {
-    cerr << "error opening pool "
+    std::cerr << "error opening pool "
 	 << chunk_pool_name << ": "
 	 << cpp_strerror(ret) << std::endl;
     goto out;
@@ -722,19 +722,19 @@ int chunk_scrub_common(const po::variables_map &opts)
   if (op_name == "chunk-get-ref" ||
       op_name == "chunk-put-ref" ||
       op_name == "chunk-repair") {
-    string target_object_name;
+    std::string target_object_name;
     uint64_t pool_id;
     object_name = get_opts_object_name(opts);
     if (opts.count("target-ref")) {
-      target_object_name = opts["target-ref"].as<string>();
+      target_object_name = opts["target-ref"].as<std::string>();
     } else {
-      cerr << "must specify target ref" << std::endl;
+      std::cerr << "must specify target ref" << std::endl;
       exit(1);
     }
     if (opts.count("target-ref-pool-id")) {
       pool_id = opts["target-ref-pool-id"].as<uint64_t>();
     } else {
-      cerr << "must specify target-ref-pool-id" << std::endl;
+      std::cerr << "must specify target-ref-pool-id" << std::endl;
       exit(1);
     }
 
@@ -746,10 +746,10 @@ int chunk_scrub_common(const po::variables_map &opts)
     hobject_t oid(sobject_t(target_object_name, CEPH_NOSNAP), "", hash, pool_id, "");
 
     auto run_op = [] (ObjectWriteOperation& op, hobject_t& oid,
-      string& object_name, IoCtx& chunk_io_ctx) -> int {
+      std::string& object_name, IoCtx& chunk_io_ctx) -> int {
       int ret = chunk_io_ctx.operate(object_name, &op);
       if (ret < 0) {
-	cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+	std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       }
       return ret;
     };
@@ -764,7 +764,7 @@ int chunk_scrub_common(const po::variables_map &opts)
     } else if (op_name == "chunk-repair") {
       ret = rados.ioctx_create2(pool_id, io_ctx);
       if (ret < 0) {
-	cerr << oid << " ref " << pool_id
+	std::cerr << oid << " ref " << pool_id
 	     << ": referencing pool does not exist" << std::endl;
 	return ret;
       }
@@ -779,17 +779,17 @@ int chunk_scrub_common(const po::variables_map &opts)
       auto p = t.cbegin();
       decode(refs, p);
       if (refs.get_type() != chunk_refs_t::TYPE_BY_OBJECT) {
-	cerr << " does not supported chunk type " << std::endl;
+	std::cerr << " does not supported chunk type " << std::endl;
 	return -1;
       }
       chunk_ref =
 	static_cast<chunk_refs_by_object_t*>(refs.r.get())->by_object.count(oid);
       if (chunk_ref < 0) {
-	cerr << object_name << " has no reference of " << target_object_name
+	std::cerr << object_name << " has no reference of " << target_object_name
 	     << std::endl;
 	return chunk_ref;
       }
-      cout << object_name << " has " << chunk_ref << " references for "
+      std::cout << object_name << " has " << chunk_ref << " references for "
 	   << target_object_name << std::endl;
 
       // read object on base pool to know the number of chunk object's references
@@ -801,15 +801,15 @@ int chunk_scrub_common(const po::variables_map &opts)
 	  return base_ref;
 	}
       }
-      cout << target_object_name << " has " << base_ref << " references for "
+      std::cout << target_object_name << " has " << base_ref << " references for "
 	   << object_name << std::endl;
       if (chunk_ref != base_ref) {
 	if (base_ref > chunk_ref) {
-	  cerr << "error : " << target_object_name << "'s ref. < " << object_name
+	  std::cerr << "error : " << target_object_name << "'s ref. < " << object_name
 	       << "' ref. " << std::endl;
 	  return -EINVAL;
 	}
-	cout << " fix dangling reference from " << chunk_ref << " to " << base_ref
+	std::cout << " fix dangling reference from " << chunk_ref << " to " << base_ref
 	     << std::endl;
 	while (base_ref != chunk_ref) {
 	  ObjectWriteOperation op;
@@ -836,7 +836,7 @@ int chunk_scrub_common(const po::variables_map &opts)
     decode(refs, p);
     auto f = Formatter::create("json-pretty");
     f->dump_object("refs", refs);
-    f->flush(cout);
+    f->flush(std::cout);
     return 0;
   }
 
@@ -846,12 +846,12 @@ int chunk_scrub_common(const po::variables_map &opts)
   pool_names.push_back(chunk_pool_name);
   ret = rados.get_pool_stats(pool_names, stats);
   if (ret < 0) {
-    cerr << "error fetching pool stats: " << cpp_strerror(ret) << std::endl;
+    std::cerr << "error fetching pool stats: " << cpp_strerror(ret) << std::endl;
     glock.unlock();
     return ret;
   }
   if (stats.find(chunk_pool_name) == stats.end()) {
-    cerr << "stats can not find pool name: " << chunk_pool_name << std::endl;
+    std::cerr << "stats can not find pool name: " << chunk_pool_name << std::endl;
     glock.unlock();
     return ret;
   }
@@ -867,9 +867,9 @@ int chunk_scrub_common(const po::variables_map &opts)
   glock.unlock();
 
   for (auto &p : estimate_threads) {
-    cout << "join " << std::endl;
+    std::cout << "join " << std::endl;
     p->join();
-    cout << "joined " << std::endl;
+    std::cout << "joined " << std::endl;
   }
 
   print_chunk_scrub();
@@ -894,25 +894,25 @@ int make_dedup_object(const po::variables_map &opts)
 
   ret = rados.init_with_context(g_ceph_context);
   if (ret < 0) {
-     cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
      goto out;
   }
   ret = rados.connect();
   if (ret) {
-     cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
+     std::cerr << "couldn't connect to cluster: " << cpp_strerror(ret) << std::endl;
      ret = -1;
      goto out;
   }
   ret = rados.ioctx_create(pool_name.c_str(), io_ctx);
   if (ret < 0) {
-    cerr << "error opening pool "
+    std::cerr << "error opening pool "
 	 << chunk_pool_name << ": "
 	 << cpp_strerror(ret) << std::endl;
     goto out;
   }
   ret = rados.ioctx_create(chunk_pool_name.c_str(), chunk_io_ctx);
   if (ret < 0) {
-    cerr << "error opening pool "
+    std::cerr << "error opening pool "
 	 << chunk_pool_name << ": "
 	 << cpp_strerror(ret) << std::endl;
     goto out;
@@ -921,27 +921,27 @@ int make_dedup_object(const po::variables_map &opts)
 
   if (op_name == "chunk-dedup") {
     uint64_t offset, length;
-    string chunk_object;
+    std::string chunk_object;
     if (opts.count("source-off")) {
       offset = opts["source-off"].as<uint64_t>();
     } else {
-      cerr << "must specify --source-off" << std::endl;
+      std::cerr << "must specify --source-off" << std::endl;
       exit(1);
     }
     if (opts.count("source-length")) {
       length = opts["source-length"].as<uint64_t>();
     } else {
-      cerr << "must specify --source-length" << std::endl;
+      std::cerr << "must specify --source-length" << std::endl;
       exit(1);
     }
     // 1. make a copy from manifest object to chunk object
     bufferlist bl;
     ret = io_ctx.read(object_name, bl, length, offset);
     if (ret < 0) {
-      cerr << " reading object in base pool fails : " << cpp_strerror(ret) << std::endl;
+      std::cerr << " reading object in base pool fails : " << cpp_strerror(ret) << std::endl;
       goto out;
     }
-    chunk_object = [&fp_algo, &bl]() -> string {
+    chunk_object = [&fp_algo, &bl]() -> std::string {
       if (fp_algo == "sha1") {
         return ceph::crypto::digest<ceph::crypto::SHA1>(bl).to_str();
       } else if (fp_algo == "sha256") {
@@ -955,7 +955,7 @@ int make_dedup_object(const po::variables_map &opts)
     }();
     ret = chunk_io_ctx.write(chunk_object, bl, length, offset);
     if (ret < 0) {
-      cerr << " writing object in chunk pool fails : " << cpp_strerror(ret) << std::endl;
+      std::cerr << " writing object in chunk pool fails : " << cpp_strerror(ret) << std::endl;
       goto out;
     }
     // 2. call set_chunk
@@ -964,7 +964,7 @@ int make_dedup_object(const po::variables_map &opts)
 	CEPH_OSD_OP_FLAG_WITH_REFERENCE);
     ret = io_ctx.operate(object_name, &op, NULL);
     if (ret < 0) {
-      cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+      std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   } else if (op_name == "object-dedup") {
@@ -973,7 +973,7 @@ int make_dedup_object(const po::variables_map &opts)
     if (opts.count("dedup-cdc-chunk-size")) {
       chunk_size = opts["dedup-cdc-chunk-size"].as<unsigned int>();
     } else {
-      cerr << "must specify --dedup-cdc-chunk-size" << std::endl;
+      std::cerr << "must specify --dedup-cdc-chunk-size" << std::endl;
       exit(1);
     }
     if (opts.count("snap")) {
@@ -985,40 +985,40 @@ int make_dedup_object(const po::variables_map &opts)
 	make_pool_str(pool_name, "fingerprint_algorithm", fp_algo),
 	inbl, NULL, NULL);
     if (ret < 0) {
-      cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+      std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;
     }
     ret = rados.mon_command(
 	make_pool_str(pool_name, "dedup_tier", chunk_pool_name),
 	inbl, NULL, NULL);
     if (ret < 0) {
-      cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+      std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;
     }
     ret = rados.mon_command(
 	make_pool_str(pool_name, "dedup_chunk_algorithm", "fastcdc"),
 	inbl, NULL, NULL);
     if (ret < 0) {
-      cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+      std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;
     }
     ret = rados.mon_command(
 	make_pool_str(pool_name, "dedup_cdc_chunk_size", chunk_size),
 	inbl, NULL, NULL);
     if (ret < 0) {
-      cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
+      std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;
     }
 
     auto create_new_deduped_object =
-      [&io_ctx](string object_name) -> int {
+      [&io_ctx](std::string object_name) -> int {
 
       // tier-flush to perform deduplication
       ObjectReadOperation flush_op;
       flush_op.tier_flush();
       int ret = io_ctx.operate(object_name, &flush_op, NULL);
       if (ret < 0) {
-	cerr << " tier_flush fail : " << cpp_strerror(ret) << std::endl;
+	std::cerr << " tier_flush fail : " << cpp_strerror(ret) << std::endl;
 	return ret;
       }
       // tier-evict
@@ -1026,7 +1026,7 @@ int make_dedup_object(const po::variables_map &opts)
       evict_op.tier_evict();
       ret = io_ctx.operate(object_name, &evict_op, NULL);
       if (ret < 0) {
-	cerr << " tier_evict fail : " << cpp_strerror(ret) << std::endl;
+	std::cerr << " tier_evict fail : " << cpp_strerror(ret) << std::endl;
 	return ret;
       }
       return ret;
@@ -1040,7 +1040,7 @@ int make_dedup_object(const po::variables_map &opts)
       op.list_snaps(&snap_set, &snap_ret);
       io_ctx.operate(object_name, &op, NULL);
 
-      for (vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
+      for (std::vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
 	r != snap_set.clones.end();
 	++r) {
 	io_ctx.snap_set_read(r->cloneid);
@@ -1062,7 +1062,7 @@ int main(int argc, const char **argv)
 {
   auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
-    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    std::cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
   }
 
@@ -1080,7 +1080,7 @@ int main(int argc, const char **argv)
     return 1;
   }
   if (opts.count("help") || opts.count("h")) {
-    cout<< desc << std::endl;
+    std::cout<< desc << std::endl;
     exit(0);
   }
 
@@ -1093,7 +1093,7 @@ int main(int argc, const char **argv)
     std::string err;
     int r = forker.prefork(err);
     if (r < 0) {
-      cerr << err << std::endl;
+      std::cerr << err << std::endl;
       return r;
     }
     if (forker.is_parent()) {
@@ -1114,7 +1114,7 @@ int main(int argc, const char **argv)
   register_async_signal_handler_oneshot(SIGINT, handle_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_signal);
 
-  string op_name = get_opts_op_name(opts);
+  std::string op_name = get_opts_op_name(opts);
   int ret = 0;
   if (op_name == "estimate") {
     ret = estimate_dedup_ratio(opts);
@@ -1138,7 +1138,7 @@ int main(int argc, const char **argv)
      */
     ret = make_dedup_object(opts);
   } else {
-    cerr << "unrecognized op " << op_name << std::endl;
+    std::cerr << "unrecognized op " << op_name << std::endl;
     exit(1);
   }
 

--- a/src/tools/ceph_dedup/common.cc
+++ b/src/tools/ceph_dedup/common.cc
@@ -1,63 +1,63 @@
 #include "common.h"
 
-string get_opts_pool_name(const po::variables_map &opts) {
+std::string get_opts_pool_name(const po::variables_map &opts) {
   if (opts.count("pool")) {
-    return opts["pool"].as<string>();
+    return opts["pool"].as<std::string>();
   }
-  cerr << "must specify pool name" << std::endl;
+  std::cerr << "must specify pool name" << std::endl;
   exit(1);
 }
 
-string get_opts_chunk_algo(const po::variables_map &opts) {
+std::string get_opts_chunk_algo(const po::variables_map &opts) {
   if (opts.count("chunk-algorithm")) {
-    string chunk_algo = opts["chunk-algorithm"].as<string>();
+    std::string chunk_algo = opts["chunk-algorithm"].as<std::string>();
     if (!CDC::create(chunk_algo, 12)) {
-      cerr << "unrecognized chunk-algorithm " << chunk_algo << std::endl;
+      std::cerr << "unrecognized chunk-algorithm " << chunk_algo << std::endl;
       exit(1);
     }
     return chunk_algo;
   }
-  cerr << "must specify chunk-algorithm" << std::endl;
+  std::cerr << "must specify chunk-algorithm" << std::endl;
   exit(1);
 }
 
-string get_opts_fp_algo(const po::variables_map &opts) {
+std::string get_opts_fp_algo(const po::variables_map &opts) {
   if (opts.count("fingerprint-algorithm")) {
-    string fp_algo = opts["fingerprint-algorithm"].as<string>();
+    std::string fp_algo = opts["fingerprint-algorithm"].as<std::string>();
     if (fp_algo != "sha1"
 	&& fp_algo != "sha256" && fp_algo != "sha512") {
-      cerr << "unrecognized fingerprint-algorithm " << fp_algo << std::endl;
+      std::cerr << "unrecognized fingerprint-algorithm " << fp_algo << std::endl;
       exit(1);
     }
     return fp_algo;
   }
-  cout << "SHA1 is set as fingerprint algorithm by default" << std::endl;
-  return string("sha1");
+  std::cout << "SHA1 is set as fingerprint algorithm by default" << std::endl;
+  return std::string("sha1");
 }
 
-string get_opts_op_name(const po::variables_map &opts) {
+std::string get_opts_op_name(const po::variables_map &opts) {
   if (opts.count("op")) {
-    return opts["op"].as<string>();
+    return opts["op"].as<std::string>();
   } else {
-    cerr << "must specify op" << std::endl;
+    std::cerr << "must specify op" << std::endl;
     exit(1);
   }
 }
 
-string get_opts_chunk_pool(const po::variables_map &opts) {
+std::string get_opts_chunk_pool(const po::variables_map &opts) {
   if (opts.count("chunk-pool")) {
-    return opts["chunk-pool"].as<string>();
+    return opts["chunk-pool"].as<std::string>();
   } else {
-    cerr << "must specify --chunk-pool" << std::endl;
+    std::cerr << "must specify --chunk-pool" << std::endl;
     exit(1);
   }
 }
 
-string get_opts_object_name(const po::variables_map &opts) {
+std::string get_opts_object_name(const po::variables_map &opts) {
   if (opts.count("object")) {
-    return opts["object"].as<string>();
+    return opts["object"].as<std::string>();
   } else {
-    cerr << "must specify object" << std::endl;
+    std::cerr << "must specify object" << std::endl;
     exit(1);
   }
 }
@@ -66,7 +66,7 @@ int get_opts_max_thread(const po::variables_map &opts) {
   if (opts.count("max-thread")) {
     return opts["max-thread"].as<int>();
   } else {
-    cout << "2 is set as the number of threads by default" << std::endl;
+    std::cout << "2 is set as the number of threads by default" << std::endl;
     return 2;
   }
 }
@@ -75,19 +75,19 @@ int get_opts_report_period(const po::variables_map &opts) {
   if (opts.count("report-period")) {
     return opts["report-period"].as<int>();
   } else {
-    cout << "10 seconds is set as report period by default" << std::endl;
+    std::cout << "10 seconds is set as report period by default" << std::endl;
     return 10;
   }
 }
 
-string make_pool_str(string pool, string var, string val)
+std::string make_pool_str(std::string pool, std::string var, std::string val)
 {
-  return string("{\"prefix\": \"osd pool set\",\"pool\":\"") + pool
-    + string("\",\"var\": \"") + var + string("\",\"val\": \"")
-    + val + string("\"}");
+  return std::string("{\"prefix\": \"osd pool set\",\"pool\":\"") + pool
+    + std::string("\",\"var\": \"") + var + std::string("\",\"val\": \"")
+    + val + std::string("\"}");
 }
 
-string make_pool_str(string pool, string var, int val)
+std::string make_pool_str(std::string pool, std::string var, int val)
 {
   return make_pool_str(pool, var, stringify(val));
 }

--- a/src/tools/ceph_dedup/common.h
+++ b/src/tools/ceph_dedup/common.h
@@ -46,19 +46,18 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_ceph_dedup
 
-using namespace std;
 namespace po = boost::program_options;
 using namespace librados;
 
 constexpr unsigned default_op_size = 1 << 26;
 
-string get_opts_pool_name(const po::variables_map &opts);
-string get_opts_chunk_algo(const po::variables_map &opts);
-string get_opts_fp_algo(const po::variables_map &opts);
-string get_opts_op_name(const po::variables_map &opts);
-string get_opts_chunk_pool(const po::variables_map &opts);
-string get_opts_object_name(const po::variables_map &opts);
+std::string get_opts_pool_name(const po::variables_map &opts);
+std::string get_opts_chunk_algo(const po::variables_map &opts);
+std::string get_opts_fp_algo(const po::variables_map &opts);
+std::string get_opts_op_name(const po::variables_map &opts);
+std::string get_opts_chunk_pool(const po::variables_map &opts);
+std::string get_opts_object_name(const po::variables_map &opts);
 int get_opts_max_thread(const po::variables_map &opts);
 int get_opts_report_period(const po::variables_map &opts);
-string make_pool_str(string pool, string var, string val);
-string make_pool_str(string pool, string var, int val);
+std::string make_pool_str(std::string pool, std::string var, std::string val);
+std::string make_pool_str(std::string pool, std::string var, int val);


### PR DESCRIPTION
Remove 'using namespace std' from common.h to maintain consistent coding practices. Although common.h is only used by ceph_dedup implementation, keeping namespace declarations out of header files prevents potential name conflicts and follows best practices for C++ code organization.

This change improves code clarity and reduces the risk of symbol collisions when standard library elements are used alongside custom implementations.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
