### PR TITLE
squid: osd_types: Restore new_object marking for delete missing entries

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4747,6 +4747,8 @@ struct pg_missing_item {
     set_delete(is_delete);
     if (old_style)
       clean_regions.mark_fully_dirty();
+    if (have == eversion_t())
+      clean_regions.mark_object_new();
   }
 
   void encode(ceph::buffer::list& bl, uint64_t features) const {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71224

---

backport of https://github.com/ceph/ceph/pull/62705
parent tracker: https://tracker.ceph.com/issues/45702

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh