### PR TITLE
doc/radosgw: Cosmetic and formatting improvements in frontends.rst

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -23,7 +23,7 @@ Options
 
 ``port`` and ``ssl_port``
 
-:Description: Sets the ipv4 & ipv6 listening port number. Can be specified multiple
+:Description: Sets the IPv4 & IPv6 listening port number. Can be specified multiple
               times as in ``port=80 port=8000``.
 :Type: Integer
 :Default: ``80``
@@ -34,7 +34,7 @@ Options
 :Description: Sets the listening address in the form ``address[:port]``, where
               the address is an IPv4 address string in dotted decimal form, or
               an IPv6 address in hexadecimal notation surrounded by square
-              brackets. Specifying a IPv6 endpoint would listen to v6 only. The
+              brackets. Specifying a IPv6 endpoint would listen to IPv6 only. The
               optional port defaults to 80 for ``endpoint`` and 443 for
               ``ssl_endpoint``. Can be specified multiple times as in
               ``endpoint=[::1] endpoint=192.168.0.100:8000``.
@@ -47,7 +47,7 @@ Options
 
 :Description: Path to the SSL certificate file used for SSL-enabled endpoints.
               If path is prefixed with ``config://``, the certificate will be
-              pulled from the ceph monitor ``config-key`` database.
+              pulled from the Ceph Monitor ``config-key`` database.
 
 :Type: String
 :Default: None
@@ -59,14 +59,14 @@ Options
               endpoints. If one is not given, the ``ssl_certificate`` file
               is used as the private key.
               If path is prefixed with ``config://``, the certificate will be
-              pulled from the ceph monitor ``config-key`` database.
+              pulled from the Ceph Monitor ``config-key`` database.
 
 :Type: String
 :Default: None
 
 ``ssl_options``
 
-:Description: Optional colon separated list of ssl context options:
+:Description: Optional colon separated list of SSL context options:
 
               ``default_workarounds`` Implement various bug workarounds.
 
@@ -102,12 +102,12 @@ Options
               the connection which means that packets will be sent as soon 
               as possible instead of waiting for a full buffer or timeout to occur.
 
-              ``1`` Disable Nagel's algorithm for all sockets.
+              ``1`` Disable Nagle's algorithm for all sockets.
 
-              ``0`` Keep the default: Nagel's algorithm enabled.
+              ``0`` Keep the default: Nagle's algorithm enabled.
 
 :Type: Integer (0 or 1)
-:Default: 0
+:Default: ``0``
 
 ``max_connection_backlog``
 
@@ -120,9 +120,9 @@ Options
 
 ``request_timeout_ms``
 
-:Description: The amount of time in milliseconds that Beast will wait
+:Description: The amount of time in milliseconds that ``beast`` will wait
               for more incoming data or outgoing data before giving up.
-              Setting this value to 0 will disable timeout.
+              Setting this value to ``0`` will disable timeout.
 
 :Type: Integer
 :Default: ``65000``
@@ -144,7 +144,7 @@ Options
               ``0`` Disallow running multiple RGW on same port.
 
 :Type: Integer (0 or 1)
-:Default: 0
+:Default: ``0``
 
 
 Generic Options
@@ -156,7 +156,7 @@ Some frontend options are generic and supported by all frontends:
 
 :Description: A prefix string that is inserted into the URI of all
               requests. For example, a swift-only frontend could supply
-              a uri prefix of ``/swift``.
+              a URI prefix of ``/swift``.
 
 :Type: String
 :Default: None


### PR DESCRIPTION
Capitalize terms like IPv4, SSL, URI consistently.

Title case for "Ceph Monitor".

Fix "Nagel" to "Nagle".

Use inline code consistently in references to configuration values and reference to "beast" front-end.

- Before: https://docs.ceph.com/en/latest/radosgw/frontends/
- Rendered PR: https://ceph--63156.org.readthedocs.build/en/63156/radosgw/frontends/



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
