### PR TITLE
Workflows to replace Github Pull Request Builder in PR checks

### DIFF
--- a/.github/workflows/pr-checks-faker.yml
+++ b/.github/workflows/pr-checks-faker.yml
@@ -1,0 +1,94 @@
+# This workflow's intent is to send 'make check' and 'API test' success statuses
+# to Pull Requests in ceph.git that do not require actually running those checks.
+# This workflow should only be triggered by other workflows.
+
+name: PR Status Check Faker
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "Pull Request Number"
+        required: true
+        type: string
+      pr_sha:
+        description: "Pull Request SHA"
+        required: true
+        type: string
+      triggered_by:
+        description: "URL of workflow that triggered the Check Faker"
+        required: true
+        type: string
+
+jobs:
+  send-status-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: read
+
+    steps:
+      - name: Get commit SHA for PR
+        id: pr
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d
+        with:
+          route: GET /repos/${{ github.repository }}/pulls/${{ inputs.pr_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract commit SHA
+        id: extract
+        env:
+          PR_SHA: ${{ steps.pr.outputs.data }}
+        run: |
+          sha=$(echo "$PR_SHA" | jq -r .head.sha)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Send fake status checks with retry
+        env:
+          SHA: ${{ steps.extract.outputs.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIGGERED_BY: ${{ inputs.triggered_by }}
+        run: |
+          post_status() {
+            local context="$1"
+            local attempts=0
+            local max_attempts=5
+            local delay=2
+
+            while (( attempts < max_attempts )); do
+              response=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/$REPO/statuses/$SHA \
+                -d "$(jq -n \
+                  --arg state "success" \
+                  --arg context "$context" \
+                  --arg description "pr-job-dispatcher workflow detected doc/container PR" \
+                  --arg target_url "$TRIGGERED_BY" \
+                  '{state: $state, context: $context, description: $description, target_url: $target_url}')")
+
+              if [[ "$response" == "201" ]]; then
+                echo "Posted status for '$context'"
+                break
+              else
+                echo "Failed to post status for '$context' (HTTP $response), retrying..."
+                (( attempts++ ))
+                sleep $(( delay ** attempts ))
+              fi
+            done
+
+            if (( attempts == max_attempts )); then
+              echo "Giving up on '$context' after $max_attempts attempts"
+              exit 1
+            fi
+          }
+
+          for context in \
+            "make check" \
+            "ceph API tests" \
+            "ceph windows tests" \
+            "make check (arm64)"; do
+            post_status "$context"
+          done

--- a/.github/workflows/pr-comment-dispatcher.yml
+++ b/.github/workflows/pr-comment-dispatcher.yml
@@ -1,0 +1,58 @@
+name: PR Comment Dispatcher
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  trigger-all-make-check:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test all'
+      jenkins_job: 'ceph-pull-requests'
+
+  trigger-all-make-check-arm64:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test all'
+      jenkins_job: 'ceph-pull-requests-arm64'
+
+  trigger-all-windows:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test all'
+      jenkins_job: 'ceph-windows-pull-requests'
+
+  trigger-all-api:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test all'
+      jenkins_job: 'ceph-api'
+
+  trigger-make-check:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test make check'
+      jenkins_job: 'ceph-pull-requests'
+
+  trigger-make-check-arm64:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test make check arm64'
+      jenkins_job: 'ceph-pull-requests-arm64'
+
+  trigger-windows:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test windows'
+      jenkins_job: 'ceph-windows-pull-requests'
+
+  trigger-api:
+    uses: ./.github/workflows/trigger-jenkins-on-comment.yml
+    with:
+      trigger_phrase: 'jenkins test api'
+      jenkins_job: 'ceph-api'

--- a/.github/workflows/pr-job-dispatcher.yml
+++ b/.github/workflows/pr-job-dispatcher.yml
@@ -1,0 +1,128 @@
+name: Pull Request Job Dispatcher
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  pr-job-dispatcher:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    outputs:
+      only_docs: ${{ steps.check-if-docs-only-pr.outputs.only_docs }}
+      only_container: ${{ steps.check-if-container-only-pr.outputs.only_container }}
+      pr_number: ${{ steps.get-pr-metadata.outputs.pr_number }}
+      pr_sha: ${{ steps.get-pr-metadata.outputs.pr_sha }}
+
+    steps:
+      - name: Get PR metadata
+        id: get-pr-metadata
+        run: |
+          echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "pr_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Get list of changed files
+        id: get-pr-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
+
+      - name: Check if only docs-related files changed
+        id: check-if-docs-only-pr
+        run: |
+          is_docs_file() {
+            local f="$1"
+            [[ "$f" == doc/* ||
+               "$f" == admin/* ||
+               "$f" == src/sample.ceph.conf ||
+               "$f" == CodingStyle ||
+               "$f" == *.rst ||
+               "$f" == *.md ||
+               "$f" == COPYING* ||
+               "$f" == README.* ||
+               "$f" == SubmittingPatches ||
+               "$f" == .readthedocs.yml ||
+               "$f" == PendingReleaseNotes ]] && return 0
+            return 1
+          }
+      
+          only_docs=true
+
+          changed_files="${{ steps.get-pr-changed-files.outputs.all_changed_files }}"
+          for file in $changed_files; do
+            echo "Checking: [$file]"
+            if ! is_docs_file "$file"; then
+              echo "$file is not a docs file"
+              only_docs=false
+              break
+            fi
+          done
+
+          echo "only_docs=$only_docs" >> "$GITHUB_OUTPUT"
+
+      - name: Check if only container-related files changed
+        id: check-if-container-only-pr
+        run: |
+          is_container_file() {
+            local f="$1"
+            [[ "$f" == container/* ||
+               "$f" == Dockerfile.build ||
+               "$f" == src/script/buildcontainer-setup.sh ||
+               "$f" == src/script/build-with-container.py ]] && return 0
+            return 1
+          }
+      
+          only_container=true
+
+          changed_files="${{ steps.get-pr-changed-files.outputs.all_changed_files }}"
+          for file in $changed_files; do
+            echo "Checking: [$file]"
+            if ! is_container_file "$file"; then
+              echo "$file is not a container file"
+              only_container=false
+              break
+            fi
+          done
+
+          echo "only_container=$only_container" >> "$GITHUB_OUTPUT"
+
+  trigger-fake-status-checks:
+    if: needs.pr-job-dispatcher.outputs.only_docs == 'true' || needs.pr-job-dispatcher.outputs.only_container == 'true'
+    permissions:
+      pull-requests: read
+      statuses: write
+    needs: pr-job-dispatcher
+    uses: ./.github/workflows/pr-checks-faker.yml
+    with:
+      pr_number: ${{ needs.pr-job-dispatcher.outputs.pr_number }}
+      pr_sha: ${{ needs.pr-job-dispatcher.outputs.pr_sha }}
+      triggered_by: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  trigger-jenkins-jobs:
+    if: needs.pr-job-dispatcher.outputs.only_docs != 'true' && needs.pr-job-dispatcher.outputs.only_container != 'true'
+    permissions:
+      contents: read
+      pull-requests: read
+    needs: pr-job-dispatcher
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Jenkins jobs with parameters
+        run: |
+          GH_PULL_REQUEST_ID="${{ needs.pr-job-dispatcher.outputs.pr_number }}"
+          GH_PULL_REQUEST_SHA="${{ needs.pr-job-dispatcher.outputs.pr_sha }}"
+          
+          for job in ceph-pull-requests ceph-pull-requests-arm64 ceph-windows-pull-requests ceph-api; do
+            echo "Triggering $job ..."
+            for attempt in {1..5}; do
+              curl --fail --retry 4 --retry-delay 5 --retry-connrefused \
+                -X POST "https://jenkins.ceph.com/job/$job/buildWithParameters" \
+                --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" \
+                --data-urlencode "GH_PULL_REQUEST_ID=$GH_PULL_REQUEST_ID" \
+                --data-urlencode "GH_PULL_REQUEST_SHA=$GH_PULL_REQUEST_SHA" \
+                --data-urlencode "TRIGGER_METHOD=Branch push" \
+                --data-urlencode "TRIGGERED_BY=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" && break
+          
+              echo "Attempt $attempt for $job failed. Retrying..."
+              sleep 3
+            done
+          done

--- a/.github/workflows/trigger-jenkins-on-comment.yml
+++ b/.github/workflows/trigger-jenkins-on-comment.yml
@@ -1,0 +1,78 @@
+name: Trigger Jenkins Job on Comment
+
+on:
+  workflow_call:
+    inputs:
+      trigger_phrase:
+        required: true
+        type: string
+      jenkins_job:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  trigger:
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, inputs.trigger_phrase)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if comment author is a collaborator
+        id: check_user
+        run: |
+          comment_user="${{ github.event.comment.user.login }}"
+          repo="${{ github.repository }}"
+          status=$(curl --retry 3 --retry-connrefused --fail -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/$repo/collaborators/$comment_user")
+          if [ "$status" -ne 204 ]; then
+            echo "$comment_user is not a collaborator. Exiting."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+      - name: Exit if unauthorized
+        if: steps.check_user.outputs.authorized != 'true'
+        run: |
+          echo "Skipping: not authorized"
+
+      - name: Extract PR number
+        id: extract_pr
+        run: |
+          pr_url="${{ github.event.issue.pull_request.url }}"
+          pr_number="${pr_url##*/}"
+          echo "GH_PULL_REQUEST_ID=$pr_number" >> "$GITHUB_ENV"
+
+      - name: Get PR SHA
+        id: pr_sha
+        run: |
+          pr_sha=$(curl --retry 3 --retry-connrefused --fail -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "${{ github.event.issue.pull_request.url }}" | jq -r .head.sha)
+          echo "pr_sha=$pr_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Jenkins job with retries
+        run: |
+          for attempt in {1..5}; do
+            echo "Triggering Jenkins job '${{ inputs.jenkins_job }}' (attempt $attempt)..."
+            curl --fail --retry 4 --retry-delay 5 --retry-connrefused -s \
+              -X POST "https://jenkins.ceph.com/job/${{ inputs.jenkins_job }}/buildWithParameters" \
+              --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" \
+              --data-urlencode "GH_PULL_REQUEST_ID=${{ env.GH_PULL_REQUEST_ID }}" \
+              --data-urlencode "GH_PULL_REQUEST_SHA=${{ steps.pr_sha.outputs.pr_sha }}" \
+              --data-urlencode "TRIGGER_METHOD=Comment by ${{ github.event.comment.user.login }} at https://github.com/${{ github.repository }}/pull/${{ github.event.issue.number }}#issuecomment-${{ github.event.comment.id }}" \
+              --data-urlencode "TRIGGERED_BY=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              && break
+
+            echo "Attempt $attempt failed. Retrying in 5s..."
+            sleep 5
+          done
+
+          echo "All attempts to trigger Jenkins job failed."
+          exit 1


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
