### PR TITLE
mgr/dashboard: Add default state when gateway groups are empty

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.html
@@ -6,11 +6,12 @@
   <cds-combo-box
       type="single"
       label="Selected Gateway Group"
-      i18n-placeholder
-      placeholder="Enter group"
+      i18n-label
+      [placeholder]="gwGroupPlaceholder"
       [items]="gwGroups"
       (selected)="onGroupSelection($event)"
-      (clear)="onGroupClear()">
+      (clear)="onGroupClear()"
+      [disabled]="gwGroupsEmpty">
     <cds-dropdown-list></cds-dropdown-list>
   </cds-combo-box>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.spec.ts
@@ -7,6 +7,7 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { ComboBoxModule, GridModule } from 'carbon-components-angular';
 import { NvmeofTabsComponent } from '../nvmeof-tabs/nvmeof-tabs.component';
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
+import { CephServiceSpec } from '~/app/shared/models/service.interface';
 
 const mockServiceDaemons = [
   {
@@ -60,7 +61,7 @@ const mockGateways = [
   }
 ];
 
-const mockGwGroups = [
+const mockformattedGwGroups = [
   {
     content: 'default',
     serviceName: 'nvmeof.rbd.default'
@@ -96,6 +97,10 @@ class MockNvmeOfService {
   listGatewayGroups() {
     return of(mockServices);
   }
+
+  formatGwGroupsList(_data: CephServiceSpec[][]) {
+    return mockformattedGwGroups;
+  }
 }
 
 class MockCephServiceService {
@@ -130,7 +135,7 @@ describe('NvmeofGatewayComponent', () => {
 
   it('should load gateway groups correctly', () => {
     expect(component.gwGroups.length).toBe(2);
-    expect(component.gwGroups).toStrictEqual(mockGwGroups);
+    expect(component.gwGroups).toStrictEqual(mockformattedGwGroups);
   });
 
   it('should set service name of gateway groups correctly', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-gateway/nvmeof-gateway.component.ts
@@ -5,16 +5,10 @@ import _ from 'lodash';
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
 
-import { NvmeofService } from '../../../shared/api/nvmeof.service';
+import { GroupsComboboxItem, NvmeofService } from '../../../shared/api/nvmeof.service';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { CephServiceService } from '~/app/shared/api/ceph-service.service';
 import { Daemon } from '~/app/shared/models/daemon.interface';
-
-type ComboBoxItem = {
-  content: string;
-  serviceName: string;
-  selected?: boolean;
-};
 
 type Gateway = {
   id: string;
@@ -28,6 +22,8 @@ enum TABS {
   'overview'
 }
 
+const DEFAULT_PLACEHOLDER = $localize`Enter group name`;
+
 @Component({
   selector: 'cd-nvmeof-gateway',
   templateUrl: './nvmeof-gateway.component.html',
@@ -35,7 +31,6 @@ enum TABS {
 })
 export class NvmeofGatewayComponent implements OnInit {
   selectedTab: TABS;
-  selectedGatewayGroup: string = null;
 
   onSelected(tab: TABS) {
     this.selectedTab = tab;
@@ -51,8 +46,11 @@ export class NvmeofGatewayComponent implements OnInit {
   gateways: Gateway[] = [];
   gatewayColumns: any;
   selection = new CdTableSelection();
-  gwGroups: ComboBoxItem[] = [];
+  gwGroups: GroupsComboboxItem[] = [];
   groupService: string = null;
+  selectedGatewayGroup: string = null;
+  gwGroupsEmpty: boolean = false;
+  gwGroupPlaceholder: string = DEFAULT_PLACEHOLDER;
 
   constructor(
     private nvmeofService: NvmeofService,
@@ -61,7 +59,7 @@ export class NvmeofGatewayComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.getGatewayGroups();
+    this.setGatewayGroups();
     this.gatewayColumns = [
       {
         name: $localize`Gateway ID`,
@@ -109,7 +107,7 @@ export class NvmeofGatewayComponent implements OnInit {
   }
 
   // Gateway groups
-  onGroupSelection(selected: ComboBoxItem) {
+  onGroupSelection(selected: GroupsComboboxItem) {
     selected.selected = true;
     this.groupService = selected.serviceName;
     this.selectedGatewayGroup = selected.content;
@@ -121,18 +119,20 @@ export class NvmeofGatewayComponent implements OnInit {
     this.getGateways();
   }
 
-  getGatewayGroups() {
+  setGatewayGroups() {
     this.nvmeofService.listGatewayGroups().subscribe((response: CephServiceSpec[][]) => {
-      this.gwGroups = response?.[0]?.length
-        ? response[0].map((group: CephServiceSpec) => {
-            return {
-              content: group?.spec?.group,
-              serviceName: group?.service_name
-            };
-          })
-        : [];
+      if (response?.[0]?.length) {
+        this.gwGroups = this.nvmeofService.formatGwGroupsList(response, true);
+      } else this.gwGroups = [];
       // Select first group if no group is selected
-      if (!this.groupService && this.gwGroups.length) this.onGroupSelection(this.gwGroups[0]);
+      if (!this.groupService && this.gwGroups.length) {
+        this.onGroupSelection(this.gwGroups[0]);
+        this.gwGroupsEmpty = false;
+        this.gwGroupPlaceholder = DEFAULT_PLACEHOLDER;
+      } else {
+        this.gwGroupsEmpty = true;
+        this.gwGroupPlaceholder = $localize`No groups available`;
+      }
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
@@ -6,11 +6,12 @@
   <cds-combo-box
       type="single"
       label="Selected Gateway Group"
-      i18n-placeholder
-      placeholder="Enter group"
+      i18n-label
+      [placeholder]="gwGroupPlaceholder"
       [items]="gwGroups"
       (selected)="onGroupSelection($event)"
-      (clear)="onGroupClear()">
+      (clear)="onGroupClear()"
+      [disabled]="gwGroupsEmpty">
     <cds-dropdown-list></cds-dropdown-list>
   </cds-combo-box>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
@@ -12,6 +12,7 @@ import { NvmeofSubsystemsComponent } from './nvmeof-subsystems.component';
 import { NvmeofTabsComponent } from '../nvmeof-tabs/nvmeof-tabs.component';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
 import { ComboBoxModule, GridModule } from 'carbon-components-angular';
+import { CephServiceSpec } from '~/app/shared/models/service.interface';
 
 const mockSubsystems = [
   {
@@ -49,9 +50,22 @@ const mockGroups = [
   2
 ];
 
+const mockformattedGwGroups = [
+  {
+    content: 'default'
+  },
+  {
+    content: 'foo'
+  }
+];
+
 class MockNvmeOfService {
   listSubsystems() {
     return of(mockSubsystems);
+  }
+
+  formatGwGroupsList(_data: CephServiceSpec[][]) {
+    return mockformattedGwGroups;
   }
 
   listGatewayGroups() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -4,8 +4,15 @@ import { HttpClient } from '@angular/common/http';
 import _ from 'lodash';
 import { Observable, of as observableOf } from 'rxjs';
 import { catchError, mapTo } from 'rxjs/operators';
+import { CephServiceSpec } from '../models/service.interface';
 
 export const MAX_NAMESPACE = 1024;
+
+export type GroupsComboboxItem = {
+  content: string;
+  serviceName?: string;
+  selected?: boolean;
+};
 
 type NvmeofRequest = {
   gw_group: string;
@@ -39,6 +46,28 @@ const UI_API_PATH = 'ui-api/nvmeof';
 })
 export class NvmeofService {
   constructor(private http: HttpClient) {}
+
+  // formats the gateway groups to be consumed for combobox item
+  formatGwGroupsList(
+    data: CephServiceSpec[][],
+    isGatewayList: boolean = false
+  ): GroupsComboboxItem[] {
+    return data[0].reduce((gwGrpList: GroupsComboboxItem[], group: CephServiceSpec) => {
+      if (isGatewayList && group?.spec?.group && group?.service_name) {
+        gwGrpList.push({
+          content: group.spec.group,
+          serviceName: group.service_name
+        });
+      } else {
+        if (group?.spec?.group) {
+          gwGrpList.push({
+            content: group.spec.group
+          });
+        }
+      }
+      return gwGrpList;
+    }, []);
+  }
 
   // Gateway groups
   listGatewayGroups() {


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/71247

- after upgrades the nvmeof service spec does not contain `group` field
- this causes UI combobox internal errors
- checking for `group` in spec and disabling the selector

### Before

https://github.com/user-attachments/assets/3fb460d0-7729-403c-89bb-a0e11dba24a7

### After

![image](https://github.com/user-attachments/assets/729411d3-d15e-4817-89f0-d7a081b2b475)

![Screenshot From 2025-05-08 09-46-51](https://github.com/user-attachments/assets/4c38046a-caf7-4ffe-86fa-38ae190c4d96)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
