### PR TITLE
cephfs, tools/cephfs_mirror: migrate from boost::variant to std::variant

### DIFF
--- a/src/include/cephfs/metrics/Types.h
+++ b/src/include/cephfs/metrics/Types.h
@@ -5,7 +5,7 @@
 #define CEPH_INCLUDE_CEPHFS_METRICS_TYPES_H
 
 #include <string>
-#include <boost/variant.hpp>
+#include <variant>
 
 #include "common/Formatter.h"
 #include "include/buffer_fwd.h"
@@ -552,17 +552,17 @@ struct UnknownPayload : public ClientMetricPayloadBase {
   }
 };
 
-typedef boost::variant<CapInfoPayload,
-                       ReadLatencyPayload,
-                       WriteLatencyPayload,
-                       MetadataLatencyPayload,
-                       DentryLeasePayload,
-                       OpenedFilesPayload,
-                       PinnedIcapsPayload,
-                       OpenedInodesPayload,
-                       ReadIoSizesPayload,
-                       WriteIoSizesPayload,
-                       UnknownPayload> ClientMetricPayload;
+typedef std::variant<CapInfoPayload,
+		     ReadLatencyPayload,
+		     WriteLatencyPayload,
+		     MetadataLatencyPayload,
+		     DentryLeasePayload,
+		     OpenedFilesPayload,
+		     PinnedIcapsPayload,
+		     OpenedInodesPayload,
+		     ReadIoSizesPayload,
+		     WriteIoSizesPayload,
+		     UnknownPayload> ClientMetricPayload;
 
 // metric update message sent by clients
 struct ClientMetricMessage {
@@ -571,7 +571,7 @@ public:
     : payload(payload) {
   }
 
-  class EncodePayloadVisitor : public boost::static_visitor<void> {
+  class EncodePayloadVisitor {
   public:
     explicit EncodePayloadVisitor(bufferlist &bl) : m_bl(bl) {
     }
@@ -587,7 +587,7 @@ public:
     bufferlist &m_bl;
   };
 
-  class DecodePayloadVisitor : public boost::static_visitor<void> {
+  class DecodePayloadVisitor {
   public:
     DecodePayloadVisitor(bufferlist::const_iterator &iter) : m_iter(iter) {
     }
@@ -602,7 +602,7 @@ public:
     bufferlist::const_iterator &m_iter;
   };
 
-  class DumpPayloadVisitor : public boost::static_visitor<void> {
+  class DumpPayloadVisitor {
   public:
     explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {
     }
@@ -617,7 +617,7 @@ public:
     Formatter *m_formatter;
   };
 
-  class PrintPayloadVisitor : public boost::static_visitor<void> {
+  class PrintPayloadVisitor {
   public:
     explicit PrintPayloadVisitor(std::ostream *out) : _out(out) {
     }
@@ -636,7 +636,7 @@ public:
   };
 
   void encode(bufferlist &bl) const {
-    boost::apply_visitor(EncodePayloadVisitor(bl), payload);
+    std::visit(EncodePayloadVisitor(bl), payload);
   }
 
   void decode(bufferlist::const_iterator &iter) {
@@ -681,11 +681,11 @@ public:
       break;
     }
 
-    boost::apply_visitor(DecodePayloadVisitor(iter), payload);
+    std::visit(DecodePayloadVisitor(iter), payload);
   }
 
   void dump(Formatter *f) const {
-    apply_visitor(DumpPayloadVisitor(f), payload);
+    std::visit(DumpPayloadVisitor(f), payload);
   }
 
   static void generate_test_instances(std::list<ClientMetricMessage*>& ls) {
@@ -693,7 +693,7 @@ public:
   }
 
   void print(std::ostream *out) const {
-    apply_visitor(PrintPayloadVisitor(out), payload);
+    std::visit(PrintPayloadVisitor(out), payload);
   }
 
   ClientMetricPayload payload;

--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -343,7 +343,7 @@ void MetricsHandler::handle_client_metrics(const cref_t<MClientMetrics> &m) {
   }
 
   for (auto &metric : m->updates) {
-    boost::apply_visitor(HandlePayloadVisitor(this, session), metric.payload);
+    std::visit(HandlePayloadVisitor(this, session), metric.payload);
   }
 }
 

--- a/src/tools/cephfs_mirror/ServiceDaemon.cc
+++ b/src/tools/cephfs_mirror/ServiceDaemon.cc
@@ -19,7 +19,7 @@ namespace mirror {
 
 namespace {
 
-struct AttributeDumpVisitor : public boost::static_visitor<void> {
+struct AttributeDumpVisitor {
   ceph::Formatter *f;
   std::string name;
 
@@ -192,7 +192,7 @@ void ServiceDaemon::update_status() {
       f.dump_string("name", filesystem.fs_name);
       for (auto &[attr_name, attr_value] : filesystem.fs_attributes) {
             AttributeDumpVisitor visitor(&f, attr_name);
-            boost::apply_visitor(visitor, attr_value);
+            std::visit(visitor, attr_value);
       }
       f.open_object_section("peers");
       for (auto &[peer, attributes] : filesystem.peer_attributes) {
@@ -201,7 +201,7 @@ void ServiceDaemon::update_status() {
         f.open_object_section("stats");
         for (auto &[attr_name, attr_value] : attributes) {
             AttributeDumpVisitor visitor(&f, attr_name);
-            boost::apply_visitor(visitor, attr_value);
+            std::visit(visitor, attr_value);
         }
         f.close_section(); // stats
         f.close_section(); // peer.uuid

--- a/src/tools/cephfs_mirror/Types.h
+++ b/src/tools/cephfs_mirror/Types.h
@@ -7,19 +7,18 @@
 #include <set>
 #include <iostream>
 #include <string_view>
+#include <variant>
 
 #include "include/rados/librados.hpp"
 #include "include/cephfs/libcephfs.h"
 #include "mds/mdstypes.h"
-
-#include <boost/variant/variant.hpp>
 
 namespace cephfs {
 namespace mirror {
 
 static const std::string CEPHFS_MIRROR_OBJECT("cephfs_mirror");
 
-typedef boost::variant<bool, uint64_t, std::string> AttributeValue;
+typedef std::variant<bool, uint64_t, std::string> AttributeValue;
 typedef std::map<std::string, AttributeValue> Attributes;
 
 // distinct filesystem identifier


### PR DESCRIPTION
Replacing boost::variant with std::variant throughout the cephfs related codebase. This change is part of our ongoing effort to reduce third-party dependencies by leveraging C++ standard library alternatives where possible.

Benefits include:
- Improved code readability and maintainability
- Reduced external dependency surface
- More consistent API usage with other components





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
