### PR TITLE
squid: mgr/dashboard: fix make check tests

### DIFF
--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -16,7 +16,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook='import sys; sys.path.append("./")'
+init-hook='import sys; sys.path.append("./"); sys.path.append("../../../python-common")'
 
 # Use multiple processes to speed up Pylint.
 jobs=1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71258

---

backport of https://github.com/ceph/ceph/pull/63180
parent tracker: https://tracker.ceph.com/issues/71246

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh