### PR TITLE
tools/cephfs/first-damage: default conf if CEPH_CONF not set

### DIFF
--- a/src/tools/cephfs/first-damage.py
+++ b/src/tools/cephfs/first-damage.py
@@ -56,7 +56,7 @@ MEMO = None
 REMOVE = False
 POOL = None
 NEXT_SNAP = None
-CONF = os.environ.get('CEPH_CONF')
+CONF = os.environ.get('CEPH_CONF', '/etc/ceph/ceph.conf')
 REPAIR_NOSNAP = None
 
 CEPH_NOSNAP = 0xfffffffffffffffe # int64 -2


### PR DESCRIPTION
If $CEPH_CONF isn't set, you get:
```
unable to get monitor info from DNS SRV with service name: ceph-mon 2025-05-08T22:40:06.091-0400 7f604286f1c0 -1 failed for service _ceph-mon._tcp 2025-05-08T22:40:06.091-0400 7f604286f1c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact Traceback (most recent call last):
  File "/root/first-damage.py", line 144, in <module>
    R.connect()
  File "rados.pyx", line 690, in rados.Rados.connect
rados.ObjectNotFound: [errno 2] RADOS object not found (error connecting to the cluster)
```
Make it default to `/etc/ceph/ceph.conf` if the env isn't set.