### PR TITLE
reef: doc/mgr: edit alerts.rst

### DIFF
--- a/doc/mgr/alerts.rst
+++ b/doc/mgr/alerts.rst
@@ -2,57 +2,74 @@ Alerts module
 =============
 
 The alerts module can send simple alert messages about cluster health
-via e-mail.  In the future, it will support other notification methods
+via e-mail. In the future, it will support other notification methods
 as well.
 
 :note: This module is *not* intended to be a robust monitoring
-       solution.  The fact that it is run as part of the Ceph cluster
+       solution. The fact that it is run as part of the Ceph cluster
        itself is fundamentally limiting in that a failure of the
-       ceph-mgr daemon prevents alerts from being sent.  This module
+       ``ceph-mgr`` daemon prevents alerts from being sent. This module
        can, however, be useful for standalone clusters that exist in
-       environments where existing monitoring infrastructure does not
+       environments where other monitoring infrastructure does not
        exist.
 
 Enabling
 --------
 
-The *alerts* module is enabled with::
+Enable the ``alerts`` module by running the following command:
 
-  ceph mgr module enable alerts
+.. prompt:: bash #
+
+   ceph mgr module enable alerts
 
 Configuration
 -------------
 
-To configure SMTP, all of the following config options must be set::
+All of the following config options must be set when configuring SMTP.  When
+setting ``mgr/alerts/smtp_destination``, specify multiple email addresses by
+separating them with commas.
 
-  ceph config set mgr mgr/alerts/smtp_host *<smtp-server>*
-  ceph config set mgr mgr/alerts/smtp_destination *<email-address-to-send-to>*
-  ceph config set mgr mgr/alerts/smtp_sender *<from-email-address>*
+.. prompt:: bash #
 
-By default, the module will use SSL and port 465.  To change that,::
+   ceph config set mgr mgr/alerts/smtp_host *<smtp-server>*
+   ceph config set mgr mgr/alerts/smtp_destination *<email-address-to-send-to>*
+   ceph config set mgr mgr/alerts/smtp_sender *<from-email-address>*
 
-  ceph config set mgr mgr/alerts/smtp_ssl false   # if not SSL
-  ceph config set mgr mgr/alerts/smtp_port *<port-number>*  # if not 465
+The alerts module uses SSL and port 465 by default. These settings can be changed by running commands of the following forms:
 
-To authenticate to the SMTP server, you must set the user and password::
+.. prompt:: bash #
 
-  ceph config set mgr mgr/alerts/smtp_user *<username>*
-  ceph config set mgr mgr/alerts/smtp_password *<password>*
+   ceph config set mgr mgr/alerts/smtp_ssl false   # if not SSL
+   ceph config set mgr mgr/alerts/smtp_port *<port-number>*  # if not 465
 
-By default, the name in the ``From:`` line is simply ``Ceph``.  To
-change that (e.g., to identify which cluster this is),::
+To authenticate to the SMTP server, you must set the user and password:
 
-  ceph config set mgr mgr/alerts/smtp_from_name 'Ceph Cluster Foo'
+.. prompt:: bash #
 
-By default, the module will check the cluster health once per minute
-and, if there is a change, send a message.  To change that
-frequency,::
+   ceph config set mgr mgr/alerts/smtp_user *<username>*
+   ceph config set mgr mgr/alerts/smtp_password *<password>*
 
-  ceph config set mgr mgr/alerts/interval *<interval>*   # e.g., "5m" for 5 minutes
+By default, the name in the ``From:`` line is simply ``Ceph``.  To change this
+default (that is, to identify which cluster this is), run a command of the
+following form:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/alerts/smtp_from_name 'Ceph Cluster Foo'
+
+By default, the alert module checks the cluster health once per minute and
+sends a message if there a change to the cluster's health status. Change the
+frequency of the alert module's cluster health checks by running a command of the following form: 
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/alerts/interval *<interval>*   # e.g., "5m" for 5 minutes
 
 Commands
 --------
 
-To force an alert to be send immediately,::
+To force an alert to be sent immediately, run the following command:
 
-  ceph alerts send
+.. prompt:: bash #
+
+   ceph alerts send


### PR DESCRIPTION
Edit doc/mgr/alerts.rst as part of the project to determine where the error is in https://github.com/ceph/ceph/pull/62782 that prevents the Jenkins tests from passing.

This commit adds to the work done in
https://github.com/ceph/ceph/pull/62782 by correcting some of the English that was present in that PR.

This is a change to one of twenty-five files in
https://github.com/ceph/ceph/pull/62782, and this commit represents one of what will be at least twenty-five other commits made to track this error down.


(cherry picked from commit db28c1f32ff67bd1087866c7976233e8ab23fa2c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
