### PR TITLE
doc/radosgw: Use ref for hyperlinks, 1st batch

### DIFF
--- a/doc/radosgw/account.rst
+++ b/doc/radosgw/account.rst
@@ -1,3 +1,5 @@
+.. _radosgw-account:
+
 ===============
  User Accounts
 ===============

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -14,7 +14,7 @@ Ceph Object Storage user management refers only to users of the Ceph Object
 Storage service and not to the Ceph Object Gateway as a user of the Ceph
 Storage Cluster. Create a user, access key, and secret key to enable end users
 to interact with Ceph Object Gateway services. Optionally, the users can belong
-to `Accounts`_ for ease of management.
+to :ref:`Accounts <radosgw-account>` for ease of management.
 
 There are two types of user: 
 
@@ -364,7 +364,7 @@ To remove a Swift secret key, run a command of the following form:
 Add or Remove Admin Capabilities
 --------------------------------
 
-The Ceph Storage Cluster provides an `Admin Ops API`_ that enables users to
+The Ceph Storage Cluster provides an :ref:`Admin Ops API <radosgw admin ops>` that enables users to
 execute administrative functions via the REST API. By default, users do NOT
 have access to this API. To enable a user to exercise administrative
 functionality, provide the user with administrative capabilities.
@@ -404,7 +404,7 @@ Users with the ``--admin`` or ``--system`` flag have global read and write
 permissions. These permissions apply to all APIs including S3 and Swift,
 unlike Admin Capabilities, and cannot be denied by IAM policy.
 
-The ``--system`` flag should only be used as documented in `Multisite Configuration`_.
+The ``--system`` flag should only be used as documented in :ref:`Multisite Configuration <multisite>`.
 
 The ``--admin`` flag can be useful for troubleshooting and recovery. For
 example, if a user accidentally removes their permissions to a bucket or
@@ -572,8 +572,7 @@ quota is set for all subsequently-created users, and that quota is enabled. See
 ``rgw_bucket_default_quota_max_objects``,
 ``rgw_bucket_default_quota_max_size``, ``rgw_user_default_quota_max_objects``,
 ``rgw_user_default_quota_max_size``, ``rgw_account_default_quota_max_objects``,
-and ``rgw_account_default_quota_max_size`` in `Ceph Object Gateway Config
-Reference`_.
+and ``rgw_account_default_quota_max_size`` in :ref:`radosgw-config-ref`.
 
 Quota Cache
 -----------
@@ -595,7 +594,7 @@ the multiple RGW instances closer to perfect quota synchronization.
 
 If all three values are set to ``0`` , then quota caching is effectively
 disabled, and multiple instances will have perfect quota enforcement.  See
-`Ceph Object Gateway Config Reference`_.
+:ref:`radosgw-config-ref`.
 
 Reading / Writing Global Quotas
 -------------------------------
@@ -929,10 +928,3 @@ example commands:
    radosgw-admin usage trim --uid=johndoe	
    radosgw-admin usage trim --uid=johndoe --end-date=2013-12-31
 
-
-.. _radosgw-admin: ../../man/8/radosgw-admin/
-.. _Pool Configuration: ../../rados/configuration/pool-pg-config-ref/
-.. _Ceph Object Gateway Config Reference: ../config-ref/
-.. _Accounts: ../account/
-.. _Admin Ops API: ../adminops/
-.. _Multisite Configuration: ../multisite/

--- a/doc/radosgw/cloud-transition.rst
+++ b/doc/radosgw/cloud-transition.rst
@@ -147,7 +147,7 @@ How to Configure
 
 See :ref:`adding_a_storage_class` for how to configure storage-class for a zonegroup. The cloud transition requires a creation of a special storage class with tier type defined as ``cloud-s3`` or ``cloud-s3-glacier``
 
-.. note:: If you have not performed previous `Multisite Configuration`_,
+.. note:: If you have not performed previous :ref:`Multisite Configuration <multisite>`,
           a ``default`` zone and zonegroup are created for you, and changes
           to the zone/zonegroup will not take effect until the Ceph Object
           Gateways (RGW daemons) are restarted. If you have created a realm for multisite,
@@ -426,5 +426,3 @@ Future Work
 * Support s3:RestoreObject operation on cloud transitioned objects.
 
 * Support transition to other cloud providers (like Azure).
-
-.. _`Multisite Configuration`: ../multisite

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -1,3 +1,5 @@
+.. _radosgw-config-ref:
+
 ======================================
  Ceph Object Gateway Config Reference
 ======================================

--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -7,7 +7,7 @@ HTTP Frontends
 .. contents::
 
 The Ceph Object Gateway supports two embedded HTTP frontend libraries
-that can be configured with ``rgw_frontends``. See `Config Reference`_
+that can be configured with ``rgw_frontends``. See :ref:`radosgw-config-ref`
 for details about the syntax.
 
 Beast
@@ -161,5 +161,3 @@ Some frontend options are generic and supported by all frontends:
 :Type: String
 :Default: None
 
-
-.. _Config Reference: ../config-ref


### PR DESCRIPTION
Use validated `:ref:` hyperlinks instead of "external links" in "target definitions" when linking within the Ceph docs:
- Add a label at beginning of referenced files if missing.
- Remove unused "target definitions".

Hyperlinks were changed to `:ref:`s in three files: `admin.rst` `cloud-transition.rst` `frontends.rst`.  
After editing it was confirmed that no occurrences of "`_" using the old target definitions remained in the file.  
The other two modified files had label added at the beginning of the file.

The rendered PR should look mostly the same as the old docs, only differing in the source RST.  
One link text is changed from "Config Reference" to the full automatic section title "Ceph Object Gateway Config Reference" which seems fine.

Labels for `account.rst` and `frontends.rst` was chosen based on existing labels on other `doc/radosgw/` files. While some use spaces and some use hyphens, the latter was chosen in this case.

To make sure no standard links remained in the 

- Before: https://docs.ceph.com/en/latest/radosgw/admin/ https://docs.ceph.com/en/latest/radosgw/cloud-transition/#how-to-configure https://docs.ceph.com/en/latest/radosgw/frontends/
- Rendered PR: https://ceph--63205.org.readthedocs.build/en/63205/radosgw/admin/ https://ceph--63205.org.readthedocs.build/en/63205/radosgw/cloud-transition/#how-to-configure https://ceph--63205.org.readthedocs.build/en/63205/radosgw/frontends/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
