### PR TITLE
squid: doc/mgr: edit administrator.rst

### DIFF
--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -10,31 +10,37 @@ Usually, you would set up a ceph-mgr daemon using a tool such
 as ceph-ansible.  These instructions describe how to set up
 a ceph-mgr daemon manually.
 
-First, create an authentication key for your daemon::
+First, create an authentication key for your daemon:
 
-    ceph auth get-or-create mgr.$name mon 'allow profile mgr' osd 'allow *' mds 'allow *'
+.. prompt:: bash #
 
-Place that key as file named ``keyring`` into ``mgr data`` path, which for a cluster "ceph"
-and mgr $name "foo" would be ``/var/lib/ceph/mgr/ceph-foo`` respective ``/var/lib/ceph/mgr/ceph-foo/keyring``.
+   ``ceph auth get-or-create mgr.$name mon 'allow profile mgr' osd 'allow *' mds 'allow *'``
 
-Start the ceph-mgr daemon::
+Place that key as file named ``keyring`` into ``mgr data`` path, which for a
+cluster "ceph" and mgr $name "foo" would be ``/var/lib/ceph/mgr/ceph-foo``
+respective ``/var/lib/ceph/mgr/ceph-foo/keyring``.
 
-    ceph-mgr -i $name
+Start the ceph-mgr daemon:
 
-Check that the mgr has come up by looking at the output
-of ``ceph status``, which should now include a mgr status line::
+.. prompt:: bash #
+
+   ceph-mgr -i $name
+
+Check that the mgr has come up by looking at the output of ``ceph status``,
+which should now include a mgr status line::
 
     mgr active: $name
 
 Client authentication
 ---------------------
 
-The manager is a new daemon which requires new CephX capabilities. If you upgrade
-a cluster from an old version of Ceph, or use the default install/deploy tools,
-your admin client should get this capability automatically. If you use tooling from
-elsewhere, you may get EACCES errors when invoking certain ceph cluster commands.
-To fix that, add a "mgr allow \*" stanza to your client's cephx capabilities by
-`Modifying User Capabilities`_.
+The manager is a new daemon which requires new CephX capabilities. If you
+upgrade a cluster from an old version of Ceph, or use the default
+install/deploy tools, your admin client should get this capability
+automatically. If you use tooling from elsewhere, you may get EACCES errors
+when invoking certain ceph cluster commands.  To fix that, add a ``mgr allow
+\*`` stanza to your client's cephx capabilities by `Modifying User
+Capabilities`_.
 
 High availability
 -----------------
@@ -66,38 +72,40 @@ issues when requesting large structures. As an example, an OSDMap with 1000 osds
 has a approximate size of 4MiB. With heavy load, on a 3000 osd cluster there has
 been a 1.5x improvement enabling the cache.
 
-Furthermore, you can run ``ceph daemon mgr.${MGRNAME} perf dump`` to retrieve perf
-counters of a mgr module. In ``mgr.cache_hit`` and ``mgr.cache_miss`` you'll find the
-hit/miss ratio of the mgr cache.
+Furthermore, you can run ``ceph daemon mgr.${MGRNAME} perf dump`` to retrieve
+perf counters of a mgr module. In ``mgr.cache_hit`` and ``mgr.cache_miss``
+you'll find the hit/miss ratio of the mgr cache.
 
 Using modules
 -------------
 
-Use the command ``ceph mgr module ls`` to see which modules are
-available, and which are currently enabled. Use ``ceph mgr module ls --format=json-pretty``
-to view detailed metadata about disabled modules. Enable or disable modules
-using the commands ``ceph mgr module enable <module>`` and
-``ceph mgr module disable <module>`` respectively.
+Use the command ``ceph mgr module ls`` to see which modules are available, and
+which are currently enabled. Use ``ceph mgr module ls --format=json-pretty`` to
+view detailed metadata about disabled modules. Enable or disable modules using
+the commands ``ceph mgr module enable <module>`` and ``ceph mgr module disable
+<module>`` respectively.
 
-If a module is *enabled* then the active ceph-mgr daemon will load
-and execute it.  In the case of modules that provide a service,
-such as an HTTP server, the module may publish its address when it
-is loaded.  To see the addresses of such modules, use the command
-``ceph mgr services``.
+If a module is *enabled* then the active ceph-mgr daemon will load and execute
+it.  In the case of modules that provide a service, such as an HTTP server, the
+module may publish its address when it is loaded.  To see the addresses of such
+modules, use the command ``ceph mgr services``.
 
-Some modules may also implement a special standby mode which runs on
-standby ceph-mgr daemons as well as the active daemon.  This enables
-modules that provide services to redirect their clients to the active
-daemon, if the client tries to connect to a standby.
+Some modules may also implement a special standby mode which runs on standby
+ceph-mgr daemons as well as the active daemon.  This enables modules that
+provide services to redirect their clients to the active daemon, if the client
+tries to connect to a standby.
 
 Consult the documentation pages for individual manager modules for more
 information about what functionality each module provides.
 
 Here is an example of enabling the :term:`Dashboard` module:
 
+.. prompt:: bash $
+
+   ceph mgr module ls
+
 .. code-block:: console
 
-	$ ceph mgr module ls
 	{
 		"enabled_modules": [
 			"restful",
@@ -108,8 +116,14 @@ Here is an example of enabling the :term:`Dashboard` module:
 		]
 	}
 
-	$ ceph mgr module enable dashboard
-	$ ceph mgr module ls
+
+.. prompt:: bash $
+
+   ceph mgr module enable dashboard
+   ceph mgr module ls
+
+.. code-block:: console
+
 	{
 		"enabled_modules": [
 			"restful",
@@ -120,7 +134,12 @@ Here is an example of enabling the :term:`Dashboard` module:
 		]
 	}
 
-	$ ceph mgr services
+.. prompt:: bash $
+
+   ceph mgr services
+
+.. code-block:: console
+
 	{
 		"dashboard": "http://myserver.com:7789/",
 		"restful": "https://myserver.com:8789/"
@@ -128,11 +147,10 @@ Here is an example of enabling the :term:`Dashboard` module:
 
 
 The first time the cluster starts, it uses the :confval:`mgr_initial_modules`
-setting to override which modules to enable.  However, this setting
-is ignored through the rest of the lifetime of the cluster: only
-use it for bootstrapping.  For example, before starting your
-monitor daemons for the first time, you might add a section like
-this to your ``ceph.conf``:
+setting to override which modules to enable.  However, this setting is ignored
+through the rest of the lifetime of the cluster: only use it for bootstrapping.
+For example, before starting your monitor daemons for the first time, you might
+add a section like this to your ``ceph.conf``:
 
 .. code-block:: ini
 
@@ -160,9 +178,11 @@ Calling module commands
 Where a module implements command line hooks, the commands will
 be accessible as ordinary Ceph commands.  Ceph will automatically incorporate
 module commands into the standard CLI interface and route them appropriately to
-the module.::
+the module.:
 
-    ceph <command | help>
+.. prompt:: bash #
+
+   ceph <command | help>
 
 Configuration
 -------------


### PR DESCRIPTION
Edit doc/mgr/administrator.rst. Add prompts and correct some of the inelegant English present in the file.

This commit is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.

Credit for this initiative should go to Ville Ojamo.


(cherry picked from commit 859950180f0b7314b097ee9b2f9f192f4cfb3ed4)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
