### PR TITLE
tentacle: crimson/os/seastore/cache/LRU: account the empty extent when adding it to LRU

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1641,7 +1641,6 @@ private:
         // absent, add to top (back)
         if (extent_loaded_length > 0) {
           current_size += extent_loaded_length;
-          get_by_ext(sizes_by_ext, extent.get_type()).account_in(extent_loaded_length);
           overall_io.in_sizes.account_in(extent_loaded_length);
           if (p_src) {
             get_by_ext(
@@ -1651,6 +1650,7 @@ private:
           }
         } // else: the extent isn't loaded upon touch_extent()/on_cache(),
           //       account the io later in increase_cached_size() upon read_extent()
+	get_by_ext(sizes_by_ext, extent.get_type()).account_in(extent_loaded_length);
         intrusive_ptr_add_ref(&extent);
         lru.push_back(extent);
 
@@ -1669,7 +1669,7 @@ private:
         // present, increase size
         assert(lru.size() > 0);
         current_size += increased_length;
-        get_by_ext(sizes_by_ext, extent.get_type()).account_in(increased_length);
+        get_by_ext(sizes_by_ext, extent.get_type()).account_parital_in(increased_length);
         overall_io.in_sizes.account_in(increased_length);
         if (p_src) {
           get_by_ext(

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2874,6 +2874,10 @@ struct cache_size_stats_t {
     ++num_extents;
   }
 
+  void account_parital_in(extent_len_t sz) {
+    size += sz;
+  }
+
   void account_out(extent_len_t sz) {
     assert(size >= sz);
     assert(num_extents > 0);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71273

---

backport of https://github.com/ceph/ceph/pull/62969
parent tracker: https://tracker.ceph.com/issues/69986

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh