### PR TITLE
doc/radosgw: Use ref for hyperlinks, 2nd batch

### DIFF
--- a/doc/radosgw/barbican.rst
+++ b/doc/radosgw/barbican.rst
@@ -3,7 +3,7 @@ OpenStack Barbican Integration
 ==============================
 
 OpenStack `Barbican`_ can be used as a secure key management service for
-`Server-Side Encryption`_.
+:ref:`Server-Side Encryption <radosgw-encryption>`.
 
 .. image:: ../images/rgw-encryption-barbican.png
 
@@ -17,7 +17,7 @@ Configure Keystone
 
 Barbican depends on Keystone for authorization and access control of its keys.
 
-See `OpenStack Keystone Integration`_.
+See :ref:`OpenStack Keystone Integration <radosgw-keystone>`.
 
 Create a Keystone user
 ======================
@@ -115,8 +115,6 @@ When using API version 3::
 
 
 .. _Barbican: https://wiki.openstack.org/wiki/Barbican
-.. _Server-Side Encryption: ../encryption
-.. _OpenStack Keystone Integration: ../keystone
 .. _Manage projects, users, and roles: https://docs.openstack.org/admin-guide/cli-manage-projects-users-and-roles.html#create-a-user
 .. _How to Create a Secret: https://developer.openstack.org/api-guide/key-manager/secrets.html#how-to-create-a-secret
 .. _SSE-KMS: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html

--- a/doc/radosgw/compression.rst
+++ b/doc/radosgw/compression.rst
@@ -1,3 +1,5 @@
+.. _radosgw-compression:
+
 ===========
 Compression
 ===========
@@ -7,7 +9,7 @@ Compression
 The Ceph Object Gateway supports server-side compression of uploaded objects.
 
 .. note:: The Reef release added a :ref:`feature_compress_encrypted` zonegroup
-   feature to enable compression with `Server-Side Encryption`_.
+   feature to enable compression with :ref:`Server-Side Encryption <radosgw-encryption>`.
 
 Supported compression plugins include the following:
 
@@ -76,7 +78,7 @@ For example:
   }
 
 .. note:: A ``default`` zone is created for you if you have not done any
-   previous `Multisite Configuration`_.
+   previous :ref:`Multisite Configuration <multisite>`.
 
 
 Statistics
@@ -113,6 +115,3 @@ uncompressed data.
 The ``size_utilized`` and ``size_kb_utilized`` fields represent the total
 size of compressed data, in bytes and kilobytes respectively.
 
-
-.. _`Server-Side Encryption`: ../encryption
-.. _`Multisite Configuration`: ../multisite

--- a/doc/radosgw/d3n_datacache.rst
+++ b/doc/radosgw/d3n_datacache.rst
@@ -57,8 +57,8 @@ Requirements
 Limitations
 -----------
 
-- D3N will not cache objects compressed by `Rados Gateway Compression`_ (OSD level compression is supported).
-- D3N will not cache objects encrypted by `Rados Gateway Encryption`_.
+- D3N will not cache objects compressed by :ref:`RADOS Gateway Compression <radosgw-compression>` (OSD level compression is supported).
+- D3N will not cache objects encrypted by :ref:`RADOS Gateway Encryption <radosgw-encryption>`.
 - D3N will be disabled if the ``rgw_max_chunk_size`` config variable value differs from the ``rgw_obj_stripe_size`` config variable value.
 
 
@@ -125,7 +125,5 @@ The following D3N related settings can be added to the Ceph configuration file
 
 .. _MOC D3N (Datacenter-scale Data Delivery Network): https://massopen.cloud/research-and-development/cloud-research/d3n/
 .. _Red Hat Research D3N Cache for Data Centers: https://research.redhat.com/blog/research_project/d3n-multilayer-cache/
-.. _Rados Gateway Compression: ../compression/
-.. _Rados Gateway Encryption: ../encryption/
 .. _RGW Data cache and CDN: ../rgw-cache/
 .. _Service Management - Mounting Files with Extra Container Arguments: ../cephadm/services/#mounting-files-with-extra-container-arguments

--- a/doc/radosgw/encryption.rst
+++ b/doc/radosgw/encryption.rst
@@ -1,3 +1,5 @@
+.. _radosgw-encryption:
+
 ==========
 Encryption
 ==========

--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -1,3 +1,5 @@
+.. _radosgw-keystone:
+
 =====================================
  Integrating with OpenStack Keystone
 =====================================

--- a/doc/radosgw/kmip.rst
+++ b/doc/radosgw/kmip.rst
@@ -3,7 +3,7 @@ KMIP Integration
 ================
 
 `KMIP`_ can be used as a secure key management service for
-`Server-Side Encryption`_ (SSE-KMS).
+:ref:`Server-Side Encryption <radosgw-encryption>` (SSE-KMS).
 
 .. ditaa::
 
@@ -53,15 +53,15 @@ here,
 1. `IBM Security Guardium Key Lifecycle Manager (SKLM)`__.  This is a well
    supported commercial product.
 
-__ SKLM_
-
-2. PyKMIP_.  This is a small python project, suitable for experimental
+2. `PyKMIP`_.  This is a small python project, suitable for experimental
    and testing use only.
+
+__ SKLM_
 
 Using IBM SKLM
 --------------
 
-IBM SKLM__ supports client authentication using certificates.
+IBM `SKLM`_ supports client authentication using certificates.
 Certificates may either be self-signed certificates created,
 for instance, using openssl, or certificates may be created
 using SKLM.  Ceph should then be configured (see below) to
@@ -69,8 +69,6 @@ use KMIP and an attempt made to use it.  This will fail,
 but it will leave an "untrusted client device certificate" in SKLM.
 This can be then upgraded to a registered client using the web
 interface to complete the registration process.
-
-__ SKLM_
 
 Find untrusted clients under ``Advanced Configuration``,
 ``Client Device Communication Certificates``.  Select
@@ -80,7 +78,7 @@ Find untrusted clients under ``Advanced Configuration``,
 Using PyKMIP 
 ------------
 
-PyKMIP_ has no special registration process, it simply
+`PyKMIP`_ has no special registration process, it simply
 trusts the certificate.  However, the certificate has to
 be issued by a certificate authority that is trusted by
 pykmip.  PyKMIP also prefers that the certificate contain
@@ -213,7 +211,6 @@ radosgw would fetch the secret from::
 
   pykmip-mybucketkey
 
-.. _Server-Side Encryption: ../encryption
 .. _KMIP: http://www.oasis-open.org/committees/kmip/
 .. _SKLM: https://www.ibm.com/products/ibm-security-key-lifecycle-manager
 .. _PyKMIP: https://pykmip.readthedocs.io/en/latest/

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -99,7 +99,7 @@ At the bottom of this diagram, we see the data distributed into the Ceph
 Storage Cluster.
 
 For additional details on setting up a cluster, see `Ceph Object Gateway for
-Production <https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/ceph_object_gateway_for_production/index/>`__.
+Production <https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/ceph_object_gateway_for_production/index/>`_.
 
 Functional Changes from Infernalis
 ==================================

--- a/doc/radosgw/s3/authentication.rst
+++ b/doc/radosgw/s3/authentication.rst
@@ -42,7 +42,7 @@ In a radosgw instance that is configured with authentication against
 OpenStack Keystone, it is possible to use Keystone as an authoritative
 source for S3 API authentication. To do so, you must set:
 
-* the ``rgw keystone`` configuration options explained in :doc:`../keystone`,
+* the ``rgw keystone`` configuration options explained in :ref:`radosgw-keystone`,
 * ``rgw s3 auth use keystone = true``.
 
 In addition, a user wishing to use the S3 API must obtain an AWS-style
@@ -66,7 +66,7 @@ access to radosgw.
 
 .. note:: Consider that most production radosgw deployments
           authenticating against OpenStack Keystone are also set up
-          for :doc:`../multitenancy`, for which special
+          for :ref:`rgw-multitenancy`, for which special
           considerations apply with respect to S3 signed URLs and
           public read ACLs.
 

--- a/doc/radosgw/vault.rst
+++ b/doc/radosgw/vault.rst
@@ -3,7 +3,7 @@ HashiCorp Vault Integration
 ===========================
 
 HashiCorp `Vault`_ can be used as a secure key management service for
-`Server-Side Encryption`_ (SSE-KMS).
+:ref:`Server-Side Encryption <radosgw-encryption>` (SSE-KMS).
 
 .. ditaa::
 
@@ -430,7 +430,6 @@ In the transit engine example above, the Object Gateway would encrypt the secret
 
   http://vaultserver:8200/v1/transit/mybucketkey
 
-.. _Server-Side Encryption: ../encryption
 .. _Vault: https://www.vaultproject.io/docs/
 .. _Token authentication method: https://www.vaultproject.io/docs/auth/token.html
 .. _Vault agent: https://www.vaultproject.io/docs/agent/index.html

--- a/doc/radosgw/zone-features.rst
+++ b/doc/radosgw/zone-features.rst
@@ -41,8 +41,8 @@ of its RGWs and OSDs have upgraded.
 compress-encrypted
 ~~~~~~~~~~~~~~~~~~
 
-This feature enables support for combining `Server-Side Encryption`_ and
-`Compression`_ on the same object. Object data gets compressed before encryption.
+This feature enables support for combining :ref:`Server-Side Encryption <radosgw-encryption>` and
+:ref:`radosgw-compression` on the same object. Object data gets compressed before encryption.
 Prior to Reef, multisite would not replicate such objects correctly, so all zones
 must upgrade to Reef or later before enabling.
 
@@ -112,6 +112,3 @@ On any cluster in the realm:
    radosgw-admin zonegroup modify --rgw-zonegroup={zonegroup-name} --disable-feature={feature-name}
    radosgw-admin period update --commit
 
-
-.. _`Server-Side Encryption`: ../encryption
-.. _`Compression`: ../compression


### PR DESCRIPTION
Use validated ":ref:" hyperlinks instead of "external links" in "target definitions" when linking within the Ceph docs:
- Add a label at beginning of referenced files if missing.
- Remove unused "target definitions".
- Updated links targeting files: compression encryption keystone

Cleaned hyperlinks usage in `kmip.rst`:
- Some links were using anonymous links (double underscore) unnecessarily (also in `multisite.rst`).
- Some links were not using backticks, add for consistency.
- Move anonymous link definition to after the ordered list to avoid unnecessary empty line between list items.

Use an already existing label for 2 intra-docs links that used full URLs in `multisite.rst` `pools.rst`.  
Use an already existing label for intra-docs link instead of file name reference in `s3/authentication.rst`.

Capitalize RADOS Gateway right in 2 links in `d3n_datacache.rst`.
Otherwise the rendered PR should look the same as the old docs, only differing in the source RST.

After editing it was confirmed that no occurrences of "`_" using the old target definitions remained in the file.

Labels for `compression.rst` `encryption.rst` and `keystone.rst` was chosen based on existing labels on other `doc/` files. While some use spaces or underscores and some use hyphens, the latter was chosen in this case.

- Before:
  - https://docs.ceph.com/en/latest/radosgw/barbican/
  - https://docs.ceph.com/en/latest/radosgw/compression/
  - https://docs.ceph.com/en/latest/radosgw/d3n_datacache/#limitations
  - https://docs.ceph.com/en/latest/radosgw/kmip/
  - https://docs.ceph.com/en/latest/radosgw/multisite/#setting-a-zone
  - https://docs.ceph.com/en/latest/radosgw/s3/authentication/#authentication-against-openstack-keystone
  - https://docs.ceph.com/en/latest/radosgw/vault/
  - https://docs.ceph.com/en/latest/radosgw/zone-features/#feature-compress-encrypted
- Rendered PR:
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/barbican/
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/compression/
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/d3n_datacache/#limitations
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/kmip/
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/multisite/#setting-a-zone
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/s3/authentication/#authentication-against-openstack-keystone
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/vault/
  - https://ceph--63227.org.readthedocs.build/en/63227/radosgw/zone-features/#feature-compress-encrypted





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
