### PR TITLE
squid: cls/rbd: write image mirror status if state is CREATING

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -5070,7 +5070,8 @@ int image_status_set(cls_method_context_t hctx, const string &global_image_id,
   if (r < 0) {
     return 0;
   }
-  if (mirror_image.state != cls::rbd::MIRROR_IMAGE_STATE_ENABLED) {
+  if (mirror_image.state != cls::rbd::MIRROR_IMAGE_STATE_ENABLED &&
+      mirror_image.state != cls::rbd::MIRROR_IMAGE_STATE_CREATING) {
     return 0;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71240

---

backport of https://github.com/ceph/ceph/pull/63050
parent tracker: https://tracker.ceph.com/issues/71138

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh