### PR TITLE
squid: integrate blockdiff with cephfs-mirror daemon

### DIFF
--- a/qa/suites/fs/mirror/overrides/ignorelist_health.yaml
+++ b/qa/suites/fs/mirror/overrides/ignorelist_health.yaml
@@ -1,1 +1,29 @@
-./.qa/cephfs/overrides/ignorelist_health.yaml
+overrides:
+  ceph:
+    log-ignorelist:
+      - FS_DEGRADED
+      - fs.*is degraded
+      - filesystem is degraded
+      - FS_INLINE_DATA_DEPRECATED
+      - FS_WITH_FAILED_MDS
+      - MDS_ALL_DOWN
+      - filesystem is offline
+      - is offline because no MDS
+      - MDS_DAMAGE
+      - MDS_DEGRADED
+      - MDS_FAILED
+      - MDS_INSUFFICIENT_STANDBY
+      - insufficient standby MDS daemons available
+      - MDS_UP_LESS_THAN_MAX
+      - online, but wants
+      - filesystem is online with fewer MDS than max_mds
+      - POOL_APP_NOT_ENABLED
+      - do not have an application enabled
+      - overall HEALTH_
+      - Replacing daemon
+      - deprecated feature inline_data
+      - BLUESTORE_SLOW_OP_ALERT
+      - slow operation indications in BlueStore
+      - experiencing slow operations in BlueStore
+      - MGR_MODULE_ERROR
+      - OSD_NEARFULL

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1584,3 +1584,53 @@ class TestMirroring(CephFSTestCase):
                    expected_snap_count == res[dir_name]['snaps_synced']):
                     break
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_sync_already_existing_snapshots(self):
+        """
+        That mirroring syncs the already existing snapshot correctly.
+        """
+        log.debug('reconfigure client auth caps')
+        self.get_ceph_cmd_result(
+            'auth', 'caps', "client.{0}".format(self.mount_b.client_id),
+                'mds', 'allow rw',
+                'mon', 'allow r',
+                'osd', 'allow rw pool={0}, allow rw pool={1}'.format(
+                    self.backup_fs.get_data_pool_name(),
+                    self.backup_fs.get_data_pool_name()))
+
+        log.debug(f'mounting filesystem {self.secondary_fs_name}')
+        self.mount_b.umount_wait()
+        self.mount_b.mount_wait(cephfs_name=self.secondary_fs_name)
+
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name)
+
+        dir_name = 'dir'
+
+        # make some change in the fs and take a snapshot
+        snap_a = "snap_a"
+        self.mount_a.run_shell(['mkdir', '-p', f'{dir_name}/d1'])
+        self.mount_a.write_n_mb(os.path.join(f'{dir_name}/d1', 'file1'), 1)
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_a}'])
+
+        # make some more changes in the fs and take another snapshot
+        snap_b = "snap_b"
+        self.mount_a.write_n_mb(os.path.join(f'{dir_name}/d1', 'file2'), 1)
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_b}'])
+
+        # make another change in the fs and don't take snapshot
+        self.mount_a.run_shell(['rm', f'{dir_name}/d1/file2'])
+
+        # add the directory for mirroring
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}')
+
+        time.sleep(60)
+
+        # confirm snapshot synced and status 'idle'
+        expected_snap_count = 2
+        self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                    peer_spec, f'/{dir_name}', snap_b, expected_snap_count)
+        self.verify_snapshot(dir_name, snap_a)
+        self.verify_snapshot(dir_name, snap_b)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -657,7 +657,7 @@ class TestMirroring(CephFSTestCase):
 
         # create a bunch of files in a directory to snap
         self.mount_a.run_shell(["mkdir", "d0"])
-        for i in range(8):
+        for i in range(100):
             filename = f'file.{i}'
             self.mount_a.write_n_mb(os.path.join('d0', filename), 1024)
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9968,7 +9968,7 @@ int Client::file_blockdiff(struct scan_state_t *state, const UserPerm &perms,
     cct->_conf.get_val<uint64_t>("client_file_blockdiff_max_concurrent_object_scans");
 
   bufferlist bl;
-  r = make_request(req, perms, nullptr, nullptr, -1, &bl);
+  r = make_request(req, perms, nullptr, nullptr, -1, &bl, CEPHFS_FEATURE_BLOCKDIFF);
   ldout(cct, 10) << __func__ << ": result=" << r << dendl;
 
   if (r < 0) {

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9852,6 +9852,144 @@ int Client::readdirplus_r(dir_result_t *d, struct dirent *de,
   return 0;
 }
 
+static void cleanup_state(Client *client, struct scan_state_t *sst)
+{
+  if (sst->fd1 != -1) {
+    client->_close(sst->fd1);
+  }
+  if (sst->fd2 != -1) {
+    client->_close(sst->fd2);
+  }
+  delete sst;
+}
+
+int Client::file_blockdiff_init_state(const char* path1, const char* path2,
+				      const UserPerm &perms, struct scan_state_t **state)
+{
+  ldout(cct, 20) << __func__ << dendl;
+
+  InodeRef inode1, inode2;
+  scan_state_t *sst = new scan_state_t();
+  sst->fd1 = sst->fd2 = -1;
+
+  /*
+   * lets have a constraint that both snapshot paths should be
+   * present - otherwise the caller should do a full copy or a
+   * delete on the path.
+   */
+  int r = open(path1, O_RDONLY, perms, 0);
+  if (r < 0) {
+    return r;
+  }
+  sst->fd1 = r;
+
+  r = open(path2, O_RDONLY, perms, 0);
+  if (r < 0) {
+    cleanup_state(this, sst);
+    return r;
+  }
+  sst->fd2 = r;
+
+  std::unique_lock lock(client_lock);
+  r = get_fd_inode(sst->fd1, &inode1);
+  if (r < 0) {
+    cleanup_state(this, sst);
+    return r;
+  }
+  r = get_fd_inode(sst->fd2, &inode2);
+  if (r < 0) {
+    cleanup_state(this, sst);
+    return r;
+  }
+
+  ldout(cct, 20) << __func__ << ": (snapid1, ino1, size)=(" << inode1->snapid
+		 << "," << std::hex << inode1->ino << std::dec << ","
+		 << inode1->size <<")" << " (snapid2, ino2, size)=("
+		 << inode2->snapid << "," << std::hex << inode2->ino << std::dec
+		 << "," << inode2->size << ")" << dendl;
+  if (inode1->ino != inode2->ino) {
+    cleanup_state(this, sst);
+    return -EINVAL;
+  }
+
+  sst->index = 0;
+  *state = sst;
+  return 0;
+}
+
+int Client::file_blockdiff_finish(struct scan_state_t *state)
+{
+  std::unique_lock lock(client_lock);
+
+  _close(state->fd1);
+  _close(state->fd2);
+  delete state;
+  return 0;
+}
+
+int Client::file_blockdiff(struct scan_state_t *state, const UserPerm &perms,
+			   std::vector<std::pair<uint64_t,uint64_t>> *blocks)
+{
+  RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
+  if (!mref_reader.is_state_satisfied()) {
+    return -ENOTCONN;
+  }
+
+  ldout(cct, 20) << __func__ << dendl;
+
+  InodeRef inode1;
+  InodeRef inode2;
+
+  std::unique_lock lock(client_lock);
+
+  int r = get_fd_inode(state->fd1, &inode1);
+  if (r < 0) {
+    return r;
+  }
+  r = get_fd_inode(state->fd2, &inode2);
+  if (r < 0) {
+    return r;
+  }
+
+  ceph_assert(inode1->ino == inode2->ino);
+
+  MetaRequest *req = new MetaRequest(CEPH_MDS_OP_FILE_BLOCKDIFF);
+
+  filepath path1, path2;
+  inode1->make_nosnap_relative_path(path1);
+  req->set_filepath(path1);
+
+  inode2->make_nosnap_relative_path(path2);
+  req->set_filepath2(path2);
+  req->set_inode(inode2.get());
+
+  req->head.args.blockdiff.scan_idx = state->index;
+  req->head.args.blockdiff.max_objects =
+    cct->_conf.get_val<uint64_t>("client_file_blockdiff_max_concurrent_object_scans");
+
+  bufferlist bl;
+  r = make_request(req, perms, nullptr, nullptr, -1, &bl);
+  ldout(cct, 10) << __func__ << ": result=" << r << dendl;
+
+  if (r < 0) {
+    return r;
+  }
+
+  BlockDiff block_diff;
+  auto p = bl.cbegin();
+  decode(block_diff, p);
+
+  ldout(cct, 10) << __func__ << ": block_diff=" << block_diff << dendl;
+  if (!block_diff.blocks.empty()) {
+    for (auto &block : block_diff.blocks) {
+      blocks->emplace_back(std::make_pair(block.first, block.second));
+    }
+  }
+
+  state->index = block_diff.scan_idx;
+  return block_diff.rval;
+}
+
 int Client::readdir_snapdiff(dir_result_t* d1, snapid_t snap2,
                              struct dirent* out_de,
                              snapid_t* out_snap)

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -144,6 +144,12 @@ class ceph_lock_state_t;
 // ========================================================
 // client interface
 
+struct scan_state_t {
+  int fd1;
+  int fd2;
+  uint64_t index;
+};
+
 struct dir_result_t {
   static const int SHIFT = 28;
   static const int64_t MASK = (1 << SHIFT) - 1;
@@ -364,6 +370,12 @@ public:
   struct dirent * readdir(dir_result_t *d);
   int readdir_r(dir_result_t *dirp, struct dirent *de);
   int readdirplus_r(dir_result_t *dirp, struct dirent *de, struct ceph_statx *stx, unsigned want, unsigned flags, Inode **out);
+
+  int file_blockdiff_init_state(const char *path1, const char *path2,
+				const UserPerm &perms, struct scan_state_t **state);
+  int file_blockdiff(struct scan_state_t *state, const UserPerm &perms,
+		     std::vector<std::pair<uint64_t,uint64_t>> *blocks);
+  int file_blockdiff_finish(struct scan_state_t *state);
 
   /*
    * Get the next snapshot delta entry.

--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -322,6 +322,7 @@ const char *ceph_mds_op_name(int op)
 	case CEPH_MDS_OP_REPAIR_INODESTATS: return "repair_inodestats";
 	case CEPH_MDS_OP_QUIESCE_PATH: return "quiesce_path";
 	case CEPH_MDS_OP_QUIESCE_INODE: return "quiesce_inode";
+        case CEPH_MDS_OP_FILE_BLOCKDIFF: return "blockdiff";
 	}
 	return "???";
 }

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -589,3 +589,12 @@ options:
   - mds_client
   flags:
   - runtime
+- name: client_file_blockdiff_max_concurrent_object_scans
+  type: uint
+  level: advanced
+  desc: maximum number of concurrent object scans
+  long_desc: Maximum number of concurrent listsnaps operations sent to RADOS.
+  default: 16
+  services:
+  - mds_client
+  min: 1

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1686,3 +1686,12 @@ options:
   services:
   - mds
   min: 8
+- name: mds_file_blockdiff_max_concurrent_object_scans
+  type: uint
+  level: advanced
+  desc: maximum number of concurrent object scans
+  long_desc: Maximum number of concurrent listsnaps operations sent to RADOS.
+  default: 16
+  services:
+  - mds
+  min: 1

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -428,6 +428,7 @@ enum {
 	CEPH_MDS_OP_LSSNAP     = 0x00402,
 	CEPH_MDS_OP_RENAMESNAP = 0x01403,
 	CEPH_MDS_OP_READDIR_SNAPDIFF   = 0x01404,
+	CEPH_MDS_OP_FILE_BLOCKDIFF = 0x01405,
 
 	// internal op
 	CEPH_MDS_OP_FRAGMENTDIR= 0x01500,
@@ -649,6 +650,12 @@ union ceph_mds_request_args {
                 __le32 offset_hash;
 		__le64 snap_other;
 	} __attribute__ ((packed)) snapdiff;
+        struct {
+                // latest scan "pointer"
+                __le64 scan_idx;
+                // how many data objects to scan in one invocation (capped by the mds).
+                __le64 max_objects;
+        } __attribute__ ((packed)) blockdiff;
 } __attribute__ ((packed));
 
 #define CEPH_MDS_REQUEST_HEAD_VERSION	3

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -648,6 +648,71 @@ struct ceph_snapdiff_info
                                    // doesn't exist in the second snapshot
 };
 
+struct ceph_file_blockdiff_result;
+
+// blockdiff stream handle
+struct ceph_file_blockdiff_info
+{
+  struct ceph_mount_info* cmount;
+  struct ceph_file_blockdiff_result* blockp;
+};
+
+// set of file block diff's
+struct cblock
+{
+  uint64_t offset;
+  uint64_t len;
+};
+struct ceph_file_blockdiff_changedblocks
+{
+  uint64_t num_blocks;
+  struct cblock *b;
+};
+
+/**
+ * Initialize blockdiff stream to get file block deltas.
+ *
+ * @param cmount the ceph mount handle to use for snapdiff retrieval.
+ * @param root_path  root path for snapshots-in-question
+ * @param rel_path subpath under the root to build delta for
+ * @param snap1 the first snapshot name
+ * @param snap2 the second snapshot name
+ * @param out_info resulting blockdiff stream handle to be used for blokdiff results
+                   retrieval via ceph_file_blockdiff().
+ * @returns 0 on success and negative error code otherwise
+ */
+int ceph_file_blockdiff_init(struct ceph_mount_info* cmount,
+                             const char* root_path,
+                             const char* rel_path,
+                             const char* snap1,
+                             const char* snap2,
+                             struct ceph_file_blockdiff_info* out_info);
+
+/**
+ * Get a set of file blockdiff's
+ *
+ * @param info blockdiff stream handle
+ * @param blocks next set of file blockdiff's (offset, length)
+ * @returns 0 or 1 on success and negative error code otherwise
+ */
+int ceph_file_blockdiff(struct ceph_file_blockdiff_info* info,
+                        struct ceph_file_blockdiff_changedblocks* blocks);
+/**
+ * Free blockdiff buffer
+ *
+ * @param blocks file block diff's from ceph_file_blockdiff()
+ * @returns None
+ */
+void ceph_free_file_blockdiff_buffer(struct ceph_file_blockdiff_changedblocks* blocks);
+
+/**
+ * Close blockdiff stream
+ *
+ * @param info blockdiff stream handle
+ * @returns 0 on success and negative error code otherwise
+ */
+int ceph_file_blockdiff_finish(struct ceph_file_blockdiff_info* info);
+
 /**
  * Opens snapdiff stream to get snapshots delta (aka snapdiff).
  *

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -747,6 +747,105 @@ extern "C" int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_di
   return cmount->get_client()->readdirplus_r(reinterpret_cast<dir_result_t*>(dirp), de, stx, want, flags, out);
 }
 
+extern "C" int ceph_file_blockdiff_init(struct ceph_mount_info* cmount,
+					const char* root_path,
+					const char* rel_path,
+					const char* snap1,
+					const char* snap2,
+					struct ceph_file_blockdiff_info* out_info)
+{
+  if (!cmount->is_mounted()) {
+    return -ENOTCONN;
+  }
+  if (!out_info || !root_path || !rel_path ||
+      !snap1 || !*snap1 || !snap2 || !*snap2) {
+    return -EINVAL;
+  }
+
+  char snapdir[PATH_MAX];
+  cmount->conf_get("client_snapdir", snapdir, sizeof(snapdir) - 1);
+
+  char path1[PATH_MAX];
+  char path2[PATH_MAX];
+  // construct snapshot paths for the files
+  int n = snprintf(path1, PATH_MAX, "%s/%s/%s/%s",
+		   root_path, snapdir, snap1, rel_path);
+  if (n < 0 || n == PATH_MAX) {
+    errno = ENAMETOOLONG;
+    return -errno;
+  }
+  n = snprintf(path2, PATH_MAX, "%s/%s/%s/%s",
+	       root_path, snapdir, snap2, rel_path);
+  if (n < 0 || n == PATH_MAX) {
+    return -ENAMETOOLONG;
+  }
+
+  int r = cmount->get_client()->file_blockdiff_init_state(path1, path2,
+							  cmount->default_perms,
+							  (struct scan_state_t **)&(out_info->blockp));
+  if (r < 0) {
+    return r;
+  }
+
+  out_info->cmount = cmount;
+  return 0;
+}
+
+extern "C" int ceph_file_blockdiff(struct ceph_file_blockdiff_info* info,
+				   struct ceph_file_blockdiff_changedblocks* blocks)
+{
+  if (!info->cmount->is_mounted()) {
+    return -ENOTCONN;
+  }
+
+  std::vector<std::pair<uint64_t,uint64_t>> _blocks;
+  struct scan_state_t *state = reinterpret_cast<scan_state_t *>(info->blockp);
+
+  int r = info->cmount->get_client()->file_blockdiff(state, info->cmount->default_perms, &_blocks);
+  if (r < 0) {
+    return r;
+  }
+
+  blocks->b = NULL;
+  blocks->num_blocks = _blocks.size();
+  if (blocks->num_blocks) {
+    struct cblock *b = (struct cblock *)calloc(blocks->num_blocks, sizeof(struct cblock));
+    if (!b) {
+      return -ENOMEM;
+    }
+
+    struct cblock *_b = b;
+    for (auto &_block : _blocks) {
+      _b->offset = _block.first;
+      _b->len = _block.second;
+      ++_b;
+    }
+
+    blocks->b = b;
+  }
+
+  return r;
+}
+
+extern "C" void ceph_free_file_blockdiff_buffer(struct ceph_file_blockdiff_changedblocks* blocks)
+{
+  if (blocks->b) {
+    free(blocks->b);
+  }
+  blocks->num_blocks = 0;
+  blocks->b = NULL;
+}
+
+extern "C" int ceph_file_blockdiff_finish(struct ceph_file_blockdiff_info* info)
+{
+  if (!info->cmount->is_mounted()) {
+    return -ENOTCONN;
+  }
+
+  struct scan_state_t *state = reinterpret_cast<scan_state_t *>(info->blockp);
+  return info->cmount->get_client()->file_blockdiff_finish(state);
+}
+
 extern "C" int ceph_open_snapdiff(struct ceph_mount_info* cmount,
                                   const char* root_path,
                                   const char* rel_path,

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14218,3 +14218,202 @@ void MDCache::upkeep_main(void)
     upkeep_cvar.wait_for(lock, interval);
   }
 }
+
+struct C_ListSnapsAggregator : public MDSIOContext {
+  C_ListSnapsAggregator(MDSRank *mds, CInode *in1, CInode *in2, BlockDiff *block_diff,
+			Context *on_finish)
+    : MDSIOContext(mds),
+      in1(in1),
+      in2(in2),
+      block_diff(block_diff),
+      on_finish(on_finish) {
+  }
+
+  void finish(int r) override {
+    mds->mdcache->aggregate_snap_sets(snap_set_context, in1, in2,
+                                      block_diff, on_finish);
+  }
+
+  virtual void print(std::ostream& os) const {
+    os << "listsnaps";
+  }
+
+  void add_snap_set_context(std::unique_ptr<MDCache::SnapSetContext> ssc) {
+    snap_set_context.push_back(std::move(ssc));
+  }
+
+  CInode *in1;
+  CInode *in2;
+  BlockDiff *block_diff;
+  Context *on_finish;
+  std::vector<std::unique_ptr<MDCache::SnapSetContext>> snap_set_context;
+};
+
+void MDCache::file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, uint64_t max_objects,
+			     MDSContext *ctx) {
+  ceph_assert(in1->last <= in2->last);
+
+  // I think this is not required since the MDS disallows setting
+  // layout when truncate_seq > 1.
+  if (in1->get_inode()->layout != in2->get_inode()->layout) {
+    dout(20) << __func__ << ": snaps have different layout: " << in1->get_inode()->layout
+	     << " vs " << in2->get_inode()->layout << dendl;
+    block_diff->blocks.union_insert(0, in2->get_inode()->size);
+    ctx->complete(0);
+    return;
+  }
+
+  uint64_t scan_idx = block_diff->scan_idx;
+  uint64_t num_objects1 = Striper::get_num_objects(in1->get_inode()->layout,
+						   in1->get_inode()->size);
+  uint64_t num_objects2 = Striper::get_num_objects(in2->get_inode()->layout,
+						   in2->get_inode()->size);
+  uint64_t num_objects_pending1 = num_objects1 - scan_idx;
+  uint64_t num_objects_pending2 = num_objects2 - scan_idx;
+
+  uint64_t scans = std::min(
+    std::min(num_objects_pending1, num_objects_pending2),
+    std::min((uint64_t)(g_conf().get_val<uint64_t>("mds_file_blockdiff_max_concurrent_object_scans")),
+	     max_objects));
+
+  dout(20) << __func__ << ": scanning " << scans << " objects" << dendl;
+  if (scans == 0) {
+    // we ran out of objects to scan - figure which ones
+    if (num_objects_pending1 == 0 && num_objects_pending2 == 0) {
+      // easy - both snaps have same number of objects
+      dout(20) << __func__ << ": equal extent" << dendl;
+      ctx->complete(0);
+    } else {
+      if (num_objects_pending1 == 0) {
+	// first snapshot has lesser number of objects - return
+	// an extent covering EOF.
+	dout(20) << __func__ << ": EOF extent" << dendl;
+	uint64_t offset = Striper::get_file_offset(g_ceph_context, &(in2->get_inode()->layout),
+						   scan_idx, 0);
+	block_diff->blocks.union_insert(offset, in2->get_inode()->size - offset);
+	ctx->complete(0);
+      } else {
+	// num_objects_pending2 == 0
+	dout(20) << __func__ << ": truncated extent" << dendl;
+	ctx->complete(0);
+      }
+    }
+
+    return;
+  }
+
+  C_ListSnapsAggregator *on_finish = new C_ListSnapsAggregator(mds, in1, in2, block_diff, ctx);
+  MDSGatherBuilder gather_ctx(g_ceph_context, on_finish);
+
+  while (scans > 0) {
+    ObjectOperation op;
+    std::unique_ptr<SnapSetContext> ssc(new SnapSetContext());
+    op.list_snaps(&ssc->snaps, &ssc->r);
+    ssc->objectid = scan_idx;
+
+    mds->objecter->read(file_object_t(in1->ino(), scan_idx),
+			OSDMap::file_to_object_locator(in2->get_inode()->layout),
+			op, LIBRADOS_SNAP_DIR, NULL, 0, gather_ctx.new_sub());
+    on_finish->add_snap_set_context(std::move(ssc));
+    ++scan_idx;
+    --scans;
+  }
+
+  gather_ctx.activate();
+}
+
+void MDCache::aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetContext>> &snap_set_ctx,
+                                  CInode *in1, CInode *in2, BlockDiff *block_diff, Context *on_finish) {
+  dout(20) << __func__ << dendl;
+
+  // always signal to the client to request again since request
+  // completion is signalled in file_blockdiff().
+  int r = 1;
+  snapid_t snapid1 = in1->last;
+  snapid_t snapid2 = in2->last;
+  uint64_t scans = snap_set_ctx.size();
+
+  interval_set<uint64_t> extents;
+  for (auto &snap_set : snap_set_ctx) {
+    dout(20) << __func__ << ": objectid=" << snap_set->objectid << ", r=" << snap_set->r
+	     << dendl;
+    if (snap_set->r != 0 && snap_set->r != -ENOENT) {
+      derr << ": failed to get snap set for objectid=" << snap_set->objectid
+	   << ", r=" << snap_set->r << dendl;
+      r = snap_set->r;
+      break;
+    }
+
+    if (snap_set->r == 0) {
+      auto &clones = snap_set->snaps.clones;
+      auto it1 = std::find_if(clones.begin(), clones.end(),
+			      [snapid1](const librados::clone_info_t &clone)
+			      {
+				return snapid1 == clone.cloneid ||
+				  (std::find(clone.snaps.begin(), clone.snaps.end(), snapid1) != clone.snaps.end());
+			      });
+      // point to "head" if not found
+      if (it1 == clones.end()) {
+	it1 = std::prev(it1);
+      }
+      auto it2 = std::find_if(clones.begin(), clones.end(),
+			      [snapid2](const librados::clone_info_t &clone)
+			      {
+				return snapid2 == clone.cloneid ||
+				  (std::find(clone.snaps.begin(), clone.snaps.end(), snapid2) != clone.snaps.end());
+			      });
+      // point to "head" if not found
+      if (it2 == clones.end()) {
+	it2 = std::prev(it2);
+      }
+
+      if (it1 == it2) {
+	dout(10) << __func__ << ": both snaps in same clone" << dendl;
+	continue;
+      }
+
+      interval_set<uint64_t> extent;
+      uint64_t offset = Striper::get_file_offset(g_ceph_context, &(in2->get_inode()->layout),
+						 snap_set->objectid, 0);
+
+      for (auto hops = std::distance(it1, it2); hops > 0; --hops) {
+	dout(20) << __func__ << ": [cloneid: " << it1->cloneid << " snaps: " << it1->snaps
+		 << " overlap: " << it1->overlap << "]" << dendl;
+	auto next_it = it1 + 1;
+	dout(20) << __func__ << ": [next cloneid: " << next_it->cloneid << " snaps: " << next_it->snaps
+		 << " overlap: " << next_it->overlap << "]" << dendl;
+	auto sz = next_it->size;
+	if (sz == 0) {
+	  // this object is a hole in the file.
+	  // TODO: report holes in blockdiff strucuter. that way,
+	  // caller can optimize and punch holes rather than writing
+	  // zeros.
+	  dout(10) << __func__ << ": hole: [" << offset << "~" << it1->size << "]" << dendl;
+	  dout(10) << __func__ << ": adding whole extent - reader will read zeros" << dendl;
+	  sz = it1->size;
+	}
+
+	extent.clear();
+	extent.union_insert(offset, sz);
+	for (auto &overlap_region : it1->overlap) {
+	  uint64_t overlap_offset = Striper::get_file_offset(g_ceph_context, &(in2->get_inode()->layout),
+							     snap_set->objectid, overlap_region.first);
+	  extent.erase(overlap_offset, overlap_region.second);
+	}
+
+	dout(20) << __func__ << ": (non overlapping) extent=" << extent << dendl;
+	extents.union_of(extent);
+	dout(20) << __func__ << ": (modified) extents=" << extents << dendl;
+	++it1;
+      }
+    }
+  }
+
+  block_diff->rval = r;
+  if (r >= 0) {
+    r = 0;
+    block_diff->scan_idx += scans;
+    block_diff->blocks = extents;
+  }
+  on_finish->complete(r);
+}

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -24,6 +24,7 @@
 #include "include/types.h"
 #include "include/filepath.h"
 #include "include/elist.h"
+#include "include/rados/rados_types.hpp"
 
 #include "messages/MCacheExpire.h"
 #include "messages/MClientQuota.h"
@@ -1151,6 +1152,17 @@ private:
   OpenFileTable open_file_table;
 
   double export_ephemeral_random_max = 0.0;
+
+  struct SnapSetContext { /* not to be confused with SnapContext */
+    int r;
+    uint64_t objectid;
+    librados::snap_set_t snaps;
+  };
+
+  void file_blockdiff(CInode *in1, CInode *in2, BlockDiff *block_diff, uint64_t max_objects,
+                      MDSContext *ctx);
+  void aggregate_snap_sets(const std::vector<std::unique_ptr<SnapSetContext>> &snap_set_ctx,
+                           CInode *in1, CInode *in2, BlockDiff *block_diff, Context *on_finish);
 
  protected:
   // track leader requests whose peers haven't acknowledged commit

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -12083,19 +12083,30 @@ bool Server::build_snap_diff(
 	continue;
       } else {
 	if (before.dn && dn->get_name() == name_before) {
-	  if (mtime == before.mtime) {
-	    dout(30) << __func__ << " timestamp not changed " << dn->get_name() << " "
-	      << dn->first << "/" << dn->last
-	      << " " << mtime
-	      << dendl;
+	  if (before.in->ino() != in->ino()) {
+	    dout(30) << __func__ << " inode changed " << dn->get_name() << " "
+		     << dn->first << "/" << dn->last
+		     << " " << before.mtime << " vs. " << mtime
+		     << dendl;
+	    if (!insert_deleted(before)) {
+	      break;
+	    }
 	    before.reset();
-	    continue;
 	  } else {
-	    dout(30) << __func__ << " timestamp changed " << dn->get_name() << " "
-	      << dn->first << "/" << dn->last
-	      << " " << before.mtime << " vs. " << mtime
-	      << dendl;
-	    before.reset();
+	    if (mtime == before.mtime) {
+	      dout(30) << __func__ << " timestamp not changed " << dn->get_name() << " "
+		       << dn->first << "/" << dn->last
+		       << " " << mtime
+		       << dendl;
+	      before.reset();
+	      continue;
+	    } else {
+	      dout(30) << __func__ << " timestamp changed " << dn->get_name() << " "
+		       << dn->first << "/" << dn->last
+		       << " " << before.mtime << " vs. " << mtime
+		       << dendl;
+	      before.reset();
+	    }
 	  }
 	}
 	dout(20) << __func__ << " new file " << dn->get_name() << " "

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -244,6 +244,8 @@ void Server::create_logger()
                    "Request type rename snapshot latency");
   plb.add_time_avg(l_mdss_req_snapdiff_latency, "req_snapdiff_latency",
 		   "Request type snapshot difference latency");
+    plb.add_time_avg(l_mdss_req_file_blockdiff_latency, "req_blockdiff_latency",
+		   "Request type file blockdiff latency");
 
   plb.set_prio_default(PerfCountersBuilder::PRIO_DEBUGONLY);
   plb.add_u64_counter(l_mdss_dispatch_client_request, "dispatch_client_request",
@@ -2182,6 +2184,9 @@ void Server::perf_gather_op_latency(const cref_t<MClientRequest> &req, utime_t l
   case CEPH_MDS_OP_READDIR_SNAPDIFF:
     code = l_mdss_req_snapdiff_latency;
     break;
+  case CEPH_MDS_OP_FILE_BLOCKDIFF:
+    code = l_mdss_req_file_blockdiff_latency;
+    break;
   default:
     dout(1) << ": unknown client op" << dendl;
     return;
@@ -2829,6 +2834,9 @@ void Server::dispatch_client_request(const MDRequestRef& mdr)
     break;
   case CEPH_MDS_OP_READDIR_SNAPDIFF:
     handle_client_readdir_snapdiff(mdr);
+    break;
+  case CEPH_MDS_OP_FILE_BLOCKDIFF:
+    handle_client_file_blockdiff(mdr);
     break;
 
   default:
@@ -3698,13 +3706,21 @@ public:
   }
 };
 
-/* If this returns null, the request has been handled
- * as appropriate: forwarded on, or the client's been replied to */
 CInode* Server::rdlock_path_pin_ref(const MDRequestRef& mdr,
 				    bool want_auth,
 				    bool no_want_auth)
 {
   const filepath& refpath = mdr->get_filepath();
+  return rdlock_path_pin_ref(mdr, refpath, want_auth, no_want_auth);
+}
+
+/* If this returns null, the request has been handled
+ * as appropriate: forwarded on, or the client's been replied to */
+CInode* Server::rdlock_path_pin_ref(const MDRequestRef& mdr,
+				    const filepath& refpath,
+				    bool want_auth,
+				    bool no_want_auth)
+{
   dout(10) << "rdlock_path_pin_ref " << *mdr << " " << refpath << dendl;
 
   if (mdr->locking_state & MutationImpl::PATH_LOCKED)
@@ -11665,6 +11681,89 @@ void Server::_renamesnap_finish(const MDRequestRef& mdr, CInode *diri, snapid_t 
   mdr->tracei = diri;
   mdr->snapid = snapid;
   respond_to_request(mdr, 0);
+}
+
+class C_MDS_file_blockdiff_finish : public ServerContext {
+public:
+  C_MDS_file_blockdiff_finish(Server *server, const MDRequestRef& mdr, CInode *in, uint64_t scan_idx)
+    : ServerContext(server),
+      mdr(mdr),
+      in(in) {
+    block_diff.rval = 0;
+    block_diff.scan_idx = scan_idx;
+  }
+
+  void finish(int r) override {
+    server->handle_file_blockdiff_finish(mdr, in, block_diff, r);
+  }
+
+private:
+  MDRequestRef mdr;
+  CInode *in;
+
+public:
+  BlockDiff block_diff;
+};
+
+void Server::handle_client_file_blockdiff(const MDRequestRef& mdr)
+{
+  const cref_t<MClientRequest>& req = mdr->client_request;
+
+  dout(10) << __func__ << dendl;
+
+  // no real need to rdlock_path_pin_ref() since the caller holds an
+  // open ref, but we need the snapped inode.
+  const filepath& refpath1 = mdr->get_filepath();
+  CInode* in1 = rdlock_path_pin_ref(mdr, refpath1, false, true);
+  if (!in1) {
+    return;
+  }
+  const filepath& refpath2 = mdr->get_filepath2();
+  CInode* in2 = rdlock_path_pin_ref(mdr, refpath2, false, true);
+  if (!in2) {
+    return;
+  }
+
+  if (!in1->is_file() || !in2->is_file()) {
+    dout(10) << __func__ << ": not a regular file req=" << req << dendl;
+    respond_to_request(mdr, -EINVAL);
+    return;
+  }
+
+  dout(20) << __func__ << ": in1=" << *in1 << dendl;
+  dout(20) << __func__ << ": in2=" << *in2 << dendl;
+
+  auto scan_idx = (uint64_t)req->head.args.blockdiff.scan_idx;
+  auto max_objects = (uint32_t)req->head.args.blockdiff.max_objects;
+
+  C_MDS_file_blockdiff_finish *ctx = new C_MDS_file_blockdiff_finish(this, mdr, in2, scan_idx);
+
+  if (in1 == in2) {
+    // does not matter if the inodes are snapped or refer to the head
+    // version -- both snaps are same.
+    dout(10) << __func__ << ": no diffs between snaps" << dendl;
+    handle_file_blockdiff_finish(mdr, in2, ctx->block_diff, 0);
+    delete ctx;
+    return;
+  }
+
+  mdcache->file_blockdiff(in1, in2, &(ctx->block_diff), max_objects, ctx);
+}
+
+void Server::handle_file_blockdiff_finish(const MDRequestRef& mdr, CInode *in, const BlockDiff &block_diff,
+					  int r) {
+  dout(10) << __func__ << ": in=" << *in << ", r=" << r << dendl;
+  if (r == 0) {
+    dout(10) << __func__ << ": blockdiff=" << block_diff << dendl;
+  }
+
+  ceph::bufferlist bl;
+  if (r == 0) {
+    encode(block_diff, bl);
+    mdr->reply_extra_bl = bl;
+  }
+
+  respond_to_request(mdr, r);
 }
 
 void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -11867,17 +11867,17 @@ void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)
   mdr->set_mds_stamp(now);
 
   mdr->snapid_diff_other = (uint64_t)req->head.args.snapdiff.snap_other;
+  dout(10) << __func__
+    << " snap " << mdr->snapid
+    << " vs. snap " << mdr->snapid_diff_other
+    << dendl;
+
   if (mdr->snapid_diff_other == mdr->snapid ||
       mdr->snapid == CEPH_NOSNAP ||
       mdr->snapid_diff_other == CEPH_NOSNAP) {
     dout(10) << "reply to " << *req << " snapdiff -EINVAL" << dendl;
     respond_to_request(mdr, -EINVAL);
   }
-
-  dout(10) << __func__
-    << " snap " << mdr->snapid
-    << " vs. snap " << mdr->snapid_diff_other
-    << dendl;
 
   unsigned max = req->head.args.snapdiff.max_entries;
   if (!max)

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -84,6 +84,7 @@ enum {
   l_mdss_cap_revoke_eviction,
   l_mdss_cap_acquisition_throttle,
   l_mdss_req_getvxattr_latency,
+  l_mdss_req_file_blockdiff_latency,
   l_mdss_last,
 };
 
@@ -196,6 +197,8 @@ public:
   void _try_open_ino(const MDRequestRef& mdr, int r, inodeno_t ino);
   CInode* rdlock_path_pin_ref(const MDRequestRef& mdr, bool want_auth,
 			      bool no_want_auth=false);
+  CInode* rdlock_path_pin_ref(const MDRequestRef& mdr, const filepath& refpath, bool want_auth,
+			      bool no_want_auth=false);
   CDentry* rdlock_path_xlock_dentry(const MDRequestRef& mdr, bool create,
 				    bool okexist=false, bool authexist=false,
 				    bool want_layout=false);
@@ -304,6 +307,9 @@ public:
   void handle_client_renamesnap(const MDRequestRef& mdr);
   void _renamesnap_finish(const MDRequestRef& mdr, CInode *diri, snapid_t snapid);
   void handle_client_readdir_snapdiff(const MDRequestRef& mdr);
+  void handle_client_file_blockdiff(const MDRequestRef& mdr);
+  void handle_file_blockdiff_finish(const MDRequestRef& mdr, CInode *in, const BlockDiff &block_diff,
+				    int r);
 
   // helpers
   bool _rename_prepare_witness(const MDRequestRef& mdr, mds_rank_t who, std::set<mds_rank_t> &witnesse,

--- a/src/mds/cephfs_features.cc
+++ b/src/mds/cephfs_features.cc
@@ -32,6 +32,7 @@ static const std::array feature_names
   "has_owner_uidgid",
   "client_mds_auth_caps",
   "charmap",
+  "blockdiff"
 };
 static_assert(feature_names.size() == CEPHFS_FEATURE_MAX + 1);
 

--- a/src/mds/cephfs_features.h
+++ b/src/mds/cephfs_features.h
@@ -50,7 +50,8 @@ namespace ceph {
 #define CEPHFS_FEATURE_HAS_OWNER_UIDGID     20
 #define CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK  21
 #define CEPHFS_FEATURE_CHARMAP              22
-#define CEPHFS_FEATURE_MAX                  22
+#define CEPHFS_FEATURE_BLOCKDIFF            23
+#define CEPHFS_FEATURE_MAX                  23
 
 #define CEPHFS_FEATURES_ALL {		\
   0, 1, 2, 3, 4,			\
@@ -73,7 +74,8 @@ namespace ceph {
   CEPHFS_FEATURE_NEW_SNAPREALM_INFO,    \
   CEPHFS_FEATURE_HAS_OWNER_UIDGID,      \
   CEPHFS_FEATURE_MDS_AUTH_CAPS_CHECK,   \
-  CEPHFS_FEATURE_CHARMAP,      \
+  CEPHFS_FEATURE_CHARMAP,               \
+  CEPHFS_FEATURE_BLOCKDIFF,             \
 }
 
 #define CEPHFS_METRIC_FEATURES_ALL {		\

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -1016,3 +1016,44 @@ void snaprealm_reconnect_t::generate_test_instances(std::list<snaprealm_reconnec
   ls.back()->realm.seq = 2;
   ls.back()->realm.parent = 1;
 }
+
+/*
+ * file block diffs
+ */
+void BlockDiff::encode(bufferlist& bl) const {
+  using ceph::encode;
+  ENCODE_START(1, 1, bl);
+  encode(rval, bl);
+  encode(scan_idx, bl);
+  encode(blocks, bl);
+  ENCODE_FINISH(bl);
+}
+
+void BlockDiff::decode(bufferlist::const_iterator &p) {
+  using ceph::decode;
+  DECODE_START(1, p);
+  decode(rval, p);
+  decode(scan_idx, p);
+  decode(blocks, p);
+  DECODE_FINISH(p);
+}
+
+void BlockDiff::dump(Formatter *f) const {
+  f->dump_int("rval", rval);
+  f->dump_unsigned("scan_idx", scan_idx);
+  f->dump_stream("blocks") << blocks;
+}
+
+void BlockDiff::generate_test_instances(std::list<BlockDiff*>& ls)
+{
+  ls.push_back(new BlockDiff());
+  ls.push_back(new BlockDiff());
+  ls.back()->rval = 0;
+  ls.back()->scan_idx = 1;
+  ls.back()->blocks.union_insert(0, 200);
+}
+
+void BlockDiff::print(ostream& out) const
+{
+  out << "{rval: " << rval << ", scan_idx=" << scan_idx << ", blocks=" << blocks << "}";
+}

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1029,4 +1029,17 @@ inline bool operator==(const MDSCacheObjectInfo& l, const MDSCacheObjectInfo& r)
 }
 WRITE_CLASS_ENCODER(MDSCacheObjectInfo)
 
+struct BlockDiff {
+  int rval;
+  uint64_t scan_idx;
+  interval_set<uint64_t> blocks;
+
+  void encode(ceph::buffer::list& bl) const;
+  void decode(ceph::buffer::list::const_iterator& p);
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(std::list<BlockDiff*>& ls);
+  void print(std::ostream& out) const;
+};
+WRITE_CLASS_ENCODER(BlockDiff);
+
 #endif

--- a/src/test/libcephfs/snapdiff.cc
+++ b/src/test/libcephfs/snapdiff.cc
@@ -11,6 +11,7 @@
  *
  */
 
+#include "include/interval_set.h"
 #include "gtest/gtest.h"
 #include "include/cephfs/libcephfs.h"
 #include "include/stat.h"
@@ -37,6 +38,9 @@ using namespace std;
 class TestMount {
   ceph_mount_info* cmount = nullptr;
   char dir_path[64];
+
+  const uint64_t BLOCK_SIZE_FACTOR = 1*1024*1024;
+  const uint64_t BLOCK_SIZE=4*BLOCK_SIZE_FACTOR;
 
 public:
   TestMount( const char* root_dir_name = "dir0") {
@@ -160,20 +164,58 @@ public:
     return r;
   }
 
-  int write_full(const char* relpath, const string& data)
+  int write_full(const char* relpath, const string& data, int64_t offset=0, bool trunc=true)
   {
     auto file_path = make_file_path(relpath);
     int fd = ceph_open(cmount, file_path.c_str(), O_WRONLY | O_CREAT, 0666);
     if (fd < 0) {
       return -EACCES;
     }
-    int r = ceph_write(cmount, fd, data.c_str(), data.size(), 0);
+    int r = ceph_write(cmount, fd, data.c_str(), data.size(), offset);
     if (r >= 0) {
-      ceph_truncate(cmount, file_path.c_str(), data.size());
+      if (trunc) {
+	ceph_truncate(cmount, file_path.c_str(), data.size());
+      }
       ceph_fsync(cmount, fd, 0);
     }
+    return r;
+
     ceph_close(cmount, fd);
     return r;
+  }
+  void generate_random_string_n(uint64_t count, uint64_t block_size,
+				const std::function<void(const std::string&)> &f)
+  {
+    static const char alphabet[] =
+      "abcdefghijklmnopqrstuvwxyz"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "0123456789";
+
+    std::random_device rd;
+    std::default_random_engine rng(rd());
+    std::uniform_int_distribution<> dist(0,sizeof(alphabet)/sizeof(*alphabet)-2);
+
+    std::vector<std::string> strs;
+    strs.reserve(count);
+    std::generate_n(std::back_inserter(strs), strs.capacity(),
+		    [&] { std::string str;
+		      str.reserve(block_size);
+		      std::generate_n(std::back_inserter(str), block_size,
+				      [&]() { return alphabet[dist(rng)];});
+		      return str; });
+    for (auto &str : strs) {
+      f(str);
+    }
+  }
+  int write_random(const char* relpath, uint64_t count, uint64_t block_size, int64_t offset=-1, bool trunc=false)
+  {
+    std::string s;
+    generate_random_string_n(count, block_size, [&s](const std::string& str) {
+      s.append(str);
+    });
+
+    std::cout << "write: [" << offset << "~" << count*block_size << " (trunc:" << trunc << ")]" << std::endl;
+    return write_full(relpath, s.c_str(), offset, trunc);
   }
   string concat_path(string_view path, string_view name) {
     string s(path);
@@ -342,6 +384,58 @@ public:
     return r;
   }
 
+  int for_each_file_blockdiff(const char* relpath,
+			      const char* snap1,
+			      const char* snap2,
+			      interval_set<uint64_t> *expected=nullptr)
+  {
+    auto s1 = make_snap_name(snap1);
+    auto s2 = make_snap_name(snap2);
+    ceph_file_blockdiff_info info;
+    int r = ceph_file_blockdiff_init(cmount,
+				     dir_path,
+				     relpath,
+				     s1.c_str(),
+				     s2.c_str(),
+				     &info);
+    if (r != 0) {
+      std::cerr << " Failed to init file block snapdiff, ret:" << r << std::endl;
+      return r;
+    }
+
+    r = 1;
+    while (r > 0) {
+      ceph_file_blockdiff_changedblocks blocks;
+      r = ceph_file_blockdiff(&info, &blocks);
+      if (r < 0) {
+	std::cerr << " Failed to get next changed block, ret:" << r << std::endl;
+	return r;
+      }
+
+      int nr_blocks = blocks.num_blocks;
+      struct cblock *b = blocks.b;
+      while (nr_blocks > 0) {
+	std::cout << " == [" << b->offset << "~" << b->len << "] == " << std::endl;
+	if (expected) {
+	  expected->erase(b->offset, b->len);
+	}
+	++b;
+	--nr_blocks;
+      }
+
+      ceph_free_file_blockdiff_buffer(&blocks);
+    }
+
+    ceph_assert(0 == ceph_file_blockdiff_finish(&info));
+    if (r < 0) {
+      std::cerr << " Failed to block diff, ret:" << r
+                << " " << relpath << ", " << snap1 << " vs. " << snap2
+                << std::endl;
+    }
+
+    return r;
+  }
+
   int mkdir(const char* relpath)
   {
     auto path = make_file_path(relpath);
@@ -391,9 +485,18 @@ public:
 		       const char* snap1,
                        const char* snap2);
 
+  void write_blocks(const std::vector<std::tuple<int64_t,uint64_t,bool>> &changes,
+		    interval_set<uint64_t> *expected=nullptr);
+
   void prepareSnapDiffLib1Cases();
   void prepareSnapDiffLib2Cases();
   void prepareSnapDiffLib3Cases();
+  void prepareBlockDiffNoChangeWithUnchangedHead();
+  void prepareBlockDiffNoChangeWithChangedHead();
+  void prepareBlockDiffChangedBlockWithUnchangedHead(interval_set<uint64_t> *expected);
+  void prepareBlockDiffChangedBlockWithChangedHead(interval_set<uint64_t> *expected);
+  void prepareBlockDiffChangedBlockWithTruncatedBlock(interval_set<uint64_t> *expected);
+  void prepareBlockDiffChangedBlockWithCustomObjectSize(interval_set<uint64_t> *expected);
   void prepareHugeSnapDiff(const std::string& name_prefix_start,
                            const std::string& name_prefix_bulk,
                            const std::string& name_prefix_end,
@@ -429,6 +532,137 @@ void TestMount::print_snap_diff(const char* relpath,
     }));
 };
 
+void TestMount::prepareBlockDiffNoChangeWithUnchangedHead()
+{
+  //************ snap1 *************
+  //************ snap2 *************
+  ASSERT_LE(0, write_random("fileA", 2, 4*1024*1024));
+  ASSERT_EQ(0, mksnap("snap1"));
+  ASSERT_EQ(0, mksnap("snap2"));
+  /* head is not modified */
+}
+
+void TestMount::prepareBlockDiffNoChangeWithChangedHead()
+{
+  //************ snap1 *************
+  //************ snap2 *************
+  ASSERT_LE(0, write_random("fileA", 2, 4*1024*1024));
+  ASSERT_EQ(0, mksnap("snap1"));
+  ASSERT_EQ(0, mksnap("snap2"));
+
+  /* modify head - fill up one object */
+  ASSERT_LE(0, write_random("fileA", 1, 4 * 1024 * 1024, -1, true));
+}
+
+// make thos helper track file holes
+void TestMount::write_blocks(const std::vector<std::tuple<int64_t,uint64_t,bool>> &changes,
+			     interval_set<uint64_t> *expected)
+{
+  for (auto &change : changes) {
+    int64_t offset = std::get<0>(change);
+    uint64_t len = std::get<1>(change);
+    bool trunc = std::get<2>(change);
+
+    uint64_t count = (len / BLOCK_SIZE);
+    uint64_t rem = (len % BLOCK_SIZE);
+    if (count) {
+      ASSERT_LE(0, write_random("fileA", count, BLOCK_SIZE, offset, trunc));
+      if (expected) {
+	expected->union_insert(offset, count*BLOCK_SIZE);
+      }
+    }
+    if (rem) {
+      offset += count * BLOCK_SIZE;
+      ASSERT_LE(0, write_random("fileA", 1, rem, offset, trunc));
+      if (expected) {
+	expected->union_insert(offset, rem);
+      }
+    }
+  }
+}
+
+void TestMount::prepareBlockDiffChangedBlockWithUnchangedHead(interval_set<uint64_t> *expected)
+{
+  //************ snap1 *************
+  ASSERT_LE(0, write_random("fileA", 5, BLOCK_SIZE));
+  ASSERT_EQ(0, mksnap("snap1"));
+
+  //************ snap2 *************
+  // overwrite first object w/ truncate
+  // partly fill fourth object (creating a hole in previous blocks)
+  srand(100);
+  std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
+    std::make_tuple(0, BLOCK_SIZE, true),
+    std::make_tuple((12*BLOCK_SIZE_FACTOR)+(rand()%100), 0.5*BLOCK_SIZE_FACTOR, false)
+  };
+  // we'll prepare expected set ourselves
+  write_blocks(changes);
+
+  ASSERT_EQ(0, mksnap("snap2"));
+  /* head is not modified */
+  auto &l = changes.back();
+  /* blockdiff swallows holes */
+  expected->union_insert(0, std::get<0>(l)+std::get<1>(l));
+}
+
+void TestMount::prepareBlockDiffChangedBlockWithChangedHead(interval_set<uint64_t> *expected)
+{
+  //************ snap1 *************
+  ASSERT_LE(0, write_random("fileA", 5, 4*1024*1024));
+  ASSERT_EQ(0, mksnap("snap1"));
+
+  //************ snap2 *************
+  // overwrite first object w/o truncate
+  // partly fill third object (no holes)
+  srand(100);
+  std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
+    std::make_tuple(0, BLOCK_SIZE, false),
+    std::make_tuple((8*BLOCK_SIZE_FACTOR)+(rand()%100), 0.5*BLOCK_SIZE_FACTOR, false)
+  };
+  write_blocks(changes, expected);
+  ASSERT_EQ(0, mksnap("snap2"));
+
+  /* modify head - fill up some objects */
+  ASSERT_LE(0, write_random("fileA", 2, 4 * 1024 * 1024, -1, false));
+}
+
+void TestMount::prepareBlockDiffChangedBlockWithTruncatedBlock(interval_set<uint64_t> *expected)
+{
+  //************ snap1 *************
+  ASSERT_LE(0, write_random("fileA", 4, 4*1024*1024));
+  ASSERT_EQ(0, mksnap("snap1"));
+
+  //************ snap2 *************
+  // write some bytes in few objects
+  // extend the file size
+  std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
+    std::make_tuple(1*BLOCK_SIZE_FACTOR, 10, false),
+    std::make_tuple((5*BLOCK_SIZE_FACTOR), 20, false),
+    std::make_tuple((14*BLOCK_SIZE_FACTOR), 10*BLOCK_SIZE_FACTOR, false)
+  };
+  write_blocks(changes, expected);
+  ASSERT_EQ(0, mksnap("snap2"));
+}
+
+void TestMount::prepareBlockDiffChangedBlockWithCustomObjectSize(interval_set<uint64_t> *expected)
+{
+  //************ snap1 *************
+  auto file_path = make_file_path("fileA");
+  ASSERT_EQ(0, ceph_mknod(cmount, file_path.c_str(), 0666, 0));
+  std::string val = std::to_string(8 * BLOCK_SIZE_FACTOR);
+  ASSERT_EQ(0, ceph_setxattr(cmount, file_path.c_str(), "ceph.file.layout.object_size", val.c_str(),
+			     val.size(), 0));
+
+  ASSERT_LE(0, write_random("fileA", 10, 4 * BLOCK_SIZE_FACTOR));
+  ASSERT_EQ(0, mksnap("snap1"));
+
+  std::vector<std::tuple<int64_t,uint64_t,bool>> changes{
+    std::make_tuple(0, 40 * BLOCK_SIZE_FACTOR, false),
+  };
+  write_blocks(changes, expected);
+  ASSERT_EQ(0, mksnap("snap2"));
+}
+
 /* The following method creates some files/folders/snapshots layout,
    described in the sheet below.
    We're to test SnapDiff readdir API against that structure.
@@ -456,6 +690,7 @@ void TestMount::print_snap_diff(const char* relpath,
 # dirD           | dirD            |
 # dirD/fileD1    | dirD/fileD1     |
 */
+
 void TestMount::prepareSnapDiffLib1Cases()
 {
   //************ snap1 *************
@@ -1805,6 +2040,96 @@ TEST(LibCephFS, HugeSnapDiffLargeDelta)
     expected.emplace_back(name_prefix_end + "D", snapid2);
     test_mount.verify_snap_diff(expected, "", "snap1", "snap2");
   }
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffNoChangeWithUnchangedHead)
+{
+  TestMount test_mount;
+
+  test_mount.prepareBlockDiffNoChangeWithUnchangedHead();
+  test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2");
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffNoChangeWithChangedHead)
+{
+  TestMount test_mount;
+
+  test_mount.prepareBlockDiffNoChangeWithChangedHead();
+  test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2");
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffChangedBlockWithUnchangedHead)
+{
+  TestMount test_mount;
+
+  interval_set<uint64_t> expected;
+  test_mount.prepareBlockDiffChangedBlockWithUnchangedHead(&expected);
+  std::cout << "expected=" << expected << std::endl;
+  test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2", &expected);
+  ASSERT_TRUE(expected.empty());
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffChangedBlockWithChangedHead)
+{
+  TestMount test_mount;
+
+  interval_set<uint64_t> expected;
+  test_mount.prepareBlockDiffChangedBlockWithChangedHead(&expected);
+  std::cout << "expected=" << expected << std::endl;
+  test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2", &expected);
+  ASSERT_TRUE(expected.empty());
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffChangedBlockWithTruncatedBlock)
+{
+  TestMount test_mount;
+
+  interval_set<uint64_t> expected;
+  test_mount.prepareBlockDiffChangedBlockWithTruncatedBlock(&expected);
+  std::cout << "expected=" << expected << std::endl;
+  test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2", &expected);
+  ASSERT_TRUE(expected.empty());
+
+  std::cout << "------------- closing -------------" << std::endl;
+  ASSERT_EQ(0, test_mount.purge_dir(""));
+  ASSERT_EQ(0, test_mount.rmsnap("snap1"));
+  ASSERT_EQ(0, test_mount.rmsnap("snap2"));
+}
+
+TEST(LibCephFS, SnapDiffChangedBlockWithCustomObjectSize)
+{
+  TestMount test_mount;
+
+  interval_set<uint64_t> expected;
+  test_mount.prepareBlockDiffChangedBlockWithCustomObjectSize(&expected);
+  std::cout << "expected=" << expected << std::endl;
+  test_mount.for_each_file_blockdiff("fileA", "snap1", "snap2", &expected);
+  ASSERT_TRUE(expected.empty());
 
   std::cout << "------------- closing -------------" << std::endl;
   ASSERT_EQ(0, test_mount.purge_dir(""));

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -68,12 +68,6 @@ std::string entry_path(const std::string &dir, const std::string &name) {
   return dir + "/" + name;
 }
 
-std::string entry_diff_path(const std::string &dir, const std::string &name) {
-  if (dir == ".")
-    return name;
-  return dir + "/" + name;
-}
-
 std::map<std::string, std::string> decode_snap_metadata(snap_metadata *snap_metadata,
                                                         size_t nr_snap_metadata) {
   std::map<std::string, std::string> metadata;
@@ -1446,7 +1440,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   std::queue<SyncEntry> sync_queue;
 
   //start with initial/default entry
-  std::string epath = ".", npath = "", nabs_path = "", nname = "";
+  std::string epath = ".", npath = "", nname = "";
   sync_queue.emplace(SyncEntry(epath, cstx));
 
   while (!sync_queue.empty()) {
@@ -1481,19 +1475,17 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       if ("." == nname || ".." == nname)
         continue;
       // create path for the newly found entry
-      npath = entry_diff_path(epath, nname);
-      nabs_path = entry_diff_path(dir_root, npath);
-
-      r = ceph_statx(sd_info.cmount, nabs_path.c_str(), &cstx,
-                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                     CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+      npath = entry_path(epath, nname);
+      r = ceph_statxat(m_local_mount, fh.c_fd, npath.c_str(), &cstx,
+                       CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                       CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                       AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
       if (r < 0) {
         // can't stat, so it's a deleted entry.
         if (DT_DIR == sd_entry.dir_entry.d_type) { // is a directory
           r = cleanup_remote_dir(dir_root, npath, fh);
           if (r < 0) {
-            derr << ": failed to remove directory=" << nabs_path << dendl;
+            derr << ": failed to remove directory=" << npath << dendl;
             break;
           }
         }
@@ -1506,17 +1498,17 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       } else {
         // stat success, update the existing entry
         struct ceph_statx tstx;
-        int rstat_r = ceph_statx(m_remote_mount, nabs_path.c_str(), &tstx,
-                                 CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                                 CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                                 AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+        int rstat_r = ceph_statxat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), &tstx,
+                                   CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                                   CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                                   AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
         if (S_ISDIR(cstx.stx_mode)) { // is a directory
           //cleanup if it's a file in the remotefs
           if ((0 == rstat_r) && !S_ISDIR(tstx.stx_mode)) {
             r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), 0);
             if (r < 0) {
               derr << ": Error in directory sync. Failed to remove file="
-                   << nabs_path << dendl;
+                   << npath << dendl;
               break;
             }
           }
@@ -1541,7 +1533,7 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
               r = cleanup_remote_dir(dir_root, npath, fh);
               if (r < 0) {
                 derr << ": Error in file sync. Failed to remove remote directory="
-                     << nabs_path << dendl;
+                     << npath << dendl;
                 break;
               }
             }

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -2,7 +2,6 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <stack>
-#include <queue>
 #include <fcntl.h>
 #include <algorithm>
 #include <sys/time.h>
@@ -1218,10 +1217,345 @@ int PeerReplayer::sync_perms(const std::string& path) {
   return 0;
 }
 
-int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current) {
+PeerReplayer::SyncMechanism::SyncMechanism(MountRef local, MountRef remote, FHandles *fh,
+                                           const Peer &peer, const Snapshot &current,
+                                           boost::optional<Snapshot> prev)
+    : m_local(local),
+      m_remote(remote),
+      m_fh(fh),
+      m_peer(peer),
+      m_current(current),
+      m_prev(prev) {
+  }
+
+PeerReplayer::SyncMechanism::~SyncMechanism() {
+}
+
+PeerReplayer::SnapDiffSync::SnapDiffSync(std::string_view dir_root, MountRef local, MountRef remote,
+                                         FHandles *fh, const Peer &peer, const Snapshot &current,
+                                         boost::optional<Snapshot> prev)
+  : SyncMechanism(local, remote, fh, peer, current, prev),
+    m_dir_root(dir_root) {
+}
+
+PeerReplayer::SnapDiffSync::~SnapDiffSync() {
+}
+
+int PeerReplayer::SnapDiffSync::init_sync() {
+  struct ceph_statx tstx;
+  int r = ceph_fstatx(m_local, m_fh->c_fd, &tstx,
+                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                      CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                      AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  if (r < 0) {
+    derr << ": failed to stat snap=" << m_current.first << ": " << cpp_strerror(r)
+         << dendl;
+    return r;
+  }
+
+  dout(20) << ": open_snapdiff for dir_root=" << m_dir_root << ", path=., prev="
+           << (*m_prev).first << ", current=" << m_current.first << dendl;
+
+  ceph_snapdiff_info info;
+  r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), ".",
+                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
+  if (r != 0) {
+    derr << ": failed to open snapdiff for " << m_dir_root << ": r=" << r << dendl;
+    return r;
+  }
+
+  m_sync_stack.emplace(SyncEntry(".", info, tstx));
+  return 0;
+}
+
+int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx *stx,
+                                          const std::function<int (const std::string&)> &dirsync_func,
+                                          const std::function<int (const std::string &)> &purge_func) {
+  dout(20) << ": sync stack size=" << m_sync_stack.size() << dendl;
+
+  while (!m_sync_stack.empty()) {
+    auto &entry = m_sync_stack.top();
+    dout(20) << ": top of stack path=" << entry.epath << dendl;
+
+    if (!entry.is_directory()) {
+      *epath = entry.epath;
+      *stx = entry.stx;
+      m_sync_stack.pop();
+      return 0;
+    }
+
+    int r;
+    std::string e_name;
+    ceph_snapdiff_entry_t sd_entry;
+    while (true) {
+      r = ceph_readdir_snapdiff(&(entry.info), &sd_entry);
+      if (r < 0) {
+        derr << ": failed to read directory=" << entry.epath << dendl;
+        break;
+      }
+      if (r == 0) {
+        break;
+      }
+
+      dout(20) << ": entry=" << sd_entry.dir_entry.d_name << ", snapid="
+               << sd_entry.snapid << dendl;
+
+      auto d_name = std::string(sd_entry.dir_entry.d_name);
+      if (d_name != "." && d_name != "..") {
+        e_name = d_name;
+        break;
+      }
+    }
+
+    if (r == 0) {
+      dout(10) << ": done for directory=" << entry.epath << dendl;
+      if (ceph_close_snapdiff(&(entry.info)) < 0) {
+        derr << ": failed to close snapdiff for " << entry.epath << dendl;
+      }
+      m_sync_stack.pop();
+      continue;
+    }
+
+    if (r < 0) {
+      return r;
+    }
+
+    auto _epath = entry_path(entry.epath, e_name);
+    dout(20) << ": epath=" << _epath << dendl;
+    if (sd_entry.snapid == (*m_prev).second) {
+      dout(20) << ": epath=" << _epath << " is deleted in current snapshot " << dendl;
+      // do not depend on d_type reported in struct dirent as the
+      // delete and create could have been processed and a restart
+      // of an interrupted sync would use the incorrect unlink API.
+      // N.B.: snapdiff returns the deleted entry before the newly
+      // created one.
+      struct ceph_statx pstx;
+      r = ceph_statxat(m_remote, m_fh->r_fd_dir_root, _epath.c_str(), &pstx,
+                       CEPH_STATX_MODE, AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+      if (r < 0 && r != -ENOENT) {
+        derr << ": failed to stat remote entry=" << _epath << ": " << cpp_strerror(r)
+             << dendl;
+        return r;
+      }
+      if (r == 0) {
+        if (!S_ISDIR(pstx.stx_mode)) {
+          r = ceph_unlinkat(m_remote, m_fh->r_fd_dir_root, _epath.c_str(), 0);
+        } else {
+          r = purge_func(_epath);
+        }
+
+        if (r < 0) {
+          derr << ": failed to propagate missing dirs: " << cpp_strerror(r) << dendl;
+          return r;
+        }
+      }
+
+      continue;
+    }
+
+    struct ceph_statx estx;
+    r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &estx,
+                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                     CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+    if (r < 0) {
+      derr << ": failed to stat epath=" << epath << ": " << cpp_strerror(r)
+           << dendl;
+      return r;
+    }
+
+    if (S_ISDIR(estx.stx_mode)) {
+      dout(20) << ": open_snapdiff for dir_root=" << m_dir_root << ", path=" << _epath
+               << ", prev=" << (*m_prev).first << ", current=" << m_current.first << dendl;
+
+      ceph_snapdiff_info info;
+      r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), _epath.c_str(),
+                             stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
+      if (r != 0) {
+        derr << ": failed to open snapdiff for " << m_dir_root << ": r=" << r << dendl;
+        return r;
+      }
+
+      m_sync_stack.emplace(SyncEntry(_epath, info, estx));
+    }
+
+    *epath = _epath;
+    *stx = estx;
+
+    return 0;
+  }
+
+  *epath = "";
+  return 0;
+}
+
+void PeerReplayer::SnapDiffSync::finish_sync() {
+  dout(20) << dendl;
+
+  while (!m_sync_stack.empty()) {
+    auto &entry = m_sync_stack.top();
+    if (entry.is_directory()) {
+      dout(20) << ": closing local directory=" << entry.epath << dendl;
+      if (ceph_close_snapdiff(&(entry.info)) < 0) {
+        derr << ": failed to close snapdiff directory=" << entry.epath << dendl;
+      }
+    }
+
+    m_sync_stack.pop();
+  }
+}
+
+PeerReplayer::RemoteSync::RemoteSync(MountRef local, MountRef remote, FHandles *fh,
+                                       const Peer &peer, const Snapshot &current,
+                                       boost::optional<Snapshot> prev)
+  : SyncMechanism(local, remote, fh, peer, current, prev) {
+}
+
+PeerReplayer::RemoteSync::~RemoteSync() {
+}
+
+int PeerReplayer::RemoteSync::init_sync() {
+  struct ceph_statx tstx;
+  int r = ceph_fstatx(m_local, m_fh->c_fd, &tstx,
+                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                      CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                      AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  if (r < 0) {
+    derr << ": failed to stat snap=" << m_current.first << ": " << cpp_strerror(r)
+         << dendl;
+    return r;
+  }
+
+  ceph_dir_result *tdirp;
+  r = ceph_fdopendir(m_local, m_fh->c_fd, &tdirp);
+  if (r < 0) {
+    derr << ": failed to open local snap=" << m_current.first << ": " << cpp_strerror(r)
+         << dendl;
+    return r;
+  }
+
+  m_sync_stack.emplace(SyncEntry(".", tdirp, tstx));
+  return 0;
+}
+
+int PeerReplayer::RemoteSync::get_entry(std::string *epath, struct ceph_statx *stx,
+                                        const std::function<int (const std::string&)> &dirsync_func,
+                                        const std::function<int (const std::string &)> &purge_func) {
+  dout(20) << ": sync stack size=" << m_sync_stack.size() << dendl;
+
+  while (!m_sync_stack.empty()) {
+    auto &entry = m_sync_stack.top();
+    dout(20) << ": top of stack path=" << entry.epath << dendl;
+
+    if (!entry.is_directory()) {
+      *epath = entry.epath;
+      *stx = entry.stx;
+      m_sync_stack.pop();
+      return 0;
+    }
+
+    // entry is a directory -- propagate deletes for missing entries
+    // (and changed inode types) to the remote filesystem.
+    if (!entry.needs_remote_sync()) {
+      int r = dirsync_func(entry.epath);
+      if (r < 0 && r != -ENOENT) {
+        derr << ": failed to propagate missing dirs: " << cpp_strerror(r) << dendl;
+        return r;
+      }
+      entry.set_remote_synced();
+    }
+
+    int r;
+    std::string e_name;
+    while (true) {
+      struct dirent de;
+      r = ceph_readdirplus_r(m_local, entry.dirp, &de, NULL,
+                             CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                             CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                             AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
+      if (r < 0) {
+        derr << ": failed to local read directory=" << entry.epath << dendl;
+        break;
+      }
+      if (r == 0) {
+        break;
+      }
+
+      auto d_name = std::string(de.d_name);
+      if (d_name != "." && d_name != "..") {
+        e_name = d_name;
+        break;
+      }
+    }
+
+    if (r == 0) {
+      dout(10) << ": done for directory=" << entry.epath << dendl;
+      if (ceph_closedir(m_local, entry.dirp) < 0) {
+        derr << ": failed to close local directory=" << entry.epath << dendl;
+      }
+      m_sync_stack.pop();
+      continue;
+    }
+
+    if (r < 0) {
+      return r;
+    }
+
+    struct ceph_statx cstx;
+    auto _epath = entry_path(entry.epath, e_name);
+    r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &cstx,
+                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                     CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+    if (r < 0) {
+      derr << ": failed to stat epath=" << _epath << ": " << cpp_strerror(r)
+           << dendl;
+      return r;
+    }
+
+    if (S_ISDIR(cstx.stx_mode)) {
+      ceph_dir_result *dirp;
+      r = opendirat(m_local, m_fh->c_fd, _epath, AT_SYMLINK_NOFOLLOW, &dirp);
+      if (r < 0) {
+        derr << ": failed to open local directory=" << _epath << ": "
+             << cpp_strerror(r) << dendl;
+        break;
+      }
+
+      m_sync_stack.emplace(SyncEntry(_epath, dirp, cstx));
+    }
+
+    *epath = _epath;
+    *stx = cstx;
+
+    return 0;
+  }
+
+  *epath = "";
+  return 0;
+}
+
+void PeerReplayer::RemoteSync::finish_sync() {
+  dout(20) << dendl;
+
+  while (!m_sync_stack.empty()) {
+    auto &entry = m_sync_stack.top();
+    if (entry.is_directory()) {
+      dout(20) << ": closing local directory=" << entry.epath << dendl;
+      if (ceph_closedir(m_local, entry.dirp) < 0) {
+        derr << ": failed to close local directory=" << entry.epath << dendl;
+      }
+    }
+
+    m_sync_stack.pop();
+  }
+}
+
+int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current,
+                                 boost::optional<Snapshot> prev) {
   dout(20) << ": dir_root=" << dir_root << ", current=" << current << dendl;
   FHandles fh;
-  int r = pre_sync_check_and_open_handles(dir_root, current, boost::none, &fh);
+  int r = pre_sync_check_and_open_handles(dir_root, current, prev, &fh);
   if (r < 0) {
     dout(5) << ": cannot proceed with sync: " << cpp_strerror(r) << dendl;
     return r;
@@ -1240,140 +1574,80 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
     return r;
   }
 
-  struct ceph_statx tstx;
-  r = ceph_fstatx(m_local_mount, fh.c_fd, &tstx,
-                  CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                  CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                  AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  SyncMechanism *syncm;
+  if (fh.p_mnt == m_local_mount) {
+    syncm = new SnapDiffSync(dir_root, m_local_mount, m_remote_mount, &fh,
+                             m_peer, current, prev);
+  } else {
+    syncm = new RemoteSync(m_local_mount, m_remote_mount, &fh,
+                           m_peer, current, boost::none);
+  }
+
+  r = syncm->init_sync();
   if (r < 0) {
-    derr << ": failed to stat snap=" << current.first << ": " << cpp_strerror(r)
-         << dendl;
+    derr << ": failed to initialize sync mechanism" << dendl;
     ceph_close(m_local_mount, fh.c_fd);
     ceph_close(fh.p_mnt, fh.p_fd);
+    delete syncm;
     return r;
   }
 
-  ceph_dir_result *tdirp;
-  r = ceph_fdopendir(m_local_mount, fh.c_fd, &tdirp);
-  if (r < 0) {
-    derr << ": failed to open local snap=" << current.first << ": " << cpp_strerror(r)
-         << dendl;
-    ceph_close(m_local_mount, fh.c_fd);
-    ceph_close(fh.p_mnt, fh.p_fd);
-    return r;
-  }
   // starting from this point we shouldn't care about manual closing of fh.c_fd,
   // it will be closed automatically when bound tdirp is closed.
-
-  std::stack<SyncEntry> sync_stack;
-  sync_stack.emplace(SyncEntry(".", tdirp, tstx));
-  while (!sync_stack.empty()) {
+  while (true) {
     if (should_backoff(dir_root, &r)) {
       dout(0) << ": backing off r=" << r << dendl;
       break;
     }
 
-    dout(20) << ": " << sync_stack.size() << " entries in stack" << dendl;
-    std::string e_name;
-    auto &entry = sync_stack.top();
-    dout(20) << ": top of stack path=" << entry.epath << dendl;
-    if (entry.is_directory()) {
-      // entry is a directory -- propagate deletes for missing entries
-      // (and changed inode types) to the remote filesystem.
-      if (!entry.needs_remote_sync()) {
-        r = propagate_deleted_entries(dir_root, entry.epath, fh);
-        if (r < 0 && r != -ENOENT) {
-          derr << ": failed to propagate missing dirs: " << cpp_strerror(r) << dendl;
-          break;
-        }
-        entry.set_remote_synced();
-      }
+    std::string epath;
+    struct ceph_statx stx;
+    r = syncm->get_entry(&epath, &stx,
+                         [this, &dir_root, &fh](const std::string &epath) {
+                           return propagate_deleted_entries(dir_root, epath, fh);
+                         },
+                         [this, &dir_root, &fh](const std::string &epath) {
+                           return cleanup_remote_dir(dir_root, epath, fh);
+                         });
+    dout(20) << ": r=" << r << dendl;
+    if (r < 0) {
+      break;
+    }
 
-      struct ceph_statx stx;
-      struct dirent de;
-      while (true) {
-        r = ceph_readdirplus_r(m_local_mount, entry.dirp, &de, &stx,
-                               CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                               CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                               AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
-        if (r < 0) {
-          derr << ": failed to local read directory=" << entry.epath << dendl;
-          break;
-        }
-        if (r == 0) {
-          break;
-        }
+    dout(20) << ": epath=" << epath << dendl;
+    if (epath == "") {
+      dout(10) << ": tree traversal done for dir_root=" << dir_root << dendl;
+      break;
+    }
 
-        auto d_name = std::string(de.d_name);
-        if (d_name != "." && d_name != "..") {
-          e_name = d_name;
-          break;
-        }
-      }
-
-      if (r == 0) {
-        dout(10) << ": done for directory=" << entry.epath << dendl;
-        if (ceph_closedir(m_local_mount, entry.dirp) < 0) {
-          derr << ": failed to close local directory=" << entry.epath << dendl;
-        }
-        sync_stack.pop();
-        continue;
-      }
+    if (S_ISDIR(stx.stx_mode)) {
+      r = remote_mkdir(epath, stx, fh);
       if (r < 0) {
         break;
-      }
-
-      auto epath = entry_path(entry.epath, e_name);
-      if (S_ISDIR(stx.stx_mode)) {
-        r = remote_mkdir(epath, stx, fh);
-        if (r < 0) {
-          break;
-        }
-        ceph_dir_result *dirp;
-        r = opendirat(m_local_mount, fh.c_fd, epath, AT_SYMLINK_NOFOLLOW, &dirp);
-        if (r < 0) {
-          derr << ": failed to open local directory=" << epath << ": "
-               << cpp_strerror(r) << dendl;
-          break;
-        }
-        sync_stack.emplace(SyncEntry(epath, dirp, stx));
-      } else {
-        sync_stack.emplace(SyncEntry(epath, stx));
       }
     } else {
       bool need_data_sync = true;
       bool need_attr_sync = true;
-      r = should_sync_entry(entry.epath, entry.stx, fh,
+      r = should_sync_entry(epath, stx, fh,
                             &need_data_sync, &need_attr_sync);
       if (r < 0) {
         break;
       }
 
-      dout(5) << ": entry=" << entry.epath << ", data_sync=" << need_data_sync
+      dout(5) << ": entry=" << epath << ", data_sync=" << need_data_sync
               << ", attr_sync=" << need_attr_sync << dendl;
       if (need_data_sync || need_attr_sync) {
-        r = remote_file_op(dir_root, entry.epath, entry.stx, fh, need_data_sync,
-                           need_attr_sync);
+        r = remote_file_op(dir_root, epath, stx, fh, need_data_sync, need_attr_sync);
         if (r < 0) {
           break;
         }
       }
-      dout(10) << ": done for epath=" << entry.epath << dendl;
-      sync_stack.pop();
+      dout(10) << ": done for epath=" << epath << dendl;
     }
   }
 
-  while (!sync_stack.empty()) {
-    auto &entry = sync_stack.top();
-    if (entry.is_directory()) {
-      dout(20) << ": closing local directory=" << entry.epath << dendl;
-      if (ceph_closedir(m_local_mount, entry.dirp) < 0) {
-        derr << ": failed to close local directory=" << entry.epath << dendl;
-      }
-    }
-
-    sync_stack.pop();
-  }
+  syncm->finish_sync();
+  delete syncm;
 
   dout(20) << " cur:" << fh.c_fd
            << " prev:" << fh.p_fd
@@ -1387,186 +1661,6 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
   // there is no need to close this fd manually.
   ceph_close(fh.p_mnt, fh.p_fd);
 
-  return r;
-}
-
-int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current,
-                                 boost::optional<Snapshot> prev) {
-  if (!prev) {
-    derr << ": invalid previous snapshot" << dendl;
-    return -ENODATA;
-  }
-
-  dout(20) << ": incremental sync check from prev=" << prev << dendl;
-
-  FHandles fh;
-  int r = pre_sync_check_and_open_handles(dir_root, current, prev, &fh);
-  if (r < 0) {
-    dout(5) << ": cannot proceed with sync: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-
-  // record that we are going to "dirty" the data under this directory root
-  auto snap_id_str{stringify(current.second)};
-  r = ceph_setxattr(m_remote_mount, dir_root.c_str(), "ceph.mirror.dirty_snap_id",
-                    snap_id_str.c_str(), snap_id_str.size(), 0);
-  if (r < 0) {
-    derr << ": error setting \"ceph.mirror.dirty_snap_id\" on dir_root=" << dir_root
-         << ": " << cpp_strerror(r) << dendl;
-    ceph_close(m_local_mount, fh.c_fd);
-    ceph_close(fh.p_mnt, fh.p_fd);
-    return r;
-  }
-
-  struct ceph_statx cstx;
-  r = ceph_fstatx(m_local_mount, fh.c_fd, &cstx,
-                  CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                  CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                  AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-  if (r < 0) {
-    derr << ": failed to stat snap=" << current.first << ": " << cpp_strerror(r)
-         << dendl;
-    ceph_close(m_local_mount, fh.c_fd);
-    ceph_close(fh.p_mnt, fh.p_fd);
-    return r;
-  }
-
-  ceph_snapdiff_info sd_info;
-  ceph_snapdiff_entry_t sd_entry;
-
-  //The queue of SyncEntry items (directories) to be synchronized.
-  //We follow a breadth first approach here based on the snapdiff output.
-  std::queue<SyncEntry> sync_queue;
-
-  //start with initial/default entry
-  std::string epath = ".", npath = "", nname = "";
-  sync_queue.emplace(SyncEntry(epath, cstx));
-
-  while (!sync_queue.empty()) {
-    if (should_backoff(dir_root, &r)) {
-      dout(0) << ": backing off r=" << r << dendl;
-      break;
-    }
-
-    dout(20) << ": " << sync_queue.size() << " entries in queue" << dendl;
-    const auto &queue_entry = sync_queue.front();
-    epath = queue_entry.epath;
-    dout(20) << ": syncing entry, path=" << epath << dendl;
-    r = ceph_open_snapdiff(fh.p_mnt, dir_root.c_str(), epath.c_str(),
-                           stringify((*prev).first).c_str(), current.first.c_str(), &sd_info);
-    if (r != 0) {
-      derr << ": failed to open snapdiff, r=" << r << dendl;
-      ceph_close(m_local_mount, fh.c_fd);
-      ceph_close(fh.p_mnt, fh.p_fd);
-      return r;
-    }
-    while (0 < (r = ceph_readdir_snapdiff(&sd_info, &sd_entry))) {
-      if (r < 0) {
-        derr << ": failed to read directory=" << epath << dendl;
-        ceph_close_snapdiff(&sd_info);
-        ceph_close(m_local_mount, fh.c_fd);
-        ceph_close(fh.p_mnt, fh.p_fd);
-        return r;
-      }
-
-      //New entry found
-      nname = sd_entry.dir_entry.d_name;
-      if ("." == nname || ".." == nname)
-        continue;
-      // create path for the newly found entry
-      npath = entry_path(epath, nname);
-      r = ceph_statxat(m_local_mount, fh.c_fd, npath.c_str(), &cstx,
-                       CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                       CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                       AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-      if (r < 0) {
-        // can't stat, so it's a deleted entry.
-        if (DT_DIR == sd_entry.dir_entry.d_type) { // is a directory
-          r = cleanup_remote_dir(dir_root, npath, fh);
-          if (r < 0) {
-            derr << ": failed to remove directory=" << npath << dendl;
-            break;
-          }
-        }
-        else { // is a file
-          r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), 0);
-          if (r < 0) {
-            break;
-          }
-        }
-      } else {
-        // stat success, update the existing entry
-        struct ceph_statx tstx;
-        int rstat_r = ceph_statxat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), &tstx,
-                                   CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                                   CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                                   AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-        if (S_ISDIR(cstx.stx_mode)) { // is a directory
-          //cleanup if it's a file in the remotefs
-          if ((0 == rstat_r) && !S_ISDIR(tstx.stx_mode)) {
-            r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, npath.c_str(), 0);
-            if (r < 0) {
-              derr << ": Error in directory sync. Failed to remove file="
-                   << npath << dendl;
-              break;
-            }
-          }
-          r = remote_mkdir(npath, cstx, fh);
-          if (r < 0) {
-            break;
-          }
-          // push it to sync_queue for later processing
-          sync_queue.emplace(SyncEntry(npath, cstx));
-        } else { // is a file
-          bool need_data_sync = true;
-          bool need_attr_sync = true;
-          r = should_sync_entry(npath, cstx, fh, &need_data_sync, &need_attr_sync);
-          if (r < 0) {
-            break;
-          }
-          dout(5) << ": entry=" << npath << ", data_sync=" << need_data_sync
-                  << ", attr_sync=" << need_attr_sync << dendl;
-          if (need_data_sync || need_attr_sync) {
-            //cleanup if it's a directory in the remotefs
-            if ((0 == rstat_r) && S_ISDIR(tstx.stx_mode)) {
-              r = cleanup_remote_dir(dir_root, npath, fh);
-              if (r < 0) {
-                derr << ": Error in file sync. Failed to remove remote directory="
-                     << npath << dendl;
-                break;
-              }
-            }
-            r = remote_file_op(dir_root, npath, cstx, fh, need_data_sync, need_attr_sync);
-            if (r < 0) {
-              break;
-            }
-          }
-        }
-      }
-    }
-    if (0 == r) {
-      dout(10) << ": successfully synchronized the entry=" << epath << dendl;
-    }
-
-    //Close the current open directory and take the next queue_entry, if success or failure.
-    r = ceph_close_snapdiff(&sd_info);
-    if (r != 0) {
-      derr << ": failed to close directory=" << epath << dendl;
-    }
-    sync_queue.pop();
-  }
-
-  dout(20) << " current:" << fh.c_fd
-           << " prev:" << fh.p_fd
-           << " ret = " << r
-           << dendl;
-
-  // @FHandles.r_fd_dir_root is closed in @unregister_directory since
-  // its used to acquire an exclusive lock on remote dir_root.
-
-  ceph_close(m_local_mount, fh.c_fd);
-  ceph_close(fh.p_mnt, fh.p_fd);
   return r;
 }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -650,8 +650,10 @@ int PeerReplayer::remote_mkdir(const std::string &epath, const struct ceph_statx
 #define NR_IOVECS 8 // # iovecs
 #define IOVEC_SIZE (8 * 1024 * 1024) // buffer size for each iovec
 int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string &epath,
-                                 const struct ceph_statx &stx, const FHandles &fh) {
-  dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << dendl;
+                                 const struct ceph_statx &stx, const FHandles &fh,
+                                 uint64_t num_blocks, struct cblock *b) {
+  dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << ", num_blocks="
+           << num_blocks << dendl;
   int l_fd;
   int r_fd;
   void *ptr;
@@ -666,7 +668,7 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
 
   l_fd = r;
   r = ceph_openat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(),
-                  O_CREAT | O_TRUNC | O_WRONLY | O_NOFOLLOW, stx.stx_mode);
+                  O_CREAT | O_WRONLY | O_NOFOLLOW, stx.stx_mode);
   if (r < 0) {
     derr << ": failed to create remote file path=" << epath << ": "
          << cpp_strerror(r) << dendl;
@@ -681,43 +683,86 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
     goto close_remote_fd;
   }
 
-  while (true) {
-    if (should_backoff(dir_root, &r)) {
-      dout(0) << ": backing off r=" << r << dendl;
-      break;
+  while (num_blocks > 0) {
+    auto offset = b->offset;
+    auto len = b->len;
+
+    dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << ", block: ["
+             << offset << "~" << len << "]" << dendl;
+
+    auto end_offset = offset + len;
+    dout(20) << ": start offset=" << offset << ", end offset=" << end_offset
+             << dendl;
+    while (offset < end_offset) {
+      if (should_backoff(dir_root, &r)) {
+        dout(0) << ": backing off r=" << r << dendl;
+        break;
+      }
+
+      auto cut_off = len;
+      if (cut_off > NR_IOVECS*IOVEC_SIZE) {
+        cut_off = NR_IOVECS*IOVEC_SIZE;
+      }
+
+      int num_buffers = cut_off / IOVEC_SIZE;
+      if (cut_off % IOVEC_SIZE) {
+        ++num_buffers;
+      }
+
+      dout(20) << ": num_buffers=" << num_buffers << dendl;
+      for (int i = 0; i < num_buffers; ++i) {
+        iov[i].iov_base = (char *)ptr + IOVEC_SIZE*i;
+        if (cut_off < IOVEC_SIZE) {
+          ceph_assert(i+1 == num_buffers);
+          iov[i].iov_len = cut_off;
+        } else {
+          iov[i].iov_len = IOVEC_SIZE;
+          cut_off -= IOVEC_SIZE;
+        }
+      }
+
+      r = ceph_preadv(m_local_mount, l_fd, iov, num_buffers, offset);
+      if (r < 0) {
+        derr << ": failed to read local file path=" << epath << ": "
+             << cpp_strerror(r) << dendl;
+        break;
+      }
+      dout(10) << ": read: " << r << " bytes" << dendl;
+      if (r == 0) {
+        break;
+      }
+
+      int iovs = (int)(r / IOVEC_SIZE);
+      int t = r % IOVEC_SIZE;
+      if (t) {
+        iov[iovs].iov_len = t;
+        ++iovs;
+      }
+
+      dout(10) << ": writing to offset: " << offset << dendl;
+      r = ceph_pwritev(m_remote_mount, r_fd, iov, iovs, offset);
+      if (r < 0) {
+        derr << ": failed to write remote file path=" << epath << ": "
+             << cpp_strerror(r) << dendl;
+        break;
+      }
+
+      offset += r;
     }
 
-    for (int i = 0; i < NR_IOVECS; ++i) {
-      iov[i].iov_base = (char*)ptr + IOVEC_SIZE*i;
-      iov[i].iov_len = IOVEC_SIZE;
-    }
-
-    r = ceph_preadv(m_local_mount, l_fd, iov, NR_IOVECS, -1);
-    if (r < 0) {
-      derr << ": failed to read local file path=" << epath << ": "
-           << cpp_strerror(r) << dendl;
-      break;
-    }
-    if (r == 0) {
-      break;
-    }
-
-    int iovs = (int)(r / IOVEC_SIZE);
-    int t = r % IOVEC_SIZE;
-    if (t) {
-      iov[iovs].iov_len = t;
-      ++iovs;
-    }
-
-    r = ceph_pwritev(m_remote_mount, r_fd, iov, iovs, -1);
-    if (r < 0) {
-      derr << ": failed to write remote file path=" << epath << ": "
-           << cpp_strerror(r) << dendl;
-      break;
-    }
+    --num_blocks;
+    ++b;
   }
 
-  if (r == 0) {
+  if (num_blocks == 0 && r >= 0) { // handle blocklist case
+    dout(20) << ": truncating epath=" << epath << " to " << stx.stx_size << " bytes"
+             << dendl;
+    r = ceph_ftruncate(m_remote_mount, r_fd, stx.stx_size);
+    if (r < 0) {
+      derr << ": failed to truncate remote file path=" << epath << ": "
+           << cpp_strerror(r) << dendl;
+      goto freeptr;
+    }
     r = ceph_fsync(m_remote_mount, r_fd, 0);
     if (r < 0) {
       derr << ": failed to sync data for file path=" << epath << ": "
@@ -725,6 +770,7 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
     }
   }
 
+freeptr:
   free(ptr);
 
 close_remote_fd:
@@ -744,18 +790,24 @@ close_local_fd:
   return r == 0 ? 0 : r;
 }
 
-int PeerReplayer::remote_file_op(const std::string &dir_root, const std::string &epath,
-                                 const struct ceph_statx &stx, const FHandles &fh,
-                                 bool need_data_sync, bool need_attr_sync) {
+int PeerReplayer::remote_file_op(SyncMechanism *syncm, const std::string &dir_root,
+                                 const std::string &epath, const struct ceph_statx &stx,
+                                 bool sync_check, const FHandles &fh, bool need_data_sync, bool need_attr_sync) {
   dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << ", need_data_sync=" << need_data_sync
            << ", need_attr_sync=" << need_attr_sync << dendl;
 
   int r;
   if (need_data_sync) {
     if (S_ISREG(stx.stx_mode)) {
-      r = copy_to_remote(dir_root, epath, stx, fh);
+      r = syncm->get_changed_blocks(epath, stx, sync_check,
+                                    [this, &dir_root, &epath, &stx, &fh](uint64_t num_blocks, struct cblock *b) {
+                                      int ret = copy_to_remote(dir_root, epath, stx, fh, num_blocks, b);
+                                      if (ret < 0) {
+                                        derr << ": failed to copy path=" << epath << ": " << ret << dendl;
+                                      }
+                                      return ret;
+                                    });
       if (r < 0) {
-        derr << ": failed to copy path=" << epath << ": " << cpp_strerror(r) << dendl;
         return r;
       }
       if (m_perf_counters) {
@@ -1231,6 +1283,23 @@ PeerReplayer::SyncMechanism::SyncMechanism(MountRef local, MountRef remote, FHan
 PeerReplayer::SyncMechanism::~SyncMechanism() {
 }
 
+int PeerReplayer::SyncMechanism::get_changed_blocks(const std::string &epath,
+                                                    const struct ceph_statx &stx, bool sync_check,
+                                                    const std::function<int (uint64_t, struct cblock *)> &callback) {
+  dout(20) << ": epath=" << epath << dendl;
+
+  struct cblock b;
+  // extent covers the whole file
+  b.offset = 0;
+  b.len = stx.stx_size;
+
+  struct ceph_file_blockdiff_changedblocks block;
+  block.num_blocks = 1;
+  block.b = &b;
+
+  return callback(block.num_blocks, block.b);
+}
+
 PeerReplayer::SnapDiffSync::SnapDiffSync(std::string_view dir_root, MountRef local, MountRef remote,
                                          FHandles *fh, const Peer &peer, const Snapshot &current,
                                          boost::optional<Snapshot> prev)
@@ -1268,7 +1337,92 @@ int PeerReplayer::SnapDiffSync::init_sync() {
   return 0;
 }
 
-int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx *stx,
+int PeerReplayer::SnapDiffSync::init_directory(const std::string &epath,
+                                               const struct ceph_statx &stx, bool pic, SyncEntry *se) {
+  dout(20) << ": epath=" << epath << dendl;
+
+  int r;
+  if (pic) {
+    dout(20) << ": non snapdiff dir_root=" << m_dir_root << ", path=" << epath << dendl;
+
+    ceph_dir_result *dirp;
+    r = opendirat(m_local, m_fh->c_fd, epath, AT_SYMLINK_NOFOLLOW, &dirp);
+    if (r < 0) {
+      derr << ": failed to open local directory=" << epath << ": " << r << dendl;
+      return r;
+    }
+
+    *se = SyncEntry(epath, dirp, stx);
+  } else {
+    dout(20) << ": open_snapdiff for dir_root=" << m_dir_root << ", path=" << epath
+             << ", prev=" << (*m_prev).first << ", current=" << m_current.first << dendl;
+
+    ceph_snapdiff_info info;
+    r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), epath.c_str(),
+                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
+    if (r != 0) {
+      derr << ": failed to open snapdiff for " << m_dir_root << ", r=" << r << dendl;
+      return r;
+    }
+
+    *se = SyncEntry(epath, info, stx);
+  }
+
+  return 0;
+}
+
+int PeerReplayer::SnapDiffSync::next_entry(SyncEntry &entry, std::string *e_name,
+                                           snapid_t *snapid) {
+  int r;
+  if (!entry.sync_is_snapdiff()) {
+    dout(20) << ": not snapdiff" << dendl;
+    struct dirent de;
+    r = ceph_readdirplus_r(m_local, entry.dirp, &de, NULL, 0,
+                           AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
+    if (r < 0) {
+      derr << ": failed to read directory=" << entry.epath << ", r=" << r << dendl;
+      return r;
+    }
+
+    if (r == 0) {
+      return 0;
+    }
+
+    *e_name = de.d_name;
+    *snapid = m_current.second;
+  } else {
+    dout(20) << ": is snapdiff" << dendl;
+    ceph_snapdiff_entry_t sd_entry;
+    r = ceph_readdir_snapdiff(&(entry.info), &sd_entry);
+    if (r < 0) {
+      derr << ": failed to read directory=" << entry.epath << ", r=" << r << dendl;
+      return r;
+    }
+
+    if (r == 0) {
+      return 0;
+    }
+
+    *e_name = sd_entry.dir_entry.d_name;
+    *snapid = sd_entry.snapid;
+  }
+
+  return 1;
+}
+
+void PeerReplayer::SnapDiffSync::fini_directory(SyncEntry &entry) {
+  if (!entry.sync_is_snapdiff()) {
+    if (ceph_closedir(m_local, entry.dirp) < 0) {
+      derr << ": failed to close local directory=" << entry.epath << dendl;
+    }
+  } else {
+    if (ceph_close_snapdiff(&(entry.info)) < 0) {
+      derr << ": failed to close snapdiff for " << entry.epath << dendl;
+    }
+  }
+}
+
+int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
                                           const std::function<int (const std::string&)> &dirsync_func,
                                           const std::function<int (const std::string &)> &purge_func) {
   dout(20) << ": sync stack size=" << m_sync_stack.size() << dendl;
@@ -1276,42 +1430,27 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
   while (!m_sync_stack.empty()) {
     auto &entry = m_sync_stack.top();
     dout(20) << ": top of stack path=" << entry.epath << dendl;
-
-    if (!entry.is_directory()) {
-      *epath = entry.epath;
-      *stx = entry.stx;
-      m_sync_stack.pop();
-      return 0;
-    }
+    ceph_assert(entry.is_directory());
 
     int r;
+    snapid_t snapid;
     std::string e_name;
-    ceph_snapdiff_entry_t sd_entry;
     while (true) {
-      r = ceph_readdir_snapdiff(&(entry.info), &sd_entry);
-      if (r < 0) {
-        derr << ": failed to read directory=" << entry.epath << dendl;
-        break;
-      }
-      if (r == 0) {
+      e_name.clear();
+      r = next_entry(entry, &e_name, &snapid);
+      if (r < 0 || r == 0) {
         break;
       }
 
-      dout(20) << ": entry=" << sd_entry.dir_entry.d_name << ", snapid="
-               << sd_entry.snapid << dendl;
-
-      auto d_name = std::string(sd_entry.dir_entry.d_name);
-      if (d_name != "." && d_name != "..") {
-        e_name = d_name;
+      dout(20) << ": entry=" << e_name << ", snapid=" << snapid << dendl;
+      if (e_name != "." && e_name != "..") {
         break;
       }
     }
 
     if (r == 0) {
       dout(10) << ": done for directory=" << entry.epath << dendl;
-      if (ceph_close_snapdiff(&(entry.info)) < 0) {
-        derr << ": failed to close snapdiff for " << entry.epath << dendl;
-      }
+      fini_directory(entry);
       m_sync_stack.pop();
       continue;
     }
@@ -1322,7 +1461,7 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
 
     auto _epath = entry_path(entry.epath, e_name);
     dout(20) << ": epath=" << _epath << dendl;
-    if (sd_entry.snapid == (*m_prev).second) {
+    if (snapid == (*m_prev).second) {
       dout(20) << ": epath=" << _epath << " is deleted in current snapshot " << dendl;
       // do not depend on d_type reported in struct dirent as the
       // delete and create could have been processed and a restart
@@ -1333,8 +1472,7 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
       r = ceph_statxat(m_remote, m_fh->r_fd_dir_root, _epath.c_str(), &pstx,
                        CEPH_STATX_MODE, AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
       if (r < 0 && r != -ENOENT) {
-        derr << ": failed to stat remote entry=" << _epath << ": " << cpp_strerror(r)
-             << dendl;
+        derr << ": failed to stat remote entry=" << _epath << ", r=" << r << dendl;
         return r;
       }
       if (r == 0) {
@@ -1345,11 +1483,12 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
         }
 
         if (r < 0) {
-          derr << ": failed to propagate missing dirs: " << cpp_strerror(r) << dendl;
+          derr << ": failed to propagate missing dirs r=" << r << dendl;
           return r;
         }
       }
 
+      m_deleted[entry.epath].emplace(e_name);
       continue;
     }
 
@@ -1359,34 +1498,89 @@ int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx 
                      CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
                      AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
     if (r < 0) {
-      derr << ": failed to stat epath=" << epath << ": " << cpp_strerror(r)
-           << dendl;
+      derr << ": failed to stat epath=" << epath << ", r=" << r << dendl;
       return r;
     }
 
+    bool pic = entry.is_purged_or_itype_changed() || m_deleted[entry.epath].contains(e_name);
     if (S_ISDIR(estx.stx_mode)) {
-      dout(20) << ": open_snapdiff for dir_root=" << m_dir_root << ", path=" << _epath
-               << ", prev=" << (*m_prev).first << ", current=" << m_current.first << dendl;
-
-      ceph_snapdiff_info info;
-      r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), _epath.c_str(),
-                             stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
-      if (r != 0) {
-        derr << ": failed to open snapdiff for " << m_dir_root << ": r=" << r << dendl;
+      SyncEntry se;
+      r = init_directory(_epath, estx, pic, &se);
+      if (r < 0) {
         return r;
       }
 
-      m_sync_stack.emplace(SyncEntry(_epath, info, estx));
+      if (pic) {
+        dout(10) << ": purge or itype change (including parent) found for entry="
+                 << se.epath << dendl;
+        se.set_purged_or_itype_changed();
+      }
+
+      m_sync_stack.emplace(se);
     }
 
     *epath = _epath;
     *stx = estx;
+    *sync_check = !pic;
 
+    dout(10) << ": sync_check=" << *sync_check << " for epath=" << *epath << dendl;
     return 0;
   }
 
   *epath = "";
   return 0;
+}
+
+int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
+                                                   const struct ceph_statx &stx, bool sync_check,
+                                                   const std::function<int (uint64_t, struct cblock *)> &callback) {
+  dout(20) << ": dir_root=" << m_dir_root << ", epath=" << epath
+           << ", sync_check=" << sync_check << dendl;
+
+  if (!sync_check) {
+    return SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+  }
+
+  ceph_file_blockdiff_info info;
+  int r = ceph_file_blockdiff_init(m_local, m_dir_root.c_str(), epath.c_str(),
+                                   (*m_prev).first.c_str(), m_current.first.c_str(), &info);
+  if (r != 0 && r != -ENOENT) {
+    derr << ": failed to init file blockdiff: r=" << r << dendl;
+    return r;
+  }
+
+  if (r < 0) {
+    dout(20) << ": new file epath=" << epath << dendl;
+    return SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+  }
+
+  r = 1;
+  while (true) {
+    ceph_file_blockdiff_changedblocks blocks;
+    r = ceph_file_blockdiff(&info, &blocks);
+    if (r < 0) {
+      derr << " failed to get next changed block: ret:" << r << dendl;
+      break;
+    }
+
+    int rr = r;
+    if (blocks.num_blocks) {
+      r = callback(blocks.num_blocks, blocks.b);
+      ceph_free_file_blockdiff_buffer(&blocks);
+      if (r < 0) {
+        derr << ": blockdiff callback returned error: r=" << r << dendl;
+        break;
+      }
+    }
+
+    if (rr == 0) {
+      break;
+    }
+    // else fetch next changed blocks
+  }
+
+  ceph_file_blockdiff_finish(&info);
+  return r;
 }
 
 void PeerReplayer::SnapDiffSync::finish_sync() {
@@ -1438,7 +1632,7 @@ int PeerReplayer::RemoteSync::init_sync() {
   return 0;
 }
 
-int PeerReplayer::RemoteSync::get_entry(std::string *epath, struct ceph_statx *stx,
+int PeerReplayer::RemoteSync::get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
                                         const std::function<int (const std::string&)> &dirsync_func,
                                         const std::function<int (const std::string &)> &purge_func) {
   dout(20) << ": sync stack size=" << m_sync_stack.size() << dendl;
@@ -1600,9 +1794,10 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
       break;
     }
 
+    bool sync_check = true;
     std::string epath;
     struct ceph_statx stx;
-    r = syncm->get_entry(&epath, &stx,
+    r = syncm->get_entry(&epath, &stx, &sync_check,
                          [this, &dir_root, &fh](const std::string &epath) {
                            return propagate_deleted_entries(dir_root, epath, fh);
                          },
@@ -1628,16 +1823,18 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
     } else {
       bool need_data_sync = true;
       bool need_attr_sync = true;
-      r = should_sync_entry(epath, stx, fh,
-                            &need_data_sync, &need_attr_sync);
-      if (r < 0) {
-        break;
+      if (sync_check) {
+        r = should_sync_entry(epath, stx, fh,
+                              &need_data_sync, &need_attr_sync);
+        if (r < 0) {
+          break;
+        }
       }
 
       dout(5) << ": entry=" << epath << ", data_sync=" << need_data_sync
               << ", attr_sync=" << need_attr_sync << dendl;
       if (need_data_sync || need_attr_sync) {
-        r = remote_file_op(dir_root, epath, stx, fh, need_data_sync, need_attr_sync);
+        r = remote_file_op(syncm, dir_root, epath, stx, sync_check, fh, need_data_sync, need_attr_sync);
         if (r < 0) {
           break;
         }

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -10,6 +10,8 @@
 #include "ServiceDaemon.h"
 #include "Types.h"
 
+#include <stack>
+
 namespace cephfs {
 namespace mirror {
 
@@ -101,6 +103,7 @@ private:
   struct SyncEntry {
     std::string epath;
     ceph_dir_result *dirp; // valid for directories
+    ceph_snapdiff_info info;
     struct ceph_statx stx;
     // set by incremental sync _after_ ensuring missing entries
     // in the currently synced snapshot have been propagated to
@@ -119,6 +122,13 @@ private:
         dirp(dirp),
         stx(stx) {
     }
+    SyncEntry(std::string_view path,
+              const ceph_snapdiff_info &info,
+              const struct ceph_statx &stx)
+      : epath(path),
+        info(info),
+        stx(stx) {
+    }
 
     bool is_directory() const {
       return S_ISDIR(stx.stx_mode);
@@ -130,6 +140,65 @@ private:
     void set_remote_synced() {
       remote_synced = true;
     }
+  };
+
+  class SyncMechanism {
+  public:
+    SyncMechanism(MountRef local, MountRef remote, FHandles *fh,
+                  const Peer &peer, /* keep dout happy */
+                  const Snapshot &current, boost::optional<Snapshot> prev);
+    virtual ~SyncMechanism() = 0;
+
+    virtual int init_sync() = 0;
+
+    virtual int get_entry(std::string *epath, struct ceph_statx *stx,
+                          const std::function<int (const std::string&)> &dirsync_func,
+                          const std::function<int (const std::string&)> &purge_func) = 0;
+
+    virtual void finish_sync() = 0;
+
+  protected:
+    MountRef m_local;
+    MountRef m_remote;
+    FHandles *m_fh;
+    Peer m_peer;
+    Snapshot m_current;
+    boost::optional<Snapshot> m_prev;
+    std::stack<PeerReplayer::SyncEntry> m_sync_stack;
+  };
+
+  class RemoteSync : public SyncMechanism {
+  public:
+    RemoteSync(MountRef local, MountRef remote, FHandles *fh,
+               const Peer &peer, /* keep dout happy */
+               const Snapshot &current, boost::optional<Snapshot> prev);
+    ~RemoteSync();
+
+    int init_sync() override;
+
+    int get_entry(std::string *epath, struct ceph_statx *stx,
+                  const std::function<int (const std::string&)> &dirsync_func,
+                  const std::function<int (const std::string&)> &purge_func);
+
+    void finish_sync();
+  };
+
+  class SnapDiffSync : public SyncMechanism {
+  public:
+    SnapDiffSync(std::string_view dir_root, MountRef local, MountRef remote,
+                 FHandles *fh, const Peer &peer, const Snapshot &current,
+                 boost::optional<Snapshot> prev);
+    ~SnapDiffSync();
+
+    int init_sync() override;
+
+    int get_entry(std::string *epeth, struct ceph_statx *stx,
+                  const std::function<int (const std::string&)> &dirsync_func,
+                  const std::function<int (const std::string&)> &purge_func);
+
+    void finish_sync();
+  private:
+    std::string m_dir_root;
   };
 
   // stats sent to service daemon
@@ -310,8 +379,9 @@ private:
 
   int do_synchronize(const std::string &dir_root, const Snapshot &current,
                      boost::optional<Snapshot> prev);
-
-  int do_synchronize(const std::string &dir_root, const Snapshot &current);
+  int do_synchronize(const std::string &dir_root, const Snapshot &current) {
+    return do_synchronize(dir_root, current, boost::none);
+  }
 
   int synchronize(const std::string &dir_root, const Snapshot &current,
                   boost::optional<Snapshot> prev);

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -109,6 +109,12 @@ private:
     // in the currently synced snapshot have been propagated to
     // the remote filesystem.
     bool remote_synced = false;
+    // includes parent dentry purge
+    bool purged_or_itype_changed = false;
+    bool is_snapdiff = false;
+
+    SyncEntry() {
+    }
 
     SyncEntry(std::string_view path,
               const struct ceph_statx &stx)
@@ -128,6 +134,7 @@ private:
       : epath(path),
         info(info),
         stx(stx) {
+      is_snapdiff = true;
     }
 
     bool is_directory() const {
@@ -140,6 +147,17 @@ private:
     void set_remote_synced() {
       remote_synced = true;
     }
+
+    bool is_purged_or_itype_changed() const {
+      return purged_or_itype_changed;
+    }
+    void set_purged_or_itype_changed() {
+      purged_or_itype_changed = true;
+    }
+
+    bool sync_is_snapdiff() const {
+      return is_snapdiff;
+    }
   };
 
   class SyncMechanism {
@@ -151,9 +169,13 @@ private:
 
     virtual int init_sync() = 0;
 
-    virtual int get_entry(std::string *epath, struct ceph_statx *stx,
+    virtual int get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
                           const std::function<int (const std::string&)> &dirsync_func,
                           const std::function<int (const std::string&)> &purge_func) = 0;
+
+    virtual int get_changed_blocks(const std::string &epath,
+                                   const struct ceph_statx &stx, bool sync_check,
+                                   const std::function<int (uint64_t, struct cblock *)> &callback);
 
     virtual void finish_sync() = 0;
 
@@ -176,7 +198,7 @@ private:
 
     int init_sync() override;
 
-    int get_entry(std::string *epath, struct ceph_statx *stx,
+    int get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
                   const std::function<int (const std::string&)> &dirsync_func,
                   const std::function<int (const std::string&)> &purge_func);
 
@@ -192,13 +214,24 @@ private:
 
     int init_sync() override;
 
-    int get_entry(std::string *epeth, struct ceph_statx *stx,
+    int get_entry(std::string *epeth, struct ceph_statx *stx, bool *sync_check,
                   const std::function<int (const std::string&)> &dirsync_func,
                   const std::function<int (const std::string&)> &purge_func);
 
+    int get_changed_blocks(const std::string &epath,
+                           const struct ceph_statx &stx, bool sync_check,
+                           const std::function<int (uint64_t, struct cblock *)> &callback);
+
     void finish_sync();
+
   private:
+    int init_directory(const std::string &epath,
+                       const struct ceph_statx &stx, bool pic, SyncEntry *se);
+    int next_entry(SyncEntry &entry, std::string *e_name, snapid_t *snapid);
+    void fini_directory(SyncEntry &entry);
+
     std::string m_dir_root;
+    std::map<std::string, std::set<std::string>> m_deleted;
   };
 
   // stats sent to service daemon
@@ -388,10 +421,11 @@ private:
   int do_sync_snaps(const std::string &dir_root);
 
   int remote_mkdir(const std::string &epath, const struct ceph_statx &stx, const FHandles &fh);
-  int remote_file_op(const std::string &dir_root, const std::string &epath, const struct ceph_statx &stx,
-                     const FHandles &fh, bool need_data_sync, bool need_attr_sync);
+  int remote_file_op(SyncMechanism *syncm, const std::string &dir_root,
+                     const std::string &epath, const struct ceph_statx &stx,
+                     bool sync_check, const FHandles &fh, bool need_data_sync, bool need_attr_sync);
   int copy_to_remote(const std::string &dir_root, const std::string &epath, const struct ceph_statx &stx,
-                     const FHandles &fh);
+                     const FHandles &fh, uint64_t num_blocks, struct cblock *b);
   int sync_perms(const std::string& path);
 };
 

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3582,9 +3582,10 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     if (formatter) {
       formatter->open_object_section("object");
       formatter->dump_string("name", *obj_name);
+      formatter->dump_int("seq", ls.seq);
       formatter->open_array_section("clones");
     } else {
-      cout << prettify(*obj_name) << ":" << std::endl;
+      cout << prettify(*obj_name) << " (seq:" << ls.seq << "):" << std::endl;
       cout << "cloneid	snaps	size	overlap" << std::endl;
     }
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/70585
https://tracker.ceph.com/issues/70584
https://tracker.ceph.com/issues/70392

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
