### PR TITLE
tentacle: mgr/dashboard: Fix delete listener

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
@@ -100,9 +100,11 @@ export class NvmeofListenersListComponent implements OnInit {
   deleteListenerModal() {
     const listener = this.selection.first();
     this.modalService.show(DeleteConfirmationModalComponent, {
-      itemDescription: 'Listener',
+      itemDescription: $localize`Listener`,
       actionDescription: 'delete',
-      itemNames: [`listener ${listener.host_name} (${listener.traddr}:${listener.trsvcid})`],
+      itemNames: [
+        $localize`listener` + ' ' + `${listener.host_name} (${listener.traddr}:${listener.trsvcid})`
+      ],
       submitActionObservable: () =>
         this.taskWrapper.wrapTaskAroundCall({
           task: new FinishedTask('nvmeof/listener/delete', {
@@ -111,6 +113,7 @@ export class NvmeofListenersListComponent implements OnInit {
           }),
           call: this.nvmeofService.deleteListener(
             this.subsystemNQN,
+            this.group,
             listener.host_name,
             listener.traddr,
             listener.trsvcid

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -130,10 +130,10 @@ describe('NvmeofService', () => {
     it('should call deleteListener', () => {
       const request = { host_name: 'ceph-node-02', traddr: '192.168.100.102', trsvcid: '4421' };
       service
-        .deleteListener(mockNQN, request.host_name, request.traddr, request.trsvcid)
+        .deleteListener(mockNQN, mockGroupName, request.host_name, request.traddr, request.trsvcid)
         .subscribe();
       const req = httpTesting.expectOne(
-        `${API_PATH}/subsystem/${mockNQN}/listener/${request.host_name}/${request.traddr}?trsvcid=${request.trsvcid}`
+        `${API_PATH}/subsystem/${mockNQN}/listener/${request.host_name}/${request.traddr}?gw_group=${mockGroupName}&trsvcid=${request.trsvcid}`
       );
       expect(req.request.method).toBe('DELETE');
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -115,12 +115,19 @@ export class NvmeofService {
     });
   }
 
-  deleteListener(subsystemNQN: string, hostName: string, traddr: string, trsvcid: string) {
+  deleteListener(
+    subsystemNQN: string,
+    group: string,
+    hostName: string,
+    traddr: string,
+    trsvcid: string
+  ) {
     return this.http.delete(
       `${API_PATH}/subsystem/${subsystemNQN}/listener/${hostName}/${traddr}`,
       {
         observe: 'response',
         params: {
+          gw_group: group,
           trsvcid
         }
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/nvmeof.ts
@@ -31,6 +31,7 @@ export interface NvmeofListener {
   adrfam: number; // 0: IPv4, 1: IPv6
   trsvcid: number; // 4420
   id?: number; // for table
+  full_addr?: string; // for table
 }
 
 export interface NvmeofSubsystemNamespace {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71289

---

backport of https://github.com/ceph/ceph/pull/63165
parent tracker: https://tracker.ceph.com/issues/71236

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh