### PR TITLE
cephadm: minor ergonomic improvements for hackers

### DIFF
--- a/src/cephadm/cephadmlib/container_lookup.py
+++ b/src/cephadm/cephadmlib/container_lookup.py
@@ -3,6 +3,7 @@
 from operator import itemgetter
 from typing import Optional, Tuple
 
+import fnmatch
 import logging
 
 from .container_engines import (
@@ -15,7 +16,8 @@ from .container_types import get_container_stats
 from .context import CephadmContext
 from .daemon_identity import DaemonIdentity
 from .daemons.ceph import ceph_daemons
-from .listing import daemons_matching
+from .exceptions import Error
+from .listing import LegacyDaemonEntry, daemons_matching
 from .listing_updaters import CoreStatusUpdater
 
 
@@ -174,3 +176,53 @@ def infer_local_ceph_image(
             reason,
         )
     return best_image.name
+
+
+def infer_daemon_identity(
+    ctx: CephadmContext, partial_name: str
+) -> DaemonIdentity:
+    """Given a partial daemon/service name, infer the identity of the
+    daemon.
+    """
+
+    if not partial_name:
+        raise Error('a daemon type is required to infer a service name')
+    if '.' in partial_name:
+        _type, _name = partial_name.split('.', 1)
+    else:
+        _type, _name = partial_name, ''
+    # allow searching for a name with just the beginning without having
+    # to expliclity supply a trailing asterisk
+    _name += '*'
+    matches = []
+    for d in daemons_matching(ctx, fsid=ctx.fsid, daemon_type=_type):
+        if isinstance(d, LegacyDaemonEntry):
+            logger.info('Ignoring legacy daemon %s', d.name)
+            continue  # ignore legacy daemons
+        if fnmatch.fnmatch(d.identity.daemon_id, _name):
+            matches.append(d)
+
+    if not matches:
+        raise Error(f'no daemons match {partial_name!r}')
+    if len(matches) > 1:
+        excess = ', '.join(d.identity.daemon_name for d in matches)
+        raise Error(f'too many daemons match {partial_name!r} ({excess})')
+    ident = matches[0].identity
+    logger.info('Inferring daemon %s', ident.daemon_name)
+    return ident
+
+
+def identify(ctx: CephadmContext) -> DaemonIdentity:
+    """Given a context try and determine a specific daemon identity to use
+    based on the --name CLI option (exact) or --infer-name (partial match)
+    option.
+    """
+    if not ctx.fsid:
+        raise Error('must pass --fsid to specify cluster')
+    name = getattr(ctx, 'name', '')
+    if name:
+        return DaemonIdentity.from_name(ctx.fsid, name)
+    iname = getattr(ctx, 'infer_name', '')
+    if iname:
+        return infer_daemon_identity(ctx, iname)
+    raise Error('must specify a daemon name (use --name for example)')


### PR DESCRIPTION
When developing on or with cephadm deployed services I frequently find myself wanting to enter deployed containers and get logs from those containers. cephadm has facilities for that but these commands (cephadm enter, cephadm logs) require and --name option to specify the name of the service/daemon to use.
This is a small problem because cephadm often sticks random characters to the end of the name, or includes the name of the host, or it includes the rank and rank genration - all for good reason and all difficult to know ahead of time. This leads to every debugging sessions starting with a dance of getting `podman ps` and/or systemd unit names into the copy-paste buffer or env vars.

Instead of this tediousness add a new option to some cephadm commands to infer the full name from a partial name, much like cephadm can infer a cluster fsid. 


---

Add an --infer-name/-i option to the cephadm enter command. This new
option is a spin on --name/-n but allows the value to be partial.
The first part of the value must be a service type (like `mgr`, `mds`,
`nfs`, etc). That can then be followed optionally by a dot (.) and
a part (or whole) of an id. For example:

Enter the one and only mgr container running on this host:
```
cephadm enter -i mgr
```

Enter a (primary) smb container running on this host belonging to
the virtual cluster "cluster1", without specifying random chars or
rank values:
```
cephadm enter -i smb.cluster1
```

If the partial name does not match any services on the host or it
matches more than 1 service on the host it will return an error.
In the case of >1 service you can then supply more characters in
the partial id to narrow down the match. For example:
```
cephadm enter -i osd
Inferring fsid bf7116b2-2b9d-11f0-bb35-525400220000
ERROR: too many daemons match 'osd' (osd.2, osd.5)

/tmp/cephadm enter -i osd.2
Inferring fsid bf7116b2-2b9d-11f0-bb35-525400220000
Inferring daemon osd.2
[ceph: root@ceph0 /]#
```
 
---

Also add a --dry-run option to more commands

Add a --dry-run option to the cephadm enter, cephadm logs, and
cephadm unit commands. Like cephadm shell --dry-run, this causes cephadm
to print the command it would have run rather than running said command.
This allows the user to copy and edit or otherwise hack on the output
to make variations on these comands without having to teach cephadm all
the possible options and switches those commands make take.
For instance I can follow recent mgr logging like so:
```
$(/tmp/cephadm logs -i mgr --dry-run | sed 's/ / --since=-1s -f /')
```


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate... this is mainly for devs/hackers
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Enough tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
