### PR TITLE
migrate libformat support from submodule to CPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,9 +41,6 @@
 [submodule "src/seastar"]
 	path = src/seastar
 	url = https://github.com/ceph/seastar.git
-[submodule "src/fmt"]
-	path = src/fmt
-	url = https://github.com/ceph/fmt.git
 [submodule "src/c-ares"]
 	path = src/c-ares
 	url = https://github.com/ceph/c-ares.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,44 @@ if(NOT HAVE_CXX11_ATOMIC)
     " ${LIBATOMIC_LINK_FLAGS}")
 endif()
 
+# Enable package management via CPM:
+include(${CMAKE_MODULE_PATH}/CPM.cmake)
+
+# We want a way to restore CPM's local package settings:
+# Parameters: string -> bool -> bool
+# Where the string is formatted for CPMAddPackage; refer-to:
+# https://github.com/cpm-cmake/CPM.cmake
+function(cpm_local_optional package_name package_source enable_package enable_system_packages)
+  if(${enable_package})
+    set(ORIG_CPM_LOCAL_PACKAGES_ONLY ${CPM_USE_LOCAL_PACKAGES_ONLY})
+
+    if(${enable_system_packages})
+      set(CPM_LOCAL_PACKAGES_ONLY ON)
+    endif()
+
+    include(${CMAKE_MODULE_PATH}/CPM.cmake)
+    CPMAddPackage(${package_source})
+
+    # Restore the original CPM settings in case someone else wants to use the module:
+    set(CPM_USE_LOCAL_PACKAGES_ONLY, ${ORIG_CPM_USE_LOCAL_PACKAGES_ONLY})
+
+    message(string(CONCAT enable_msg "-- Enabled " ${package_name} " support"))
+  endif()
+endfunction()
+
+# libformat (fmt):
+set(WITH_FMT ON)
+set(FMT_LIB fmt)
+option(WITH_SYSTEM_FMT "build against system fmt" OFF)
+cpm_local_optional("libformat (fmt)" "gh:fmtlib/fmt#8.1.1" WITH_LIBFMT WITH_SYSTEM_FMT)
+
+set(FMT_LIB fmt)
+option(WITH_FMT_HEADER_ONLY "use header-only version of fmt library" OFF)
+if (WITH_FMT_HEADER_ONLY)
+  message(STATUS "Using fmt header-only.")
+  set(FMT_LIB fmt-header-only)
+endif()
+
 option(WITH_RDMA "Enable RDMA in async messenger" ON)
 if(WITH_RDMA)
   find_package(verbs REQUIRED)
@@ -521,23 +559,25 @@ endif()
 # This needs to come before any tests using Catch2.
 option(WITH_CATCH2 "Enable Catch2 unit tests" ON)
 option(WITH_SYSTEM_CATCH2 "Enable Catch2 unit tests (require system packages)" OFF)
+cpm_local_optional("Catch2" "gh:catchorg/Catch2@3.8.1" WITH_CATCH2 WITH_SYSTEM_CATCH2)
 
-if(WITH_CATCH2)
-  # Save pre-existing definitions (if any):
-  set(ORIG_CPM_LOCAL_PACKAGES_ONLY ${CPM_USE_LOCAL_PACKAGES_ONLY})
-
-    if(WITH_SYSTEM_CATCH2)
-   set(CPM_LOCAL_PACKAGES_ONLY ON)
-  endif()
-
-  include(${CMAKE_MODULE_PATH}/CPM.cmake)
-  CPMAddPackage("gh:catchorg/Catch2@3.8.1")
-
-  # Restore the original CPM settings in case someone else wants to use the module:
-  set(CPM_USE_LOCAL_PACKAGES_ONLY, ${ORIG_CPM_USE_LOCAL_PACKAGES_ONLY})
-
-  message("-- Enabled Catch2 support")
-endif()
+#JFW:
+#if(WITH_CATCH2)
+#  # Save pre-existing definitions (if any):
+#  set(ORIG_CPM_LOCAL_PACKAGES_ONLY ${CPM_USE_LOCAL_PACKAGES_ONLY})
+#
+#    if(WITH_SYSTEM_CATCH2)
+#   set(CPM_LOCAL_PACKAGES_ONLY ON)
+#  endif()
+#
+#  include(${CMAKE_MODULE_PATH}/CPM.cmake)
+#  CPMAddPackage("gh:catchorg/Catch2@3.8.1")
+#
+#  # Restore the original CPM settings in case someone else wants to use the module:
+#  set(CPM_USE_LOCAL_PACKAGES_ONLY, ${ORIG_CPM_USE_LOCAL_PACKAGES_ONLY})
+#
+#  message("-- Enabled Catch2 support")
+#endif()
 
 #option for RGW
 option(WITH_RADOSGW "RADOS Gateway is enabled" ON)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -297,7 +297,6 @@ BuildRequires:	libnbd-devel
 BuildRequires:	libcurl-devel
 BuildRequires:	libcap-devel
 BuildRequires:	libcap-ng-devel
-BuildRequires:	fmt-devel >= 6.2.1
 BuildRequires:	pkgconfig(libudev)
 BuildRequires:	libnl3-devel
 BuildRequires:	liboath-devel

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -356,31 +356,6 @@ if(NOT TARGET RapidJSON::RapidJSON)
     INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/s3select/rapidjson/include")
 endif()
 
-option(WITH_FMT_HEADER_ONLY "use header-only version of fmt library" OFF)
-option(WITH_SYSTEM_FMT "build against system fmt" OFF)
-if(WITH_SYSTEM_FMT)
-  find_package(fmt 8.1.1...11.1.4 REQUIRED)
-endif()
-if (WITH_FMT_HEADER_ONLY)
-  message(STATUS "Using fmt header-only.")
-  set(FMT_LIB fmt::fmt-header-only)
-else()
-  message(STATUS "Linking to fmt library.")
-  set(FMT_LIB fmt::fmt)
-endif()
-if(fmt_FOUND)
-  message(STATUS "Building with system fmt.")
-else()
-  message(STATUS "Building fmt as submodule")
-  set(old_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
-  set(BUILD_SHARED_LIBS FALSE)
-  set(FMT_INSTALL OFF)
-  add_subdirectory(fmt)
-  set(BUILD_SHARED_LIBS ${old_BUILD_SHARED_LIBS})
-  unset(old_BUILD_SHARED_LIBS)
-  include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/fmt/include")
-endif()
-
 # in osd/PeeringState.h, the number of elements in PeeringState::Active::reactions
 # is now 21 which exceeds the default value of BOOST_MPL_LIMIT_VECTOR_SIZE, which
 # is 20. so we need to override it. see
@@ -473,8 +448,6 @@ set_source_files_properties(ceph_ver.c
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)
 add_library(common-objs OBJECT ${libcommon_files})
 target_link_libraries(common-objs legacy-option-headers)
-target_compile_definitions(common-objs PRIVATE
-  $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 
 if(WITH_JAEGER)
   add_dependencies(common-objs jaeger_base)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,3 +1,5 @@
+
+
 add_library(common_buffer_obj OBJECT
   buffer.cc)
 
@@ -194,8 +196,7 @@ target_include_directories(common-common-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_compile_definitions(common-common-objs PRIVATE
   "CMAKE_INSTALL_LIBDIR=\"${CMAKE_INSTALL_LIBDIR}\""
   "CEPH_INSTALL_FULL_PKGLIBDIR=\"${CEPH_INSTALL_FULL_PKGLIBDIR}\""
-  "CEPH_INSTALL_DATADIR=\"${CEPH_INSTALL_DATADIR}\""
-  $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
+  "CEPH_INSTALL_DATADIR=\"${CEPH_INSTALL_DATADIR}\"")
 target_link_libraries(common-common-objs legacy-option-headers)
 
 set(common_mountcephfs_srcs

--- a/src/msg/CMakeLists.txt
+++ b/src/msg/CMakeLists.txt
@@ -45,8 +45,6 @@ if(HAVE_RDMA)
 endif()
 
 add_library(common-msg-objs OBJECT ${msg_srcs})
-target_compile_definitions(common-msg-objs PRIVATE
-  $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 target_include_directories(common-msg-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(common-msg-objs
   PUBLIC

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -1,12 +1,7 @@
 add_library(neorados_objs OBJECT
   RADOSImpl.cc)
-target_compile_definitions(neorados_objs PRIVATE
-  $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 add_library(neorados_api_obj OBJECT
   RADOS.cc)
-target_compile_definitions(neorados_api_obj PRIVATE
-  $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
-
 add_library(libneorados STATIC
   $<TARGET_OBJECTS:neorados_api_obj>
   $<TARGET_OBJECTS:neorados_objs>)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -1,3 +1,5 @@
+
+
 find_program(GPERF gperf)
 if(NOT GPERF)
   message(FATAL_ERROR "Can't find gperf")
@@ -312,7 +314,6 @@ target_link_libraries(rgw_common
     ${LUA_LIBRARIES}
     RapidJSON::RapidJSON
     Boost::context
-    ${FMT_LIB}
     OpenSSL::SSL
     BLAKE3::blake3)
 target_include_directories(rgw_common

--- a/src/test/rgw/test_rgw_hex.cc
+++ b/src/test/rgw/test_rgw_hex.cc
@@ -6,6 +6,8 @@
 
 #include "rgw/rgw_hex.h"
 
+#include "fmt/core.h"
+
 #include <ranges>
 #include <cstring>
 
@@ -15,8 +17,23 @@ using std::array;
 using std::string;
 using std::string_view;
 
+TEST_CASE("library versions") {
+  int version = FMT_VERSION;
+  int major = version / 10000;
+  int minor = (version % 10000) / 100;
+  int patch = version % 100;
+
+  auto s = fmt::format("JFW: libfmt version: {}.{}.{}\n", major, minor, patch);
+
+  INFO(s);
+
+  FAIL(s);
+}
+
+
 TEST_CASE("hexdigit", "[rgw]") {
 
+INFO(
   SECTION("simple heuristic checks", "check known edge-cases") {
     CHECK(-EINVAL == hexdigit('\0'));
 


### PR DESCRIPTION
Migrates libformat (fmt) support from git submodule to CPM/CMake.

Proof-of-concept showing how to accomplish this. The idea is to have a bit more flexibility and
increased integration during build (consistent with other CMake build entities).

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
