### PR TITLE
doc/monitoring: correct list formatting

### DIFF
--- a/doc/monitoring/index.rst
+++ b/doc/monitoring/index.rst
@@ -215,42 +215,50 @@ Pool metrics
 ============
 
 Ceph pool metrics have the following labels:
+
 * ``instance``: The IP address of the exporter providing the metric
 * ``pool_id``: Numeric identifier of the Ceph pool
 * ``job``: Prometheus scrape job name
 
 
 Pool-specific metrics include:
-* ``ceph_pool_metadata``: Information about the pool that can be used together
-  with other metrics to provide more information in query resultss and
-  graphs. In addition to the above three common labels this metric
-  provides the following:
 
-    * ``compression_mode``: Compression type enabled for the pool. Values are ``lz4``, ``snappy``,
-       ``zlib``, ``zstd``, and ``none`). Example: ``compression_mode="none"``
+   * ``ceph_pool_metadata``: Information about the pool that can be used
+     together with other metrics to provide more information in query resultss
+     and graphs.  In addition to the above three common labels this metric
+     provides the following:
+
+    * ``compression_mode``: Compression type enabled for the pool. Values are
+      ``lz4``, ``snappy``, ``zlib``, ``zstd``, and ``none`). Example:
+      ``compression_mode="none"``
 
     * ``description``: Brief description of the pool data protection strategy
-      including replica number or EC profile. Example: ``description="replica:3"``
+      including replica number or EC profile. Example:
+      ``description="replica:3"``
 
     * ``name``: Name of the pool. Example: ``name=".mgr"``
 
-    * ``type``: Data protection strategy, replicated or EC. ``Example: type="replicated"``
+    * ``type``: Data protection strategy, replicated or EC. ``Example:
+      type="replicated"``
 
-* ``ceph_pool_bytes_used``: Total raw capacity (after replication or EC) consumed by user data and metadata
+    * ``ceph_pool_bytes_used``: Total raw capacity (after replication or EC)
+      consumed by user data and metadata
 
-* ``ceph_pool_stored``: Total client data stored in the pool (before data protection)
+    * ``ceph_pool_stored``: Total client data stored in the pool (before data
+      protection)
 
-* ``ceph_pool_compress_under_bytes``: Data eligible to be compressed in the pool
+    * ``ceph_pool_compress_under_bytes``: Data eligible to be compressed in
+      the pool
 
-* ``ceph_pool_compress_bytes_used``:  Data compressed in the pool
+    * ``ceph_pool_compress_bytes_used``:  Data compressed in the pool
 
-* ``ceph_pool_rd``: Client read operations per pool (reads per second)
+    * ``ceph_pool_rd``: Client read operations per pool (reads per second)
 
-* ``ceph_pool_rd_bytes``: Client read operations in bytes per pool
+    * ``ceph_pool_rd_bytes``: Client read operations in bytes per pool
 
-* ``ceph_pool_wr``: Client write operations per pool (writes per second)
+    * ``ceph_pool_wr``: Client write operations per pool (writes per second)
 
-* ``ceph_pool_wr_bytes``: Client write operation in bytes per pool
+    * ``ceph_pool_wr_bytes``: Client write operation in bytes per pool
 
 
 **Useful queries**:
@@ -295,26 +303,31 @@ Example:
 
 Generic metrics
 ---------------
-* ``ceph_rgw_metadata``: Provides generic information about an RGW daemon. This
-  can be used together with other metrics to provide contextual
-  information in queries and graphs. In addtion to the three common labels, this
-  metric provides the following:
 
-    * ``ceph_daemon``: Name of the RGW daemon instance. Example:
+* ``ceph_rgw_metadata``: Provides generic information about an RGW daemon.
+  This can be used together with other metrics to provide contextual
+  information in queries and graphs. In addtion to the three common labels,
+  this metric provides the following:
+
+  * ``ceph_daemon``: Name of the RGW daemon instance. Example:
     ``ceph_daemon="rgw.rgwtest.cephtest-node-00.sxizyq"``
-    * ``ceph_version``: Version of the RGW daemon. Example: ``ceph_version="ceph
-    version 17.2.6 (d7ff0d10654d2280e08f1ab989c7cdf3064446a5) quincy (stable)"``
-    * ``hostname``: Name of the host where the daemon runs. Example:
+
+  * ``ceph_version``: Version of the RGW daemon. Example: ``ceph_version="ceph
+    version 17.2.6 (d7ff0d10654d2280e08f1ab989c7cdf3064446a5) quincy
+    (stable)"``
+
+  * ``hostname``: Name of the host where the daemon runs. Example:
     ``hostname:"cephtest-node-00.cephlab.com"``
 
-* ``ceph_rgw_req``: Number of requests processed by the daemon (``GET``+``PUT``+``DELETE``).
-    Useful for detecting bottlenecks and optimizing load distribution.
+  * ``ceph_rgw_req``: Number of requests processed by the daemon
+    (``GET``+``PUT``+``DELETE``).  Useful for detecting bottlenecks and
+    optimizing load distribution.
 
-* ``ceph_rgw_qlen``: Operations queue length for the daemon.
-    Useful for detecting bottlenecks and optimizing load distribution.
+  * ``ceph_rgw_qlen``: Operations queue length for the daemon.  Useful for
+    detecting bottlenecks and optimizing load distribution.
 
-* ``ceph_rgw_failed_req``: Aborted requests.
-    Useful for detecting daemon errors.
+  * ``ceph_rgw_failed_req``: Aborted requests.  Useful for detecting daemon
+    errors.
 
 
 GET operation metrics


### PR DESCRIPTION
Correct list formatting in doc/monitoring/index.rst.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
