### PR TITLE
doc/mgr: edit crash.rst

### DIFF
--- a/doc/mgr/crash.rst
+++ b/doc/mgr/crash.rst
@@ -6,13 +6,17 @@ it in the Ceph cluster for later analysis.
 Enabling
 --------
 
-The *crash* module is enabled with::
+Enable the *crash* module by running the following command:
 
-  ceph mgr module enable crash
+.. prompt:: bash #
 
-The *crash* upload key is generated with::
+   ceph mgr module enable crash
 
-  ceph auth get-or-create client.crash mon 'profile crash' mgr 'profile crash'
+Generate the *crash* upload key by running the following command:
+
+.. prompt:: bash #
+
+   ceph auth get-or-create client.crash mon 'profile crash' mgr 'profile crash'
 
 On each node, you should store this key in
 ``/etc/ceph/ceph.client.crash.keyring``.
@@ -39,57 +43,61 @@ and a keyring needs to be in ``/etc/ceph``.
 
 Commands
 --------
-::
 
-  ceph crash post -i <metafile>
+.. prompt:: bash #
+
+   ceph crash post -i <metafile>
 
 Save a crash dump.  The metadata file is a JSON blob stored in the crash
 dir as ``meta``.  As usual, the ceph command can be invoked with ``-i -``,
 and will read from stdin.
 
-::
+.. prompt:: bash #
 
-  ceph crash rm <crashid>
+   ceph crash rm <crashid>
 
 Remove a specific crash dump.
 
-::
+.. prompt:: bash #
 
-  ceph crash ls
+   ceph crash ls
 
 List the timestamp/uuid crashids for all new and archived crash info.
 
-::
 
-  ceph crash ls-new
+.. prompt:: bash #
+
+   ceph crash ls-new
 
 List the timestamp/uuid crashids for all newcrash info.
 
-::
 
-  ceph crash stat
+.. prompt:: bash #
+
+   ceph crash stat
 
 Show a summary of saved crash info grouped by age.
 
-::
+.. prompt:: bash #
 
-  ceph crash info <crashid>
+   ceph crash info <crashid>
 
 Show all details of a saved crash.
 
-::
+
+.. prompt:: bash #
 
    ceph crash prune <keep>
 
 Remove saved crashes older than 'keep' days.  <keep> must be an integer.
 
-::
+.. prompt:: bash #
 
    ceph crash archive <crashid>
 
 Archive a crash report so that it is no longer considered for the ``RECENT_CRASH`` health check and does not appear in the ``crash ls-new`` output (it will still appear in the ``crash ls`` output).
 
-::
+.. prompt:: bash #
 
    ceph crash archive-all
 


### PR DESCRIPTION
Edit doc/mgr/crash.rst. Add prompts and correct some of the inelegant English present in the file.

This commit is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.

Credit for this initiative should go to Ville Ojamo.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
