### PR TITLE
tentacle: osd/scrub: remove (was: fix) deadline calculations

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -551,7 +551,7 @@ You may set values for the following keys:
 
 .. describe:: scrub_min_interval
    
-   :Description: Sets the minimum interval (in seconds) between successive shallow / light scrubs of the pool's PGs when the load is low. If the default value of ``0`` is in effect, then the value of ``osd_scrub_min_interval`` from central config is used.
+   :Description: Sets the minimum interval (in seconds) between successive shallow (light) scrubs of the pool's PGs. If this pool attribute is unchanged from its default (``0``), the value of ``osd_scrub_min_interval`` from central config is used instead.
 
    :Type: Double
    :Default: ``0``
@@ -560,7 +560,7 @@ You may set values for the following keys:
 
 .. describe:: scrub_max_interval
    
-   :Description: Sets the maximum interval (in seconds) between successive shallow / light scrubs of the pool's PGs regardless of cluster load. If the value of ``scrub_max_interval`` is ``0``, then the value ``osd_scrub_max_interval`` from central config is used.
+   :Description: Sets the maximum interval (in seconds) between successive shallow (light) scrubs of the pool's PGs. Affects the 'overdue' attribute appearing in scrub scheduler dumps. If unchanged from its default of ``0``, the value of ``osd_scrub_max_interval`` from central config is used instead.
 
    :Type: Double
    :Default: ``0``
@@ -569,7 +569,7 @@ You may set values for the following keys:
 
 .. describe:: deep_scrub_interval
    
-   :Description: Sets the interval (in seconds) for successive pool deep scrubs of the pool's PGs. If the value of ``deep_scrub_interval`` is ``0``, the value ``osd_deep_scrub_interval`` from central config is used.
+   :Description: Sets the interval (in seconds) for successive pool deep scrubs of the pool's PGs. If unchanged from its default of ``0``, the value of ``osd_deep_scrub_interval`` from central config is used instead.
 
    :Type: Double
    :Default: ``0``

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -157,7 +157,6 @@ void ScrubQueue::dump_scrubs(ceph::Formatter* f) const
 	f->dump_stream("pgid") << e.pgid;
 	f->dump_stream("sched_time") << e.schedule.not_before;
 	f->dump_stream("orig_sched_time") << e.schedule.scheduled_at;
-	f->dump_stream("deadline") << e.schedule.deadline;
 	f->dump_bool(
 	    "forced",
 	    e.schedule.scheduled_at == PgScrubber::scrub_must_stamp());
@@ -167,7 +166,6 @@ void ScrubQueue::dump_scrubs(ceph::Formatter* f) const
                                        : "deep");
         f->dump_stream("urgency") << fmt::format("{}", e.urgency);
         f->dump_bool("eligible", e.schedule.not_before <= query_time);
-        f->dump_bool("overdue", e.schedule.deadline < query_time);
         f->dump_stream("last_issue") << fmt::format("{}", e.last_issue);
       },
       std::numeric_limits<int>::max());

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -110,20 +110,13 @@ void ScrubJob::adjust_shallow_schedule(
   if (ScrubJob::requires_randomization(shallow_target.urgency())) {
     utime_t adj_not_before = last_scrub;
     utime_t adj_target = last_scrub;
-    sh_times.deadline = adj_target;
 
     // add a random delay to the proposed scheduled time
     adj_target += app_conf.shallow_interval;
     double r = rand() / (double)RAND_MAX;
     adj_target +=
-	  app_conf.shallow_interval * app_conf.interval_randomize_ratio * r;
+	app_conf.shallow_interval * app_conf.interval_randomize_ratio * r;
 
-    // the deadline can be updated directly into the scrub-job
-    if (app_conf.max_shallow) {
-      sh_times.deadline += *app_conf.max_shallow;
-    } else {
-      sh_times.deadline = utime_t::max();
-    }
     if (adj_not_before < adj_target) {
       adj_not_before = adj_target;
     }
@@ -132,16 +125,13 @@ void ScrubJob::adjust_shallow_schedule(
 
   } else {
 
-    // the target time is already set. Make sure to reset the n.b. and
-    // the (irrelevant) deadline
+    // the target time is already set. Make sure to reset the n.b.
     sh_times.not_before = sh_times.scheduled_at;
-    sh_times.deadline = utime_t::max();
   }
 
   dout(10) << fmt::format(
-		  "adjusted: nb:{:s} target:{:s} deadline:{:s} ({})",
-		  sh_times.not_before, sh_times.scheduled_at, sh_times.deadline,
-		  state_desc())
+		  "adjusted: nb:{:s} target:{:s} ({})", sh_times.not_before,
+		  sh_times.scheduled_at, state_desc())
 	   << dendl;
 }
 
@@ -253,7 +243,6 @@ void ScrubJob::adjust_deep_schedule(
 	   << dendl;
 
   auto& dp_times = deep_target.sched_info.schedule;  // shorthand
-  dp_times.deadline = utime_t::max(); // no 'max' for deep scrubs
 
   if (ScrubJob::requires_randomization(deep_target.urgency())) {
     utime_t adj_target = last_deep;
@@ -369,7 +358,6 @@ void ScrubJob::dump(ceph::Formatter* f) const
   f->dump_stream("pgid") << pgid;
   f->dump_stream("sched_time") << get_sched_time();
   f->dump_stream("orig_sched_time") << sch.scheduled_at;
-  f->dump_stream("deadline") << sch.deadline;
   f->dump_bool("forced", entry.urgency >= urgency_t::operator_requested);
 }
 

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -122,7 +122,7 @@ void ScrubJob::adjust_shallow_schedule(
     if (app_conf.max_shallow) {
       sh_times.deadline += *app_conf.max_shallow;
     } else {
-      sh_times.deadline = utime_t{};
+      sh_times.deadline = utime_t::max();
     }
     if (adj_not_before < adj_target) {
       adj_not_before = adj_target;
@@ -135,7 +135,7 @@ void ScrubJob::adjust_shallow_schedule(
     // the target time is already set. Make sure to reset the n.b. and
     // the (irrelevant) deadline
     sh_times.not_before = sh_times.scheduled_at;
-    sh_times.deadline = sh_times.scheduled_at;
+    sh_times.deadline = utime_t::max();
   }
 
   dout(10) << fmt::format(
@@ -257,12 +257,8 @@ void ScrubJob::adjust_deep_schedule(
                     app_conf.deep_randomize_ratio, adj_target)
              << dendl;
 
-    // the deadline can be updated directly into the scrub-job
-    if (app_conf.max_shallow) {
-      dp_times.deadline += *app_conf.max_shallow;  // RRR fix
-    } else {
-      dp_times.deadline = utime_t{};
-    }
+    dp_times.deadline += app_conf.max_deep;
+
     if (adj_not_before < adj_target) {
       adj_not_before = adj_target;
     }
@@ -272,7 +268,7 @@ void ScrubJob::adjust_deep_schedule(
     // the target time is already set. Make sure to reset the n.b. and
     // the (irrelevant) deadline
     dp_times.not_before = dp_times.scheduled_at;
-    dp_times.deadline = dp_times.scheduled_at;
+    dp_times.deadline = utime_t::max();
   }
 
   dout(10) << fmt::format(

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -38,14 +38,6 @@ struct sched_conf_t {
   double deep_interval{0.0};
 
   /**
-   * the maximum interval between shallow scrubs, after which the
-   * (info-only) "overdue" field in the scheduler dump is set.
-   * Determined by either the pool or the cluster configuration.
-   * Empty if no limit is configured.
-   */
-  std::optional<double> max_shallow;
-
-  /**
    * interval_randomize_ratio
    *
    * We add an extra random duration to the configured times when doing
@@ -212,16 +204,15 @@ class ScrubJob {
 
   /**
    * Given a proposed time for the next scrub, and the relevant
-   * configuration, adjust_schedule() determines the actual target time,
-   * the deadline, and the 'not_before' time for the scrub.
+   * configuration, adjust_schedule() determines the actual target time
+   * and the 'not_before' time for the scrub.
    * The new values are updated into the scrub-job.
    *
    * Specifically:
    * - for high-priority scrubs: the 'not_before' is set to the
    *   (untouched) proposed target time.
    * - for regular scrubs: the proposed time is adjusted (delayed) based
-   *   on the configuration; the deadline is set further out (if configured)
-   *   and the n.b. is reset to the target.
+   *   on the configuration; the n.b. is reset to the target.
    */
   void adjust_shallow_schedule(
     utime_t last_scrub,
@@ -434,8 +425,8 @@ struct formatter<Scrub::sched_conf_t> {
   {
     return fmt::format_to(
 	ctx.out(),
-	"periods:s:{}/{},d:{},iv-ratio:{},deep-rand:{},on-inv:{}",
-	cf.shallow_interval, cf.max_shallow.value_or(-1.0), cf.deep_interval,
+	"periods:s:{},d:{},iv-ratio:{},deep-rand:{},on-inv:{}",
+	cf.shallow_interval, cf.deep_interval,
 	cf.interval_randomize_ratio, cf.deep_randomize_ratio,
 	cf.mandatory_on_invalid);
   }

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -44,15 +44,13 @@ struct sched_conf_t {
   std::optional<double> max_shallow;
 
   /**
-   * the maximum interval between deep scrubs.
-   * For deep scrubs - there is no equivalent of scrub_max_interval. Per the
-   * documentation, once deep_scrub_interval has passed, we are already
-   * "overdue", at least as far as the "ignore allowed load" window is
-   * concerned. \todo based on users complaints (and the fact that the
-   * interaction between the configuration parameters is clear to no one),
-   * this will be revised shortly.
+   * the maximum interval between deep scrubs, after which the
+   * (info-only) "overdue" field in the scheduler dump is set.
+   * There is no specific configuration parameter to control the
+   * deep scrubs max. Instead - we set it to 4 times the average
+   * interval.
    */
-  double max_deep{0.0};
+  double max_deep{std::numeric_limits<double>::max()};
 
   /**
    * interval_randomize_ratio
@@ -226,7 +224,7 @@ class ScrubJob {
    * The new values are updated into the scrub-job.
    *
    * Specifically:
-   * - for high-priority scrubs: n.b. & deadline are set equal to the
+   * - for high-priority scrubs: the 'not_before' is set to the
    *   (untouched) proposed target time.
    * - for regular scrubs: the proposed time is adjusted (delayed) based
    *   on the configuration; the deadline is set further out (if configured)

--- a/src/osd/scrubber/scrub_queue_entry.h
+++ b/src/osd/scrubber/scrub_queue_entry.h
@@ -60,7 +60,7 @@ enum class urgency_t {
  * a specific scrub level. Namely - it identifies the [pg,level] combination,
  * the 'urgency' attribute of the scheduled scrub (which determines most of
  * its behavior and scheduling decisions) and the actual time attributes
- * for scheduling (target, deadline, not_before).
+ * for scheduling (target time & not_before).
  */
 struct SchedEntry {
   constexpr SchedEntry(spg_t pgid, scrub_level_t level)
@@ -78,7 +78,7 @@ struct SchedEntry {
 
   urgency_t urgency{urgency_t::periodic_regular};
 
-  /// scheduled_at, not-before & the deadline times
+  /// scheduled_at and not-before times
   Scrub::scrub_schedule_t schedule;
 
   /// either 'none', or the reason for the latest failure/delay (for
@@ -211,9 +211,9 @@ struct formatter<Scrub::SchedEntry> {
   auto format(const Scrub::SchedEntry& st, FormatContext& ctx) const
   {
     return fmt::format_to(
-	ctx.out(), "{}/{},nb:{:s},({},tr:{:s},dl:{:s})", st.pgid,
+	ctx.out(), "{}/{},nb:{:s},({},tr:{:s})", st.pgid,
 	(st.level == scrub_level_t::deep ? "dp" : "sh"), st.schedule.not_before,
-	st.urgency, st.schedule.scheduled_at, st.schedule.deadline);
+	st.urgency, st.schedule.scheduled_at);
   }
 };
 }  // namespace fmt

--- a/src/osd/scrubber/scrub_queue_entry.h
+++ b/src/osd/scrubber/scrub_queue_entry.h
@@ -61,9 +61,6 @@ enum class urgency_t {
  * the 'urgency' attribute of the scheduled scrub (which determines most of
  * its behavior and scheduling decisions) and the actual time attributes
  * for scheduling (target, deadline, not_before).
- *
- * In this commit - the 'urgency' attribute is not fully used yet, and some
- * of the scrub behavior is still controlled by the 'planned scrub' flags.
  */
 struct SchedEntry {
   constexpr SchedEntry(spg_t pgid, scrub_level_t level)

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -124,25 +124,13 @@ enum class schedule_result_t {
 };
 
 /// a collection of the basic scheduling information of a scrub target:
-/// target time to scrub, the 'not before' time, and a deadline.
+/// target time to scrub, and the 'not before'.
 struct scrub_schedule_t {
   /**
    * the time at which we are allowed to start the scrub. Never
    * decreasing after 'scheduled_at' is set.
    */
   utime_t not_before{utime_t::max()};
-
-  /**
-   * the 'deadline' is the time by which we expect the periodic scrub to
-   * complete. It is determined by the SCRUB_MAX_INTERVAL pool configuration
-   * and by osd_scrub_max_interval;
-   * Note: the 'deadline' has only a limited effect on scheduling: when
-   * comparing jobs having identical urgency and target time (scheduled_at'),
-   * the job with the earlier 'deadline' is preferred.
-   * Being past deadline also sets the 'overdue' flag in scrub
-   * scheduling dumps.
-   */
-  utime_t deadline{utime_t::max()};
 
   /**
    * the 'scheduled_at' is the time at which we intended the scrub to be scheduled.
@@ -161,12 +149,9 @@ struct scrub_schedule_t {
   {
     // when compared - the 'not_before' is ignored, assuming
     // we never compare jobs with different eligibility status.
-    auto cmp1 = scheduled_at <=> rhs.scheduled_at;
-    if (cmp1 != 0) {
-      return cmp1;
-    }
-    return deadline <=> rhs.deadline;
+    return scheduled_at <=> rhs.scheduled_at;
   };
+
   bool operator==(const scrub_schedule_t& rhs) const = default;
 };
 
@@ -191,8 +176,7 @@ struct formatter<Scrub::OSDRestrictions> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
-  auto format(const Scrub::OSDRestrictions& conds, FormatContext& ctx) const
-  {
+  auto format(const Scrub::OSDRestrictions& conds, FormatContext& ctx) const {
     return fmt::format_to(
 	ctx.out(), "<{}.{}.{}.{}.{}>",
 	conds.max_concurrency_reached ? "max-scrubs" : "",
@@ -207,11 +191,9 @@ template <>
 struct formatter<Scrub::scrub_schedule_t> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
   template <typename FormatContext>
-  auto format(const Scrub::scrub_schedule_t& sc, FormatContext& ctx) const
-  {
+  auto format(const Scrub::scrub_schedule_t& sc, FormatContext& ctx) const {
     return fmt::format_to(
-	ctx.out(), "nb:{:s}(at:{:s},dl:{:s})", sc.not_before,
-        sc.scheduled_at, sc.deadline);
+	ctx.out(), "nb:{:s}(at:{:s})", sc.not_before, sc.scheduled_at);
   }
 };
 

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -136,9 +136,11 @@ struct scrub_schedule_t {
    * the 'deadline' is the time by which we expect the periodic scrub to
    * complete. It is determined by the SCRUB_MAX_INTERVAL pool configuration
    * and by osd_scrub_max_interval;
-   * Once passed, the scrub will be allowed to run even if the OSD is
-   * overloaded.It would also have higher priority than other
-   * auto-scheduled scrubs.
+   * Note: the 'deadline' has only a limited effect on scheduling: when
+   * comparing jobs having identical urgency and target time (scheduled_at'),
+   * the job with the earlier 'deadline' is preferred.
+   * Being past deadline also sets the 'overdue' flag in scrub
+   * scheduling dumps.
    */
   utime_t deadline{utime_t::max()};
 


### PR DESCRIPTION
The scrub scheduling deadlines are calculated based on pool and OSD configuration parameters. The specifics of the calculations are modified to match the new scrub scheduling design.

Comments and documentation are updated to reflect the fact that the deadlines no longer have any meaningful effect on scrub scheduling.

Fixes: https://tracker.ceph.com/issues/71295
Backport of https://github.com/ceph/ceph/pull/63183