### PR TITLE
tentacle: crimson/osd/pg: set log_entry_update_waiting_on prior to sending requests

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -180,7 +180,12 @@ ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptib
       pg.wait_for_active_blocker,
       &decltype(pg.wait_for_active_blocker)::wait));
 
+  DEBUGDPP("{}.{}: waited for active, entering get_obc stage ",
+           pg, *this, this_instance_id);
+
   co_await ihref.enter_stage<interruptor>(client_pp(pg).get_obc, *this);
+
+  DEBUGDPP("{}.{}: entered get_obc stage", pg, *this, this_instance_id);
 
   if (int res = op_info.set_from_op(&*m, *pg.get_osdmap());
       res != 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71309

---

backport of https://github.com/ceph/ceph/pull/63233
parent tracker: https://tracker.ceph.com/issues/71204

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh