### PR TITLE
rgw: Change keystone credential secret load api method

### DIFF
--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -570,8 +570,6 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
       std::string blob_string;
       JSONDecoder::decode_json("blob", blob_string, *credential_iter, true);
 
-      int blob_size = blob_string.length();
-
       JSONParser blob_parser;
       if (!blob_parser.parse(blob_string.c_str(), blob_string.length())) {
         ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed 'blob' section in json" << dendl;

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -557,7 +557,7 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   /* now parse response */
 
   JSONParser parser;
-  if (! parser.parse(token_body_bl.c_str(), token_body_bl.length())) {
+  if (!parser.parse(token_body_bl.c_str(), token_body_bl.length())) {
     ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed json." << dendl;
     return make_pair(boost::none, -EINVAL);
   }

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -572,25 +572,21 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
 
       int blob_size = blob_string.length();
 
-      // declaring character array
-      char blob_size_char_array[blob_size + 1];
-      strcpy(blob_size_char_array, blob_string.c_str());
-
       JSONParser blob_parser;
-      if (!blob_parser.parse(blob_size_char_array, blob_size)) {
-          ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed 'blob' section in json" << dendl;
-          return make_pair(boost::none, -EINVAL);
+      if (!blob_parser.parse(blob_string.c_str(), blob_string.length())) {
+        ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed 'blob' section in json" << dendl;
+        return make_pair(boost::none, -EINVAL);
       }
 
       JSONObjIter json_blob_iterator = blob_parser.find_first("secret");
-        
-      if (!json_blob_iterator.end()) {
-          secret_string = (*json_blob_iterator)->get_data();
 
-          ldpp_dout(dpp, 10) << "Loaded secret for access key [" << access_key_id << "] with credential ID [" << access_key_actual_id << "]." << dendl;
+      if (!json_blob_iterator.end()) {
+        secret_string = (*json_blob_iterator)->get_data();
+
+        ldpp_dout(dpp, 10) << "Loaded secret for access key [" << access_key_id << "] with credential ID [" << access_key_actual_id << "]." << dendl;
       } else {
-          ldpp_dout(dpp, 0) << "Keystone credential secret not found in the response from Keystone server blob [" << blob_string << "] ." << dendl;
-          return make_pair(boost::none, -EINVAL);
+        ldpp_dout(dpp, 0) << "Keystone credential secret not found in the response from Keystone server blob [" << blob_string << "] ." << dendl;
+        return make_pair(boost::none, -EINVAL);
       }
     } else {
       ldpp_dout(dpp, 0) << "Keystone credential not present in return from server" << dendl;

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -505,10 +505,15 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   }
 
   keystone_url.append("v3/");
-  keystone_url.append("users/");
-  keystone_url.append(user_id);
-  keystone_url.append("/credentials/OS-EC2/");
-  keystone_url.append(std::string(access_key_id));
+  keystone_url.append("credentials/");
+
+  sha256_digest_t hash = calc_hash_sha256(access_key_id);
+
+  char hex_str[(CEPH_CRYPTO_SHA256_DIGESTSIZE * 2) + 1];
+  buf_to_hex((unsigned char *)hash.v, CEPH_CRYPTO_SHA256_DIGESTSIZE, hex_str);
+
+  std::string access_key_actual_id = std::string(hex_str);
+  keystone_url.append(access_key_actual_id);
 
   /* get authentication token for Keystone. */
   std::string admin_token;
@@ -553,7 +558,7 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
 
   JSONParser parser;
   if (! parser.parse(token_body_bl.c_str(), token_body_bl.length())) {
-    ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed json" << dendl;
+    ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed json." << dendl;
     return make_pair(boost::none, -EINVAL);
   }
 
@@ -562,7 +567,31 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
 
   try {
     if (!credential_iter.end()) {
-      JSONDecoder::decode_json("secret", secret_string, *credential_iter, true);
+      std::string blob_string;
+      JSONDecoder::decode_json("blob", blob_string, *credential_iter, true);
+
+      int blob_size = blob_string.length();
+
+      // declaring character array
+      char blob_size_char_array[blob_size + 1];
+      strcpy(blob_size_char_array, blob_string.c_str());
+
+      JSONParser blob_parser;
+      if (!blob_parser.parse(blob_size_char_array, blob_size)) {
+          ldpp_dout(dpp, 0) << "Keystone credential parse error: malformed 'blob' section in json" << dendl;
+          return make_pair(boost::none, -EINVAL);
+      }
+
+      JSONObjIter json_blob_iterator = blob_parser.find_first("secret");
+        
+      if (!json_blob_iterator.end()) {
+          secret_string = (*json_blob_iterator)->get_data();
+
+          ldpp_dout(dpp, 10) << "Loaded secret for access key [" << access_key_id << "] with credential ID [" << access_key_actual_id << "]." << dendl;
+      } else {
+          ldpp_dout(dpp, 0) << "Keystone credential secret not found in the response from Keystone server blob [" << blob_string << "] ." << dendl;
+          return make_pair(boost::none, -EINVAL);
+      }
     } else {
       ldpp_dout(dpp, 0) << "Keystone credential not present in return from server" << dendl;
       return make_pair(boost::none, -EINVAL);


### PR DESCRIPTION

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - The Signed-off-by line in every git commit is important; see <span class="x x-first x-last">[Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/master/</span>SubmittingPatches.rst<span class="x x-first x-last">)</span>
-->

Keystone <> Ceph RadosGW integration used the API "/users/{user_id}/credentials/OS-EC2/{credential_id}" to retrieve the secret key of the user and store it (the secret key) in RadosGW cache. That API was used because Ceph RadosGW has the access Key and not the credential ID. However, despite the notation used in the documentation, `{credential_id}`, the value the API expects is the access key and not the credential ID. That is why RadosGW can retrieve the secret key via that API with the access key.
    
That API endpoint uses 3 DB queries to complete its processing. It validates the user making the request, the authenticated user, to see if the user executing the request has access to the access key requested (https://github.com/openstack/keystone/blob/fc9efc45b26d23a3b28ac0bc74da3f537dfda89b/keystone/api/users.py#L425), and then, it also validates the `{user_id}` parameter (https://github.com/openstack/keystone/blob/fc9efc45b26d23a3b28ac0bc74da3f537dfda89b/keystone/api/users.py#L429), to see if it is a valid user (ignoring the fact that it might be interesting to see if the `{user_id}` is the actual user ID of the access key used in {credential_id}), and then, finally, the third DB query (https://github.com/openstack/keystone/blob/fc9efc45b26d23a3b28ac0bc74da3f537dfda89b/keystone/api/users.py#L431), it retrieves the credential from the DB.
    
It turns out that the credential ID is derived from the access key value (https://github.com/openstack/keystone/blob/fc9efc45b26d23a3b28ac0bc74da3f537dfda89b/keystone/api/users.py#L430); therefore, one can use a more direct approach to retrieve that secret value via the credential API (https://docs.openstack.org/api-ref/identity/v3/?expanded=show-credential-details-detail#show-credential-details). The credential API, if used directly, would remove DB queries (https://github.com/openstack/keystone/blob/fc9efc45b26d23a3b28ac0bc74da3f537dfda89b/keystone/api/credentials.py#L139), as it goes directly in the DB and accesses the credential requested (after having checked if the user of the token that is used in the request has access to the API). RadosGW's keystone user has access to this API (normally, operators give admin permissions); therefore, this seems to be a more direct approach to load the secret key.
    
This PR introduces the changes necessary to use the "/credentials" API, instead of the "/users/{user_id}/credentials/OS-EC2/{credential_id}" API.

P.S. It is my very first Ceph PR. Therefore, if I am missing something, or if there is something that needs improvement, let me know, and I will address the requests as soon as possible.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
