### PR TITLE
tools/ceph_dedup: improve const-ness and use ranged-for loop when appropriate 

### DIFF
--- a/src/tools/ceph_dedup/ceph_dedup_daemon.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_daemon.cc
@@ -365,11 +365,9 @@ void SampleDedupWorkerThread::crawl()
 	op.list_snaps(&snap_set, &snap_ret);
 	io_ctx.operate(target.oid, &op, NULL);
 
-	for (std::vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
-	  r != snap_set.clones.end();
-	  ++r) {
-	  io_ctx.snap_set_read(r->cloneid);
-	  try_dedup_and_accumulate_result(target, r->cloneid);
+	for (const auto& clone : snap_set.clones) {
+	  io_ctx.snap_set_read(clone.cloneid);
+	  try_dedup_and_accumulate_result(target, clone.cloneid);
 	}
       } else {
 	try_dedup_and_accumulate_result(target);

--- a/src/tools/ceph_dedup/ceph_dedup_daemon.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_daemon.cc
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include "common.h"
 #include "log/Log.h"
 

--- a/src/tools/ceph_dedup/ceph_dedup_daemon.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_daemon.cc
@@ -190,13 +190,13 @@ public:
       }
     }
 
-    bool contains(std::string& fp) {
+    bool contains(const std::string& fp) {
       std::shared_lock lock(fingerprint_lock);
       return fp_map.contains(fp);
     }
 
     // return true if the chunk is duplicate
-    bool add(chunk_t& chunk) {
+    bool add(const chunk_t& chunk) {
       std::unique_lock lock(fingerprint_lock);
       auto entry = fp_map.find(chunk.fingerprint);
       total_bytes += chunk.size;
@@ -246,7 +246,7 @@ public:
       fp_store(chunk_threshold, report_period, fpstore_threshold),
       sampling_ratio(static_cast<double>(sampling_ratio) / 100) { }
 
-    bool is_all_stop() {
+    bool is_all_stop() const {
       std::shared_lock l{glock};
       return all_stop;
     }
@@ -319,14 +319,14 @@ private:
     ObjectCursor end,
     size_t max_object_count);
   std::vector<size_t> sample_object(size_t count);
-  void try_dedup_and_accumulate_result(ObjectItem &object, snap_t snap = 0);
+  void try_dedup_and_accumulate_result(const ObjectItem &object, snap_t snap = 0);
   int do_chunk_dedup(chunk_t &chunk, snap_t snap);
-  bufferlist read_object(ObjectItem &object);
+  bufferlist read_object(const ObjectItem &object);
   std::vector<std::tuple<bufferlist, std::pair<uint64_t, uint64_t>>> do_cdc(
-    ObjectItem &object,
-    bufferlist &data);
-  std::string generate_fingerprint(bufferlist chunk_data);
-  AioCompRef do_async_evict(std::string oid);
+    const ObjectItem &object,
+    const bufferlist &data) const;
+  std::string generate_fingerprint(const bufferlist& chunk_data) const;
+  AioCompRef do_async_evict(const std::string& oid);
 
   IoCtx io_ctx;
   IoCtx chunk_io_ctx;
@@ -393,7 +393,7 @@ void SampleDedupWorkerThread::crawl()
   }
 }
 
-AioCompRef SampleDedupWorkerThread::do_async_evict(std::string oid)
+AioCompRef SampleDedupWorkerThread::do_async_evict(const std::string& oid)
 {
   Rados rados;
   ObjectReadOperation op_tier;
@@ -443,7 +443,7 @@ std::vector<size_t> SampleDedupWorkerThread::sample_object(size_t count)
 }
 
 void SampleDedupWorkerThread::try_dedup_and_accumulate_result(
-  ObjectItem &object, snap_t snap)
+  const ObjectItem &object, snap_t snap)
 {
   bufferlist data = read_object(object);
   if (data.length() == 0) {
@@ -504,7 +504,7 @@ void SampleDedupWorkerThread::try_dedup_and_accumulate_result(
   total_object_size += object_size;
 }
 
-bufferlist SampleDedupWorkerThread::read_object(ObjectItem &object)
+bufferlist SampleDedupWorkerThread::read_object(const ObjectItem &object)
 {
   bufferlist whole_data;
   size_t offset = 0;
@@ -527,8 +527,8 @@ bufferlist SampleDedupWorkerThread::read_object(ObjectItem &object)
 }
 
 std::vector<std::tuple<bufferlist, std::pair<uint64_t, uint64_t>>> SampleDedupWorkerThread::do_cdc(
-  ObjectItem &object,
-  bufferlist &data)
+  const ObjectItem &object,
+  const bufferlist &data) const
 {
   std::vector<std::tuple<bufferlist, std::pair<uint64_t, uint64_t>>> ret;
 
@@ -544,7 +544,7 @@ std::vector<std::tuple<bufferlist, std::pair<uint64_t, uint64_t>>> SampleDedupWo
   return ret;
 }
 
-std::string SampleDedupWorkerThread::generate_fingerprint(bufferlist chunk_data)
+std::string SampleDedupWorkerThread::generate_fingerprint(const bufferlist& chunk_data) const
 {
   std::string ret;
 

--- a/src/tools/ceph_dedup/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_tool.cc
@@ -1040,10 +1040,8 @@ int make_dedup_object(const po::variables_map &opts)
       op.list_snaps(&snap_set, &snap_ret);
       io_ctx.operate(object_name, &op, NULL);
 
-      for (std::vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
-	r != snap_set.clones.end();
-	++r) {
-	io_ctx.snap_set_read(r->cloneid);
+      for (const auto& clone : snap_set.clones) {
+	io_ctx.snap_set_read(clone.cloneid);
 	ret = create_new_deduped_object(object_name);
 	if (ret < 0) {
 	  goto out;


### PR DESCRIPTION
-  Replace iterator loops with range-based loops 
- Add const qualifiers and reference parameters

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
