### PR TITLE
pybind/cephfs: add blockdiff api bindings

### DIFF
--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -71,6 +71,17 @@ cdef extern from "cephfs/libcephfs.h" nogil:
         dirent dir_entry
         uint64_t snapid
 
+    cdef struct ceph_file_blockdiff_info:
+        pass
+
+    cdef struct cblock:
+        uint64_t offset
+        uint64_t len
+
+    cdef struct ceph_file_blockdiff_changedblocks:
+        uint64_t num_blocks
+        cblock *b
+
     ctypedef void* rados_t
 
     const char *ceph_version(int *major, int *minor, int *patch)
@@ -169,6 +180,16 @@ cdef extern from "cephfs/libcephfs.h" nogil:
                            ceph_snapdiff_info *out)
     int ceph_readdir_snapdiff(ceph_snapdiff_info *snapdiff, ceph_snapdiff_entry_t *out);
     int ceph_close_snapdiff(ceph_snapdiff_info *snapdiff)
+    int ceph_file_blockdiff_init(ceph_mount_info *cmount,
+                                 const char *root_path,
+                                 const char *rel_path,
+                                 const char *snap1,
+                                 const char *snap2,
+                                 ceph_file_blockdiff_info *out_info)
+    int ceph_file_blockdiff(ceph_file_blockdiff_info *info,
+                            ceph_file_blockdiff_changedblocks *blocks)
+    void ceph_free_file_blockdiff_buffer(ceph_file_blockdiff_changedblocks *blocks)
+    int ceph_file_blockdiff_finish(ceph_file_blockdiff_info *info)
     int ceph_rmdir(ceph_mount_info *cmount, const char *path)
     const char* ceph_getcwd(ceph_mount_info *cmount)
     int ceph_sync_fs(ceph_mount_info *cmount)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -395,6 +395,43 @@ cdef class SnapDiffHandle(object):
             raise make_ex(ret, "closesnapdiff failed")
         self.opened = 0
 
+cdef class BlockDiffHandle(object):
+    cdef LibCephFS lib
+    cdef ceph_file_blockdiff_info handle
+    cdef int opened
+
+    def __cinit__(self, _lib):
+        self.opened = 0
+        self.lib = _lib
+
+    def __dealloc__(self):
+        self.closeblockdiff()
+
+    def readblock(self):
+        self.lib.require_state("mounted")
+
+        cdef:
+            ceph_file_blockdiff_changedblocks chblks
+        with nogil:
+            if self.opened:
+                ret = ceph_file_blockdiff(&self.handle, &chblks)
+            else:
+                raise make_ex(EBADF, "dir is not open")
+        if ret < 0:
+            raise make_ex(ret, f"ceph_file_blockdiff failed, return value: {ret}")
+        elif ret == 0:
+            return None, None, None
+        return chblks.num_blocks, chblks.b.offset, chblks.b.len
+
+    def closeblockdiff(self):
+        if not self.opened:
+            return
+        self.lib.require_state("mounted")
+        with nogil:
+            ret = ceph_file_blockdiff_finish(&self.handle)
+        if ret < 0:
+            raise make_ex(ret, "closeblockdiff failed")
+        self.opened = 0
 
 def cstr(val, name, encoding="utf-8", opt=False) -> bytes:
     """
@@ -1089,6 +1126,36 @@ cdef class LibCephFS(object):
         if ret < 0:
             raise make_ex(ret, "open_snapdiff failed for {} vs. {}"
                 .format(snap1.decode('utf-8'), snap2.decode('utf-8')))
+        h.opened = 1
+        return h
+
+    def openblockdiff(self, root_path, rel_path, snap1name,
+                            snap2name) -> BlockDiffHandle:
+        """
+        Opens the blockdiff
+
+        :param root_path: the path name of the directory to open.  Must be either an absolute path
+                          or a path relative to the current working directory.
+        :param rel_path: the path of the file relative to root_path.
+        :returns: the open directory stream handle
+        """
+        self.require_state("mounted")
+
+        h = BlockDiffHandle(self)
+        root_path = cstr(root_path, 'root')
+        rel_path = cstr(rel_path, 'relp')
+        snap1 = cstr(snap1name, 'snap1')
+        snap2 = cstr(snap2name, 'snap2')
+        cdef:
+            char* _root = root_path
+            char* _relp = rel_path
+            char* _snap1 = snap1
+            char* _snap2 = snap2
+        with nogil:
+            ret = ceph_file_blockdiff_init(self.cluster, _root, _relp, _snap1, _snap2, &h.handle)
+        if ret < 0:
+            raise make_ex(ret, "file blockdiff init failed for "
+                  f"{snap1.decode('utf-8')} vs. {snap2.decode('utf-8')}")
         h.opened = 1
         return h
 

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -73,6 +73,12 @@ cdef nogil:
         dirent dir_entry
         uint64_t snapid
 
+    cdef struct ceph_file_blockdiff_info:
+        int dummy
+
+    cdef struct ceph_file_blockdiff_changedblocks:
+        int dummy
+
     ctypedef void* rados_t
 
     const char *ceph_version(int *major, int *minor, int *patch):
@@ -239,6 +245,18 @@ cdef nogil:
         pass
     int ceph_close_snapdiff(ceph_snapdiff_info *snapdiff):
         pass
+    int ceph_file_blockdiff_init(ceph_mount_info *cmount, const char *root_path,
+                                 const char *rel_path, const char *snap1,
+                                 const char *snap2,
+                                 ceph_file_blockdiff_info *out_info):
+        pass
+    int ceph_file_blockdiff(ceph_file_blockdiff_info *info, ceph_file_blockdiff_changedblocks *blocks):
+        pass
+    void ceph_free_file_blockdiff_buffer(ceph_file_blockdiff_changedblocks *blocks):
+        pass
+    int ceph_file_blockdiff_finish(ceph_file_blockdiff_info *info):
+        pass
+
     int ceph_rmdir(ceph_mount_info *cmount, const char *path):
         pass
     const char* ceph_getcwd(ceph_mount_info *cmount):

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -840,6 +840,35 @@ def test_snapdiff(testdir):
     assert_equal(cnt, 2)
     diff.close()
 
+    # remove directory
+    purge_dir(b"/snapdiff_test");
+
+def test_blockdiff(testdir):
+    """
+    Tests the incremental sync syncs only the changed portions of a huge file.
+    """
+    cephfs.mkdir("/blockdiff_testdir", 0o755)
+    fd = cephfs.open('/blockdiff_testdir/file-1', 'w', 0o755)
+    cephfs.write(fd, b"1234", 0)
+    cephfs.close(fd)
+    # take a snapshot
+    cephfs.mksnap("/blockdiff_testdir", "snap1", 0o755)
+    # make modifications to the file
+    fd = cephfs.open('/blockdiff_testdir/file-1', 'w', 0o755)
+    cephfs.write(fd, b"5678", 4)
+    cephfs.close(fd)
+    # take a snapshot
+    cephfs.mksnap("/blockdiff_testdir", "snap2", 0o755)
+    diff = cephfs.openblockdiff(b"/blockdiff_testdir", b"file-1", b"snap1", b"snap2")
+    num_blocks, offset, length = diff.readblock()
+    assert_equal(1, num_blocks)
+    assert_equal(0, offset)
+    assert_equal(8, length)
+    diff.closeblockdiff()
+
+    # remove directory
+    purge_dir(b"/blockdiff_testdir")
+
 def test_single_target_command():
     command = {'prefix': u'session ls', 'format': 'json'}
     mds_spec  = "a"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/71205


