### PR TITLE
doc/radosgw: Use ref for hyperlinking to multisite

### DIFF
--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -143,8 +143,8 @@ master zonegroup.
 See `Pools`_ for instructions on creating and tuning pools for Ceph Object
 Storage.
 
-See `Sync Policy Config`_ for instructions on defining fine-grained bucket sync
-policy rules.
+See :ref:`Sync Policy Config <radosgw-multisite-sync-policy>` for instructions
+on defining fine-grained bucket sync policy rules.
 
 .. _master-zone-label:
 
@@ -831,9 +831,8 @@ to a multi-site system, follow these steps:
 
       systemctl restart ceph-radosgw@rgw.`hostname -s`
 
-After completing this procedure, proceed to `Configure a Secondary
-Zone <#configure-secondary-zones>`_ and create a secondary zone
-in the master zonegroup.
+After completing this procedure, proceed to :ref:`secondary-zone-label`
+and create a secondary zone in the master zonegroup.
 
 Multi-Site Configuration Reference
 ==================================
@@ -1604,4 +1603,3 @@ instance.
 
 
 .. _`Pools`: ../pools
-.. _`Sync Policy Config`: ../multisite-sync-policy

--- a/doc/radosgw/placement.rst
+++ b/doc/radosgw/placement.rst
@@ -100,7 +100,7 @@ The zone placement configuration can be queried with:
       ...
   }
 
-.. note:: If you have not done any previous `Multisite Configuration`_,
+.. note:: If you have not done any previous :ref:`Multisite Configuration <multisite>`,
           a ``default`` zone and zonegroup are created for you, and changes
           to the zone/zonegroup will not take effect until the Ceph Object
           Gateways are restarted. If you have created a realm for multisite,
@@ -272,4 +272,3 @@ names be used with Ceph, including ``INTELLIGENT-TIERING``, ``STANDARD_IA``,
 libraries.
 
 .. _`Pools`: ../pools
-.. _`Multisite Configuration`: ../multisite

--- a/doc/radosgw/pools.rst
+++ b/doc/radosgw/pools.rst
@@ -5,8 +5,8 @@ Pools
 The Ceph Object Gateway uses several pools for its various storage needs,
 which are listed in the Zone object (see ``radosgw-admin zone get``). A
 single zone named ``default`` is created automatically with pool names
-starting with ``default.rgw.``, but a `Multisite Configuration`_ will have
-multiple zones.
+starting with ``default.rgw.``, but a :ref:`Multisite Configuration <multisite>`
+will have multiple zones.
 
 Tuning
 ======
@@ -51,4 +51,3 @@ the following pool entries use namespaces of the ``us-east.rgw.meta`` pool::
     "user_swift_pool": "us-east.rgw.meta:users.swift",
     "user_uid_pool": "us-east.rgw.meta:users.uid",
 
-.. _`Multisite Configuration`: ../multisite

--- a/doc/radosgw/s3/commons.rst
+++ b/doc/radosgw/s3/commons.rst
@@ -24,8 +24,8 @@ Plan`_ for more information.
 
 To configure virtual hosted buckets, you can either set ``rgw_dns_name =
 cname.domain.com`` in ``ceph.conf`` or add ``cname.domain.com`` to the list of
-``hostnames`` in your zonegroup configuration. See `Ceph Object Gateway -
-Multisite Configuration`_ for more on zonegroups.
+``hostnames`` in your zonegroup configuration. See :ref:`Ceph Object Gateway -
+Multisite Configuration <multisite>` for more on zonegroups.
 
 Here is an example of a ``ceph config set`` comamnd that sets ``rgw_dns_name``
 to ``cname.domain.com``:
@@ -135,5 +135,4 @@ Common Response Status
 | ``500``       | InternalError                     |
 +---------------+-----------------------------------+
 
-.. _`Ceph Object Gateway - Multisite Configuration`: ../../multisite
 .. _`Amazon S3 Path Deprecation Plan`: https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/


### PR DESCRIPTION
Use validated ":ref:" hyperlinks instead of "external links" in "target definitions" when linking within the Ceph docs:
- Update to use existing label in multisite.rst.
- Remove unused "target definitions".

Also use existing label for linking from `multisite.rst`.  
Fix a broken link within `multisite.rst`. *This changes the rendered text to use automatic link text from the section title*.

Otherwise the rendered PR should look the same as the old docs, only differing in the source RST.

- Before/after (no change in rendered PR): https://docs.ceph.com/en/latest/radosgw/multisite/#requirements-and-assumptions https://ceph--63293.org.readthedocs.build/en/63293/radosgw/multisite/#requirements-and-assumptions
- Before/after (link works now, use automatic link text from section title), scroll down to end of the section: https://docs.ceph.com/en/latest/radosgw/multisite/#migrating-a-single-site-deployment-to-multi-site https://ceph--63293.org.readthedocs.build/en/63293/radosgw/multisite/#migrating-a-single-site-deployment-to-multi-site
- Before/after (no change in rendered PR), scroll down to end of the section: https://docs.ceph.com/en/latest/radosgw/placement/#zonegroup-zone-configuration https://ceph--63293.org.readthedocs.build/en/63293/radosgw/placement/#zonegroup-zone-configuration
- Before/after (no change in rendered PR): https://docs.ceph.com/en/latest/radosgw/pools/ https://ceph--63293.org.readthedocs.build/en/63293/radosgw/pools/
- Before/after (no change in rendered PR): https://docs.ceph.com/en/latest/radosgw/s3/commons/ https://ceph--63293.org.readthedocs.build/en/63293/radosgw/s3/commons/




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
