### PR TITLE
doc: Use existing labels and ref for hyperlinks in architecture.rst

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -206,7 +206,7 @@ monitor, two in a cluster that contains three monitors, three in a cluster that
 contains five monitors, four in a cluster that contains six monitors, and so
 on).
 
-See the `Monitor Config Reference`_ for more detail on configuring monitors.
+See the :ref:`monitor-config-reference` for more detail on configuring monitors.
 
 .. index:: architecture; high availability authentication
 
@@ -368,9 +368,9 @@ daemons. The authentication is not extended beyond the Ceph client. If a user
 accesses the Ceph client from a remote host, cephx authentication will not be
 applied to the connection between the user's host and the client host.
 
-See `Cephx Config Guide`_ for more on configuration details.
+See :ref:`rados-cephx-config-ref` for more on configuration details.
 
-See `User Management`_ for more on user management.
+See :ref:`user-management` for more on user management.
 
 See :ref:`A Detailed Description of the Cephx Authentication Protocol
 <cephx_2012_peter>` for more on the distinction between authorization and
@@ -433,8 +433,8 @@ the greater cluster provides several benefits:
    mismatches in object size and finds metadata mismatches, and is usually
    performed daily. Ceph OSD Daemons perform deeper scrubbing by comparing the
    data in objects, bit-for-bit, against their checksums. Deep scrubbing finds
-   bad sectors on drives that are not detectable with light scrubs. See `Data
-   Scrubbing`_ for details on configuring scrubbing.
+   bad sectors on drives that are not detectable with light scrubs. See :ref:`Data
+   Scrubbing <rados_config_scrubbing>` for details on configuring scrubbing.
 
 #. **Replication:** Data replication involves collaboration between Ceph
    Clients and Ceph OSD Daemons. Ceph OSD Daemons use the CRUSH algorithm to
@@ -525,7 +525,7 @@ Pools set at least the following parameters:
 - The Number of Placement Groups, and
 - The CRUSH Rule to Use.
 
-See `Set Pool Values`_ for details.
+See :ref:`setpoolvalues` for details.
 
 
 .. index: architecture; placement group mapping
@@ -626,7 +626,7 @@ which is the process of bringing all of the OSDs that store a Placement Group
 (PG) into agreement about the state of all of the RADOS objects (and their
 metadata) in that PG. Ceph OSD Daemons `Report Peering Failure`_ to the Ceph
 Monitors. Peering issues usually resolve themselves; however, if the problem
-persists, you may need to refer to the `Troubleshooting Peering Failure`_
+persists, you may need to refer to the :ref:`Troubleshooting Peering Failure <failures-osd-peering>`
 section.
 
 .. Note:: PGs that agree on the state of the cluster do not necessarily have
@@ -721,7 +721,7 @@ scrubbing by comparing data in objects bit-for-bit.  Deep scrubbing (by default
 performed weekly) finds bad blocks on a drive that weren't apparent in a light
 scrub.
 
-See `Data Scrubbing`_ for details on configuring scrubbing.
+See :ref:`Data Scrubbing <rados_config_scrubbing>` for details on configuring scrubbing.
 
 
 
@@ -1219,8 +1219,8 @@ appliances do not fully utilize the CPU and RAM of a typical commodity server,
 Ceph does. From heartbeats, to  peering, to rebalancing the cluster or
 recovering from faults,  Ceph offloads work from clients (and from a centralized
 gateway which doesn't exist in the Ceph architecture) and uses the computing
-power of the OSDs to perform the work. When referring to `Hardware
-Recommendations`_ and the `Network Config Reference`_,  be cognizant of the
+power of the OSDs to perform the work. When referring to :ref:`hardware-recommendations`
+and the `Network Config Reference`_,  be cognizant of the
 foregoing concepts to understand how Ceph utilizes computing resources.
 
 .. index:: Ceph Protocol, librados
@@ -1574,7 +1574,7 @@ another application.
    correspond in a 1:1 manner with an object stored in the storage cluster. It
    is possible for an S3 or Swift object to map to multiple Ceph objects.
 
-See `Ceph Object Storage`_ for details.
+See :ref:`object-gateway` for details.
 
 
 .. index:: Ceph Block Device; block device; RBD; Rados Block Device
@@ -1671,26 +1671,15 @@ instance for high availability.
 
 .. _RADOS - A Scalable, Reliable Storage Service for Petabyte-scale Storage Clusters: https://ceph.io/assets/pdfs/weil-rados-pdsw07.pdf
 .. _Paxos: https://en.wikipedia.org/wiki/Paxos_(computer_science)
-.. _Monitor Config Reference: ../rados/configuration/mon-config-ref
-.. _Monitoring OSDs and PGs: ../rados/operations/monitoring-osd-pg
 .. _Heartbeats: ../rados/configuration/mon-osd-interaction
 .. _Monitoring OSDs: ../rados/operations/monitoring-osd-pg/#monitoring-osds
 .. _CRUSH - Controlled, Scalable, Decentralized Placement of Replicated Data: https://ceph.io/assets/pdfs/weil-crush-sc06.pdf
-.. _Data Scrubbing: ../rados/configuration/osd-config-ref#scrubbing
 .. _Report Peering Failure: ../rados/configuration/mon-osd-interaction#osds-report-peering-failure
-.. _Troubleshooting Peering Failure: ../rados/troubleshooting/troubleshooting-pg#placement-group-down-peering-failure
-.. _Ceph Authentication and Authorization: ../rados/operations/auth-intro/
-.. _Hardware Recommendations: ../start/hardware-recommendations
 .. _Network Config Reference: ../rados/configuration/network-config-ref
-.. _Data Scrubbing: ../rados/configuration/osd-config-ref#scrubbing
 .. _striping: https://en.wikipedia.org/wiki/Data_striping
 .. _RAID: https://en.wikipedia.org/wiki/RAID
 .. _RAID 0: https://en.wikipedia.org/wiki/RAID_0#RAID_0
-.. _Ceph Object Storage: ../radosgw/
 .. _RESTful: https://en.wikipedia.org/wiki/RESTful
 .. _Erasure Code Notes: https://github.com/ceph/ceph/blob/40059e12af88267d0da67d8fd8d9cd81244d8f93/doc/dev/osd_internals/erasure_coding/developer_notes.rst
 .. _Cache Tiering: ../rados/operations/cache-tiering
-.. _Set Pool Values: ../rados/operations/pools#set-pool-values
 .. _Kerberos: https://en.wikipedia.org/wiki/Kerberos_(protocol)
-.. _Cephx Config Guide: ../rados/configuration/auth-config-ref
-.. _User Management: ../rados/operations/user-management

--- a/doc/start/hardware-recommendations.rst
+++ b/doc/start/hardware-recommendations.rst
@@ -1,7 +1,7 @@
 .. _hardware-recommendations:
 
 ==========================
- hardware recommendations
+ Hardware Recommendations
 ==========================
 
 Ceph is designed to run on commodity hardware, which makes building and
@@ -73,7 +73,7 @@ administrative tasks (like monitoring and metrics) as well as increased
 consumption during recovery:  provisioning ~8GB *per BlueStore OSD* is thus
 advised.
 
-Monitors and managers (ceph-mon and ceph-mgr)
+Monitors and Managers (ceph-mon and ceph-mgr)
 ---------------------------------------------
 
 Monitor and manager daemon memory usage scales with the size of the
@@ -88,7 +88,7 @@ tuning the following settings:
 * :confval:`rocksdb_cache_size`
 
 
-Metadata servers (ceph-mds)
+Metadata Servers (ceph-mds)
 ---------------------------
 
 CephFS metadata daemon memory utilization depends on the configured size of


### PR DESCRIPTION
Use validated ":ref:" hyperlinks instead of "external links" in "target definitions" when linking within the Ceph docs:
- Update to use existing labels when linkin from architecture.rst.
- Remove unused "target definitions".

Also use title case for section titles in `doc/start/hardware-recommendations.rst` because change to use link text generated from section title.

Other than generated link texts the rendered PR should look the same as the old docs, only differing in the source RST.

Fixes a duplicate target definition.  
Only links with destinations that already have existing labels were updated to `:ref:`.

- Before/after (no change in rendered PR): https://docs.ceph.com/en/latest/architecture/#high-availability-monitors https://ceph--63294.org.readthedocs.build/en/63294/architecture/#high-availability-monitors
- Before/after (use generated link text), scroll down to end of the section: https://docs.ceph.com/en/latest/architecture/#high-availability-authentication https://ceph--63294.org.readthedocs.build/en/63294/architecture/#high-availability-authentication
- Before/after (no change in rendered PR), scroll down to list item 3: https://docs.ceph.com/en/latest/architecture/#smart-daemons-enable-hyperscale https://ceph--63294.org.readthedocs.build/en/63294/architecture/#smart-daemons-enable-hyperscale
- Before/after (use generated link text): https://docs.ceph.com/en/latest/architecture/#about-pools https://ceph--63294.org.readthedocs.build/en/63294/architecture/#about-pools
- Before/after (no change in rendered PR): https://docs.ceph.com/en/latest/architecture/#peering-and-sets https://ceph--63294.org.readthedocs.build/en/63294/architecture/#peering-and-sets
- Before/after (no change in rendered PR): https://docs.ceph.com/en/latest/architecture/#data-consistency https://ceph--63294.org.readthedocs.build/en/63294/architecture/#data-consistency
- Before/after (no change in rendered PR): https://docs.ceph.com/en/latest/architecture/#summary https://ceph--63294.org.readthedocs.build/en/63294/architecture/#summary



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
