### PR TITLE
mgr/dashboard: Add missing fields to subsytem list API/CLI

### DIFF
--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -39,6 +39,9 @@ class Subsystem(NamedTuple):
     namespace_count: int
     subtype: str
     max_namespaces: int
+    has_dhchap_key: bool
+    allow_any_host: bool
+    created_without_key: bool = False
 
 
 class SubsystemList(NamedTuple):

--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -151,6 +151,7 @@ else:
 
     def _lazily_create_namedtuple(data: Any, target_type: Type[NamedTuple],
                                   depth: int, max_depth: int) -> Generator:
+        # pylint: disable=protected-access
         """ Lazily create NamedTuple from a dict """
         field_values = {}
         for field, field_type in zip(target_type._fields,
@@ -170,8 +171,7 @@ else:
                 except StopIteration:
                     return
             else:
-                # If the field is missing assign None
-                field_values[field] = None
+                field_values[field] = target_type._field_defaults.get(field)
 
         namedtuple_instance = target_type(**field_values)  # type: ignore
         yield namedtuple_instance

--- a/src/pybind/mgr/dashboard/tests/test_nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_nvmeof_client.py
@@ -301,6 +301,11 @@ class EmptyModel(NamedTuple):
     pass
 
 
+class ModelWithDefaultParam(NamedTuple):
+    a: str
+    b: str = 'iamdefault'
+
+
 @pytest.fixture(name="person_func")
 def fixture_person_func():
     @convert_to_model(Boy)
@@ -354,6 +359,23 @@ class TestConvertToModel:
 
         result = get_adult()
         assert result == {'name': 'Charlie', 'age': 40, "children": [], 'hobby': None}
+
+    def test_fields_default_value(self, disable_message_to_dict):
+        # pylint: disable=unused-argument
+        @convert_to_model(ModelWithDefaultParam)
+        def get() -> dict:
+            return {"a": "bla"}
+
+        result = get()
+        assert result == {'a': 'bla', 'b': "iamdefault"}
+
+        # pylint: disable=unused-argument
+        @convert_to_model(ModelWithDefaultParam)
+        def get2() -> dict:
+            return {"a": "bla", "b": 'notdefault'}
+
+        result = get2()
+        assert result == {'a': 'bla', 'b': "notdefault"}
 
     def test_nested_fields(self, disable_message_to_dict):
         # pylint: disable=unused-argument


### PR DESCRIPTION
These fields appears in the old cli, so I added them to the new one as well.

example output:
```
[myuser@myvm ~]# ceph nvmeof subsystem list | jq
{
  "status": 0,
  "error_message": "Success",
  "subsystems": [
    {
      "nqn": "nqn.2016-06.io.spdk:cnode1.mygroup1",
      "enable_ha": true,
      "serial_number": "Ceph49004842768254",
      "model_number": "Ceph bdev Controller",
      "min_cntlid": 1,
      "max_cntlid": 2040,
      "namespace_count": 4,
      "subtype": "NVMe",
      "max_namespaces": 1024,
      "has_dhchap_key": false,
      "allow_any_host": true,
      "created_without_key": false
    },
    {
      "nqn": "nqn.2016-06.io.spdk:cnode2.mygroup1",
      "enable_ha": true,
      "serial_number": "Ceph4136752652420",
      "model_number": "Ceph bdev Controller",
      "min_cntlid": 1,
      "max_cntlid": 2040,
      "namespace_count": 4,
      "subtype": "NVMe",
      "max_namespaces": 1024,
      "has_dhchap_key": false,
      "allow_any_host": true,
      "created_without_key": false
    }
  ]
}
[myuser@myvm ~]# docker run -it --rm quay.io/ceph/nvmeof-cli:1.5.1 --server-address=10.242.64.51 --format=json subsystem list
Unable to find image 'quay.io/ceph/nvmeof-cli:1.5.1' locally
1.5.1: Pulling from ceph/nvmeof-cli
99a7ec374c4d: Already exists
cababc96ad2e: Pull complete
a7cd759c2692: Pull complete
2aa11fe54d35: Pull complete
Digest: sha256:5f829c9535da9db0a34564b4ff1684c7b878a4efe39f9d1fdff0eeafd4a4f05f
Status: Downloaded newer image for quay.io/ceph/nvmeof-cli:1.5.1
{
    "error_message": "Success",
    "subsystems": [
        {
            "nqn": "nqn.2016-06.io.spdk:cnode1.mygroup1",
            "enable_ha": true,
            "serial_number": "Ceph49004842768254",
            "model_number": "Ceph bdev Controller",
            "min_cntlid": 1,
            "max_cntlid": 2040,
            "namespace_count": 4,
            "subtype": "NVMe",
            "max_namespaces": 1024,
            "has_dhchap_key": false,
            "allow_any_host": true,
            "created_without_key": false
        },
        {
            "nqn": "nqn.2016-06.io.spdk:cnode2.mygroup1",
            "enable_ha": true,
            "serial_number": "Ceph4136752652420",
            "model_number": "Ceph bdev Controller",
            "min_cntlid": 1,
            "max_cntlid": 2040,
            "namespace_count": 4,
            "subtype": "NVMe",
            "max_namespaces": 1024,
            "has_dhchap_key": false,
            "allow_any_host": true,
            "created_without_key": false
        }
    ],
    "status": 0
}
```

fixes: https://tracker.ceph.com/issues/71351
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x]Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
