### PR TITLE
reef: pybind/mgr: attempt to fix mypy importing from python-common

### DIFF
--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -67,7 +67,7 @@ commands =
 
 [testenv:mypy]
 setenv =
-    MYPYPATH = {toxinidir}/..
+    MYPYPATH = {toxinidir}/..:{toxinidir}/../../python-common
 passenv =
     MYPYPATH
 basepython = python3


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/59845

For some reason mypy on python 3.12 can no longer automatically find imports from python-common. Help it out by expanding the MYPYPATH value for the tox.ini.


(cherry picked from commit d1c942a98499560bb15c50db4498f12f4916866f)