### PR TITLE
reef: doc: Fix missing blank line Sphinx warnings

### DIFF
--- a/doc/cephfs/troubleshooting.rst
+++ b/doc/cephfs/troubleshooting.rst
@@ -81,13 +81,13 @@ things to do:
 * **Deny all reconnect to clients.** This effectively blocklists all existing
   CephFS sessions so all mounts will hang or become unavailable.
 
-.. code:: bash
+  .. code:: bash
 
-   ceph config set mds mds_deny_all_reconnect true
+     ceph config set mds mds_deny_all_reconnect true
 
   Remember to undo this after the MDS becomes active.
 
-.. note:: This does not prevent new sessions from connecting. For that, see the ``refuse_client_session`` file system setting.
+  .. note:: This does not prevent new sessions from connecting. For that, see the ``refuse_client_session`` file system setting.
 
 * **Extend the MDS heartbeat grace period**. This avoids replacing an MDS that appears
   "stuck" doing some operation. Sometimes recovery of an MDS may involve an
@@ -96,23 +96,23 @@ things to do:
   normal amount of time to complete (indicated by your reading this document).
   Avoid unnecessary replacement loops by extending the heartbeat graceperiod:
 
-.. code:: bash
+  .. code:: bash
 
-   ceph config set mds mds_heartbeat_grace 3600
+     ceph config set mds mds_heartbeat_grace 3600
 
-  This has the effect of having the MDS continue to send beacons to the monitors
-  even when its internal "heartbeat" mechanism has not been reset (beat) in one
-  hour. Note the previous mechanism for achieving this was via the
-  `mds_beacon_grace` monitor setting.
+  .. note:: This has the effect of having the MDS continue to send beacons to the monitors
+            even when its internal "heartbeat" mechanism has not been reset (beat) in one
+            hour. The previous mechanism for achieving this was via the
+            `mds_beacon_grace` monitor setting.
 
 * **Disable open file table prefetch.** Normally, the MDS will prefetch
   directory contents during recovery to heat up its cache. During long
   recovery, the cache is probably already hot **and large**. So this behavior
   can be undesirable. Disable using:
 
-.. code:: bash
+  .. code:: bash
 
-   ceph config set mds mds_oft_prefetch_dirfrags false
+     ceph config set mds mds_oft_prefetch_dirfrags false
 
 * **Turn off clients.** Clients reconnecting to the newly ``up:active`` MDS may
   cause new load on the file system when it's just getting back on its feet.
@@ -122,9 +122,9 @@ things to do:
 
   You can do this manually or use the new file system tunable:
 
-.. code:: bash
+  .. code:: bash
 
-   ceph fs set <fs_name> refuse_client_session true
+     ceph fs set <fs_name> refuse_client_session true
 
   That prevents any clients from establishing new sessions with the MDS.
 
@@ -139,26 +139,27 @@ things to do:
   asynchronously purging trashed/deleted subvolumes. To help troubleshooting or
   recovery effort, these purge threads can be disabled using:
 
-.. code:: bash
+  .. code:: bash
 
-    ceph config set mgr mgr/volumes/pause_purging true
+     ceph config set mgr mgr/volumes/pause_purging true
 
   To resume purging run::
 
-    ceph config set mgr mgr/volumes/pause_purging false
+     ceph config set mgr mgr/volumes/pause_purging false
 
 .. _pause-clone-threads:
+
 * **Turn off async cloner threads** The volumes plugin spawns threads for
   asynchronously cloning subvolume snapshots. To help troubleshooting or
   recovery effort, these cloner threads can be disabled using:
 
-.. code:: bash
+  .. code:: bash
 
-    ceph config set mgr mgr/volumes/pause_cloning true
+     ceph config set mgr mgr/volumes/pause_cloning true
 
   To resume cloning run::
 
-    ceph config set mgr mgr/volumes/pause_cloning false
+     ceph config set mgr mgr/volumes/pause_cloning false
 
 
 

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -207,6 +207,7 @@ mirroring module. This means that ``/a/b/../b`` is equivalent to ``/a/b``:
    mkdir -p /d0/d1/d2
    ceph fs snapshot mirror add cephfs /d0/d1/d2 {}
    ceph fs snapshot mirror add cephfs /d0/d1/../d1/d2
+
 ::
 
   Error EEXIST: directory /d0/d1/d2 is already tracked
@@ -217,6 +218,7 @@ directories are not allowed to be added for mirroring:
 .. prompt:: bash $
 
    ceph fs snapshot mirror add cephfs /d0/d1
+
 ::
 
    Error EINVAL: /d0/d1 is a ancestor of tracked path /d0/d1/d2
@@ -224,6 +226,7 @@ directories are not allowed to be added for mirroring:
 .. prompt:: bash $
 
    ceph fs snapshot mirror add cephfs /d0/d1/d2/d3
+
 ::
 
    Error EINVAL: /d0/d1/d2/d3 is a subtree of tracked path /d0/d1/d2


### PR DESCRIPTION
Fix four warnings from Sphinx about missing blank line after explicit markup.

Indent content in list items correctly, fixing formatting errors.


(cherry picked from commit 5e1b3cd566fd700b36001551d1c7e092fc850def)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
