### PR TITLE
reef: mon/test_mon_osdmap_prune: Use first_pinned instead of first_committed

### DIFF
--- a/qa/workunits/mon/test_mon_osdmap_prune.sh
+++ b/qa/workunits/mon/test_mon_osdmap_prune.sh
@@ -33,7 +33,9 @@ function wait_for_trim() {
 
   for ((i=0; i < ${#delays[*]}; ++i)); do
     fc=$(ceph report | jq '.osdmap_first_committed')
-    if [[ $fc -eq $epoch ]]; then
+    manifest="$(ceph report | jq '.osdmap_manifest')"
+    first_pinned_map=$(ceph report | jq '.osdmap_manifest.first_pinned')
+    if [[ $first_pinned_map -eq $epoch ]]; then
       return 0
     fi
     sleep ${delays[$i]}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69773

---

backport of https://github.com/ceph/ceph/pull/61397
parent tracker: https://tracker.ceph.com/issues/47838

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh