### PR TITLE
crimson: [discussion] Decide on assert strategy

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -61,7 +61,7 @@ void AdminSocket::register_command(std::unique_ptr<AdminSocketHook>&& hook)
 {
   auto prefix = hook->prefix;
   auto [it, added] = hooks.emplace(prefix, std::move(hook));
-  assert(added);
+  ceph_assert(added);
   logger().info("register_command(): {})", it->first);
 }
 
@@ -252,7 +252,7 @@ seastar::future<> AdminSocket::start(const std::string& path)
   // listen in background
   task = seastar::keep_doing([this] {
     return seastar::try_with_gate(stop_gate, [this] {
-      assert(!connected_sock.has_value());
+      ceph_assert(!connected_sock.has_value());
       return server_sock->accept().then([this](seastar::accept_result acc) {
         connected_sock = std::move(acc.connection);
         return seastar::do_with(connected_sock->input(),
@@ -260,7 +260,7 @@ seastar::future<> AdminSocket::start(const std::string& path)
           [this](auto& input, auto& output) mutable {
           return handle_client(input, output);
         }).finally([this] {
-          assert(connected_sock.has_value());
+          ceph_assert(connected_sock.has_value());
           connected_sock.reset();
         });
       }).handle_exception([this](auto ep) {
@@ -287,7 +287,7 @@ seastar::future<> AdminSocket::stop()
     connected_sock->shutdown_output();
   }
   return stop_gate.close().then([this] {
-    assert(task.has_value());
+    ceph_assert(task.has_value());
     return task->then([] {
       logger().info("AdminSocket: stopped");
       return seastar::now();
@@ -457,7 +457,7 @@ public:
   {
     std::string var;
     [[maybe_unused]] bool found = cmd_getval(cmdmap, "var", var);
-    assert(found);
+    ceph_assert(found);
     std::string conf_val;
     if (int r = local_conf().get_val(var, &conf_val); r < 0) {
       return seastar::make_ready_future<tell_result_t>(

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -232,7 +232,7 @@ Connection::do_auth_single(Connection::request_t what)
     }
     break;
   default:
-    assert(0);
+    ceph_assert(0);
   }
   logger().info("sending {}", *m);
   return conn->send(std::move(m)).then([this] {
@@ -371,13 +371,13 @@ int Connection::handle_auth_bad_method(uint32_t old_auth_method,
   auth_registry.get_supported_methods(conn->get_peer_type(), &auth_supported);
   auto p = std::find(auth_supported.begin(), auth_supported.end(),
                      old_auth_method);
-  assert(p != auth_supported.end());
+  ceph_assert(p != auth_supported.end());
   p = std::find_first_of(std::next(p), auth_supported.end(),
                          allowed_methods.begin(), allowed_methods.end());
   if (p == auth_supported.end()) {
     logger().error("server allowed_methods {} but i only support {}",
                    allowed_methods, auth_supported);
-    assert(auth_done);
+    ceph_assert(auth_done);
     auth_done->set_exception(std::system_error(make_error_code(
       crimson::net::error::negotiation_failure)));
     return -EACCES;
@@ -472,7 +472,7 @@ void Client::tick()
                                        active_con->renew_tickets(),
                                        active_con->renew_rotating_keyring()).discard_result();
     } else {
-      assert(is_hunting());
+      ceph_assert(is_hunting());
       logger().info("{} continuing the hunt", __func__);
       return authenticate();
     }
@@ -1005,7 +1005,7 @@ seastar::future<bool> Client::reopen_session(int rank)
     auto conn = msgr.connect(peer, CEPH_ENTITY_TYPE_MON);
     auto& mc = pending_conns.emplace_back(
       seastar::make_shared<Connection>(auth_registry, conn, &keyring));
-    assert(conn->get_peer_addr().is_msgr2());
+    ceph_assert(conn->get_peer_addr().is_msgr2());
     return mc->authenticate_v2().then([peer, this](auto result) {
       if (result == Connection::auth_result_t::success) {
         _finish_auth(peer);
@@ -1077,7 +1077,7 @@ Client::run_command(std::string&& cmd,
 seastar::future<> Client::send_message(MessageURef m)
 {
   if (active_con && ready_to_send) {
-    assert(pending_messages.empty());
+    ceph_assert(pending_messages.empty());
     return active_con->get_conn()->send(std::move(m));
   } else {
     auto& delayed = pending_messages.emplace_back(std::move(m));
@@ -1152,7 +1152,7 @@ seastar::future<> Client::renew_subs()
 
 seastar::future<> Client::wait_for_config()
 {
-  assert(!config_updated);
+  ceph_assert(!config_updated);
   config_updated = seastar::promise<>();
   return config_updated->get_future();
 }

--- a/src/crimson/net/FrameAssemblerV2.h
+++ b/src/crimson/net/FrameAssemblerV2.h
@@ -31,7 +31,7 @@ public:
   FrameAssemblerV2(FrameAssemblerV2 &&) = delete;
 
   void set_shard_id(seastar::shard_id _sid) {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     clear();
     sid = _sid;
   }
@@ -134,7 +134,7 @@ public:
 
   template <class F>
   ceph::bufferlist get_buffer(F &tx_frame) {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     auto bl = tx_frame.get_buffer(tx_frame_asm);
     log_main_preamble(bl);
     return bl;
@@ -142,7 +142,7 @@ public:
 
   template <class F, bool may_cross_core = true>
   seastar::future<> write_flush_frame(F &tx_frame) {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     auto bl = get_buffer(tx_frame);
 #ifdef UNIT_TESTS_BUILT
     return intercept_frame(F::tag, true

--- a/src/crimson/net/Interceptor.h
+++ b/src/crimson/net/Interceptor.h
@@ -26,7 +26,7 @@ inline const char* get_bp_name(custom_bp_t bp) {
                                          "BANNER_PAYLOAD_READ",
                                          "SOCKET_CONNECTING",
                                          "SOCKET_ACCEPTED"};
-  assert(index < std::size(bp_names));
+  ceph_assert(index < std::size(bp_names));
   return bp_names[index];
 }
 
@@ -144,7 +144,7 @@ struct fmt::formatter<crimson::net::bp_action_t> : fmt::formatter<std::string_vi
                                                "FAULT",
                                                "BLOCK",
                                                "STALL"};
-    assert(static_cast<size_t>(action) < std::size(action_names));
+    ceph_assert(static_cast<size_t>(action) < std::size(action_names));
     return formatter<std::string_view>::format(action_names[static_cast<size_t>(action)], ctx);
   }
 };
@@ -178,7 +178,7 @@ struct fmt::formatter<crimson::net::Breakpoint> : fmt::formatter<std::string_vie
                                             "KEEPALIVE2",
                                             "KEEPALIVE2_ACK",
                                             "ACK"};
-    assert(static_cast<size_t>(tag_bp.tag) < std::size(tag_names));
+    ceph_assert(static_cast<size_t>(tag_bp.tag) < std::size(tag_names));
     return fmt::format_to(ctx.out(), "{}_{}",
 			  tag_names[static_cast<size_t>(tag_bp.tag)],
 			  tag_bp.type == crimson::net::bp_type_t::WRITE ? "WRITE" : "READ");

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -85,7 +85,7 @@ private:
     if (pr_exit_io.has_value()) {
       return pr_exit_io->get_shared_future();
     } else {
-      assert(!need_exit_io);
+      ceph_assert(!need_exit_io);
       return seastar::now();
     }
   }

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -56,7 +56,7 @@ public:
   }
 
   bool is_shutdown() const {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     return socket_is_shutdown;
   }
 
@@ -64,7 +64,7 @@ public:
   // unfortunately, there's no way to identify which port I'm using as
   // connector with current seastar interface.
   void learn_ephemeral_port_as_connector(uint16_t port) {
-    assert(side == side_t::connector &&
+    ceph_assert(side == side_t::connector &&
            (ephemeral_port == 0 || ephemeral_port == port));
     ephemeral_port = port;
   }
@@ -95,20 +95,20 @@ public:
 
   // shutdown for tests
   void force_shutdown() {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     socket.shutdown_input();
     socket.shutdown_output();
   }
 
   // shutdown input_stream only, for tests
   void force_shutdown_in() {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     socket.shutdown_input();
   }
 
   // shutdown output_stream only, for tests
   void force_shutdown_out() {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     socket.shutdown_output();
   }
 

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -51,31 +51,31 @@ bool SocketConnection::is_connected() const
 #ifdef UNIT_TESTS_BUILT
 bool SocketConnection::is_protocol_ready() const
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_ready();
 }
 
 bool SocketConnection::is_protocol_standby() const {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_standby();
 }
 
 bool SocketConnection::is_protocol_closed() const
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_closed();
 }
 
 bool SocketConnection::is_protocol_closed_clean() const
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return protocol->is_closed_clean();
 }
 
 #endif
 bool SocketConnection::peer_wins() const
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return (messenger.get_myaddr() > peer_addr || policy.server);
 }
 
@@ -115,7 +115,7 @@ void
 SocketConnection::start_connect(const entity_addr_t& _peer_addr,
                                 const entity_name_t& _peer_name)
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   protocol->start_connect(_peer_addr, _peer_name);
 }
 
@@ -123,26 +123,26 @@ void
 SocketConnection::start_accept(SocketFRef&& sock,
                                const entity_addr_t& _peer_addr)
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   protocol->start_accept(std::move(sock), _peer_addr);
 }
 
 seastar::future<>
 SocketConnection::close_clean_yielded()
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return protocol->close_clean_yielded();
 }
 
 seastar::socket_address SocketConnection::get_local_address() const {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return socket->get_local_address();
 }
 
 ConnectionRef
 SocketConnection::get_local_shared_foreign_from_this()
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return make_local_shared_foreign(
       seastar::make_foreign(shared_from_this()));
 }
@@ -150,7 +150,7 @@ SocketConnection::get_local_shared_foreign_from_this()
 SocketMessenger &
 SocketConnection::get_messenger() const
 {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   return messenger;
 }
 
@@ -161,40 +161,40 @@ SocketConnection::get_messenger_shard_id() const
 }
 
 void SocketConnection::set_peer_type(entity_type_t peer_type) {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   // it is not allowed to assign an unknown value when the current
   // value is known
-  assert(!(peer_type == 0 &&
+  ceph_assert(!(peer_type == 0 &&
            peer_name.type() != 0));
   // it is not allowed to assign a different known value when the
   // current value is also known.
-  assert(!(peer_type != 0 &&
+  ceph_assert(!(peer_type != 0 &&
            peer_name.type() != 0 &&
            peer_type != peer_name.type()));
   peer_name._type = peer_type;
 }
 
 void SocketConnection::set_peer_id(int64_t peer_id) {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   // it is not allowed to assign an unknown value when the current
   // value is known
-  assert(!(peer_id == entity_name_t::NEW &&
+  ceph_assert(!(peer_id == entity_name_t::NEW &&
            peer_name.num() != entity_name_t::NEW));
   // it is not allowed to assign a different known value when the
   // current value is also known.
-  assert(!(peer_id != entity_name_t::NEW &&
+  ceph_assert(!(peer_id != entity_name_t::NEW &&
            peer_name.num() != entity_name_t::NEW &&
            peer_id != peer_name.num()));
   peer_name._num = peer_id;
 }
 
 void SocketConnection::set_features(uint64_t f) {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   features = f;
 }
 
 void SocketConnection::set_socket(Socket *s) {
-  assert(seastar::this_shard_id() == msgr_sid);
+  ceph_assert(seastar::this_shard_id() == msgr_sid);
   socket = s;
 }
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -120,12 +120,12 @@ class SocketConnection : public Connection {
   }
 
   user_private_t &get_user_private() override {
-    assert(has_user_private());
+    ceph_assert(has_user_private());
     return *user_private;
   }
 
   void set_user_private(std::unique_ptr<user_private_t> new_user_private) override {
-    assert(!has_user_private());
+    ceph_assert(!has_user_private());
     user_private = std::move(new_user_private);
   }
 

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -54,12 +54,12 @@ public:
   bool set_addr_unknowns(const entity_addrvec_t &addr) override;
 
   void set_auth_client(crimson::auth::AuthClient *ac) override {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     auth_client = ac;
   }
 
   void set_auth_server(crimson::auth::AuthServer *as) override {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     auth_server = as;
   }
 
@@ -71,23 +71,23 @@ public:
                         const entity_name_t& peer_name) override;
 
   bool owns_connection(Connection &conn) const override {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     return this == &static_cast<SocketConnection&>(conn).get_messenger();
   }
 
   // can only wait once
   seastar::future<> wait() override {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     return shutdown_promise.get_future();
   }
 
   void stop() override {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     dispatchers.clear();
   }
 
   bool is_started() const override {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     return !dispatchers.empty();
   }
 
@@ -112,12 +112,12 @@ public:
 // SocketMessenger public interfaces
 public:
   crimson::auth::AuthClient* get_auth_client() const {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     return auth_client;
   }
 
   crimson::auth::AuthServer* get_auth_server() const {
-    assert(seastar::this_shard_id() == sid);
+    ceph_assert(seastar::this_shard_id() == sid);
     return auth_server;
   }
 

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -15,8 +15,8 @@ class Dispatcher;
 class ChainedDispatchers {
 public:
   void assign(const dispatchers_t& _dispatchers) {
-    assert(empty());
-    assert(!_dispatchers.empty());
+    ceph_assert(empty());
+    ceph_assert(!_dispatchers.empty());
     dispatchers = _dispatchers;
   }
   void clear() {

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -164,7 +164,7 @@ public:
    */
 
   void set_handshake_listener(HandshakeListener &hl) {
-    assert(seastar::this_shard_id() == get_shard_id());
+    ceph_assert(seastar::this_shard_id() == get_shard_id());
     ceph_assert_always(handshake_listener == nullptr);
     handshake_listener = &hl;
   }
@@ -261,13 +261,13 @@ public:
     }
 
     io_state_t get_io_state() const {
-      assert(seastar::this_shard_id() == sid);
+      ceph_assert(seastar::this_shard_id() == sid);
       return io_state;
     }
 
     void set_io_state(io_state_t new_state) {
-      assert(seastar::this_shard_id() == sid);
-      assert(io_state != new_state);
+      ceph_assert(seastar::this_shard_id() == sid);
+      ceph_assert(io_state != new_state);
       pr_io_state_changed.set_value();
       pr_io_state_changed = seastar::promise<>();
       if (io_state == io_state_t::open) {
@@ -281,35 +281,35 @@ public:
     }
 
     seastar::future<> wait_state_change() {
-      assert(seastar::this_shard_id() == sid);
+      ceph_assert(seastar::this_shard_id() == sid);
       return pr_io_state_changed.get_future();
     }
 
     template <typename Func>
     void dispatch_in_background(
         const char *what, SocketConnection &who, Func &&func) {
-      assert(seastar::this_shard_id() == sid);
+      ceph_assert(seastar::this_shard_id() == sid);
       ceph_assert_always(!gate.is_closed());
       gate.dispatch_in_background(what, who, std::move(func));
     }
 
     void enter_in_dispatching() {
-      assert(seastar::this_shard_id() == sid);
-      assert(io_state == io_state_t::open);
+      ceph_assert(seastar::this_shard_id() == sid);
+      ceph_assert(io_state == io_state_t::open);
       ceph_assert_always(!in_exit_dispatching.has_value());
       in_exit_dispatching = seastar::promise<>();
     }
 
     void exit_in_dispatching() {
-      assert(seastar::this_shard_id() == sid);
-      assert(io_state != io_state_t::open);
+      ceph_assert(seastar::this_shard_id() == sid);
+      ceph_assert(io_state != io_state_t::open);
       ceph_assert_always(in_exit_dispatching.has_value());
       in_exit_dispatching->set_value();
       in_exit_dispatching = std::nullopt;
     }
 
     bool try_enter_out_dispatching(SocketConnection &conn) {
-      assert(seastar::this_shard_id() == sid);
+      ceph_assert(seastar::this_shard_id() == sid);
       if (out_dispatching) {
         // already dispatching out
         return false;
@@ -338,7 +338,7 @@ public:
 
     void exit_out_dispatching(
         const char *what, SocketConnection &conn) {
-      assert(seastar::this_shard_id() == sid);
+      ceph_assert(seastar::this_shard_id() == sid);
       ceph_assert_always(out_dispatching);
       out_dispatching = false;
       notify_out_dispatching_stopped(what, conn);
@@ -347,13 +347,13 @@ public:
     seastar::future<> wait_io_exit_dispatching();
 
     seastar::future<> close() {
-      assert(seastar::this_shard_id() == sid);
-      assert(!gate.is_closed());
+      ceph_assert(seastar::this_shard_id() == sid);
+      ceph_assert(!gate.is_closed());
       return gate.close();
     }
 
     bool assert_closed_and_exit() const {
-      assert(seastar::this_shard_id() == sid);
+      ceph_assert(seastar::this_shard_id() == sid);
       if (gate.is_closed()) {
         ceph_assert_always(io_state == io_state_t::drop ||
                            io_state == io_state_t::switched);

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -155,7 +155,7 @@ AlienStore::exists(
 AlienStore::mount_ertr::future<> AlienStore::mount()
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return tp->submit([this] {
     return store->mount();
   }).then([] (const int r) -> mount_ertr::future<> {
@@ -186,7 +186,7 @@ seastar::future<> AlienStore::umount()
       }
       return store->umount();
     }).then([] (int r) {
-      assert(r == 0);
+      ceph_assert(r == 0);
       return seastar::now();
     });
   });
@@ -196,7 +196,7 @@ AlienStore::mkfs_ertr::future<> AlienStore::mkfs(uuid_d osd_fsid)
 {
   logger().debug("{}", __func__);
   store->set_fsid(osd_fsid);
-  assert(tp);
+  ceph_assert(tp);
   return tp->submit([this] {
     return store->mkfs();
   }).then([] (int r) -> mkfs_ertr::future<> {
@@ -217,7 +217,7 @@ AlienStore::list_objects(CollectionRef ch,
 			uint32_t op_flags) const
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(std::vector<ghobject_t>(), ghobject_t(),
                          [=, this] (auto &objects, auto &next) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()),
@@ -227,7 +227,7 @@ AlienStore::list_objects(CollectionRef ch,
                                     store->get_ideal_list_max(),
                                     &objects, &next);
     }).then([&objects, &next] (int r) {
-      assert(r == 0);
+      ceph_assert(r == 0);
       return seastar::make_ready_future<
 	std::tuple<std::vector<ghobject_t>, ghobject_t>>(
 	  std::move(objects), std::move(next));
@@ -238,7 +238,7 @@ AlienStore::list_objects(CollectionRef ch,
 seastar::future<CollectionRef> AlienStore::create_new_collection(const coll_t& cid)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return tp->submit([this, cid] {
     ObjectStore::CollectionHandle c = store->create_new_collection(cid);
     return get_alien_coll_ref(std::move(c));
@@ -248,7 +248,7 @@ seastar::future<CollectionRef> AlienStore::create_new_collection(const coll_t& c
 seastar::future<CollectionRef> AlienStore::open_collection(const coll_t& cid)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return tp->submit([this, cid] {
     ObjectStore::CollectionHandle c = store->open_collection(cid);
     if (!c) {
@@ -262,13 +262,13 @@ seastar::future<CollectionRef> AlienStore::open_collection(const coll_t& cid)
 seastar::future<std::vector<coll_core_t>> AlienStore::list_collections()
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
 
   return do_with_op_gate(std::vector<coll_t>{}, [this] (auto &ls) {
     return tp->submit([this, &ls] {
       return store->list_collections(ls);
     }).then([&ls] (int r) -> seastar::future<std::vector<coll_core_t>> {
-      assert(r == 0);
+      ceph_assert(r == 0);
       std::vector<coll_core_t> ret;
       ret.resize(ls.size());
       std::transform(
@@ -283,13 +283,13 @@ seastar::future<> AlienStore::set_collection_opts(CollectionRef ch,
                                       const pool_opts_t& opts)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
 
   return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this] {
     auto c = static_cast<AlienCollection*>(ch.get());
     return store->set_collection_opts(c->collection, opts);
   }).then([] (int r) {
-    assert(r==0);
+    ceph_assert(r==0);
     return seastar::now();
   });
 }
@@ -302,7 +302,7 @@ AlienStore::read(CollectionRef ch,
                  uint32_t op_flags)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(ceph::bufferlist{}, [=, this] (auto &bl) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this, &bl] {
       auto c = static_cast<AlienCollection*>(ch.get());
@@ -327,7 +327,7 @@ AlienStore::readv(CollectionRef ch,
 		  uint32_t op_flags)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(ceph::bufferlist{},
     [this, ch, oid, &m, op_flags](auto& bl) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()),
@@ -354,7 +354,7 @@ AlienStore::get_attr(CollectionRef ch,
 		     uint32_t op_flags) const
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(ceph::bufferlist{}, std::string{name},
                          [=, this] (auto &value, const auto& name) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this, &value, &name] {
@@ -383,7 +383,7 @@ AlienStore::get_attrs(CollectionRef ch,
 		      uint32_t op_flags)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(attrs_t{}, [=, this] (auto &aset) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this, &aset] {
       auto c = static_cast<AlienCollection*>(ch.get());
@@ -406,7 +406,7 @@ auto AlienStore::omap_get_values(CollectionRef ch,
   -> read_errorator::future<omap_values_t>
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(omap_values_t{}, [=, this] (auto &values) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this, &values] {
       auto c = static_cast<AlienCollection*>(ch.get());
@@ -416,7 +416,7 @@ auto AlienStore::omap_get_values(CollectionRef ch,
       if (r == -ENOENT) {
         return crimson::ct_error::enoent::make();
       } else {
-        assert(r == 0);
+        ceph_assert(r == 0);
         return read_errorator::make_ready_future<omap_values_t>(
 	  std::move(values));
       }
@@ -431,7 +431,7 @@ auto AlienStore::omap_get_values(CollectionRef ch,
   -> read_errorator::future<std::tuple<bool, omap_values_t>>
 {
   logger().debug("{} with_start", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(omap_values_t{}, [=, this] (auto &values) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this, &values] {
       auto c = static_cast<AlienCollection*>(ch.get());
@@ -479,7 +479,7 @@ seastar::future<> AlienStore::do_transaction_no_callbacks(
 	AlienCollection* alien_coll = static_cast<AlienCollection*>(ch.get());
         // moving the `ch` is crucial for buildability on newer S* versions.
 	return alien_coll->with_lock([this, ch=std::move(ch), id, &txn, &done] {
-	  assert(tp);
+	  ceph_assert(tp);
 	  return tp->submit(ch->get_cid().hash_to_shard(tp->size()),
 	    [this, ch, id, &txn, &done, &alien=seastar::engine().alien()] {
 	    txn.register_on_commit(new OnCommit(id, done, alien, txn));
@@ -487,7 +487,7 @@ seastar::future<> AlienStore::do_transaction_no_callbacks(
 	    return store->queue_transaction(c->collection, std::move(txn));
 	  });
 	}).then([&done] (int r) {
-	  assert(r == 0);
+	  ceph_assert(r == 0);
 	  return done.get_future();
 	});
     });
@@ -496,7 +496,7 @@ seastar::future<> AlienStore::do_transaction_no_callbacks(
 seastar::future<> AlienStore::inject_data_error(const ghobject_t& o)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return op_gates.simple_dispatch("inject_data_error", [=, this] {
     return tp->submit([o, this] {
       return store->inject_data_error(o);
@@ -507,7 +507,7 @@ seastar::future<> AlienStore::inject_data_error(const ghobject_t& o)
 seastar::future<> AlienStore::inject_mdata_error(const ghobject_t& o)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return op_gates.simple_dispatch("inject_mdata_error", [=, this] {
     return tp->submit([o, this] {
       return store->inject_mdata_error(o);
@@ -519,12 +519,12 @@ seastar::future<> AlienStore::write_meta(const std::string& key,
                                          const std::string& value)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return op_gates.simple_dispatch("write_meta", [=, this] {
     return tp->submit([=, this] {
       return store->write_meta(key, value);
     }).then([] (int r) {
-      assert(r == 0);
+      ceph_assert(r == 0);
       return seastar::make_ready_future<>();
     });
   });
@@ -534,7 +534,7 @@ seastar::future<std::tuple<int, std::string>>
 AlienStore::read_meta(const std::string& key)
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return op_gates.simple_dispatch("read_meta", [this, key] {
     return tp->submit([key, this] {
       std::string value;
@@ -563,12 +563,12 @@ uuid_d AlienStore::get_fsid() const
 seastar::future<store_statfs_t> AlienStore::stat() const
 {
   logger().info("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(store_statfs_t{}, [this] (store_statfs_t &st) {
     return tp->submit([this, &st] {
       return store->statfs(&st, nullptr);
     }).then([&st] (int r) {
-      assert(r == 0);
+      ceph_assert(r == 0);
       return seastar::make_ready_future<store_statfs_t>(std::move(st));
     });
   });
@@ -577,13 +577,13 @@ seastar::future<store_statfs_t> AlienStore::stat() const
 seastar::future<store_statfs_t> AlienStore::pool_statfs(int64_t pool_id) const
 {
   logger().info("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(store_statfs_t{}, [this, pool_id] (store_statfs_t &st) {
     return tp->submit([this, pool_id, &st]{
       bool per_pool_omap_stats = false;
       return store->pool_statfs(pool_id, &st, &per_pool_omap_stats);
     }).then([&st] (int r) {
-      assert(r==0);
+      ceph_assert(r==0);
       return seastar::make_ready_future<store_statfs_t>(std::move(st));
     });
   });
@@ -600,7 +600,7 @@ seastar::future<struct stat> AlienStore::stat(
   const ghobject_t& oid,
   uint32_t op_flags)
 {
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate((struct stat){}, [this, ch, oid](auto& st) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [this, ch, oid, &st] {
       auto c = static_cast<AlienCollection*>(ch.get());
@@ -613,7 +613,7 @@ seastar::future<struct stat> AlienStore::stat(
 seastar::future<std::string> AlienStore::get_default_device_class()
 {
   logger().debug("{}", __func__);
-  assert(tp);
+  ceph_assert(tp);
   return op_gates.simple_dispatch("get_default_device_class", [=, this] {
     return tp->submit([=, this] {
       return store->get_default_device_class();
@@ -628,7 +628,7 @@ auto AlienStore::omap_get_header(CollectionRef ch,
 				 uint32_t op_flags)
   -> get_attr_errorator::future<ceph::bufferlist>
 {
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(ceph::bufferlist(), [=, this](auto& bl) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this, &bl] {
       auto c = static_cast<AlienCollection*>(ch.get());
@@ -654,7 +654,7 @@ AlienStore::read_errorator::future<std::map<uint64_t, uint64_t>> AlienStore::fie
   uint64_t len,
   uint32_t op_flags)
 {
-  assert(tp);
+  ceph_assert(tp);
   return do_with_op_gate(std::map<uint64_t, uint64_t>(), [=, this](auto& destmap) {
     return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this, &destmap] {
       auto c = static_cast<AlienCollection*>(ch.get());

--- a/src/crimson/os/alienstore/thread_pool.cc
+++ b/src/crimson/os/alienstore/thread_pool.cc
@@ -6,7 +6,6 @@
 #include <chrono>
 #include <pthread.h>
 
-#include "include/ceph_assert.h"
 #include "include/intarith.h" // for round_up_to()
 #include "crimson/common/config_proxy.h"
 

--- a/src/crimson/os/alienstore/thread_pool.h
+++ b/src/crimson/os/alienstore/thread_pool.h
@@ -14,6 +14,7 @@
 #include <seastar/core/resource.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
+#include "include/ceph_assert.h"
 
 // std::counting_semaphore is buggy in libstdc++-11
 // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104928),
@@ -85,7 +86,7 @@ public:
       if (!is_stopping()) {
         WorkItem* work_item = nullptr;
         [[maybe_unused]] bool popped = pending.pop(work_item);
-        assert(popped);
+        ceph_assert(popped);
         return work_item;
       }
     }
@@ -97,7 +98,7 @@ public:
   }
   void push_back(WorkItem* work_item) {
     [[maybe_unused]] bool pushed = pending.push(work_item);
-    assert(pushed);
+    ceph_assert(pushed);
     sem.release();
   }
 private:

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -48,7 +48,7 @@ private:
       return "singleton_ec";
     }
     std::string message([[maybe_unused]] const int ev) const final {
-      assert(ev == 42);
+      ceph_assert(ev == 42);
       return MsgV;
     }
   };
@@ -666,7 +666,7 @@ int CyanStore::Shard::_write(
 {
   logger().debug("{} {} {} {} ~ {}",
                 __func__, cid, oid, offset, len);
-  assert(len == bl.length());
+  ceph_assert(len == bl.length());
 
   auto c = _get_collection(cid);
   if (!c)
@@ -907,7 +907,7 @@ int CyanStore::Shard::_create_collection(const coll_t& cid, int bits)
   if (!result.second)
     return -EEXIST;
   auto p = new_coll_map.find(cid);
-  assert(p != new_coll_map.end());
+  ceph_assert(p != new_coll_map.end());
   result.first->second = p->second;
   result.first->second->bits = bits;
   new_coll_map.erase(p);

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -234,7 +234,7 @@ void segments_info_t::mark_empty(
        num_empty, num_open, num_closed);
   ceph_assert(segment_info.is_closed());
   auto type = segment_info.type;
-  assert(type != segment_type_t::NULL_SEG);
+  ceph_assert(type != segment_type_t::NULL_SEG);
   ceph_assert(num_closed > 0);
   --num_closed;
   ++num_empty;
@@ -351,7 +351,7 @@ JournalTrimmerImpl::config_t
 JournalTrimmerImpl::config_t::get_default(
   std::size_t roll_size, backend_type_t type)
 {
-  assert(roll_size);
+  ceph_assert(roll_size);
   std::size_t target_dirty_bytes = 0;
   std::size_t target_alloc_bytes = 0;
   std::size_t max_journal_bytes = 0;
@@ -360,7 +360,7 @@ JournalTrimmerImpl::config_t::get_default(
     target_alloc_bytes = 2 * roll_size;
     max_journal_bytes = 16 * roll_size;
   } else {
-    assert(type == backend_type_t::RANDOM_BLOCK);
+    ceph_assert(type == backend_type_t::RANDOM_BLOCK);
     target_dirty_bytes = roll_size / 4;
     target_alloc_bytes = roll_size / 4;
     max_journal_bytes = roll_size / 2;
@@ -378,7 +378,7 @@ JournalTrimmerImpl::config_t
 JournalTrimmerImpl::config_t::get_test(
   std::size_t roll_size, backend_type_t type)
 {
-  assert(roll_size);
+  ceph_assert(roll_size);
   std::size_t target_dirty_bytes = 0;
   std::size_t target_alloc_bytes = 0;
   std::size_t max_journal_bytes = 0;
@@ -387,7 +387,7 @@ JournalTrimmerImpl::config_t::get_test(
     target_alloc_bytes = 2 * roll_size;
     max_journal_bytes = 4 * roll_size;
   } else {
-    assert(type == backend_type_t::RANDOM_BLOCK);
+    ceph_assert(type == backend_type_t::RANDOM_BLOCK);
     target_dirty_bytes = roll_size / 36;
     target_alloc_bytes = roll_size / 4;
     max_journal_bytes = roll_size / 2;
@@ -505,7 +505,7 @@ void JournalTrimmerImpl::update_journal_tails(
 
 journal_seq_t JournalTrimmerImpl::get_tail_limit() const
 {
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
       backend_type,
       -static_cast<device_off_t>(config.max_journal_bytes),
@@ -516,7 +516,7 @@ journal_seq_t JournalTrimmerImpl::get_tail_limit() const
 
 journal_seq_t JournalTrimmerImpl::get_dirty_tail_target() const
 {
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
       backend_type,
       -static_cast<device_off_t>(config.target_journal_dirty_bytes),
@@ -527,7 +527,7 @@ journal_seq_t JournalTrimmerImpl::get_dirty_tail_target() const
 
 journal_seq_t JournalTrimmerImpl::get_alloc_tail_target() const
 {
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
       backend_type,
       -static_cast<device_off_t>(config.target_journal_alloc_bytes),
@@ -597,7 +597,7 @@ JournalTrimmerImpl::trim_ertr::future<>
 JournalTrimmerImpl::trim_alloc()
 {
   LOG_PREFIX(JournalTrimmerImpl::trim_alloc);
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
 
   auto& shard_stats = extent_callback->get_shard_stats();
   ++(shard_stats.trim_alloc_num);
@@ -633,7 +633,7 @@ JournalTrimmerImpl::trim_alloc()
   }).finally([this, FNAME, &shard_stats] {
     DEBUG("finish, alloc_tail={}", journal_alloc_tail);
 
-    assert(shard_stats.pending_bg_num);
+    ceph_assert(shard_stats.pending_bg_num);
     --(shard_stats.pending_bg_num);
   });
 }
@@ -642,7 +642,7 @@ JournalTrimmerImpl::trim_ertr::future<>
 JournalTrimmerImpl::trim_dirty()
 {
   LOG_PREFIX(JournalTrimmerImpl::trim_dirty);
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
 
   auto& shard_stats = extent_callback->get_shard_stats();
   ++(shard_stats.trim_dirty_num);
@@ -684,7 +684,7 @@ JournalTrimmerImpl::trim_dirty()
   }).finally([this, FNAME, &shard_stats] {
     DEBUG("finish, dirty_tail={}", journal_dirty_tail);
 
-    assert(shard_stats.pending_bg_num);
+    ceph_assert(shard_stats.pending_bg_num);
     --(shard_stats.pending_bg_num);
   });
 }
@@ -734,7 +734,7 @@ bool SpaceTrackerSimple::equals(const SpaceTrackerI &_other) const
 
   if (other.live_bytes_by_segment.size() != live_bytes_by_segment.size()) {
     ERROR("different segment counts, bug in test");
-    assert(0 == "segment counts should match");
+    ceph_assert(0 == "segment counts should match");
     return false;
   }
 
@@ -757,8 +757,8 @@ int64_t SpaceTrackerDetailed::SegmentMap::allocate(
   const extent_len_t block_size)
 {
   LOG_PREFIX(SegmentMap::allocate);
-  assert(offset % block_size == 0);
-  assert(len % block_size == 0);
+  ceph_assert(offset % block_size == 0);
+  ceph_assert(len % block_size == 0);
 
   const auto b = (offset / block_size);
   const auto e = (offset + len) / block_size;
@@ -784,8 +784,8 @@ int64_t SpaceTrackerDetailed::SegmentMap::release(
   const extent_len_t block_size)
 {
   LOG_PREFIX(SegmentMap::release);
-  assert(offset % block_size == 0);
-  assert(len % block_size == 0);
+  ceph_assert(offset % block_size == 0);
+  ceph_assert(len % block_size == 0);
 
   const auto b = (offset / block_size);
   const auto e = (offset + len) / block_size;
@@ -811,7 +811,7 @@ bool SpaceTrackerDetailed::equals(const SpaceTrackerI &_other) const
 
   if (other.segment_usage.size() != segment_usage.size()) {
     ERROR("different segment counts, bug in test");
-    assert(0 == "segment counts should match");
+    ceph_assert(0 == "segment counts should match");
     return false;
   }
 
@@ -999,7 +999,7 @@ segment_id_t SegmentCleaner::allocate_segment(
     rewrite_gen_t generation)
 {
   LOG_PREFIX(SegmentCleaner::allocate_segment);
-  assert(seq != NULL_SEG_SEQ);
+  ceph_assert(seq != NULL_SEG_SEQ);
   ceph_assert(type == segment_type_t::OOL ||
               trimmer != nullptr); // segment_type_t::JOURNAL
   for (auto it = segments.begin();
@@ -1011,7 +1011,7 @@ segment_id_t SegmentCleaner::allocate_segment(
       auto old_usage = calc_utilization(seg_id);
       segments.mark_open(seg_id, seq, type, category, generation);
       if (type == segment_type_t::JOURNAL) {
-        assert(trimmer != nullptr);
+        ceph_assert(trimmer != nullptr);
         trimmer->set_journal_head_sequence(seq);
       }
       background_callback->maybe_wake_background();
@@ -1072,13 +1072,13 @@ double SegmentCleaner::calc_gc_benefit_cost(
     }
   }
 
-  assert(gc_formula == gc_formula_t::BENEFIT);
+  ceph_assert(gc_formula == gc_formula_t::BENEFIT);
   auto modify_time = segments[id].modify_time;
   double age_factor = 0.5; // middle value if age is invalid
   if (likely(bound_time != NULL_TIME &&
              modify_time != NULL_TIME &&
              now_time > modify_time)) {
-    assert(modify_time >= bound_time);
+    ceph_assert(modify_time >= bound_time);
     double age_bound = bound_time.time_since_epoch().count();
     double age_now = now_time.time_since_epoch().count();
     double age_segment = modify_time.time_since_epoch().count();
@@ -1150,7 +1150,7 @@ SegmentCleaner::do_reclaim_space(
         for (auto &cached_backref : cached_backref_entries) {
           if (cached_backref.laddr == L_ADDR_NULL) {
             auto it = backref_entries.find(cached_backref.paddr);
-            assert(it->len == cached_backref.len);
+            ceph_assert(it->len == cached_backref.len);
             backref_entries.erase(it);
           } else {
             backref_entries.emplace(cached_backref);
@@ -1202,7 +1202,7 @@ SegmentCleaner::do_reclaim_space(
       });
     });
   }).finally([&shard_stats] {
-    assert(shard_stats.pending_bg_num);
+    ceph_assert(shard_stats.pending_bg_num);
     --(shard_stats.pending_bg_num);
   });
 }
@@ -1210,7 +1210,7 @@ SegmentCleaner::do_reclaim_space(
 SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
 {
   LOG_PREFIX(SegmentCleaner::clean_space);
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   ceph_assert(can_clean_space());
   if (!reclaim_state) {
     segment_id_t seg_id = get_next_reclaim_segment();
@@ -1336,7 +1336,7 @@ SegmentCleaner::mount_ret SegmentCleaner::mount()
   const auto& sms = sm_group->get_segment_managers();
   INFO("{} segment managers", sms.size());
 
-  assert(background_callback->get_state() == state_t::MOUNT);
+  ceph_assert(background_callback->get_state() == state_t::MOUNT);
   
   space_tracker.reset(
     detailed ?
@@ -1523,21 +1523,21 @@ bool SegmentCleaner::check_usage()
     {
       if (paddr.is_absolute_segmented()) {
         if (is_backref_node(type)) {
-	  assert(laddr == L_ADDR_NULL);
-	  assert(backref_key.is_absolute_segmented()
+	  ceph_assert(laddr == L_ADDR_NULL);
+	  ceph_assert(backref_key.is_absolute_segmented()
                  || backref_key == P_ADDR_MIN);
           tracker->allocate(
             paddr.as_seg_paddr().get_segment_id(),
             paddr.as_seg_paddr().get_segment_off(),
             len);
         } else if (laddr == L_ADDR_NULL) {
-	  assert(backref_key == P_ADDR_NULL);
+	  ceph_assert(backref_key == P_ADDR_NULL);
           tracker->release(
             paddr.as_seg_paddr().get_segment_id(),
             paddr.as_seg_paddr().get_segment_off(),
             len);
         } else {
-	  assert(backref_key == P_ADDR_NULL);
+	  ceph_assert(backref_key == P_ADDR_NULL);
           tracker->allocate(
             paddr.as_seg_paddr().get_segment_id(),
             paddr.as_seg_paddr().get_segment_off(),
@@ -1554,8 +1554,8 @@ void SegmentCleaner::mark_space_used(
   extent_len_t len)
 {
   LOG_PREFIX(SegmentCleaner::mark_space_used);
-  assert(background_callback->get_state() >= state_t::SCAN_SPACE);
-  assert(len);
+  ceph_assert(background_callback->get_state() >= state_t::SCAN_SPACE);
+  ceph_assert(len);
   // TODO: drop
   if (!addr.is_absolute_segmented()) {
     return;
@@ -1572,7 +1572,7 @@ void SegmentCleaner::mark_space_used(
   adjust_segment_util(old_usage, new_usage);
 
   background_callback->maybe_wake_background();
-  assert(ret > 0);
+  ceph_assert(ret > 0);
   DEBUG("segment {} new len: {}~0x{:x}, live_bytes: 0x{:x}",
         seg_addr.get_segment_id(),
         addr,
@@ -1585,8 +1585,8 @@ void SegmentCleaner::mark_space_free(
   extent_len_t len)
 {
   LOG_PREFIX(SegmentCleaner::mark_space_free);
-  assert(background_callback->get_state() >= state_t::SCAN_SPACE);
-  assert(len);
+  ceph_assert(background_callback->get_state() >= state_t::SCAN_SPACE);
+  ceph_assert(len);
   // TODO: drop
   if (!addr.is_absolute_segmented()) {
     return;
@@ -1606,7 +1606,7 @@ void SegmentCleaner::mark_space_free(
   auto new_usage = calc_utilization(seg_addr.get_segment_id());
   adjust_segment_util(old_usage, new_usage);
   background_callback->maybe_wake_blocked_io();
-  assert(ret >= 0);
+  ceph_assert(ret >= 0);
   DEBUG("segment {} free len: {}~0x{:x}, live_bytes: 0x{:x}",
         seg_addr.get_segment_id(),
         addr,
@@ -1659,7 +1659,7 @@ segment_id_t SegmentCleaner::get_next_reclaim_segment() const
 
 bool SegmentCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   stats.projected_used_bytes += projected_usage;
   if (should_block_io_on_clean()) {
     stats.projected_used_bytes -= projected_usage;
@@ -1673,7 +1673,7 @@ bool SegmentCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 
 void SegmentCleaner::release_projected_usage(std::size_t projected_usage)
 {
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   ceph_assert(stats.projected_used_bytes >= projected_usage);
   stats.projected_used_bytes -= projected_usage;
   background_callback->maybe_wake_blocked_io();
@@ -1722,7 +1722,7 @@ void RBMCleaner::mark_space_used(
   extent_len_t len)
 {
   LOG_PREFIX(RBMCleaner::mark_space_used);
-  assert(addr.is_absolute_random_block());
+  ceph_assert(addr.is_absolute_random_block());
   auto rbms = rb_group->get_rb_managers();
   for (auto rbm : rbms) {
     if (addr.get_device_id() == rbm->get_device_id()) {
@@ -1741,7 +1741,7 @@ void RBMCleaner::mark_space_free(
   extent_len_t len)
 {
   LOG_PREFIX(RBMCleaner::mark_space_free);
-  assert(addr.is_absolute_random_block());
+  ceph_assert(addr.is_absolute_random_block());
   auto rbms = rb_group->get_rb_managers();
   for (auto rbm : rbms) {
     if (addr.get_device_id() == rbm->get_device_id()) {
@@ -1771,14 +1771,14 @@ void RBMCleaner::commit_space_used(paddr_t addr, extent_len_t len)
 
 bool RBMCleaner::try_reserve_projected_usage(std::size_t projected_usage)
 {
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   stats.projected_used_bytes += projected_usage;
   return true;
 }
 
 void RBMCleaner::release_projected_usage(std::size_t projected_usage)
 {
-  assert(background_callback->is_ready());
+  ceph_assert(background_callback->is_ready());
   ceph_assert(stats.projected_used_bytes >= projected_usage);
   stats.projected_used_bytes -= projected_usage;
   background_callback->maybe_wake_blocked_io();
@@ -1813,7 +1813,7 @@ RBMCleaner::mount_ret RBMCleaner::mount()
 
 bool RBMCleaner::check_usage()
 {
-  assert(detailed);
+  ceph_assert(detailed);
   const auto& rbms = rb_group->get_rb_managers();
   RBMSpaceTracker tracker(rbms);
   extent_callback->with_transaction_weak(
@@ -1832,19 +1832,19 @@ bool RBMCleaner::check_usage()
       for (auto rbm : rbms) {
 	if (rbm->get_device_id() == paddr.get_device_id()) {
 	  if (is_backref_node(type)) {
-	    assert(laddr == L_ADDR_NULL);
-	    assert(backref_key.is_absolute_random_block()
+	    ceph_assert(laddr == L_ADDR_NULL);
+	    ceph_assert(backref_key.is_absolute_random_block()
 	           || backref_key == P_ADDR_MIN);
 	    tracker.allocate(
 	      paddr,
 	      len);
 	  } else if (laddr == L_ADDR_NULL) {
-	    assert(backref_key == P_ADDR_NULL);
+	    ceph_assert(backref_key == P_ADDR_NULL);
 	    tracker.release(
 	      paddr,
 	      len);
 	  } else {
-	    assert(backref_key == P_ADDR_NULL);
+	    ceph_assert(backref_key == P_ADDR_NULL);
 	    tracker.allocate(
 	      paddr,
 	      len);
@@ -1863,11 +1863,11 @@ bool RBMCleaner::equals(const RBMSpaceTracker &_other) const
   auto rbs = rb_group->get_rb_managers();
   //TODO: multiple rbm allocator
   auto rbm = rbs[0];
-  assert(rbm);
+  ceph_assert(rbm);
 
   if (rbm->get_device()->get_available_size() / rbm->get_block_size()
       != other.block_usage.size()) {
-    assert(0 == "block counts should match");
+    ceph_assert(0 == "block counts should match");
     return false;
   }
   bool all_match = true;

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -86,8 +86,8 @@ struct segment_info_t {
 
   void update_modify_time(sea_time_point _modify_time, std::size_t _num_extents) {
     ceph_assert(!is_closed());
-    assert(_modify_time != NULL_TIME);
-    assert(_num_extents != 0);
+    ceph_assert(_modify_time != NULL_TIME);
+    ceph_assert(_num_extents != 0);
     if (modify_time == NULL_TIME) {
       modify_time = _modify_time;
       num_extents = _num_extents;
@@ -125,11 +125,11 @@ public:
   }
 
   std::size_t get_num_segments() const {
-    assert(segments.size() > 0);
+    ceph_assert(segments.size() > 0);
     return segments.size();
   }
   segment_off_t get_segment_size() const {
-    assert(segment_size > 0);
+    ceph_assert(segment_size > 0);
     return segment_size;
   }
   std::size_t get_num_in_journal_open() const {
@@ -178,7 +178,7 @@ public:
   }
   /// the unavailable space that is not writable
   std::size_t get_unavailable_bytes() const {
-    assert(total_bytes >= get_available_bytes());
+    ceph_assert(total_bytes >= get_available_bytes());
     return total_bytes - get_available_bytes();
   }
   std::size_t get_available_bytes_in_open() const {
@@ -193,9 +193,9 @@ public:
       return JOURNAL_SEQ_NULL;
     }
     auto &segment_info = segments[journal_segment_id];
-    assert(!segment_info.is_empty());
-    assert(segment_info.type == segment_type_t::JOURNAL);
-    assert(segment_info.seq != NULL_SEG_SEQ);
+    ceph_assert(!segment_info.is_empty());
+    ceph_assert(segment_info.type == segment_type_t::JOURNAL);
+    ceph_assert(segment_info.seq != NULL_SEG_SEQ);
     return journal_seq_t{
       segment_info.seq,
       paddr_t::make_seg_paddr(
@@ -250,7 +250,7 @@ public:
       return;
     }
 
-    assert(tp != NULL_TIME);
+    ceph_assert(tp != NULL_TIME);
     segments[id].update_modify_time(tp, num);
   }
 
@@ -483,9 +483,9 @@ public:
     if (!check_is_ready()) {
       return 0;
     }
-    assert(get_journal_head().segment_seq >=
+    ceph_assert(get_journal_head().segment_seq >=
            get_journal_tail().segment_seq);
-    assert(get_journal_head_sequence() >=
+    ceph_assert(get_journal_head_sequence() >=
            get_journal_head().segment_seq);
     return get_journal_head_sequence() + 1 -
            get_journal_tail().segment_seq;
@@ -732,7 +732,7 @@ class SpaceTrackerSimple : public SpaceTrackerI {
 
   int64_t update_usage(segment_id_t segment, int64_t delta) {
     live_bytes_by_segment[segment].live_bytes += delta;
-    assert(live_bytes_by_segment[segment].live_bytes >= 0);
+    ceph_assert(live_bytes_by_segment[segment].live_bytes >= 0);
     return live_bytes_by_segment[segment].live_bytes;
   }
 public:
@@ -993,7 +993,7 @@ public:
     }
 
     void find_valid() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       auto &device_vec = parent.device_to_blocks[device_id];
       if (device_vec.size() == 0 ||
 	  get_block_id() == device_vec.size()) {
@@ -1038,7 +1038,7 @@ public:
     }
 
     iterator<is_const>& operator++() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       auto block_size = parent.device_block_size[device_id];
       blk_off += block_size;
       find_valid();
@@ -1055,22 +1055,22 @@ public:
     }
     template <bool c = is_const, std::enable_if_t<c, int> = 0>
     const std::pair<const device_off_t, const T&> *operator->() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return &*current;
     }
     template <bool c = is_const, std::enable_if_t<!c, int> = 0>
     std::pair<const device_off_t, T&> *operator->() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return &*current;
     }
     template <bool c = is_const, std::enable_if_t<c, int> = 0>
     const std::pair<const device_off_t, const T&> &operator*() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return *current;
     }
     template <bool c = is_const, std::enable_if_t<!c, int> = 0>
     std::pair<const device_off_t, T&> &operator*() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return *current;
     }
   };
@@ -1294,7 +1294,7 @@ public:
   void close_segment(segment_id_t segment) final;
 
   void update_segment_avail_bytes(segment_type_t type, paddr_t offset) final {
-    assert(type == segment_type_t::OOL ||
+    ceph_assert(type == segment_type_t::OOL ||
            trimmer != nullptr); // segment_type_t::JOURNAL
     segments.update_written_to(type, offset);
     background_callback->maybe_wake_background();
@@ -1355,7 +1355,7 @@ public:
   void release_projected_usage(size_t) final;
 
   bool should_block_io_on_clean() const final {
-    assert(background_callback->is_ready());
+    ceph_assert(background_callback->is_ready());
     if (get_segments_reclaimable() == 0) {
       return false;
     }
@@ -1364,12 +1364,12 @@ public:
   }
 
   bool can_clean_space() const final {
-    assert(background_callback->is_ready());
+    ceph_assert(background_callback->is_ready());
     return get_segments_reclaimable() > 0;
   }
 
   bool should_clean_space() const final {
-    assert(background_callback->is_ready());
+    ceph_assert(background_callback->is_ready());
     if (get_segments_reclaimable() == 0) {
       return false;
     }
@@ -1406,7 +1406,7 @@ private:
   static constexpr std::size_t UTIL_BUCKETS = 12;
   static std::size_t get_bucket_index(double util) {
     auto index = std::floor(util * 10);
-    assert(index < UTIL_BUCKETS);
+    ceph_assert(index < UTIL_BUCKETS);
     return index;
   }
   double calc_utilization(segment_id_t id) const {
@@ -1417,7 +1417,7 @@ private:
       return UTIL_STATE_EMPTY;
     } else {
       auto ret = space_tracker->calc_utilization(id);
-      assert(ret >= 0 && ret < 1);
+      ceph_assert(ret >= 0 && ret < 1);
       return ret;
     }
   }
@@ -1453,7 +1453,7 @@ private:
         target_gen = generation + 1;
       }
 
-      assert(is_target_rewrite_generation(target_gen));
+      ceph_assert(is_target_rewrite_generation(target_gen));
       return {generation,
               target_gen,
               segment_size,
@@ -1470,7 +1470,7 @@ private:
     }
 
     void advance(std::size_t bytes) {
-      assert(!is_complete());
+      ceph_assert(!is_complete());
       start_pos = end_pos;
       auto &end_seg_paddr = end_pos.as_seg_paddr();
       auto next_off = end_seg_paddr.get_segment_off() + bytes;
@@ -1511,7 +1511,7 @@ private:
     }
   }
   std::size_t get_segments_reclaimable() const {
-    assert(segments.get_num_closed() >= get_segments_in_journal_closed());
+    ceph_assert(segments.get_num_closed() >= get_segments_in_journal_closed());
     return segments.get_num_closed() - get_segments_in_journal_closed();
   }
 
@@ -1522,7 +1522,7 @@ private:
   std::size_t get_unavailable_unreclaimable_bytes() const {
     auto ret = (segments.get_num_open() + get_segments_in_journal_closed()) *
                segments.get_segment_size();
-    assert(ret >= segments.get_available_bytes_in_open());
+    ceph_assert(ret >= segments.get_available_bytes_in_open());
     return ret - segments.get_available_bytes_in_open();
   }
   /// the unavailable space that can be reclaimed
@@ -1533,7 +1533,7 @@ private:
   }
   /// the unavailable space that is not alive
   std::size_t get_unavailable_unused_bytes() const {
-    assert(segments.get_unavailable_bytes() > stats.used_bytes);
+    ceph_assert(segments.get_unavailable_bytes() > stats.used_bytes);
     return segments.get_unavailable_bytes() - stats.used_bytes;
   }
   double get_reclaim_ratio() const {
@@ -1566,7 +1566,7 @@ private:
   void adjust_segment_util(double old_usage, double new_usage) {
     auto old_index = get_bucket_index(old_usage);
     auto new_index = get_bucket_index(new_usage);
-    assert(stats.segment_util.buckets[old_index].count > 0);
+    ceph_assert(stats.segment_util.buckets[old_index].count > 0);
     stats.segment_util.buckets[old_index].count--;
     stats.segment_util.buckets[new_index].count++;
   }
@@ -1577,7 +1577,7 @@ private:
       segment_type_t s_type,
       data_category_t category,
       rewrite_gen_t generation) {
-    assert(background_callback->get_state() == state_t::MOUNT);
+    ceph_assert(background_callback->get_state() == state_t::MOUNT);
     ceph_assert(s_type == segment_type_t::OOL ||
                 trimmer != nullptr); // segment_type_t::JOURNAL
     auto old_usage = calc_utilization(segment);

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -72,7 +72,7 @@ BtreeBackrefManager::mkfs(
   LOG_PREFIX(BtreeBackrefManager::mkfs);
   INFOT("start", t);
   return cache.get_root(t).si_then([this, &t](auto croot) {
-    assert(croot->is_mutation_pending());
+    ceph_assert(croot->is_mutation_pending());
     croot->get_root().backref_root = BackrefBtree::mkfs(croot, get_context(t));
     return mkfs_iertr::now();
   }).handle_error_interruptible(
@@ -565,7 +565,7 @@ BtreeBackrefManager::retrieve_backref_extents_in_range(
       [this, &extents, &t](auto &ent) {
       // only the gc fiber which is single can rewrite backref extents,
       // so it must be alive
-      assert(is_backref_node(ent.type));
+      ceph_assert(is_backref_node(ent.type));
       LOG_PREFIX(BtreeBackrefManager::retrieve_backref_extents_in_range);
       DEBUGT("getting backref extent of type {} at {}, key {}",
 	t,
@@ -582,7 +582,7 @@ BtreeBackrefManager::retrieve_backref_extents_in_range(
 	  return btree.get_internal_if_live(
 	    c, ent.paddr, ent.key, BACKREF_NODE_SIZE);
 	} else {
-	  assert(ent.type == extent_types_t::BACKREF_LEAF);
+	  ceph_assert(ent.type == extent_types_t::BACKREF_LEAF);
 	  return btree.get_leaf_if_live(
 	    c, ent.paddr, ent.key, BACKREF_NODE_SIZE);
 	}

--- a/src/crimson/os/seastore/backref_entry.h
+++ b/src/crimson/os/seastore/backref_entry.h
@@ -31,7 +31,7 @@ struct backref_entry_t {
       laddr(laddr),
       len(len),
       type(type) {
-    assert(len > 0);
+    ceph_assert(len > 0);
   }
   paddr_t paddr = P_ADDR_NULL;
   laddr_t laddr = L_ADDR_NULL;
@@ -87,8 +87,8 @@ struct backref_entry_t {
       const laddr_t& laddr,
       extent_len_t len,
       extent_types_t type) {
-    assert(is_backref_mapped_type(type));
-    assert(laddr != L_ADDR_NULL);
+    ceph_assert(is_backref_mapped_type(type));
+    ceph_assert(laddr != L_ADDR_NULL);
     return std::make_unique<backref_entry_t>(
       paddr, laddr, len, type);
   }
@@ -97,7 +97,7 @@ struct backref_entry_t {
       const paddr_t& paddr,
       extent_len_t len,
       extent_types_t type) {
-    assert(is_backref_mapped_type(type) ||
+    ceph_assert(is_backref_mapped_type(type) ||
 	   is_retired_placeholder_type(type));
     return std::make_unique<backref_entry_t>(
       paddr, L_ADDR_NULL, len, type);

--- a/src/crimson/os/seastore/backref_mapping.h
+++ b/src/crimson/os/seastore/backref_mapping.h
@@ -29,27 +29,27 @@ public:
   ~BackrefMapping() = default;
 
   bool is_viewable() const {
-    assert(cursor);
+    ceph_assert(cursor);
     return cursor->is_viewable();
   }
 
   extent_len_t get_length() const {
-    assert(cursor);
+    ceph_assert(cursor);
     return cursor->get_length();
   }
 
   laddr_t get_val() const {
-    assert(cursor);
+    ceph_assert(cursor);
     return cursor->get_laddr();
   }
 
   paddr_t get_key() const {
-    assert(cursor);
+    ceph_assert(cursor);
     return cursor->get_paddr();
   }
 
   extent_types_t get_type() const {
-    assert(cursor);
+    ceph_assert(cursor);
     return cursor->get_type();
   }
 };

--- a/src/crimson/os/seastore/btree/btree_types.cc
+++ b/src/crimson/os/seastore/btree/btree_types.cc
@@ -38,11 +38,11 @@ bool modified_since(T &&extent, uint64_t iter_modifications) {
   using backref::BackrefLeafNode;
   using lba::LBALeafNode;
   if constexpr (std::is_same_v<key_t, laddr_t>) {
-    assert(extent->get_type() == extent_types_t::LADDR_LEAF);
+    ceph_assert(extent->get_type() == extent_types_t::LADDR_LEAF);
     auto leaf = extent->template cast<LBALeafNode>();
     return leaf->modified_since(iter_modifications);
   } else {
-    assert(extent->get_type() == extent_types_t::BACKREF_LEAF);
+    ceph_assert(extent->get_type() == extent_types_t::BACKREF_LEAF);
     auto leaf = extent->template cast<BackrefLeafNode>();
     return leaf->modified_since(iter_modifications);
   }
@@ -58,7 +58,7 @@ bool BtreeCursor<key_t, val_t>::is_viewable() const {
   }
 
   auto [viewable, state] = parent->is_viewable_by_trans(ctx.trans);
-  assert(state != CachedExtent::viewable_state_t::invalid);
+  ceph_assert(state != CachedExtent::viewable_state_t::invalid);
   SUBTRACET(seastore_cache, "{} with viewable state {}",
             ctx.trans, *parent, state);
   return viewable;

--- a/src/crimson/os/seastore/btree/btree_types.h
+++ b/src/crimson/os/seastore/btree/btree_types.h
@@ -239,12 +239,12 @@ struct BtreeCursor {
 
   bool is_end() const {
     auto max_key = min_max_t<key_t>::max;
-    assert((key != max_key) == (bool)val);
+    ceph_assert((key != max_key) == (bool)val);
     return key == max_key;
   }
 
   extent_len_t get_length() const {
-    assert(!is_end());
+    ceph_assert(!is_end());
     return val->len;
   }
 };
@@ -253,30 +253,30 @@ struct LBACursor : BtreeCursor<laddr_t, lba::lba_map_val_t> {
   using Base = BtreeCursor<laddr_t, lba::lba_map_val_t>;
   using Base::BtreeCursor;
   bool is_indirect() const {
-    assert(!is_end());
+    ceph_assert(!is_end());
     return val->pladdr.is_laddr();
   }
   laddr_t get_laddr() const {
     return key;
   }
   paddr_t get_paddr() const {
-    assert(!is_indirect());
-    assert(!is_end());
+    ceph_assert(!is_indirect());
+    ceph_assert(!is_end());
     return val->pladdr.get_paddr();
   }
   laddr_t get_intermediate_key() const {
-    assert(is_indirect());
-    assert(!is_end());
+    ceph_assert(is_indirect());
+    ceph_assert(!is_end());
     return val->pladdr.get_laddr();
   }
   checksum_t get_checksum() const {
-    assert(!is_end());
-    assert(!is_indirect());
+    ceph_assert(!is_end());
+    ceph_assert(!is_indirect());
     return val->checksum;
   }
   extent_ref_count_t get_refcount() const {
-    assert(!is_end());
-    assert(!is_indirect());
+    ceph_assert(!is_end());
+    ceph_assert(!is_indirect());
     return val->refcount;
   }
   std::unique_ptr<LBACursor> duplicate() const {
@@ -292,11 +292,11 @@ struct BackrefCursor : BtreeCursor<paddr_t, backref::backref_map_val_t> {
     return key;
   }
   laddr_t get_laddr() const {
-    assert(!is_end());
+    ceph_assert(!is_end());
     return val->laddr;
   }
   extent_types_t get_type() const {
-    assert(!is_end());
+    ceph_assert(!is_end());
     return val->type;
   }
 };

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -79,7 +79,7 @@ public:
       mapped_space_visitor_t *visitor=nullptr) const
     {
       assert_valid();
-      assert(!is_end());
+      ceph_assert(!is_end());
 
       auto ret = *this;
       ret.leaf.pos++;
@@ -104,7 +104,7 @@ public:
     iterator_fut prev(op_context_t c) const
     {
       assert_valid();
-      assert(!is_begin());
+      ceph_assert(!is_begin());
 
       auto ret = *this;
 
@@ -122,7 +122,7 @@ public:
         }
       }
 
-      assert(depth_with_space <= ret.get_depth()); // must not be begin()
+      ceph_assert(depth_with_space <= ret.get_depth()); // must not be begin()
       return seastar::do_with(
         std::move(ret),
         [](const internal_node_t &internal) { return --internal.end(); },
@@ -137,20 +137,20 @@ public:
           return lookup_depth_range(
             c, ret, depth_with_space - 1, 0, li, ll, nullptr
           ).si_then([&ret] {
-            assert(!ret.at_boundary());
+            ceph_assert(!ret.at_boundary());
             return std::move(ret);
           });
         });
     }
 
     void assert_valid() const {
-      assert(leaf.node);
-      assert(leaf.pos <= leaf.node->get_size());
+      ceph_assert(leaf.node);
+      ceph_assert(leaf.pos <= leaf.node->get_size());
 
       for (auto &i: internal) {
 	(void)i;
-	assert(i.node);
-	assert(i.pos < i.node->get_size());
+	ceph_assert(i.node);
+	ceph_assert(i.pos < i.node->get_size());
       }
     }
 
@@ -159,23 +159,23 @@ public:
     }
 
     auto &get_internal(depth_t depth) {
-      assert(depth > 1);
-      assert((depth - 2) < internal.size());
+      ceph_assert(depth > 1);
+      ceph_assert((depth - 2) < internal.size());
       return internal[depth - 2];
     }
 
     const auto &get_internal(depth_t depth) const {
-      assert(depth > 1);
-      assert((depth - 2) < internal.size());
+      ceph_assert(depth > 1);
+      ceph_assert((depth - 2) < internal.size());
       return internal[depth - 2];
     }
 
     node_key_t get_key() const {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return leaf.node->iter_idx(leaf.pos).get_key();
     }
     node_val_t get_val() const {
-      assert(!is_end());
+      ceph_assert(!is_end());
       auto ret = leaf.node->iter_idx(leaf.pos).get_val();
       if constexpr (
         std::is_same_v<crimson::os::seastore::lba::lba_map_val_t,
@@ -202,7 +202,7 @@ public:
     }
 
     std::unique_ptr<cursor_t> get_cursor(op_context_t ctx) const {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return std::make_unique<cursor_t>(
         ctx,
 	leaf.node,
@@ -241,8 +241,8 @@ public:
       }
 
       auto get_iter() {
-	assert(pos != INVALID);
-	assert(pos < node->get_size());
+	ceph_assert(pos != INVALID);
+	ceph_assert(pos < node->get_size());
 	return node->iter_idx(pos);
       }
     };
@@ -251,7 +251,7 @@ public:
     node_position_t<leaf_node_t> leaf;
 
     bool at_boundary() const {
-      assert(leaf.pos <= leaf.node->get_size());
+      ceph_assert(leaf.pos <= leaf.node->get_size());
       return leaf.pos == leaf.node->get_size();
     }
 
@@ -261,7 +261,7 @@ public:
       op_context_t c,
       mapped_space_visitor_t *visitor)
     {
-      assert(at_boundary());
+      ceph_assert(at_boundary());
       depth_t depth_with_space = 2;
       for (; depth_with_space <= get_depth(); ++depth_with_space) {
         if ((get_internal(depth_with_space).pos + 1) <
@@ -326,7 +326,7 @@ public:
   /// mkfs
   using mkfs_ret = phy_tree_root_t;
   static mkfs_ret mkfs(RootBlockRef &root_block, op_context_t c) {
-    assert(root_block->is_mutation_pending());
+    ceph_assert(root_block->is_mutation_pending());
     auto root_leaf = c.cache.template alloc_new_non_data_extent<leaf_node_t>(
       c.trans,
       node_size,
@@ -359,9 +359,9 @@ public:
     return lookup(
       c,
       [addr](const internal_node_t &internal) {
-        assert(internal.get_size() > 0);
+        ceph_assert(internal.get_size() > 0);
         auto iter = internal.upper_bound(addr);
-        assert(iter != internal.begin());
+        ceph_assert(iter != internal.begin());
         --iter;
         return iter;
       },
@@ -472,13 +472,13 @@ public:
       Transaction::get_extent_ret ret;
 
       if constexpr (std::is_base_of_v<typename internal_node_t::base_t, child_node_t>) {
-        assert(i->get_val() != P_ADDR_ZERO);
+        ceph_assert(i->get_val() != P_ADDR_ZERO);
         ret = c.trans.get_extent(
           i->get_val().maybe_relative_to(node->get_paddr()),
           &child_node);
       } else {
         if (i->get_val().pladdr.is_laddr()) {
-          assert(!node->children[i->get_offset()] ||
+          ceph_assert(!node->children[i->get_offset()] ||
                   is_reserved_ptr(node->children[i->get_offset()]));
           continue;
         }
@@ -486,46 +486,46 @@ public:
           i->get_val().pladdr.get_paddr().maybe_relative_to(node->get_paddr()),
           &child_node);
         if (i->get_val().pladdr.get_paddr() == P_ADDR_ZERO) {
-          assert(ret == Transaction::get_extent_ret::ABSENT);
+          ceph_assert(ret == Transaction::get_extent_ret::ABSENT);
         }
       }
       if (ret == Transaction::get_extent_ret::PRESENT) {
         if (child_node->is_stable_written()) {
-          assert(child_node->is_valid());
+          ceph_assert(child_node->is_valid());
           auto cnode = child_node->template cast<child_node_t>();
-          assert(cnode->has_parent_tracker());
+          ceph_assert(cnode->has_parent_tracker());
           if (node->is_pending()) {
             auto &n = node->get_stable_for_key(i->get_key());
-            assert(cnode->get_parent_node().get() == &n);
+            ceph_assert(cnode->get_parent_node().get() == &n);
             auto pos = n.lower_bound(i->get_key()).get_offset();
-            assert(pos < n.get_size());
-            assert(n.children[pos] == cnode.get());
+            ceph_assert(pos < n.get_size());
+            ceph_assert(n.children[pos] == cnode.get());
           } else {
-            assert(cnode->get_parent_node().get() == node.get());
-            assert(node->children[i->get_offset()] == cnode.get());
+            ceph_assert(cnode->get_parent_node().get() == node.get());
+            ceph_assert(node->children[i->get_offset()] == cnode.get());
           }
         } else if (child_node->is_pending()) {
           if (child_node->is_mutation_pending()) {
             auto &prior = (child_node_t &)*child_node->get_prior_instance();
-            assert(prior.is_valid());
-            assert(prior.is_parent_valid());
+            ceph_assert(prior.is_valid());
+            ceph_assert(prior.is_parent_valid());
             if (node->is_mutation_pending()) {
               auto &n = node->get_stable_for_key(i->get_key());
-              assert(prior.get_parent_node().get() == &n);
+              ceph_assert(prior.get_parent_node().get() == &n);
               auto pos = n.lower_bound(i->get_key()).get_offset();
-              assert(pos < n.get_size());
-              assert(n.children[pos] == &prior);
+              ceph_assert(pos < n.get_size());
+              ceph_assert(n.children[pos] == &prior);
             } else {
-              assert(prior.get_parent_node().get() == node.get());
-              assert(node->children[i->get_offset()] == &prior);
+              ceph_assert(prior.get_parent_node().get() == node.get());
+              ceph_assert(node->children[i->get_offset()] == &prior);
             }
           } else {
             auto cnode = child_node->template cast<child_node_t>();
             auto pos = node->find(i->get_key()).get_offset();
             auto child = node->children[pos];
-            assert(child);
-            assert(child == cnode.get());
-            assert(cnode->is_parent_valid());
+            ceph_assert(child);
+            ceph_assert(child == cnode.get());
+            ceph_assert(cnode->is_parent_valid());
           }
         } else {
           ceph_assert(!child_node->is_valid());
@@ -537,7 +537,7 @@ public:
         if (node->is_pending()) {
           auto &n = node->get_stable_for_key(i->get_key());
           auto pos = n.lower_bound(i->get_key()).get_offset();
-          assert(pos < n.get_size());
+          ceph_assert(pos < n.get_size());
           child = n.children[pos];
         } else {
           child = node->children[i->get_offset()];
@@ -547,9 +547,9 @@ public:
           if constexpr (
             std::is_base_of_v<typename internal_node_t::base_t, child_node_t>)
           {
-            assert(!c.cache.test_query_cache(i->get_val()));
+            ceph_assert(!c.cache.test_query_cache(i->get_val()));
           } else {
-            assert(i->get_val().pladdr.is_paddr()
+            ceph_assert(i->get_val().pladdr.is_paddr()
               ? (bool)!c.cache.test_query_cache(
                   i->get_val().pladdr.get_paddr())
               : true);
@@ -558,16 +558,16 @@ public:
             if constexpr(
               !std::is_base_of_v<typename internal_node_t::base_t,
                                  child_node_t>) {
-              assert(i->get_val().pladdr.is_paddr());
-              assert(i->get_val().pladdr.get_paddr() == P_ADDR_ZERO);
+              ceph_assert(i->get_val().pladdr.is_paddr());
+              ceph_assert(i->get_val().pladdr.get_paddr() == P_ADDR_ZERO);
             } else {
               ceph_abort();
             }
           }
         } else {
           auto c = static_cast<child_node_t*>(child);
-          assert(c->has_parent_tracker());
-          assert(c->get_parent_node().get() == node.get()
+          ceph_assert(c->has_parent_tracker());
+          ceph_assert(c->get_parent_node().get() == node.get()
             || (node->is_pending() && c->is_stable()
                 && c->get_parent_node().get() == &node->get_stable_for_key(
                   i->get_key())));
@@ -595,16 +595,16 @@ public:
       }
       if (depth > 1) {
         auto &node = iter.get_internal(depth).node;
-        assert(node->is_valid());
+        ceph_assert(node->is_valid());
         if (depth > 2 ) {
           check_node<internal_node_t>(c, node);
         } else {
           check_node<leaf_node_t>(c, node);
         }
       } else {
-        assert(depth == 1);
+        ceph_assert(depth == 1);
         auto &node = iter.leaf.node;
-        assert(node->is_valid());
+        ceph_assert(node->is_valid());
         check_node<typename leaf_node_t::child_t>(c, node);
       }
       return seastar::now();
@@ -728,9 +728,9 @@ public:
               }
               auto iter = typename leaf_node_t::const_iterator(
                   ret.leaf.node.get(), ret.leaf.pos);
-              assert(iter == ret.leaf.node->lower_bound(laddr));
-              assert(iter == ret.leaf.node->end() || iter->get_key() > laddr);
-              assert(laddr >= ret.leaf.node->get_meta().begin &&
+              ceph_assert(iter == ret.leaf.node->lower_bound(laddr));
+              ceph_assert(iter == ret.leaf.node->end() || iter->get_key() > laddr);
+              ceph_assert(laddr >= ret.leaf.node->get_meta().begin &&
                      laddr < ret.leaf.node->get_meta().end);
               ret.leaf.node->insert(iter, laddr, val);
               return insert_ret(
@@ -812,7 +812,7 @@ public:
       "remove element at {}",
       c.trans,
       iter.is_end() ? min_max_t<node_key_t>::max : iter.get_key());
-    assert(!iter.is_end());
+    ceph_assert(!iter.is_end());
     ++(get_tree_stats<self_type>(c.trans).num_erases);
     return seastar::do_with(
       iter,
@@ -846,7 +846,7 @@ public:
     op_context_t c,
     CachedExtentRef e)
   {
-    assert(!e->is_logical());
+    ceph_assert(!e->is_logical());
     LOG_PREFIX(FixedKVTree::init_cached_extent);
     SUBTRACET(seastore_fixedkv_tree, "extent {}", c.trans, *e);
     if (e->get_type() == internal_node_t::TYPE) {
@@ -973,7 +973,7 @@ public:
             addr,
             len,
             *internal_node);
-          assert(internal_node->get_node_meta().begin == laddr);
+          ceph_assert(internal_node->get_node_meta().begin == laddr);
           return CachedExtentRef(internal_node);
         }
       }
@@ -1001,7 +1001,7 @@ public:
     op_context_t c,
     CachedExtentRef e) {
     LOG_PREFIX(FixedKVBtree::rewrite_extent);
-    assert(is_lba_backref_node(e->get_type()));
+    ceph_assert(is_lba_backref_node(e->get_type()));
     
     auto do_rewrite = [&](auto &fixed_kv_extent) {
       auto n_fixed_kv_extent = c.cache.template alloc_new_non_data_extent<
@@ -1037,7 +1037,7 @@ public:
       auto lint = e->cast<internal_node_t>();
       return do_rewrite(*lint);
     } else {
-      assert(e->get_type() == leaf_node_t::TYPE);
+      ceph_assert(e->get_type() == leaf_node_t::TYPE);
       auto lleaf = e->cast<leaf_node_t>();
       return do_rewrite(*lleaf);
     }
@@ -1069,7 +1069,7 @@ public:
     return lower_bound(
       c, laddr, nullptr, depth + 1
     ).si_then([=, this](auto iter) {
-      assert(iter.get_depth() >= depth);
+      ceph_assert(iter.get_depth() >= depth);
       if (depth == iter.get_depth()) {
         SUBTRACET(seastore_fixedkv_tree, "update at root", c.trans);
 
@@ -1107,8 +1107,8 @@ public:
         set_root_node(nextent);
       } else {
         auto &parent = iter.get_internal(depth + 1);
-        assert(parent.node);
-        assert(parent.pos < parent.node->get_size());
+        ceph_assert(parent.node);
+        ceph_assert(parent.pos < parent.node->get_size());
         auto piter = parent.node->iter_idx(parent.pos);
 
         if (piter->get_key() != laddr) {
@@ -1187,25 +1187,25 @@ private:
       depth,
       begin,
       end);
-    assert(depth > 1);
+    ceph_assert(depth > 1);
     auto init_internal = [c, depth, begin, end,
                           parent_pos=std::move(parent_pos)]
                           (internal_node_t &node) {
       using tree_root_linker_t = TreeRootLinker<RootBlock, internal_node_t>;
-      assert(!node.is_pending());
-      assert(!node.is_linked());
+      ceph_assert(!node.is_pending());
+      ceph_assert(!node.is_linked());
       node.range = fixed_kv_node_meta_t<node_key_t>{begin, end, depth};
       if (parent_pos) {
         auto &parent = parent_pos->node;
         parent->link_child(&node, parent_pos->pos);
       } else {
-        assert(node.range.is_root());
+        ceph_assert(node.range.is_root());
         auto root_block = c.cache.get_root_fast(c.trans);
         if (root_block->is_mutation_pending()) {
           auto &stable_root = (RootBlockRef&)*root_block->get_prior_instance();
           tree_root_linker_t::link_root(stable_root, &node);
         } else {
-          assert(!root_block->is_pending());
+          ceph_assert(!root_block->is_pending());
           tree_root_linker_t::link_root(root_block, &node);
         }
       }
@@ -1237,7 +1237,7 @@ private:
       // This can only happen during init_cached_extent
       // or when backref extent being rewritten by gc space reclaiming
       if (!ret->is_pending() && !ret->is_linked()) {
-        assert(ret->is_dirty()
+        ceph_assert(ret->is_dirty()
           || (is_backref_node(ret->get_type())
             && ret->is_clean()));
         init_internal(*ret);
@@ -1278,20 +1278,20 @@ private:
                       parent_pos=std::move(parent_pos)]
                       (leaf_node_t &node) {
       using tree_root_linker_t = TreeRootLinker<RootBlock, leaf_node_t>;
-      assert(!node.is_pending());
-      assert(!node.is_linked());
+      ceph_assert(!node.is_pending());
+      ceph_assert(!node.is_linked());
       node.range = fixed_kv_node_meta_t<node_key_t>{begin, end, 1};
       if (parent_pos) {
         auto &parent = parent_pos->node;
         parent->link_child(&node, parent_pos->pos);
       } else {
-        assert(node.range.is_root());
+        ceph_assert(node.range.is_root());
         auto root_block = c.cache.get_root_fast(c.trans);
         if (root_block->is_mutation_pending()) {
           auto &stable_root = (RootBlockRef&)*root_block->get_prior_instance();
           tree_root_linker_t::link_root(stable_root, &node);
         } else {
-          assert(!root_block->is_pending());
+          ceph_assert(!root_block->is_pending());
           tree_root_linker_t::link_root(root_block, &node);
         }
       }
@@ -1322,7 +1322,7 @@ private:
       // This can only happen during init_cached_extent
       // or when backref extent being rewritten by gc space reclaiming
       if (!ret->is_pending() && !ret->is_linked()) {
-        assert(ret->is_dirty()
+        ceph_assert(ret->is_dirty()
           || (is_backref_node(ret->get_type())
             && ret->is_clean()));
         init_leaf(*ret);
@@ -1438,7 +1438,7 @@ private:
     F &f,
     mapped_space_visitor_t *visitor
   ) {
-    assert(depth > 1);
+    ceph_assert(depth > 1);
     auto &parent_entry = iter.get_internal(depth + 1);
     auto parent = parent_entry.node;
     auto node_iter = parent->iter_idx(parent_entry.pos);
@@ -1447,7 +1447,7 @@ private:
       auto &entry = iter.get_internal(depth);
       entry.node = node;
       auto node_iter = f(*node);
-      assert(node_iter != node->end());
+      ceph_assert(node_iter != node->end());
       entry.pos = node_iter->get_offset();
       if (visitor)
         (*visitor)(
@@ -1476,8 +1476,8 @@ private:
           parent_entry.pos,
           *child);
         auto &cnode = (typename internal_node_t::base_t &)*child;
-        assert(cnode.get_node_meta().begin == node_iter.get_key());
-        assert(cnode.get_node_meta().end > node_iter.get_key());
+        ceph_assert(cnode.get_node_meta().begin == node_iter.get_key());
+        ceph_assert(cnode.get_node_meta().end > node_iter.get_key());
         return on_found(child->template cast<internal_node_t>());
       });
     }
@@ -1513,7 +1513,7 @@ private:
   ) {
     auto &parent_entry = iter.get_internal(2);
     auto parent = parent_entry.node;
-    assert(parent);
+    ceph_assert(parent);
     auto node_iter = parent->iter_idx(parent_entry.pos);
 
     auto on_found = [visitor, &iter, &f](LeafNodeRef node) {
@@ -1547,8 +1547,8 @@ private:
           parent_entry.pos,
           *child);
         [[maybe_unused]] auto &cnode = (typename internal_node_t::base_t &)*child;
-        assert(cnode.get_node_meta().begin == node_iter.get_key());
-        assert(cnode.get_node_meta().end > node_iter.get_key());
+        ceph_assert(cnode.get_node_meta().begin == node_iter.get_key());
+        ceph_assert(cnode.get_node_meta().end > node_iter.get_key());
         return on_found(child->template cast<leaf_node_t>());
       });
     }
@@ -1610,7 +1610,7 @@ private:
 		    li,
 		    visitor);
 		} else {
-		  assert(d == 1);
+		  ceph_assert(d == 1);
 		  return lookup_leaf(
 		    c,
 		    iter,
@@ -1643,7 +1643,7 @@ private:
     mapped_space_visitor_t *visitor
   ) const {
     LOG_PREFIX(FixedKVBtree::lookup);
-    assert(min_depth > 0);
+    ceph_assert(min_depth > 0);
     return seastar::do_with(
       iterator{get_root().get_depth()},
       std::forward<LI>(lookup_internal),
@@ -1704,7 +1704,7 @@ private:
     node_key_t laddr,
     iterator &iter)
   {
-    assert(iter.is_end() || iter.get_key() >= laddr);
+    ceph_assert(iter.is_end() || iter.get_key() >= laddr);
     if (!iter.is_end() && iter.get_key() == laddr) {
       return seastar::now();
     } else if (iter.leaf.node->get_node_meta().begin <= laddr) {
@@ -1712,23 +1712,23 @@ private:
       auto p = iter;
       if (p.leaf.pos > 0) {
         --p.leaf.pos;
-        assert(p.get_key() < laddr);
+        ceph_assert(p.get_key() < laddr);
       }
 #endif
       return seastar::now();
     } else {
-      assert(iter.leaf.pos == 0);
+      ceph_assert(iter.leaf.pos == 0);
       return iter.prev(
         c
       ).si_then([laddr, &iter](auto p) {
         boost::ignore_unused(laddr); // avoid clang warning;
-        assert(p.leaf.node->get_node_meta().begin <= laddr);
-        assert(p.get_key() < laddr);
+        ceph_assert(p.leaf.node->get_node_meta().begin <= laddr);
+        ceph_assert(p.get_key() < laddr);
         // Note, this is specifically allowed to violate the iterator
         // invariant that pos is a valid index for the node in the event
         // that the insertion point is at the end of a node.
         p.leaf.pos++;
-        assert(p.at_boundary());
+        ceph_assert(p.at_boundary());
         iter = p;
         return seastar::now();
       });
@@ -1919,7 +1919,7 @@ private:
                 if (pos.node->get_size() == 1) {
                   SUBTRACET(seastore_fixedkv_tree, "collapsing root", c.trans);
                   c.cache.retire_extent(c.trans, pos.node);
-                  assert(pos.pos == 0);
+                  ceph_assert(pos.pos == 0);
                   auto node_iter = pos.get_iter();
                   iter.internal.pop_back();
                   get_tree_stats<self_type>(c.trans).depth = iter.get_depth();
@@ -1972,7 +1972,7 @@ private:
     node_key_t begin,
     node_key_t end,
     typename std::optional<node_position_t<internal_node_t>> parent_pos) {
-    assert(depth == 1);
+    ceph_assert(depth == 1);
     return get_leaf_node(c, addr, begin, end, std::move(parent_pos));
   }
 
@@ -2003,7 +2003,7 @@ private:
     }
 
     auto iter = parent_pos.get_iter();
-    assert(iter.get_offset() < parent_pos.node->get_size());
+    ceph_assert(iter.get_offset() < parent_pos.node->get_size());
     bool donor_is_left = ((iter.get_offset() + 1) == parent_pos.node->get_size());
     auto donor_iter = donor_is_left ? (iter - 1) : (iter + 1);
     auto next_iter = donor_iter + 1;
@@ -2061,7 +2061,7 @@ private:
           replacement_r.get());
 
         if (donor_is_left) {
-          assert(parent_pos.pos > 0);
+          ceph_assert(parent_pos.pos > 0);
           parent_pos.pos--;
         }
 
@@ -2104,11 +2104,11 @@ private:
           donor_iter.get_offset(),
           *child);
         auto &node = (typename internal_node_t::base_t&)*child;
-        assert(donor_is_left ?
+        ceph_assert(donor_is_left ?
           node.get_node_meta().end == pos.node->get_node_meta().begin :
           node.get_node_meta().begin == pos.node->get_node_meta().end);
-        assert(node.get_node_meta().begin == donor_iter.get_key());
-        assert(node.get_node_meta().end > donor_iter.get_key());
+        ceph_assert(node.get_node_meta().begin == donor_iter.get_key());
+        ceph_assert(node.get_node_meta().end > donor_iter.get_key());
         return do_merge(child->template cast<NodeType>());
       });
     }

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -54,8 +54,8 @@ struct FixedKVNode : CachedExtent {
   }
 
   void on_rewrite(Transaction &t, CachedExtent &extent, extent_len_t off) final {
-    assert(get_type() == extent.get_type());
-    assert(off == 0);
+    ceph_assert(get_type() == extent.get_type());
+    ceph_assert(off == 0);
     range = get_node_meta();
     do_on_rewrite(t, extent);
     
@@ -74,14 +74,14 @@ struct FixedKVNode : CachedExtent {
 	make_record_relative_paddr(0).block_relative_to(get_paddr()));
     } else {
       // backend_type_t::RANDOM_BLOCK
-      assert(get_paddr().is_absolute());
+      ceph_assert(get_paddr().is_absolute());
     }
   }
 
   void on_delta_write(paddr_t record_block_offset) final {
     // All in-memory relative addrs are necessarily record-relative
-    assert(get_prior_instance());
-    assert(pending_for_transaction);
+    ceph_assert(get_prior_instance());
+    ceph_assert(pending_for_transaction);
     resolve_relative_addrs(record_block_offset);
   }
 
@@ -226,7 +226,7 @@ struct FixedKVInternalNode
   }
 
   CachedExtentRef duplicate_for_write(Transaction&) override {
-    assert(delta_buffer.empty());
+    ceph_assert(delta_buffer.empty());
     return CachedExtentRef(new node_type_t(*this));
   };
 
@@ -407,7 +407,7 @@ struct FixedKVInternalNode
     if (this->is_initial_pending()) {
       for (auto i = from; i != to; ++i) {
 	if (i->get_val().is_relative()) {
-	  assert(i->get_val().is_block_relative());
+	  ceph_assert(i->get_val().is_block_relative());
 	  i->set_val(this->get_paddr().add_relative(i->get_val()));
 	}
       }
@@ -419,7 +419,7 @@ struct FixedKVInternalNode
     if (this->is_initial_pending()) {
       for (auto i = from; i != to; ++i) {
 	if (i->get_val().is_relative()) {
-	  assert(i->get_val().is_record_relative());
+	  ceph_assert(i->get_val().is_record_relative());
 	  i->set_val(i->get_val().block_relative_to(this->get_paddr()));
 	}
       }
@@ -447,7 +447,7 @@ struct FixedKVInternalNode
 
   void apply_delta_and_adjust_crc(
     paddr_t base, const ceph::bufferlist &_bl) {
-    assert(_bl.length());
+    ceph_assert(_bl.length());
     ceph::bufferlist bl = _bl;
     bl.rebuild();
     typename node_layout_t::delta_buffer_t buffer;
@@ -464,17 +464,17 @@ struct FixedKVInternalNode
   }
 
   bool at_max_capacity() const {
-    assert(this->get_size() <= node_layout_t::get_capacity());
+    ceph_assert(this->get_size() <= node_layout_t::get_capacity());
     return this->get_size() == node_layout_t::get_capacity();
   }
 
   bool at_min_capacity() const {
-    assert(this->get_size() >= (get_min_capacity() - 1));
+    ceph_assert(this->get_size() >= (get_min_capacity() - 1));
     return this->get_size() <= get_min_capacity();
   }
 
   bool below_min_capacity() const {
-    assert(this->get_size() >= (get_min_capacity() - 1));
+    ceph_assert(this->get_size() >= (get_min_capacity() - 1));
     return this->get_size() < get_min_capacity();
   }
 };
@@ -624,7 +624,7 @@ struct FixedKVLeafNode
   }
 
   CachedExtentRef duplicate_for_write(Transaction&) override {
-    assert(delta_buffer.empty());
+    ceph_assert(delta_buffer.empty());
     return CachedExtentRef(new node_type_t(*static_cast<node_type_t*>(this)));
   };
 
@@ -749,7 +749,7 @@ struct FixedKVLeafNode
 
   void apply_delta_and_adjust_crc(
     paddr_t base, const ceph::bufferlist &_bl) {
-    assert(_bl.length());
+    ceph_assert(_bl.length());
     ceph::bufferlist bl = _bl;
     bl.rebuild();
     typename node_layout_t::delta_buffer_t buffer;
@@ -772,17 +772,17 @@ struct FixedKVLeafNode
   }
 
   bool at_max_capacity() const {
-    assert(this->get_size() <= node_layout_t::get_capacity());
+    ceph_assert(this->get_size() <= node_layout_t::get_capacity());
     return this->get_size() == node_layout_t::get_capacity();
   }
 
   bool at_min_capacity() const {
-    assert(this->get_size() >= (get_min_capacity() - 1));
+    ceph_assert(this->get_size() >= (get_min_capacity() - 1));
     return this->get_size() <= get_min_capacity();
   }
 
   bool below_min_capacity() const {
-    assert(this->get_size() >= (get_min_capacity() - 1));
+    ceph_assert(this->get_size() >= (get_min_capacity() - 1));
     return this->get_size() < get_min_capacity();
   }
 };

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -40,8 +40,8 @@ void intrusive_ptr_release(CachedExtent *);
 // Note: BufferSpace::to_full_ptr() also creates extent ptr.
 
 inline ceph::bufferptr create_extent_ptr_rand(extent_len_t len) {
-  assert(is_aligned(len, CEPH_PAGE_SIZE));
-  assert(len > 0);
+  ceph_assert(is_aligned(len, CEPH_PAGE_SIZE));
+  ceph_assert(len > 0);
   return ceph::bufferptr(buffer::create_page_aligned(len));
 }
 
@@ -179,7 +179,7 @@ struct load_range_t {
 
   extent_len_t get_end() const {
     extent_len_t end = offset + ptr.length();
-    assert(end > offset);
+    ceph_assert(end > offset);
     return end;
   }
 };
@@ -188,9 +188,9 @@ struct load_ranges_t {
   std::list<load_range_t> ranges;
 
   void push_back(extent_len_t offset, ceph::bufferptr ptr) {
-    assert(ranges.empty() ||
+    ceph_assert(ranges.empty() ||
            (ranges.back().get_end() < offset));
-    assert(ptr.length());
+    ceph_assert(ptr.length());
     length += ptr.length();
     ranges.push_back({offset, std::move(ptr)});
   }
@@ -235,12 +235,12 @@ private:
       extent_len_t hole_offset,
       extent_len_t hole_length,
       const map_t::const_iterator& next_it) {
-    assert(!buffer_map.contains(hole_offset));
+    ceph_assert(!buffer_map.contains(hole_offset));
     ceph::bufferlist bl;
     create_hole_append_bl(ret, bl, hole_offset, hole_length);
     auto it = buffer_map.insert(
         next_it, std::pair{hole_offset, std::move(bl)});
-    assert(next_it == std::next(it));
+    ceph_assert(next_it == std::next(it));
     return it;
   }
 
@@ -293,7 +293,7 @@ public:
             placement_hint_t hint,
             rewrite_gen_t gen,
 	    transaction_id_t trans_id) {
-    assert(gen == NULL_GENERATION || is_rewrite_generation(gen));
+    ceph_assert(gen == NULL_GENERATION || is_rewrite_generation(gen));
     state = _state;
     set_paddr(paddr);
     user_hint = hint;
@@ -407,8 +407,8 @@ public:
   virtual extent_types_t get_type() const = 0;
 
   virtual bool is_logical() const {
-    assert(!is_logical_type(get_type()));
-    assert(is_physical_type(get_type()));
+    ceph_assert(!is_logical_type(get_type()));
+    ceph_assert(is_physical_type(get_type()));
     return false;
   }
 
@@ -417,11 +417,11 @@ public:
   }
 
   void rewrite(Transaction &t, CachedExtent &e, extent_len_t o) {
-    assert(is_initial_pending());
+    ceph_assert(is_initial_pending());
     if (!e.is_pending()) {
       prior_instance = &e;
     } else {
-      assert(e.is_mutation_pending());
+      ceph_assert(e.is_mutation_pending());
       prior_instance = e.get_prior_instance();
     }
     e.get_bptr().copy_out(
@@ -645,22 +645,22 @@ public:
   bool is_fully_loaded() const {
     if (ptr.has_value()) {
       // length == 0 iff root
-      assert(length == loaded_length);
-      assert(!buffer_space.has_value());
+      ceph_assert(length == loaded_length);
+      ceph_assert(!buffer_space.has_value());
       return true;
     } else { // ptr is std::nullopt
-      assert(length > loaded_length);
-      assert(buffer_space.has_value());
+      ceph_assert(length > loaded_length);
+      ceph_assert(buffer_space.has_value());
       return false;
     }
   }
 
   /// Return true if range offset~_length is loaded
   bool is_range_loaded(extent_len_t offset, extent_len_t _length) {
-    assert(is_aligned(offset, CEPH_PAGE_SIZE));
-    assert(is_aligned(_length, CEPH_PAGE_SIZE));
-    assert(_length > 0);
-    assert(offset + _length <= length);
+    ceph_assert(is_aligned(offset, CEPH_PAGE_SIZE));
+    ceph_assert(is_aligned(_length, CEPH_PAGE_SIZE));
+    ceph_assert(_length > 0);
+    ceph_assert(offset + _length <= length);
     if (is_fully_loaded()) {
       return true;
     }
@@ -669,7 +669,7 @@ public:
 
   /// Get buffer by given offset and _length.
   ceph::bufferlist get_range(extent_len_t offset, extent_len_t _length) {
-    assert(is_range_loaded(offset, _length));
+    ceph_assert(is_range_loaded(offset, _length));
     ceph::bufferlist res;
     if (is_fully_loaded()) {
       res.append(ceph::bufferptr(get_bptr(), offset, _length));
@@ -712,11 +712,11 @@ public:
 
   /// Get ref to raw buffer
   virtual bufferptr &get_bptr() {
-    assert(ptr.has_value());
+    ceph_assert(ptr.has_value());
     return *ptr;
   }
   virtual const bufferptr &get_bptr() const {
-    assert(ptr.has_value());
+    ceph_assert(ptr.has_value());
     return *ptr;
   }
 
@@ -748,7 +748,7 @@ public:
 
   /// assign the target rewrite generation for the followup rewrite
   void set_target_rewrite_generation(rewrite_gen_t gen) {
-    assert(is_target_rewrite_generation(gen));
+    ceph_assert(is_target_rewrite_generation(gen));
 
     user_hint = placement_hint_t::REWRITE;
     rewrite_generation = gen;
@@ -919,9 +919,9 @@ protected:
       loaded_length(_ptr.length()) {
     ptr = std::move(_ptr);
 
-    assert(ptr->is_page_aligned());
-    assert(length > 0);
-    assert(is_fully_loaded());
+    ceph_assert(ptr->is_page_aligned());
+    ceph_assert(length > 0);
+    ceph_assert(is_fully_loaded());
     // must call init() to fully initialize
   }
 
@@ -931,9 +931,9 @@ protected:
     : length(_length),
       loaded_length(0),
       buffer_space(std::in_place) {
-    assert(is_aligned(length, CEPH_PAGE_SIZE));
-    assert(length > 0);
-    assert(!is_fully_loaded());
+    ceph_assert(is_aligned(length, CEPH_PAGE_SIZE));
+    ceph_assert(length > 0);
+    ceph_assert(!is_fully_loaded());
     // must call init() to fully initialize
   }
 
@@ -946,8 +946,8 @@ protected:
       version(other.version),
       poffset(other.poffset) {
     // the extent must be fully loaded before CoW
-    assert(other.is_fully_loaded());
-    assert(is_aligned(length, CEPH_PAGE_SIZE));
+    ceph_assert(other.is_fully_loaded());
+    ceph_assert(is_aligned(length, CEPH_PAGE_SIZE));
     if (length > 0) {
       ptr = create_extent_ptr_rand(length);
       other.ptr->copy_out(0, length, ptr->c_str());
@@ -955,7 +955,7 @@ protected:
       ptr = ceph::bufferptr(0);
     }
 
-    assert(is_fully_loaded());
+    ceph_assert(is_fully_loaded());
   }
 
   struct share_buffer_t {};
@@ -969,10 +969,10 @@ protected:
       version(other.version),
       poffset(other.poffset) {
     // the extent must be fully loaded before CoW
-    assert(other.is_fully_loaded());
-    assert(is_aligned(length, CEPH_PAGE_SIZE));
-    assert(length > 0);
-    assert(is_fully_loaded());
+    ceph_assert(other.is_fully_loaded());
+    ceph_assert(is_aligned(length, CEPH_PAGE_SIZE));
+    ceph_assert(length > 0);
+    ceph_assert(is_fully_loaded());
   }
 
   // 0 length is only possible for the RootBlock
@@ -981,7 +981,7 @@ protected:
     : ptr(ceph::bufferptr(0)),
       length(0),
       loaded_length(0) {
-    assert(is_fully_loaded());
+    ceph_assert(is_fully_loaded());
     // must call init() to fully initialize
   }
 
@@ -991,8 +991,8 @@ protected:
       length(_length),
       loaded_length(0),
       buffer_space(std::in_place) {
-    assert(!is_fully_loaded());
-    assert(is_aligned(length, CEPH_PAGE_SIZE));
+    ceph_assert(!is_fully_loaded());
+    ceph_assert(is_aligned(length, CEPH_PAGE_SIZE));
     // must call init() to fully initialize
   }
 
@@ -1030,7 +1030,7 @@ protected:
 
   void set_paddr(paddr_t offset, bool need_update_mapping = false) {
     if (need_update_mapping) {
-      assert(!prior_poffset);
+      ceph_assert(!prior_poffset);
       prior_poffset = poffset;
     }
     poffset = offset;
@@ -1070,19 +1070,19 @@ protected:
 
   /// Returns the ranges to load, convert to fully loaded is possible
   load_ranges_t load_ranges(extent_len_t offset, extent_len_t _length) {
-    assert(is_aligned(offset, CEPH_PAGE_SIZE));
-    assert(is_aligned(_length, CEPH_PAGE_SIZE));
-    assert(_length > 0);
-    assert(offset + _length <= length);
-    assert(!is_fully_loaded());
+    ceph_assert(is_aligned(offset, CEPH_PAGE_SIZE));
+    ceph_assert(is_aligned(_length, CEPH_PAGE_SIZE));
+    ceph_assert(_length > 0);
+    ceph_assert(offset + _length <= length);
+    ceph_assert(!is_fully_loaded());
 
     if (loaded_length == 0 && _length == length) {
-      assert(offset == 0);
+      ceph_assert(offset == 0);
       // skip rebuilding the buffer from buffer_space
       ptr = create_extent_ptr_rand(length);
       loaded_length = _length;
       buffer_space.reset();
-      assert(is_fully_loaded());
+      ceph_assert(is_fully_loaded());
       on_fully_loaded();
       load_ranges_t ret;
       ret.push_back(offset, *ptr);
@@ -1091,12 +1091,12 @@ protected:
 
     load_ranges_t ret = buffer_space->load_ranges(offset, _length);
     loaded_length += ret.length;
-    assert(length >= loaded_length);
+    ceph_assert(length >= loaded_length);
     if (length == loaded_length) {
       // convert to fully loaded
       ptr = buffer_space->to_full_ptr(length);
       buffer_space.reset();
-      assert(is_fully_loaded());
+      ceph_assert(is_fully_loaded());
       on_fully_loaded();
       // adjust ret since the ptr has been rebuild
       for (load_range_t& range : ret.ranges) {
@@ -1149,7 +1149,7 @@ struct trans_retired_extent_link_t {
   trans_retired_extent_link_t(CachedExtentRef extent, transaction_id_t id)
     : extent(extent), trans_view{id}
   {
-    assert(extent->is_stable());
+    ceph_assert(extent->is_stable());
     extent->retired_transactions.insert(trans_view);
   }
 };
@@ -1247,25 +1247,25 @@ public:
     ceph_assert(a == b);
 
     [[maybe_unused]] auto [iter, inserted] = extent_index.insert(extent);
-    assert(inserted);
+    ceph_assert(inserted);
     extent.parent_index = this;
 
     bytes += extent.get_length();
   }
 
   void erase(CachedExtent &extent) {
-    assert(extent.parent_index);
-    assert(extent.is_linked());
+    ceph_assert(extent.parent_index);
+    ceph_assert(extent.is_linked());
     [[maybe_unused]] auto erased = extent_index.erase(
       extent_index.s_iterator_to(extent));
     extent.parent_index = nullptr;
 
-    assert(erased);
+    ceph_assert(erased);
     bytes -= extent.get_length();
   }
 
   void replace(CachedExtent &to, CachedExtent &from) {
-    assert(to.get_length() == from.get_length());
+    ceph_assert(to.get_length() == from.get_length());
     extent_index.replace_node(extent_index.s_iterator_to(from), to);
     from.parent_index = nullptr;
     to.parent_index = this;
@@ -1304,8 +1304,8 @@ public:
   }
 
   ~ExtentIndex() {
-    assert(extent_index.empty());
-    assert(bytes == 0);
+    ceph_assert(extent_index.empty());
+    ceph_assert(bytes == 0);
   }
 
 private:
@@ -1382,7 +1382,7 @@ public:
      seen_by_users(other.seen_by_users) {}
 
   void on_rewrite(Transaction &t, CachedExtent &extent, extent_len_t off) final {
-    assert(get_type() == extent.get_type());
+    ceph_assert(get_type() == extent.get_type());
     auto &lextent = (LogicalCachedExtent&)extent;
     set_laddr((lextent.get_laddr() + off).checked_to_laddr());
     seen_by_users = lextent.seen_by_users;
@@ -1398,7 +1398,7 @@ public:
   // handled under TransactionManager,
   // user should not set this by themselves.
   void set_seen_by_users() {
-    assert(!seen_by_users);
+    ceph_assert(!seen_by_users);
     seen_by_users = true;
   }
 
@@ -1407,7 +1407,7 @@ public:
   }
 
   laddr_t get_laddr() const {
-    assert(laddr != L_ADDR_NULL);
+    ceph_assert(laddr != L_ADDR_NULL);
     return laddr;
   }
 
@@ -1422,8 +1422,8 @@ public:
   }
 
   bool is_logical() const final {
-    assert(is_logical_type(get_type()));
-    assert(!is_physical_type(get_type()));
+    ceph_assert(is_logical_type(get_type()));
+    ceph_assert(!is_physical_type(get_type()));
     return true;
   }
 
@@ -1455,7 +1455,7 @@ protected:
   virtual void logical_on_delta_write() {}
 
   void on_delta_write(paddr_t record_block_offset) final {
-    assert(is_exist_mutation_pending() ||
+    ceph_assert(is_exist_mutation_pending() ||
 	   get_prior_instance());
     logical_on_delta_write();
   }

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.cc
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.cc
@@ -30,7 +30,7 @@ void delta_t::replay(coll_map_t &l) const
     break;
   }
   case op_t::INVALID: {
-    assert(0 == "impossible");
+    ceph_assert(0 == "impossible");
     break;
   }
   __builtin_unreachable();
@@ -66,7 +66,7 @@ CollectionNode::create(coll_context_t cc, coll_t coll, unsigned bits)
   }
   logger().debug("CollectionNode::create {} {} {}", coll, bits, *this);
   auto [iter, inserted] = decoded.insert(coll, bits);
-  assert(inserted);
+  ceph_assert(inserted);
   if (encoded_sizeof((base_coll_map_t&)decoded) > get_bptr().length()) {
     decoded.erase(iter);
     return create_ret(

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -108,7 +108,7 @@ struct CollectionNode : LogicalChildNode {
   delta_buffer_t delta_buffer;
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
-    assert(delta_buffer.empty());
+    ceph_assert(delta_buffer.empty());
     return CachedExtentRef(new CollectionNode(*this));
   }
   delta_buffer_t *maybe_get_delta_buffer() {
@@ -148,7 +148,7 @@ struct CollectionNode : LogicalChildNode {
     encode((base_coll_map_t&)decoded, bl);
     auto iter = bl.begin();
     auto size = encoded_sizeof((base_coll_map_t&)decoded);
-    assert(size <= get_bptr().length());
+    ceph_assert(size <= get_bptr().length());
     get_bptr().zero();
     iter.copy(size, get_bptr().c_str());
 
@@ -172,7 +172,7 @@ struct CollectionNode : LogicalChildNode {
   }
 
   void apply_delta(const ceph::bufferlist &bl) final {
-    assert(bl.length());
+    ceph_assert(bl.length());
     delta_buffer_t buffer;
     auto bptr = bl.begin();
     decode(buffer, bptr);

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
@@ -45,15 +45,15 @@ FlatCollectionManager::get_root_ret
 FlatCollectionManager::get_coll_root(const coll_root_t &coll_root, Transaction &t)
 {
   logger().debug("FlatCollectionManager: {}", __func__);
-  assert(coll_root.get_location() != L_ADDR_NULL);
+  ceph_assert(coll_root.get_location() != L_ADDR_NULL);
   auto cc = get_coll_context(t);
   return cc.tm.read_extent<CollectionNode>(
     cc.t,
     coll_root.get_location(),
     coll_root.get_size()
   ).si_then([](auto maybe_indirect_extent) {
-    assert(!maybe_indirect_extent.is_indirect());
-    assert(!maybe_indirect_extent.is_clone);
+    ceph_assert(!maybe_indirect_extent.is_indirect());
+    ceph_assert(!maybe_indirect_extent.is_clone);
     return get_root_iertr::make_ready_future<CollectionNodeRef>(
         std::move(maybe_indirect_extent.extent));
   });
@@ -76,7 +76,7 @@ FlatCollectionManager::create(coll_root_t &coll_root, Transaction &t,
 
 	// TODO return error probably, but such a nonsensically large number of
 	// collections would create a ton of other problems as well
-	assert(new_size < MAX_FLAT_BLOCK_SIZE);
+	ceph_assert(new_size < MAX_FLAT_BLOCK_SIZE);
         return tm.alloc_non_data_extent<CollectionNode>(
 	  t, L_ADDR_MIN, new_size
 	).si_then([=, this, &coll_root, &t] (auto &&root_extent) {
@@ -86,7 +86,7 @@ FlatCollectionManager::create(coll_root_t &coll_root, Transaction &t,
 	  return root_extent->create(
 	    get_coll_context(t), cid, info.split_bits
 	  ).si_then([=, this, &t](auto result) {
-	    assert(result == CollectionNode::create_result_t::SUCCESS);
+	    ceph_assert(result == CollectionNode::create_result_t::SUCCESS);
 	    return tm.remove(t, extent->get_laddr());
 	  }).si_then([] (auto) {
             return create_iertr::make_ready_future<>();

--- a/src/crimson/os/seastore/device.cc
+++ b/src/crimson/os/seastore/device.cc
@@ -43,7 +43,7 @@ Device::make_device(const std::string& device, device_type_t dtype)
       return ret;
     });
   } 
-  assert(get_default_backend_of_device(dtype) == backend_type_t::RANDOM_BLOCK);
+  ceph_assert(get_default_backend_of_device(dtype) == backend_type_t::RANDOM_BLOCK);
   return get_rb_device(device
   ).then([](DeviceRef ret) {
     return ret;

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -67,7 +67,7 @@ CircularBoundedJournal::submit_record(
 {
   LOG_PREFIX(CircularBoundedJournal::submit_record);
   DEBUG("H{} {} start ...", (void*)&handle, record);
-  assert(write_pipeline);
+  ceph_assert(write_pipeline);
   return do_submit_record(
     std::move(record), handle, std::move(on_submission)
   ).safe_then([this, t_src] {
@@ -150,7 +150,7 @@ Journal::replay_ret CircularBoundedJournal::replay_segment(
               r_header, locator.record_block_base);
         return crimson::ct_error::input_output_error::make();
       }
-      assert(locator.write_result.start_seq != JOURNAL_SEQ_NULL);
+      ceph_assert(locator.write_result.start_seq != JOURNAL_SEQ_NULL);
       auto cursor_addr = convert_paddr_to_abs_addr(locator.write_result.start_seq.offset);
       DEBUG("{} at {}", r_header, cursor_addr);
       journal_seq_t start_seq = locator.write_result.start_seq;

--- a/src/crimson/os/seastore/journal/circular_journal_space.cc
+++ b/src/crimson/os/seastore/journal/circular_journal_space.cc
@@ -43,7 +43,7 @@ CircularJournalSpace::roll_ertr::future<> CircularJournalSpace::roll() {
     get_device_id());
   auto seq = get_written_to();
   seq.segment_seq++;
-  assert(seq.segment_seq < MAX_SEG_SEQ);
+  ceph_assert(seq.segment_seq < MAX_SEG_SEQ);
   set_written_to(
     journal_seq_t{seq.segment_seq, paddr});
   return roll_ertr::now();
@@ -52,17 +52,17 @@ CircularJournalSpace::roll_ertr::future<> CircularJournalSpace::roll() {
 CircularJournalSpace::write_ertr::future<>
 CircularJournalSpace::write(ceph::bufferlist&& to_write) {
   LOG_PREFIX(CircularJournalSpace::write);
-  assert(get_written_to().segment_seq != NULL_SEG_SEQ);
+  ceph_assert(get_written_to().segment_seq != NULL_SEG_SEQ);
   auto encoded_size = to_write.length();
   if (encoded_size > get_records_available_size()) {
     ceph_abort("should be impossible with EPM reservation");
   }
-  assert(encoded_size + get_rbm_addr(get_written_to())
+  ceph_assert(encoded_size + get_rbm_addr(get_written_to())
 	 < get_journal_end());
 
   auto target = get_rbm_addr(get_written_to());
   auto new_written_to = target + encoded_size;
-  assert(new_written_to < get_journal_end());
+  ceph_assert(new_written_to < get_journal_end());
   paddr_t paddr = convert_abs_addr_to_paddr(
     new_written_to,
     get_device_id());
@@ -94,10 +94,10 @@ CircularJournalSpace::open_ret CircularJournalSpace::open(bool is_mkfs) {
 
   if (is_mkfs) {
     LOG_PREFIX(CircularJournalSpace::open);
-    assert(device);
+    ceph_assert(device);
     ceph::bufferlist bl;
     CircularJournalSpace::cbj_header_t head;
-    assert(device->get_journal_size());
+    ceph_assert(device->get_journal_size());
     head.dirty_tail =
       journal_seq_t{0,
 	convert_abs_addr_to_paddr(
@@ -180,7 +180,7 @@ CircularJournalSpace::read_header_ret
 CircularJournalSpace::read_header()
 {
   LOG_PREFIX(CircularJournalSpace::read_header);
-  assert(device);
+  ceph_assert(device);
   auto bptr = bufferptr(ceph::buffer::create_page_aligned(
 			device->get_block_size()));
   DEBUG("reading {}", device->get_shard_journal_start());
@@ -228,9 +228,9 @@ CircularJournalSpace::write_header()
   DEBUG(
     "sync header of CircularJournalSpace, length {}",
     bl.length());
-  assert(device);
+  ceph_assert(device);
   auto iter = bl.begin();
-  assert(bl.length() < get_block_size());
+  ceph_assert(bl.length() < get_block_size());
   bufferptr bp = bufferptr(ceph::buffer::create_page_aligned(get_block_size()));
   iter.copy(bl.length(), bp.c_str());
   return device->write(device->get_shard_journal_start(), std::move(bp)

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -149,8 +149,8 @@ class CircularJournalSpace : public JournalAllocator {
   }
   void set_written_to(journal_seq_t seq) {
     [[maybe_unused]] rbm_abs_addr addr = convert_paddr_to_abs_addr(seq.offset);
-    assert(addr >= get_records_start());
-    assert(addr < get_journal_end());
+    ceph_assert(addr >= get_records_start());
+    ceph_assert(addr < get_journal_end());
     written_to = seq;
   }
   device_id_t get_device_id() const {
@@ -186,12 +186,12 @@ class CircularJournalSpace : public JournalAllocator {
       - rbm_tail;
   }
   size_t get_records_total_size() const {
-    assert(device);
+    ceph_assert(device);
     // a block is for header and a block is reserved to denote the end
     return device->get_journal_size() - (2 * get_block_size());
   }
   rbm_abs_addr get_records_start() const {
-    assert(device);
+    ceph_assert(device);
     return device->get_shard_journal_start() + get_block_size();
   }
   size_t get_records_available_size() const {
@@ -209,14 +209,14 @@ class CircularJournalSpace : public JournalAllocator {
     return get_records_available_size() >= size;
   }
   rbm_abs_addr get_journal_end() const {
-    assert(device);
+    ceph_assert(device);
     return device->get_shard_journal_start() + device->get_journal_size();
   }
 
   read_ertr::future<> read(
     uint64_t offset,
     bufferptr &bptr) {
-    assert(device);
+    ceph_assert(device);
     return device->read(offset, bptr);
   }
 

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -98,7 +98,7 @@ public:
   }
 
   const record_group_size_t& get_submit_size() const {
-    assert(state != state_t::EMPTY);
+    ceph_assert(state != state_t::EMPTY);
     return pending.size;
   }
 
@@ -107,12 +107,12 @@ public:
   }
 
   bool needs_flush() const {
-    assert(state != state_t::SUBMITTING);
-    assert(pending.get_size() <= batch_capacity);
+    ceph_assert(state != state_t::SUBMITTING);
+    ceph_assert(pending.get_size() <= batch_capacity);
     if (state == state_t::EMPTY) {
       return false;
     } else {
-      assert(state == state_t::PENDING);
+      ceph_assert(state == state_t::PENDING);
       return (pending.get_size() >= batch_capacity ||
               pending.size.get_encoded_length() > batch_flush_size);
     }
@@ -129,7 +129,7 @@ public:
   evaluation_t evaluate_submit(
       const record_size_t& rsize,
       extent_len_t block_size) const {
-    assert(!needs_flush());
+    ceph_assert(!needs_flush());
     auto submit_size = pending.size.get_encoded_length_after(
         rsize, block_size);
     bool is_full = submit_size.get_encoded_length() > batch_flush_size;
@@ -285,8 +285,8 @@ public:
   submit_ret submit(record_t&&, bool with_atomic_roll_segment=false);
 
   void update_committed_to(const journal_seq_t& new_committed_to) {
-    assert(new_committed_to != JOURNAL_SEQ_NULL);
-    assert(committed_to == JOURNAL_SEQ_NULL ||
+    ceph_assert(new_committed_to != JOURNAL_SEQ_NULL);
+    ceph_assert(committed_to == JOURNAL_SEQ_NULL ||
            committed_to <= new_committed_to);
     committed_to = new_committed_to;
   }
@@ -311,11 +311,11 @@ private:
   void decrement_io_with_flush();
 
   void pop_free_batch() {
-    assert(p_current_batch == nullptr);
-    assert(!free_batch_ptrs.empty());
+    ceph_assert(p_current_batch == nullptr);
+    ceph_assert(!free_batch_ptrs.empty());
     p_current_batch = free_batch_ptrs.front();
-    assert(p_current_batch->is_empty());
-    assert(p_current_batch == &batches[p_current_batch->get_index()]);
+    ceph_assert(p_current_batch->is_empty());
+    ceph_assert(p_current_batch == &batches[p_current_batch->get_index()]);
     free_batch_ptrs.pop_front();
   }
 

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -115,7 +115,7 @@ SegmentAllocator::do_open(bool is_mkfs)
     bl.append(bp);
 
     ceph_assert(sref->get_write_ptr() == 0);
-    assert((unsigned)header_length == bl.length());
+    ceph_assert((unsigned)header_length == bl.length());
     written_to = header_length;
     auto new_journal_seq = journal_seq_t{
       new_segment_seq,
@@ -185,15 +185,15 @@ SegmentAllocator::write_ertr::future<>
 SegmentAllocator::write(ceph::bufferlist&& to_write)
 {
   LOG_PREFIX(SegmentAllocator::write);
-  assert(can_write());
+  ceph_assert(can_write());
   auto write_length = to_write.length();
   auto write_start_offset = written_to;
   if (unlikely(LOCAL_LOGGER.is_enabled(seastar::log_level::trace))) {
     TRACE("{} {}~0x{:x}", print_name, get_written_to(), write_length);
   }
-  assert(write_length > 0);
-  assert((write_length % get_block_size()) == 0);
-  assert(!needs_roll(write_length));
+  ceph_assert(write_length > 0);
+  ceph_assert((write_length % get_block_size()) == 0);
+  ceph_assert(!needs_roll(write_length));
 
   written_to += write_length;
   segment_provider.update_segment_avail_bytes(
@@ -232,7 +232,7 @@ SegmentAllocator::close_segment_ertr::future<>
 SegmentAllocator::close_segment()
 {
   LOG_PREFIX(SegmentAllocator::close_segment);
-  assert(can_write());
+  ceph_assert(can_write());
   // Note: make sure no one can access the current segment once closing
   auto seg_to_close = std::move(current_segment);
   auto close_segment_id = seg_to_close->get_segment_id();
@@ -262,7 +262,7 @@ SegmentAllocator::close_segment()
   bl.clear();
   bl.append(bp);
 
-  assert(bl.length() == sm_group.get_rounded_tail_length());
+  ceph_assert(bl.length() == sm_group.get_rounded_tail_length());
 
   auto p_seg_to_close = seg_to_close.get();
   return p_seg_to_close->advance_wp(

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -39,7 +39,7 @@ class SegmentAllocator : public JournalAllocator {
                    SegmentSeqAllocator &ssa);
 
   segment_id_t get_segment_id() const {
-    assert(can_write());
+    ceph_assert(can_write());
     return current_segment->get_segment_id();
   }
 
@@ -64,14 +64,14 @@ class SegmentAllocator : public JournalAllocator {
   }
 
   segment_nonce_t get_nonce() const final {
-    assert(can_write());
+    ceph_assert(can_write());
     return current_segment_nonce;
   }
 
   // returns true iff the current segment has insufficient space
   bool needs_roll(std::size_t length) const final {
-    assert(can_write());
-    assert(current_segment->get_write_capacity() ==
+    ceph_assert(can_write());
+    ceph_assert(current_segment->get_write_capacity() ==
            sm_group.get_segment_size());
     auto write_capacity = current_segment->get_write_capacity() -
                           sm_group.get_rounded_tail_length();

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -152,7 +152,7 @@ SegmentedJournal::scan_last_segment(
   const segment_header_t &segment_header)
 {
   LOG_PREFIX(SegmentedJournal::scan_last_segment);
-  assert(segment_id == segment_header.physical_segment_id);
+  ceph_assert(segment_id == segment_header.physical_segment_id);
   trimmer.update_journal_tails(
       segment_header.dirty_tail, segment_header.alloc_tail);
   auto seq = journal_seq_t{
@@ -295,7 +295,7 @@ SegmentedJournal::replay_segment(
 	      auto [is_applied, ext] = ret;
               if (is_applied) {
                 // see Cache::replay_delta()
-                assert(delta_type != extent_types_t::JOURNAL_TAIL);
+                ceph_assert(delta_type != extent_types_t::JOURNAL_TAIL);
                 if (delta_type == extent_types_t::ALLOC_INFO) {
                   ++stats.num_alloc_deltas;
                 } else {
@@ -359,7 +359,7 @@ seastar::future<> SegmentedJournal::flush(OrderingHandle &handle)
 {
   LOG_PREFIX(SegmentedJournal::flush);
   DEBUG("H{} flush ...", (void*)&handle);
-  assert(write_pipeline);
+  ceph_assert(write_pipeline);
   return handle.enter(write_pipeline->device_submission
   ).then([this, &handle] {
     return handle.enter(write_pipeline->finalize);
@@ -427,7 +427,7 @@ SegmentedJournal::submit_record(
 {
   LOG_PREFIX(SegmentedJournal::submit_record);
   DEBUG("H{} {} start ...", (void*)&handle, record);
-  assert(write_pipeline);
+  ceph_assert(write_pipeline);
   auto expected_size = record_group_size_t(
       record.size,
       journal_segment_allocator.get_block_size()

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -82,7 +82,7 @@ public:
       return alloc_contiguous_mappings(
 	t, hint, alloc_infos, alloc_policy_t::linear_search
       ).si_then([](auto cursors) {
-	assert(cursors.size() == 1);
+	ceph_assert(cursors.size() == 1);
 	return LBAMapping::create_direct(std::move(cursors.front()));
       });
     });
@@ -108,7 +108,7 @@ public:
 	  ceph_assert(cursors.front()->is_indirect());
 	  return update_refcount(t, intermediate_base, 1, false
 	  ).si_then([cursors=std::move(cursors)](auto p) mutable {
-	    assert(p.is_alive_mapping());
+	    ceph_assert(p.is_alive_mapping());
 	    auto mapping = LBAMapping::create_indirect(
 	      p.take_cursor(), std::move(cursors.front()));
 	    ceph_assert(mapping.is_stable());
@@ -128,8 +128,8 @@ public:
     extent_ref_count_t refcount) final
   {
     // The real checksum will be updated upon transaction commit
-    assert(ext.get_last_committed_crc() == 0);
-    assert(!ext.has_laddr());
+    ceph_assert(ext.get_last_committed_crc() == 0);
+    ceph_assert(!ext.has_laddr());
     std::vector<alloc_mapping_info_t> alloc_infos = {
       alloc_mapping_info_t::create_direct(
 	L_ADDR_NULL,
@@ -144,7 +144,7 @@ public:
       return alloc_contiguous_mappings(
 	t, hint, alloc_infos, alloc_policy_t::linear_search
       ).si_then([](auto cursors) {
-	assert(cursors.size() == 1);
+	ceph_assert(cursors.size() == 1);
 	return LBAMapping::create_direct(std::move(cursors.front()));
       });
     });
@@ -157,11 +157,11 @@ public:
     extent_ref_count_t refcount) final
   {
     std::vector<alloc_mapping_info_t> alloc_infos;
-    assert(!extents.empty());
+    ceph_assert(!extents.empty());
     auto has_laddr = extents.front()->has_laddr();
     for (auto &extent : extents) {
-      assert(extent);
-      assert(extent->has_laddr() == has_laddr);
+      ceph_assert(extent);
+      ceph_assert(extent->has_laddr() == has_laddr);
       alloc_infos.emplace_back(
 	alloc_mapping_info_t::create_direct(
 	  extent->has_laddr() ? extent->get_laddr() : L_ADDR_NULL,
@@ -180,12 +180,12 @@ public:
 	  t, hint, alloc_infos, alloc_policy_t::deterministic)
 #ifndef NDEBUG
 	.si_then([&alloc_infos](std::list<LBACursorRef> cursors) {
-	  assert(alloc_infos.size() == cursors.size());
+	  ceph_assert(alloc_infos.size() == cursors.size());
 	  auto info_p = alloc_infos.begin();
 	  auto cursor_p = cursors.begin();
 	  for (; info_p != alloc_infos.end(); info_p++, cursor_p++) {
 	    auto &cursor = *cursor_p;
-	    assert(cursor->get_laddr() == info_p->key);
+	    ceph_assert(cursor->get_laddr() == info_p->key);
 	  }
 	  return alloc_extent_iertr::make_ready_future<
 	    std::list<LBACursorRef>>(std::move(cursors));
@@ -352,7 +352,7 @@ private:
 
     bool is_alive_mapping() const {
       if (ret.index() == 1) {
-	assert(std::get<1>(ret));
+	ceph_assert(std::get<1>(ret));
 	return true;
       } else {
 	return false;
@@ -360,17 +360,17 @@ private:
     }
 
     const removed_mapping_t& get_removed_mapping() const {
-      assert(is_removed_mapping());
+      ceph_assert(is_removed_mapping());
       return std::get<0>(ret);
     }
 
     const LBACursor& get_cursor() const {
-      assert(is_alive_mapping());
+      ceph_assert(is_alive_mapping());
       return *std::get<1>(ret);
     }
 
     LBACursorRef take_cursor() {
-      assert(is_alive_mapping());
+      ceph_assert(is_alive_mapping());
       return std::move(std::get<1>(ret));
     }
 
@@ -381,9 +381,9 @@ private:
 	ceph_assert(val.pladdr.is_paddr());
 	return {v.laddr, val.refcount, val.pladdr, val.len};
       } else {
-	assert(is_alive_mapping());
+	ceph_assert(is_alive_mapping());
 	auto &c = get_cursor();
-	assert(c.val);
+	ceph_assert(c.val);
 	ceph_assert(!c.is_indirect());
 	return {c.get_laddr(), c.val->refcount, c.val->pladdr, c.val->len};
       }

--- a/src/crimson/os/seastore/lba/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba/lba_btree_node.h
@@ -154,7 +154,7 @@ struct LBALeafNode
       this->pending_for_transaction,
       iter.get_offset(),
       iter.get_key());
-    assert(iter != this->end());
+    ceph_assert(iter != this->end());
     this->on_modify();
     this->remove_child_ptr(iter.get_offset());
     return this->journal_remove(
@@ -173,7 +173,7 @@ struct LBALeafNode
 	auto val = i->get_val();
 	if (val.pladdr.is_paddr()
 	    && val.pladdr.get_paddr().is_relative()) {
-	  assert(val.pladdr.get_paddr().is_block_relative());
+	  ceph_assert(val.pladdr.get_paddr().is_block_relative());
 	  val.pladdr = this->get_paddr().add_relative(val.pladdr.get_paddr());
 	  i->set_val(val);
 	}
@@ -189,7 +189,7 @@ struct LBALeafNode
 	auto val = i->get_val();
 	if (val.pladdr.is_paddr()
 	    && val.pladdr.get_paddr().is_relative()) {
-	  assert(val.pladdr.get_paddr().is_record_relative());
+	  ceph_assert(val.pladdr.get_paddr().is_record_relative());
 	  val.pladdr = val.pladdr.get_paddr().block_relative_to(this->get_paddr());
 	  i->set_val(val);
 	}

--- a/src/crimson/os/seastore/lba_mapping.cc
+++ b/src/crimson/os/seastore/lba_mapping.cc
@@ -36,13 +36,13 @@ using lba::LBALeafNode;
 get_child_ret_t<LBALeafNode, LogicalChildNode>
 LBAMapping::get_logical_extent(Transaction &t)
 {
-  assert(is_linked_direct());
+  ceph_assert(is_linked_direct());
   ceph_assert(direct_cursor->is_viewable());
   ceph_assert(direct_cursor->ctx.trans.get_trans_id()
 	      == t.get_trans_id());
-  assert(!direct_cursor->is_end());
+  ceph_assert(!direct_cursor->is_end());
   auto &i = *direct_cursor;
-  assert(i.pos != BTREENODE_POS_NULL);
+  ceph_assert(i.pos != BTREENODE_POS_NULL);
   ceph_assert(t.get_trans_id() == i.ctx.trans.get_trans_id());
   auto p = direct_cursor->parent->cast<LBALeafNode>();
   return p->template get_child<LogicalChildNode>(
@@ -50,9 +50,9 @@ LBAMapping::get_logical_extent(Transaction &t)
 }
 
 bool LBAMapping::is_stable() const {
-  assert(is_linked_direct());
+  ceph_assert(is_linked_direct());
   ceph_assert(direct_cursor->is_viewable());
-  assert(!direct_cursor->is_end());
+  ceph_assert(!direct_cursor->is_end());
   auto leaf = direct_cursor->parent->cast<LBALeafNode>();
   return leaf->is_child_stable(
     direct_cursor->ctx,
@@ -61,9 +61,9 @@ bool LBAMapping::is_stable() const {
 }
 
 bool LBAMapping::is_data_stable() const {
-  assert(is_linked_direct());
+  ceph_assert(is_linked_direct());
   ceph_assert(direct_cursor->is_viewable());
-  assert(!direct_cursor->is_end());
+  ceph_assert(!direct_cursor->is_end());
   auto leaf = direct_cursor->parent->cast<LBALeafNode>();
   return leaf->is_child_data_stable(
     direct_cursor->ctx,

--- a/src/crimson/os/seastore/lba_mapping.h
+++ b/src/crimson/os/seastore/lba_mapping.h
@@ -19,9 +19,9 @@ class LBAMapping {
     : direct_cursor(std::move(direct)),
       indirect_cursor(std::move(indirect))
   {
-    assert(is_linked_direct());
-    assert(!direct_cursor->is_indirect());
-    assert(!indirect_cursor || indirect_cursor->is_indirect());
+    ceph_assert(is_linked_direct());
+    ceph_assert(!direct_cursor->is_indirect());
+    ceph_assert(!indirect_cursor || indirect_cursor->is_indirect());
   }
 
 public:
@@ -45,12 +45,12 @@ public:
   }
 
   bool is_indirect() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return (bool)indirect_cursor;
   }
 
   bool is_viewable() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return direct_cursor->is_viewable()
 	&& (!indirect_cursor || indirect_cursor->is_viewable());
   }
@@ -60,16 +60,16 @@ public:
   bool is_stable() const;
   bool is_data_stable() const;
   bool is_clone() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return direct_cursor->get_refcount() > 1;
   }
   bool is_zero_reserved() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return get_val().is_zero();
   }
 
   extent_len_t get_length() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     if (is_indirect()) {
       return indirect_cursor->get_length();
     }
@@ -77,17 +77,17 @@ public:
   }
 
   paddr_t get_val() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return direct_cursor->get_paddr();
   }
 
   checksum_t get_checksum() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return direct_cursor->get_checksum();
   }
 
   laddr_t get_key() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     if (is_indirect()) {
       return indirect_cursor->get_laddr();
     }
@@ -96,22 +96,22 @@ public:
 
    // An lba pin may be indirect, see comments in lba/btree_lba_manager.h
   laddr_t get_intermediate_key() const {
-    assert(is_indirect());
+    ceph_assert(is_indirect());
     return indirect_cursor->get_intermediate_key();
   }
   laddr_t get_intermediate_base() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return direct_cursor->get_laddr();
   }
   extent_len_t get_intermediate_length() const {
-    assert(is_linked_direct());
+    ceph_assert(is_linked_direct());
     return direct_cursor->get_length();
   }
   // The start offset of the indirect cursor related to direct cursor
   extent_len_t get_intermediate_offset() const {
-    assert(is_indirect());
-    assert(get_intermediate_base() <= get_intermediate_key());
-    assert(get_intermediate_key() + get_length() <=
+    ceph_assert(is_indirect());
+    ceph_assert(get_intermediate_base() <= get_intermediate_key());
+    ceph_assert(get_intermediate_key() + get_length() <=
 	   get_intermediate_base() + get_intermediate_length());
     return get_intermediate_base().get_byte_distance<
       extent_len_t>(get_intermediate_key());

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -64,7 +64,7 @@ struct node_cmp_t {
   using is_transparent = key_t;
   bool operator()(const TCachedExtentRef<T> &l,
 		  const TCachedExtentRef<T> &r) const {
-    assert(l->get_end() <= r->get_begin()
+    ceph_assert(l->get_end() <= r->get_begin()
       || r->get_end() <= l->get_begin()
       || (l->get_begin() == r->get_begin()
 	  && l->get_end() == r->get_end()));
@@ -106,7 +106,7 @@ protected:
 
   void set_root_parent_from_prior_instance() {
     auto &me = down_cast();
-    assert(me.is_mutation_pending());
+    ceph_assert(me.is_mutation_pending());
     auto pi = me.get_prior_instance();
     auto &prior = *pi->template cast<T>();
     ceph_assert(prior.parent_of_root);
@@ -121,7 +121,7 @@ protected:
   }
 
   void destroy() {
-    assert(down_cast().is_btree_root());
+    ceph_assert(down_cast().is_btree_root());
     ceph_assert(parent_of_root);
     TreeRootLinker<ParentT, T>::unlink_root(parent_of_root);
   }
@@ -131,7 +131,7 @@ protected:
 
   void on_initial_write() {
     auto &me = down_cast();
-    assert(me.is_btree_root());
+    ceph_assert(me.is_btree_root());
     me.reset_parent_tracker();
   }
 private:
@@ -197,7 +197,7 @@ public:
     return parent_tracker && parent_tracker->is_valid();
   }
   TCachedExtentRef<ParentT> get_parent_node() const {
-    assert(parent_tracker);
+    ceph_assert(parent_tracker);
     return parent_tracker->get_parent();
   }
   virtual key_t node_begin() const = 0;
@@ -301,11 +301,11 @@ class ParentNode {
 public:
   TCachedExtentRef<T> find_pending_version(Transaction &t, node_key_t key) {
     auto &me = down_cast();
-    assert(me.is_stable());
+    ceph_assert(me.is_stable());
     auto mut_iter = me.mutation_pending_extents.find(
       t.get_trans_id(), trans_spec_view_t::cmp_t());
     if (mut_iter != me.mutation_pending_extents.end()) {
-      assert(copy_dests_by_trans.find(t.get_trans_id()) ==
+      ceph_assert(copy_dests_by_trans.find(t.get_trans_id()) ==
 	copy_dests_by_trans.end());
       return static_cast<T*>(&(*mut_iter));
     }
@@ -330,8 +330,8 @@ public:
     node_key_t key)
   {
     auto &me = down_cast();
-    assert(children.capacity());
-    assert(key == down_cast().iter_idx(pos).get_key());
+    ceph_assert(children.capacity());
+    ceph_assert(key == down_cast().iter_idx(pos).get_key());
     auto child = children[pos];
     ceph_assert(!is_reserved_ptr(child));
     if (is_valid_child_ptr(child)) {
@@ -354,12 +354,12 @@ public:
 
   void link_child(BaseChildNode<T, node_key_t>* child, btreenode_pos_t pos) {
     auto &me = down_cast();
-    assert(pos < me.get_size());
-    assert(pos < children.capacity());
-    assert(child);
+    ceph_assert(pos < me.get_size());
+    ceph_assert(pos < children.capacity());
+    ceph_assert(child);
     ceph_assert(!me.is_pending());
-    assert(child->valid() && !child->pending());
-    assert(!children[pos]);
+    ceph_assert(child->valid() && !child->pending());
+    ceph_assert(!children[pos]);
     ceph_assert(is_valid_child_ptr(child));
     update_child_ptr(pos, child);
   }
@@ -369,13 +369,13 @@ public:
     BaseChildNode<T, node_key_t>* child,
     btreenode_pos_t size = 0)
   {
-    assert(child);
+    ceph_assert(child);
     auto &me = down_cast();
     if (size == 0) {
       size = me.get_size();
     }
     maybe_expand_children(size + 1);
-    assert(size < children.capacity());
+    ceph_assert(size < children.capacity());
     auto raw_children = children.data();
     std::memmove(
       &raw_children[offset + 1],
@@ -415,7 +415,7 @@ protected:
     auto &copy_dests = static_cast<copy_dests_t&>(*iter);
     [[maybe_unused]] auto [it, inserted] =
       copy_dests.dests_by_key.insert(dest);
-    assert(inserted || it->get() == dest.get());
+    ceph_assert(inserted || it->get() == dest.get());
   }
 
   void del_copy_dest(Transaction &t, TCachedExtentRef<T> dest) {
@@ -555,8 +555,8 @@ protected:
     T &right)
   {
     auto &me = down_cast();
-    assert(!left.my_tracker);
-    assert(!right.my_tracker);
+    ceph_assert(!left.my_tracker);
+    ceph_assert(!right.my_tracker);
     btreenode_pos_t pivot = me.get_node_split_pivot();
     left.maybe_expand_children(pivot);
     right.maybe_expand_children(me.get_size() - pivot);
@@ -639,8 +639,8 @@ protected:
     replacement_left.maybe_expand_children(pivot_idx);
     replacement_right.maybe_expand_children(r_size + l_size - pivot_idx);
 
-    assert(!replacement_left.my_tracker);
-    assert(!replacement_right.my_tracker);
+    ceph_assert(!replacement_left.my_tracker);
+    ceph_assert(!replacement_right.my_tracker);
     if (pivot_idx < l_size) {
       // deal with left
       if (left.is_pending()) {
@@ -720,9 +720,9 @@ protected:
 
   void set_children_from_prior_instance() {
     auto &me = down_cast();
-    assert(me.get_prior_instance());
+    ceph_assert(me.get_prior_instance());
     auto &prior = *me.get_prior_instance()->template cast<T>();
-    assert(prior.my_tracker || prior.is_children_empty());
+    ceph_assert(prior.my_tracker || prior.is_children_empty());
 
     if (prior.my_tracker) {
       prior.my_tracker->reset_parent(&me);
@@ -732,7 +732,7 @@ protected:
       // to adjust them to point to the new tracker
       adjust_ptracker_for_children();
     }
-    assert(my_tracker || is_children_empty());
+    ceph_assert(my_tracker || is_children_empty());
   }
 
   template<typename iter_t>
@@ -803,9 +803,9 @@ protected:
   // for mutation pending and rewritten extents
   void take_children_from_prior_instance() {
     auto &me = down_cast();
-    assert(me.is_mutation_pending() ? true : copy_sources.size() == 1);
+    ceph_assert(me.is_mutation_pending() ? true : copy_sources.size() == 1);
     auto prior = me.get_prior_instance()->template cast<T>();
-    assert(
+    ceph_assert(
       me.is_mutation_pending()
 	? true
 	: copy_sources.begin()->get() == prior.get());
@@ -829,7 +829,7 @@ protected:
       } else {
 	take_children_from_stable_sources();
       }
-      assert(me.validate_stable_children());
+      ceph_assert(me.validate_stable_children());
       me.copy_sources.clear();
     }
   }
@@ -861,7 +861,7 @@ protected:
     auto &me = down_cast();
     ceph_assert(!me.is_rewrite());
     take_children_from_prior_instance();
-    assert(me.validate_stable_children());
+    ceph_assert(me.validate_stable_children());
   }
 
   // children are considered stable if any of the following case is true:
@@ -876,13 +876,13 @@ protected:
     node_key_t key,
     bool data_only = false) const {
     auto &me = down_cast();
-    assert(key == me.iter_idx(pos).get_key());
+    ceph_assert(key == me.iter_idx(pos).get_key());
     auto child = this->children[pos];
     if (is_reserved_ptr(child)) {
       return true;
     } else if (is_valid_child_ptr(child)) {
-      assert(dynamic_cast<CachedExtent*>(child)->is_logical());
-      assert(
+      ceph_assert(dynamic_cast<CachedExtent*>(child)->is_logical());
+      ceph_assert(
 	dynamic_cast<CachedExtent*>(child)->is_pending_in_trans(t.get_trans_id())
 	|| me.is_stable_written());
       if (data_only) {
@@ -898,7 +898,7 @@ protected:
       auto spos = sparent.lower_bound(key).get_offset();
       auto child = sparent.children[spos];
       if (is_valid_child_ptr(child)) {
-	assert(dynamic_cast<CachedExtent*>(child)->is_logical());
+	ceph_assert(dynamic_cast<CachedExtent*>(child)->is_logical());
 	if (data_only) {
 	  return etvr.is_viewable_extent_data_stable(
 	    t, dynamic_cast<CachedExtent*>(child));
@@ -929,7 +929,7 @@ private:
       }
     } else {
       // children.capacity() is static and assigned upon construction
-      assert(size <= children.capacity());
+      ceph_assert(size <= children.capacity());
     }
   }
   void maybe_shink_children() {
@@ -996,11 +996,11 @@ protected:
   // because they will be destroyed altogether with their parents
   // upon transaction invalidation.
   void destroy() {
-    assert(!down_cast().is_btree_root());
-    assert(this->has_parent_tracker());
+    ceph_assert(!down_cast().is_btree_root());
+    ceph_assert(this->has_parent_tracker());
     auto off = get_parent_pos();
     auto parent = this->get_parent_node();
-    assert(parent->children[off] == &down_cast());
+    ceph_assert(parent->children[off] == &down_cast());
     parent->children[off] = nullptr;
   }
 private:
@@ -1013,13 +1013,13 @@ private:
 
   void _take_parent_from_prior() {
     auto &me = down_cast();
-    assert(!me.is_btree_root());
+    ceph_assert(!me.is_btree_root());
     auto &prior = static_cast<T&>(*me.get_prior_instance());
     this->parent_tracker = prior.BaseChildNode<ParentT, key_t>::parent_tracker;
-    assert(this->has_parent_tracker());
+    ceph_assert(this->has_parent_tracker());
     auto off = get_parent_pos();
     auto parent = this->get_parent_node();
-    assert(me.get_prior_instance().get() ==
+    ceph_assert(me.get_prior_instance().get() ==
 	   dynamic_cast<CachedExtent*>(parent->children[off]));
     parent->children[off] = &me;
   }
@@ -1027,15 +1027,15 @@ private:
   btreenode_pos_t get_parent_pos() const {
     auto &me = down_cast();
     auto parent = this->get_parent_node();
-    assert(parent);
+    ceph_assert(parent);
     //TODO: can this search be avoided?
     auto key = me.get_begin();
     auto iter = parent->lower_bound(key);
     if (iter.get_key() > key) {
-      assert(iter != parent->end());
+      ceph_assert(iter != parent->end());
       iter--;
     }
-    assert(iter.get_key() == me.get_begin());
+    ceph_assert(iter.get_key() == me.get_begin());
     return iter.get_offset();
   }
   bool valid() const final {

--- a/src/crimson/os/seastore/logical_child_node.h
+++ b/src/crimson/os/seastore/logical_child_node.h
@@ -40,7 +40,7 @@ public:
   }
 protected:
   void on_replace_prior() final {
-    assert(is_seen_by_users());
+    ceph_assert(is_seen_by_users());
     lba_child_node_t::on_replace_prior();
     do_on_replace_prior();
   }

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -44,7 +44,7 @@ public:
     changes.push_back(b);
   }
   void apply_changes_to(bufferptr &b) const {
-    assert(!changes.empty());
+    ceph_assert(!changes.empty());
     for (auto p : changes) {
       auto iter = p.bl.cbegin();
       iter.copy(p.bl.length(), b.c_str() + p.offset);
@@ -60,13 +60,13 @@ public:
     return *ptr;
   }
   bufferptr &&move_cached_bptr() {
-    assert(has_cached_bptr());
+    ceph_assert(has_cached_bptr());
     apply_changes_to(*ptr);
     return std::move(*ptr);
   }
 private:
   void apply_changes_to_cache(const bufferptr &_ptr) const {
-    assert(!is_empty());
+    ceph_assert(!is_empty());
     if (!has_cached_bptr()) {
       ptr = ceph::buffer::copy(_ptr.c_str(), _ptr.length());
     }
@@ -137,7 +137,7 @@ struct ObjectDataBlock : crimson::os::seastore::LogicalChildNode {
         cached_overwrites.apply_changes_to(CachedExtent::get_bptr());
       }
     } else {
-      assert(cached_overwrites.is_empty());
+      ceph_assert(cached_overwrites.is_empty());
     }
   }
 

--- a/src/crimson/os/seastore/omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager.h
@@ -156,7 +156,7 @@ public:
     }
 
     auto with_reduced_max(size_t reduced_by) const {
-      assert(reduced_by <= max_result_size);
+      ceph_assert(reduced_by <= max_result_size);
       return omap_list_config_t(
 	max_result_size - reduced_by,
 	first_inclusive,

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
@@ -43,7 +43,7 @@ BtreeOMapManager::initialize_omap(Transaction &t, laddr_t hint,
 BtreeOMapManager::get_root_ret
 BtreeOMapManager::get_omap_root(omap_context_t oc, const omap_root_t &omap_root)
 {
-  assert(omap_root.get_location() != L_ADDR_NULL);
+  ceph_assert(omap_root.get_location() != L_ADDR_NULL);
   laddr_t laddr = omap_root.get_location();
   if (omap_root.get_depth() > 1) {
     return omap_load_extent<OMapInnerNode>(
@@ -233,7 +233,7 @@ BtreeOMapManager::omap_rm_key_range(
 {
   LOG_PREFIX(BtreeOMapManager::omap_rm_key_range);
   DEBUGT("{} ~ {}", t, first, last);
-  assert(first <= last);
+  ceph_assert(first <= last);
   return seastar::do_with(
     std::make_optional<std::string>(first),
     std::make_optional<std::string>(last),
@@ -276,7 +276,7 @@ BtreeOMapManager::omap_list(
   LOG_PREFIX(BtreeOMapManager::omap_list);
   if (first && last) {
     DEBUGT("{}, first: {}, last: {}", t, omap_root, *first, *last);
-    assert(last >= first);
+    ceph_assert(last >= first);
   } else if (first) {
     DEBUGT("{}, first: {}", t, omap_root, *first);
   } else if (last) {

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
@@ -122,8 +122,8 @@ struct OMapNode : LogicalChildNode {
     const ceph::bufferlist &value) const = 0;
 
   void init_range(std::string _begin, std::string _end) {
-    assert(begin.empty());
-    assert(end.empty());
+    ceph_assert(begin.empty());
+    ceph_assert(end.empty());
     if (_begin == BEGIN_KEY && _end == END_KEY) {
       root = true;
     }

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -233,7 +233,7 @@ OMapInnerNode::list(
   LOG_PREFIX(OMapInnerNode::list);
   if (first && last) {
     DEBUGT("first: {}, last: {}, this: {}", oc.t, *first, *last, *this);
-    assert(*first <= *last);
+    ceph_assert(*first <= *last);
   } else if (first) {
     DEBUGT("first: {}, this: {}", oc.t, *first, *this);
   } else if (last) {
@@ -248,7 +248,7 @@ OMapInnerNode::list(
   auto last_iter = last ?
     get_containing_child(*last) + 1:
     iter_cend();
-  assert(first_iter != iter_cend());
+  ceph_assert(first_iter != iter_cend());
 
   return seastar::do_with(
     first_iter,
@@ -271,7 +271,7 @@ OMapInnerNode::list(
           return list_iertr::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);
         }
-	assert(result.size() < config.max_result_size);
+	ceph_assert(result.size() < config.max_result_size);
         return get_child_node(oc, iter
         ).si_then([&, config, oc](auto &&extent) {
 	  ceph_assert(!extent->is_btree_root());
@@ -290,21 +290,21 @@ OMapInnerNode::list(
 	    boost::ignore_unused(config);   // avoid clang warning;
             auto &[child_complete, child_result] = child_ret;
             if (result.size() && child_result.size()) {
-              assert(child_result.begin()->first > result.rbegin()->first);
+              ceph_assert(child_result.begin()->first > result.rbegin()->first);
             }
             if (child_result.size() && first && iter == fiter) {
 	      if (config.first_inclusive) {
-		assert(child_result.begin()->first >= *first);
+		ceph_assert(child_result.begin()->first >= *first);
 	      } else {
-		assert(child_result.begin()->first > *first);
+		ceph_assert(child_result.begin()->first > *first);
 	      }
             }
             if (child_result.size() && last && iter == liter - 1) {
 	      [[maybe_unused]] auto biter = --(child_result.end());
 	      if (config.last_inclusive) {
-		assert(biter->first <= *last);
+		ceph_assert(biter->first <= *last);
 	      } else {
-		assert(biter->first < *last);
+		ceph_assert(biter->first < *last);
 	      }
             }
             result.merge(std::move(child_result));
@@ -313,7 +313,7 @@ OMapInnerNode::list(
 		seastar::stop_iteration::yes);
 	    }
             ++iter;
-            assert(child_complete);
+            ceph_assert(child_complete);
             return list_iertr::make_ready_future<seastar::stop_iteration>(
               seastar::stop_iteration::no);
           });
@@ -344,7 +344,7 @@ OMapInnerNode::clear(omap_context_t oc)
 	return clear_iertr::now();
       });
     } else {
-      assert(ndepth == 1);
+      ceph_assert(ndepth == 1);
       return dec_ref(oc, laddr
       ).si_then([ref = OMapNodeRef(this)] {
 	return clear_iertr::now();
@@ -452,7 +452,7 @@ OMapInnerNode::merge_entry(
     if (l->can_merge(r)) {
       DEBUGT("make_full_merge l {} r {} liter {} riter {}",
 	oc.t, *l, *r, liter->get_key(), riter->get_key());
-      assert(entry->extent_is_below_min());
+      ceph_assert(entry->extent_is_below_min());
       return l->make_full_merge(oc, r
       ).si_then([liter=liter, riter=riter, l=l, r=r, oc, this]
 		(auto &&replacement) {
@@ -471,7 +471,7 @@ OMapInnerNode::merge_entry(
         std::vector<laddr_t> dec_laddrs {l->get_laddr(), r->get_laddr()};
 	auto next = liter + 1;
 	auto end = next == iter_cend() ? get_end() : next.get_key();
-	assert(end == r->get_end());
+	ceph_assert(end == r->get_end());
 	replacement->init_range(liter.get_key(), std::move(end));
 	if (get_meta().depth > 2) { // replacement is an inner node
 	  auto &rep = *replacement->template cast<OMapInnerNode>();
@@ -582,7 +582,7 @@ OMapInnerNode::get_containing_child(const std::string &key)
 {
   auto iter = string_upper_bound(key);
   iter--;
-  assert(iter.contains(key));
+  ceph_assert(iter.contains(key));
   return iter;
 }
 
@@ -833,7 +833,7 @@ OMapInnerNode::get_child_node(
   omap_context_t oc,
   internal_const_iterator_t child_pt)
 {
-  assert(get_meta().depth > 1);
+  ceph_assert(get_meta().depth > 1);
   child_pos_t<OMapInnerNode> child_pos(nullptr, 0);
   auto laddr = child_pt->get_val();
   auto next = child_pt + 1;

--- a/src/crimson/os/seastore/omap_manager/btree/omap_types.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_types.h
@@ -17,13 +17,13 @@ struct omap_node_meta_t {
 
   static omap_node_meta_t merge_from(
     const omap_node_meta_t &lhs, const omap_node_meta_t &rhs) {
-    assert(lhs.depth == rhs.depth);
+    ceph_assert(lhs.depth == rhs.depth);
     return omap_node_meta_t{lhs.depth};
   }
 
   static std::pair<omap_node_meta_t, omap_node_meta_t>
   rebalance(const omap_node_meta_t &lhs, const omap_node_meta_t &rhs) {
-    assert(lhs.depth == rhs.depth);
+    ceph_assert(lhs.depth == rhs.depth);
     return std::make_pair(
       omap_node_meta_t{lhs.depth},
       omap_node_meta_t{lhs.depth});

--- a/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
+++ b/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
@@ -33,13 +33,13 @@ static void copy_from_foreign(
   iterator tgt,
   const_iterator from_src,
   const_iterator to_src) {
-  assert(tgt->node != from_src->node);
-  assert(to_src->node == from_src->node);
+  ceph_assert(tgt->node != from_src->node);
+  ceph_assert(to_src->node == from_src->node);
   if (from_src == to_src)
     return;
 
   auto to_copy = from_src->get_right_ptr_end() - to_src->get_right_ptr_end();
-  assert(to_copy > 0);
+  ceph_assert(to_copy > 0);
   memcpy(
     tgt->get_right_ptr_end() - to_copy,
     to_src->get_right_ptr_end(),
@@ -67,11 +67,11 @@ static void copy_from_local(
   iterator tgt,
   iterator from_src,
   iterator to_src) {
-  assert(tgt->node == from_src->node);
-  assert(to_src->node == from_src->node);
+  ceph_assert(tgt->node == from_src->node);
+  ceph_assert(to_src->node == from_src->node);
 
   auto to_copy = from_src->get_right_ptr_end() - to_src->get_right_ptr_end();
-  assert(to_copy > 0);
+  ceph_assert(to_copy > 0);
   int adjust_offset = tgt > from_src? -len : len;
   memmove(to_src->get_right_ptr_end() + adjust_offset,
           to_src->get_right_ptr_end(),
@@ -344,19 +344,19 @@ public:
 
     iter_t operator--(int) {
       auto ret = *this;
-      assert(index > 0);
+      ceph_assert(index > 0);
       --index;
       return ret;
     }
 
     iter_t &operator--() {
-      assert(index > 0);
+      ceph_assert(index > 0);
       --index;
       return *this;
     }
 
     uint16_t operator-(const iter_t &rhs) const {
-      assert(rhs.node == node);
+      ceph_assert(rhs.node == node);
       return index - rhs.index;
     }
 
@@ -368,17 +368,17 @@ public:
     }
 
     uint16_t operator<(const iter_t &rhs) const {
-      assert(rhs.node == node);
+      ceph_assert(rhs.node == node);
       return index < rhs.index;
     }
 
     uint16_t operator>(const iter_t &rhs) const {
-      assert(rhs.node == node);
+      ceph_assert(rhs.node == node);
       return index > rhs.index;
     }
 
     friend bool operator==(const iter_t &lhs, const iter_t &rhs) {
-      assert(lhs.node == rhs.node);
+      ceph_assert(lhs.node == rhs.node);
       return lhs.index == rhs.index;
     }
 
@@ -418,7 +418,7 @@ public:
     void update_offset(int offset) {
       static_assert(!is_const);
       auto key = get_node_key();
-      assert(offset + key.key_off >= 0);
+      ceph_assert(offset + key.key_off >= 0);
       key.key_off += offset;
       set_node_key(key);
     }
@@ -432,10 +432,10 @@ public:
 
     void set_node_val(const std::string &str) {
       static_assert(!is_const);
-      assert(str.size() == get_node_key().key_len);
-      assert(get_node_key().key_off >= str.size());
-      assert(get_node_key().key_off < OMAP_INNER_BLOCK_SIZE);
-      assert(str.size() < OMAP_INNER_BLOCK_SIZE);
+      ceph_assert(str.size() == get_node_key().key_len);
+      ceph_assert(get_node_key().key_off >= str.size());
+      ceph_assert(get_node_key().key_off < OMAP_INNER_BLOCK_SIZE);
+      ceph_assert(str.size() < OMAP_INNER_BLOCK_SIZE);
       ::memcpy(get_node_val_ptr(), str.data(), str.size());
     }
 
@@ -455,7 +455,7 @@ public:
     }
 
     bool contains(std::string_view key) const {
-      assert(*this != node->iter_end());
+      ceph_assert(*this != node->iter_end());
       auto next = *this + 1;
       if (next == node->iter_end()) {
         return get_key() <= key;
@@ -507,8 +507,8 @@ public:
   StringKVInnerNodeLayout(char *buf) : buf(buf) {}
 
   void set_layout_buf(char *_buf) {
-    assert(buf == nullptr);
-    assert(_buf != nullptr);
+    ceph_assert(buf == nullptr);
+    ceph_assert(_buf != nullptr);
     buf = _buf;
   }
 
@@ -699,7 +699,7 @@ public:
     StringKVInnerNodeLayout &left,
     StringKVInnerNodeLayout &right) const {
     auto piviter = get_split_pivot();
-    assert(piviter != iter_end());
+    ceph_assert(piviter != iter_end());
 
     copy_from_foreign(left.iter_begin(), iter_begin(), piviter);
     left.set_size(piviter - iter_begin());
@@ -851,12 +851,12 @@ private:
     const std::string &key,
     laddr_t val) {
     if (iter != iter_begin()) {
-      assert((iter - 1)->get_key() < key);
+      ceph_assert((iter - 1)->get_key() < key);
     }
     if (iter != iter_end()) {
-      assert(iter->get_key() > key);
+      ceph_assert(iter->get_key() > key);
     }
-    assert(!is_overflow(key.size()));
+    ceph_assert(!is_overflow(key.size()));
 
     if (iter != iter_end()) {
       copy_from_local(key.size(), iter + 1, iter, iter_end());
@@ -880,14 +880,14 @@ private:
   void inner_update(
     iterator iter,
     laddr_t addr) {
-    assert(iter != iter_end());
+    ceph_assert(iter != iter_end());
     auto node_key = iter->get_node_key();
     node_key.laddr = addr;
     iter->set_node_key(node_key);
   }
 
   void inner_remove(iterator iter) {
-    assert(iter != iter_end());
+    ceph_assert(iter != iter_end());
     if ((iter + 1) != iter_end())
       copy_from_local(iter->get_node_key().key_len, iter, iter + 1, iter_end());
     set_size(get_size() - 1);
@@ -980,7 +980,7 @@ public:
     }
 
     uint16_t operator-(const iter_t &rhs) const {
-      assert(rhs.node == node);
+      ceph_assert(rhs.node == node);
       return index - rhs.index;
     }
 
@@ -996,22 +996,22 @@ public:
     }
 
     uint16_t operator<(const iter_t &rhs) const {
-      assert(rhs.node == node);
+      ceph_assert(rhs.node == node);
       return index < rhs.index;
     }
 
     uint16_t operator>(const iter_t &rhs) const {
-      assert(rhs.node == node);
+      ceph_assert(rhs.node == node);
       return index > rhs.index;
     }
 
     bool operator==(const iter_t &rhs) const {
-      assert(node == rhs.node);
+      ceph_assert(node == rhs.node);
       return rhs.index == index;
     }
 
     bool operator!=(const iter_t &rhs) const {
-      assert(node == rhs.node);
+      ceph_assert(node == rhs.node);
       return index != rhs.index;
     }
 
@@ -1050,7 +1050,7 @@ public:
 
     void update_offset(int offset) {
       auto key = get_node_key();
-      assert(offset + key.key_off >= 0);
+      ceph_assert(offset + key.key_off >= 0);
       key.key_off += offset;
       set_node_key(key);
     }
@@ -1065,8 +1065,8 @@ public:
     void set_node_val(const std::string &key, const ceph::bufferlist &val) {
       static_assert(!is_const);
       auto node_key = get_node_key();
-      assert(key.size() == node_key.key_len);
-      assert(val.length() == node_key.val_len);
+      ceph_assert(key.size() == node_key.key_len);
+      ceph_assert(val.length() == node_key.val_len);
       ::memcpy(get_node_val_ptr(), key.data(), key.size());
       auto bliter = val.begin();
       bliter.copy(node_key.val_len, get_node_val_ptr() + node_key.key_len);
@@ -1144,9 +1144,9 @@ public:
   StringKVLeafNodeLayout() : buf(nullptr) {}
 
   void set_layout_buf(char *_buf, extent_len_t _len) {
-    assert(_len > 0);
-    assert(buf == nullptr);
-    assert(_buf != nullptr);
+    ceph_assert(_len > 0);
+    ceph_assert(buf == nullptr);
+    ceph_assert(_buf != nullptr);
     buf = _buf;
     len = _len;
   }
@@ -1298,7 +1298,7 @@ public:
   }
 
   auto get_len() const {
-    assert(len > 0);
+    ceph_assert(len > 0);
     return len;
   }
 
@@ -1476,12 +1476,12 @@ private:
     const std::string &key,
     const bufferlist &val) {
     if (iter != iter_begin()) {
-      assert((iter - 1)->get_key() < key);
+      ceph_assert((iter - 1)->get_key() < key);
     }
     if (iter != iter_end()) {
-      assert(iter->get_key() > key);
+      ceph_assert(iter->get_key() > key);
     }
-    assert(!is_overflow(key.size(), val.length()));
+    ceph_assert(!is_overflow(key.size(), val.length()));
     omap_leaf_key_t node_key;
     if (iter == iter_begin()) {
       node_key.key_off = key.size() + val.length();
@@ -1505,14 +1505,14 @@ private:
     iterator iter,
     const std::string &key,
     const ceph::bufferlist &val) {
-    assert(iter != iter_end());
+    ceph_assert(iter != iter_end());
     leaf_remove(iter);
-    assert(!is_overflow(key.size(), val.length()));
+    ceph_assert(!is_overflow(key.size(), val.length()));
     leaf_insert(iter, key, val);
   }
 
   void leaf_remove(iterator iter) {
-    assert(iter != iter_end());
+    ceph_assert(iter != iter_end());
     if ((iter + 1) != iter_end()) {
       omap_leaf_key_t key = iter->get_node_key();
       copy_from_local(key.key_len + key.val_len, iter, iter + 1, iter_end());
@@ -1542,18 +1542,18 @@ inline void delta_inner_t::replay(StringKVInnerNodeLayout &l) {
     }
     case op_t::UPDATE: {
       auto iter = l.find_string_key(key);
-      assert(iter != l.iter_end());
+      ceph_assert(iter != l.iter_end());
       l.inner_update(iter, addr);
       break;
     }
     case op_t::REMOVE: {
       auto iter = l.find_string_key(key);
-      assert(iter != l.iter_end());
+      ceph_assert(iter != l.iter_end());
       l.inner_remove(iter);
       break;
     }
     default:
-      assert(0 == "Impossible");
+      ceph_assert(0 == "Impossible");
   }
 }
 
@@ -1565,18 +1565,18 @@ inline void delta_leaf_t::replay(StringKVLeafNodeLayout &l) {
     }
     case op_t::UPDATE: {
       auto iter = l.find_string_key(key);
-      assert(iter != l.iter_end());
+      ceph_assert(iter != l.iter_end());
       l.leaf_update(iter, key, val);
       break;
     }
     case op_t::REMOVE: {
       auto iter = l.find_string_key(key);
-      assert(iter != l.iter_end());
+      ceph_assert(iter != l.iter_end());
       l.leaf_remove(iter);
       break;
     }
     default:
-      assert(0 == "Impossible");
+      ceph_assert(0 == "Impossible");
   }
 }
 

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -50,7 +50,7 @@ struct onode_layout_t {
     } else if (type == omap_type_t::OMAP) {
       return omap_root;
     } else {
-      assert(type == omap_type_t::LOG);
+      ceph_assert(type == omap_type_t::LOG);
       return log_root;
     }
   }
@@ -96,8 +96,8 @@ public:
   virtual void clear_snapset(Transaction&) = 0;
 
   laddr_t get_metadata_hint(uint64_t block_size) const {
-    assert(default_metadata_offset);
-    assert(default_metadata_range);
+    ceph_assert(default_metadata_offset);
+    ceph_assert(default_metadata_range);
     uint64_t range_blocks = default_metadata_range / block_size;
     auto random_offset = default_metadata_offset +
         (((uint32_t)std::rand() % range_blocks) * block_size);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -221,7 +221,7 @@ FLTreeOnodeManager::erase_onode_ret FLTreeOnodeManager::erase_onode(
   OnodeRef &onode)
 {
   auto &flonode = static_cast<FLTreeOnode&>(*onode);
-  assert(flonode.is_alive());
+  ceph_assert(flonode.is_alive());
   flonode.mark_delete();
   return tree.erase(trans, flonode);
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -76,7 +76,7 @@ struct FLTreeOnode final : Onode, Value {
     return status != status_t::DELETED;
   }
   const onode_layout_t &get_layout() const final {
-    assert(status != status_t::DELETED);
+    ceph_assert(status != status_t::DELETED);
     return *read_payload<onode_layout_t>();
   }
 
@@ -84,7 +84,7 @@ struct FLTreeOnode final : Onode, Value {
   void with_mutable_layout(
     Transaction &t,
     layout_func_t &&layout_func) {
-    assert(status != status_t::DELETED);
+    ceph_assert(status != status_t::DELETED);
     auto p = prepare_mutate_payload<
       onode_layout_t,
       Recorder>(t);
@@ -120,7 +120,7 @@ struct FLTreeOnode final : Onode, Value {
   }
 
   void update_omap_root(Transaction &t, omap_root_t &oroot) final {
-    assert(oroot.get_type() == omap_type_t::OMAP);
+    ceph_assert(oroot.get_type() == omap_type_t::OMAP);
     with_mutable_layout(
       t,
       [&oroot](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -135,7 +135,7 @@ struct FLTreeOnode final : Onode, Value {
   }
 
   void update_log_root(Transaction &t, omap_root_t &lroot) final {
-    assert(lroot.get_type() == omap_type_t::LOG);
+    ceph_assert(lroot.get_type() == omap_type_t::LOG);
     with_mutable_layout(
       t,
       [&lroot](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -150,7 +150,7 @@ struct FLTreeOnode final : Onode, Value {
   }
 
   void update_xattr_root(Transaction &t, omap_root_t &xroot) final {
-    assert(xroot.get_type() == omap_type_t::XATTR);
+    ceph_assert(xroot.get_type() == omap_type_t::XATTR);
     with_mutable_layout(
       t,
       [&xroot](NodeExtentMutable &payload_mut, Recorder *recorder) {
@@ -246,7 +246,7 @@ struct FLTreeOnode final : Onode, Value {
   }
 
   void mark_delete() {
-    assert(status != status_t::DELETED);
+    ceph_assert(status != status_t::DELETED);
     status = status_t::DELETED;
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -175,15 +175,15 @@ inline std::ostream& operator<<(std::ostream& os, const tree_stats_t& stats) {
      << "\n  ratio nodes leaf  = " << stats.ratio_nodes_leaf()
      << "\n  ratio filled leaf = " << stats.ratio_filled_leaf()
      << "\n  ratio key compression = " << stats.ratio_key_compression();
-  assert(stats.num_kvs_internal + 1 == stats.num_nodes());
+  ceph_assert(stats.num_kvs_internal + 1 == stats.num_nodes());
   return os;
 }
 
 template <typename PtrType>
 void reset_ptr(PtrType& ptr, const char* origin_base,
                const char* new_base, extent_len_t node_size) {
-  assert((const char*)ptr > origin_base);
-  assert((const char*)ptr - origin_base < (int)node_size);
+  ceph_assert((const char*)ptr > origin_base);
+  ceph_assert((const char*)ptr - origin_base < (int)node_size);
   ptr = reinterpret_cast<PtrType>(
       (const char*)ptr - origin_base + new_base);
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
@@ -33,7 +33,7 @@ class DeltaRecorder {
   }
 
   ValueDeltaRecorder* get_value_recorder() const {
-    assert(value_recorder);
+    ceph_assert(value_recorder);
     return value_recorder.get();
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -31,7 +31,7 @@ class NodeExtent : public LogicalChildNode {
     return get_bptr().c_str();
   }
   NodeExtentMutable get_mutable() {
-    assert(is_mutable());
+    ceph_assert(is_mutable());
     return do_get_mutable();
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -44,7 +44,7 @@ class DummyNodeExtent final: public NodeExtent {
   ~DummyNodeExtent() override = default;
 
   void retire() {
-    assert(state == extent_state_t::INITIAL_WRITE_PENDING);
+    ceph_assert(state == extent_state_t::INITIAL_WRITE_PENDING);
     state = extent_state_t::INVALID;
     bufferptr empty_bptr;
     get_bptr().swap(empty_bptr);
@@ -137,30 +137,30 @@ class DummyNodeExtentManager final: public NodeExtentManager {
   read_iertr::future<NodeExtentRef> read_extent_sync(
       Transaction& t, laddr_t addr) {
     auto iter = allocate_map.find(addr);
-    assert(iter != allocate_map.end());
+    ceph_assert(iter != allocate_map.end());
     auto extent = iter->second;
     SUBTRACET(seastore_onode,
         "read {}B at {} -- {}",
         t, extent->get_length(), extent->get_laddr(), *extent);
-    assert(extent->get_laddr() == addr);
+    ceph_assert(extent->get_laddr() == addr);
     return read_iertr::make_ready_future<NodeExtentRef>(extent);
   }
 
   alloc_iertr::future<NodeExtentRef> alloc_extent_sync(
       Transaction& t, extent_len_t len) {
-    assert(len % ALIGNMENT == 0);
+    ceph_assert(len % ALIGNMENT == 0);
     auto r = ceph::buffer::create_aligned(len, ALIGNMENT);
     auto addr = laddr_t::from_byte_offset(
       reinterpret_cast<laddr_t::Unsigned>(r->get_data()));
     auto bp = ceph::bufferptr(std::move(r));
     auto extent = Ref<DummyNodeExtent>(new DummyNodeExtent(std::move(bp)));
     extent->set_laddr(addr);
-    assert(allocate_map.find(extent->get_laddr()) == allocate_map.end());
+    ceph_assert(allocate_map.find(extent->get_laddr()) == allocate_map.end());
     allocate_map.insert({extent->get_laddr(), extent});
     SUBDEBUGT(seastore_onode,
         "allocated {}B at {} -- {}",
         t, extent->get_length(), extent->get_laddr(), *extent);
-    assert(extent->get_length() == len);
+    ceph_assert(extent->get_length() == len);
     return alloc_iertr::make_ready_future<NodeExtentRef>(extent);
   }
 
@@ -171,7 +171,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     auto len = extent.get_length();
     extent.retire();
     auto iter = allocate_map.find(addr);
-    assert(iter != allocate_map.end());
+    ceph_assert(iter != allocate_map.end());
     allocate_map.erase(iter);
     SUBDEBUGT(seastore_onode, "retired {}B at {}", t, len, addr);
     return retire_iertr::now();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -55,7 +55,7 @@ NodeExtentRef SeastoreNodeExtent::mutate(
   auto ret = extent->cast<SeastoreNodeExtent>();
   // A replayed extent may already have an empty recorder, we discard it for
   // simplicity.
-  assert(!ret->recorder || ret->recorder->is_empty());
+  ceph_assert(!ret->recorder || ret->recorder->is_empty());
   ret->recorder = std::move(_recorder);
   return ret;
 }
@@ -75,8 +75,8 @@ void SeastoreNodeExtent::apply_delta(const ceph::bufferlist& bl)
   } else {
 #ifndef NDEBUG
     auto header = get_header();
-    assert(recorder->node_type() == header.get_node_type());
-    assert(recorder->field_type() == *header.get_field_type());
+    ceph_assert(recorder->node_type() == header.get_node_type());
+    ceph_assert(recorder->field_type() == *header.get_field_type());
 #endif
   }
   auto mut = do_get_mutable();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -65,7 +65,7 @@ class SeastoreNodeExtent final: public NodeExtent {
     return CachedExtentRef(new SeastoreNodeExtent(*this));
   }
   ceph::bufferlist get_delta() override {
-    assert(recorder);
+    ceph_assert(recorder);
     return recorder->get_delta();
   }
   void apply_delta(const ceph::bufferlist&) override;
@@ -87,9 +87,9 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       TransactionManager &tm, laddr_t min, double p_eagain)
       : TransactionManagerHandle(tm), addr_min{min}, p_eagain{p_eagain} {
     if constexpr (INJECT_EAGAIN) {
-      assert(p_eagain > 0.0 && p_eagain < 1.0);
+      ceph_assert(p_eagain > 0.0 && p_eagain < 1.0);
     } else {
-      assert(p_eagain == 0.0);
+      ceph_assert(p_eagain == 0.0);
     }
   }
 
@@ -119,9 +119,9 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       SUBTRACET(seastore_onode,
           "read {}B at {} -- {}",
           t, e->get_length(), e->get_laddr(), *e);
-      assert(!maybe_indirect_extent.is_indirect());
-      assert(!maybe_indirect_extent.is_clone);
-      assert(e->get_laddr() == addr);
+      ceph_assert(!maybe_indirect_extent.is_indirect());
+      ceph_assert(!maybe_indirect_extent.is_clone);
+      ceph_assert(e->get_laddr() == addr);
       std::ignore = addr;
       return read_iertr::make_ready_future<NodeExtentRef>(e);
     });
@@ -148,7 +148,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
             t, len, *extent);
         ceph_abort("fatal error");
       }
-      assert(extent->get_length() == len);
+      ceph_assert(extent->get_length() == len);
       std::ignore = len;
       return NodeExtentRef(extent);
     }).handle_error_interruptible(
@@ -175,7 +175,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       }
     }
     return tm.remove(t, extent).si_then([addr, len, &t] (unsigned cnt) {
-      assert(cnt == 0);
+      ceph_assert(cnt == 0);
       SUBTRACET(seastore_onode, "retired {}B at {} ...", t, len, addr);
     });
   }
@@ -213,7 +213,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
   bool trigger_eagain() {
     if (generate_eagain) {
       double dice = rd();
-      assert(rd.min() == 0);
+      ceph_assert(rd.min() == 0);
       dice /= rd.max();
       return dice <= p_eagain;
     } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/test_replay.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/test_replay.h
@@ -19,19 +19,19 @@ class TestReplayExtent final: public NodeExtent {
   using Ref = crimson::os::seastore::TCachedExtentRef<TestReplayExtent>;
 
   void prepare_replay(NodeExtentRef from_extent) {
-    assert(get_length() == from_extent->get_length());
+    ceph_assert(get_length() == from_extent->get_length());
     auto mut = do_get_mutable();
     std::memcpy(mut.get_write(), from_extent->get_read(), get_length());
   }
 
   void replay_and_verify(NodeExtentRef replayed_extent) {
-    assert(get_length() == replayed_extent->get_length());
+    ceph_assert(get_length() == replayed_extent->get_length());
     auto mut = do_get_mutable();
     auto bl = recorder->get_delta();
-    assert(bl.length());
+    ceph_assert(bl.length());
     auto p = bl.cbegin();
     recorder->apply_delta(p, mut, *this);
-    assert(p == bl.end());
+    ceph_assert(p == bl.end());
     auto cmp = std::memcmp(get_read(), replayed_extent->get_read(), get_length());
     ceph_assert(cmp == 0 && "replay mismatch!");
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_mutable.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_mutable.h
@@ -19,7 +19,7 @@ namespace crimson::os::seastore::onode {
 class NodeExtentMutable {
  public:
   void copy_in_absolute(void* dst, const void* src, extent_len_t len) {
-    assert(is_safe(dst, len));
+    ceph_assert(is_safe(dst, len));
     std::memcpy(dst, src, len);
   }
   template <typename T>
@@ -41,9 +41,9 @@ class NodeExtentMutable {
   }
 
   void shift_absolute(const void* src, extent_len_t len, int offset) {
-    assert(is_safe(src, len));
+    ceph_assert(is_safe(src, len));
     char* to = (char*)src + offset;
-    assert(is_safe(to, len));
+    ceph_assert(is_safe(to, len));
     if (len != 0) {
       std::memmove(to, src, len);
     }
@@ -53,7 +53,7 @@ class NodeExtentMutable {
   }
 
   void set_absolute(void* dst, int value, extent_len_t len) {
-    assert(is_safe(dst, len));
+    ceph_assert(is_safe(dst, len));
     std::memset(dst, value, len);
   }
   void set_relative(extent_len_t dst_offset, int value, extent_len_t len) {
@@ -63,7 +63,7 @@ class NodeExtentMutable {
 
   template <typename T>
   void validate_inplace_update(const T& updated) {
-    assert(is_safe(&updated, sizeof(T)));
+    ceph_assert(is_safe(&updated, sizeof(T)));
   }
 
   const char* get_read() const { return p_start; }
@@ -71,7 +71,7 @@ class NodeExtentMutable {
   extent_len_t get_length() const {
 #ifndef NDEBUG
     if (node_offset == 0) {
-      assert(is_valid_node_size(length));
+      ceph_assert(is_valid_node_size(length));
     }
 #endif
     return length;
@@ -79,12 +79,12 @@ class NodeExtentMutable {
   node_offset_t get_node_offset() const { return node_offset; }
 
   NodeExtentMutable get_mutable_absolute(const void* dst, node_offset_t len) const {
-    assert(node_offset == 0);
-    assert(is_safe(dst, len));
-    assert((const char*)dst != get_read());
+    ceph_assert(node_offset == 0);
+    ceph_assert(is_safe(dst, len));
+    ceph_assert((const char*)dst != get_read());
     auto ret = *this;
     node_offset_t offset = (const char*)dst - get_read();
-    assert(offset != 0);
+    ceph_assert(offset != 0);
     ret.p_start += offset;
     ret.length = len;
     ret.node_offset = offset;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
@@ -67,7 +67,7 @@ struct NodeLayoutReplayableT {
 
   static void update_child_addr(
       NodeExtentMutable& mut, const laddr_t new_addr, laddr_packed_t* p_addr) {
-    assert(NODE_TYPE == node_type_t::INTERNAL);
+    ceph_assert(NODE_TYPE == node_type_t::INTERNAL);
     mut.copy_in_absolute(p_addr, new_addr);
   }
 
@@ -77,12 +77,12 @@ struct NodeLayoutReplayableT {
       const position_t& _erase_pos) {
     if (_erase_pos.is_end()) {
       // must be internal node
-      assert(node_stage.is_level_tail());
+      ceph_assert(node_stage.is_level_tail());
       // return erase_stage, last_pos
       return update_last_to_tail(mut, node_stage);
     }
 
-    assert(node_stage.keys() != 0);
+    ceph_assert(node_stage.keys() != 0);
     position_t erase_pos = _erase_pos;
     auto erase_stage = stage_t::erase(mut, node_stage, erase_pos);
     // return erase_stage, next_pos
@@ -92,7 +92,7 @@ struct NodeLayoutReplayableT {
   static position_t make_tail(
       NodeExtentMutable& mut,
       const node_stage_t& node_stage) {
-    assert(!node_stage.is_level_tail());
+    ceph_assert(!node_stage.is_level_tail());
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
       auto [r_stage, r_last_pos] = update_last_to_tail(mut, node_stage);
       std::ignore = r_stage;
@@ -109,7 +109,7 @@ struct NodeLayoutReplayableT {
       NodeExtentMutable& mut,
       const node_stage_t& node_stage) {
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
-      assert(node_stage.keys() != 0);
+      ceph_assert(node_stage.keys() != 0);
       position_t last_pos;
       laddr_t last_value;
       {
@@ -121,7 +121,7 @@ struct NodeLayoutReplayableT {
 
       auto erase_pos = last_pos;
       auto erase_stage = stage_t::erase(mut, node_stage, erase_pos);
-      assert(erase_pos.is_end());
+      ceph_assert(erase_pos.is_end());
 
       node_stage_t::update_is_level_tail(mut, node_stage, true);
       auto p_last_value = const_cast<laddr_packed_t*>(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -20,8 +20,8 @@ enum class field_type_t : uint8_t {
 };
 inline uint8_t to_unsigned(field_type_t type) {
   auto value = static_cast<uint8_t>(type);
-  assert(value >= FIELD_TYPE_MAGIC);
-  assert(value < static_cast<uint8_t>(field_type_t::_MAX));
+  ceph_assert(value >= FIELD_TYPE_MAGIC);
+  ceph_assert(value < static_cast<uint8_t>(field_type_t::_MAX));
   return value - FIELD_TYPE_MAGIC;
 }
 inline std::ostream& operator<<(std::ostream &os, field_type_t type) {
@@ -38,7 +38,7 @@ enum class node_type_t : uint8_t {
 inline std::ostream& operator<<(std::ostream &os, const node_type_t& type) {
   const char* const names[] = {"L", "I"};
   auto index = static_cast<uint8_t>(type);
-  assert(index <= 1u);
+  ceph_assert(index <= 1u);
   os << names[index];
   return os;
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
@@ -19,7 +19,7 @@ memory_range_t ITER_T::insert_prefix(
   // 1. insert range
   char* p_insert;
   if (is_end) {
-    assert(!iter.has_next());
+    ceph_assert(!iter.has_next());
     p_insert = const_cast<char*>(iter.p_start());
   } else {
     p_insert = const_cast<char*>(iter.p_end());
@@ -56,7 +56,7 @@ void ITER_T::update_size(
 {
   node_offset_t offset = iter.get_back_offset();
   int new_size = change + offset;
-  assert(new_size > 0 && new_size < (int)mut.get_length());
+  ceph_assert(new_size > 0 && new_size < (int)mut.get_length());
   mut.copy_in_absolute(
       (void*)iter.get_item_range().p_end, node_offset_t(new_size));
 }
@@ -64,9 +64,9 @@ void ITER_T::update_size(
 template <node_type_t NODE_TYPE>
 node_offset_t ITER_T::trim_until(NodeExtentMutable& mut, const ITER_T& iter)
 {
-  assert(iter.index() != 0);
+  ceph_assert(iter.index() != 0);
   size_t ret = iter.p_end() - iter.p_items_start;
-  assert(ret < mut.get_length());
+  ceph_assert(ret < mut.get_length());
   return ret;
 }
 
@@ -75,8 +75,8 @@ node_offset_t ITER_T::trim_at(
     NodeExtentMutable& mut, const ITER_T& iter, node_offset_t trimmed)
 {
   size_t trim_size = iter.p_start() - iter.p_items_start + trimmed;
-  assert(trim_size < mut.get_length());
-  assert(iter.get_back_offset() > trimmed);
+  ceph_assert(trim_size < mut.get_length());
+  ceph_assert(iter.get_back_offset() > trimmed);
   node_offset_t new_offset = iter.get_back_offset() - trimmed;
   mut.copy_in_absolute((void*)iter.item_range.p_end, new_offset);
   return trim_size;
@@ -88,7 +88,7 @@ node_offset_t ITER_T::erase(
 {
   node_offset_t erase_size = iter.p_end() - iter.p_start();
   const char* p_shift_start = p_left_bound;
-  assert(p_left_bound <= iter.p_start());
+  ceph_assert(p_left_bound <= iter.p_start());
   extent_len_t shift_len = iter.p_start() - p_left_bound;
   int shift_off = erase_size;
   mut.shift_absolute(p_shift_start, shift_len, shift_off);
@@ -107,7 +107,7 @@ APPEND_T::Appender(NodeExtentMutable* p_mut,
                    const item_iterator_t& iter,
                    bool open) : p_mut{p_mut}
 {
-  assert(!iter.has_next());
+  ceph_assert(!iter.has_next());
   if (open) {
     p_append = const_cast<char*>(iter.get_key().p_start());
     p_offset_while_open = const_cast<char*>(iter.item_range.p_end);
@@ -126,7 +126,7 @@ bool APPEND_T::append(const ITER_T& src, index_t& items)
   if (is_valid_index(items)) {
     for (auto i = 1u; i <= items; ++i) {
       if (!src.has_next()) {
-        assert(i == items);
+        ceph_assert(i == items);
         append_till_end = true;
         break;
       }
@@ -136,7 +136,7 @@ bool APPEND_T::append(const ITER_T& src, index_t& items)
     if (items == INDEX_END) {
       append_till_end = true;
     } else {
-      assert(items == INDEX_LAST);
+      ceph_assert(items == INDEX_LAST);
     }
     items = 0;
     while (src.has_next()) {
@@ -154,7 +154,7 @@ bool APPEND_T::append(const ITER_T& src, index_t& items)
   } else {
     p_start = src.p_end();
   }
-  assert(p_end >= p_start);
+  ceph_assert(p_end >= p_start);
   size_t append_size = p_end - p_start;
   p_append -= append_size;
   p_mut->copy_in_absolute(p_append, p_start, append_size);
@@ -187,7 +187,7 @@ template <node_type_t NODE_TYPE>
 template <KeyT KT>
 void APPEND_T::wrap_nxt(char* _p_append)
 {
-  assert(_p_append < p_append);
+  ceph_assert(_p_append < p_append);
   p_mut->copy_in_absolute(
       p_offset_while_open, node_offset_t(p_offset_while_open - _p_append));
   p_append = _p_append;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
@@ -42,8 +42,8 @@ class item_iterator_t {
       : node_size{range.node_size},
         p_items_start(range.range.p_start),
         p_items_end(range.range.p_end) {
-    assert(is_valid_node_size(node_size));
-    assert(p_items_start < p_items_end);
+    ceph_assert(is_valid_node_size(node_size));
+    ceph_assert(p_items_start < p_items_end);
     next_item_range(p_items_end);
   }
 
@@ -59,18 +59,18 @@ class item_iterator_t {
   key_get_type get_key() const {
     if (!key.has_value()) {
       key = ns_oid_view_t(item_range.p_end);
-      assert(item_range.p_start < (*key).p_start());
+      ceph_assert(item_range.p_start < (*key).p_start());
     }
     return *key;
   }
   node_offset_t size() const {
     size_t ret = item_range.p_end - item_range.p_start + sizeof(node_offset_t);
-    assert(ret < node_size);
+    ceph_assert(ret < node_size);
     return ret;
   };
   node_offset_t size_to_nxt() const {
     size_t ret = get_key().size() + sizeof(node_offset_t);
-    assert(ret < node_size);
+    ceph_assert(ret < node_size);
     return ret;
   }
   node_offset_t size_overhead() const {
@@ -80,11 +80,11 @@ class item_iterator_t {
     return {{item_range.p_start, get_key().p_start()}, node_size};
   }
   bool has_next() const {
-    assert(p_items_start <= item_range.p_start);
+    ceph_assert(p_items_start <= item_range.p_start);
     return p_items_start < item_range.p_start;
   }
   const item_iterator_t<NODE_TYPE>& operator++() const {
-    assert(has_next());
+    ceph_assert(has_next());
     next_item_range(item_range.p_start);
     key.reset();
     ++_index;
@@ -93,9 +93,9 @@ class item_iterator_t {
   void encode(const char* p_node_start, ceph::bufferlist& encoded) const {
     int start_offset = p_items_start - p_node_start;
     int stage_size = p_items_end - p_items_start;
-    assert(start_offset > 0);
-    assert(stage_size > 0);
-    assert(start_offset + stage_size <= (int)node_size);
+    ceph_assert(start_offset > 0);
+    ceph_assert(stage_size > 0);
+    ceph_assert(start_offset + stage_size <= (int)node_size);
     ceph::encode(static_cast<node_offset_t>(start_offset), encoded);
     ceph::encode(static_cast<node_offset_t>(stage_size), encoded);
     ceph::encode(_index, encoded);
@@ -108,9 +108,9 @@ class item_iterator_t {
     ceph::decode(start_offset, delta);
     node_offset_t stage_size;
     ceph::decode(stage_size, delta);
-    assert(start_offset > 0);
-    assert(stage_size > 0);
-    assert((unsigned)start_offset + stage_size <= node_size);
+    ceph_assert(start_offset > 0);
+    ceph_assert(stage_size > 0);
+    ceph_assert((unsigned)start_offset + stage_size <= node_size);
     index_t index;
     ceph::decode(index, delta);
 
@@ -154,11 +154,11 @@ class item_iterator_t {
  private:
   void next_item_range(const char* p_end) const {
     auto p_item_end = p_end - sizeof(node_offset_t);
-    assert(p_items_start < p_item_end);
+    ceph_assert(p_items_start < p_item_end);
     back_offset = reinterpret_cast<const node_offset_packed_t*>(p_item_end)->value;
-    assert(back_offset);
+    ceph_assert(back_offset);
     const char* p_item_start = p_item_end - back_offset;
-    assert(p_items_start <= p_item_start);
+    ceph_assert(p_items_start <= p_item_start);
     item_range = {p_item_start, p_item_end};
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.cc
@@ -10,7 +10,7 @@ namespace crimson::os::seastore::onode {
 void string_key_view_t::append_str(
     NodeExtentMutable& mut, std::string_view str, char*& p_append)
 {
-  assert(is_valid_size(str.length()));
+  ceph_assert(is_valid_size(str.length()));
   p_append -= sizeof(string_size_t);
   string_size_t len = str.length();
   mut.copy_in_absolute(p_append, len);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -84,7 +84,7 @@ struct string_key_view_t {
       auto _p_key = p_length - length;
       p_key = static_cast<const char*>(_p_key);
     } else {
-      assert(length == MARKER_MAX || length == MARKER_MIN);
+      ceph_assert(length == MARKER_MAX || length == MARKER_MIN);
       p_key = nullptr;
     }
   }
@@ -94,7 +94,7 @@ struct string_key_view_t {
     } else if (length == MARKER_MAX) {
       return Type::MAX;
     } else {
-      assert(is_valid_size(length));
+      ceph_assert(is_valid_size(length));
       return Type::STR;
     }
   }
@@ -114,22 +114,22 @@ struct string_key_view_t {
   }
   node_offset_t size() const {
     size_t ret = length + sizeof(string_size_t);
-    assert(ret < MAX_NODE_SIZE);
+    ceph_assert(ret < MAX_NODE_SIZE);
     return ret;
   }
   node_offset_t size_logical() const {
-    assert(type() == Type::STR);
-    assert(is_valid_size(length));
+    ceph_assert(type() == Type::STR);
+    ceph_assert(is_valid_size(length));
     return length;
   }
   node_offset_t size_overhead() const {
-    assert(type() == Type::STR);
+    ceph_assert(type() == Type::STR);
     return sizeof(string_size_t);
   }
 
   std::string_view to_string_view() const {
-    assert(type() == Type::STR);
-    assert(is_valid_size(length));
+    ceph_assert(type() == Type::STR);
+    ceph_assert(is_valid_size(length));
     return {p_key, length};
   }
   bool operator==(const string_key_view_t& x) const {
@@ -151,7 +151,7 @@ struct string_key_view_t {
 #ifndef NDEBUG
     string_size_t current_length;
     std::memcpy(&current_length, p_length, sizeof(string_size_t));
-    assert(length == current_length);
+    ceph_assert(length == current_length);
 #endif
   }
 
@@ -159,7 +159,7 @@ struct string_key_view_t {
       NodeExtentMutable&, std::string_view, char*& p_append);
 
   static void test_append_str(std::string_view str, char*& p_append) {
-    assert(is_valid_size(str.length()));
+    ceph_assert(is_valid_size(str.length()));
     p_append -= sizeof(string_size_t);
     string_size_t len = str.length();
     std::memcpy(p_append, &len, sizeof(string_size_t));
@@ -208,17 +208,17 @@ class string_view_masked_t {
   }
   explicit string_view_masked_t(std::string_view str)
       : type{Type::STR}, view{str} {
-    assert(string_key_view_t::is_valid_size(view.size()));
+    ceph_assert(string_key_view_t::is_valid_size(view.size()));
   }
 
   Type get_type() const { return type; }
   std::string_view to_string_view() const {
-    assert(get_type() == Type::STR);
+    ceph_assert(get_type() == Type::STR);
     return view;
   }
   string_size_t size() const {
-    assert(get_type() == Type::STR);
-    assert(string_key_view_t::is_valid_size(view.size()));
+    ceph_assert(get_type() == Type::STR);
+    ceph_assert(string_key_view_t::is_valid_size(view.size()));
     return view.size();
   }
   bool operator==(const string_view_masked_t& x) const {
@@ -232,14 +232,14 @@ class string_view_masked_t {
   }
   auto operator<=>(std::string_view rhs) const {
     using Type = string_view_masked_t::Type;
-    assert(string_key_view_t::is_valid_size(rhs.size()));
+    ceph_assert(string_key_view_t::is_valid_size(rhs.size()));
     auto lhs_type = get_type();
     if (lhs_type == Type::MIN) {
       return std::strong_ordering::less;
     } else if (lhs_type == Type::MAX) {
       return std::strong_ordering::greater;
     } else { // r_type == Type::STR
-      assert(string_key_view_t::is_valid_size(size()));
+      ceph_assert(string_key_view_t::is_valid_size(size()));
       return to_string_view() <=> rhs;
     }
   }
@@ -282,8 +282,8 @@ inline auto operator<=>(const string_view_masked_t& l, const string_view_masked_
   auto l_type = l.get_type();
   auto r_type = r.get_type();
   if (l_type == Type::STR && r_type == Type::STR) {
-    assert(string_key_view_t::is_valid_size(l.size()));
-    assert(string_key_view_t::is_valid_size(r.size()));
+    ceph_assert(string_key_view_t::is_valid_size(l.size()));
+    ceph_assert(string_key_view_t::is_valid_size(r.size()));
     return l.to_string_view() <=> r.to_string_view();
   } else if (l_type == r_type) {
     return std::strong_ordering::equal;
@@ -323,18 +323,18 @@ struct ns_oid_view_t {
   node_offset_t size() const {
     if (type() == Type::STR) {
       size_t ret = nspace.size() + oid.size();
-      assert(ret < MAX_NODE_SIZE);
+      ceph_assert(ret < MAX_NODE_SIZE);
       return ret;
     } else {
       return sizeof(string_size_t);
     }
   }
   node_offset_t size_logical() const {
-    assert(type() == Type::STR);
+    ceph_assert(type() == Type::STR);
     return nspace.size_logical() + oid.size_logical();
   }
   node_offset_t size_overhead() const {
-    assert(type() == Type::STR);
+    ceph_assert(type() == Type::STR);
     return nspace.size_overhead() + oid.size_overhead();
   }
   bool operator==(const ns_oid_view_t& x) const {
@@ -386,7 +386,7 @@ inline auto operator<=>(const ns_oid_view_t& l, const ns_oid_view_t& r) {
 }
 
 inline const ghobject_t _MIN_OID() {
-  assert(ghobject_t().is_min());
+  ceph_assert(ghobject_t().is_min());
   // don't extern _MIN_OID
   return ghobject_t();
 }
@@ -399,7 +399,7 @@ inline const ghobject_t _MIN_OID() {
 inline const ghobject_t _MAX_OID() {
   auto ret = ghobject_t(shard_id_t(MAX_SHARD), MAX_POOL, MAX_CRUSH,
                         "MAX", "MAX", MAX_SNAP, MAX_GEN);
-  assert(ret.hobj.get_hash() == ret.hobj.get_bitwise_key_u32());
+  ceph_assert(ret.hobj.get_hash() == ret.hobj.get_bitwise_key_u32());
   return ret;
 }
 
@@ -423,8 +423,8 @@ class key_hobj_t {
       ghobj = _ghobj;
     }
     // I can be in the range of [_MIN_OID, _MAX_OID]
-    assert(ghobj >= _MIN_OID());
-    assert(ghobj <= _MAX_OID());
+    ceph_assert(ghobj >= _MIN_OID());
+    ceph_assert(ghobj <= _MAX_OID());
   }
   /*
    * common interfaces as a full_key_t
@@ -492,11 +492,11 @@ class key_hobj_t {
     std::string nspace;
     [[maybe_unused]] auto nspace_masked = string_view_masked_t::decode(nspace, delta);
     // TODO(cross-node string dedup)
-    assert(nspace_masked.get_type() == string_view_masked_t::Type::STR);
+    ceph_assert(nspace_masked.get_type() == string_view_masked_t::Type::STR);
     std::string oid;
     [[maybe_unused]] auto oid_masked = string_view_masked_t::decode(oid, delta);
     // TODO(cross-node string dedup)
-    assert(oid_masked.get_type() == string_view_masked_t::Type::STR);
+    ceph_assert(oid_masked.get_type() == string_view_masked_t::Type::STR);
     snap_t snap;
     ceph::decode(snap, delta);
     gen_t gen;
@@ -574,19 +574,19 @@ class key_view_t {
   }
 
   const shard_pool_t& shard_pool_packed() const {
-    assert(has_shard_pool());
+    ceph_assert(has_shard_pool());
     return *p_shard_pool;
   }
   const crush_t& crush_packed() const {
-    assert(has_crush());
+    ceph_assert(has_crush());
     return *p_crush;
   }
   const ns_oid_view_t& ns_oid_view() const {
-    assert(has_ns_oid());
+    ceph_assert(has_ns_oid());
     return *p_ns_oid;
   }
   const snap_gen_t& snap_gen_packed() const {
-    assert(has_snap_gen());
+    ceph_assert(has_snap_gen());
     return *p_snap_gen;
   }
 
@@ -596,7 +596,7 @@ class key_view_t {
   }
 
   ghobject_t to_ghobj() const {
-    assert(is_valid_key(*this));
+    ceph_assert(is_valid_key(*this));
     return ghobject_t(
         shard_id_t(shard()), pool(), crush(),
         std::string(nspace()), std::string(oid()), snap(), gen());
@@ -604,19 +604,19 @@ class key_view_t {
 
   void replace(const crush_t& key) { p_crush = &key; }
   void set(const crush_t& key) {
-    assert(!has_crush());
+    ceph_assert(!has_crush());
     replace(key);
   }
   inline void replace(const shard_pool_crush_t& key);
   inline void set(const shard_pool_crush_t& key);
   void replace(const ns_oid_view_t& key) { p_ns_oid = key; }
   void set(const ns_oid_view_t& key) {
-    assert(!has_ns_oid());
+    ceph_assert(!has_ns_oid());
     replace(key);
   }
   void replace(const snap_gen_t& key) { p_snap_gen = &key; }
   void set(const snap_gen_t& key) {
-    assert(!has_snap_gen());
+    ceph_assert(!has_snap_gen());
     replace(key);
   }
 
@@ -773,7 +773,7 @@ void key_view_t::replace(const shard_pool_crush_t& key) {
 
 void key_view_t::set(const shard_pool_crush_t& key) {
   set(key.crush);
-  assert(!has_shard_pool());
+  ceph_assert(!has_shard_pool());
   replace(key);
 }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
@@ -32,7 +32,7 @@ const char* NODE_T::p_left_bound() const
 template <typename FieldType, node_type_t NODE_TYPE>
 node_offset_t NODE_T::size_to_nxt_at(index_t index) const
 {
-  assert(index < keys());
+  ceph_assert(index < keys());
   if constexpr (FIELD_TYPE == field_type_t::N0 ||
                 FIELD_TYPE == field_type_t::N1) {
     return FieldType::estimate_insert_one();
@@ -55,13 +55,13 @@ container_range_t NODE_T::get_nxt_container(index_t index) const
         index, node_size);
     auto item_end_offset = p_fields->get_item_end_offset(
         index, node_size);
-    assert(item_start_offset < item_end_offset);
+    ceph_assert(item_start_offset < item_end_offset);
     auto item_p_start = p_start() + item_start_offset;
     auto item_p_end = p_start() + item_end_offset;
     if constexpr (FIELD_TYPE == field_type_t::N2) {
       // range for sub_items_t<NODE_TYPE>
       item_p_end = ns_oid_view_t(item_p_end).p_start();
-      assert(item_p_start < item_p_end);
+      ceph_assert(item_p_start < item_p_end);
     } else {
       // range for item_iterator_t<NODE_TYPE>
     }
@@ -85,8 +85,8 @@ template <typename FieldType, node_type_t NODE_TYPE>
 void NODE_T::update_is_level_tail(
     NodeExtentMutable& mut, const node_extent_t& extent, bool value)
 {
-  assert(mut.get_length() == extent.node_size);
-  assert(mut.get_read() == extent.p_start());
+  ceph_assert(mut.get_length() == extent.node_size);
+  ceph_assert(mut.get_read() == extent.p_start());
   node_header_t::update_is_level_tail(mut, extent.p_fields->header, value);
 }
 
@@ -96,13 +96,13 @@ memory_range_t NODE_T::insert_prefix_at(
     NodeExtentMutable& mut, const node_extent_t& node, const Key& key,
     index_t index, node_offset_t size, const char* p_left_bound)
 {
-  assert(mut.get_length() == node.node_size);
-  assert(mut.get_read() == node.p_start());
+  ceph_assert(mut.get_length() == node.node_size);
+  ceph_assert(mut.get_read() == node.p_start());
   if constexpr (FIELD_TYPE == field_type_t::N0 ||
                 FIELD_TYPE == field_type_t::N1) {
-    assert(index <= node.keys());
-    assert(p_left_bound == node.p_left_bound());
-    assert(size > FieldType::estimate_insert_one());
+    ceph_assert(index <= node.keys());
+    ceph_assert(p_left_bound == node.p_left_bound());
+    ceph_assert(size > FieldType::estimate_insert_one());
     auto size_right = size - FieldType::estimate_insert_one();
     const char* p_insert = node.p_start() +
                            node.fields().get_item_end_offset(index, mut.get_length());
@@ -139,9 +139,9 @@ template <typename FieldType, node_type_t NODE_TYPE>
 void NODE_T::update_size_at(
     NodeExtentMutable& mut, const node_extent_t& node, index_t index, int change)
 {
-  assert(mut.get_length() == node.node_size);
-  assert(mut.get_read() == node.p_start());
-  assert(index < node.keys());
+  ceph_assert(mut.get_length() == node.node_size);
+  ceph_assert(mut.get_read() == node.p_start());
+  ceph_assert(index < node.keys());
   FieldType::update_size_at(mut, node.fields(), index, change);
 }
 
@@ -149,11 +149,11 @@ template <typename FieldType, node_type_t NODE_TYPE>
 node_offset_t NODE_T::trim_until(
     NodeExtentMutable& mut, const node_extent_t& node, index_t index)
 {
-  assert(mut.get_length() == node.node_size);
-  assert(mut.get_read() == node.p_start());
-  assert(!node.is_level_tail());
+  ceph_assert(mut.get_length() == node.node_size);
+  ceph_assert(mut.get_read() == node.p_start());
+  ceph_assert(!node.is_level_tail());
   auto keys = node.keys();
-  assert(index <= keys);
+  ceph_assert(index <= keys);
   if (index == keys) {
     return 0;
   }
@@ -172,10 +172,10 @@ node_offset_t NODE_T::trim_at(
     NodeExtentMutable& mut, const node_extent_t& node,
     index_t index, node_offset_t trimmed)
 {
-  assert(mut.get_length() == node.node_size);
-  assert(mut.get_read() == node.p_start());
-  assert(!node.is_level_tail());
-  assert(index < node.keys());
+  ceph_assert(mut.get_length() == node.node_size);
+  ceph_assert(mut.get_read() == node.p_start());
+  ceph_assert(!node.is_level_tail());
+  ceph_assert(index < node.keys());
   if constexpr (std::is_same_v<FieldType, internal_fields_3_t>) {
     ceph_abort("not implemented");
   } else {
@@ -183,7 +183,7 @@ node_offset_t NODE_T::trim_at(
     node_offset_t offset = node.p_fields->get_item_start_offset(
         index, node_size);
     size_t new_offset = offset + trimmed;
-    assert(new_offset < node.p_fields->get_item_end_offset(index, node_size));
+    ceph_assert(new_offset < node.p_fields->get_item_end_offset(index, node_size));
     mut.copy_in_absolute(const_cast<void*>(node.p_fields->p_offset(index)),
                          node_offset_t(new_offset));
     mut.copy_in_absolute(
@@ -198,13 +198,13 @@ node_offset_t NODE_T::erase_at(
     NodeExtentMutable& mut, const node_extent_t& node,
     index_t index, const char* p_left_bound)
 {
-  assert(mut.get_length() == node.node_size);
-  assert(mut.get_read() == node.p_start());
+  ceph_assert(mut.get_length() == node.node_size);
+  ceph_assert(mut.get_read() == node.p_start());
   if constexpr (FIELD_TYPE == field_type_t::N0 ||
                 FIELD_TYPE == field_type_t::N1) {
-    assert(node.keys() > 0);
-    assert(index < node.keys());
-    assert(p_left_bound == node.p_left_bound());
+    ceph_assert(node.keys() > 0);
+    ceph_assert(index < node.keys());
+    ceph_assert(p_left_bound == node.p_left_bound());
     return FieldType::erase_at(mut, node.fields(), index, p_left_bound);
   } else {
     ceph_abort("not implemented");
@@ -228,9 +228,9 @@ template <KeyT KT>
 APPEND_T::Appender(NodeExtentMutable* p_mut, const node_extent_t& node, bool open)
     : p_mut{p_mut}, p_start{p_mut->get_write()}
 {
-  assert(p_start == node.p_start());
-  assert(node.keys());
-  assert(node.node_size == p_mut->get_length());
+  ceph_assert(p_start == node.p_start());
+  ceph_assert(node.keys());
+  ceph_assert(node.node_size == p_mut->get_length());
   extent_len_t node_size = node.node_size;
   if (open) {
     // seek as open_nxt()
@@ -267,19 +267,19 @@ template <typename FieldType, node_type_t NODE_TYPE>
 template <KeyT KT>
 void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
 {
-  assert(from <= src.keys());
+  ceph_assert(from <= src.keys());
   if (p_src == nullptr) {
     p_src = &src;
   } else {
-    assert(p_src == &src);
+    ceph_assert(p_src == &src);
   }
-  assert(p_src->node_size == p_mut->get_length());
+  ceph_assert(p_src->node_size == p_mut->get_length());
   extent_len_t node_size = src.node_size;
   if (items == 0) {
     return;
   }
-  assert(from < src.keys());
-  assert(from + items <= src.keys());
+  ceph_assert(from < src.keys());
+  ceph_assert(from + items <= src.keys());
   num_keys += items;
   if constexpr (std::is_same_v<FieldType, internal_fields_3_t>) {
     std::ignore = node_size;
@@ -293,8 +293,8 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
     node_offset_t left_size = offset_left_end - offset_left_start;
     if (num_keys == 0) {
       // no need to adjust offset
-      assert(from == 0);
-      assert(p_start + offset_left_start == p_append_left);
+      ceph_assert(from == 0);
+      ceph_assert(p_start + offset_left_start == p_append_left);
       p_mut->copy_in_absolute(p_append_left,
           src.p_start() + offset_left_start, left_size);
     } else {
@@ -313,12 +313,12 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
       for (auto i = from; i < from + items; ++i) {
         int new_offset = src.fields().get_item_start_offset(i, node_size) +
                          offset_change;
-        assert(new_offset > 0);
-        assert(new_offset < (int)node_size);
+        ceph_assert(new_offset > 0);
+        ceph_assert(new_offset < (int)node_size);
         p_mut->copy_in_absolute(p_offset_dst, node_offset_t(new_offset));
         p_offset_dst += step_size;
       }
-      assert(p_append_left + left_size + sizeof(typename FieldType::key_t) ==
+      ceph_assert(p_append_left + left_size + sizeof(typename FieldType::key_t) ==
              p_offset_dst);
     }
     p_append_left += left_size;
@@ -329,8 +329,8 @@ void APPEND_T::append(const node_extent_t& src, index_t from, index_t items)
     auto offset_right_end = src.fields().get_item_end_offset(
         from, node_size);
     int right_size = offset_right_end - offset_right_start;
-    assert(right_size > 0);
-    assert(right_size < (int)node_size);
+    ceph_assert(right_size > 0);
+    ceph_assert(right_size < (int)node_size);
     p_append_right -= right_size;
     p_mut->copy_in_absolute(p_append_right,
         src.p_start() + offset_right_start, node_offset_t(right_size));
@@ -385,13 +385,13 @@ template <typename FieldType, node_type_t NODE_TYPE>
 template <KeyT KT>
 char* APPEND_T::wrap()
 {
-  assert(p_append_left <= p_append_right);
-  assert(p_src);
+  ceph_assert(p_append_left <= p_append_right);
+  ceph_assert(p_src);
   if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
     if (p_src->is_level_tail()) {
       laddr_t tail_value = p_src->get_end_p_laddr()->value;
       p_append_right -= sizeof(laddr_t);
-      assert(p_append_left <= p_append_right);
+      ceph_assert(p_append_left <= p_append_right);
       p_mut->copy_in_absolute(p_append_right, tail_value);
     }
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
@@ -35,12 +35,12 @@ template <typename SlotType>
 void F013_T::update_size_at(
     NodeExtentMutable& mut, const me_t& node, index_t index, int change)
 {
-  assert(index <= node.num_keys);
+  ceph_assert(index <= node.num_keys);
   [[maybe_unused]] extent_len_t node_size = mut.get_length();
 #ifndef NDEBUG
   // check underflow
   if (change < 0 && index != node.num_keys) {
-    assert(node.get_item_start_offset(index, node_size) <
+    ceph_assert(node.get_item_start_offset(index, node_size) <
            node.get_item_end_offset(index, node_size));
   }
 #endif
@@ -49,8 +49,8 @@ void F013_T::update_size_at(
        ++p_slot) {
     node_offset_t offset = p_slot->right_offset;
     int new_offset = offset - change;
-    assert(new_offset > 0);
-    assert(new_offset < (int)node_size);
+    ceph_assert(new_offset > 0);
+    ceph_assert(new_offset < (int)node_size);
     mut.copy_in_absolute(
         (void*)&(p_slot->right_offset),
         node_offset_t(new_offset));
@@ -58,8 +58,8 @@ void F013_T::update_size_at(
 #ifndef NDEBUG
   // check overflow
   if (change > 0 && index != node.num_keys) {
-    assert(node.num_keys > 0);
-    assert(node.get_key_start_offset(node.num_keys, node_size) <=
+    ceph_assert(node.num_keys > 0);
+    ceph_assert(node.get_key_start_offset(node.num_keys, node_size) <=
            node.slots[node.num_keys - 1].right_offset);
   }
 #endif
@@ -87,7 +87,7 @@ void F013_T::insert_at(
     NodeExtentMutable& mut, const Key& key,
     const me_t& node, index_t index, node_offset_t size_right)
 {
-  assert(index <= node.num_keys);
+  ceph_assert(index <= node.num_keys);
   extent_len_t node_size = mut.get_length();
   update_size_at(mut, node, index, size_right);
   auto p_insert = const_cast<char*>(fields_start(node)) +
@@ -98,8 +98,8 @@ void F013_T::insert_at(
   mut.copy_in_absolute((void*)&node.num_keys, num_keys_t(node.num_keys + 1));
   append_key(mut, key_t::from_key(key), p_insert);
   int new_offset = node.get_item_end_offset(index, node_size) - size_right;
-  assert(new_offset > 0);
-  assert(new_offset < (int)node_size);
+  ceph_assert(new_offset > 0);
+  ceph_assert(new_offset < (int)node_size);
   append_offset(mut, new_offset, p_insert);
 }
 #define IA_TEMPLATE(ST, KT) template void F013_INST(ST)::      \
@@ -119,7 +119,7 @@ node_offset_t F013_T::erase_at(
   extent_len_t node_size = mut.get_length();
   auto offset_item_start = node.get_item_start_offset(index, node_size);
   auto offset_item_end = node.get_item_end_offset(index, node_size);
-  assert(offset_item_start < offset_item_end);
+  ceph_assert(offset_item_start < offset_item_end);
   auto erase_size = offset_item_end - offset_item_start;
   // fix and shift the left part
   update_size_at(mut, node, index + 1, -erase_size);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
@@ -94,7 +94,7 @@ const char* fields_start(const FieldType& node) {
 template <node_type_t NODE_TYPE, typename FieldType>
 node_range_t fields_free_range_before(
     const FieldType& node, index_t index, extent_len_t node_size) {
-  assert(index <= node.num_keys);
+  ceph_assert(index <= node.num_keys);
   extent_len_t offset_start = node.get_key_start_offset(index, node_size);
   extent_len_t offset_end = node.get_item_end_offset(index, node_size);
   if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
@@ -102,8 +102,8 @@ node_range_t fields_free_range_before(
       offset_end -= sizeof(laddr_t);
     }
   }
-  assert(offset_start <= offset_end);
-  assert(offset_end - offset_start < node_size);
+  ceph_assert(offset_start <= offset_end);
+  ceph_assert(offset_end - offset_start < node_size);
   return {offset_start, offset_end};
 }
 
@@ -148,25 +148,25 @@ struct _node_fields_013_t {
   }
   key_get_type get_key(
       index_t index, extent_len_t node_size) const {
-    assert(index < num_keys);
+    ceph_assert(index < num_keys);
     return slots[index].key;
   }
   node_offset_t get_key_start_offset(
       index_t index, extent_len_t node_size) const {
-    assert(index <= num_keys);
+    ceph_assert(index <= num_keys);
     auto offset = HEADER_SIZE + sizeof(SlotType) * index;
-    assert(offset < node_size);
+    ceph_assert(offset < node_size);
     return offset;
   }
   node_offset_t get_item_start_offset(
       index_t index, extent_len_t node_size) const {
-    assert(index < num_keys);
+    ceph_assert(index < num_keys);
     auto offset = slots[index].right_offset;
-    assert(offset < node_size);
+    ceph_assert(offset < node_size);
     return offset;
   }
   const void* p_offset(index_t index) const {
-    assert(index < num_keys);
+    ceph_assert(index < num_keys);
     return &slots[index].right_offset;
   }
   extent_len_t get_item_end_offset(
@@ -242,27 +242,27 @@ struct node_fields_2_t {
   }
   key_get_type get_key(
       index_t index, extent_len_t node_size) const {
-    assert(index < num_keys);
+    ceph_assert(index < num_keys);
     auto item_end_offset = get_item_end_offset(index, node_size);
     const char* p_start = fields_start(*this);
     return key_t(p_start + item_end_offset);
   }
   node_offset_t get_key_start_offset(
       index_t index, extent_len_t node_size) const {
-    assert(index <= num_keys);
+    ceph_assert(index <= num_keys);
     auto offset = HEADER_SIZE + sizeof(node_offset_t) * num_keys;
-    assert(offset < node_size);
+    ceph_assert(offset < node_size);
     return offset;
   }
   node_offset_t get_item_start_offset(
       index_t index, extent_len_t node_size) const {
-    assert(index < num_keys);
+    ceph_assert(index < num_keys);
     auto offset = offsets[index];
-    assert(offset < node_size);
+    ceph_assert(offset < node_size);
     return offset;
   }
   const void* p_offset(index_t index) const {
-    assert(index < num_keys);
+    ceph_assert(index < num_keys);
     return &offsets[index];
   }
   extent_len_t get_item_end_offset(
@@ -340,14 +340,14 @@ struct internal_fields_3_t {
   }
   key_get_type get_key(
       index_t index, extent_len_t node_size) const {
-    assert(index < num_keys);
+    ceph_assert(index < num_keys);
     return keys[index];
   }
   template <node_type_t NODE_TYPE>
   std::enable_if_t<NODE_TYPE == node_type_t::INTERNAL, node_offset_t>
   free_size_before(index_t index, extent_len_t node_size) const {
-    assert(index <= num_keys);
-    assert(num_keys <= get_max_num_keys(node_size));
+    ceph_assert(index <= num_keys);
+    ceph_assert(num_keys <= get_max_num_keys(node_size));
     extent_len_t free = total_size(node_size) - HEADER_SIZE -
                         index * ITEM_SIZE;
     if (is_level_tail() && index == num_keys) {
@@ -360,15 +360,15 @@ struct internal_fields_3_t {
       index_t index, extent_len_t node_size) const {
 #ifndef NDEBUG
     if (is_level_tail()) {
-      assert(index <= num_keys);
+      ceph_assert(index <= num_keys);
     } else {
-      assert(index < num_keys);
+      ceph_assert(index < num_keys);
     }
 #endif
     auto p_addrs = reinterpret_cast<const laddr_packed_t*>(
         &keys[get_num_keys_limit(node_size)]);
     auto ret = p_addrs + index;
-    assert((const char*)ret < fields_start(*this) + node_size);
+    ceph_assert((const char*)ret < fields_start(*this) + node_size);
     return ret;
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -49,7 +49,7 @@ struct MatchHistory {
 
   const std::optional<MatchKindCMP>&
   get_by_stage(match_stage_t stage) const {
-    assert(is_valid_stage(stage));
+    ceph_assert(is_valid_stage(stage));
     if (stage == STAGE_RIGHT) {
       return right_match;
     } else if (stage == STAGE_STRING) {
@@ -66,9 +66,9 @@ struct MatchHistory {
   void set(MatchKindCMP match) {
     static_assert(is_valid_stage(STAGE));
     if constexpr (STAGE < STAGE_TOP) {
-      assert(*get<STAGE + 1>() == MatchKindCMP::EQ);
+      ceph_assert(*get<STAGE + 1>() == MatchKindCMP::EQ);
     }
-    assert(!get<STAGE>().has_value() || *get<STAGE>() != MatchKindCMP::EQ);
+    ceph_assert(!get<STAGE>().has_value() || *get<STAGE>() != MatchKindCMP::EQ);
     const_cast<std::optional<MatchKindCMP>&>(get<STAGE>()) = match;
   }
 
@@ -123,7 +123,7 @@ template <match_stage_t STAGE>
 const bool MatchHistory::is_GT() const {
   static_assert(is_valid_stage(STAGE));
   if constexpr (STAGE < STAGE_TOP) {
-    assert(get<STAGE + 1>() == MatchKindCMP::EQ);
+    ceph_assert(get<STAGE + 1>() == MatchKindCMP::EQ);
   }
   return _check_GT_t<STAGE>::eval(this);
 }
@@ -137,12 +137,12 @@ struct staged_position_t {
     if (index == INDEX_END) {
       return true;
     } else {
-      assert(is_valid_index(index));
+      ceph_assert(is_valid_index(index));
       return false;
     }
   }
   index_t& index_by_stage(match_stage_t stage) {
-    assert(stage <= STAGE);
+    ceph_assert(stage <= STAGE);
     if (STAGE == stage) {
       return index;
     } else {
@@ -155,24 +155,24 @@ struct staged_position_t {
   void assert_next_to(const me_t& prv) const {
 #ifndef NDEBUG
     if (is_end()) {
-      assert(!prv.is_end());
+      ceph_assert(!prv.is_end());
     } else if (index == prv.index) {
-      assert(!nxt.is_end());
+      ceph_assert(!nxt.is_end());
       nxt.assert_next_to(prv.nxt);
     } else if (index == prv.index + 1) {
-      assert(!prv.nxt.is_end());
-      assert(nxt == nxt_t::begin());
+      ceph_assert(!prv.nxt.is_end());
+      ceph_assert(nxt == nxt_t::begin());
     } else {
-      assert(false);
+      ceph_assert(false);
     }
 #endif
   }
 
   me_t& operator-=(const me_t& o) {
-    assert(is_valid_index(o.index));
-    assert(index >= o.index);
+    ceph_assert(is_valid_index(o.index));
+    ceph_assert(index >= o.index);
     if (index != INDEX_END) {
-      assert(is_valid_index(index));
+      ceph_assert(is_valid_index(index));
       index -= o.index;
       if (index == 0) {
         nxt -= o.nxt;
@@ -182,8 +182,8 @@ struct staged_position_t {
   }
 
   me_t& operator+=(const me_t& o) {
-    assert(is_valid_index(index));
-    assert(is_valid_index(o.index));
+    ceph_assert(is_valid_index(index));
+    ceph_assert(is_valid_index(o.index));
     index += o.index;
     nxt += o.nxt;
     return *this;
@@ -216,7 +216,7 @@ struct staged_position_t {
     if (index == INDEX_LAST) {
       return fmt::format("LAST, {}", nxt.fmt_print());
     }
-    assert(is_valid_index(index));
+    ceph_assert(is_valid_index(index));
     return fmt::format("{}, {}", index, nxt.fmt_print());
   }
 };
@@ -228,30 +228,30 @@ struct staged_position_t<STAGE_BOTTOM> {
     if (index == INDEX_END) {
       return true;
     } else {
-      assert(is_valid_index(index));
+      ceph_assert(is_valid_index(index));
       return false;
     }
   }
   index_t& index_by_stage(match_stage_t stage) {
-    assert(stage == STAGE_BOTTOM);
+    ceph_assert(stage == STAGE_BOTTOM);
     return index;
   }
 
   auto operator<=>(const me_t&) const = default;
 
   me_t& operator-=(const me_t& o) {
-    assert(is_valid_index(o.index));
-    assert(index >= o.index);
+    ceph_assert(is_valid_index(o.index));
+    ceph_assert(index >= o.index);
     if (index != INDEX_END) {
-      assert(is_valid_index(index));
+      ceph_assert(is_valid_index(index));
       index -= o.index;
     }
     return *this;
   }
 
   me_t& operator+=(const me_t& o) {
-    assert(is_valid_index(index));
-    assert(is_valid_index(o.index));
+    ceph_assert(is_valid_index(index));
+    ceph_assert(is_valid_index(o.index));
     index += o.index;
     return *this;
   }
@@ -259,9 +259,9 @@ struct staged_position_t<STAGE_BOTTOM> {
   void assert_next_to(const me_t& prv) const {
 #ifndef NDEBUG
     if (is_end()) {
-      assert(!prv.is_end());
+      ceph_assert(!prv.is_end());
     } else {
-      assert(index == prv.index + 1);
+      ceph_assert(index == prv.index + 1);
     }
 #endif
   }
@@ -287,7 +287,7 @@ struct staged_position_t<STAGE_BOTTOM> {
     if (index == INDEX_LAST) {
       return "LAST";
     }
-    assert(is_valid_index(index));
+    ceph_assert(is_valid_index(index));
     return std::to_string(index);
   }
 };
@@ -301,19 +301,19 @@ const staged_position_t<STAGE>& cast_down(const search_position_t& pos) {
   } else if constexpr (STAGE == STAGE_STRING) {
 #ifndef NDEBUG
     if (pos.is_end()) {
-      assert(pos.nxt.is_end());
+      ceph_assert(pos.nxt.is_end());
     } else {
-      assert(pos.index == 0u);
+      ceph_assert(pos.index == 0u);
     }
 #endif
     return pos.nxt;
   } else if constexpr (STAGE == STAGE_RIGHT) {
 #ifndef NDEBUG
     if (pos.is_end()) {
-      assert(pos.nxt.nxt.is_end());
+      ceph_assert(pos.nxt.nxt.is_end());
     } else {
-      assert(pos.index == 0u);
-      assert(pos.nxt.index == 0u);
+      ceph_assert(pos.index == 0u);
+      ceph_assert(pos.nxt.index == 0u);
     }
 #endif
     return pos.nxt.nxt;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/super.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/super.h
@@ -50,7 +50,7 @@ class Super {
   Super& operator=(const Super&) = delete;
   Super& operator=(Super&&) = delete;
   virtual ~Super() {
-    assert(tracked_root_node == nullptr);
+    ceph_assert(tracked_root_node == nullptr);
     tracker.do_untrack_super(t, *this);
   }
 
@@ -58,15 +58,15 @@ class Super {
   virtual void write_root_laddr(context_t, laddr_t) = 0;
 
   void do_track_root(Node& root) {
-    assert(tracked_root_node == nullptr);
+    ceph_assert(tracked_root_node == nullptr);
     tracked_root_node = &root;
   }
   void do_untrack_root(Node& root) {
-    assert(tracked_root_node == &root);
+    ceph_assert(tracked_root_node == &root);
     tracked_root_node = nullptr;
   }
   Node* get_p_root() const {
-    assert(tracked_root_node != nullptr);
+    ceph_assert(tracked_root_node != nullptr);
     return tracked_root_node;
   }
 
@@ -90,18 +90,18 @@ class Super {
  */
 class RootNodeTrackerIsolated final : public RootNodeTracker {
  public:
-  ~RootNodeTrackerIsolated() override { assert(is_clean()); }
+  ~RootNodeTrackerIsolated() override { ceph_assert(is_clean()); }
  protected:
   bool is_clean() const override {
     return tracked_supers.empty();
   }
   void do_track_super(Transaction& t, Super& super) override {
-    assert(tracked_supers.find(&t) == tracked_supers.end());
+    ceph_assert(tracked_supers.find(&t) == tracked_supers.end());
     tracked_supers[&t] = &super;
   }
   void do_untrack_super(Transaction& t, Super& super) override {
     [[maybe_unused]] auto removed = tracked_supers.erase(&t);
-    assert(removed);
+    ceph_assert(removed);
   }
   ::Ref<Node> get_root(Transaction& t) const override;
   std::map<Transaction*, Super*> tracked_supers;
@@ -115,17 +115,17 @@ class RootNodeTrackerIsolated final : public RootNodeTracker {
  */
 class RootNodeTrackerShared final : public RootNodeTracker {
  public:
-  ~RootNodeTrackerShared() override { assert(is_clean()); }
+  ~RootNodeTrackerShared() override { ceph_assert(is_clean()); }
  protected:
   bool is_clean() const override {
     return tracked_super == nullptr;
   }
   void do_track_super(Transaction&, Super& super) override {
-    assert(is_clean());
+    ceph_assert(is_clean());
     tracked_super = &super;
   }
   void do_untrack_super(Transaction&, Super& super) override {
-    assert(tracked_super == &super);
+    ceph_assert(tracked_super == &super);
     tracked_super = nullptr;
   }
   ::Ref<Node> get_root(Transaction&) const override;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -182,7 +182,7 @@ class KVPool {
         } else {
           ns_size = ns_sizes[rd() % ns_sizes.size()];
           oid_size = oid_sizes[rd() % oid_sizes.size()];
-          assert(ns_size && oid_size);
+          ceph_assert(ns_size && oid_size);
         }
         for (index_t k = range0.first; k < range0.second; ++k) {
           kvs.emplace_back(
@@ -226,21 +226,21 @@ class KVPool {
   static ghobject_t make_raw_oid(
       index_t index2, index_t index1, index_t index0,
       size_t ns_size, size_t oid_size) {
-    assert(index1 < 10);
+    ceph_assert(index1 < 10);
     std::ostringstream os_ns;
     std::ostringstream os_oid;
     if (index1 == 0) {
-      assert(!ns_size);
-      assert(!oid_size);
+      ceph_assert(!ns_size);
+      ceph_assert(!oid_size);
     } else {
       os_ns << "ns" << index1;
       auto current_size = (size_t)os_ns.tellp();
-      assert(ns_size >= current_size);
+      ceph_assert(ns_size >= current_size);
       os_ns << std::string(ns_size - current_size, '_');
 
       os_oid << "oid" << index1;
       current_size = (size_t)os_oid.tellp();
-      assert(oid_size >= current_size);
+      ceph_assert(oid_size >= current_size);
       os_oid << std::string(oid_size - current_size, '_');
     }
 
@@ -317,7 +317,7 @@ class TreeBuilder {
       validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
       return tree->find(t, p_kv->key
       ).si_then([cursor, p_kv](auto cursor_) mutable {
-        assert(!cursor_.is_end());
+        ceph_assert(!cursor_.is_end());
         ceph_assert(cursor_.get_ghobj() == p_kv->key);
         ceph_assert(cursor_.value() == cursor.value());
         validate_cursor_from_item(p_kv->key, p_kv->value, cursor_);
@@ -371,7 +371,7 @@ class TreeBuilder {
               return seastar::make_ready_future<seastar::stop_iteration>(
                 seastar::stop_iteration::yes);
             }
-            assert(c_iter != cursors->end());
+            ceph_assert(c_iter != cursors->end());
             auto p_kv = **ref_kv_iter;
             // validate values in tree keep intact
             return tree->find(t, p_kv->key).si_then([&c_iter, ref_kv_iter](auto cursor) {
@@ -416,7 +416,7 @@ class TreeBuilder {
   }
 
   eagain_ifuture<> erase(Transaction& t, std::size_t erase_size) {
-    assert(erase_size <= kvs.size());
+    ceph_assert(erase_size <= kvs.size());
     kvs.shuffle();
     auto erase_end = kvs.random_begin() + erase_size;
     auto ref_kv_iter = seastar::make_lw_shared<iterator_t>();
@@ -487,7 +487,7 @@ class TreeBuilder {
       if constexpr (TRACK) {
         *ref_kv_iter = kvs.begin();
         for (auto& [k, c] : *cursors) {
-          assert(*ref_kv_iter != kvs.end());
+          ceph_assert(*ref_kv_iter != kvs.end());
           auto p_kv = **ref_kv_iter;
           validate_cursor_from_item(p_kv->key, p_kv->value, c);
           ++(*ref_kv_iter);
@@ -514,7 +514,7 @@ class TreeBuilder {
 
   eagain_ifuture<> validate_one(
       Transaction& t, const iterator_t& iter_seq) {
-    assert(iter_seq != kvs.end());
+    ceph_assert(iter_seq != kvs.end());
     auto next_iter = iter_seq + 1;
     auto p_kv = *iter_seq;
     return tree->find(t, p_kv->key

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -18,7 +18,7 @@ ValueDeltaRecorder::get_encoded(NodeExtentMutable& payload_mut)
 {
   ceph::encode(node_delta_op_t::SUBOP_UPDATE_VALUE, encoded);
   node_offset_t offset = payload_mut.get_node_offset();
-  assert(offset > sizeof(value_header_t));
+  ceph_assert(offset > sizeof(value_header_t));
   offset -= sizeof(value_header_t);
   ceph::encode(offset, encoded);
   return encoded;
@@ -33,7 +33,7 @@ Value::~Value() {}
 
 bool Value::is_tracked() const
 {
-  assert(!p_cursor->is_end());
+  ceph_assert(!p_cursor->is_end());
   return p_cursor->is_tracked();
 }
 
@@ -44,12 +44,12 @@ void Value::invalidate()
 
 eagain_ifuture<> Value::extend(Transaction& t, value_size_t extend_size)
 {
-  assert(is_tracked());
+  ceph_assert(is_tracked());
   [[maybe_unused]] auto target_size = get_payload_size() + extend_size;
   return p_cursor->extend_value(get_context(t), extend_size)
 #ifndef NDEBUG
   .si_then([this, target_size] {
-    assert(target_size == get_payload_size());
+    ceph_assert(target_size == get_payload_size());
   })
 #endif
   ;
@@ -57,13 +57,13 @@ eagain_ifuture<> Value::extend(Transaction& t, value_size_t extend_size)
 
 eagain_ifuture<> Value::trim(Transaction& t, value_size_t trim_size)
 {
-  assert(is_tracked());
-  assert(get_payload_size() > trim_size);
+  ceph_assert(is_tracked());
+  ceph_assert(get_payload_size() > trim_size);
   [[maybe_unused]] auto target_size = get_payload_size() - trim_size;
   return p_cursor->trim_value(get_context(t), trim_size)
 #ifndef NDEBUG
   .si_then([this, target_size] {
-    assert(target_size == get_payload_size());
+    ceph_assert(target_size == get_payload_size());
   })
 #endif
   ;
@@ -72,7 +72,7 @@ eagain_ifuture<> Value::trim(Transaction& t, value_size_t trim_size)
 const value_header_t* Value::read_value_header() const
 {
   auto ret = p_cursor->read_value_header(vb.get_header_magic());
-  assert(ret->payload_size <= vb.get_max_value_payload_size());
+  ceph_assert(ret->payload_size <= vb.get_max_value_payload_size());
   return ret;
 }
 
@@ -109,7 +109,7 @@ build_value_recorder_by_type(ceph::bufferlist& encoded,
     ret = nullptr;
     break;
   }
-  assert(!ret || ret->get_header_magic() == magic);
+  ceph_assert(!ret || ret->get_header_magic() == magic);
   return ret;
 }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -197,7 +197,7 @@ class Value {
 
   /// Returns the value payload size.
   value_size_t get_payload_size() const {
-    assert(is_tracked());
+    ceph_assert(is_tracked());
     return read_value_header()->payload_size;
   }
 
@@ -219,13 +219,13 @@ class Value {
   template <typename PayloadT, typename ValueDeltaRecorderT>
   std::pair<NodeExtentMutable&, ValueDeltaRecorderT*>
   prepare_mutate_payload(Transaction& t) {
-    assert(is_tracked());
-    assert(sizeof(PayloadT) <= get_payload_size());
+    ceph_assert(is_tracked());
+    ceph_assert(sizeof(PayloadT) <= get_payload_size());
 
     auto value_mutable = do_prepare_mutate_payload(t);
-    assert(value_mutable.first.get_write() ==
+    ceph_assert(value_mutable.first.get_write() ==
            const_cast<const Value*>(this)->template read_payload<char>());
-    assert(value_mutable.first.get_length() == get_payload_size());
+    ceph_assert(value_mutable.first.get_length() == get_payload_size());
     return {value_mutable.first,
             static_cast<ValueDeltaRecorderT*>(value_mutable.second)};
   }
@@ -233,10 +233,10 @@ class Value {
   /// Get the latest payload pointer for read.
   template <typename PayloadT>
   const PayloadT* read_payload() const {
-    assert(is_tracked());
+    ceph_assert(is_tracked());
     // see Value documentation
     static_assert(alignof(PayloadT) == 1);
-    assert(sizeof(PayloadT) <= get_payload_size());
+    ceph_assert(sizeof(PayloadT) <= get_payload_size());
     return reinterpret_cast<const PayloadT*>(read_value_header()->get_payload());
   }
 
@@ -308,7 +308,7 @@ struct ValueBuilderImpl final : public ValueBuilder {
   build_value_recorder(ceph::bufferlist& encoded) const override {
     std::unique_ptr<ValueDeltaRecorder> ret =
       std::make_unique<typename ValueImpl::Recorder>(encoded);
-    assert(ret->get_header_magic() == get_header_magic());
+    ceph_assert(ret->get_header_magic() == get_header_magic());
     return ret;
   }
 
@@ -316,7 +316,7 @@ struct ValueBuilderImpl final : public ValueBuilder {
 			NodeExtentManager& nm,
                         const ValueBuilder& vb,
                         Ref<tree_cursor_t>& p_cursor) const {
-    assert(vb.get_header_magic() == get_header_magic());
+    ceph_assert(vb.get_header_magic() == get_header_magic());
     return ValueImpl(hobj, nm, vb, p_cursor);
   }
 };

--- a/src/crimson/os/seastore/random_block_manager/avlallocator.cc
+++ b/src/crimson/os/seastore/random_block_manager/avlallocator.cc
@@ -60,11 +60,11 @@ void AvlAllocator::_remove_from_tree(rbm_abs_addr start, rbm_abs_addr size)
     available_size += r->length();
     _extent_size_tree_try_insert(*rs);
   } else if (left_over) {
-    assert(is_aligned(start, block_size));
+    ceph_assert(is_aligned(start, block_size));
     rs->end = start;
     _extent_size_tree_try_insert(*rs);
   } else if (right_over) {
-    assert(is_aligned(end, block_size));
+    ceph_assert(is_aligned(end, block_size));
     rs->start = end;
     _extent_size_tree_try_insert(*rs);
   } else {
@@ -78,7 +78,7 @@ rbm_abs_addr AvlAllocator::find_block(size_t size)
   auto iter = extent_size_tree.lower_bound(
     extent_range_t{base_addr, base_addr + size}, comp);
   for (; iter != extent_size_tree.end(); ++iter) {
-    assert(is_aligned(iter->start, block_size));
+    ceph_assert(is_aligned(iter->start, block_size));
     rbm_abs_addr off = iter->start;
     if (off + size <= iter->end) {
       return off;
@@ -97,7 +97,7 @@ extent_len_t AvlAllocator::find_block(
     max_size = p->end - p->start;
   }
 
-  assert(max_size);
+  ceph_assert(max_size);
   if (max_size <= size) {
     start = p->start;
     return max_size;
@@ -189,12 +189,12 @@ std::optional<interval_set<rbm_abs_addr>> AvlAllocator::alloc_extent(
     return std::nullopt;
   }
 
-  assert(!result.empty());
-  assert(result.num_intervals() == 1);
+  ceph_assert(!result.empty());
+  ceph_assert(result.num_intervals() == 1);
   for (auto p : result) {
     DEBUG("result start: {}, end: {}", p.first, p.first + p.second);
     if (detailed) {
-      assert(!reserved_extent_tracker.contains(p.first, p.second));
+      ceph_assert(!reserved_extent_tracker.contains(p.first, p.second));
       reserved_extent_tracker.insert(p.first, p.second);
     }
   }
@@ -233,11 +233,11 @@ std::optional<interval_set<rbm_abs_addr>> AvlAllocator::alloc_extents(
   
   try_to_alloc_block(size);
 
-  assert(!result.empty());
+  ceph_assert(!result.empty());
   for (auto p : result) {
     DEBUG("result start: {}, end: {}", p.first, p.first + p.second);
     if (detailed) {
-      assert(!reserved_extent_tracker.contains(p.first, p.second));
+      ceph_assert(!reserved_extent_tracker.contains(p.first, p.second));
       reserved_extent_tracker.insert(p.first, p.second);
     }
   }
@@ -246,8 +246,8 @@ std::optional<interval_set<rbm_abs_addr>> AvlAllocator::alloc_extents(
 
 void AvlAllocator::free_extent(rbm_abs_addr addr, size_t size)
 {
-  assert(total_size);
-  assert(total_size > available_size);
+  ceph_assert(total_size);
+  ceph_assert(total_size > available_size);
   _add_to_tree(addr, size);
   if (detailed && reserved_extent_tracker.contains(addr, size)) {
     reserved_extent_tracker.erase(addr, size);

--- a/src/crimson/os/seastore/random_block_manager/avlallocator.h
+++ b/src/crimson/os/seastore/random_block_manager/avlallocator.h
@@ -84,7 +84,7 @@ public:
 
   void close() {
     if (!detailed) {
-      assert(reserved_extent_tracker.size() == 0);
+      ceph_assert(reserved_extent_tracker.size() == 0);
     }
     extent_size_tree.clear();
     extent_tree.clear_and_dispose(dispose_rs{});
@@ -106,7 +106,7 @@ public:
 
   void complete_allocation(rbm_abs_addr start, size_t size) final {
     if (detailed) {
-      assert(reserved_extent_tracker.contains(start, size));
+      ceph_assert(reserved_extent_tracker.contains(start, size));
       reserved_extent_tracker.erase(start, size);
     }
   }

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -19,7 +19,7 @@ namespace crimson::os::seastore {
 device_config_t get_rbm_ephemeral_device_config(
     std::size_t index, std::size_t num_devices)
 {
-  assert(num_devices > index);
+  ceph_assert(num_devices > index);
   magic_t magic = 0xfffa;
   auto type = device_type_t::RANDOM_BLOCK_EPHEMERAL;
   bool is_major_device;
@@ -49,7 +49,7 @@ device_config_t get_rbm_ephemeral_device_config(
 paddr_t BlockRBManager::alloc_extent(size_t size)
 {
   LOG_PREFIX(BlockRBManager::alloc_extent);
-  assert(allocator);
+  ceph_assert(allocator);
   auto alloc = allocator->alloc_extent(size);
   if (!alloc) {
     return P_ADDR_NULL;
@@ -69,7 +69,7 @@ BlockRBManager::allocate_ret_bare
 BlockRBManager::alloc_extents(size_t size)
 {
   LOG_PREFIX(BlockRBManager::alloc_extents);
-  assert(allocator);
+  ceph_assert(allocator);
   auto alloc = allocator->alloc_extents(size);
   if (!alloc) {
     return {};
@@ -96,16 +96,16 @@ BlockRBManager::alloc_extents(size_t size)
 void BlockRBManager::complete_allocation(
     paddr_t paddr, size_t size)
 {
-  assert(allocator);
+  ceph_assert(allocator);
   rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
   allocator->complete_allocation(addr, size);
 }
 
 BlockRBManager::open_ertr::future<> BlockRBManager::open()
 {
-  assert(device);
-  assert(device->get_available_size() > 0);
-  assert(device->get_block_size() > 0);
+  ceph_assert(device);
+  ceph_assert(device->get_available_size() > 0);
+  ceph_assert(device->get_block_size() > 0);
   auto ool_start = get_start_rbm_addr();
   allocator->init(
     ool_start,

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -77,13 +77,13 @@ public:
   write_ertr::future<> write(rbm_abs_addr addr, bufferlist &bl);
 
   device_id_t get_device_id() const final {
-    assert(device);
+    ceph_assert(device);
     return device->get_device_id();
   }
 
   uint64_t get_free_blocks() const final { 
     // TODO: return correct free blocks after block allocator is introduced
-    assert(device);
+    ceph_assert(device);
     return get_size() / get_block_size();
   }
   const seastore_meta_t &get_meta() const final {
@@ -94,17 +94,17 @@ public:
   }
 
   void mark_space_used(paddr_t paddr, size_t len) final {
-    assert(allocator);
+    ceph_assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
-    assert(addr >= get_start_rbm_addr() &&
+    ceph_assert(addr >= get_start_rbm_addr() &&
 	   addr + len <= device->get_shard_end());
     allocator->mark_extent_used(addr, len);
   }
 
   void mark_space_free(paddr_t paddr, size_t len) final {
-    assert(allocator);
+    ceph_assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
-    assert(addr >= get_start_rbm_addr() &&
+    ceph_assert(addr >= get_start_rbm_addr() &&
 	   addr + len <= device->get_shard_end());
     allocator->free_extent(addr, len);
   }
@@ -116,9 +116,9 @@ public:
   }
 
   rbm_extent_state_t get_extent_state(paddr_t paddr, size_t size) final {
-    assert(allocator);
+    ceph_assert(allocator);
     rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
-    assert(addr >= get_start_rbm_addr() &&
+    ceph_assert(addr >= get_start_rbm_addr() &&
 	   addr + size <= device->get_shard_end());
     return allocator->get_extent_state(addr, size);
   }

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -70,7 +70,7 @@ open_ertr::future<> NVMeBlockDevice::open_for_io(
   return seastar::do_for_each(io_device, [=, this](auto &target_device) {
     return seastar::open_file_dma(in_path, mode).then([this](
       auto file) {
-      assert(io_device.size() > stream_index_to_open);
+      ceph_assert(io_device.size() > stream_index_to_open);
       io_device[stream_index_to_open] = std::move(file);
       return seastar::now();
     });
@@ -120,7 +120,7 @@ write_ertr::future<> NVMeBlockDevice::write(
       bptr.length());
   auto length = bptr.length();
 
-  assert((length % super.block_size) == 0);
+  ceph_assert((length % super.block_size) == 0);
   uint16_t supported_stream = stream;
   if (stream >= stream_id_count) {
     supported_stream = WRITE_LIFE_NOT_SET;
@@ -161,7 +161,7 @@ read_ertr::future<> NVMeBlockDevice::read(
   if (length == 0) {
     return read_ertr::now();
   }
-  assert((length % super.block_size) == 0);
+  ceph_assert((length % super.block_size) == 0);
 
   if (is_end_to_end_data_protection()) {
     return nvme_read(offset, length, bptr.c_str());

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -51,7 +51,7 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
 	  ((super.size / shard_num) % super.block_size);
 	shard_infos[i].size = aligned_size;
 	shard_infos[i].start_offset = i * aligned_size;
-	assert(shard_infos[i].size > super.journal_size);
+	ceph_assert(shard_infos[i].size > super.journal_size);
       }
       super.shard_infos = shard_infos;
       super.shard_num = shard_num;
@@ -100,7 +100,7 @@ write_ertr::future<> RBMDevice::write_rbm_superblock()
   encode(super, bl);
   auto iter = bl.begin();
   auto bp = bufferptr(ceph::buffer::create_page_aligned(super.block_size));
-  assert(bl.length() < super.block_size);
+  ceph_assert(bl.length() < super.block_size);
   iter.copy(bl.length(), bp.c_str());
   return write(RBM_START_ADDRESS, bp);
 }
@@ -109,7 +109,7 @@ read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
   rbm_abs_addr addr)
 {
   LOG_PREFIX(RBMDevice::read_rbm_superblock);
-  assert(super.block_size > 0);
+  ceph_assert(super.block_size > 0);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(super.block_size)),
     [this, addr, FNAME](auto &bptr) {
@@ -134,7 +134,7 @@ read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
       bufferlist meta_b_header;
       super_block.crc = 0;
       encode(super_block, meta_b_header);
-      assert(ceph::encoded_sizeof<rbm_superblock_t>(super_block) <
+      ceph_assert(ceph::encoded_sizeof<rbm_superblock_t>(super_block) <
 	  super_block.block_size);
 
       // Do CRC verification only if data protection is not supported.
@@ -169,7 +169,7 @@ RBMDevice::mount_ret RBMDevice::do_shard_mount()
       crimson::ct_error::assert_all{
       "Invalid error stat_device in RBMDevice::do_shard_mount"}
     ).safe_then([this](auto st) {
-      assert(st.block_size > 0);
+      ceph_assert(st.block_size > 0);
       super.block_size = st.block_size;
       return read_rbm_superblock(RBM_START_ADDRESS
       ).safe_then([this](auto s) {

--- a/src/crimson/os/seastore/randomblock_manager_group.h
+++ b/src/crimson/os/seastore/randomblock_manager_group.h
@@ -23,11 +23,11 @@ public:
   }
 
   std::vector<RandomBlockManager*> get_rb_managers() const {
-    assert(device_ids.size());
+    ceph_assert(device_ids.size());
     std::vector<RandomBlockManager*> ret;
     for (auto& device_id : device_ids) {
       auto rb_device = rb_devices[device_id].get();
-      assert(rb_device->get_device_id() == device_id);
+      ceph_assert(rb_device->get_device_id() == device_id);
       ret.emplace_back(rb_device);
     }
     return ret;
@@ -47,18 +47,18 @@ public:
   }
 
   auto get_block_size() const {
-    assert(device_ids.size());
+    ceph_assert(device_ids.size());
     return rb_devices[*device_ids.begin()]->get_block_size();
   }
 
   const seastore_meta_t &get_meta() const {
-    assert(device_ids.size());
+    ceph_assert(device_ids.size());
     return rb_devices[*device_ids.begin()]->get_meta();
   }
 
 private:
   bool has_device(device_id_t id) const {
-    assert(id <= DEVICE_ID_MAX_VALID);
+    ceph_assert(id <= DEVICE_ID_MAX_VALID);
     return device_ids.count(id) >= 1;
   }
 

--- a/src/crimson/os/seastore/record_scanner.cc
+++ b/src/crimson/os/seastore/record_scanner.cc
@@ -76,7 +76,7 @@ RecordScanner::scan_valid_records(
 	      });
 	  });
 	} else {
-	  assert(!cursor.pending_record_groups.empty());
+	  ceph_assert(!cursor.pending_record_groups.empty());
 	  auto &next = cursor.pending_record_groups.front();
 	  return read_validate_data(next.offset, next.header
 	  ).safe_then([this, FNAME, &budget_used, &cursor, &handler, &next](auto valid) {

--- a/src/crimson/os/seastore/record_scanner.h
+++ b/src/crimson/os/seastore/record_scanner.h
@@ -34,7 +34,7 @@ public:
       auto& seg_addr = addr.as_seg_paddr();
       return seg_addr.get_segment_off();
     }
-    assert(addr.is_absolute_random_block());
+    ceph_assert(addr.is_absolute_random_block());
     auto& blk_addr = addr.as_blk_paddr();
     return blk_addr.get_device_off();
   }

--- a/src/crimson/os/seastore/root_block.cc
+++ b/src/crimson/os/seastore/root_block.cc
@@ -21,7 +21,7 @@ void RootBlock::on_replace_prior() {
 	  static_cast<lba::LBAInternalNode*>(prior.lba_root_node)
 	);
       } else {
-	assert(lba_root->range.depth == 1);
+	ceph_assert(lba_root->range.depth == 1);
 	TreeRootLinker<RootBlock, lba::LBALeafNode>::link_root(
 	  this_ref,
 	  static_cast<lba::LBALeafNode*>(prior.lba_root_node)
@@ -41,7 +41,7 @@ void RootBlock::on_replace_prior() {
 	  static_cast<backref::BackrefInternalNode*>(prior.backref_root_node)
 	);
       } else {
-	assert(backref_root->range.depth == 1);
+	ceph_assert(backref_root->range.depth == 1);
 	TreeRootLinker<RootBlock, backref::BackrefLeafNode>::link_root(
 	  this_ref,
 	  static_cast<backref::BackrefLeafNode*>(prior.backref_root_node)

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -74,7 +74,7 @@ struct RootBlock : CachedExtent {
 
   /// overwrites root
   void apply_delta_and_adjust_crc(paddr_t base, const ceph::bufferlist &_bl) final {
-    assert(_bl.length() == sizeof(root_t));
+    ceph_assert(_bl.length() == sizeof(root_t));
     ceph::bufferlist bl = _bl;
     bl.rebuild();
     root = *reinterpret_cast<const root_t*>(bl.front().c_str());

--- a/src/crimson/os/seastore/root_meta.h
+++ b/src/crimson/os/seastore/root_meta.h
@@ -40,7 +40,7 @@ struct RootMetaBlock : LogicalChildNode {
   /// overwrites root
   void apply_delta(const ceph::bufferlist &_bl) final
   {
-    assert(_bl.length() == MAX_META_LENGTH);
+    ceph_assert(_bl.length() == MAX_META_LENGTH);
     ceph::bufferlist bl = _bl;
     bl.rebuild();
     get_bptr().copy_in(0, MAX_META_LENGTH, bl.front().c_str());

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -219,7 +219,7 @@ seastar::future<> SeaStore::start()
   using crimson::common::get_conf;
   std::string type = get_conf<std::string>("seastore_main_device_type");
   device_type_t d_type = string_to_device_type(type);
-  assert(d_type == device_type_t::SSD ||
+  ceph_assert(d_type == device_type_t::SSD ||
          d_type == device_type_t::RANDOM_BLOCK_SSD);
 
   ceph_assert(root != "");
@@ -309,7 +309,7 @@ SeaStore::mount_ertr::future<> SeaStore::mount()
 	    ceph_assert(sec_dev->get_sharded_device().get_block_size()
 			>= laddr_t::UNIT_SIZE);
             boost::ignore_unused(magic);  // avoid clang warning;
-            assert(sec_dev->get_sharded_device().get_magic() == magic);
+            ceph_assert(sec_dev->get_sharded_device().get_magic() == magic);
             secondaries.emplace_back(std::move(sec_dev));
           });
         }).safe_then([this] {
@@ -442,7 +442,7 @@ SeaStore::Shard::mkfs_managers()
       "Invalid error in Shard::mkfs_managers"
     }
   ).finally([this] {
-    assert(shard_stats.pending_io_num);
+    ceph_assert(shard_stats.pending_io_num);
     --(shard_stats.pending_io_num);
     // XXX: it's wrong to assume no failure
     --(shard_stats.processing_postlock_io_num);
@@ -566,7 +566,7 @@ SeaStore::mkfs_ertr::future<> SeaStore::mkfs(uuid_d new_osd_fsid)
         return fut.then([this, &sds, new_osd_fsid] {
           device_id_t id = 0;
           device_type_t d_type = device->get_device_type();
-          assert(d_type == device_type_t::SSD ||
+          ceph_assert(d_type == device_type_t::SSD ||
             d_type == device_type_t::RANDOM_BLOCK_SSD);
           if (d_type == device_type_t::RANDOM_BLOCK_SSD) {
             id = static_cast<device_id_t>(DEVICE_ID_RANDOM_BLOCK_MIN);
@@ -979,11 +979,11 @@ SeaStore::Shard::list_objects(CollectionRef ch,
 		    next_objects.begin(),
 		    next_objects.end());
 		  std::get<1>(ret) = std::get<1>(_ret);
-		  assert(limit >= next_objects.size());
+		  ceph_assert(limit >= next_objects.size());
 		  limit -= next_objects.size();
 		  DEBUGT("got {} objects, left limit {}",
 		    t, next_objects.size(), limit);
-		  assert(limit == 0 ||
+		  ceph_assert(limit == 0 ||
 			 std::get<1>(ret) == pend ||
 			 std::get<1>(ret) == ghobject_t::get_max());
 		  if (last && std::get<1>(ret) == pend) {
@@ -1013,7 +1013,7 @@ SeaStore::Shard::list_objects(CollectionRef ch,
       }
     );
   }).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1097,7 +1097,7 @@ SeaStore::Shard::list_collections()
       "Invalid error in SeaStoreS::list_collections"
     }
   ).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1159,7 +1159,7 @@ SeaStore::Shard::read(
     [this, offset, len, op_flags](auto &t, auto &onode) {
     return _read(t, onode, offset, len, op_flags);
   }).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1191,7 +1191,7 @@ SeaStore::Shard::exists(
     }),
     crimson::ct_error::assert_all{"unexpected error"}
   ).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1274,7 +1274,7 @@ SeaStore::Shard::get_attr(
       "EIO when getting attrs"},
     crimson::ct_error::pass_further_all{}
   ).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1329,7 +1329,7 @@ SeaStore::Shard::get_attrs(
       "EIO when getting attrs"},
     crimson::ct_error::pass_further_all{}
   ).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1373,7 +1373,7 @@ seastar::future<struct stat> SeaStore::Shard::stat(
       "Invalid error in SeaStoreS::stat"
     }
   ).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1421,7 +1421,7 @@ SeaStore::Shard::omap_get_values(
     return omaptree_get_values(
       t, std::move(root), keys);
   }).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1449,7 +1449,7 @@ SeaStore::Shard::omap_get_values(
     return omaptree_get_values(
       t, std::move(root), start);
   }).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1511,7 +1511,7 @@ SeaStore::Shard::fiemap(
     [this, off, len](auto &t, auto &onode) {
     return _fiemap(t, onode, off, len);
   }).finally([this] {
-    assert(shard_stats.pending_read_num);
+    ceph_assert(shard_stats.pending_read_num);
     --(shard_stats.pending_read_num);
   });
 }
@@ -1592,7 +1592,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
       });
     }
   ).finally([this] {
-    assert(shard_stats.pending_io_num);
+    ceph_assert(shard_stats.pending_io_num);
     --(shard_stats.pending_io_num);
     // XXX: it's wrong to assume no failure
     --(shard_stats.processing_postlock_io_num);
@@ -1615,7 +1615,7 @@ seastar::future<> SeaStore::Shard::flush(CollectionRef ch)
       });
     }
   ).finally([this] {
-    assert(shard_stats.pending_flush_num);
+    ceph_assert(shard_stats.pending_flush_num);
     --(shard_stats.pending_flush_num);
   });
 }
@@ -1683,7 +1683,7 @@ SeaStore::Shard::_do_transaction_step(
   return fut.si_then([&, op, this, FNAME](auto get_onode) {
     OnodeRef& onode = onodes[op->oid];
     if (!onode) {
-      assert(get_onode);
+      ceph_assert(get_onode);
       onode = get_onode;
     }
     OnodeRef& d_onode = onodes[op->dest_oid];
@@ -1697,8 +1697,8 @@ SeaStore::Shard::_do_transaction_step(
       //      support parallel extents loading
       return onode_manager->get_or_create_onode(*ctx.transaction, dest_oid
       ).si_then([&d_onode](auto dest_onode) {
-	assert(dest_onode);
-	assert(!d_onode);
+	ceph_assert(dest_onode);
+	ceph_assert(!d_onode);
 	d_onode = dest_onode;
 	return seastar::now();
       });
@@ -1708,7 +1708,7 @@ SeaStore::Shard::_do_transaction_step(
   }).si_then([&ctx, &i, &onodes, op, this, FNAME]() -> tm_ret {
     const ghobject_t& oid = i.get_oid(op->oid);
     OnodeRef& onode = onodes[op->oid];
-    assert(onode);
+    ceph_assert(onode);
     try {
       switch (op->op) {
       case Transaction::OP_REMOVE:
@@ -2354,7 +2354,7 @@ seastar::future<> SeaStore::Shard::write_meta(
   }).handle_error(
     crimson::ct_error::assert_all{"Invalid error in SeaStoreS::write_meta"}
   ).finally([this] {
-    assert(shard_stats.pending_io_num);
+    ceph_assert(shard_stats.pending_io_num);
     --(shard_stats.pending_io_num);
     // XXX: it's wrong to assume no failure,
     // but failure leads to fatal error
@@ -2631,7 +2631,7 @@ SeaStore::Shard::omaptree_do_clear(
   Transaction& t,
   omap_root_t&& root)
 {
-  assert(!root.is_null());
+  ceph_assert(!root.is_null());
   return seastar::do_with(
     BtreeOMapManager(*transaction_manager),
     std::move(root),
@@ -2639,7 +2639,7 @@ SeaStore::Shard::omaptree_do_clear(
   {
     return omap_manager.omap_clear(root, t
     ).si_then([&root] {
-      assert(root.is_null());
+      ceph_assert(root.is_null());
       return root;
     });
   });
@@ -2668,13 +2668,13 @@ void omaptree_update_root(
   omap_root_t& root,
   Onode& onode)
 {
-  assert(root.must_update());
+  ceph_assert(root.must_update());
   if (root.get_type() == omap_type_t::OMAP) {
     onode.update_omap_root(t, root);
   } else if (root.get_type() == omap_type_t::XATTR) {
     onode.update_xattr_root(t, root);
   } else {
-    assert(root.get_type() == omap_type_t::LOG);
+    ceph_assert(root.get_type() == omap_type_t::LOG);
     onode.update_log_root(t, root);
   }
 }
@@ -2693,8 +2693,8 @@ SeaStore::Shard::omaptree_clear(
   DEBUGT("{} ...", t, root.get_type());
   return omaptree_do_clear(t, std::move(root)
   ).si_then([&t, &onode, FNAME](auto root) {
-    assert(root.is_null());
-    assert(root.must_update());
+    ceph_assert(root.is_null());
+    ceph_assert(root.must_update());
     omaptree_update_root(t, root, onode);
     DEBUGT("{} done", t, root.get_type());
   });
@@ -2722,7 +2722,7 @@ SeaStore::Shard::omaptree_clone(
 	auto &attrs = std::get<1>(p);
 	if (attrs.empty()) {
 	  DEBUGT("{} list got 0 values, all complete", t, type);
-	  assert(complete);
+	  ceph_assert(complete);
 	  return base_iertr::make_ready_future<
 	    seastar::stop_iteration>(
 	      seastar::stop_iteration::yes);
@@ -2769,7 +2769,7 @@ SeaStore::Shard::omaptree_set_keys(
     [this, &t, &onode, kvs=std::move(kvs)]
     (auto &omap_manager, auto &root) mutable
   {
-    assert(root.get_type() < omap_type_t::NONE);
+    ceph_assert(root.get_type() < omap_type_t::NONE);
     base_iertr::future<> maybe_create_root = base_iertr::now();
     if (root.is_null()) {
       maybe_create_root = omaptree_initialize(

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -258,7 +258,7 @@ public:
       op_type_t op_type,
       F &&f) {
       // The below repeat_io_num requires MUTATE
-      assert(src == Transaction::src_t::MUTATE);
+      ceph_assert(src == Transaction::src_t::MUTATE);
       return seastar::do_with(
         internal_context_t(
           ch, std::move(t),
@@ -266,20 +266,20 @@ public:
 	    src, tname, t.get_fadvise_flags())),
         std::forward<F>(f),
         [this, op_type](auto &ctx, auto &f) {
-        assert(shard_stats.starting_io_num);
+        ceph_assert(shard_stats.starting_io_num);
         --(shard_stats.starting_io_num);
         ++(shard_stats.waiting_collock_io_num);
 
 	return ctx.transaction->get_handle().take_collection_lock(
 	  static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
 	).then([this] {
-	  assert(shard_stats.waiting_collock_io_num);
+	  ceph_assert(shard_stats.waiting_collock_io_num);
 	  --(shard_stats.waiting_collock_io_num);
 	  ++(shard_stats.waiting_throttler_io_num);
 
 	  return throttler.get(1);
 	}).then([&, this] {
-	  assert(shard_stats.waiting_throttler_io_num);
+	  ceph_assert(shard_stats.waiting_throttler_io_num);
 	  --(shard_stats.waiting_throttler_io_num);
 	  ++(shard_stats.processing_inlock_io_num);
 
@@ -319,7 +319,7 @@ public:
         ](auto &oid, auto &ret, auto &f)
       {
         return repeat_eagain([&, this, ch, src, tname, cache_hint_flags] {
-          assert(src == Transaction::src_t::READ);
+          ceph_assert(src == Transaction::src_t::READ);
           ++(shard_stats.repeat_read_num);
 
           return transaction_manager->with_transaction_intr(
@@ -452,7 +452,7 @@ public:
 
     seastar::metrics::histogram& get_latency(
       op_type_t op_type) {
-      assert(static_cast<std::size_t>(op_type) < stats.op_lat.size());
+      ceph_assert(static_cast<std::size_t>(op_type) < stats.op_lat.size());
       return stats.op_lat[static_cast<std::size_t>(op_type)];
     }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -171,7 +171,7 @@ public:
 
   segment_id_t(internal_segment_id_t _segment)
     : segment(_segment) {
-    assert(device_id_to_paddr_type(device_id()) == paddr_types_t::SEGMENT);
+    ceph_assert(device_id_to_paddr_type(device_id()) == paddr_types_t::SEGMENT);
   }
 
   [[gnu::always_inline]]
@@ -299,11 +299,11 @@ public:
   }
 
   T& operator[](segment_id_t id) {
-    assert(id.device_segment_id() < device_to_segments[id.device_id()].size());
+    ceph_assert(id.device_segment_id() < device_to_segments[id.device_id()].size());
     return device_to_segments[id.device_id()][id.device_segment_id()];
   }
   const T& operator[](segment_id_t id) const {
-    assert(id.device_segment_id() < device_to_segments[id.device_id()].size());
+    ceph_assert(id.device_segment_id() < device_to_segments[id.device_id()].size());
     return device_to_segments[id.device_id()][id.device_segment_id()];
   }
 
@@ -332,7 +332,7 @@ public:
 
   auto device_begin(device_id_t id) {
     auto ret = iterator<false>::lower_bound(*this, id, 0);
-    assert(ret->first.device_id() == id);
+    ceph_assert(ret->first.device_id() == id);
     return ret;
   }
   auto device_end(device_id_t id) {
@@ -370,7 +370,7 @@ private:
     }
 
     void find_valid() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       auto &device_vec = parent.device_to_segments[device_id];
       if (device_vec.size() == 0 ||
 	  device_segment_id == device_vec.size()) {
@@ -415,7 +415,7 @@ private:
     }
 
     iterator<is_const>& operator++() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       ++device_segment_id;
       find_valid();
       return *this;
@@ -432,12 +432,12 @@ private:
 
     template <bool c = is_const, std::enable_if_t<c, int> = 0>
     const std::pair<const segment_id_t, const T&> *operator->() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return &*current;
     }
     template <bool c = is_const, std::enable_if_t<!c, int> = 0>
     std::pair<const segment_id_t, T&> *operator->() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return &*current;
     }
 
@@ -445,7 +445,7 @@ private:
       is_const, const std::pair<const segment_id_t, const T&>&,
       std::pair<const segment_id_t, T&>&>;
     reference operator*() {
-      assert(!is_end());
+      ceph_assert(!is_end());
       return *current;
     }
   };
@@ -553,14 +553,14 @@ public:
   static paddr_t make_blk_paddr(
     device_id_t device,
     device_off_t offset) {
-    assert(device_id_to_paddr_type(device) == paddr_types_t::RANDOM_BLOCK);
+    ceph_assert(device_id_to_paddr_type(device) == paddr_types_t::RANDOM_BLOCK);
     return paddr_t(device, offset);
   }
 
   static paddr_t make_res_paddr(
     device_id_t device,
     device_off_t offset) {
-    assert(device_id_to_paddr_type(device) == paddr_types_t::RESERVED);
+    ceph_assert(device_id_to_paddr_type(device) == paddr_types_t::RESERVED);
     return paddr_t(device, offset);
   }
 
@@ -578,13 +578,13 @@ public:
 
   paddr_t add_block_relative(paddr_t o) const {
     // special version mainly for documentation purposes
-    assert(o.is_block_relative());
+    ceph_assert(o.is_block_relative());
     return add_relative(o);
   }
 
   paddr_t add_record_relative(paddr_t o) const {
     // special version mainly for documentation purposes
-    assert(o.is_record_relative());
+    ceph_assert(o.is_record_relative());
     return add_relative(o);
   }
 
@@ -597,7 +597,7 @@ public:
    * base must be either absolute or record_relative.
    */
   paddr_t maybe_relative_to(paddr_t base) const {
-    assert(!base.is_block_relative());
+    ceph_assert(!base.is_block_relative());
     if (is_block_relative()) {
       return base.add_block_relative(*this);
     } else {
@@ -715,9 +715,9 @@ private:
   paddr_t(device_id_t d_id, device_off_t offset)
     : paddr_t((static_cast<internal_paddr_t>(d_id) << DEVICE_OFF_BITS) |
               encode_device_off(offset)) {
-    assert(offset >= DEVICE_OFF_MIN);
-    assert(offset <= DEVICE_OFF_MAX);
-    assert(!is_absolute_segmented());
+    ceph_assert(offset >= DEVICE_OFF_MIN);
+    ceph_assert(offset <= DEVICE_OFF_MAX);
+    ceph_assert(!is_absolute_segmented());
   }
 
   paddr_t(internal_paddr_t val);
@@ -754,15 +754,15 @@ struct seg_paddr_t : public paddr_t {
   }
 
   void set_segment_off(segment_off_t off) {
-    assert(off >= 0);
+    ceph_assert(off >= 0);
     internal_paddr = (internal_paddr & SEGMENT_ID_MASK);
     internal_paddr |= static_cast<u_segment_off_t>(off);
   }
 
   paddr_t add_offset(device_off_t o) const {
     device_off_t off = get_segment_off() + o;
-    assert(off >= 0);
-    assert(off <= SEGMENT_OFF_MAX);
+    ceph_assert(off >= 0);
+    ceph_assert(off <= SEGMENT_OFF_MAX);
     return paddr_t::make_seg_paddr(
         get_segment_id(), static_cast<segment_off_t>(off));
   }
@@ -779,15 +779,15 @@ struct blk_paddr_t : public paddr_t {
   }
 
   void set_device_off(device_off_t off) {
-    assert(off >= 0);
-    assert(off <= DEVICE_OFF_MAX);
+    ceph_assert(off >= 0);
+    ceph_assert(off <= DEVICE_OFF_MAX);
     internal_paddr = (internal_paddr & DEVICE_ID_MASK);
     internal_paddr |= encode_device_off(off);
   }
 
   paddr_t add_offset(device_off_t o) const {
-    assert(o >= DEVICE_OFF_MIN);
-    assert(o <= DEVICE_OFF_MAX);
+    ceph_assert(o >= DEVICE_OFF_MIN);
+    ceph_assert(o <= DEVICE_OFF_MAX);
     auto off = get_device_off() + o;
     return paddr_t::make_blk_paddr(get_device_id(), off);
   }
@@ -804,23 +804,23 @@ struct res_paddr_t : public paddr_t {
   }
 
   void set_device_off(device_off_t off) {
-    assert(has_device_off(get_device_id()));
-    assert(off >= DEVICE_OFF_MIN);
-    assert(off <= DEVICE_OFF_MAX);
+    ceph_assert(has_device_off(get_device_id()));
+    ceph_assert(off >= DEVICE_OFF_MIN);
+    ceph_assert(off <= DEVICE_OFF_MAX);
     internal_paddr = (internal_paddr & DEVICE_ID_MASK);
     internal_paddr |= encode_device_off(off);
   }
 
   paddr_t add_offset(device_off_t o) const {
-    assert(has_device_off(get_device_id()));
-    assert(o >= DEVICE_OFF_MIN);
-    assert(o <= DEVICE_OFF_MAX);
+    ceph_assert(has_device_off(get_device_id()));
+    ceph_assert(o >= DEVICE_OFF_MIN);
+    ceph_assert(o <= DEVICE_OFF_MAX);
     auto off = get_device_off() + o;
     return paddr_t::make_res_paddr(get_device_id(), off);
   }
 
   paddr_t block_relative_to(const res_paddr_t &rhs) const {
-    assert(rhs.is_record_relative() && is_record_relative());
+    ceph_assert(rhs.is_record_relative() && is_record_relative());
     auto off = get_device_off() - rhs.get_device_off();
     return paddr_t::make_res_paddr(DEVICE_ID_BLOCK_RELATIVE, off);
   }
@@ -847,32 +847,32 @@ inline paddr_t make_delayed_temp_paddr(device_off_t off) {
 }
 
 inline const seg_paddr_t& paddr_t::as_seg_paddr() const {
-  assert(is_absolute_segmented());
+  ceph_assert(is_absolute_segmented());
   return *static_cast<const seg_paddr_t*>(this);
 }
 
 inline seg_paddr_t& paddr_t::as_seg_paddr() {
-  assert(is_absolute_segmented());
+  ceph_assert(is_absolute_segmented());
   return *static_cast<seg_paddr_t*>(this);
 }
 
 inline const blk_paddr_t& paddr_t::as_blk_paddr() const {
-  assert(is_absolute_random_block());
+  ceph_assert(is_absolute_random_block());
   return *static_cast<const blk_paddr_t*>(this);
 }
 
 inline blk_paddr_t& paddr_t::as_blk_paddr() {
-  assert(is_absolute_random_block());
+  ceph_assert(is_absolute_random_block());
   return *static_cast<blk_paddr_t*>(this);
 }
 
 inline const res_paddr_t& paddr_t::as_res_paddr() const {
-  assert(get_addr_type() == paddr_types_t::RESERVED);
+  ceph_assert(get_addr_type() == paddr_types_t::RESERVED);
   return *static_cast<const res_paddr_t*>(this);
 }
 
 inline res_paddr_t& paddr_t::as_res_paddr() {
-  assert(get_addr_type() == paddr_types_t::RESERVED);
+  ceph_assert(get_addr_type() == paddr_types_t::RESERVED);
   return *static_cast<res_paddr_t*>(this);
 }
 
@@ -880,13 +880,13 @@ inline paddr_t::paddr_t(internal_paddr_t val) : internal_paddr(val) {
 #ifndef NDEBUG
   auto type = get_addr_type();
   if (type == paddr_types_t::SEGMENT) {
-    assert(as_seg_paddr().get_segment_off() >= 0);
+    ceph_assert(as_seg_paddr().get_segment_off() >= 0);
   } else if (type == paddr_types_t::RANDOM_BLOCK) {
-    assert(as_blk_paddr().get_device_off() >= 0);
+    ceph_assert(as_blk_paddr().get_device_off() >= 0);
   } else {
-    assert(type == paddr_types_t::RESERVED);
+    ceph_assert(type == paddr_types_t::RESERVED);
     if (!has_device_off(get_device_id())) {
-      assert(as_res_paddr().get_device_off() == 0);
+      ceph_assert(as_res_paddr().get_device_off() == 0);
     }
   }
 #endif
@@ -906,7 +906,7 @@ inline paddr_t paddr_t::add_offset(device_off_t o) const {
 }
 
 inline paddr_t paddr_t::add_relative(paddr_t o) const {
-  assert(o.is_relative());
+  ceph_assert(o.is_relative());
   auto &res_o = o.as_res_paddr();
   return add_offset(res_o.get_device_off());
 }
@@ -969,7 +969,7 @@ enum class backend_type_t {
 std::ostream& operator<<(std::ostream& out, backend_type_t);
 
 constexpr backend_type_t get_default_backend_of_device(device_type_t dtype) {
-  assert(dtype != device_type_t::NONE &&
+  ceph_assert(dtype != device_type_t::NONE &&
 	 dtype != device_type_t::NUM_TYPES);
   if (dtype >= device_type_t::HDD &&
       dtype <= device_type_t::EPHEMERAL_MAIN) {
@@ -1094,7 +1094,7 @@ public:
   static constexpr unsigned UNIT_MASK = UNIT_SIZE - 1;
 
   static laddr_t from_byte_offset(Unsigned value) {
-    assert((value & UNIT_MASK) == 0);
+    ceph_assert((value & UNIT_MASK) == 0);
     return laddr_t(value >> UNIT_SHIFT);
   }
 
@@ -1110,7 +1110,7 @@ public:
     p += sizeof(Unsigned);
   }
   void decode(::ceph::buffer::ptr::const_iterator& p) {
-    assert(static_cast<std::size_t>(p.get_end() - p.get_pos()) >= sizeof(Unsigned));
+    ceph_assert(static_cast<std::size_t>(p.get_end() - p.get_pos()) >= sizeof(Unsigned));
     memcpy((char *)&value, p.get_pos_add(sizeof(Unsigned)), sizeof(Unsigned));
   }
 
@@ -1122,51 +1122,51 @@ public:
 	: base(base.value), offset(0) {}
     laddr_offset_t(laddr_t base, extent_len_t offset)
 	: base(base.value), offset(offset) {
-      assert(offset < laddr_t::UNIT_SIZE);
+      ceph_assert(offset < laddr_t::UNIT_SIZE);
     }
 
     laddr_t get_roundup_laddr() const {
       if (offset == 0) {
 	return laddr_t(base);
       } else {
-	assert(offset < laddr_t::UNIT_SIZE);
+	ceph_assert(offset < laddr_t::UNIT_SIZE);
 	return laddr_t(base + 1);
       }
     }
     laddr_t get_aligned_laddr() const { return laddr_t(base); }
     extent_len_t get_offset() const {
-      assert(offset < laddr_t::UNIT_SIZE);
+      ceph_assert(offset < laddr_t::UNIT_SIZE);
       return offset;
     }
     laddr_t checked_to_laddr() const {
-      assert(offset == 0);
+      ceph_assert(offset == 0);
       return laddr_t(base);
     }
 
     template<std::unsigned_integral U>
     U get_byte_distance(const laddr_t &l) const {
-      assert(offset < UNIT_SIZE);
+      ceph_assert(offset < UNIT_SIZE);
       if (base >= l.value) {
 	Unsigned udiff = base - l.value;
-	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	ceph_assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
 	return (static_cast<U>(udiff) << UNIT_SHIFT) + offset;
       } else { // base < l.value
 	Unsigned udiff = l.value - base;
-	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	ceph_assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
 	return (static_cast<U>(udiff) << UNIT_SHIFT) - offset;
       }
     }
 
     template<std::unsigned_integral U>
     U get_byte_distance(const laddr_offset_t &l) const {
-      assert(offset < UNIT_SIZE);
+      ceph_assert(offset < UNIT_SIZE);
       if (*this >= l) {
 	Unsigned udiff = base - l.base;
-	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	ceph_assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
 	return ((static_cast<U>(udiff) << UNIT_SHIFT) + offset) - l.offset;
       } else { // *this < l
 	Unsigned udiff = l.base - base;
-	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	ceph_assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
 	return ((static_cast<U>(udiff) << UNIT_SHIFT) + l.offset) - offset;
       }
     }
@@ -1209,11 +1209,11 @@ public:
   U get_byte_distance(const laddr_offset_t &l) const {
     if (value <= l.base) {
       Unsigned udiff = l.base - value;
-      assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+      ceph_assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
       return (static_cast<U>(udiff) << UNIT_SHIFT) + l.offset;
     } else { // value > l.base
       Unsigned udiff = value - l.base;
-      assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+      ceph_assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
       return (static_cast<U>(udiff) << UNIT_SHIFT) - l.offset;
     }
   }
@@ -1223,7 +1223,7 @@ public:
     Unsigned diff = value > l.value
 	? value - l.value
 	: l.value - value;
-    assert(diff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+    ceph_assert(diff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
     return static_cast<U>(diff) << UNIT_SHIFT;
   }
 
@@ -1253,7 +1253,7 @@ public:
 				  const loffset_t &offset) {
     auto base = laddr;
     base.value += offset >> laddr_t::UNIT_SHIFT;
-    assert(base.value >= laddr.value);
+    ceph_assert(base.value >= laddr.value);
     return laddr_offset_t(base, offset & laddr_t::UNIT_MASK);
   }
   friend laddr_offset_t operator+(const loffset_t &offset,
@@ -1265,7 +1265,7 @@ public:
     auto base = laddr;
     auto diff = (offset + laddr_t::UNIT_SIZE - 1) >> laddr_t::UNIT_SHIFT;
     base.value -= diff;
-    assert(base.value <= laddr.value);
+    ceph_assert(base.value <= laddr.value);
     offset = (diff << laddr_t::UNIT_SHIFT) - offset;
     return laddr_offset_t(base, offset);
   }
@@ -1342,12 +1342,12 @@ struct pladdr_t {
   bool operator==(const pladdr_t &) const = default;
 
   paddr_t get_paddr() const {
-    assert(pladdr.index() == 1);
+    ceph_assert(pladdr.index() == 1);
     return paddr_t(std::get<1>(pladdr));
   }
 
   laddr_t get_laddr() const {
-    assert(pladdr.index() == 0);
+    ceph_assert(pladdr.index() == 0);
     return laddr_t(std::get<0>(pladdr));
   }
 
@@ -1383,7 +1383,7 @@ struct __attribute__((packed)) pladdr_le_t {
     if (addr_type == addr_type_t::LADDR) {
       return pladdr_t(laddr_t(pladdr));
     } else {
-      assert(addr_type == addr_type_t::PADDR);
+      ceph_assert(addr_type == addr_type_t::PADDR);
       return pladdr_t(paddr_t(pladdr));
     }
   }
@@ -1476,11 +1476,11 @@ constexpr bool is_logical_type(extent_types_t type) {
   if ((type >= extent_types_t::ROOT_META &&
        type <= extent_types_t::OBJECT_DATA_BLOCK) ||
       type == extent_types_t::TEST_BLOCK) {
-    assert(is_logical_metadata_type(type) ||
+    ceph_assert(is_logical_metadata_type(type) ||
            is_data_type(type));
     return true;
   } else {
-    assert(!is_logical_metadata_type(type) &&
+    ceph_assert(!is_logical_metadata_type(type) &&
            !is_data_type(type));
     return false;
   }
@@ -1513,12 +1513,12 @@ constexpr bool is_physical_type(extent_types_t type) {
   if (type <= extent_types_t::DINK_LADDR_LEAF ||
       (type >= extent_types_t::TEST_BLOCK_PHYSICAL &&
        type <= extent_types_t::BACKREF_LEAF)) {
-    assert(is_root_type(type) ||
+    ceph_assert(is_root_type(type) ||
            is_lba_backref_node(type) ||
            type == extent_types_t::TEST_BLOCK_PHYSICAL);
     return true;
   } else {
-    assert(!is_root_type(type) &&
+    ceph_assert(!is_root_type(type) &&
            !is_lba_backref_node(type) &&
            type != extent_types_t::TEST_BLOCK_PHYSICAL);
     return false;
@@ -1530,12 +1530,12 @@ constexpr bool is_backref_mapped_type(extent_types_t type) {
        type <= extent_types_t::OBJECT_DATA_BLOCK) ||
       type == extent_types_t::TEST_BLOCK ||
       type == extent_types_t::TEST_BLOCK_PHYSICAL) {
-    assert(is_logical_type(type) ||
+    ceph_assert(is_logical_type(type) ||
 	   is_lba_node(type) ||
 	   type == extent_types_t::TEST_BLOCK_PHYSICAL);
     return true;
   } else {
-    assert(!is_logical_type(type) &&
+    ceph_assert(!is_logical_type(type) &&
 	   !is_lba_node(type) &&
 	   type != extent_types_t::TEST_BLOCK_PHYSICAL);
     return false;
@@ -1546,11 +1546,11 @@ constexpr bool is_real_type(extent_types_t type) {
   if (type <= extent_types_t::OBJECT_DATA_BLOCK ||
       (type >= extent_types_t::TEST_BLOCK &&
        type <= extent_types_t::BACKREF_LEAF)) {
-    assert(is_logical_type(type) ||
+    ceph_assert(is_logical_type(type) ||
            is_physical_type(type));
     return true;
   } else {
-    assert(!is_logical_type(type) &&
+    ceph_assert(!is_logical_type(type) &&
            !is_physical_type(type));
     return false;
   }
@@ -1669,10 +1669,10 @@ std::ostream &operator<<(std::ostream &out, mod_time_point_printer_t tp);
 constexpr sea_time_point
 get_average_time(const sea_time_point& t1, std::size_t n1,
                  const sea_time_point& t2, std::size_t n2) {
-  assert(t1 != NULL_TIME);
-  assert(t2 != NULL_TIME);
+  ceph_assert(t1 != NULL_TIME);
+  ceph_assert(t2 != NULL_TIME);
   auto new_size = n1 + n2;
-  assert(new_size > 0);
+  ceph_assert(new_size > 0);
   auto c1 = t1.time_since_epoch().count();
   auto c2 = t2.time_since_epoch().count();
   auto c_ret = c1 / new_size * n1 + c2 / new_size * n2;
@@ -2046,7 +2046,7 @@ struct alloc_blk_t {
     extent_len_t len,
     extent_types_t type)
     : paddr(paddr), laddr(laddr), len(len), type(type) {
-    assert(len > 0);
+    ceph_assert(len > 0);
   }
 
   explicit alloc_blk_t() = default;
@@ -2069,8 +2069,8 @@ struct alloc_blk_t {
       const laddr_t& laddr,
       extent_len_t len,
       extent_types_t type) {
-    assert(is_backref_mapped_type(type));
-    assert(laddr != L_ADDR_NULL);
+    ceph_assert(is_backref_mapped_type(type));
+    ceph_assert(laddr != L_ADDR_NULL);
     return alloc_blk_t(paddr, laddr, len, type);
   }
 
@@ -2078,7 +2078,7 @@ struct alloc_blk_t {
       const paddr_t& paddr,
       extent_len_t len,
       extent_types_t type) {
-    assert(is_backref_mapped_type(type) ||
+    ceph_assert(is_backref_mapped_type(type) ||
 	   is_retired_placeholder_type(type));
     return alloc_blk_t(paddr, L_ADDR_NULL, len, type);
   }
@@ -2286,7 +2286,7 @@ struct record_t {
   record_t(record_type_t r_type,
            transaction_type_t t_type)
   : trans_type{t_type} {
-    assert(r_type != RECORD_TYPE_NULL);
+    ceph_assert(r_type != RECORD_TYPE_NULL);
     size.record_type = r_type;
   }
 
@@ -2316,10 +2316,10 @@ struct record_t {
   }
 
   std::size_t get_delta_size() const {
-    assert(size.record_type < record_type_t::MAX);
+    ceph_assert(size.record_type < record_type_t::MAX);
     if (size.record_type == record_type_t::OOL) {
       // OOL won't contain metadata
-      assert(deltas.size() == 0);
+      ceph_assert(deltas.size() == 0);
       return 0;
     }
     // JOURNAL
@@ -2335,7 +2335,7 @@ struct record_t {
   void push_back(extent_t&& extent, sea_time_point &t) {
     ceph_assert(t != NULL_TIME);
     if (extents.size() == 0) {
-      assert(modify_time == NULL_TIME);
+      ceph_assert(modify_time == NULL_TIME);
       modify_time = t;
     } else {
       modify_time = get_average_time(modify_time, extents.size(), t, 1);
@@ -2407,20 +2407,20 @@ struct record_group_size_t {
   extent_len_t get_raw_mdlength() const;
 
   extent_len_t get_mdlength() const {
-    assert(block_size > 0);
-    assert(record_type < record_type_t::MAX);
+    ceph_assert(block_size > 0);
+    ceph_assert(record_type < record_type_t::MAX);
     if (record_type == record_type_t::JOURNAL) {
       return p2roundup(get_raw_mdlength(), block_size);
     } else {
       // OOL won't contain metadata
-      assert(get_raw_mdlength() == 0);
+      ceph_assert(get_raw_mdlength() == 0);
       return 0;
     }
   }
 
   extent_len_t get_encoded_length() const {
-    assert(block_size > 0);
-    assert(dlength % block_size == 0);
+    ceph_assert(block_size > 0);
+    ceph_assert(dlength % block_size == 0);
     return get_mdlength() + dlength;
   }
 
@@ -2433,7 +2433,7 @@ struct record_group_size_t {
   }
 
   double get_fullness() const {
-    assert(block_size > 0);
+    ceph_assert(block_size > 0);
     return ((double)(get_raw_mdlength() + dlength) /
             get_encoded_length());
   }
@@ -2465,7 +2465,7 @@ struct record_group_t {
       extent_len_t block_size) {
     size.account(record.size, block_size);
     records.push_back(std::move(record));
-    assert(size.get_encoded_length() < SEGMENT_OFF_MAX);
+    ceph_assert(size.get_encoded_length() < SEGMENT_OFF_MAX);
   }
 
   void reserve(std::size_t limit) {
@@ -2587,7 +2587,7 @@ struct scan_valid_records_cursor {
   void emplace_record_group(const record_group_header_t&, ceph::bufferlist&&);
 
   void pop_record_group() {
-    assert(!pending_record_groups.empty());
+    ceph_assert(!pending_record_groups.empty());
     ++num_consumed_records;
     pending_record_groups.pop_front();
   }
@@ -2605,7 +2605,7 @@ template <typename CounterT>
 CounterT& get_by_src(
     counter_by_src_t<CounterT>& counters_by_src,
     transaction_type_t src) {
-  assert(static_cast<std::size_t>(src) < counters_by_src.size());
+  ceph_assert(static_cast<std::size_t>(src) < counters_by_src.size());
   return counters_by_src[static_cast<std::size_t>(src)];
 }
 
@@ -2613,7 +2613,7 @@ template <typename CounterT>
 const CounterT& get_by_src(
     const counter_by_src_t<CounterT>& counters_by_src,
     transaction_type_t src) {
-  assert(static_cast<std::size_t>(src) < counters_by_src.size());
+  ceph_assert(static_cast<std::size_t>(src) < counters_by_src.size());
   return counters_by_src[static_cast<std::size_t>(src)];
 }
 
@@ -2641,7 +2641,7 @@ CounterT& get_by_ext(
     counter_by_extent_t<CounterT>& counters_by_ext,
     extent_types_t ext) {
   auto index = static_cast<uint8_t>(ext);
-  assert(index < EXTENT_TYPES_MAX);
+  ceph_assert(index < EXTENT_TYPES_MAX);
   return counters_by_ext[index];
 }
 
@@ -2650,7 +2650,7 @@ const CounterT& get_by_ext(
     const counter_by_extent_t<CounterT>& counters_by_ext,
     extent_types_t ext) {
   auto index = static_cast<uint8_t>(ext);
-  assert(index < EXTENT_TYPES_MAX);
+  ceph_assert(index < EXTENT_TYPES_MAX);
   return counters_by_ext[index];
 }
 
@@ -2886,8 +2886,8 @@ struct cache_size_stats_t {
   }
 
   void account_out(extent_len_t sz) {
-    assert(size >= sz);
-    assert(num_extents > 0);
+    ceph_assert(size >= sz);
+    ceph_assert(num_extents > 0);
     size -= sz;
     --num_extents;
   }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -969,7 +969,7 @@ enum class backend_type_t {
 std::ostream& operator<<(std::ostream& out, backend_type_t);
 
 constexpr backend_type_t get_default_backend_of_device(device_type_t dtype) {
-  ceph_assert(dtype != device_type_t::NONE &&
+  assert(dtype != device_type_t::NONE &&
 	 dtype != device_type_t::NUM_TYPES);
   if (dtype >= device_type_t::HDD &&
       dtype <= device_type_t::EPHEMERAL_MAIN) {
@@ -1476,11 +1476,11 @@ constexpr bool is_logical_type(extent_types_t type) {
   if ((type >= extent_types_t::ROOT_META &&
        type <= extent_types_t::OBJECT_DATA_BLOCK) ||
       type == extent_types_t::TEST_BLOCK) {
-    ceph_assert(is_logical_metadata_type(type) ||
+    assert(is_logical_metadata_type(type) ||
            is_data_type(type));
     return true;
   } else {
-    ceph_assert(!is_logical_metadata_type(type) &&
+    assert(!is_logical_metadata_type(type) &&
            !is_data_type(type));
     return false;
   }
@@ -1513,12 +1513,12 @@ constexpr bool is_physical_type(extent_types_t type) {
   if (type <= extent_types_t::DINK_LADDR_LEAF ||
       (type >= extent_types_t::TEST_BLOCK_PHYSICAL &&
        type <= extent_types_t::BACKREF_LEAF)) {
-    ceph_assert(is_root_type(type) ||
+    assert(is_root_type(type) ||
            is_lba_backref_node(type) ||
            type == extent_types_t::TEST_BLOCK_PHYSICAL);
     return true;
   } else {
-    ceph_assert(!is_root_type(type) &&
+    assert(!is_root_type(type) &&
            !is_lba_backref_node(type) &&
            type != extent_types_t::TEST_BLOCK_PHYSICAL);
     return false;
@@ -1530,12 +1530,12 @@ constexpr bool is_backref_mapped_type(extent_types_t type) {
        type <= extent_types_t::OBJECT_DATA_BLOCK) ||
       type == extent_types_t::TEST_BLOCK ||
       type == extent_types_t::TEST_BLOCK_PHYSICAL) {
-    ceph_assert(is_logical_type(type) ||
+    assert(is_logical_type(type) ||
 	   is_lba_node(type) ||
 	   type == extent_types_t::TEST_BLOCK_PHYSICAL);
     return true;
   } else {
-    ceph_assert(!is_logical_type(type) &&
+    assert(!is_logical_type(type) &&
 	   !is_lba_node(type) &&
 	   type != extent_types_t::TEST_BLOCK_PHYSICAL);
     return false;
@@ -1546,11 +1546,11 @@ constexpr bool is_real_type(extent_types_t type) {
   if (type <= extent_types_t::OBJECT_DATA_BLOCK ||
       (type >= extent_types_t::TEST_BLOCK &&
        type <= extent_types_t::BACKREF_LEAF)) {
-    ceph_assert(is_logical_type(type) ||
+    assert(is_logical_type(type) ||
            is_physical_type(type));
     return true;
   } else {
-    ceph_assert(!is_logical_type(type) &&
+    assert(!is_logical_type(type) &&
            !is_physical_type(type));
     return false;
   }
@@ -1669,10 +1669,10 @@ std::ostream &operator<<(std::ostream &out, mod_time_point_printer_t tp);
 constexpr sea_time_point
 get_average_time(const sea_time_point& t1, std::size_t n1,
                  const sea_time_point& t2, std::size_t n2) {
-  ceph_assert(t1 != NULL_TIME);
-  ceph_assert(t2 != NULL_TIME);
+  assert(t1 != NULL_TIME);
+  assert(t2 != NULL_TIME);
   auto new_size = n1 + n2;
-  ceph_assert(new_size > 0);
+  assert(new_size > 0);
   auto c1 = t1.time_since_epoch().count();
   auto c2 = t2.time_since_epoch().count();
   auto c_ret = c1 / new_size * n1 + c2 / new_size * n2;

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -141,7 +141,7 @@ static read_ertr::future<> do_read(
 {
   LOG_PREFIX(block_do_read);
   TRACE("{} poffset=0x{:x}~0x{:x} ...", device_id_printer_t{device_id}, offset, len);
-  assert(len <= bptr.length());
+  ceph_assert(len <= bptr.length());
   return device.dma_read(
     offset,
     bptr.c_str(),
@@ -287,7 +287,7 @@ write_superblock(
   LOG_PREFIX(block_write_superblock);
   DEBUG("{} write {}", device_id_printer_t{device_id}, sb);
   sb.validate();
-  assert(ceph::encoded_sizeof<block_sm_superblock_t>(sb) <
+  ceph_assert(ceph::encoded_sizeof<block_sm_superblock_t>(sb) <
 	 sb.block_size);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sb.block_size)),
@@ -296,7 +296,7 @@ write_superblock(
     bufferlist bl;
     encode(sb, bl);
     auto iter = bl.begin();
-    assert(bl.length() < sb.block_size);
+    ceph_assert(bl.length() < sb.block_size);
     iter.copy(bl.length(), bp.c_str());
     return do_write(device_id, device, 0, bp);
   });
@@ -329,7 +329,7 @@ read_superblock(seastar::file &device, seastar::stat_data sd)
         ERROR("got decode error!");
         ceph_assert(0 == "invalid superblock");
       }
-      assert(ceph::encoded_sizeof<block_sm_superblock_t>(ret) <
+      ceph_assert(ceph::encoded_sizeof<block_sm_superblock_t>(ret) <
              sd.block_size);
       return BlockSegmentManager::access_ertr::future<block_sm_superblock_t>(
         BlockSegmentManager::access_ertr::ready_future_marker{},
@@ -392,9 +392,9 @@ Segment::close_ertr::future<> BlockSegmentManager::segment_close(
   int unused_bytes = get_segment_size() - write_pointer;
   INFO("{} unused_bytes=0x{:x} ...", id, unused_bytes);
 
-  assert(unused_bytes >= 0);
-  assert(id.device_id() == get_device_id());
-  assert(tracker);
+  ceph_assert(unused_bytes >= 0);
+  ceph_assert(id.device_id() == get_device_id());
+  ceph_assert(tracker);
 
   tracker->set(s_id, segment_state_t::CLOSED);
   ++stats.closed_segments;
@@ -410,8 +410,8 @@ Segment::write_ertr::future<> BlockSegmentManager::segment_write(
   ceph::bufferlist bl,
   bool ignore_check)
 {
-  assert(addr.get_device_id() == get_device_id());
-  assert((bl.length() % superblock.block_size) == 0);
+  ceph_assert(addr.get_device_id() == get_device_id());
+  ceph_assert((bl.length() % superblock.block_size) == 0);
   stats.data_write.increment(bl.length());
   return do_writev(
       get_device_id(),
@@ -576,7 +576,7 @@ SegmentManager::open_ertr::future<SegmentRef> BlockSegmentManager::open(
   auto s_id = id.device_segment_id();
   INFO("{} ...", id);
 
-  assert(id.device_id() == get_device_id());
+  ceph_assert(id.device_id() == get_device_id());
 
   if (s_id >= get_num_segments()) {
     ERROR("{} segment-id out of range {}", id, get_num_segments());
@@ -609,7 +609,7 @@ SegmentManager::release_ertr::future<> BlockSegmentManager::release(
   auto s_id = id.device_segment_id();
   INFO("{} ...", id);
 
-  assert(id.device_id() == get_device_id());
+  ceph_assert(id.device_id() == get_device_id());
 
   if (s_id >= get_num_segments()) {
     ERROR("{} segment-id out of range {}", id, get_num_segments());
@@ -642,7 +642,7 @@ SegmentManager::read_ertr::future<> BlockSegmentManager::read(
   auto p_off = get_offset(addr);
   DEBUG("{} offset=0x{:x}~0x{:x} poffset=0x{:x} ...", id, s_off, len, p_off);
 
-  assert(addr.get_device_id() == get_device_id());
+  ceph_assert(addr.get_device_id() == get_device_id());
 
   if (s_off % superblock.block_size != 0 ||
       len % superblock.block_size != 0) {

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -60,14 +60,14 @@ public:
   }
 
   segment_state_t get(device_segment_id_t offset) const {
-    assert(offset < get_capacity());
+    ceph_assert(offset < get_capacity());
     return static_cast<segment_state_t>(
       layout.template Pointer<0>(
 	bptr.c_str())[offset]);
   }
 
   void set(device_segment_id_t offset, segment_state_t state) {
-    assert(offset < get_capacity());
+    ceph_assert(offset < get_capacity());
     layout.template Pointer<0>(bptr.c_str())[offset] =
       static_cast<uint8_t>(state);
   }
@@ -163,7 +163,7 @@ public:
   }
 
   device_id_t get_device_id() const final {
-    assert(device_id <= DEVICE_ID_MAX_VALID);
+    ceph_assert(device_id <= DEVICE_ID_MAX_VALID);
     return device_id;
   }
   secondary_device_set_t& get_secondary_devices() final {
@@ -223,8 +223,8 @@ private:
   seastar::file device;
 
   void set_device_id(device_id_t id) {
-    assert(id <= DEVICE_ID_MAX_VALID);
-    assert(device_id == DEVICE_ID_NULL ||
+    ceph_assert(id <= DEVICE_ID_MAX_VALID);
+    ceph_assert(device_id == DEVICE_ID_NULL ||
            device_id == id);
     device_id = id;
   }

--- a/src/crimson/os/seastore/segment_manager/ephemeral.cc
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.cc
@@ -38,7 +38,7 @@ device_config_t get_ephemeral_device_config(
     std::size_t num_cold_devices)
 {
   auto num_devices = num_main_devices + num_cold_devices;
-  assert(num_devices > index);
+  ceph_assert(num_devices > index);
   auto get_sec_dtype = [num_main_devices](std::size_t idx) {
     if (idx < num_main_devices) {
       return device_type_t::EPHEMERAL_MAIN;

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -72,7 +72,7 @@ class EphemeralSegmentManager final : public SegmentManager {
   std::optional<device_config_t> device_config;
 
   device_type_t get_device_type() const final {
-    assert(device_config);
+    ceph_assert(device_config);
     return device_config->spec.dtype;
   }
 
@@ -102,7 +102,7 @@ public:
   }
 
   device_id_t get_device_id() const final {
-    assert(device_config);
+    ceph_assert(device_config);
     return device_config->spec.id;
   }
 
@@ -132,12 +132,12 @@ public:
   }
 
   const seastore_meta_t &get_meta() const final {
-    assert(device_config);
+    ceph_assert(device_config);
     return device_config->meta;
   }
 
   secondary_device_set_t& get_secondary_devices() final {
-    assert(device_config);
+    ceph_assert(device_config);
     return device_config->secondary_devices;
   }
 

--- a/src/crimson/os/seastore/segment_manager/zbd.cc
+++ b/src/crimson/os/seastore/segment_manager/zbd.cc
@@ -83,12 +83,12 @@ static zbd_sm_metadata_t make_metadata(
 
   // Using only SWR zones in a SMR drive, for now
   auto skipped_zones = RESERVED_ZONES + nr_cnv_zones;
-  assert(num_zones > skipped_zones);
+  ceph_assert(num_zones > skipped_zones);
 
   // TODO: support Option::size_t seastore_segment_size
   // to allow zones_per_segment > 1 with striping.
   size_t zone_size = zone_size_sectors << SECT_SHIFT;
-  assert(total_size == num_zones * zone_size);
+  ceph_assert(total_size == num_zones * zone_size);
   size_t zone_capacity = zone_capacity_sectors << SECT_SHIFT;
   size_t segment_size = zone_size;
   size_t zones_per_segment = segment_size / zone_size;
@@ -324,7 +324,7 @@ static write_ertr::future<> do_writev(
 static ZBDSegmentManager::access_ertr::future<>
 write_metadata(seastar::file &device, zbd_sm_metadata_t sb)
 {
-  assert(ceph::encoded_sizeof_bounded<zbd_sm_metadata_t>() <
+  ceph_assert(ceph::encoded_sizeof_bounded<zbd_sm_metadata_t>() <
 	 sb.block_size);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sb.block_size)),
@@ -334,7 +334,7 @@ write_metadata(seastar::file &device, zbd_sm_metadata_t sb)
       bufferlist bl;
       encode(sb, bl);
       auto iter = bl.begin();
-      assert(bl.length() < sb.block_size);
+      ceph_assert(bl.length() < sb.block_size);
       DEBUG("buffer length 0x{:x}", bl.length());
       iter.copy(bl.length(), bp.c_str());
       DEBUG("doing writeout");
@@ -349,7 +349,7 @@ static read_ertr::future<> do_read(
   bufferptr &bptr)
 {
   LOG_PREFIX(ZBDSegmentManager::do_read);
-  assert(len <= bptr.length());
+  ceph_assert(len <= bptr.length());
   DEBUG("offset 0x{:x} len 0x{:x}",
     offset,
     len);
@@ -375,7 +375,7 @@ static
 ZBDSegmentManager::access_ertr::future<zbd_sm_metadata_t>
 read_metadata(seastar::file &device, seastar::stat_data sd)
 {
-  assert(ceph::encoded_sizeof_bounded<zbd_sm_metadata_t>() <
+  ceph_assert(ceph::encoded_sizeof_bounded<zbd_sm_metadata_t>() <
 	 sd.block_size);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(sd.block_size)),
@@ -701,8 +701,8 @@ Segment::write_ertr::future<> ZBDSegmentManager::segment_write(
   bool ignore_check)
 {
   LOG_PREFIX(ZBDSegmentManager::segment_write);
-  assert(addr.get_device_id() == get_device_id());
-  assert((bl.length() % metadata.block_size) == 0);
+  ceph_assert(addr.get_device_id() == get_device_id());
+  ceph_assert((bl.length() % metadata.block_size) == 0);
   auto& seg_addr = addr.as_seg_paddr();
   DEBUG("write to segment {} at offset 0x{:x}, physical offset 0x{:x}, len 0x{:x}",
     seg_addr.get_segment_id(),
@@ -816,7 +816,7 @@ Segment::write_ertr::future<> ZBDSegment::advance_wp(
     return write_ertr::now();
   }
 
-  assert(padding_bytes % manager.metadata.block_size == 0);
+  ceph_assert(padding_bytes % manager.metadata.block_size == 0);
 
   return write_padding_bytes(padding_bytes);
 }

--- a/src/crimson/os/seastore/segment_manager_group.cc
+++ b/src/crimson/os/seastore/segment_manager_group.cc
@@ -12,7 +12,7 @@ namespace crimson::os::seastore {
 SegmentManagerGroup::read_segment_tail_ret
 SegmentManagerGroup::read_segment_tail(segment_id_t segment)
 {
-  assert(has_device(segment.device_id()));
+  ceph_assert(has_device(segment.device_id()));
   auto& segment_manager = *segment_managers[segment.device_id()];
   return segment_manager.read(
     paddr_t::make_seg_paddr(
@@ -54,7 +54,7 @@ SegmentManagerGroup::read_segment_tail(segment_id_t segment)
 SegmentManagerGroup::read_segment_header_ret
 SegmentManagerGroup::read_segment_header(segment_id_t segment)
 {
-  assert(has_device(segment.device_id()));
+  ceph_assert(has_device(segment.device_id()));
   auto& segment_manager = *segment_managers[segment.device_id()];
   return segment_manager.read(
     paddr_t::make_seg_paddr(segment, 0),
@@ -95,7 +95,7 @@ void SegmentManagerGroup::initialize_cursor(
   scan_valid_records_cursor &cursor)
 {
   LOG_PREFIX(SegmentManagerGroup::initialize_cursor);
-  assert(has_device(cursor.get_segment_id().device_id()));
+  ceph_assert(has_device(cursor.get_segment_id().device_id()));
   auto& segment_manager =
     *segment_managers[cursor.get_segment_id().device_id()];
   if (cursor.get_segment_offset() == 0) {
@@ -109,7 +109,7 @@ SegmentManagerGroup::read_ret
 SegmentManagerGroup::read(paddr_t start, size_t len) 
 {
   LOG_PREFIX(SegmentManagerGroup::read);
-  assert(has_device(start.get_device_id()));
+  ceph_assert(has_device(start.get_device_id()));
   auto& segment_manager = *segment_managers[start.get_device_id()];
   TRACE("reading data {}~0x{:x}", start, len);
   return segment_manager.read(

--- a/src/crimson/os/seastore/segment_manager_group.h
+++ b/src/crimson/os/seastore/segment_manager_group.h
@@ -23,11 +23,11 @@ public:
   }
 
   std::vector<SegmentManager*> get_segment_managers() const {
-    assert(device_ids.size());
+    ceph_assert(device_ids.size());
     std::vector<SegmentManager*> ret;
     for (auto& device_id : device_ids) {
       auto segment_manager = segment_managers[device_id];
-      assert(segment_manager->get_device_id() == device_id);
+      ceph_assert(segment_manager->get_device_id() == device_id);
       ret.emplace_back(segment_manager);
     }
     return ret;
@@ -57,17 +57,17 @@ public:
    * Assume all segment managers share the same following information.
    */
   extent_len_t get_block_size() const {
-    assert(device_ids.size());
+    ceph_assert(device_ids.size());
     return segment_managers[*device_ids.begin()]->get_block_size();
   }
 
   segment_off_t get_segment_size() const {
-    assert(device_ids.size());
+    ceph_assert(device_ids.size());
     return segment_managers[*device_ids.begin()]->get_segment_size();
   }
 
   const seastore_meta_t &get_meta() const {
-    assert(device_ids.size());
+    ceph_assert(device_ids.size());
     return segment_managers[*device_ids.begin()]->get_meta();
   }
 
@@ -110,19 +110,19 @@ public:
 
   using open_ertr = SegmentManager::open_ertr;
   open_ertr::future<SegmentRef> open(segment_id_t id) {
-    assert(has_device(id.device_id()));
+    ceph_assert(has_device(id.device_id()));
     return segment_managers[id.device_id()]->open(id);
   }
 
   using release_ertr = SegmentManager::release_ertr;
   release_ertr::future<> release_segment(segment_id_t id) {
-    assert(has_device(id.device_id()));
+    ceph_assert(has_device(id.device_id()));
     return segment_managers[id.device_id()]->release(id);
   }
 
 private:
   bool has_device(device_id_t id) const {
-    assert(id <= DEVICE_ID_MAX_VALID);
+    ceph_assert(id <= DEVICE_ID_MAX_VALID);
     return device_ids.count(id) >= 1;
   }
 

--- a/src/crimson/os/seastore/segment_seq_allocator.h
+++ b/src/crimson/os/seastore/segment_seq_allocator.h
@@ -32,7 +32,7 @@ private:
       type,
       segment_seq_printer_t{seq},
       segment_seq_printer_t{next_segment_seq});
-    assert(type == segment_type_t::JOURNAL
+    ceph_assert(type == segment_type_t::JOURNAL
       ? seq >= next_segment_seq
       : true);
     if (seq > next_segment_seq)

--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -322,7 +322,7 @@ BackfillState::Enqueuing::update_on_peers(const hobject_t& check)
 	std::ignore = backfill_state().progress_tracker->enqueue_push(
 	  primary_bi.begin);
 	auto &[v, peers] = backfills[primary_bi.begin];
-	assert(v == obj_v || v == eversion_t());
+	ceph_assert(v == obj_v || v == eversion_t());
 	v = obj_v;
 	peers.push_back(bt);
       } else {
@@ -337,7 +337,7 @@ BackfillState::Enqueuing::update_on_peers(const hobject_t& check)
 	std::ignore = backfill_state().progress_tracker->enqueue_push(
 	  primary_bi.begin);
 	auto &[v, peers] = backfills[primary_bi.begin];
-	assert(v == obj_v || v == eversion_t());
+	ceph_assert(v == obj_v || v == eversion_t());
 	v = obj_v;
 	peers.push_back(bt);
       }
@@ -715,11 +715,11 @@ void BackfillState::ProgressTracker::complete_to(
          it->second.stage != op_stage_t::enqueued_push;
        it = registry.erase(it)) {
     auto& [soid, item] = *it;
-    assert(item.stats);
+    ceph_assert(item.stats);
     peering_state().update_complete_backfill_object_stats(
       soid,
       *item.stats);
-    assert(soid > new_last_backfill);
+    ceph_assert(soid > new_last_backfill);
     new_last_backfill = soid;
   }
   if (may_push_to_max &&

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -121,7 +121,7 @@ crimson::net::Messenger& Heartbeat::get_back_msgr() const
 
 void Heartbeat::add_peer(osd_id_t _peer, epoch_t epoch)
 {
-  assert(whoami != _peer);
+  ceph_assert(whoami != _peer);
   auto [iter, added] = peers.try_emplace(_peer, *this, _peer);
   auto& peer = iter->second;
   peer.set_epoch_added(epoch);
@@ -203,7 +203,7 @@ Heartbeat::osds_t Heartbeat::get_peers() const
 
 void Heartbeat::remove_peer(osd_id_t peer)
 {
-  assert(peers.count(peer) == 1);
+  ceph_assert(peers.count(peer) == 1);
   peers.erase(peer);
 }
 
@@ -492,13 +492,13 @@ void Heartbeat::Connection::reset(bool is_replace)
 
 seastar::future<> Heartbeat::Connection::send(MessageURef msg)
 {
-  assert(is_connected);
+  ceph_assert(is_connected);
   return conn->send(std::move(msg));
 }
 
 void Heartbeat::Connection::validate()
 {
-  assert(is_connected);
+  ceph_assert(is_connected);
   auto peer_addr = listener.get_peer_addr(type);
   if (conn->get_peer_addr() != peer_addr) {
     logger().info("Heartbeat::Connection::validate(): "
@@ -525,8 +525,8 @@ void Heartbeat::Connection::retry()
 
 void Heartbeat::Connection::set_connected()
 {
-  assert(conn);
-  assert(!is_connected);
+  ceph_assert(conn);
+  ceph_assert(!is_connected);
   ceph_assert(conn->is_connected());
   is_connected = true;
   listener.increase_connected();
@@ -534,8 +534,8 @@ void Heartbeat::Connection::set_connected()
 
 void Heartbeat::Connection::set_unconnected()
 {
-  assert(conn);
-  assert(is_connected);
+  ceph_assert(conn);
+  ceph_assert(is_connected);
   conn = nullptr;
   is_connected = false;
   listener.decrease_connected();
@@ -543,7 +543,7 @@ void Heartbeat::Connection::set_unconnected()
 
 void Heartbeat::Connection::connect()
 {
-  assert(!conn);
+  ceph_assert(!conn);
   auto addr = listener.get_peer_addr(type);
   conn = msgr.connect(addr, entity_name_t(CEPH_ENTITY_TYPE_OSD, peer));
   if (conn->is_connected()) {
@@ -576,14 +576,14 @@ Heartbeat::Session::failed_since(Heartbeat::clock::time_point now) const
 
 void Heartbeat::Session::set_inactive_history(clock::time_point now)
 {
-  assert(!connected);
+  ceph_assert(!connected);
   if (ping_history.empty()) {
     const utime_t sent_stamp{now};
     const auto deadline =
       now + std::chrono::seconds(local_conf()->osd_heartbeat_grace);
     ping_history.emplace(sent_stamp, reply_t{deadline, 0});
   } else { // the entry is already added
-    assert(ping_history.size() == 1);
+    ceph_assert(ping_history.size() == 1);
   }
 }
 

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -142,14 +142,14 @@ class Heartbeat::ConnectionListener {
   ConnectionListener(size_t connections) : connections{connections} {}
 
   void increase_connected() {
-    assert(connected < connections);
+    ceph_assert(connected < connections);
     ++connected;
     if (connected == connections) {
       on_connected();
     }
   }
   void decrease_connected() {
-    assert(connected > 0);
+    ceph_assert(connected > 0);
     if (connected == connections) {
       on_disconnected();
     }
@@ -280,7 +280,7 @@ class Heartbeat::Session {
   bool pinged() const {
     if (clock::is_zero(first_tx)) {
       // i can never receive a pong without sending any ping message first.
-      assert(clock::is_zero(last_rx_front) &&
+      ceph_assert(clock::is_zero(last_rx_front) &&
              clock::is_zero(last_rx_back));
       return false;
     } else {
@@ -319,14 +319,14 @@ class Heartbeat::Session {
   }
 
   void on_connected() {
-    assert(!connected);
+    ceph_assert(!connected);
     connected = true;
     ping_history.clear();
   }
 
   void on_ping(const utime_t& sent_stamp,
                const clock::time_point& deadline) {
-    assert(connected);
+    ceph_assert(connected);
     [[maybe_unused]] auto [reply, added] =
       ping_history.emplace(sent_stamp, reply_t{deadline, 2});
   }
@@ -334,14 +334,14 @@ class Heartbeat::Session {
   bool on_pong(const utime_t& ping_stamp,
                Connection::type_t type,
                clock::time_point now) {
-    assert(connected);
+    ceph_assert(connected);
     auto ping = ping_history.find(ping_stamp);
     if (ping == ping_history.end()) {
       // old replies, deprecated by newly sent pings.
       return false;
     }
     auto& unacked = ping->second.unacknowledged;
-    assert(unacked);
+    ceph_assert(unacked);
     if (type == Connection::type_t::front) {
       last_rx_front = now;
       unacked--;
@@ -356,7 +356,7 @@ class Heartbeat::Session {
   }
 
   void on_disconnected() {
-    assert(connected);
+    ceph_assert(connected);
     connected = false;
     if (!ping_history.empty()) {
       // we lost our ping_history of the last session, but still need to keep

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -37,7 +37,7 @@ static inline int execute_osd_op(cls_method_context_t hctx, OSDOp& op)
   reinterpret_cast<crimson::osd::OpsExecuter*>(hctx)->execute_op(op)
   .handle_error_interruptible(
     osd_op_errorator::all_same_way([&ret] (const std::error_code& err) {
-      assert(err.value() > 0);
+      ceph_assert(err.value() > 0);
       ret = -err.value();
       return seastar::now();
     })).get(); // we're blocking here which requires `seastar::thread`.
@@ -79,7 +79,7 @@ int cls_read(cls_method_context_t hctx,
 
 int cls_get_request_origin(cls_method_context_t hctx, entity_inst_t *origin)
 {
-  assert(origin);
+  ceph_assert(origin);
 
   try {
     const auto& message = \

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -199,7 +199,7 @@ public:
 
   template <typename ListType>
   void remove_from(ListType&& list) {
-    assert(list_link_cnt > 0);
+    ceph_assert(list_link_cnt > 0);
     if (--list_link_cnt == 0) {
       list.erase(std::decay_t<ListType>::s_iterator_to(*this));
     }

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -61,7 +61,7 @@ public:
       }
 
       void demote_excl_to(RWState::State lock_type) {
-	assert(state == RWState::RWEXCL);
+	ceph_assert(state == RWState::RWEXCL);
 	switch (lock_type) {
 	case RWState::RWWRITE:
 	  obc->lock.demote_to_write();
@@ -84,7 +84,7 @@ public:
       }
 
       auto lock_to(RWState::State lock_type) {
-	assert(state == RWState::RWNONE);
+	ceph_assert(state == RWState::RWNONE);
 	switch (lock_type) {
 	case RWState::RWWRITE:
 	  return interruptor::make_interruptible(

--- a/src/crimson/osd/object_metadata_helper.cc
+++ b/src/crimson/osd/object_metadata_helper.cc
@@ -26,7 +26,7 @@ subsets_t calc_clone_subsets(
   subsets_t subsets;
   logger().debug("{}: {} clone_overlap {} ",
                  __func__, soid, snapset.clone_overlap);
-  assert(missing.get_items().contains(soid));
+  ceph_assert(missing.get_items().contains(soid));
   const pg_missing_item &missing_item = missing.get_items().at(soid);
   auto dirty_regions = missing_item.clean_regions.get_dirty_regions();
   if (dirty_regions.empty()) {
@@ -65,7 +65,7 @@ subsets_t calc_clone_subsets(
   auto soid_snap_iter = find(snapset.clones.begin(),
                              snapset.clones.end(),
                              soid.snap);
-  assert(soid_snap_iter != snapset.clones.end());
+  ceph_assert(soid_snap_iter != snapset.clones.end());
   auto soid_snap_index = soid_snap_iter - snapset.clones.begin();
 
   // any overlap with next older clone?
@@ -156,7 +156,7 @@ subsets_t calc_head_subsets(
   if (obj_size) {
     subsets.data_subset.insert(0, obj_size);
   }
-  assert(missing.get_items().contains(head));
+  ceph_assert(missing.get_items().contains(head));
   const pg_missing_item &missing_item = missing.get_items().at(head);
   // let data_subset store only the modified content of the object.
   subsets.data_subset.intersection_of(missing_item.clean_regions.get_dirty_regions());

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -200,7 +200,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_watch(
       return seastar::now();
     },
     [](auto&& ctx, ObjectContextRef obc, Ref<PG> pg) {
-      assert(pg);
+      ceph_assert(pg);
       auto [it, emplaced] = obc->watchers.try_emplace(ctx.key, nullptr);
       if (emplaced) {
         const auto& [cookie, entity] = ctx.key;
@@ -397,8 +397,8 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_list_watchers(
   for (const auto& [key, info] : os.oi.watchers) {
     logger().debug("{}: key cookie={}, entity={}",
                    __func__, key.first, key.second);
-    assert(key.first == info.cookie);
-    assert(key.second.is_client());
+    ceph_assert(key.first == info.cookie);
+    ceph_assert(key.second.is_client());
     response.entries.emplace_back(watch_item_t{
       key.second, info.cookie, info.timeout_seconds, info.addr});
   }
@@ -839,8 +839,8 @@ OpsExecuter::flush_changes_and_submit(
 {
   const bool want_mutate = !txn.empty();
   // osd_op_params are instantiated by every wr-like operation.
-  assert(osd_op_params || !want_mutate);
-  assert(obc);
+  ceph_assert(osd_op_params || !want_mutate);
+  ceph_assert(obc);
 
   auto submitted = interruptor::now();
   auto all_completed = interruptor::now();
@@ -902,8 +902,8 @@ pg_log_entry_t OpsExecuter::prepare_head_update(
   ceph::os::Transaction &txn)
 {
   LOG_PREFIX(OpsExecuter::prepare_head_update);
-  assert(obc->obs.oi.soid.snap >= CEPH_MAXSNAP);
-  assert(obc->obs.oi.soid.is_head());
+  ceph_assert(obc->obs.oi.soid.snap >= CEPH_MAXSNAP);
+  ceph_assert(obc->obs.oi.soid.is_head());
 
   update_clone_overlap();
   if (cloning_ctx) {
@@ -1071,7 +1071,7 @@ void OpsExecuter::update_clone_overlap() {
     return;
   }
 
-  assert(osd_op_params);
+  ceph_assert(osd_op_params);
   osd_op_params->modified_ranges.intersection_of(*newest_overlap);
   newest_overlap->subtract(osd_op_params->modified_ranges);
   delta_stats.num_bytes += osd_op_params->modified_ranges.size();

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -523,7 +523,7 @@ void OpsExecuter::RollbackHelper<Func>::rollback_obc_if_modified()
   // typically append them before any write. If OpsExecuter hasn't
   // seen any modifying operation, `obc` is supposed to be kept
   // unchanged.
-  assert(ox);
+  ceph_assert(ox);
   const auto need_rollback = ox->has_seen_write();
   crimson::get_logger(ceph_subsys_osd).debug(
     "{}: object {} got error, need_rollback={}",

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -922,7 +922,7 @@ OSD::do_ms_dispatch(
             [f_conn=std::move(f_conn), m=std::move(m), this]() mutable {
           auto conn = make_local_shared_foreign(std::move(f_conn));
           auto ret = do_ms_dispatch(conn, std::move(m));
-          assert(ret.has_value());
+          ceph_assert(ret.has_value());
           return std::move(ret.value());
         });
       });
@@ -1757,7 +1757,7 @@ seastar::future<> OSD::handle_pg_remove(
 seastar::future<> OSD::check_osdmap_features()
 {
   LOG_PREFIX(OSD::check_osdmap_features);
-  assert(seastar::this_shard_id() == PRIMARY_CORE);
+  ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
   if (osdmap->require_osd_release != last_require_osd_release) {
     DEBUG("updating require_osd_release from {} to {}",
           to_string(last_require_osd_release),

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -177,29 +177,29 @@ public:
     : l_conn(std::move(conn)) {}
 
   crimson::net::Connection &get_local_connection() {
-    assert(l_conn);
-    assert(!r_conn);
+    ceph_assert(l_conn);
+    ceph_assert(!r_conn);
     return *l_conn;
   };
 
   crimson::net::Connection &get_foreign_connection() {
-    assert(r_conn);
-    assert(!l_conn);
+    ceph_assert(r_conn);
+    ceph_assert(!l_conn);
     return *r_conn;
   };
 
   crimson::net::ConnectionFFRef prepare_remote_submission() {
-    assert(l_conn);
-    assert(!r_conn);
+    ceph_assert(l_conn);
+    ceph_assert(!r_conn);
     auto ret = seastar::make_foreign(std::move(l_conn));
     l_conn.reset();
     return ret;
   }
 
   void finish_remote_submission(crimson::net::ConnectionFFRef conn) {
-    assert(conn);
-    assert(!l_conn);
-    assert(!r_conn);
+    ceph_assert(conn);
+    ceph_assert(!l_conn);
+    ceph_assert(!r_conn);
     r_conn = make_local_shared_foreign(std::move(conn));
   }
 
@@ -207,7 +207,7 @@ public:
     if (l_conn) {
       return *l_conn;
     } else {
-      assert(r_conn);
+      ceph_assert(r_conn);
       return *r_conn;
     }
   }

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -522,7 +522,7 @@ ClientRequest::do_process(
   {
     auto all_completed = interruptor::now();
     if (ret) {
-      assert(should_log_error(*ret));
+      ceph_assert(should_log_error(*ret));
       if (op_info.may_write()) {
 	auto rep_tid = pg->shard_services.get_tid();
 	auto version = co_await pg->submit_error_log(
@@ -562,7 +562,7 @@ ClientRequest::do_process(
     // For all ops except for CMPEXT, the correct error value is encoded
     // in e. For CMPEXT, osdop.rval has the actual error value.
     if (err == -ct_error::cmp_fail_error_value) {
-      assert(!m->ops.empty());
+      ceph_assert(!m->ops.empty());
       for (auto &osdop : m->ops) {
 	if (osdop.rval < 0) {
 	  reply->set_result(osdop.rval);

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -193,12 +193,12 @@ public:
 
   public:
     void add_request(ClientRequest &request) {
-      assert(!request.ordering_hook.is_linked());
+      ceph_assert(!request.ordering_hook.is_linked());
       intrusive_ptr_add_ref(&request);
       list.push_back(request);
     }
     void remove_request(ClientRequest &request) {
-      assert(request.ordering_hook.is_linked());
+      ceph_assert(request.ordering_hook.is_linked());
       list.erase(list_t::s_iterator_to(request));
       intrusive_ptr_release(&request);
     }

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -28,8 +28,8 @@ namespace crimson::osd {
 InternalClientRequest::InternalClientRequest(Ref<PG> pg)
   : pg(pg), start_epoch(pg->get_osdmap_epoch())
 {
-  assert(bool(this->pg));
-  assert(this->pg->is_primary());
+  ceph_assert(bool(this->pg));
+  ceph_assert(this->pg->is_primary());
 }
 
 InternalClientRequest::~InternalClientRequest()
@@ -55,7 +55,7 @@ InternalClientRequest::interruptible_future<>
 InternalClientRequest::with_interruption()
 {
   LOG_PREFIX(InternalClientRequest::with_interruption);
-  assert(pg->is_active());
+  ceph_assert(pg->is_active());
 
   obc_orderer = pg->obc_loader.get_obc_orderer(get_target_oid());
   auto obc_manager = pg->obc_loader.get_obc_manager(
@@ -81,7 +81,7 @@ InternalClientRequest::with_interruption()
 	 std::size(osd_ops));
   [[maybe_unused]] const int ret = op_info.set_from_op(
     std::as_const(osd_ops), pg->get_pgid().pgid, *pg->get_osdmap());
-  assert(ret == 0);
+  ceph_assert(ret == 0);
 
   co_await pg->obc_loader.load_and_lock(
     obc_manager, pg->get_lock_type(op_info)

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -149,7 +149,7 @@ SnapTrimObjSubEvent::remove_clone(
                    *this, coid.snap);
     return crimson::ct_error::enoent::make();
   }
-  assert(p != head_obc->ssc->snapset.clones.end());
+  ceph_assert(p != head_obc->ssc->snapset.clones.end());
   snapid_t last = coid.snap;
   delta_stats.num_bytes -= head_obc->ssc->snapset.get_clone_bytes(last);
 

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -168,9 +168,9 @@ void PG::check_blocklisted_watchers()
 {
   logger().debug("{}", __func__);
   obc_registry.for_each([this](ObjectContextRef obc) {
-    assert(obc);
+    ceph_assert(obc);
     for (const auto& [key, watch] : obc->watchers) {
-      assert(watch->get_pg() == this);
+      ceph_assert(watch->get_pg() == this);
       const auto& ea = watch->get_peer_addr();
       logger().debug("watch: Found {} cookie {}. Checking entity_add_t {}",
                      watch->get_entity(), watch->get_cookie(), ea);
@@ -656,7 +656,7 @@ void PG::on_active_advmap(const OSDMapRef &osdmap)
     }
     logger().info("{}: {} new removed snaps {}, snap_trimq now{}",
                   *this, __func__, it->second, snap_trimq);
-    assert(!bad || !local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
+    ceph_assert(!bad || !local_conf().get_val<bool>("osd_debug_verify_cached_snaps"));
   }
 }
 
@@ -668,7 +668,7 @@ PG::interruptible_future<bool> PG::do_recover_missing(
   DEBUGDPP(
     "reqid {} check for recovery, {}",
     *this, reqid, soid);
-  assert(is_primary());
+  ceph_assert(is_primary());
   eversion_t ver;
   auto &missing_loc = peering_state.get_missing_loc();
   bool needs_recovery_or_backfill = false;
@@ -785,7 +785,7 @@ seastar::future<> PG::init(
   peering_state.init(
     role, newup, new_up_primary, newacting,
     new_acting_primary, history, pi, t);
-  assert(coll_ref);
+  ceph_assert(coll_ref);
   return shard_services.get_store().exists(
     get_collection_ref(), pgid.make_snapmapper_oid()
   ).safe_then([&t, this](bool existed) {
@@ -937,8 +937,8 @@ void PG::enqueue_push_for_backfill(
   const eversion_t &v,
   const std::vector<pg_shard_t> &peers)
 {
-  assert(recovery_handler);
-  assert(recovery_handler->backfill_state);
+  ceph_assert(recovery_handler);
+  ceph_assert(recovery_handler->backfill_state);
   auto backfill_state = recovery_handler->backfill_state.get();
   backfill_state->enqueue_standalone_push(obj, v, peers);
 }
@@ -948,8 +948,8 @@ void PG::enqueue_delete_for_backfill(
   const eversion_t &v,
   const std::vector<pg_shard_t> &peers)
 {
-  assert(recovery_handler);
-  assert(recovery_handler->backfill_state);
+  ceph_assert(recovery_handler);
+  ceph_assert(recovery_handler->backfill_state);
   auto backfill_state = recovery_handler->backfill_state.get();
   backfill_state->enqueue_standalone_delete(obj, v, peers);
 }
@@ -1003,10 +1003,10 @@ PG::interruptible_future<> PG::repair_object(
   eversion_t& v) 
 {
   // see also PrimaryLogPG::rep_repair_primary_object()
-  assert(is_primary());
+  ceph_assert(is_primary());
   logger().debug("{}: {} peers osd.{}", __func__, oid, get_acting_recovery_backfill());
   // Add object to PG's missing set if it isn't there already
-  assert(!get_local_missing().is_missing(oid));
+  ceph_assert(!get_local_missing().is_missing(oid));
   peering_state.force_object_missing(pg_whoami, oid, v);
   auto [op, fut] = get_shard_services().start_operation<UrgentRecovery>(
     oid, v, this, get_shard_services(), get_osdmap_epoch());
@@ -1276,7 +1276,7 @@ void PG::check_blocklisted_obc_watchers(
         obc, winfo, src.second, this);
       watch->disconnect();
       auto [it, emplaced] = obc->watchers.emplace(src, std::move(watch));
-      assert(emplaced);
+      ceph_assert(emplaced);
       logger().debug("added watch for obj {}, client {}",
         obc->get_oid(), src.second);
     }
@@ -1579,7 +1579,7 @@ void PG::on_change(ceph::os::Transaction &t) {
 void PG::context_registry_on_change() {
   std::vector<seastar::shared_ptr<crimson::osd::Watch>> watchers;
   obc_registry.for_each([&watchers](ObjectContextRef obc) {
-    assert(obc);
+    ceph_assert(obc);
     for (auto j = obc->watchers.begin();
          j != obc->watchers.end();
          j = obc->watchers.erase(j)) {

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -483,7 +483,7 @@ PGBackend::write_iertr::future<> PGBackend::_truncate(
   uint32_t truncate_seq)
 {
   if (truncate_seq) {
-    assert(offset == truncate_size);
+    ceph_assert(offset == truncate_size);
     if (truncate_seq <= os.oi.truncate_seq) {
       logger().debug("{} truncate seq {} <= current {}, no-op",
                      __func__, truncate_seq, os.oi.truncate_seq);
@@ -756,7 +756,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
 {
   const ceph_osd_op& op = osd_op.op;
   snapid_t snapid = (uint64_t)op.snap.snapid;
-  assert(os.oi.soid.is_head());
+  ceph_assert(os.oi.soid.is_head());
   logger().debug("{} deleting {} and rolling back to old snap {}",
                   __func__, os.oi.soid ,snapid);
   hobject_t target_coid = os.oi.soid;
@@ -1515,7 +1515,7 @@ PGBackend::omap_get_vals(
   .safe_then_interruptible(
     [=, &osd_op] (auto&& ret) {
       auto [done, vals] = std::move(ret);
-      assert(done);
+      ceph_assert(done);
       ceph::bufferlist result;
       bool truncated = false;
       uint32_t num = 0;

--- a/src/crimson/osd/pg_map.cc
+++ b/src/crimson/osd/pg_map.cc
@@ -20,7 +20,7 @@ seastar::future<core_id_t> PGShardMapping::get_or_create_pg_mapping(
   auto find_iter = pg_to_core.find(pgid);
   if (find_iter != pg_to_core.end()) {
     auto core_found = find_iter->second;
-    assert(core_found != NULL_CORE);
+    ceph_assert(core_found != NULL_CORE);
     if (core_expected != NULL_CORE && core_expected != core_found) {
       ERROR("the mapping is inconsistent for pg {}: core {}, expected {}",
             pgid, core_found, core_expected);
@@ -38,7 +38,7 @@ seastar::future<core_id_t> PGShardMapping::get_or_create_pg_mapping(
         // this pgid was already mapped within primary_mapping, assert that the
         // mapping is consistent and avoid emplacing once again.
         auto core_found = find_iter->second;
-        assert(core_found != NULL_CORE);
+        ceph_assert(core_found != NULL_CORE);
         if (core_expected != NULL_CORE) {
           if (core_expected != core_found) {
             ERROR("the mapping is inconsistent for pg {} (primary): core {}, expected {}",
@@ -75,11 +75,11 @@ seastar::future<core_id_t> PGShardMapping::get_or_create_pg_mapping(
         ++(count_iter->second);
         [[maybe_unused]] auto [insert_iter, inserted] =
           primary_mapping.pg_to_core.emplace(pgid, core_to_update);
-        assert(inserted);
+        ceph_assert(inserted);
         DEBUG("mapping pg {} to core {} (primary): num_pgs {}",
               pgid, core_to_update, count_iter->second);
       }
-      assert(core_to_update != NULL_CORE);
+      ceph_assert(core_to_update != NULL_CORE);
       return primary_mapping.container().invoke_on_others(
           [pgid, core_to_update, FNAME](auto &other_mapping) {
         auto find_iter = other_mapping.pg_to_core.find(pgid);
@@ -88,7 +88,7 @@ seastar::future<core_id_t> PGShardMapping::get_or_create_pg_mapping(
                 pgid, core_to_update);
           [[maybe_unused]] auto [insert_iter, inserted] =
             other_mapping.pg_to_core.emplace(pgid, core_to_update);
-          assert(inserted);
+          ceph_assert(inserted);
         } else {
           auto core_found = find_iter->second;
           if (core_found != core_to_update) {
@@ -135,10 +135,10 @@ seastar::future<> PGShardMapping::remove_pg_mapping(spg_t pgid) {
       ERROR("trying to remove non-exist mapping for pg {} (primary)", pgid);
       ceph_abort("The pg mapping is inconsistent!");
     }
-    assert(find_iter->second != NULL_CORE);
+    ceph_assert(find_iter->second != NULL_CORE);
     auto count_iter = primary_mapping.core_to_num_pgs.find(find_iter->second);
-    assert(count_iter != primary_mapping.core_to_num_pgs.end());
-    assert(count_iter->second > 0);
+    ceph_assert(count_iter != primary_mapping.core_to_num_pgs.end());
+    ceph_assert(count_iter->second > 0);
     --(count_iter->second);
     primary_mapping.pg_to_core.erase(find_iter);
     DEBUG("pg {} mapping erased (primary)", pgid);
@@ -149,7 +149,7 @@ seastar::future<> PGShardMapping::remove_pg_mapping(spg_t pgid) {
         ERROR("trying to remove non-exist mapping for pg {} (others)", pgid);
         ceph_abort("The pg mapping is inconsistent!");
       }
-      assert(find_iter->second != NULL_CORE);
+      ceph_assert(find_iter->second != NULL_CORE);
       other_mapping.pg_to_core.erase(find_iter);
       DEBUG("pg {} mapping erased (others)", pgid);
     });

--- a/src/crimson/osd/pg_meta.cc
+++ b/src/crimson/osd/pg_meta.cc
@@ -46,14 +46,14 @@ seastar::future<epoch_t> PGMeta::get_epoch()
       {
         // sanity check
         auto infover = find_value<__u8>(values, infover_key);
-        assert(infover);
+        ceph_assert(infover);
         if (*infover < 10) {
           throw std::runtime_error("incompatible pg meta");
         }
       }
       {
         auto epoch = find_value<epoch_t>(values, epoch_key);
-        assert(epoch);
+        ceph_assert(epoch);
         return seastar::make_ready_future<epoch_t>(*epoch);
       }
     },
@@ -76,7 +76,7 @@ seastar::future<std::tuple<pg_info_t, PastIntervals>> PGMeta::load()
     {
       // sanity check
       auto infover = find_value<__u8>(values, infover_key);
-      assert(infover);
+      ceph_assert(infover);
       if (infover < 10) {
         throw std::runtime_error("incompatible pg meta");
       }
@@ -84,14 +84,14 @@ seastar::future<std::tuple<pg_info_t, PastIntervals>> PGMeta::load()
     pg_info_t info;
     {
       auto found = find_value<pg_info_t>(values, info_key);
-      assert(found);
+      ceph_assert(found);
       info = *std::move(found);
     }
     PastIntervals past_intervals;
     {
       using biginfo_t = std::pair<PastIntervals, decltype(info.purged_snaps)>;
       auto big_info = find_value<biginfo_t>(values, biginfo_key);
-      assert(big_info);
+      ceph_assert(big_info);
       past_intervals = std::move(big_info->first);
       info.purged_snaps = std::move(big_info->second);
     }

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -110,7 +110,7 @@ private:
     const hobject_t &soid,
     eversion_t need) {
     auto backend = pg->get_recovery_backend();
-    assert(backend);
+    ceph_assert(backend);
     return backend->recover_object(soid, need);
   }
 

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -207,7 +207,7 @@ RecoveryBackend::handle_backfill_remove(
 {
   LOG_PREFIX(RecoveryBackend::handle_backfill_remove);
   DEBUGDPP("m.ls={}", pg, m.ls);
-  assert(m.get_type() == MSG_OSD_PG_BACKFILL_REMOVE);
+  ceph_assert(m.get_type() == MSG_OSD_PG_BACKFILL_REMOVE);
 
   ObjectStore::Transaction t;
   for ([[maybe_unused]] const auto& [soid, ver] : m.ls) {

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -46,7 +46,7 @@ public:
   virtual ~RecoveryBackend() {}
   std::pair<WaitForObjectRecovery&, bool> add_recovering(const hobject_t& soid) {
     auto [it, added] = recovering.emplace(soid, new WaitForObjectRecovery(pg));
-    assert(it->second);
+    ceph_assert(it->second);
     return {*(it->second), added};
   }
   seastar::future<> add_unfound(const hobject_t &soid) {
@@ -62,7 +62,7 @@ public:
     }
   }
   WaitForObjectRecovery& get_recovering(const hobject_t& soid) {
-    assert(is_recovering(soid));
+    ceph_assert(is_recovering(soid));
     return *(recovering.at(soid));
   }
   void remove_recovering(const hobject_t& soid) {

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -181,7 +181,7 @@ ReplicatedBackend::submit_transaction(
       // for now, only actingset_changed can cause peers
       // to be nullptr
       ERRORDPP("peers is null, this should be impossible", dpp);
-      assert(0 == "impossible");
+      ceph_assert(0 == "impossible");
     }
     if (--peers->pending == 0) {
       // no peers other than me, replication size is 1
@@ -279,13 +279,13 @@ ReplicatedBackend::request_committed(const osd_reqid_t& reqid,
   // mustn't have finished, as that would mean later client_requests
   // has finished before earlier ones.
   //
-  // The following line of code should be "assert(pending_txn.at_version == at_version)",
+  // The following line of code should be "ceph_assert(pending_txn.at_version == at_version)",
   // as there can be only one transaction at any time in pending_trans due to
   // PG::request_pg_pipeline. But there's a high possibility that we will
   // improve the parallelism here in the future, which means there may be multiple
   // client requests in flight, so we loosed the restriction to as follows. Correct
   // me if I'm wrong:-)
-  assert(iter != pending_trans.end() && iter->second.at_version == at_version);
+  ceph_assert(iter != pending_trans.end() && iter->second.at_version == at_version);
   if (iter->second.pending) {
     return iter->second.all_committed.get_shared_future();
   } else {

--- a/src/crimson/osd/scrub/scrub_machine.cc
+++ b/src/crimson/osd/scrub/scrub_machine.cc
@@ -11,7 +11,7 @@ WaitUpdate::WaitUpdate(my_context ctx) : ScrubState(ctx)
 {
   auto &cs = context<ChunkState>();
   cs.range_reserved = true;
-  assert(cs.range);
+  ceph_assert(cs.range);
   get_scrub_context().reserve_range(cs.range->start, cs.range->end);
 }
 

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -266,7 +266,7 @@ private:
     meta_coll = std::make_unique<OSDMeta>(std::forward<Args>(args)...);
   }
   OSDMeta &get_meta_coll() {
-    assert(meta_coll);
+    ceph_assert(meta_coll);
     return *meta_coll;
   }
 

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -40,7 +40,7 @@ private:
 
 const hobject_t& WatchTimeoutRequest::get_target_oid() const
 {
-  assert(watch->obc);
+  ceph_assert(watch->obc);
   return watch->obc->get_oid();
 }
 
@@ -64,7 +64,7 @@ WatchTimeoutRequest::get_do_osd_ops_params() const
 std::vector<OSDOp> WatchTimeoutRequest::create_osd_ops()
 {
   logger().debug("{}", __func__);
-  assert(watch);
+  ceph_assert(watch);
   OSDOp osd_op;
   osd_op.op.op = CEPH_OSD_OP_WATCH;
   osd_op.op.flags = 0;
@@ -202,13 +202,13 @@ void Watch::cancel_notify(const uint64_t notify_id)
                  __func__,  get_watcher_gid(), get_cookie(),
                  notify_id);
   const auto it = in_progress_notifies.find(notify_id);
-  assert(it != std::end(in_progress_notifies));
+  ceph_assert(it != std::end(in_progress_notifies));
   in_progress_notifies.erase(it);
 }
 
 void Watch::do_watch_timeout()
 {
-  assert(pg);
+  ceph_assert(pg);
   auto [op, fut] = pg->get_shard_services().start_operation<WatchTimeoutRequest>(
     shared_from_this(), pg);
   std::ignore = std::move(fut).then([op=std::move(op), this] {
@@ -261,11 +261,11 @@ seastar::future<> Notify::remove_watcher(WatchRef watch)
     return seastar::now();
   }
   [[maybe_unused]] const auto num_removed = watchers.erase(watch);
-  assert(num_removed > 0);
+  ceph_assert(num_removed > 0);
   if (watchers.empty()) {
     complete = true;
     [[maybe_unused]] bool was_armed = timeout_timer.cancel();
-    assert(was_armed);
+    ceph_assert(was_armed);
     return send_completion();
   } else {
     return seastar::now();

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -63,7 +63,7 @@ public:
       timeout_timer([this] {
         return do_watch_timeout();
       }) {
-    assert(this->pg);
+    ceph_assert(this->pg);
   }
   ~Watch();
 
@@ -172,16 +172,16 @@ class Notify : public seastar::enable_shared_from_this<Notify> {
 
   using ptr_t = seastar::shared_ptr<Notify>;
   friend bool operator<(const ptr_t& lhs, const ptr_t& rhs) {
-    assert(lhs);
-    assert(rhs);
+    ceph_assert(lhs);
+    ceph_assert(rhs);
     return lhs->get_id() < rhs->get_id();
   }
   friend bool operator<(const ptr_t& ptr, const uint64_t id) {
-    assert(ptr);
+    ceph_assert(ptr);
     return ptr->get_id() < id;
   }
   friend bool operator<(const uint64_t id, const ptr_t& ptr) {
-    assert(ptr);
+    ceph_assert(ptr);
     return id < ptr->get_id();
   }
 
@@ -216,7 +216,7 @@ Notify::Notify(WatchIteratorT begin,
     conn(std::move(conn)),
     client_gid(client_gid),
     user_version(user_version) {
-  assert(!std::empty(watchers));
+  ceph_assert(!std::empty(watchers));
   if (ninfo.timeout) {
     timeout_timer.arm(std::chrono::seconds{ninfo.timeout});
   }

--- a/src/crimson/tools/perf_crimson_msgr.cc
+++ b/src/crimson/tools/perf_crimson_msgr.cc
@@ -64,10 +64,10 @@ seastar::future<T*> create_sharded(Args... args) {
 double get_reactor_utilization() {
   auto &value_map = seastar::metrics::impl::get_value_map();
   auto found = value_map.find("reactor_utilization");
-  assert(found != value_map.end());
+  ceph_assert(found != value_map.end());
   auto &[full_name, metric_family] = *found;
   std::ignore = full_name;
-  assert(metric_family.size() == 1);
+  ceph_assert(metric_family.size() == 1);
   const auto& [labels, metric] = *metric_family.begin();
   std::ignore = labels;
   auto value = (*metric)();
@@ -220,7 +220,7 @@ static seastar::future<> run(
 
       std::optional<seastar::future<>> ms_dispatch(
           crimson::net::ConnectionRef c, MessageRef m) override {
-        assert(c->get_shard_id() == seastar::this_shard_id());
+        ceph_assert(c->get_shard_id() == seastar::this_shard_id());
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
 
         auto &server = container().local();
@@ -610,7 +610,7 @@ static seastar::future<> run(
           crimson::net::ConnectionRef conn,
           seastar::shard_id prv_shard) override {
         ceph_assert_always(prv_shard == seastar::this_shard_id());
-        assert(is_active());
+        ceph_assert(is_active());
         unsigned index = static_cast<ConnectionPriv&>(conn->get_user_private()).index;
         auto &conn_state = conn_states[index];
         conn_state.conn_stats.finish_connecting();
@@ -618,12 +618,12 @@ static seastar::future<> run(
 
       std::optional<seastar::future<>> ms_dispatch(
           crimson::net::ConnectionRef conn, MessageRef m) override {
-        assert(is_active());
+        ceph_assert(is_active());
         // server replies with MOSDOp to generate server-side write workload
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
 
         unsigned index = static_cast<ConnectionPriv&>(conn->get_user_private()).index;
-        assert(index < num_conns);
+        ceph_assert(index < num_conns);
         auto &conn_state = conn_states[index];
 
         auto msg_id = m->get_tid();
@@ -906,7 +906,7 @@ static seastar::future<> run(
           }
           if (client.server_sid.has_value() &&
               seastar::this_shard_id() == *client.server_sid) {
-            assert(!client.is_active());
+            ceph_assert(!client.is_active());
             report.set_server_reactor_utilization(get_reactor_utilization());
           }
         }).then([&report] {

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -37,7 +37,7 @@ void add_log_entry(
   unsigned entry_size,
   std::map<std::string, ceph::buffer::list> *omap)
 {
-  assert(omap);
+  ceph_assert(omap);
   bufferlist bl;
   bl.append(ceph::buffer::create('0', entry_size));
 
@@ -181,7 +181,7 @@ seastar::future<> FSDriver::mkfs()
 {
   return init(
   ).then([this] {
-    assert(fs);
+    ceph_assert(fs);
     uuid_d uuid;
     uuid.generate_random();
     return fs->mkfs(uuid).handle_error(


### PR DESCRIPTION
_WIP: pushed for discussion / performance evaluation._

### Summarizing current options:

1) Move all assert -> ceph_assert (with a -5% throughput price)
2) Enabling asserts in teuthology only (Meaning, release builds will differ from continuous qa runs)
3) Promote critical asserts to ceph_assert as an on-going effort (same as coroutine changes) and keep testing with explicit *-debug in the suite until then.
4) Test both builds with and without NDEBUG in crimson qa runs, regularly, to make sure both keep passing.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
