### PR TITLE
Snaptrim perf optimize

### DIFF
--- a/qa/snaptrim/snaptirm_test.sh
+++ b/qa/snaptrim/snaptirm_test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# 
+# Author: Max Wang <wangzechen@inspur.com>
+#
+# This project is used to create a 400G data snapshot and delete it.
+# Calculate the delay of snapshot deletion in the osd log.
+# The result is saved in ./test/result.log
+
+function run() {
+    # Start 10 OSDs using vstart
+    cd ../../build
+    rm -rf ./test/result.log
+    MON=1 OSD=1 MDS=1 RGW=1 ../src/vstart.sh -n --without-dashboard
+
+    # Create snap
+    ceph osd pool create snap-test-pool 256 256
+    rbd -p snap-test-pool create --image rbd-test-0 --size 400G
+    rbd -p snap-test-pool bench --image rbd-test-0 --io-size 4M --io-total 400G --io-type write --io-pattern seq
+    rbd snap create rbd-test-0@snap0 -p snap-test-pool
+
+    # Write data,then purge snap
+    rbd -p snap-test-pool bench --image rbd-test-0 --io-size 4M --io-total 400G --io-type write --io-pattern seq
+    rbd snap rm rbd-test-0@snap0 -p snap-test-pool
+
+    # Collect the results from the osd log
+    mkdir -p ./test
+    for num in {0..9};do
+        cat ./out/osd.${num}.log | grep l_osd_snap_trim_get_raw_object_lat >> ./test/result.log
+    done
+}

--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -57,7 +57,8 @@ public:
   /// Returns next key
   virtual int get_next(
     const K &key,       ///< [in] key after which to get next
-    pair<K, V> *next    ///< [out] first key after key
+    pair<K, V> *next,    ///< [out] first key after key
+    bool with_lower_bound = true ///< [in] need rocksdb call lower_bound to seek
     ) = 0; ///< @return 0 on success, -ENOENT if there is no next
 
   virtual ~StoreDriver() {}
@@ -83,7 +84,8 @@ public:
   /// Fetch first key/value pair after specified key
   int get_next(
     K key,               ///< [in] key after which to get next
-    pair<K, V> *next     ///< [out] next key
+    pair<K, V> *next,     ///< [out] next key
+    bool with_lower_bound = true ///< [in] need rocksdb call lower_bound to seek
     ) {
     while (true) {
       pair<K, boost::optional<V> > cached;
@@ -91,7 +93,7 @@ public:
       bool got_cached = in_progress.get_next(key, &cached);
 
       bool got_store = false;
-      int r = driver->get_next(key, &store);
+      int r = driver->get_next(key, &store, with_lower_bound);
       if (r < 0 && r != -ENOENT) {
 	return r;
       } else if (r == 0) {

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3422,6 +3422,22 @@ std::vector<Option> get_global_options() {
     .set_default(2)
     .set_description("Time in seconds to sleep before next snap trim when data is on HDD and journal is on SSD"),
 
+    Option("osd_next_snap_trim_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Time in seconds to sleep before next snap trim (overrides values below)"),
+
+    Option("osd_next_snap_trim_sleep_hdd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(5)
+    .set_description("Time in seconds to sleep before next snap trim for HDDs"),
+
+    Option("osd_next_snap_trim_sleep_ssd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Time in seconds to sleep before next snap trim for SSDs"),
+
+    Option("osd_next_snap_trim_sleep_hybrid", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(2)
+    .set_description("Time in seconds to sleep before next snap trim when data is on HDD and journal is on SSD"),
+
     Option("osd_scrub_invalid_stats", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1889,6 +1889,14 @@ public:
     const ghobject_t &oid  ///< [in] object
     ) = 0;
 
+  virtual ObjectMap::ObjectMapIterator get_omap_iterator(
+    CollectionHandle &c,   ///< [in] collection
+    const ghobject_t &oid,  ///< [in] object
+    bool with_lower_bound  ///< [in] if invoke lower_bound to rocksdb's seek
+    ) {
+    return get_omap_iterator(c, oid);
+  };
+
   virtual int flush_journal() { return -EOPNOTSUPP; }
 
   virtual int dump_journal(ostream& out) { return -EOPNOTSUPP; }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4033,14 +4033,16 @@ void BlueStore::MempoolThread::_update_cache_settings()
 #define dout_prefix *_dout << "bluestore.OmapIteratorImpl(" << this << ") "
 
 BlueStore::OmapIteratorImpl::OmapIteratorImpl(
-  CollectionRef c, OnodeRef o, KeyValueDB::Iterator it)
+  CollectionRef c, OnodeRef o, KeyValueDB::Iterator it, bool with_lower_bound)
   : c(c), o(o), it(it)
 {
   RWLock::RLocker l(c->lock);
   if (o->onode.has_omap()) {
     get_omap_key(o->onode.nid, string(), &head);
     get_omap_tail(o->onode.nid, &tail);
-    it->lower_bound(head);
+    if(with_lower_bound) {
+      it->lower_bound(head);
+    }
   }
 }
 
@@ -10479,6 +10481,14 @@ ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
   const ghobject_t &oid  ///< [in] object
   )
 {
+  return get_omap_iterator(c_, oid, true);
+}
+ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
+  CollectionHandle &c_,              ///< [in] collection
+  const ghobject_t &oid  ///< [in] object
+  bool with_lower_bound
+  )
+{
   Collection *c = static_cast<Collection *>(c_.get());
   dout(10) << __func__ << " " << c->get_cid() << " " << oid << dendl;
   if (!c->exists) {
@@ -10494,7 +10504,7 @@ ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
   dout(10) << __func__ << " has_omap = " << (int)o->onode.has_omap() <<dendl;
   KeyValueDB::Iterator it = db->get_iterator(
     o->onode.is_pgmeta_omap() ? PREFIX_PGMETA_OMAP : PREFIX_OMAP);
-  return ObjectMap::ObjectMapIterator(new OmapIteratorImpl(c, o, it));
+  return ObjectMap::ObjectMapIterator(new OmapIteratorImpl(c, o, it, with_lower_bound));
 }
 
 // -----------------

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1485,7 +1485,7 @@ public:
     string _stringify() const;
 
   public:
-    OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it);
+    OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it, , bool with_lower_bound = true);
     int seek_to_first() override;
     int upper_bound(const string &after) override;
     int lower_bound(const string &to) override;
@@ -2673,7 +2673,12 @@ public:
     CollectionHandle &c,   ///< [in] collection
     const ghobject_t &oid  ///< [in] object
     ) override;
-
+  ObjectMap::ObjectMapIterator get_omap_iterator(
+    CollectionHandle &c,   ///< [in] collection
+    const ghobject_t &oid,  ///< [in] object
+    bool with_lower_bound   ///< [in] need rocksdb call lower_bound to seek
+  ) override;
+  
   void set_fsid(uuid_d u) override {
     fsid = u;
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3034,6 +3034,18 @@ float OSD::get_osd_snap_trim_sleep()
   return cct->_conf.get_val<double>("osd_snap_trim_sleep_hdd");
 }
 
+float OSD::get_osd_next_snap_trim_sleep()
+{
+  float osd_next_snap_trim_sleep = cct->_conf.get_val<double>("osd_next_snap_trim_sleep");
+  if (osd_next_snap_trim_sleep > 0)
+    return osd_next_snap_trim_sleep;
+  if (!store_is_rotational && !journal_is_rotational)
+    return cct->_conf.get_val<double>("osd_next_snap_trim_sleep_ssd");
+  if (store_is_rotational && !journal_is_rotational)
+    return cct->_conf.get_val<double>("osd_next_snap_trim_sleep_hybrid");
+  return cct->_conf.get_val<double>("osd_next_snap_trim_sleep_hdd");
+}
+
 int OSD::init()
 {
   OSDMapRef osdmap;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3968,6 +3968,9 @@ void OSD::create_logger()
   osd_plb.add_u64_counter(
     l_osd_pg_biginfo, "osd_pg_biginfo", "PG updated its biginfo attr");
 
+  osd_plb.add_time_avg(
+    l_osd_snap_trim_get_raw_object_lat, "osd_snap_trim_get_raw_object_lat", "snaptrim clone objects read latency");
+
   logger = osd_plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2337,6 +2337,7 @@ private:
   float get_osd_recovery_sleep();
   float get_osd_delete_sleep();
   float get_osd_snap_trim_sleep();
+  float get_osd_next_snap_trim_sleep();
 
   void probe_smart(const string& devid, ostream& ss);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -185,6 +185,8 @@ enum {
   l_osd_pg_fastinfo,
   l_osd_pg_biginfo,
 
+  l_osd_snap_trim_get_raw_object_lat,
+
   l_osd_last,
 };
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15475,6 +15475,9 @@ boost::statechart::result PrimaryLogPG::AwaitAsyncWork::react(const DoSnapWork&)
   }
   ceph_assert(!to_trim.empty());
 
+  utime_t lat = ceph_clock_now() - begin_get_trim_object_time;
+  pg->osd->logger->tinc(l_osd_snap_trim_get_raw_object_lat, lat);
+
   for (auto &&object: to_trim) {
     // Get next
     ldout(pg->cct, 10) << "AwaitAsyncWork react trimming " << object << dendl;

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -71,9 +71,12 @@ public:
   int get_keys(
     const std::set<std::string> &keys,
     std::map<std::string, bufferlist> *out) override;
+  // If "with_lower_bound = false",
+  // After that, creating iter will not be called "it->lower_bound(head);"
   int get_next(
     const std::string &key,
-    pair<std::string, bufferlist> *next) override;
+    pair<std::string, bufferlist> *next,
+    bool with_lower_bound = true) override;
 };
 
 /**
@@ -216,7 +219,9 @@ public:
   int get_next_objects_to_trim(
     snapid_t snap,              ///< [in] snap to check
     unsigned max,               ///< [in] max to get
-    vector<hobject_t> *out      ///< [out] next objects to trim (must be empty)
+    vector<hobject_t> *out,     ///< [out] next objects to trim (must be empty)
+    std::string &last_key,      ///< [out] last trim key
+    std::set<string>& last_prefixes      ///< [out] last_prefixes to trim
     );  ///< @return error, -ENOENT if no more objects
 
   /// Remove mapping for oid


### PR DESCRIPTION
<!-- Title -->
[snaptrim]: Optimize snaptrim object scanning logic to reduce deletion time and CPU usage

<!-- Commit Message -->
[snaptrim]: Optimize snaptrim object scanning logic

Avoid full scans in each iteration by storing the last scanned object as a prefix for the next query. Introduced a new config option `osd_next_snap_trim_sleep` (default: 0) to control the sleep interval during snaptrim, reducing CPU pressure.

Problem Description
When deleting snapshots with over 10k objects, due to the linear scanning of object entries, the deletion time may be as long as 400 seconds. In addition, the accumulation of idle empty snapshots will cause the entire storage node to maintain a CPU usage rate of over 60% continuously.

Solution
More than 95% of the current snapshot deletion delay is spent on RocksDB seeks. The optimization involves saving the last scanned object as a prefix for the next query, avoiding full scans in each iteration. A dynamic sleep mechanism has also been introduced, controlled by a new configuration parameter:
osd_next_snap_trim_sleep (default: 0)

Verification:
| Scenario            | Before    | After     |
|---------------------|-----------|-----------|
| 10k objects         | 400s      | 8s        |
| 1k empty snaps      | 60% CPU   | <5% CPU   |

Integration test added at: qa/snaptrim/snaptrim_test.sh
Tracker issue: https://tracker.ceph.com/issues/71394

Signed-off-by: wzc <wangzechen@inspur.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
