### PR TITLE
Improve error handling and add --resume flag to 'ceph rgw realm bootstrap'

### DIFF
--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -184,6 +184,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                  placement: Optional[str] = None,
                                  zone_endpoints: Optional[str] = None,
                                  start_radosgw: Optional[bool] = True,
+                                 resume: Optional[bool] = False,
                                  inbuf: Optional[str] = None) -> HandleCommandResult:
         """Bootstrap new rgw realm, zonegroup, and zone"""
 
@@ -207,9 +208,26 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         try:
             for spec in rgw_specs:
                 self.create_pools(spec)
-                RGWAM(self.env).realm_bootstrap(spec, start_radosgw)
+                RGWAM(self.env).realm_bootstrap(spec, start_radosgw, resume)
+
         except RGWAMException as e:
             self.log.error('cmd run exception: (%d) %s' % (e.retcode, e.message))
+            if rgw_specs:
+                spec = rgw_specs[0]
+                existing = []
+                if spec.rgw_realm in RGWAM(self.env).realm_op().list():
+                    existing.append(f"realm: {spec.rgw_realm}")
+                if spec.rgw_zonegroup in RGWAM(self.env).zonegroup_op().list():
+                    existing.append(f"realm: {spec.rgw_zonegroup}")
+                if spec.rgw_zone in RGWAM(self.env).zone_op().list():
+                    existing.append(f"realm: {spec.rgw_zone}")
+
+                if existing:
+                    e.stderr = (e.stderr or '') + (
+                        f"\nNote: Partial bootstrap detected – {', '.join(existing)} already exist.\n"
+                        f"To resume, run:\n  ceph rgw realm bootstrap --resume -i <spec.yaml>\n"
+                    )
+
             return HandleCommandResult(retval=e.retcode, stdout=e.stdout, stderr=e.stderr)
         except PoolCreationError as e:
             self.log.error(f'Pool creation failure: {str(e)}')

--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -533,19 +533,20 @@ class RGWAM:
         except RGWAMCmdRunException as e:
             raise RGWAMException('failed to update period', e)
 
-    def realm_bootstrap(self, rgw_spec, start_radosgw=True):
+    def realm_bootstrap(self, rgw_spec, start_radosgw=True, resume=False):
 
         realm_name = rgw_spec.rgw_realm
         zonegroup_name = rgw_spec.rgw_zonegroup
         zone_name = rgw_spec.rgw_zone
 
         # Some sanity checks
-        if realm_name in self.realm_op().list():
-            raise RGWAMException(f'Realm {realm_name} already exists')
-        if zonegroup_name in self.zonegroup_op().list():
-            raise RGWAMException(f'Zonegroup {zonegroup_name} already exists')
-        if zone_name in self.zone_op().list():
-            raise RGWAMException(f'Zone {zone_name} already exists')
+        if not resume:
+            if realm_name in self.realm_op().list():
+                raise RGWAMException(f'Realm {realm_name} already exists')
+            if zonegroup_name in self.zonegroup_op().list():
+                raise RGWAMException(f'Zonegroup {zonegroup_name} already exists')
+            if zone_name in self.zone_op().list():
+                raise RGWAMException(f'Zone {zone_name} already exists')
 
         # Create RGW entities and update the period
         realm = self.create_realm(realm_name)


### PR DESCRIPTION
Improve error handling and add --resume flag to 'ceph rgw realm bootstrap' for partial recovery

This patch enhances the `ceph rgw realm bootstrap` command by improving error
messaging and introducing a `--resume` flag to support recovery from partial
bootstrap failures.

Logs:
```
[ceph: root@ceph-node-0 ~]# ceph rgw realm bootstrap -i rgw-test.yaml
Error EIO: 
Note: Partial bootstrap detected – the following entities were already created during a previous bootstrap attempt: realm: my_realm4, realm: my_zonegroup4, realm: my_zone4
To resume, run:
  ceph rgw realm bootstrap --resume -i <spec.yaml>

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
