### PR TITLE
squid: rgw-admin: report correct error code for non-existent bucket on deletion

### DIFF
--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -858,6 +858,11 @@ def task(ctx, config):
     (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name, 'purge-objects' : True})
     assert ret == 200
 
+    # TESTCASE 'rm-bucket', 'bucket', 'rm', 'non-existent bucket', 'correct error'
+    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'rm'], {'bucket' : bucket_name})
+    assert ret == 404
+    assert out['Code'] == 'NoSuchBucket'
+
     # TESTCASE 'caps-add', 'caps', 'add', 'add user cap', 'succeeds'
     caps = 'usage=read'
     (ret, out) = rgwadmin_rest(admin_conn, ['caps', 'add'], {'uid' :  user1, 'user-caps' : caps})

--- a/src/rgw/driver/rados/rgw_rest_bucket.cc
+++ b/src/rgw/driver/rados/rgw_rest_bucket.cc
@@ -234,6 +234,9 @@ void RGWOp_Bucket_Remove::execute(optional_yield y)
   const bool is_forwarded = s->info.args.exists(RGW_SYS_PARAM_PREFIX "zonegroup");
 
   op_ret = RGWBucketAdminOp::remove_bucket(driver, *s->penv.site, op_state, y, s, bypass_gc, true, is_forwarded);
+  if (op_ret == -ENOENT) {
+    op_ret = -ERR_NO_SUCH_BUCKET;
+  }
 }
 
 class RGWOp_Set_Bucket_Quota : public RGWRESTOp {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71172

---
backport of https://github.com/ceph/ceph/pull/63081
parent tracker: https://tracker.ceph.com/issues/71159