### PR TITLE
OSD: EC recovery zero detect

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -141,6 +141,19 @@ static ceph::spinlock debug_lock;
     raw_zeros(char *dataptr, unsigned l, int mempool)
       : raw_combined(dataptr, l, mempool) {
       memset(dataptr, 0, l);
+#ifndef _WIN32
+      if (mprotect(dataptr, l, PROT_READ) != 0) {
+        ceph_abort_msg("mprotect on raw_zeros failed");
+      }
+#endif
+    }
+
+    ~raw_zeros() {
+#ifndef _WIN32
+      if (mprotect(data, len, PROT_WRITE | PROT_READ) != 0) {
+        ceph_abort_msg("mprotect on destroing raw_zeros failed");
+      }
+#endif
     }
 
     static constexpr unsigned ZERO_AREA_NUM_PAGES = 4;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -129,6 +129,7 @@ struct error_code;
   class raw_claimed_char;
   class raw_unshareable; // diagnostic, unshareable char buffer
   class raw_combined;
+  class raw_zeros;
   class raw_claim_buffer;
 
 
@@ -303,6 +304,9 @@ struct error_code;
     unsigned wasted() const;
 
     int cmp(const ptr& o) const;
+    /// is_zero_fast() is a variant aware about deduplicated zeros.
+    /// In Tentacle it shall NOT be used by anybody except ECBackend.
+    bool is_zero_fast() const;
     bool is_zero() const;
 
     // modifiers
@@ -930,6 +934,8 @@ struct error_code;
       return *_carriage;
     }
 
+    ptr always_zeroed_bptr();
+
   public:
     // cons/des
     list()
@@ -1163,6 +1169,11 @@ struct error_code;
     void append(std::istream& in);
     contiguous_filler append_hole(unsigned len);
     void append_zero(unsigned len);
+    /// append_zero2() is a temporary, short-living variant that deduplicates zeros.
+    /// In Tentacle it shall NOT be used by anybody except ECBackend.
+    /// In future release it will likely replace the append_zero() variant but
+    /// other changes at the interface are needed to make the transition safe.
+    void append_zero2(unsigned len);
     void prepend_zero(unsigned len);
 
     reserve_t obtain_contiguous_space(const unsigned len);

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -1007,5 +1007,14 @@ public:
 template<typename T, template<typename, typename, typename ...> class C, bool strict>
 struct fmt::is_range<interval_set<T, C, strict>, char> : std::false_type {};
 
+template <typename T>
+struct is_interval_set : std::false_type {};
+
+template <typename T, template<typename, typename, typename ...> class C, bool strict>
+struct is_interval_set<interval_set<T, C, strict>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_interval_set_v = is_interval_set<T>::value;
+
 #undef strict_mode_assert
 #endif

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -525,7 +525,8 @@ struct ClientReadCompleter final : ECCommon::ReadCompleter {
       /* Decode any missing buffers */
       int r = res.buffers_read.decode(read_pipeline.ec_impl,
                                   req.shard_want_to_read,
-                                  req.object_size);
+                                  req.object_size,
+                                  read_pipeline.get_parent()->get_dpp());
       ceph_assert( r == 0 );
       dout(30) << __func__ << ": after decode: "
                << res.buffers_read.debug_string(2048, 8)

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -68,9 +68,9 @@ void ECTransaction::Generate::encode_and_write() {
      */
     read_sem->zero_pad(plan.will_write);
     to_write.pad_with_other(plan.will_write, *read_sem);
-    r = to_write.encode_parity_delta(ec_impl, *read_sem);
+    r = to_write.encode_parity_delta(ec_impl, *read_sem, dpp);
   } else {
-    r = to_write.encode(ec_impl);
+    r = to_write.encode(ec_impl, dpp);
   }
   ceph_assert(r == 0);
   // Remove any unnecessary writes.

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -481,15 +481,44 @@ TEST(BufferPtr, cmp) {
   EXPECT_LE(1, af.cmp(acc));
 }
 
+TEST(BufferPtr, is_zero_fast) {
+  // there is no easy way to create `raw_zeros` instances outside
+  // of bufferlist, thus use list::append_zero() to instantiate
+  buffer::list zeroed_bl;
+  zeroed_bl.append_zero2(42);
+  {
+    const auto& zeroed_bptr = zeroed_bl.front();
+    EXPECT_TRUE(zeroed_bptr.is_zero());
+    EXPECT_TRUE(zeroed_bptr.is_zero_fast());
+  }
+  {
+    buffer::ptr sub_zeroed_bptr(zeroed_bl.front(), 0, 42/2);
+    EXPECT_TRUE(sub_zeroed_bptr.is_zero());
+    EXPECT_TRUE(sub_zeroed_bptr.is_zero_fast());
+  }
+  {
+    buffer::ptr zeroed_empty_bptr(zeroed_bl.front(), 0, 0);
+    EXPECT_TRUE(zeroed_empty_bptr.is_zero());
+    EXPECT_TRUE(zeroed_empty_bptr.is_zero_fast());
+  }
+}
+
 TEST(BufferPtr, is_zero) {
   char str[2] = { '\0', 'X' };
   {
     const bufferptr ptr(buffer::create_static(2, str));
     EXPECT_FALSE(ptr.is_zero());
+    EXPECT_FALSE(ptr.is_zero_fast());
   }
   {
     const bufferptr ptr(buffer::create_static(1, str));
     EXPECT_TRUE(ptr.is_zero());
+    EXPECT_FALSE(ptr.is_zero_fast());
+  }
+  {
+    const bufferptr ptr(buffer::create_static(0, str));
+    EXPECT_TRUE(ptr.is_zero());
+    EXPECT_FALSE(ptr.is_zero_fast());
   }
 }
 

--- a/src/test/osd/TestECUtil.cc
+++ b/src/test/osd/TestECUtil.cc
@@ -646,7 +646,7 @@ TEST(ECUtil, slice_iterator)
   out_set.insert_range(shard_id_t(0), 3);
   shard_extent_map_t sem(&sinfo);
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
     ASSERT_TRUE(iter.get_out_bufferptrs().empty());
   }
 
@@ -660,7 +660,7 @@ TEST(ECUtil, slice_iterator)
   sem.insert_in_shard(shard_id_t(0), 0, a);
   sem.insert_in_shard(shard_id_t(1), 0, b);
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
 
     {
       auto out = iter.get_out_bufferptrs();
@@ -699,7 +699,7 @@ TEST(ECUtil, slice_iterator)
   sem.insert_in_shard(shard_id_t(1), 4096*4, e);
 
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
 
     {
       auto out = iter.get_out_bufferptrs();
@@ -755,7 +755,7 @@ TEST(ECUtil, slice_iterator)
   sem.insert_in_shard(shard_id_t(1), 4096*2, d);
 
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
 
     {
       auto out = iter.get_out_bufferptrs();
@@ -794,7 +794,7 @@ TEST(ECUtil, slice_iterator_subset_out)
   out_set.insert(shard_id_t(1));
   shard_extent_map_t sem(&sinfo);
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
     ASSERT_TRUE(iter.get_in_bufferptrs().empty());
     ASSERT_TRUE(iter.get_out_bufferptrs().empty());
   }
@@ -809,7 +809,7 @@ TEST(ECUtil, slice_iterator_subset_out)
   sem.insert_in_shard(shard_id_t(0), 0, a);
   sem.insert_in_shard(shard_id_t(1), 0, b);
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
 
     {
       auto in = iter.get_in_bufferptrs();
@@ -841,7 +841,7 @@ TEST(ECUtil, slice_iterator_subset_out)
   sem.insert_in_shard(shard_id_t(1), 4096*4, e);
 
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
 
     {
       auto in = iter.get_in_bufferptrs();
@@ -896,7 +896,7 @@ TEST(ECUtil, slice_iterator_subset_out)
   sem.insert_in_shard(shard_id_t(1), 4096*2, d);
 
   {
-    auto iter = sem.begin_slice_iterator(out_set);
+    auto iter = sem.begin_slice_iterator(out_set, nullptr);
 
     {
       auto in = iter.get_in_bufferptrs();


### PR DESCRIPTION
Optimised EC already performs "sparse writes":

- Writes are padded out to 4k with zeros if required. 
- Where encoding is required, unmapped is interpreted as zeros.
- Optimised EC does not yet support or use sparse reads. 

The problem is that when recovering a missing shard from coding, we cannot tell the difference between a 4k extent containing zeros to an unmapped 4k region.  This is a major issue because the size of the data on the OSDs will increase significantly when being recovered.

To solve the space issue, this PR plans to convert any recovered 4k buffer to be "unmapped" at the backend. 

There are two techniques that could be employed here:
- Scan for aligned 4k buffers that are zeros
- Perform a sparse read during recovery and skip decode where all shards are unmapped. 

This PR implements the FIRST of these as it entirely solves the space issue and we will leave the second as a backfill performance enhancement for the future. 

I want to put this in after fixing a number of EC bugs, so as it is easier to test, however, it has caused some concern, specifically in conjunction with @rzarzynski 's zero buffer PR.  

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
