### PR TITLE
reef: doc/mgr: edit diskpredictor.rst

### DIFF
--- a/doc/mgr/diskprediction.rst
+++ b/doc/mgr/diskprediction.rst
@@ -4,48 +4,61 @@
 Diskprediction Module
 =====================
 
-The *diskprediction* module leverages Ceph device health check to collect disk health metrics and uses internal predictor module to produce the disk failure prediction and returns back to Ceph. It doesn't require any external server for data analysis and output results. Its internal predictor's accuracy is around 70%.
+The ``diskprediction`` module leverages Ceph device health checks to collect
+disk health metrics and uses the internal predictor module to produce disk
+failure predictions and returns them back to Ceph. It requires no external
+server for data analysis and the outputting of results. Its internal
+predictor's accuracy is around 70%.
 
 Enabling
 ========
 
-Run the following command to enable the *diskprediction_local* module in the Ceph
-environment::
+Run the following command to enable the ``diskprediction_local`` module in the
+Ceph environment:
 
-    ceph mgr module enable diskprediction_local
+.. prompt:: bash #
 
-
-To enable the local predictor::
-
-    ceph config set global device_failure_prediction_mode local
-
-To disable prediction::
-
-    ceph config set global device_failure_prediction_mode none
+   ceph mgr module enable diskprediction_local
 
 
-*diskprediction_local* requires at least six datasets of device health metrics to
-make prediction of the devices' life expectancy. And these health metrics are
-collected only if health monitoring is :ref:`enabled <enabling-monitoring>`.
+Run the following command to enable the local predictor:
 
-Run the following command to retrieve the life expectancy of given device.
+.. prompt:: bash #
 
-::
+   ceph config set global device_failure_prediction_mode local
 
-    ceph device predict-life-expectancy <device id>
+Run the following command to disable prediction:
+
+.. prompt:: bash #
+
+   ceph config set global device_failure_prediction_mode none
+
+
+``diskprediction_local`` requires at least six datasets of device health
+metrics to make prediction of the devices' life expectancy. And these health
+metrics are collected only if health monitoring is :ref:`enabled
+<enabling-monitoring>`.
+
+Run the following command to retrieve the life expectancy of a given device:
+
+.. prompt:: bash #
+
+   ceph device predict-life-expectancy <device id>
 
 Configuration
 =============
 
-The module performs the prediction on a daily basis by default. You can adjust
-this interval with::
+The module performs the prediction on a daily basis by default. Adjust this
+interval by running a command of the following form:
 
-  ceph config set mgr mgr/diskprediction_local/predict_interval <interval-in-seconds>
+.. prompt:: bash #
+
+   ceph config set mgr mgr/diskprediction_local/predict_interval <interval-in-seconds>
 
 Debugging
 =========
 
-If you want to debug the DiskPrediction module mapping to Ceph logging level,
+To debug the DiskPrediction module mapping to Ceph logging level,
 use the following command.
 
 ::
@@ -54,6 +67,6 @@ use the following command.
 
         debug mgr = 20
 
-With logging set to debug for the manager the module will print out logging
-message with prefix *mgr[diskprediction]* for easy filtering.
+With logging set to ``debug`` for the Manager, the module will print logging
+messages with the prefix ``mgr[diskprediction]``. This facilitates filtering. 
 


### PR DESCRIPTION
Edit doc/mgr/diskpredictor.rst. This includes the rewriting of sentences so that they now appear in grammatically-correct English.

This is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.


(cherry picked from commit 4d628d93ce7d56e26e381bae2fcbfc5dfd78fa7e)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
