### PR TITLE
squid: rgw/d3n: fix valgrind invalid read during exit

### DIFF
--- a/src/rgw/driver/rados/rgw_d3n_datacache.cc
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.cc
@@ -104,7 +104,7 @@ void D3nDataCache::init(CephContext *_cct) {
   struct aioinit ainit{0};
   ainit.aio_threads = cct->_conf.get_val<int64_t>("rgw_d3n_libaio_aio_threads");
   ainit.aio_num = cct->_conf.get_val<int64_t>("rgw_d3n_libaio_aio_num");
-  ainit.aio_idle_time = 5;
+  ainit.aio_idle_time = 2;
   aio_init(&ainit);
 #endif
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71421

---

backport of https://github.com/ceph/ceph/pull/63352
parent tracker: https://tracker.ceph.com/issues/64835

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh