### PR TITLE
tentacle: orch/module: Make orch unpause an alias for orch resume

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2300,6 +2300,12 @@ Usage:
         self.resume()
         return HandleCommandResult()
 
+    @_cli_write_command('orch unpause')
+    def _unpause(self) -> HandleCommandResult:
+        """Alias to orch resume"""
+        self.resume()
+        return HandleCommandResult()
+
     @_cli_write_command('orch cancel')
     def _cancel(self) -> HandleCommandResult:
         """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71407

---

backport of https://github.com/ceph/ceph/pull/63048
parent tracker: https://tracker.ceph.com/issues/71135

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh