### PR TITLE
doc/radosgw: Cosmetic improvements in cloud-transition.rst

### DIFF
--- a/doc/radosgw/cloud-transition.rst
+++ b/doc/radosgw/cloud-transition.rst
@@ -24,12 +24,12 @@ Cloud Storage Class Tier Type
 
 * ``tier-type`` (string)
 
-The type of remote cloud service that will be used to transition objects.
-The below tier types are supported:
+  The type of remote cloud service that will be used to transition objects.
+  The below tier types are supported:
 
-* ``cloud-s3`` : Regular S3 compatible object store service
+  * ``cloud-s3`` : Regular S3 compatible object store service.
 
-* ``cloud-s3-glacier`` : S3 Glacier or Tape storage services
+  * ``cloud-s3-glacier`` : S3 Glacier or Tape storage services.
 
 
 Cloud Storage Class Tier Configuration
@@ -59,66 +59,66 @@ Cloud Transition Specific Configurables
 
 * ``access_key`` (string)
 
-The remote cloud S3 access key.
+  The remote cloud S3 access key.
 
 * ``secret`` (string)
 
-The secret key for the remote cloud S3 service.
+  The secret key for the remote cloud S3 service.
 
 * ``endpoint`` (string)
 
-URL of remote cloud S3 service.
+  URL of remote cloud S3 service.
 
 * ``region`` (string)
 
-The remote cloud S3 service region name.
+  The remote cloud S3 service region name.
 
 * ``host_style`` (path | virtual)
 
-Type of host style to be used when accessing the remote cloud S3 service (default: ``path``).
+  Type of host style to be used when accessing the remote cloud S3 service (default: ``path``).
 
 * ``acls`` (array)
 
-Contains a list of ``acl_mappings``.
+  Contains a list of ``acl_mappings``.
 
 * ``acl_mapping`` (container)
 
-Each ``acl_mapping`` structure contains ``type``, ``source_id``, and ``dest_id``. These
-define the ACL mutation to be done on each object. An ACL mutation makes it possible to
-convert a source userid to a destination userid.
+  Each ``acl_mapping`` structure contains ``type``, ``source_id``, and ``dest_id``. These
+  define the ACL mutation to be done on each object. An ACL mutation makes it possible to
+  convert a source userid to a destination userid.
 
 * ``type`` (id | email | uri)
 
-ACL type: ``id`` defines userid, ``email`` defines user by email,
-and ``uri`` defines user by ``uri`` (group).
+  ACL type: ``id`` defines userid, ``email`` defines user by email,
+  and ``uri`` defines user by ``uri`` (group).
 
 * ``source_id`` (string)
 
-ID of user in the source zone.
+  ID of user in the source zone.
 
 * ``dest_id`` (string)
 
-ID of user on the destination.
+  ID of user on the destination.
 
 * ``target_path`` (string)
 
-A string that defines how the target path is constructed. The target path
-specifies a prefix to which the source bucket-name/object-name is appended.
-If not specified the ``target_path`` created is ``rgwx-${zonegroup}-${storage-class}-cloud-bucket``.
+  A string that defines how the target path is constructed. The target path
+  specifies a prefix to which the source bucket-name/object-name is appended.
+  If not specified the ``target_path`` created is ``rgwx-${zonegroup}-${storage-class}-cloud-bucket``.
 
-For example: ``target_path = rgwx-archive-${zonegroup}/``
+  For example: ``target_path = rgwx-archive-${zonegroup}/``
 
 * ``target_storage_class`` (string)
 
-A string that defines the target storage class to which the object transitions.
-If not specified, the object is transitioned to the ``STANDARD`` storage class.
+  A string that defines the target storage class to which the object transitions.
+  If not specified, the object is transitioned to the ``STANDARD`` storage class.
 
 * ``retain_head_object`` (true | false)
 
-If ``true``, the metadata of the object transitioned to the cloud service is retained.
-If ``false`` (default), the object is deleted after the transition.
-This option is ignored for current-versioned objects. For more details,
-refer to the "Versioned Objects" section below.
+  If ``true``, the metadata of the object transitioned to the cloud service is retained.
+  If ``false`` (default), the object is deleted after the transition.
+  This option is ignored for current-versioned objects. For more details,
+  refer to the "Versioned Objects" section below.
 
 
 S3 Specific Configurables
@@ -135,17 +135,17 @@ when accessing cloud services::
 
 * ``multipart_sync_threshold`` (integer)
 
-Objects this size or larger will be transitioned to the cloud using multipart upload.
+  Objects this size or larger will be transitioned to the cloud using multipart upload.
 
 * ``multipart_min_part_size`` (integer)
 
-Minimum part size to use when transitioning objects using multipart upload.
+  Minimum part size to use when transitioning objects using multipart upload.
 
 
 How to Configure
 ~~~~~~~~~~~~~~~~
 
-See :ref:`adding_a_storage_class` for how to configure storage-class for a zonegroup. The cloud transition requires a creation of a special storage class with tier type defined as ``cloud-s3`` or ``cloud-s3-glacier``
+See :ref:`adding_a_storage_class` for how to configure storage-class for a zonegroup. The cloud transition requires a creation of a special storage class with tier type defined as ``cloud-s3`` or ``cloud-s3-glacier``.
 
 .. note:: If you have not performed previous :ref:`Multisite Configuration <multisite>`,
           a ``default`` zone and zonegroup are created for you, and changes
@@ -352,7 +352,7 @@ attributes are added to the objects being transitioned:
 * ``x-rgw-cloud-keep-attrs`` : ``true`` / ``false``
 
    If set to default ``true``, the cloud service should map and store all
-   ``the x-amz-meta-*`` attributes. If it cannot, then the operation should fail.
+   the ``x-amz-meta-*`` attributes. If it cannot, then the operation should fail.
 
    If set to ``false``, the cloud service can ignore such attributes and
    just store the object data being sent.
@@ -422,8 +422,8 @@ The objects transitioned to cloud can now be restored. For more information, ref
 Future Work
 -----------
 
-* Send presigned redirect or read-through the objects transitioned to cloud
+* Send presigned redirect or read-through the objects transitioned to cloud.
 
-* Support s3:RestoreObject operation on cloud transitioned objects.
+* Support ``s3:RestoreObject`` operation on cloud transitioned objects.
 
 * Support transition to other cloud providers (like Azure).


### PR DESCRIPTION
Indent text that should belong to list items so they are formatted as list items.

Add missing full stop for a few sentences.

Move "the" outside of inline preformatted.
Format S3 API operation name with inline preformatted which seems common.

Before: https://docs.ceph.com/en/latest/radosgw/cloud-transition/
Rendered PR: https://ceph--63446.org.readthedocs.build/en/63446/radosgw/cloud-transition/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
