### PR TITLE
doc/radosgw: Fix capitalization, tab use, punctuation in two files

### DIFF
--- a/doc/radosgw/nfs.rst
+++ b/doc/radosgw/nfs.rst
@@ -13,7 +13,7 @@ protocols (S3 and Swift).
 In particular, the Ceph Object Gateway can now be configured to
 provide file-based access when embedded in the NFS-Ganesha NFS server.
 
-The simplest and preferred way of managing nfs-ganesha clusters and rgw exports
+The simplest and preferred way of managing NFS-Ganesha clusters and RGW exports
 is using ``ceph nfs ...`` commands. See :doc:`/mgr/nfs` for more details.
 
 librgw
@@ -34,7 +34,7 @@ Namespace Conventions
 =====================
 
 The implementation conforms to Amazon Web Services (AWS) hierarchical
-namespace conventions which map UNIX-style path names onto S3 buckets
+namespace conventions which map Unix-style path names onto S3 buckets
 and objects.
 
 The top level of the attached namespace consists of S3 buckets,
@@ -103,7 +103,7 @@ following characteristics:
 
     * additional RGW authentication types such as Keystone are not currently supported
 
-Manually configuring an NFS-Ganesha Instance
+Manually Configuring an NFS-Ganesha Instance
 ============================================
 
 Each NFS RGW instance is an NFS-Ganesha server instance *embedding*
@@ -191,8 +191,8 @@ variables in the RGW config section::
 ``ceph_conf`` gives a path to a non-default ceph.conf file to use
 
 
-Other useful NFS-Ganesha configuration:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Other Useful NFS-Ganesha Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Any EXPORT block which should support NFSv3 should include version 3
 in the NFS_Protocols setting. Additionally, NFSv3 is the last major
@@ -239,45 +239,45 @@ Example::
   
   LOG {
 
-	Components {
-		MEMLEAKS = FATAL;
-		FSAL = FATAL;
-		NFSPROTO = FATAL;
-		NFS_V4 = FATAL;
-		EXPORT = FATAL;
-		FILEHANDLE = FATAL;
-		DISPATCH = FATAL;
-		CACHE_INODE = FATAL;
-		CACHE_INODE_LRU = FATAL;
-		HASHTABLE = FATAL;
-		HASHTABLE_CACHE = FATAL;
-		DUPREQ = FATAL;
-		INIT = DEBUG;
-		MAIN = DEBUG;
-		IDMAPPER = FATAL;
-		NFS_READDIR = FATAL;
-		NFS_V4_LOCK = FATAL;
-		CONFIG = FATAL;
-		CLIENTID = FATAL;
-		SESSIONS = FATAL;
-		PNFS = FATAL;
-		RW_LOCK = FATAL;
-		NLM = FATAL;
-		RPC = FATAL;
-		NFS_CB = FATAL;
-		THREAD = FATAL;
-		NFS_V4_ACL = FATAL;
-		STATE = FATAL;
-		FSAL_UP = FATAL;
-		DBUS = FATAL;
-	}
-	# optional: redirect log output
- #	Facility {
- #		name = FILE;
- #		destination = "/tmp/ganesha-rgw.log";
- #		enable = active;
-	}
- }
+    Components {
+        MEMLEAKS = FATAL;
+        FSAL = FATAL;
+        NFSPROTO = FATAL;
+        NFS_V4 = FATAL;
+        EXPORT = FATAL;
+        FILEHANDLE = FATAL;
+        DISPATCH = FATAL;
+        CACHE_INODE = FATAL;
+        CACHE_INODE_LRU = FATAL;
+        HASHTABLE = FATAL;
+        HASHTABLE_CACHE = FATAL;
+        DUPREQ = FATAL;
+        INIT = DEBUG;
+        MAIN = DEBUG;
+        IDMAPPER = FATAL;
+        NFS_READDIR = FATAL;
+        NFS_V4_LOCK = FATAL;
+        CONFIG = FATAL;
+        CLIENTID = FATAL;
+        SESSIONS = FATAL;
+        PNFS = FATAL;
+        RW_LOCK = FATAL;
+        NLM = FATAL;
+        RPC = FATAL;
+        NFS_CB = FATAL;
+        THREAD = FATAL;
+        NFS_V4_ACL = FATAL;
+        STATE = FATAL;
+        FSAL_UP = FATAL;
+        DBUS = FATAL;
+    }
+  # optional: redirect log output
+  # Facility {
+  #     name = FILE;
+  #     destination = "/tmp/ganesha-rgw.log";
+  #     enable = active;
+  # }
+  }
 
 Running Multiple NFS Gateways
 =============================
@@ -315,7 +315,7 @@ if a Swift container name contains underscores, it is not a valid S3
 bucket name and will be rejected unless ``rgw_relaxed_s3_bucket_names``
 is set to true.
 
-Configuring NFSv4 clients
+Configuring NFSv4 Clients
 =========================
 
 To access the namespace, mount the configured NFS-Ganesha export(s)

--- a/doc/radosgw/sync-modules.rst
+++ b/doc/radosgw/sync-modules.rst
@@ -9,7 +9,7 @@ create multiple zones and mirror data and metadata between them. ``Sync Modules`
 are built atop of the multisite framework that allows for forwarding data and
 metadata to a different external tier. A sync module allows for a set of actions
 to be performed whenever a change in data occurs (metadata ops like bucket or
-user creation etc. are also regarded as changes in data). As the rgw multisite
+user creation etc. are also regarded as changes in data). As the RGW multisite
 changes are eventually consistent at remote sites, changes are propagated
 asynchronously. This would allow for unlocking use cases such as backing up the
 object storage to an external cloud cluster or a custom backup solution using
@@ -17,12 +17,12 @@ tape drives, indexing metadata in ElasticSearch etc.
 
 A sync module configuration is local to a zone. The sync module determines
 whether the zone exports data or can only consume data that was modified in
-another zone. As of luminous the supported sync plugins are `elasticsearch`_,
+another zone. As of Luminous the supported sync plugins are `elasticsearch`_,
 ``rgw``, which is the default sync plugin that synchronizes data between the
 zones and ``log`` which is a trivial sync plugin that logs the metadata
 operation that happens in the remote zones. The following docs are written with
 the example of a zone using `elasticsearch sync module`_, the process would be similar
-for configuring any sync plugin
+for configuring any sync plugin.
 
 .. toctree::
    :maxdepth: 1
@@ -40,7 +40,7 @@ Requirements and Assumptions
 Let us assume a simple multisite configuration as described in the :ref:`multisite`
 docs, of 2 zones ``us-east`` and ``us-west``, let's add a third zone
 ``us-east-es`` which is a zone that only processes metadata from the other
-sites. This zone can be in the same or a different ceph cluster as ``us-east``.
+sites. This zone can be in the same or a different Ceph cluster as ``us-east``.
 This zone would only consume metadata from other zones and RGWs in this zone
 will not serve any end user requests directly.
 
@@ -71,7 +71,7 @@ For example in the ``elasticsearch`` sync module
                                --tier-config=endpoint=http://localhost:9200,num_shards=10,num_replicas=1
 
 
-For the various supported tier-config options refer to the `elasticsearch sync module`_ docs
+For the various supported tier-config options refer to the `elasticsearch sync module`_ docs.
 
 Finally update the period
 


### PR DESCRIPTION
Use title case consistently in section titles.

Capitalize first letter for Ceph, Unix, Luminous.

Capitalize RGW and NFS-Ganesha consistently.

Remove a colon from end of a section title in `nfs.rst`.

Add full stops at end of two sentences in `sync-modules.rst`.

Change tabs into four spaces in `nfs.rst`.
Also use comments more sensibly in logging example in `nfs.rst`:
- Indent the comments consistently, fixing a leading space in the beginning of the rendered preformatted block.
- Also comment out the closing brace.

For `nfs.rst`:
- Before: https://docs.ceph.com/en/latest/radosgw/nfs/
- Rendered PR: https://ceph--63450.org.readthedocs.build/en/63450/radosgw/nfs/

For `sync-modules.rst`:
- Before: https://docs.ceph.com/en/latest/radosgw/sync-modules/
- Rendered PR: https://ceph--63450.org.readthedocs.build/en/63450/radosgw/sync-modules/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
