### PR TITLE
doc/mgr: edit modules.rst.

### DIFF
--- a/doc/mgr/modules.rst
+++ b/doc/mgr/modules.rst
@@ -1,5 +1,3 @@
-
-
 .. _mgr-module-dev:
 
 ceph-mgr module developer's guide
@@ -8,14 +6,14 @@ ceph-mgr module developer's guide
 .. warning::
 
     This is developer documentation, describing Ceph internals that
-    are only relevant to people writing ceph-mgr modules.
+    are relevant only to people writing ceph-mgr modules.
 
 Creating a module
 -----------------
 
-In pybind/mgr/, create a python module.  Within your module, create a class
+In ``pybind/mgr/``, create a python module.  Within your module, create a class
 that inherits from ``MgrModule``.  For ceph-mgr to detect your module, your
-directory must contain a file called `module.py`.
+directory must contain a file called ``module.py``.
 
 The most important methods to override are:
 
@@ -36,11 +34,13 @@ creating these modules.
 Installing a module
 -------------------
 
-Once your module is present in the location set by the
-``mgr module path`` configuration setting, you can enable it
-via the ``ceph mgr module enable`` command::
+Once your module is present in the location set by the ``mgr module path``
+configuration setting, you can enable it via the ``ceph mgr module enable``
+command:
 
-  ceph mgr module enable mymodule
+.. prompt:: bash #
+
+   ceph mgr module enable mymodule
 
 Note that the MgrModule interface is not stable, so any modules maintained
 outside of the Ceph tree are liable to break when run against any newer
@@ -57,11 +57,14 @@ import the ``logging`` package and get a logger instance with the
 
 Each module has a ``log_level`` option that specifies the current Python
 logging level of the module.
-To change or query the logging level of the module use the following Ceph
-commands::
 
-  ceph config get mgr mgr/<module_name>/log_level
-  ceph config set mgr mgr/<module_name>/log_level <info|debug|critical|error|warning|>
+To change or query the logging level of the module use the following Ceph
+commands:
+
+.. prompt:: bash #
+
+   ceph config get mgr mgr/<module_name>/log_level
+   ceph config set mgr mgr/<module_name>/log_level <info|debug|critical|error|warning|>
 
 The logging level used upon the module's start is determined by the current
 logging level of the mgr daemon, unless if the ``log_level`` option was
@@ -74,29 +77,35 @@ level is mapped to the module python logging level as follows:
 * <= +inf is DEBUG
 
 We can unset the module log level and fallback to the mgr daemon logging level
-by running the following command::
+by running the following command:
 
-  ceph config set mgr mgr/<module_name>/log_level ''
+.. prompt:: bash #
+
+   ceph config set mgr mgr/<module_name>/log_level ''
 
 By default, modules' logging messages are processed by the Ceph logging layer
-where they will be recorded in the mgr daemon's log file.
-But it's also possible to send a module's logging message to it's own file.
+where they will be recorded in the mgr daemon's log file.  But it's also
+possible to send a module's logging message to its own file.
 
-The module's log file will be located in the same directory as the mgr daemon's
+The module's log file is located in the same directory as the Manager daemon's
 log file with the following name pattern::
 
    <mgr_daemon_log_file_name>.<module_name>.log
 
-To enable the file logging on a module use the following command::
+To enable the file logging on a module, use the following command:
+
+.. prompt:: bash #
 
    ceph config set mgr mgr/<module_name>/log_to_file true
 
-When the module's file logging is enabled, module's logging messages stop
-being written to the mgr daemon's log file and are only written to the
+When the module's file logging is enabled, the module's logging messages stop
+being written to the Manager daemon's log file and are written only to the
 module's log file.
 
 It's also possible to check the status and disable the file logging with the
-following commands::
+following commands:
+
+.. prompt:: bash #
 
    ceph config get mgr mgr/<module_name>/log_to_file
    ceph config set mgr mgr/<module_name>/log_to_file false
@@ -108,9 +117,10 @@ following commands::
 Exposing commands
 -----------------
 
-There are two approaches for exposing a command. The first method involves using
-the ``@CLICommand`` decorator to decorate the methods needed to handle a command.
-The second method uses a ``COMMANDS`` attribute defined for the module class.
+There are two approaches for exposing a command. The first method involves
+using the ``@CLICommand`` decorator to decorate the methods needed to handle a
+command. The second method uses a ``COMMANDS`` attribute defined for the
+module class.
 
 
 The CLICommand approach
@@ -411,34 +421,35 @@ You must declare your available configuration options in the
         Option(name="my_option")
     ]
 
-If you try to use set_module_option or get_module_option on options not declared
-in ``MODULE_OPTIONS``, an exception will be raised.
+If you try to use ``set_module_option`` or ``get_module_option`` on options
+not declared in ``MODULE_OPTIONS``, an exception will be raised.
 
 You may choose to provide setter commands in your module to perform
-high level validation.  Users can also modify configuration using
-the normal `ceph config set` command, where the configuration options
-for a mgr module are named like `mgr/<module name>/<option>`.
+high-level validation. Users can also modify configuration using
+the normal ``ceph config set`` command, where the configuration options
+for a Manager module have names of the form ``mgr/<module name>/<option>``.
 
-If a configuration option is different depending on which node the mgr
+If a configuration option is different, depending on which node the Manager 
 is running on, then use *localized* configuration (
 ``get_localized_module_option``, ``set_localized_module_option``).
 This may be necessary for options such as what address to listen on.
 Localized options may also be set externally with ``ceph config set``,
 where they key name is like ``mgr/<module name>/<mgr id>/<option>``
 
-If you need to load and store data (e.g. something larger, binary, or multiline),
-use the KV store instead of configuration options (see next section).
+If you need to load and store data (e.g. something larger, binary, or
+multiline), use the KV store instead of configuration options (see next
+section).
 
 Hints for using config options:
 
-* Reads are fast: ceph-mgr keeps a local in-memory copy, so in many cases
-  you can just do a get_module_option every time you use a option, rather than
+* Reads are fast: ceph-mgr keeps a local in-memory copy, so in many cases you
+  can just do a ``get_module_option`` every time you use a option, rather than
   copying it out into a variable.
 * Writes block until the value is persisted (i.e. round trip to the monitor),
   but reads from another thread will see the new value immediately.
-* If a user has used `config set` from the command line, then the new
-  value will become visible to `get_module_option` immediately, although the
-  mon->mgr update is asynchronous, so `config set` will return a fraction
+* If a user has used ``config set`` from the command line, then the new
+  value will become visible to ``get_module_option`` immediately, although the
+  mon->mgr update is asynchronous, so ``config set`` will return a fraction
   of a second before the new value is visible on the mgr.
 * To delete a config value (i.e. revert to default), just pass ``None`` to
   set_module_option.
@@ -687,7 +698,7 @@ we need to
 Following is a sample session, in which the Ceph version is queried by
 inputting ``print(mgr.version)`` at the prompt. And later
 ``timeit`` module is imported to measure the execution time of
-`mgr.get_mgr_id()`.
+``mgr.get_mgr_id()``.
 
 .. code-block:: console
 


### PR DESCRIPTION
Edit doc/mgr/modules.rst. Improve some of the English.

This is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.

This commit and the PR of which it is a part includes the changes made in https://github.com/ceph/ceph/pull/62782 and some corrections to glaring grammatical errors. However, this file could use a careful grammar pass. As it currently stands, it contains run-on sentences and English that is acceptable in conversation but not acceptable in written communication.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
