### PR TITLE
doc/mgr: edit prometheus.rst

### DIFF
--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -20,7 +20,7 @@ Enabling Prometheus output
 
 Enable the ``prometheus`` module by running the below command :
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph mgr module enable prometheus
 
@@ -50,9 +50,9 @@ configurable with ``ceph config set``, with keys
 is registered with Prometheus's `registry
 <https://github.com/prometheus/prometheus/wiki/Default-port-allocations>`_.
 
-.. prompt:: bash $
+.. prompt:: bash #
    
-   ceph config set mgr mgr/prometheus/server_addr 0.0.0.
+   ceph config set mgr mgr/prometheus/server_addr 0.0.0.0
    ceph config set mgr mgr/prometheus/server_port 9283
 
 .. warning::
@@ -70,7 +70,7 @@ might be useful to increase the scrape interval.
 To set a different scrape interval in the Prometheus module, set
 ``scrape_interval`` to the desired value:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/scrape_interval 20
 
@@ -93,13 +93,13 @@ set`` commands.
 To configure the module to respond with possibly stale data, set
 the cache strategy to ``return``:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
-    ceph config set mgr mgr/prometheus/stale_cache_strategy return
+   ceph config set mgr mgr/prometheus/stale_cache_strategy return
 
 To configure the module to respond with "service unavailable", set it to ``fail``:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/stale_cache_strategy fail
 
@@ -113,7 +113,7 @@ If you are using the ``prometheus`` module behind a reverse proxy or
 load balancer, you can simplify discovery of the active instance by switching
 to ``error``-mode:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/standby_behaviour error
 
@@ -121,7 +121,7 @@ If set, the ``prometheus`` module will respond with a HTTP error when requesting
 from the standby instance. The default error code is 500, but you can configure
 the HTTP response code with:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/standby_error_status_code 503
 
@@ -129,7 +129,7 @@ Valid error codes are between 400-599.
 
 To switch back to the default behaviour, simply set the config key to ``default``:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/standby_behaviour default
 
@@ -154,17 +154,20 @@ The metrics take the following form:
 
 The health check history may be retrieved and cleared by running the following commands:
 
-::
+.. prompt:: bash #
 
-    ceph healthcheck history ls [--format {plain|json|json-pretty}]
-    ceph healthcheck history clear
+   ceph healthcheck history ls [--format {plain|json|json-pretty}]
+   ceph healthcheck history clear
 
 The ``ceph healthcheck ls`` command provides an overview of the health checks that the cluster has
 encountered since the last ``clear`` command was issued:
 
+.. prompt:: bash #
+
+   ceph healthcheck history ls
+
 ::
 
-    [ceph: root@c8-node1 /]# ceph healthcheck history ls
     Healthcheck Name          First Seen (UTC)      Last seen (UTC)       Count  Active
     OSDMAP_FLAGS              2021/09/16 03:17:47   2021/09/16 22:07:40       2    No
     OSD_DOWN                  2021/09/17 00:11:59   2021/09/17 00:11:59       1   Yes
@@ -184,13 +187,13 @@ statistics are collected for all namespaces in the pool.
 
 To enable collection of stats for RBD pools named ``pool1``, ``pool2`` and ``poolN``:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/rbd_stats_pools "pool1,pool2,poolN"
 
 A wildcard can be used to indicate all pools or namespaces:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/rbd_stats_pools "*"
 
@@ -203,7 +206,7 @@ RBD image.
 
 To set the sync interval to 10 minutes run the following command:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/rbd_stats_pools_refresh_interval 600
 
@@ -214,7 +217,7 @@ With the introduction of the ``ceph-exporter`` daemon, the ``prometheus`` module
 perf counters as Prometheus metrics by default. However, one may re-enable exporting these metrics by setting
 the module option ``exclude_perf_counters`` to ``false``:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/prometheus/exclude_perf_counters false
 


### PR DESCRIPTION
Edit doc/mgr/prometheus.rst.

This is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

