### PR TITLE
doc/mgr: edit smb.rst

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -53,9 +53,9 @@ Cluster Commands
 Create Cluster
 ++++++++++++++
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>] [--clustering=<clustering>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>]
+   ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>] [--clustering=<clustering>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>]
 
 Create a new logical cluster, identified by the cluster id value. The cluster
 create command must specify the authentication mode the cluster will use. This
@@ -117,9 +117,9 @@ password_filter_out
 Remove Cluster
 ++++++++++++++
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb cluster rm <cluster_id> [--password-filter=<password_filter>]
+   ceph smb cluster rm <cluster_id> [--password-filter=<password_filter>]
 
 Remove a logical SMB cluster from the Ceph cluster.
 
@@ -138,9 +138,9 @@ password_filter
 List Clusters
 ++++++++++++++
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb cluster ls [--format=<format>]
+   ceph smb cluster ls [--format=<format>]
 
 Print a listing of cluster ids. The output defaults to JSON, select YAML
 encoding with the ``--format=yaml`` option.
@@ -152,9 +152,9 @@ Share Commands
 Create Share
 ++++++++++++
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb share create <cluster_id> <share_id> <cephfs_volume> <path> [--share-name=<share_name>] [--subvolume=<subvolume>] [--readonly]
+   ceph smb share create <cluster_id> <share_id> <cephfs_volume> <path> [--share-name=<share_name>] [--subvolume=<subvolume>] [--readonly]
 
 Create a new SMB share, hosted by the named cluster, that maps to the given
 CephFS volume and path.
@@ -182,9 +182,9 @@ readonly
 Remove Share
 ++++++++++++
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb share rm <cluster_id> <share_id>
+   ceph smb share rm <cluster_id> <share_id>
 
 Remove an SMB Share from the cluster.
 
@@ -192,9 +192,9 @@ Remove an SMB Share from the cluster.
 List Shares
 +++++++++++
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb share ls <cluster_id> [--format=<format>]
+   ceph smb share ls <cluster_id> [--format=<format>]
 
 Print a listing of share ids. The output defaults to JSON, select YAML
 encoding with the ``--format=yaml`` option.
@@ -210,16 +210,16 @@ Resource specifications can be written in either JSON or YAML. These resource
 specifications can be applied to the cluster using the ``ceph smb apply``
 command, for example:
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb apply -i /path/to/resources.yaml
+   ceph smb apply -i /path/to/resources.yaml
 
 In addition to the resource specification the ``apply`` sub-command accepts
 options that control how the input and output of the command behave:
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb apply [--format=<format>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>] -i <input>
+   ceph smb apply [--format=<format>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>] -i <input>
 
 Options:
 
@@ -245,16 +245,16 @@ input
 Resources that have already been applied to the Ceph cluster configuration can
 be viewed using the ``ceph smb show`` command. For example:
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb show ceph.smb.cluster.cluster1
+   ceph smb show ceph.smb.cluster.cluster1
 
 The ``show`` command can show all resources, resources of a given type, or specific
 resource items. Options can be provided that control the output of the command.
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb show [resource_name...] [--format=<format>] [--results=<results>] [--password-filter=<password_filter>]
+   ceph smb show [resource_name...] [--format=<format>] [--results=<results>] [--password-filter=<password_filter>]
 
 Options:
 
@@ -292,9 +292,9 @@ password_filter
 
 For example:
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb show ceph.smb.cluster.bob ceph.smb.share.bob
+   ceph smb show ceph.smb.cluster.bob ceph.smb.share.bob
 
 Will show one cluster resource (if it exists) for the cluster "bob" as well as
 all share resources associated with the cluster "bob".
@@ -819,9 +819,9 @@ configuration file. First, create the YAML with the contents:
 Save this text to a YAML file named ``resources.yaml`` and make it available
 on a cluster admin host. Then run:
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb apply -i resources.yaml
+   ceph smb apply -i resources.yaml
 
 The command will print a summary of the changes made and begin to automatically
 deploy the needed resources. See `Accessing Shares`_ for more information
@@ -850,9 +850,9 @@ action with a new file ``removed.yaml`` containing:
 
 By issuing the command:
 
-.. code:: bash
+.. prompt:: bash #
 
-    $ ceph smb apply -i removed.yaml
+   ceph smb apply -i removed.yaml
 
 
 SMB Cluster Management


### PR DESCRIPTION
Edit doc/mgr/smb.rst.

This is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

