### PR TITLE
squid: mgr/dashboard: accept dot(.) in user_id & restrict tenant validation in user form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -167,11 +167,36 @@ describe('RgwUserFormComponent', () => {
       formHelper.expectValid('user_id');
     }));
 
+    it('should validate that username can contain dot(.)', fakeAsync(() => {
+      spyOn(rgwUserService, 'get').and.returnValue(throwError('foo'));
+      formHelper.setValue('user_id', 'user.name', true);
+      tick(DUE_TIMER);
+      formHelper.expectValid('user_id');
+    }));
+
     it('should validate that username is invalid', fakeAsync(() => {
       spyOn(rgwUserService, 'get').and.returnValue(observableOf({}));
       formHelper.setValue('user_id', 'abc', true);
       tick(DUE_TIMER);
       formHelper.expectError('user_id', 'notUnique');
+    }));
+  });
+
+  describe('tenant validation', () => {
+    it('should validate that tenant is valid', fakeAsync(() => {
+      spyOn(rgwUserService, 'get').and.returnValue(throwError('foo'));
+      formHelper.setValue('show_tenant', true, true);
+      formHelper.setValue('tenant', 'new_tenant123', true);
+      tick(DUE_TIMER);
+      formHelper.expectValid('tenant');
+    }));
+
+    it('should validate that tenant is invalid', fakeAsync(() => {
+      spyOn(rgwUserService, 'get').and.returnValue(observableOf({}));
+      formHelper.setValue('show_tenant', true, true);
+      formHelper.setValue('tenant', 'new-tenant.dummy', true);
+      tick(DUE_TIMER);
+      formHelper.expectError('tenant', 'pattern');
     }));
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -74,7 +74,7 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
       // General
       user_id: [
         null,
-        [Validators.required, Validators.pattern(/^[a-zA-Z0-9!@#%^&*()_-]+$/)],
+        [Validators.required, Validators.pattern(/^[a-zA-Z0-9!@#%^&*()._-]+$/)],
         this.editing
           ? []
           : [
@@ -86,7 +86,7 @@ export class RgwUserFormComponent extends CdForm implements OnInit {
       show_tenant: [this.editing],
       tenant: [
         null,
-        [Validators.pattern(/^[a-zA-Z0-9!@#%^&*()_-]+$/)],
+        [Validators.pattern(/^[a-zA-Z0-9_]+$/)],
         this.editing
           ? []
           : [


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71364

---

backport of https://github.com/ceph/ceph/pull/63319
parent tracker: https://tracker.ceph.com/issues/71341

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh