### PR TITLE
doc/radosgw: Small improvements in cloud-restore.rst

### DIFF
--- a/doc/radosgw/cloud-restore.rst
+++ b/doc/radosgw/cloud-restore.rst
@@ -24,8 +24,8 @@ API can be used to restore the object temporarily.
 Cloud Storage Class Tier Configuration
 --------------------------------------
 
-The `tier configuration <https://docs.ceph.com/en/latest/radosgw/cloud-transition/#cloud-storage-class-configuration>`_
-of the cloud storage class configured for data transition is used to restore
+The :ref:`radosgw_cloud_tier_configuration`
+of the storage class configured for data transition is used to restore
 objects as well::
 
     {
@@ -48,7 +48,7 @@ The below options have been added to the tier configuration to facilitate object
 
 * ``restore_storage_class`` (string)
 
-The storage class to which object data is to be restored. Default value is ``STANDARD``.
+  The storage class to which object data is to be restored. Default value is ``STANDARD``.
 
 
 Read-through Specific Configurables
@@ -56,12 +56,12 @@ Read-through Specific Configurables
 
 * ``allow_read_through`` (``true`` | ``false``)
 
-If true, enables ``read-through``. Objects can then be restored using the ``S3 GetObject`` API.
+  If ``true``, enables ``read-through``. Objects can then be restored using the ``S3 GetObject`` API.
 
 * ``read_through_restore_days`` (integer)
 
-The duration for which objects restored via ``read-through`` are retained.
-Default value is 1 day.
+  The duration for which objects restored via ``read-through`` are retained.
+  Default value is ``1`` day.
 
 For example:
 
@@ -90,12 +90,12 @@ the following configurables should be set accordingly:
 
 * ``glacier_restore_days`` (integer)
 
-The duration for which the objects are to be restored on the remote cloud service.
+  The duration for which the objects are to be restored on the remote cloud service.
 
 * ``glacier_restore_tier_type`` (``Standard`` | ``Expedited``)
 
-The type of retrieval within the cloud service, which may represent different
-pricing. Supported options are ``Standard`` and ``Expedited``.
+  The type of retrieval within the cloud service, which may represent different
+  pricing. Supported options are ``Standard`` and ``Expedited``.
 
 
 For example:
@@ -167,7 +167,7 @@ Examples of Restore Objects
 Using the S3 RestoreObject CLI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Th `S3 restore-object <https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html>`_
+The `S3 restore-object <https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/restore-object.html>`_
 CLI supports these options:
 
 .. prompt:: bash $
@@ -180,7 +180,7 @@ CLI supports these options:
                               }
 
 
-Note: ``Days`` is optional and if not provided, the object is restored permanently.
+.. note:: The parameter ``Days`` is optional and if not provided, the object is restored permanently.
 
 Example 1:
 
@@ -219,8 +219,8 @@ Example 3:
 
 This will restore the object ``doc3.rtf`` for ``read_through_restore_days`` days.
 
-Note: The above CLI command may time out if object restoration takes too long.
-You can verify the restore status before reissuing the command.
+.. note:: The above CLI command may time out if object restoration takes too long.
+          You can verify the restore status before reissuing the command.
 
 
 Verifying the Restoration Status
@@ -242,7 +242,7 @@ details.
 
 Example:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    radosgw-admin object stat --bucket bucket1 --object doc1.rtf
 
@@ -255,8 +255,8 @@ Storage
 ~~~~~~~
 Objects are restored to the storage class configured via ``restore_storage_class``
 in the tier-config. However, as
-per `<https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html>`_
-the storage class of restored objects should remain unchanged. Therefore, for
+per `S3 RestoreObject <https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html>`_
+API the storage class of restored objects should remain unchanged. Therefore, for
 temporary copies, the ``x-amz-storage-class`` will continue to reflect the
 original cloud-tier storage class.
 
@@ -269,7 +269,7 @@ The ``mtime`` of the transitioned and restored objects should remain unchanged.
 Lifecycle
 ~~~~~~~~~
 ``Temporary`` copies are not subject to transition to the cloud. However, as is the
-case with cloud-transitioned objects, they can be deleted via regular LC (Life Cycle)
+case with cloud-transitioned objects, they can be deleted via regular lifecycle (LC)
 expiration rules or an external S3 ``delete`` request.
 
 ``Permanent`` copies are treated as regular objects and are subject to applicable LC

--- a/doc/radosgw/cloud-transition.rst
+++ b/doc/radosgw/cloud-transition.rst
@@ -31,6 +31,7 @@ Cloud Storage Class Tier Type
 
   * ``cloud-s3-glacier`` : S3 Glacier or Tape storage services.
 
+.. _radosgw_cloud_tier_configuration:
 
 Cloud Storage Class Tier Configuration
 --------------------------------------


### PR DESCRIPTION
Add a label in file cloud-transition.rst for linking to it.
Change a link using full URL of Ceph docs to use :ref: and said label.

Indent text in unordered lists so that they are rendered as list items.

Use consistently double backticks for references to configuration values.

Change one external link pointing to old v1 of AWS CLI to the recommended v2 docs.

Change another external link pointing to old v1 of AWS CLI to the current AWS API doc instead and add link text instead of rendering the whole URL.
However, both the old and the new text (which are the same) do not currently seem to explicitly confirm the claim "storage class of restored objects should remain unchanged".

Change one CLI command prompt to privileged prompt because it uses radosgw-admin.

Use "lifecycle" consistently instead of "Life Cycle" in one place and put the acronym "LC" inside parenthesis instead of the full spelling.

Fix typo "Th" into "The".

Use admonitions instead of spelling out "Note: [...]".

Small improvement to language in one admonition.

- Before: https://docs.ceph.com/en/latest/radosgw/cloud-restore/
- Rendered PR: https://ceph--63480.org.readthedocs.build/en/63480/radosgw/cloud-restore/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
