### PR TITLE
tentacle: docs: add release notes and docs for availability score feature 

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -149,7 +149,7 @@
   users to view the availability score for each pool in a cluster. A pool is considered 
   unavailable if any PG in the pool is not in active state or if there are unfound 
   objects. Otherwise the pool is considered available. The score is updated every 
-  5 seconds. 
+  5 seconds. This feature is in tech preview. 
   Related trackers:
    - https://tracker.ceph.com/issues/67777
 

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -145,6 +145,14 @@
   `s3:GetObjectRetention` are also considered when fetching the source object.
   Replication of tags is controlled by the `s3:GetObject(Version)Tagging` permission.
 
+* RADOS: A new command, `ceph osd pool availability-status`, has been added that allows
+  users to view the availability score for each pool in a cluster. A pool is considered 
+  unavailable if any PG in the pool is not in active state or if there are unfound 
+  objects. Otherwise the pool is considered available. The score is updated every 
+  5 seconds. 
+  Related trackers:
+   - https://tracker.ceph.com/issues/67777
+
 >=19.2.1
 
 * CephFS: Command `fs subvolume create` now allows tagging subvolumes through option

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -738,3 +738,39 @@ Print active connections and their TCP round trip time and retransmission counte
 
 	248     89      1       mgr.0   863     1677    0
 	3       86      2       mon.0   230     278     0
+
+Tracking Data Availability Score of a Cluster
+=============================================
+
+Ceph internally tracks the data availability of each pool in a cluster.
+To check the data availability score of each pool in a cluster, 
+the following command can be invoked: 
+
+
+.. prompt:: bash $
+
+   ceph osd pool availability-status
+
+If the cluster has 4 pools, this is what the ``availability-status`` 
+will report:  
+
+.. prompt:: bash $
+
+   POOL       	UPTIME  DOWNTIME  NUMFAILURES  MTBF  MTTR  SCORE 	AVAILABLE
+   rbd            	2m   	21s        	1	2m   21s  0.888889      	1
+   .mgr          	86s    	0s        	0	0s	0s     	1      	1
+   cephfs.a.meta 	77s    	0s        	0	0s	0s     	1      	1
+   cephfs.a.data 	76s    	0s        	0	0s	0s     	1      	1
+
+We consider a pool unavailable if there is potentially any data loss. 
+This means, if there are any PG in the pool not in 
+active state or if there are unfound objects, some data might be
+either unreachable or lost. In such cases, we mark the pool as 
+unavailable. Otherwise the pool is considered available. 
+For example: A pool will be marked available even if an OSD is down 
+as long as PG replication ensures there is no data loss. 
+
+We first calculate the Mean Time Between Failures (MTBF) and 
+Mean Time To Recover (MTTR) and arrive at the availability score 
+by finding ratio of MTBF to total time (ie MTTR + MTBF).  The score
+is updated every 5 seconds. 

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -751,8 +751,7 @@ the following command can be invoked:
 
    ceph osd pool availability-status
 
-If the cluster has 4 pools, this is what the ``availability-status`` 
-will report:  
+Example output:  
 
 .. prompt:: bash $
 
@@ -762,15 +761,12 @@ will report:
    cephfs.a.meta 	77s    	0s        	0	0s	0s     	1      	1
    cephfs.a.data 	76s    	0s        	0	0s	0s     	1      	1
 
-We consider a pool unavailable if there is potentially any data loss. 
-This means, if there are any PG in the pool not in 
-active state or if there are unfound objects, some data might be
-either unreachable or lost. In such cases, we mark the pool as 
-unavailable. Otherwise the pool is considered available. 
-For example: A pool will be marked available even if an OSD is down 
-as long as PG replication ensures there is no data loss. 
+A pool is considered ``unavailable`` when at least one PG in the pool 
+becomes inactive or there is at least one unfound object in the pool. 
+Otherwise the pool is considered ``available``. 
 
 We first calculate the Mean Time Between Failures (MTBF) and 
-Mean Time To Recover (MTTR) and arrive at the availability score 
+Mean Time To Recover (MTTR) from the uptime and downtime recorded 
+for each pool and arrive at the availability score 
 by finding ratio of MTBF to total time (ie MTTR + MTBF).  The score
 is updated every 5 seconds. 

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -768,5 +768,7 @@ Otherwise the pool is considered ``available``.
 We first calculate the Mean Time Between Failures (MTBF) and 
 Mean Time To Recover (MTTR) from the uptime and downtime recorded 
 for each pool and arrive at the availability score 
-by finding ratio of MTBF to total time (ie MTTR + MTBF).  The score
-is updated every 5 seconds. 
+by finding ratio of MTBF to total time (ie MTTR + MTBF).  
+
+The score is updated every 5 seconds. This interval is currently 
+not configurable. 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71440

---

backport of https://github.com/ceph/ceph/pull/63181
parent tracker: https://tracker.ceph.com/issues/71439

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh