### PR TITLE
[mgr]: API get or create and return the full cephx user w/ key

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/ceph_users.py
+++ b/src/pybind/mgr/dashboard/controllers/ceph_users.py
@@ -63,11 +63,16 @@ class CephUserEndpoints:
             caps.append(cap['entity'])
             caps.append(cap['cap'])
 
-        logger.debug("Sending command 'auth add' of entity '%s' with caps '%s'",
+        logger.debug("Sending command 'auth get-or-create' of entity '%s' with caps '%s'",
                      user_entity, str(caps))
-        CephUserEndpoints._run_auth_command('auth add', entity=user_entity, caps=caps)
+        return CephUserEndpoints._run_auth_command('auth get-or-create', entity=user_entity, caps=caps)
 
-        return f"Successfully created user '{user_entity}'"
+    @staticmethod
+    def user_get(_, user_entity: str):
+        """
+        Get a ceph user with its key and capabilities.
+        """
+        return CephUserEndpoints._run_auth_command('auth get', entity=user_entity)
 
     @staticmethod
     def user_delete(_, user_entities: str):
@@ -218,6 +223,13 @@ edit_form = Form(path='/cluster/user/edit',
                         })
     ),
     extra_endpoints=[
+        ('get', CRUDCollectionMethod(
+            func=CephUserEndpoints.user_get,
+            doc=EndpointDoc("Get Ceph User with key",
+                            parameters={
+                                "user_entity": Param(str, "Entity to get")
+                            })
+        )),
         ('export', CRUDCollectionMethod(
             func=RESTController.Collection('POST', 'export')(CephUserEndpoints.export),
             doc=EndpointDoc("Export Ceph Users",


### PR DESCRIPTION
Add get-or-create to the RESTful API and return the created CephX with its key.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
