### PR TITLE
crimson: Enable asserts in release builds

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -1,6 +1,24 @@
 add_library(crimson::cflags INTERFACE IMPORTED)
 set(crimson_cflag_definitions "WITH_CRIMSON=1")
 
+# In order to keep build in asserts in Crimson in release builds
+# we would need to disable NDEBUG. As some of our code relies on
+# NDEBUG for other checks, let's use a dedicated CRIMSON_DEBUG instead.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CRIMSON_DEBUG CACHE BOOL ON)
+endif()
+# Also allow for release builds to disable asserts.
+if(NOT DEFINED CRIMSON_WITH_ASSERTS)
+  set(CRIMSON_WITH_ASSERTS CACHE BOOL ON)
+endif()
+if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  if(CRIMSON_WITH_ASSERTS)
+    # Enable asserts
+    string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  endif()
+endif()
+
+
 set_target_properties(crimson::cflags PROPERTIES
   INTERFACE_COMPILE_DEFINITIONS "${crimson_cflag_definitions}"
   INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CXX>:-Wno-non-virtual-dtor>

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -10,7 +10,7 @@
 
 #include "crimson/common/log.h"
 #include "crimson/common/errorator.h"
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
 #define INTR_FUT_DEBUG(FMT_MSG, ...) crimson::get_logger(\
   ceph_subsys_crimson_interrupt).trace(FMT_MSG, ##__VA_ARGS__)
 #else

--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -517,7 +517,7 @@ public:
 template <class T>
 class PipelineStageIT : public BlockerT<T> {
 public:
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   const core_id_t core = seastar::this_shard_id();
 #endif
 };

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -45,11 +45,10 @@ class tri_mutex : private read_lock,
 {
 public:
   tri_mutex() = default;
-#ifdef NDEBUG
-  tri_mutex(const std::string &obj_str) : name() {}
+#ifdef CRIMSON_DEBUG
+  tri_mutex(const std::string &obj_str) : name(obj_str) {}
 #else
-  tri_mutex(const std::string &obj_str) : name(obj_str) {
-  }
+  tri_mutex(const std::string &obj_str) : name() {}
 #endif
   ~tri_mutex();
 

--- a/src/crimson/net/FrameAssemblerV2.cc
+++ b/src/crimson/net/FrameAssemblerV2.cc
@@ -139,7 +139,7 @@ bool FrameAssemblerV2::has_socket() const
 bool FrameAssemblerV2::is_socket_valid() const
 {
   assert(seastar::this_shard_id() == sid);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   if (has_socket() && socket->get_shard_id() == sid) {
     assert(socket->is_shutdown() == is_socket_shutdown);
   }

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -293,7 +293,7 @@ void ProtocolV2::fault(
                   where,
                   get_state_name(state),
                   e_what);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (expected_state == state_t::REPLACING) {
       assert(state == state_t::CLOSING);
     } else if (expected_state == state_t::READY) {

--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -112,7 +112,7 @@ Socket::Socket(
 Socket::~Socket()
 {
   assert(seastar::this_shard_id() == sid);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   assert(closed);
 #endif
 }
@@ -258,7 +258,7 @@ seastar::future<>
 Socket::close()
 {
   assert(seastar::this_shard_id() == sid);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   ceph_assert_always(!closed);
   closed = true;
 #endif
@@ -417,7 +417,7 @@ ShardedServerSocket::accept(accept_func_t &&_fn_accept)
       return seastar::keep_doing([&ss] {
         return ss.listener->accept(
         ).then([&ss](seastar::accept_result accept_result) {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
           if (ss.dispatch_only_on_primary_sid) {
             // see seastar::listen_options::set_fixed_cpu()
             ceph_assert_always(seastar::this_shard_id() == ss.primary_sid);

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -121,7 +121,7 @@ private:
   side_t side;
   uint16_t ephemeral_port;
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   bool closed = false;
 #endif
 

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1708,7 +1708,7 @@ private:
     if (!iter.is_end() && iter.get_key() == laddr) {
       return seastar::now();
     } else if (iter.leaf.node->get_node_meta().begin <= laddr) {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       auto p = iter;
       if (p.leaf.pos > 0) {
         --p.leaf.pos;

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -100,7 +100,7 @@ void Cache::retire_absent_extent_addr(
   assert(paddr.is_absolute());
 
   CachedExtentRef ext;
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   auto result = t.get_extent(paddr, &ext);
   assert(result != Transaction::get_extent_ret::PRESENT
     && result != Transaction::get_extent_ret::RETIRED);
@@ -1164,7 +1164,7 @@ CachedExtentRef Cache::duplicate_for_write(
   LOG_PREFIX(Cache::duplicate_for_write);
   assert(i->is_fully_loaded());
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   if (i->is_logical()) {
     assert(static_cast<LogicalCachedExtent&>(*i).has_laddr());
     assert(static_cast<LogicalCachedExtent&>(*i).is_seen_by_users());
@@ -1777,7 +1777,7 @@ void Cache::complete_commit(
       is_inline = true;
       i->set_paddr(final_block_start.add_relative(i->get_paddr()));
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (i->get_paddr().is_root() || epm.get_checksum_needed(i->get_paddr())) {
       assert(i->get_last_committed_crc() == i->calc_crc32c());
     } else {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -383,7 +383,7 @@ public:
     CachedExtentRef ret;
     LOG_PREFIX(Cache::get_absent_extent);
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     auto r = t.get_extent(offset, &ret);
     if (r != Transaction::get_extent_ret::ABSENT) {
       SUBERRORT(seastore_cache, "unexpected non-absent extent {}", t, *ret);
@@ -861,7 +861,7 @@ private:
   ) {
     LOG_PREFIX(Cache::_get_absent_extent_by_type);
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     CachedExtentRef ret;
     auto r = t.get_extent(offset, &ret);
     if (r != Transaction::get_extent_ret::ABSENT) {

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -489,7 +489,7 @@ ExtentPlacementManager::write_delayed_ool_extents(
   return trans_intr::do_for_each(alloc_map, [&t](auto& p) {
     auto writer = p.first;
     auto& extents = p.second;
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     std::for_each(
       extents.begin(),
       extents.end(),

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -164,7 +164,7 @@ bool RecordSubmitter::is_available() const
 {
   auto ret = !wait_available_promise.has_value() &&
              !has_io_error;
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   if (ret) {
     // unconditional invariants
     ceph_assert(journal_allocator.can_write());

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -381,7 +381,7 @@ BtreeLBAManager::alloc_sparse_mappings(
   alloc_policy_t policy)
 {
   ceph_assert(hint != L_ADDR_NULL);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   assert(alloc_infos.front().key != L_ADDR_NULL);
   for (size_t i = 1; i < alloc_infos.size(); i++) {
     auto &prev = alloc_infos[i - 1];
@@ -742,7 +742,7 @@ BtreeLBAManager::refresh_lba_mapping(Transaction &t, LBAMapping mapping)
 	return refresh_lba_cursor(c, btree, *mapping.indirect_cursor);
       }
       return refresh_lba_cursor_iertr::make_ready_future();
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     }).si_then([&mapping] {
       assert(mapping.is_viewable());
 #endif
@@ -986,7 +986,7 @@ BtreeLBAManager::remap_mappings(
       });
     }).si_then([&state] {
       assert(state.ret.size() == state.remaps.size());
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       auto mapping_it = state.ret.begin();
       auto remap_it = state.remaps.begin();
       for (;mapping_it != state.ret.end(); mapping_it++, remap_it++) {

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -178,7 +178,7 @@ public:
       if (has_laddr) {
 	return alloc_sparse_mappings(
 	  t, hint, alloc_infos, alloc_policy_t::deterministic)
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
 	.si_then([&alloc_infos](std::list<LBACursorRef> cursors) {
 	  assert(alloc_infos.size() == cursors.size());
 	  auto info_p = alloc_infos.begin();

--- a/src/crimson/os/seastore/linked_tree_node.h
+++ b/src/crimson/os/seastore/linked_tree_node.h
@@ -705,7 +705,7 @@ protected:
       push_copy_sources(t, replacement_right, right);
     }
   }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   bool is_children_empty() const {
     for (auto it = children.begin();
 	it != children.begin() + down_cast().get_size();
@@ -834,7 +834,7 @@ protected:
     }
   }
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   bool validate_stable_children() {
     LOG_PREFIX(FixedKVInternalNode::validate_stable_children);
     auto &me = down_cast();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -273,7 +273,7 @@ class Node
     }
 
     void validate_input_key(const key_hobj_t& key, value_magic_t magic) const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       if (match() == MatchKindBS::EQ) {
         assert(key == p_cursor->get_key_view(magic));
       } else {
@@ -540,7 +540,7 @@ class InternalNode final : public Node {
   void validate_child_inconsistent(const Node& child) const;
 
   void validate_tracked_children() const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     for (auto& kv : tracked_child_nodes) {
       assert(kv.first == kv.second->parent_info().position);
       validate_child(*kv.second);
@@ -706,7 +706,7 @@ class LeafNode final : public Node {
   void track_split(const search_position_t&, Ref<LeafNode>);
   void track_erase(const search_position_t&, match_stage_t);
   void validate_tracked_cursors() const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     for (auto& kv : tracked_cursors) {
       assert(kv.first == kv.second->get_position());
       validate_cursor(*kv.second);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -10,7 +10,7 @@
 #include "node_layout_replayable.h"
 #include "value.h"
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
 #include "node_extent_manager/test_replay.h"
 #endif
 
@@ -315,7 +315,7 @@ class NodeExtentAccessorT {
       // extent is invalid or retired
       ceph_abort("impossible path");
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     auto ref_recorder = recorder_t::create_for_replay();
     test_recorder = static_cast<recorder_t*>(ref_recorder.get());
     test_extent = TestReplayExtent::create(
@@ -382,7 +382,7 @@ class NodeExtentAccessorT {
       recorder->template encode_insert<KT>(
           key, value, insert_pos, insert_stage, insert_size);
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->prepare_replay(extent);
     test_recorder->template encode_insert<KT>(
         key, value, insert_pos, insert_stage, insert_size);
@@ -390,7 +390,7 @@ class NodeExtentAccessorT {
     auto ret = layout_t::template insert<KT>(
         *mut, read(), key, value,
         insert_pos, insert_stage, insert_size);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->replay_and_verify(extent);
 #endif
     return ret;
@@ -402,12 +402,12 @@ class NodeExtentAccessorT {
     if (state == nextent_state_t::MUTATION_PENDING) {
       recorder->encode_split(split_at, read().p_start());
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->prepare_replay(extent);
     test_recorder->encode_split(split_at, read().p_start());
 #endif
     layout_t::split(*mut, read(), split_at);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->replay_and_verify(extent);
 #endif
   }
@@ -427,7 +427,7 @@ class NodeExtentAccessorT {
           split_at, key, value, insert_pos, insert_stage, insert_size,
           read().p_start());
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->prepare_replay(extent);
     test_recorder->template encode_split_insert<KT>(
         split_at, key, value, insert_pos, insert_stage, insert_size,
@@ -436,7 +436,7 @@ class NodeExtentAccessorT {
     auto ret = layout_t::template split_insert<KT>(
         *mut, read(), split_at, key, value,
         insert_pos, insert_stage, insert_size);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->replay_and_verify(extent);
 #endif
     return ret;
@@ -450,13 +450,13 @@ class NodeExtentAccessorT {
       recorder->encode_update_child_addr(
           new_addr, p_addr, read().p_start(), get_length());
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->prepare_replay(extent);
     test_recorder->encode_update_child_addr(
         new_addr, p_addr, read().p_start(), get_length());
 #endif
     layout_t::update_child_addr(*mut, new_addr, p_addr);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->replay_and_verify(extent);
 #endif
   }
@@ -467,12 +467,12 @@ class NodeExtentAccessorT {
     if (state == nextent_state_t::MUTATION_PENDING) {
       recorder->encode_erase(pos);
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->prepare_replay(extent);
     test_recorder->encode_erase(pos);
 #endif
     auto ret = layout_t::erase(*mut, read(), pos);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->replay_and_verify(extent);
 #endif
     return ret;
@@ -484,12 +484,12 @@ class NodeExtentAccessorT {
     if (state == nextent_state_t::MUTATION_PENDING) {
       recorder->encode_make_tail();
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->prepare_replay(extent);
     test_recorder->encode_make_tail();
 #endif
     auto ret = layout_t::make_tail(*mut, read());
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     test_extent->replay_and_verify(extent);
 #endif
     return ret;
@@ -568,7 +568,7 @@ class NodeExtentAccessorT {
       eagain_iertr::pass_further{},
       crimson::ct_error::assert_all(fmt::format(
         "{} addr={}", FNAME, addr).c_str())
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     ).si_then([c] {
       assert(!c.t.is_conflicted());
     }
@@ -584,7 +584,7 @@ class NodeExtentAccessorT {
   // owned by extent
   recorder_t* recorder;
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   // verify record replay using a different memory block
   TestReplayExtent::Ref test_extent;
   recorder_t* test_recorder;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -73,7 +73,7 @@ void SeastoreNodeExtent::apply_delta(const ceph::bufferlist& bl)
     auto node_type = header.get_node_type();
     recorder = create_replay_recorder(node_type, *field_type);
   } else {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     auto header = get_header();
     assert(recorder->node_type() == header.get_node_type());
     assert(recorder->field_type() == *header.get_field_type());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_mutable.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_mutable.h
@@ -69,7 +69,7 @@ class NodeExtentMutable {
   const char* get_read() const { return p_start; }
   char* get_write() { return p_start; }
   extent_len_t get_length() const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (node_offset == 0) {
       assert(is_valid_node_size(length));
     }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -192,7 +192,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       dump(sos);
       SUBTRACE(seastore_onode, "-- dump\n{}", sos.str());
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (!is_keys_empty()) {
       validate_layout();
     }
@@ -391,7 +391,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   const std::string& get_name() const override { return name; }
 
   void validate_layout() const override {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     stage_t::validate(extent.read());
 #endif
   }
@@ -425,7 +425,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     } else {
       ceph_abort("impossible path");
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (pp_value) {
       assert((const char*)(*pp_value) - extent.read().p_start() <
              extent.get_length());
@@ -439,7 +439,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     assert(!is_keys_empty());
     assert(!pos.is_end());
     auto& _pos = cast_down<STAGE>(pos);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     auto nxt_pos = _pos;
 #endif
     if (!p_index_key && pp_value) {
@@ -448,7 +448,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     } else {
       ceph_abort("not implemented");
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     auto _nxt_pos = _pos;
     stage_t::template get_next_slot<false, false>(
         extent.read(), _nxt_pos, nullptr, nullptr);
@@ -514,7 +514,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     if (index_key) {
       result_raw = stage_t::template lower_bound<true>(
           node_stage, key, history, index_key);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       if (!result_raw.is_end()) {
         key_view_t index;
         stage_t::template get_slot<true, false>(
@@ -525,7 +525,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     } else {
       result_raw = stage_t::lower_bound(node_stage, key, history);
     }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (result_raw.is_end()) {
       assert(result_raw.mstat == MSTAT_END);
     } else {
@@ -588,7 +588,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       SUBTRACE(seastore_onode, "-- dump\n{}", sos.str());
     }
     validate_layout();
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     key_view_t index;
     get_slot(insert_pos, &index, nullptr);
     assert(index == key);
@@ -768,14 +768,14 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
           insert_pos, insert_stage);
       p_value = extent.template split_insert_replayable<KEY_TYPE>(
           split_at, key, value, insert_pos, insert_stage, insert_size);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       key_view_t index;
       get_slot(_insert_pos, &index, nullptr);
       assert(index == key);
 #endif
     } else {
       SUBDEBUG(seastore_onode, "-- left trim ...");
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       key_view_t index;
       right_impl.get_slot(_insert_pos, &index, nullptr);
       assert(index == key);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -148,7 +148,7 @@ struct string_key_view_t {
                 extent_len_t node_size) {
     reset_ptr(p_key, origin_base, new_base, node_size);
     reset_ptr(p_length, origin_base, new_base, node_size);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     string_size_t current_length;
     std::memcpy(&current_length, p_length, sizeof(string_size_t));
     assert(length == current_length);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -115,7 +115,7 @@ class node_extent_t {
   }
 
   static void validate(const FieldType& fields) {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     assert(fields.header.get_node_type() == NODE_TYPE);
     assert(fields.header.get_field_type() == FieldType::FIELD_TYPE);
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
@@ -190,7 +190,7 @@ class node_extent_t<FieldType, NODE_TYPE>::Appender {
  public:
   Appender(NodeExtentMutable* p_mut, char* p_append)
     : p_mut{p_mut}, p_start{p_append} {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     auto p_fields = reinterpret_cast<const FieldType*>(p_append);
     assert(*(p_fields->header.get_field_type()) == FIELD_TYPE);
     assert(p_fields->header.get_node_type() == NODE_TYPE);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
@@ -37,7 +37,7 @@ void F013_T::update_size_at(
 {
   assert(index <= node.num_keys);
   [[maybe_unused]] extent_len_t node_size = mut.get_length();
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   // check underflow
   if (change < 0 && index != node.num_keys) {
     assert(node.get_item_start_offset(index, node_size) <
@@ -55,7 +55,7 @@ void F013_T::update_size_at(
         (void*)&(p_slot->right_offset),
         node_offset_t(new_offset));
   }
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   // check overflow
   if (change > 0 && index != node.num_keys) {
     assert(node.num_keys > 0);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
@@ -358,7 +358,7 @@ struct internal_fields_3_t {
 
   const laddr_packed_t* get_p_child_addr(
       index_t index, extent_len_t node_size) const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (is_level_tail()) {
       assert(index <= num_keys);
     } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -76,7 +76,7 @@ inline bool matchable(field_type_t type, match_stat_t mstat) {
    * if key matches the node's compressed prefix, return true
    * else, return false
    */
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   if (mstat == MSTAT_END) {
     assert(type == field_type_t::N0);
   }
@@ -563,7 +563,7 @@ struct staged {
       return !container.has_next();
     }
     bool is_end() const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       if (_is_end) {
         assert(!container.has_next());
       }
@@ -1900,7 +1900,7 @@ struct staged {
               insert_pos.nxt, insert_stage, insert_size,
               is_insert_left, split_at.nxt());
           assert(is_insert_left.has_value());
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
           if (locate_nxt) {
             assert(*is_insert_left == true);
           }
@@ -1914,7 +1914,7 @@ struct staged {
           locate_nxt = NXT_STAGE_T::recursively_locate_split(
               current_size, extra_size + split_iter.size_to_nxt(),
               target_size, split_at.nxt());
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
           if (split_iter.index() < insert_index) {
             assert(*is_insert_left == false);
           } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -153,7 +153,7 @@ struct staged_position_t {
   auto operator<=>(const me_t& o) const = default;
 
   void assert_next_to(const me_t& prv) const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (is_end()) {
       assert(!prv.is_end());
     } else if (index == prv.index) {
@@ -257,7 +257,7 @@ struct staged_position_t<STAGE_BOTTOM> {
   }
 
   void assert_next_to(const me_t& prv) const {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (is_end()) {
       assert(!prv.is_end());
     } else {
@@ -299,7 +299,7 @@ const staged_position_t<STAGE>& cast_down(const search_position_t& pos) {
   if constexpr (STAGE == STAGE_LEFT) {
     return pos;
   } else if constexpr (STAGE == STAGE_STRING) {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (pos.is_end()) {
       assert(pos.nxt.is_end());
     } else {
@@ -308,7 +308,7 @@ const staged_position_t<STAGE>& cast_down(const search_position_t& pos) {
 #endif
     return pos.nxt;
   } else if constexpr (STAGE == STAGE_RIGHT) {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (pos.is_end()) {
       assert(pos.nxt.nxt.is_end());
     } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -279,7 +279,7 @@ class TreeBuilder {
 
   eagain_ifuture<> bootstrap(Transaction& t) {
     std::ostringstream oss;
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     oss << "debug=on, ";
 #else
     oss << "debug=off, ";
@@ -313,7 +313,7 @@ class TreeBuilder {
       auto success = ret.second;
       auto cursor = std::move(ret.first);
       initialize_cursor_from_item(t, p_kv->key, p_kv->value, cursor, success);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
       return tree->find(t, p_kv->key
       ).si_then([cursor, p_kv](auto cursor_) mutable {
@@ -404,7 +404,7 @@ class TreeBuilder {
       boost::ignore_unused(this);
       boost::ignore_unused(p_kv);
       ceph_assert(size == 1);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
       return tree->contains(t, p_kv->key
       ).si_then([] (bool ret) {
         ceph_assert(ret == false);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -47,7 +47,7 @@ eagain_ifuture<> Value::extend(Transaction& t, value_size_t extend_size)
   assert(is_tracked());
   [[maybe_unused]] auto target_size = get_payload_size() + extend_size;
   return p_cursor->extend_value(get_context(t), extend_size)
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   .si_then([this, target_size] {
     assert(target_size == get_payload_size());
   })
@@ -61,7 +61,7 @@ eagain_ifuture<> Value::trim(Transaction& t, value_size_t trim_size)
   assert(get_payload_size() > trim_size);
   [[maybe_unused]] auto target_size = get_payload_size() - trim_size;
   return p_cursor->trim_value(get_context(t), trim_size)
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   .si_then([this, target_size] {
     assert(target_size == get_payload_size());
   })

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -211,7 +211,7 @@ seastar::future<> SeaStore::start()
   INFO("...");
 
   ceph_assert(seastar::this_shard_id() == primary_core);
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   bool is_test = true;
 #else
   bool is_test = false;
@@ -1554,7 +1554,7 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
                num_bytes,
                ctx.iter.colls.size(),
                ctx.iter.objects.size());
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
 	TRACET(" transaction dump:\n", t);
 	JSONFormatter f(true);
 	f.open_object_section("transaction");

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -877,7 +877,7 @@ inline res_paddr_t& paddr_t::as_res_paddr() {
 }
 
 inline paddr_t::paddr_t(internal_paddr_t val) : internal_paddr(val) {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   auto type = get_addr_type();
   if (type == paddr_types_t::SEGMENT) {
     assert(as_seg_paddr().get_segment_off() >= 0);

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -129,7 +129,7 @@ public:
   void add_present_to_retired_set(CachedExtentRef ref) {
     assert(ref->get_paddr().is_real_location());
     assert(!is_weak());
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     auto [result, ext] = do_get_extent(ref->get_paddr());
     assert(result == get_extent_ret::PRESENT);
     assert(ext == ref);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -327,7 +327,7 @@ TransactionManager::update_lba_mappings(
 	    extent->set_last_committed_crc(CRC_NULL);
 	  }
 	}
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
 	if (get_checksum_needed(extent->get_paddr())) {
 	  assert(extent->get_last_committed_crc() == extent->calc_crc32c());
 	} else {
@@ -510,7 +510,7 @@ TransactionManager::rewrite_logical_extent(
 
     DEBUGT("rewriting meta -- {} to {}", t, *extent, *nextent);
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     if (get_checksum_needed(extent->get_paddr())) {
       assert(extent->get_last_committed_crc() == extent->calc_crc32c());
     } else {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -485,7 +485,7 @@ public:
     // must be user-oriented required by (the potential) maybe_init
     assert(is_user_transaction(t.get_src()));
 
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
     std::sort(remaps.begin(), remaps.end(),
       [](remap_entry_t x, remap_entry_t y) {
         return x.offset < y.offset;
@@ -969,7 +969,7 @@ private:
     if (v.has_child()) {
       return v.get_child_fut(
       ).si_then([pin=std::move(pin)](auto extent) {
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
         auto lextent = extent->template cast<LogicalChildNode>();
         auto pin_laddr = pin.get_intermediate_base();
         assert(lextent->get_laddr() == pin_laddr);

--- a/src/crimson/osd/lsan_suppressions.cc
+++ b/src/crimson/osd/lsan_suppressions.cc
@@ -1,4 +1,4 @@
-#ifndef _NDEBUG
+#ifdef CRIMSON_DEBUG
 // The callbacks we define here will be called from the sanitizer runtime, but
 // aren't referenced from the Chrome executable. We must ensure that those
 // callbacks are not sanitizer-instrumented, and that they aren't stripped by
@@ -17,4 +17,4 @@ static char kLSanDefaultSuppressions[] =
 SANITIZER_HOOK_ATTRIBUTE const char *__lsan_default_suppressions() {
   return kLSanDefaultSuppressions;
 }
-#endif // ! _NDEBUG
+#endif // CRIMSON_DEBUG

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -236,10 +236,10 @@ struct HistoricBackend
   }
 
   static const ClientRequest& to_client_request(const Operation& op) {
-#ifdef NDEBUG
-    return static_cast<const ClientRequest&>(op);
-#else
+#ifdef CRIMSON_DEBUG
     return dynamic_cast<const ClientRequest&>(op);
+#else
+    return static_cast<const ClientRequest&>(op);
 #endif
   }
 

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -147,7 +147,7 @@ void TMDriver::init()
   shard_stats = {};
 
   std::vector<Device*> sec_devices;
-#ifndef NDEBUG
+#ifdef CRIMSON_DEBUG
   tm = make_transaction_manager(device.get(), sec_devices, shard_stats, true);
 #else
   tm = make_transaction_manager(device.get(), sec_devices, shard_stats, false);


### PR DESCRIPTION
Followup to https://github.com/ceph/ceph/pull/63384 alternative approach.

It seems that we want asserts to be tested regularly in our suite. As `ceph_assert` performance overhead is noticeable enabling built in asserts could be the middle ground. We would still be able to disable asserts with `CRIMSON_DISABLE_ASSERTS`. This could be defined in a `*crimson-rel` build option (or a new flavor), see builders pseudo:
```
if [[ "$BRANCH" == *-crimson-rel ]]; then
  CEPH_EXTRA_CMAKE_ARGS+=" -DCRIMSON_DISABLE_ASSERTS=ON"
  printf 'Disabling asserts in branch %s. CEPH_EXTRA_CMAKE_ARGS: %s\n' "$BRANCH" "$CEPH_EXTRA_CMAKE_ARGS"
fi
```

TODO: evaluate asserts vs ceph_assert diffrence? It's possible that both will bring roughly the same overhead. However, the advantage here is that these asserts are easily turned off when needed.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
