### PR TITLE
crimson/os/seastore/async_cleaner: set different threshold for starting and stopping trimming dirty

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -348,7 +348,7 @@ void JournalTrimmerImpl::config_t::validate() const
   ceph_assert(rewrite_dirty_bytes_per_trans > 0);
   ceph_assert(rewrite_dirty_bytes_per_cycle >=
     rewrite_dirty_bytes_per_trans);
-  ceph_assert(rewrite_backref_bytes_per_cycle > 0);
+  ceph_assert(max_backref_bytes_per_cycle > 0);
 }
 
 JournalTrimmerImpl::config_t
@@ -379,7 +379,7 @@ JournalTrimmerImpl::config_t::get_default(
     max_journal_bytes,
     1<<26,// rewrite_dirty_bytes_per_cycle
     1<<17,// rewrite_dirty_bytes_per_trans
-    1<<24 // rewrite_backref_bytes_per_cycle
+    1<<24 // max_backref_bytes_per_cycle
   };
 }
 
@@ -413,7 +413,7 @@ JournalTrimmerImpl::config_t::get_test(
       ? 1<<25
       : target_dirty_bytes / 2,// rewrite_dirty_bytes_per_cycle
     1<<17,// rewrite_dirty_bytes_per_trans
-    1<<24 // rewrite_backref_bytes_per_cycle
+    1<<24 // max_backref_bytes_per_cycle
   };
 }
 
@@ -659,7 +659,7 @@ JournalTrimmerImpl::trim_alloc()
       return backref_manager.merge_cached_backrefs(
         t,
         target,
-        config.rewrite_backref_bytes_per_cycle
+        config.max_backref_bytes_per_cycle
       ).si_then([this, FNAME, &t](auto trim_alloc_to)
         -> ExtentCallbackInterface::submit_transaction_direct_iertr::future<>
       {

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -377,9 +377,9 @@ JournalTrimmerImpl::config_t::get_default(
     target_alloc_bytes,
     min_journal_bytes,
     max_journal_bytes,
-    1<<26,// rewrite_dirty_bytes_per_cycle
-    1<<17,// rewrite_dirty_bytes_per_trans
-    1<<24 // max_backref_bytes_per_cycle
+    1<<26,// rewrite_dirty_bytes_per_cycle, 64MB
+    1<<17,// rewrite_dirty_bytes_per_trans, 128KB
+    1<<24 // max_backref_bytes_per_cycle, 16MB
   };
 }
 
@@ -411,9 +411,9 @@ JournalTrimmerImpl::config_t::get_test(
     max_journal_bytes,
     (target_dirty_bytes > 1<<26)
       ? 1<<25
-      : target_dirty_bytes / 2,// rewrite_dirty_bytes_per_cycle
-    1<<17,// rewrite_dirty_bytes_per_trans
-    1<<24 // max_backref_bytes_per_cycle
+      : target_dirty_bytes / 2, // rewrite_dirty_bytes_per_cycle
+    1<<17,// rewrite_dirty_bytes_per_trans, 128KB
+    1<<24 // max_backref_bytes_per_cycle, 16MB
   };
 }
 

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -517,8 +517,8 @@ public:
     std::size_t rewrite_dirty_bytes_per_cycle = 0;
     /// Number of bytes to rewrite dirty per transaction
     std::size_t rewrite_dirty_bytes_per_trans = 0;
-    /// Number of bytes to rewrite backref per cycle
-    std::size_t rewrite_backref_bytes_per_cycle = 0;
+    /// Maximum number of bytes of new backref extents per cycle
+    std::size_t max_backref_bytes_per_cycle = 0;
 
     void validate() const;
 
@@ -566,7 +566,7 @@ public:
       journal_seq_t dirty_tail, journal_seq_t alloc_tail) final;
 
   std::size_t get_trim_size_per_cycle() const final {
-    return config.rewrite_backref_bytes_per_cycle +
+    return config.max_backref_bytes_per_cycle +
       get_dirty_bytes_to_trim();
   }
 

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -503,14 +503,14 @@ class JournalTrimmerImpl : public JournalTrimmer {
 public:
   struct config_t {
     /// Number of minimum bytes to start trimming dirty,
-    //	this must be larger than or equal to min_journal_bytes,
+    //	this must be larger than or equal to min_journal_dirty_bytes,
     //	otherwise trim_dirty may never happen.
     std::size_t target_journal_dirty_bytes = 0;
     /// Number of minimum bytes to stop trimming allocation
     /// (having the corresponding backrefs unmerged)
     std::size_t target_journal_alloc_bytes = 0;
     /// Number of minimum dirty bytes of the journal.
-    std::size_t min_journal_bytes = 0;
+    std::size_t min_journal_dirty_bytes = 0;
     /// Number of maximum bytes to block user transactions.
     std::size_t max_journal_bytes = 0;
     /// Number of bytes to rewrite dirty per cycle
@@ -667,10 +667,10 @@ private:
   }
   std::size_t get_max_dirty_bytes_to_trim() const {
     auto journal_dirty_bytes = get_journal_dirty_bytes();
-    if (journal_dirty_bytes <= config.min_journal_bytes) {
+    if (journal_dirty_bytes <= config.min_journal_dirty_bytes) {
       return 0;
     }
-    return journal_dirty_bytes - config.min_journal_bytes;
+    return journal_dirty_bytes - config.min_journal_dirty_bytes;
   }
   std::size_t get_dirty_bytes_to_trim() const {
     return std::min(get_max_dirty_bytes_to_trim(),


### PR DESCRIPTION
At present, the trim_dirty starts and stops at the same threshold *target_dirty_bytes*, which leads to very frequent *trim_dirty* operations that further invalidate transactions.

We've observed that long read transactions kept being invalidated by *trim_dirty*, which led to starvations.

Fixes: https://tracker.ceph.com/issues/71443
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
