### PR TITLE
tools/ceph-erasure-code-tool: Fix issue stopping parity shards being generated when running encode.

### DIFF
--- a/src/tools/erasure-code/ceph-erasure-code-tool.cc
+++ b/src/tools/erasure-code/ceph-erasure-code-tool.cc
@@ -215,6 +215,7 @@ int do_encode(const std::vector<const char*> &args) {
   }
 
   sinfo->ro_range_to_shard_extent_map(0, input_data.length(), input_data, encoded_data);
+  encoded_data.insert_parity_buffers();
   r = encoded_data.encode(ec_impl, nullptr, encoded_data.get_ro_end());
   if (r < 0) {
     std::cerr << "failed to encode: " << cpp_strerror(r) << std::endl;


### PR DESCRIPTION
The erasure code tool has been updated to work with the new EC, the do_encode function which enables the encode option of the tool has a bug which stops the parity shards being generated:

```
(venv-3.12) [root@connorfaukibmcom-san-motoko-centos9base2025010615010000 build]# ceph-erasure-code-tool encode k=4,m=2,technique=reed_sol_van,plugin=jerasure,w=8 4096 0,1,2,3,4,5 /tmp/ec/obj-no-fix
(venv-3.12) [root@connorfaukibmcom-san-motoko-centos9base2025010615010000 build]# ls /tmp/ec/obj-no-fix*
/tmp/ec/obj-no-fix  /tmp/ec/obj-no-fix.0  /tmp/ec/obj-no-fix.1    /tmp/ec/obj-no-fix.2  /tmp/ec/obj-no-fix.3
```

Here an object of 4 shards should be encoded to produce 4 data shards + 2 parity shards, but only the data shards are produced by the tool.

This happens because the parity buffers have not been inserted into the extent map pre-encode. Interestingly, this does not cause encode to fail, instead it does no work and returns r == 0. So the encode 'succeeds' but ultimately does not produce the data shards as shown above.

This fix simply inserts the parity buffers into the extent map pre-encode, which results in the correct behaviour:

```
(venv-3.12) [root@connorfaukibmcom-san-motoko-centos9base2025010615010000 build]# ceph-erasure-code-tool encode k=4,m=2,technique=reed_sol_van,plugin=jerasure,w=8 4096 0,1,2,3,4,5 /tmp/ec/obj-with-fix
(venv-3.12) [root@connorfaukibmcom-san-motoko-centos9base2025010615010000 build]# ls /tmp/ec/obj-with-fix*
/tmp/ec/obj-with-fix  /tmp/ec/obj-with-fix.0  /tmp/ec/obj-with-fix.1  /tmp/ec/obj-with-fix.2  /tmp/ec/obj-with-fix.3  /tmp/ec/obj-with-fix.4  /tmp/ec/obj-with-fix.5
```

Signed-off-by: Connor Fawcett <connorfa@uk.ibm.com>
Fixes: https://tracker.ceph.com/issues/71459


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
