### PR TITLE
osd/scrub: no auto-repair in 'after_repair' type of scrubs

### DIFF
--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -411,6 +411,12 @@ bool ScrubJob::has_high_queue_priority(urgency_t urgency)
 
 bool ScrubJob::is_repair_implied(urgency_t urgency)
 {
-  return urgency == urgency_t::after_repair ||
+  return urgency == urgency_t::repairing || urgency == urgency_t::must_repair;
+}
+
+bool ScrubJob::is_autorepair_allowed(urgency_t urgency)
+{
+  // note: 'after-repair' scrubs are not allowed to auto-repair
+  return urgency == urgency_t::periodic_regular ||
 	 urgency == urgency_t::repairing || urgency == urgency_t::must_repair;
 }

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -371,6 +371,8 @@ class ScrubJob {
   static bool has_high_queue_priority(urgency_t urgency);
 
   static bool is_repair_implied(urgency_t urgency);
+
+  static bool is_autorepair_allowed(urgency_t urgency);
 };
 }  // namespace Scrub
 

--- a/src/osd/scrubber/scrub_queue_entry.h
+++ b/src/osd/scrubber/scrub_queue_entry.h
@@ -34,8 +34,7 @@ namespace Scrub {
  *
  * 'after_repair' - triggered immediately after a recovery process
  *   ('m_after_repair_scrub_required' was set).
- *   This type of scrub is always deep.
- *   (note: this urgency level is not implemented in this commit)
+ *   This type of scrub is always deep, and never auto-repairs.
  *
  * 'repairing' - the target is currently being deep-scrubbed with the repair
  *   flag set. Triggered by a previous shallow scrub that ended with errors.


### PR DESCRIPTION
The deep scrubs that are initiated after a full "peering" repair, are not supposed to auto-repair any errors - just report them.

This behavior detail was inadvertently changed recently, and is fixed here.

Fixes: https://tracker.ceph.com/issues/71463

