### PR TITLE
osd, mon, extblkdev: add support for thin provisioned NVMe devices

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,6 @@
 [submodule "src/lss"]
 	path = src/lss
 	url = https://chromium.googlesource.com/linux-syscall-support
+[submodule "src/nvme"]
+	path = src/nvme
+	url = https://github.com/linux-nvme/libnvme

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -176,9 +176,11 @@ class HealthTest(DashboardTestCase):
                     'id': int
                 })),
                 'stats': JObj({
-                    'total_avail_bytes': int,
                     'total_bytes': int,
+                    'total_avail_bytes': int,
                     'total_used_bytes': int,
+                    'total_raw_bytes': int,
+                    'total_avail_raw_bytes': int,
                     'total_used_raw_bytes': int,
                     'total_used_raw_ratio': float,
                     'num_osds': int,

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -246,7 +246,7 @@ public:
   bool is_discard_supported() const { return support_discard; }
 
   /// hook to provide utilization of thinly-provisioned device
-  virtual int get_ebd_state(ExtBlkDevState &state) const {
+  virtual int get_ebd_statfs(store_statfs_t &statfs) const {
     return -ENOENT;
   }
 

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -467,12 +467,12 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
   return 0;
 }
 
-int KernelDevice::get_ebd_state(ExtBlkDevState &state) const
+int KernelDevice::get_ebd_statfs(store_statfs_t &statfs) const
 {
   // use compression driver plugin to determine physical size and availability
   // VDO specific get_thin_utilization has moved into VDO plugin
   if (ebd_impl) {
-    return ebd_impl->get_state(state);
+    return ebd_impl->get_statfs(statfs);
   }
   return -ENOENT;
 }

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -282,23 +282,31 @@ int KernelDevice::open(const string& p)
       size = st.st_size;
     }
 
-    char partition[PATH_MAX], devname[PATH_MAX];
+    char partition[PATH_MAX], _devname[PATH_MAX];
     if ((r = blkdev_buffered.partition(partition, PATH_MAX)) ||
-	(r = blkdev_buffered.wholedisk(devname, PATH_MAX))) {
+	(r = blkdev_buffered.wholedisk(_devname, PATH_MAX))) {
       derr << "unable to get device name for " << path << ": "
 	<< cpp_strerror(r) << dendl;
       rotational = true;
     } else {
-      dout(20) << __func__ << " devname " << devname << dendl;
+      std::set<std::string> devices;
+      this->devname = _devname;
+      dout(10) << __func__ << " devname: " << _devname << dendl;
+      get_devices(&devices);
       rotational = blkdev_buffered.is_rotational();
       support_discard = blkdev_buffered.support_discard();
       optimal_io_size = blkdev_buffered.get_optimal_io_size();
-      this->devname = devname;
+      dout(10) << __func__
+               << " devices: " << devices
+               << " rotational: " << rotational
+               << " support_discard: " << support_discard
+               << " optimal_io_size: " << optimal_io_size
+               << dendl;
       // check if any extended block device plugin recognizes this device
       // detect_vdo has moved into the VDO plugin
-      int rc = extblkdev::detect_device(cct, devname, ebd_impl);
+      int rc = extblkdev::detect_device(cct, _devname, devices, ebd_impl);
       if (rc != 0) {
-	dout(20) << __func__ << " no plugin volume maps to " << devname << dendl;
+	dout(0) << __func__ << " no plugin volume maps to " << _devname << dendl;
       }
     }
   }

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -147,7 +147,7 @@ public:
   }
   int get_devices(std::set<std::string> *ls) const override;
 
-  int get_ebd_state(ExtBlkDevState &state) const override;
+  int get_ebd_statfs(store_statfs_t& statfs) const override;
 
   int read(uint64_t off, uint64_t len, ceph::buffer::list *pbl,
 	   IOContext *ioc,

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -1379,7 +1379,9 @@ public:
   store_statfs_t get_stat() const final {
     store_statfs_t st;
     st.total = segments.get_total_bytes();
+    st.total_raw = st.total;
     st.available = segments.get_total_bytes() - stats.used_bytes;
+    st.avail_raw = st.available;
     st.allocated = stats.used_bytes;
     st.data_stored = stats.used_bytes;
 
@@ -1747,7 +1749,9 @@ public:
   store_statfs_t get_stat() const final {
     store_statfs_t st;
     st.total = get_total_bytes();
+    st.total_raw = st.total;
     st.available = get_total_bytes() - get_journal_bytes() - stats.used_bytes;
+    st.avail_raw = st.available;
     st.allocated = get_journal_bytes() + stats.used_bytes;
     st.data_stored = get_journal_bytes() + stats.used_bytes;
     return st;

--- a/src/extblkdev/CMakeLists.txt
+++ b/src/extblkdev/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(extblkdev_plugin_dir ${CEPH_INSTALL_PKGLIBDIR}/extblkdev)
 
 add_subdirectory(vdo)
+add_subdirectory(thin_nvme)
 
 add_library(extblkdev STATIC ExtBlkDevPlugin.cc)
 
@@ -12,4 +13,4 @@ if(LINUX)
 endif()
 
 add_custom_target(extblkdev_plugins DEPENDS
-    ceph_ebd_vdo)
+    ceph_ebd_vdo ceph_ebd_thin_nvme)

--- a/src/extblkdev/ExtBlkDevInterface.h
+++ b/src/extblkdev/ExtBlkDevInterface.h
@@ -42,24 +42,9 @@ typedef void *cap_t;
 #endif
 
 #include "common/PluginRegistry.h"
+#include "osd/osd_types.h"
 
 namespace ceph {
-  class ExtBlkDevState {
-    uint64_t logical_total=0;
-    uint64_t logical_avail=0;
-    uint64_t physical_total=0;
-    uint64_t physical_avail=0;
-  public:
-    uint64_t get_logical_total(){return logical_total;}
-    uint64_t get_logical_avail(){return logical_avail;}
-    uint64_t get_physical_total(){return physical_total;}
-    uint64_t get_physical_avail(){return physical_avail;}
-    void set_logical_total(uint64_t alogical_total){logical_total=alogical_total;}
-    void set_logical_avail(uint64_t alogical_avail){logical_avail=alogical_avail;}
-    void set_physical_total(uint64_t aphysical_total){physical_total=aphysical_total;}
-    void set_physical_avail(uint64_t aphysical_avail){physical_avail=aphysical_avail;}
-  };
-
 
   class ExtBlkDevInterface {
   public:
@@ -83,14 +68,15 @@ namespace ceph {
     virtual const std::string& get_devname() const = 0;
 
     /**
-     * Provide status of underlying physical storage after compression
+     * Provide total/available stats of underlying physical storage
+     * after compression
      *
      * Return 0 on success or a negative errno on error.
      *
-     * @param [out] state current state of the undelying device
+     * @param [out] statfs updated total/available statfs members
      * @return 0 on success or a negative errno on error.
      */
-    virtual int get_state(ExtBlkDevState& state) = 0;
+    virtual int get_statfs(store_statfs_t& statfs) = 0;
 
     /**
      * Populate property map with meta data of device.

--- a/src/extblkdev/ExtBlkDevInterface.h
+++ b/src/extblkdev/ExtBlkDevInterface.h
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <map>
+#include <set>
 #include <ostream>
 #include <memory>
 #ifdef __linux__
@@ -56,9 +57,11 @@ namespace ceph {
      * Return 0 on success or a negative errno on error
      *
      * @param [in] logdevname name of device to check for support by this plugin
+     * @param [in] devices names of physical devices to check for support by this plugin
      * @return 0 on success or a negative errno on error.
      */
-    virtual int init(const std::string& logdevname) = 0;
+    virtual int init(const std::string& logdevname,
+                     const std::set<std::string>& devices) = 0;
 
     /**
      * Return the name of the underlying device detected by **init** method
@@ -116,10 +119,12 @@ namespace ceph {
      * Factory method, creating ExtBlkDev instances
      *
      * @param [in] logdevname name of logic device, may be composed of physical devices
+     * @param [in] devices list of physical device names
      * @param [out] ext_blk_dev object created on successful device support detection
      * @return 0 on success or a negative errno on error.
      */
     virtual int factory(const std::string& logdevname,
+                        const std::set<std::string>& devices,
                         ExtBlkDevInterfaceRef& ext_blk_dev) = 0;
   };
 

--- a/src/extblkdev/ExtBlkDevPlugin.cc
+++ b/src/extblkdev/ExtBlkDevPlugin.cc
@@ -220,7 +220,8 @@ namespace ceph {
 
     // scan extblkdev plugins for support of this device
     int detect_device(CephContext *cct,
-		      const std::string &logdevname,
+		      const std::string& logdevname,
+		      const std::set<std::string>& devices,
 		      ExtBlkDevInterfaceRef& ebd_impl)
     {
       int rc = -ENOENT;
@@ -229,7 +230,7 @@ namespace ceph {
       std::lock_guard l(registry->lock);
       auto ptype = registry->plugins.find("extblkdev");
       if (ptype == registry->plugins.end()) {
-	return -ENOENT;
+	return rc;
       }
 
       for (auto& it : ptype->second) {
@@ -241,7 +242,7 @@ namespace ceph {
 	  derr << __func__ << " Is not an extblkdev plugin: " << it.first << dendl;
 	  return -ENOENT;
 	}
-	rc = ebdplugin->factory(logdevname, ebd_impl);
+	rc = ebdplugin->factory(logdevname, devices, ebd_impl);
 	if (rc == 0) {
 	  plg_name = it.first;
 	  break;

--- a/src/extblkdev/ExtBlkDevPlugin.h
+++ b/src/extblkdev/ExtBlkDevPlugin.h
@@ -30,7 +30,8 @@ namespace ceph {
   namespace extblkdev {
     int preload(CephContext *cct);
     int detect_device(CephContext *cct,
-			  const std::string &logdevname,
+			  const std::string& logdevname,
+			  const std::set<std::string>& devices,
 			  ExtBlkDevInterfaceRef& ebd_impl);
     int release_device(ExtBlkDevInterfaceRef& ebd_impl);
   }

--- a/src/extblkdev/thin_nvme/CMakeLists.txt
+++ b/src/extblkdev/thin_nvme/CMakeLists.txt
@@ -1,0 +1,9 @@
+# thin_nvme plugin
+
+set(thin_nvme_srcs
+  ExtBlkDevPluginThinNVMe.cc
+  ExtBlkDevThinNVMe.cc
+)
+
+add_library(ceph_ebd_thin_nvme SHARED ${thin_nvme_srcs})
+install(TARGETS ceph_ebd_thin_nvme DESTINATION ${extblkdev_plugin_dir})

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include <set>
+#include "ceph_ver.h"
+#include "ExtBlkDevPluginThinNVMe.h"
+#include "common/ceph_context.h"
+
+
+// This plugin does not require any capabilities to be set
+int ExtBlkDevPluginThinNVMe::get_required_cap_set(cap_t caps)
+{
+  return 0;
+}
+
+
+int ExtBlkDevPluginThinNVMe::factory(const std::string& logdevname,
+				ceph::ExtBlkDevInterfaceRef& ext_blk_dev)
+{
+  auto dev = new ExtBlkDevThinNVMe(cct);
+  int r = dev->init(logdevname);
+  if (r != 0) {
+    delete dev;
+    return r;
+  }
+  ext_blk_dev.reset(dev);
+  return 0;
+};
+
+const char *__ceph_plugin_version() { return CEPH_GIT_NICE_VER; }
+
+int __ceph_plugin_init(CephContext *cct,
+		       const std::string& type,
+		       const std::string& name)
+{
+  auto plg = new ExtBlkDevPluginThinNVMe(cct);
+  if(plg == 0) return -ENOMEM;
+  int rc = cct->get_plugin_registry()->add(type, name, plg);
+  if(rc != 0){
+    delete plg;
+  }
+  return rc;
+}

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.cc
@@ -20,15 +20,24 @@
 // This plugin does not require any capabilities to be set
 int ExtBlkDevPluginThinNVMe::get_required_cap_set(cap_t caps)
 {
+  cap_value_t arr[1];
+  arr[0] = CAP_SYS_ADMIN;
+  if (cap_set_flag(caps, CAP_PERMITTED, 1, arr, CAP_SET) < 0) {
+    return -errno;
+  }
+  if (cap_set_flag(caps, CAP_EFFECTIVE, 1, arr, CAP_SET) < 0) {
+    return -errno;
+  }
   return 0;
 }
 
 
 int ExtBlkDevPluginThinNVMe::factory(const std::string& logdevname,
+                                const std::set<std::string>& devices,
 				ceph::ExtBlkDevInterfaceRef& ext_blk_dev)
 {
   auto dev = new ExtBlkDevThinNVMe(cct);
-  int r = dev->init(logdevname);
+  int r = dev->init(logdevname, devices);
   if (r != 0) {
     delete dev;
     return r;

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph distributed storage system
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef CEPH_EXT_BLK_DEV_PLUGIN_THIN_NVME_H
+#define CEPH_EXT_BLK_DEV_PLUGIN_THIN_NVME_H
+
+#include "ExtBlkDevThinNVMe.h"
+
+class ExtBlkDevPluginThinNVMe : public ceph::ExtBlkDevPlugin {
+public:
+  explicit ExtBlkDevPluginThinNVMe(CephContext *cct) : ExtBlkDevPlugin(cct) {}
+  int get_required_cap_set(cap_t caps) override;
+  int factory(const std::string& logdevname,
+	      ceph::ExtBlkDevInterfaceRef& ext_blk_dev) override;
+};
+
+#endif

--- a/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevPluginThinNVMe.h
@@ -20,6 +20,7 @@ public:
   explicit ExtBlkDevPluginThinNVMe(CephContext *cct) : ExtBlkDevPlugin(cct) {}
   int get_required_cap_set(cap_t caps) override;
   int factory(const std::string& logdevname,
+              const std::set<std::string>& devices,
 	      ceph::ExtBlkDevInterfaceRef& ext_blk_dev) override;
 };
 

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
@@ -89,14 +89,14 @@ int ExtBlkDevThinNVMe::get_statfs(store_statfs_t& buf)
     uint64_t nuse = ns_data.nuse * lba_size; // Namespace usage: the current capacity utilization (in bytes)
                                              // of the namespace
 
-    buf.total = ns_data.nsze * lba_size;
-    buf.available = (ns_data.ncap - ns_data.nuse) * lba_size;
-    buf.raw_use = ns_data.nuse * lba_size;
-    dout(0) << __func__ << " stats (nsze/ncap/nuse):"
-                        << nsze << "/"
-                        << ncap << "/"
-                        << nuse
-                        << dendl;
+    buf.total_raw = ns_data.ncap * lba_size;
+    buf.avail_raw = (ns_data.ncap - ns_data.nuse) * lba_size;
+    dout(10) << __func__ << std::hex
+                         << " stats (nsze/ncap/nuse):"
+                         << nsze << "/"
+                         << ncap << "/"
+                         << nuse
+                         << std::dec << dendl;
   }
   return r;
 }

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
@@ -1,0 +1,108 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
+#include <errno.h>
+#include <string>
+
+#include <linux/nvme_ioctl.h>
+#include <sys/ioctl.h>
+
+#include "ExtBlkDevThinNVMe.h"
+#include "common/blkdev.h"
+#include "nvme/src/nvme/types.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+#include "common/debug.h"
+
+#define dout_subsys ceph_subsys_bdev
+#define dout_context cct
+#undef dout_prefix
+#define dout_prefix *_dout << "ThinNVMe(" << this << ") "
+
+int ExtBlkDevThinNVMe::init(const std::string& alogdevname)
+{
+  dout(3) << __func__ << " devname:" << alogdevname << dendl;
+  logdevname = alogdevname;
+  int _dev = -1;
+  int _ns = -1;
+  int n = -1;
+  int r = sscanf(alogdevname.c_str(), "nvme%dn%d%n", &_dev, &_ns, &n);
+  if (r == 2 && n == int(alogdevname.length())) {
+    // FIXME: make additional checking for vendor/model or something
+    ceph_assert(_dev >= 0);
+    ceph_assert(_ns >= 0);
+    std::string dev_name("/dev/nvme");
+    dev_name += stringify(_dev);
+    int _fd = open(dev_name.c_str(), O_RDONLY);
+    if (_fd < 0) {
+      r = -errno;
+      derr << __func__ << " failed to open " << dev_name.c_str() << ": " << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
+    r = 0;
+    dev = _dev;
+    ns = _ns;
+    fd = _fd;
+    dout(3) << __func__ << " use dev:" << dev << " ns:" << ns << " as thin NVMe device" << dendl;
+  } else {
+    r = -EINVAL;
+  }
+  return r;
+}
+
+int ExtBlkDevThinNVMe::get_statfs(store_statfs_t& buf)
+{
+  if (fd < 0) {
+    return -EBADF;
+  }
+  struct nvme_admin_cmd cmd = {};
+  struct nvme_id_ns ns_data = {};
+
+  cmd.opcode = nvme_admin_identify;
+  cmd.nsid = ns;
+  cmd.addr = (__u64)&ns_data;
+  cmd.data_len = sizeof(ns_data);
+  cmd.cdw10 = 0; // CNS value for Identify Namespace (0x00)
+
+
+  int r = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+  if (r < 0) {
+    r = -errno;
+    derr << __func__ << " ioctl failed: " << r << " " << cpp_strerror(-r) << dendl;
+  } else {
+    uint64_t lba_size = 1ULL << ns_data.lbaf[ns_data.flbas & 0x0F].ds;
+
+    uint64_t nsze = ns_data.nsze * lba_size; // Namespace(logical) size: bytes available to the host
+    uint64_t ncap = ns_data.ncap * lba_size; // Namespace capacity: the actual capacity (in bytes) provided
+    uint64_t nuse = ns_data.nuse * lba_size; // Namespace usage: the current capacity utilization (in bytes)
+                                             // of the namespace
+
+    buf.total = ns_data.nsze * lba_size;
+    buf.available = (ns_data.ncap - ns_data.nuse) * lba_size;
+    buf.raw_use = ns_data.nuse * lba_size;
+    dout(0) << __func__ << " stats (nsze/ncap/nuse):"
+                        << nsze << "/"
+                        << ncap << "/"
+                        << nuse
+                        << dendl;
+  }
+  return r;
+}
+
+int ExtBlkDevThinNVMe::collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
+{
+  (*pm)[prefix + "thin_nvme"] = "1";
+  return 0;
+}

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.cc
@@ -30,24 +30,39 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "ThinNVMe(" << this << ") "
 
-int ExtBlkDevThinNVMe::init(const std::string& alogdevname)
+int ExtBlkDevThinNVMe::init(const std::string& alogdevname,
+                            const std::set<std::string>& devices)
 {
-  dout(3) << __func__ << " devname:" << alogdevname << dendl;
+  int r;
+  dout(3) << __func__
+          << " devname:" << alogdevname
+          << " devices:" << devices
+          << dendl;
+  if (devices.size() != 1) {
+    dout(5) << __func__ << " none or multiple physical devices behind, skipping."
+            << dendl;
+    r = -EINVAL;
+    return r;
+  }
   logdevname = alogdevname;
+  auto device = *devices.begin();
   int _dev = -1;
   int _ns = -1;
   int n = -1;
-  int r = sscanf(alogdevname.c_str(), "nvme%dn%d%n", &_dev, &_ns, &n);
-  if (r == 2 && n == int(alogdevname.length())) {
-    // FIXME: make additional checking for vendor/model or something
+  r = sscanf(device.c_str(), "nvme%dn%d%n", &_dev, &_ns, &n);
+  if (r == 2 && n == int(device.length())) {
     ceph_assert(_dev >= 0);
     ceph_assert(_ns >= 0);
     std::string dev_name("/dev/nvme");
     dev_name += stringify(_dev);
+    dev_name += 'n';
+    dev_name += stringify(_ns);
     int _fd = open(dev_name.c_str(), O_RDONLY);
     if (_fd < 0) {
       r = -errno;
-      derr << __func__ << " failed to open " << dev_name.c_str() << ": " << cpp_strerror(-r) << dendl;
+      derr << __func__
+           << " failed to open " << dev_name.c_str() << ": " << cpp_strerror(-r)
+           << dendl;
       return r;
     }
 
@@ -76,7 +91,6 @@ int ExtBlkDevThinNVMe::get_statfs(store_statfs_t& buf)
   cmd.data_len = sizeof(ns_data);
   cmd.cdw10 = 0; // CNS value for Identify Namespace (0x00)
 
-
   int r = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
   if (r < 0) {
     r = -errno;
@@ -104,5 +118,10 @@ int ExtBlkDevThinNVMe::get_statfs(store_statfs_t& buf)
 int ExtBlkDevThinNVMe::collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
 {
   (*pm)[prefix + "thin_nvme"] = "1";
+  std::string id = "nvme";
+  id += stringify(dev);
+  id += 'n';
+  id += stringify(ns);
+  (*pm)[prefix + "thin_nvme_id"] = id;
   return 0;
 }

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
@@ -1,0 +1,41 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_EXT_BLK_DEV_THIN_NVME_H
+#define CEPH_EXT_BLK_DEV_THIN_NVME_H
+
+#include "extblkdev/ExtBlkDevInterface.h"
+#include "include/compat.h"
+
+class ExtBlkDevThinNVMe final : public ceph::ExtBlkDevInterface
+{
+  std::string name;   // name of the underlying vdo device
+  std::string logdevname; // name of the top level logical device
+  int dev = -1;
+  int ns = -1;
+  int fd = -1;
+  CephContext *cct;
+
+public:
+  explicit ExtBlkDevThinNVMe(CephContext *cct) : cct(cct) {}
+  ~ExtBlkDevThinNVMe() {
+    if (fd >= 0)
+      VOID_TEMP_FAILURE_RETRY(::close(fd));
+  }
+  int init(const std::string& logdevname) override;
+  const std::string& get_devname() const override {return name;}
+  int get_statfs(store_statfs_t& statfs) override;
+  int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) override;
+};
+
+#endif

--- a/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
+++ b/src/extblkdev/thin_nvme/ExtBlkDevThinNVMe.h
@@ -32,7 +32,7 @@ public:
     if (fd >= 0)
       VOID_TEMP_FAILURE_RETRY(::close(fd));
   }
-  int init(const std::string& logdevname) override;
+  int init(const std::string& logdevname, const std::set<std::string>& devices) override;
   const std::string& get_devname() const override {return name;}
   int get_statfs(store_statfs_t& statfs) override;
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) override;

--- a/src/extblkdev/vdo/ExtBlkDevPluginVdo.cc
+++ b/src/extblkdev/vdo/ExtBlkDevPluginVdo.cc
@@ -32,10 +32,11 @@ int ExtBlkDevPluginVdo::get_required_cap_set(cap_t caps)
 
 
 int ExtBlkDevPluginVdo::factory(const std::string& logdevname,
+                                const std::set<std::string>& devices,
 				ceph::ExtBlkDevInterfaceRef& ext_blk_dev)
 {
   auto vdo = new ExtBlkDevVdo(cct);
-  int r = vdo->init(logdevname);
+  int r = vdo->init(logdevname, devices);
   if (r != 0) {
     delete vdo;
     return r;

--- a/src/extblkdev/vdo/ExtBlkDevPluginVdo.h
+++ b/src/extblkdev/vdo/ExtBlkDevPluginVdo.h
@@ -29,6 +29,7 @@ public:
   explicit ExtBlkDevPluginVdo(CephContext *cct) : ExtBlkDevPlugin(cct) {}
   int get_required_cap_set(cap_t caps) override;
   int factory(const std::string& logdevname,
+              const std::set<std::string>& devices,
 	      ceph::ExtBlkDevInterfaceRef& ext_blk_dev) override;
 };
 

--- a/src/extblkdev/vdo/ExtBlkDevVdo.cc
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.cc
@@ -113,15 +113,14 @@ int ExtBlkDevVdo::init(const std::string& alogdevname)
   return get_vdo_stats_handle();
 }
 
-
-int ExtBlkDevVdo::get_state(ceph::ExtBlkDevState& state)
+int ExtBlkDevVdo::get_statfs(store_statfs_t& statfs)
 {
   int64_t block_size = get_vdo_stat("block_size");
   int64_t physical_blocks = get_vdo_stat("physical_blocks");
   int64_t overhead_blocks_used = get_vdo_stat("overhead_blocks_used");
   int64_t data_blocks_used = get_vdo_stat("data_blocks_used");
   int64_t logical_blocks = get_vdo_stat("logical_blocks");
-  int64_t logical_blocks_used = get_vdo_stat("logical_blocks_used");
+  //int64_t logical_blocks_used = get_vdo_stat("logical_blocks_used");
   if (!block_size
       || !physical_blocks
       || !overhead_blocks_used
@@ -137,23 +136,21 @@ int ExtBlkDevVdo::get_state(ceph::ExtBlkDevState& state)
   }
   int64_t avail_blocks =
     physical_blocks - overhead_blocks_used - data_blocks_used;
-  int64_t logical_avail_blocks =
-    logical_blocks - logical_blocks_used;
-  state.set_logical_total(block_size * logical_blocks);
-  state.set_logical_avail(block_size * logical_avail_blocks);
-  state.set_physical_total(block_size * physical_blocks);
-  state.set_physical_avail(block_size * avail_blocks);
+
+  statfs.total = block_size * physical_blocks;
+  statfs.available = block_size * avail_blocks;
+
   return 0;
 }
 
 int ExtBlkDevVdo::collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm)
 {
-  ceph::ExtBlkDevState state;
-  int rc = get_state(state);
+  store_statfs_t statfs;
+  int rc = get_statfs(statfs);
   if(rc != 0){
     return rc;
   }
   (*pm)[prefix + "vdo"] = "true";
-  (*pm)[prefix + "vdo_physical_size"] = stringify(state.get_physical_total());
+  (*pm)[prefix + "vdo_physical_size"] = stringify(statfs.total);
   return 0;
 }

--- a/src/extblkdev/vdo/ExtBlkDevVdo.cc
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.cc
@@ -137,8 +137,8 @@ int ExtBlkDevVdo::get_statfs(store_statfs_t& statfs)
   int64_t avail_blocks =
     physical_blocks - overhead_blocks_used - data_blocks_used;
 
-  statfs.total = block_size * physical_blocks;
-  statfs.available = block_size * avail_blocks;
+  statfs.total_raw = block_size * physical_blocks;
+  statfs.avail_raw = block_size * avail_blocks;
 
   return 0;
 }

--- a/src/extblkdev/vdo/ExtBlkDevVdo.cc
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.cc
@@ -106,7 +106,8 @@ int64_t ExtBlkDevVdo::get_vdo_stat(const char *property)
 }
 
 
-int ExtBlkDevVdo::init(const std::string& alogdevname)
+int ExtBlkDevVdo::init(const std::string& alogdevname,
+                       const std::set<std::string>& /*devices*/)
 {
   logdevname = alogdevname;
   // get directory handle for VDO metadata

--- a/src/extblkdev/vdo/ExtBlkDevVdo.h
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.h
@@ -46,7 +46,7 @@ public:
   int64_t get_vdo_stat(const char *property);
   virtual int init(const std::string& logdevname);
   virtual const std::string& get_devname() const {return name;}
-  virtual int get_state(ceph::ExtBlkDevState& state);
+  virtual int get_statfs(store_statfs_t& statfs);
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm);
 };
 

--- a/src/extblkdev/vdo/ExtBlkDevVdo.h
+++ b/src/extblkdev/vdo/ExtBlkDevVdo.h
@@ -44,7 +44,7 @@ public:
   int _get_vdo_stats_handle(const std::string& devname);
   int get_vdo_stats_handle();
   int64_t get_vdo_stat(const char *property);
-  virtual int init(const std::string& logdevname);
+  virtual int init(const std::string& logdevname, const std::set<std::string>& devices);
   virtual const std::string& get_devname() const {return name;}
   virtual int get_statfs(store_statfs_t& statfs);
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm);

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -275,7 +275,7 @@ void MgrStatMonitor::update_logger()
 
   mon.cluster_logger->set(l_cluster_osd_bytes, digest.osd_sum.statfs.total);
   mon.cluster_logger->set(l_cluster_osd_bytes_used,
-                           digest.osd_sum.statfs.get_used_raw());
+                           digest.osd_sum.statfs.get_used());
   mon.cluster_logger->set(l_cluster_osd_bytes_avail,
                            digest.osd_sum.statfs.available);
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -379,6 +379,7 @@ void PGMapDigest::print_oneline_summary(ceph::Formatter *f, ostream *out) const
     f->dump_int("total_avail_bytes", osd_sum.statfs.available);
     f->dump_int("total_used_bytes", osd_sum.statfs.get_used());
     f->dump_int("total_used_raw_bytes", osd_sum.statfs.get_used_raw());
+    f->dump_int("total_avail_raw_bytes", osd_sum.statfs.get_avail_raw());
   }
 
   // make non-negative; we can get negative values if osds send
@@ -1935,6 +1936,7 @@ void PGMap::dump_osd_stats(ostream& ss) const
   tab.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("USED_RAW", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("AVAIL_RAW", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("HB_PEERS", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("PG_SUM", TextTable::LEFT, TextTable::RIGHT);
@@ -1947,6 +1949,7 @@ void PGMap::dump_osd_stats(ostream& ss) const
         << byte_u_t(p->second.statfs.get_used())
         << byte_u_t(p->second.statfs.available)
         << byte_u_t(p->second.statfs.get_used_raw())
+        << byte_u_t(p->second.statfs.get_avail_raw())
         << byte_u_t(p->second.statfs.total)
         << p->second.hb_peers
         << get_num_pg_by_osd(p->first)
@@ -1958,6 +1961,7 @@ void PGMap::dump_osd_stats(ostream& ss) const
       << byte_u_t(osd_sum.statfs.get_used())
       << byte_u_t(osd_sum.statfs.available)
       << byte_u_t(osd_sum.statfs.get_used_raw())
+      << byte_u_t(osd_sum.statfs.get_avail_raw())
       << byte_u_t(osd_sum.statfs.total)
       << TextTable::endrow;
 
@@ -1972,12 +1976,14 @@ void PGMap::dump_osd_sum_stats(ostream& ss) const
   tab.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("USED_RAW", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("AVAIL_RAW", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("TOTAL", TextTable::LEFT, TextTable::RIGHT);
 
   tab << "sum"
       << byte_u_t(osd_sum.statfs.get_used())
       << byte_u_t(osd_sum.statfs.available)
       << byte_u_t(osd_sum.statfs.get_used_raw())
+      << byte_u_t(osd_sum.statfs.get_avail_raw())
       << byte_u_t(osd_sum.statfs.total)
       << TextTable::endrow;
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -848,6 +848,8 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     f->dump_int("total_bytes", osd_sum.statfs.total);
     f->dump_int("total_avail_bytes", osd_sum.statfs.available);
     f->dump_int("total_used_bytes", osd_sum.statfs.get_used());
+    f->dump_int("total_raw_bytes", osd_sum.statfs.total_raw);
+    f->dump_int("total_avail_raw_bytes", osd_sum.statfs.get_avail_raw());
     f->dump_int("total_used_raw_bytes", osd_sum.statfs.get_used_raw());
     f->dump_float("total_used_raw_ratio", osd_sum.statfs.get_used_raw_ratio());
     f->dump_unsigned("num_osds", osd_sum.num_osds);
@@ -860,6 +862,8 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
       f->dump_int("total_bytes", i.second.statfs.total);
       f->dump_int("total_avail_bytes", i.second.statfs.available);
       f->dump_int("total_used_bytes", i.second.statfs.get_used());
+      f->dump_int("total_raw_bytes", i.second.statfs.total_raw);
+      f->dump_int("total_avail_raw_bytes", i.second.statfs.get_avail_raw());
       f->dump_int("total_used_raw_bytes", i.second.statfs.get_used_raw());
       f->dump_float("total_used_raw_ratio",
 		    i.second.statfs.get_used_raw_ratio());
@@ -873,6 +877,7 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     tbl.define_column("SIZE", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("AVAIL", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("USED", TextTable::RIGHT, TextTable::RIGHT);
+    tbl.define_column("RAW AVAIL", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("RAW USED", TextTable::RIGHT, TextTable::RIGHT);
     tbl.define_column("%RAW USED", TextTable::RIGHT, TextTable::RIGHT);
 
@@ -882,6 +887,7 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
       tbl << stringify(byte_u_t(i.second.statfs.total))
 	  << stringify(byte_u_t(i.second.statfs.available))
 	  << stringify(byte_u_t(i.second.statfs.get_used()))
+	  << stringify(byte_u_t(i.second.statfs.get_avail_raw()))
 	  << stringify(byte_u_t(i.second.statfs.get_used_raw()))
 	  << percentify(i.second.statfs.get_used_raw_ratio()*100.0)
 	  << TextTable::endrow;
@@ -890,11 +896,12 @@ void PGMapDigest::dump_cluster_stats(stringstream *ss,
     tbl << stringify(byte_u_t(osd_sum.statfs.total))
         << stringify(byte_u_t(osd_sum.statfs.available))
         << stringify(byte_u_t(osd_sum.statfs.get_used()))
+        << stringify(byte_u_t(osd_sum.statfs.get_avail_raw()))
         << stringify(byte_u_t(osd_sum.statfs.get_used_raw()))
 	<< percentify(osd_sum.statfs.get_used_raw_ratio()*100.0)
 	<< TextTable::endrow;
 
-    *ss << "--- RAW STORAGE ---\n";
+    *ss << "--- STORAGE ---\n";
     *ss << tbl;
   }
 }

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -4050,9 +4050,9 @@ int reweight::by_utilization(
   } else {
     // by osd utilization
     int num_osd = std::max<size_t>(1, pgm.osd_stat.size());
-    if ((uint64_t)pgm.osd_sum.statfs.total / num_osd
+    if ((uint64_t)pgm.osd_sum.statfs.total_raw / num_osd
 	< g_conf()->mon_reweight_min_bytes_per_osd) {
-      *ss << "Refusing to reweight: we only have " << pgm.osd_sum.statfs.kb()
+      *ss << "Refusing to reweight: we only have " << pgm.osd_sum.statfs.kb_total_raw()
 	  << " kb across all osds!\n";
       return -EDOM;
     }
@@ -4065,7 +4065,7 @@ int reweight::by_utilization(
     }
 
     average_util = (double)pgm.osd_sum.statfs.get_used_raw() /
-      (double)pgm.osd_sum.statfs.total;
+      (double)pgm.osd_sum.statfs.total_raw;
   }
 
   // adjust down only if we are above the threshold
@@ -4116,7 +4116,7 @@ int reweight::by_utilization(
 	pgs_by_osd[p.first] / osdmap.crush->get_item_weightf(p.first);
     } else {
       osd_util.second =
-	(double)p.second.statfs.get_used_raw() / (double)p.second.statfs.total;
+	(double)p.second.statfs.get_used_raw() / (double)p.second.statfs.total_raw;
     }
     util_by_osd.push_back(osd_util);
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12196,6 +12196,17 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
 {
   buf->reset();
 
+  uint64_t bfree = alloc->get_free();
+
+  int rc = bdev->get_ebd_statfs(*buf);
+  if (rc == 0) {
+    // we are limited by both the size of the virtual device and the
+    // underlying physical device.
+    buf->available = std::min(bfree, buf->available);
+  } else {
+    buf->total = bdev->get_size();
+    buf->available = bfree;
+  }
   auto prefix = per_pool_omap == OMAP_BULK ?
     PREFIX_OMAP :
     per_pool_omap == OMAP_PER_POOL ?
@@ -12203,9 +12214,6 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
       PREFIX_PERPG_OMAP;
   buf->omap_allocated =
     db->estimate_prefix_size(prefix, string());
-
-  uint64_t bfree = alloc->get_free();
-
   if (bluefs) {
     buf->internally_reserved = 0;
     // include dedicated db, too, if that isn't the shared device.
@@ -12217,21 +12225,6 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
       bluefs->get_used()
       - buf->omap_allocated;
   }
-
-  ExtBlkDevState ebd_state;
-  int rc = bdev->get_ebd_state(ebd_state);
-  if (rc == 0) {
-    buf->total += ebd_state.get_physical_total();
-
-    // we are limited by both the size of the virtual device and the
-    // underlying physical device.
-    bfree = std::min(bfree, ebd_state.get_physical_avail());
-
-    buf->allocated = ebd_state.get_physical_total() - ebd_state.get_physical_avail();;
-  } else {
-    buf->total += bdev->get_size();
-  }
-  buf->available = bfree;
 
   logger->set(l_bluestore_omap, buf->omap_allocated);
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12197,15 +12197,13 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
   buf->reset();
 
   uint64_t bfree = alloc->get_free();
+  buf->total = bdev->get_size();
+  buf->available = bfree;
 
   int rc = bdev->get_ebd_statfs(*buf);
-  if (rc == 0) {
-    // we are limited by both the size of the virtual device and the
-    // underlying physical device.
-    buf->available = std::min(bfree, buf->available);
-  } else {
-    buf->total = bdev->get_size();
-    buf->available = bfree;
+  if (rc != 0) {
+    buf->total_raw = buf->total;
+    buf->avail_raw = buf->available;
   }
   auto prefix = per_pool_omap == OMAP_BULK ?
     PREFIX_OMAP :

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1108,7 +1108,9 @@ float OSDService::compute_adjusted_ratio(osd_stat_t new_stat, float *pratio,
   if (backfill_adjusted) {
     dout(20) << __func__ << " backfill adjusted " << new_stat << dendl;
   }
-  return ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
+  float ratio = ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
+  dout(5) << __func__ << " ratio:" << ratio << " pratio: " << *pratio << dendl;
+  return ratio;
 }
 
 void OSDService::send_message_osd_cluster(int peer, Message *m, epoch_t from_epoch)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1009,7 +1009,7 @@ void OSDService::set_statfs(const struct store_statfs_t &stbuf,
 {
   uint64_t bytes = stbuf.total;
   uint64_t avail = stbuf.available;
-  uint64_t used = stbuf.get_used_raw();
+  uint64_t used = stbuf.get_used();
 
   // For testing fake statfs values so it doesn't matter if all
   // OSDs are using the same partition.

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1099,14 +1099,19 @@ float OSDService::compute_adjusted_ratio(osd_stat_t new_stat, float *pratio,
   }
 
   // Check all pgs and adjust kb_used to include all pending backfill data
-  int backfill_adjusted = 0;
+  int64_t backfill_adjusted = 0;
   vector<PGRef> pgs;
   osd->_get_pgs(&pgs);
   for (auto p : pgs) {
-    backfill_adjusted += p->pg_stat_adjust(&new_stat);
+    backfill_adjusted += p->get_pg_stat_adjustment();
   }
   if (backfill_adjusted) {
-    dout(20) << __func__ << " backfill adjusted " << new_stat << dendl;
+    dout(20) << __func__ << " before backfill adjusted " << new_stat << dendl;
+    if (new_stat.statfs.available > backfill_adjusted)
+      new_stat.statfs.available -= backfill_adjusted;
+    else
+      new_stat.statfs.available = 0;
+    dout(20) << __func__ << " after backfill adjusted " << new_stat << dendl;
   }
   float ratio = ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
   dout(5) << __func__ << " ratio:" << ratio << " pratio: " << *pratio << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1086,17 +1086,9 @@ void OSDService::set_osd_stat_repaired(int64_t count)
 float OSDService::compute_adjusted_ratio(osd_stat_t new_stat, float *pratio,
 				         uint64_t adjust_used)
 {
-  *pratio =
-   ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
-
-  if (adjust_used) {
-    dout(20) << __func__ << " Before kb_used() " << new_stat.statfs.kb_used()  << dendl;
-    if (new_stat.statfs.available > adjust_used)
-      new_stat.statfs.available -= adjust_used;
-    else
-      new_stat.statfs.available = 0;
-    dout(20) << __func__ << " After kb_used() " << new_stat.statfs.kb_used() << dendl;
-  }
+  uint64_t used = new_stat.statfs.get_used_raw();
+  uint64_t total = new_stat.statfs.total_raw;
+  *pratio = ((float)used) / ((float)total);
 
   // Check all pgs and adjust kb_used to include all pending backfill data
   int64_t backfill_adjusted = 0;
@@ -1105,15 +1097,16 @@ float OSDService::compute_adjusted_ratio(osd_stat_t new_stat, float *pratio,
   for (auto p : pgs) {
     backfill_adjusted += p->get_pg_stat_adjustment();
   }
-  if (backfill_adjusted) {
-    dout(20) << __func__ << " before backfill adjusted " << new_stat << dendl;
-    if (new_stat.statfs.available > backfill_adjusted)
-      new_stat.statfs.available -= backfill_adjusted;
-    else
-      new_stat.statfs.available = 0;
-    dout(20) << __func__ << " after backfill adjusted " << new_stat << dendl;
-  }
-  float ratio = ((float)new_stat.statfs.get_used_raw()) / ((float)new_stat.statfs.total);
+  uint64_t avail = (float)new_stat.statfs.get_avail_raw();
+  uint64_t adjustment = adjust_used + backfill_adjusted;;
+  adjustment = avail < adjustment ? avail : adjustment;
+
+  dout(20) << __func__ << " adjust used:" << adjust_used
+                       << " backfill adjusted:" << backfill_adjusted
+                       << " avail raw:" << avail
+                       << " target adjustment: " << adjustment
+                       << dendl;
+  float ratio = ((float)(used + adjustment) / ((float)total));
   dout(5) << __func__ << " ratio:" << ratio << " pratio: " << *pratio << dendl;
   return ratio;
 }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -7069,12 +7069,15 @@ protected:
       dumped_osds.insert(qi.id);
     float reweight = qi.is_bucket() ? -1 : osdmap->get_weightf(qi.id);
     int64_t kb = 0, kb_used = 0, kb_used_data = 0, kb_used_omap = 0,
-      kb_used_meta = 0, kb_avail = 0;
+      kb_used_meta = 0, kb_avail = 0, kb_used_raw = 0, kb_avail_raw = 0;
     double util = 0;
     if (get_bucket_utilization(qi.id, &kb, &kb_used, &kb_used_data,
-			       &kb_used_omap, &kb_used_meta, &kb_avail))
-      if (kb_used && kb)
-        util = 100.0 * (double)kb_used / (double)kb;
+			       &kb_used_omap, &kb_used_meta, &kb_avail,
+			       &kb_used_raw, &kb_avail_raw)) {
+      auto kb_raw = kb_used_raw + kb_avail_raw;
+      if (kb_raw)
+        util = 100.0 * (double)kb_used_raw / (double)kb_raw;
+    }
 
     double var = 1.0;
     if (average_util)
@@ -7084,7 +7087,8 @@ protected:
 
     dump_item(qi, reweight, kb, kb_used,
 	      kb_used_data, kb_used_omap, kb_used_meta,
-	      kb_avail, util, var, num_pgs, f);
+	      kb_avail, util, kb_used_raw, kb_avail_raw,
+	      var, num_pgs, f);
 
     if (!qi.is_bucket() && reweight > 0) {
       if (min_var < 0 || var < min_var)
@@ -7108,6 +7112,8 @@ protected:
 			 int64_t kb_used_meta,
 			 int64_t kb_avail,
 			 double& util,
+			 int64_t kb_used_raw,
+			 int64_t kb_avail_raw,
 			 double& var,
 			 const size_t num_pgs,
 			 F *f) = 0;
@@ -7124,9 +7130,10 @@ protected:
           !should_dump(i))
 	continue;
       int64_t kb_i, kb_used_i, kb_used_data_i, kb_used_omap_i, kb_used_meta_i,
-	kb_avail_i;
+	kb_avail_i, kb_used_raw_i, kb_avail_raw_i;
       if (get_osd_utilization(i, &kb_i, &kb_used_i, &kb_used_data_i,
-			      &kb_used_omap_i, &kb_used_meta_i, &kb_avail_i)) {
+			      &kb_used_omap_i, &kb_used_meta_i, &kb_avail_i,
+			      &kb_used_raw_i, &kb_avail_raw_i)) {
 	kb += kb_i;
 	kb_used += kb_used_i;
       }
@@ -7138,15 +7145,19 @@ protected:
 			   int64_t* kb_used_data,
 			   int64_t* kb_used_omap,
 			   int64_t* kb_used_meta,
-			   int64_t* kb_avail) const {
+			   int64_t* kb_avail,
+			   int64_t* kb_used_raw,
+			   int64_t* kb_avail_raw) const {
     const osd_stat_t *p = pgmap.get_osd_stat(id);
     if (!p) return false;
     *kb = p->statfs.kb();
-    *kb_used = p->statfs.kb_used_raw();
+    *kb_used = p->statfs.kb_used();
     *kb_used_data = p->statfs.kb_used_data();
     *kb_used_omap = p->statfs.kb_used_omap();
     *kb_used_meta = p->statfs.kb_used_internal_metadata();
     *kb_avail = p->statfs.kb_avail();
+    *kb_used_raw = p->statfs.kb_used_raw();
+    *kb_avail_raw = p->statfs.kb_avail_raw();
     
     return true;
   }
@@ -7155,7 +7166,10 @@ protected:
 			      int64_t* kb_used_data,
 			      int64_t* kb_used_omap,
 			      int64_t* kb_used_meta,
-			      int64_t* kb_avail) const {
+			      int64_t* kb_avail,
+			      int64_t* kb_used_raw,
+			      int64_t* kb_avail_raw
+			      ) const {
     if (id >= 0) {
       if (osdmap->is_out(id) || !should_dump(id)) {
         *kb = 0;
@@ -7164,10 +7178,13 @@ protected:
 	*kb_used_omap = 0;
 	*kb_used_meta = 0;
         *kb_avail = 0;
+        *kb_used_raw = 0;
+        *kb_avail_raw = 0;
         return true;
       }
       return get_osd_utilization(id, kb, kb_used, kb_used_data,
-				 kb_used_omap, kb_used_meta, kb_avail);
+				 kb_used_omap, kb_used_meta, kb_avail,
+				 kb_used_raw, kb_avail_raw);
     }
 
     *kb = 0;
@@ -7176,14 +7193,18 @@ protected:
     *kb_used_omap = 0;
     *kb_used_meta = 0;
     *kb_avail = 0;
+    *kb_used_raw = 0;
+    *kb_avail_raw = 0;
 
     for (int k = osdmap->crush->get_bucket_size(id) - 1; k >= 0; k--) {
       int item = osdmap->crush->get_bucket_item(id, k);
       int64_t kb_i = 0, kb_used_i = 0, kb_used_data_i = 0,
-	kb_used_omap_i = 0, kb_used_meta_i = 0, kb_avail_i = 0;
+	kb_used_omap_i = 0, kb_used_meta_i = 0, kb_avail_i = 0,
+	kb_used_raw_i = 0, kb_avail_raw_i = 0;
       if (!get_bucket_utilization(item, &kb_i, &kb_used_i,
 				  &kb_used_data_i, &kb_used_omap_i,
-				  &kb_used_meta_i, &kb_avail_i))
+				  &kb_used_meta_i, &kb_avail_i,
+				  &kb_used_raw_i, &kb_avail_raw_i))
 	return false;
       *kb += kb_i;
       *kb_used += kb_used_i;
@@ -7191,6 +7212,8 @@ protected:
       *kb_used_omap += kb_used_omap_i;
       *kb_used_meta += kb_used_meta_i;
       *kb_avail += kb_avail_i;
+      *kb_used_raw += kb_used_raw_i;
+      *kb_avail_raw += kb_avail_raw_i;
     }
     return true;
   }
@@ -7225,12 +7248,14 @@ public:
     tbl->define_column("WEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("REWEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("SIZE", TextTable::LEFT, TextTable::RIGHT);
-    tbl->define_column("RAW USE", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("USE", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("DATA", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("OMAP", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("META", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("AVAIL", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("%USE", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("RAW USE", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("RAW AVAIL", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("VAR", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("PGS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("STATUS", TextTable::LEFT, TextTable::RIGHT);
@@ -7246,12 +7271,14 @@ public:
 	 << ""
 	 << "" << "TOTAL"
 	 << byte_u_t(sum.statfs.total)
-	 << byte_u_t(sum.statfs.get_used_raw())
+	 << byte_u_t(sum.statfs.get_used())
 	 << byte_u_t(sum.statfs.allocated)
 	 << byte_u_t(sum.statfs.omap_allocated)
 	 << byte_u_t(sum.statfs.internal_metadata)
 	 << byte_u_t(sum.statfs.available)
 	 << lowprecision_t(average_util)
+	 << byte_u_t(sum.statfs.get_used_raw())
+	 << byte_u_t(sum.statfs.get_avail_raw())
 	 << ""
 	 << TextTable::endrow;
   }
@@ -7273,6 +7300,8 @@ protected:
 			 int64_t kb_used_meta,
 			 int64_t kb_avail,
 			 double& util,
+			 int64_t kb_used_raw,
+			 int64_t kb_avail_raw,
 			 double& var,
 			 const size_t num_pgs,
 			 TextTable *tbl) override {
@@ -7290,6 +7319,8 @@ protected:
 	 << byte_u_t(kb_used_meta << 10)
 	 << byte_u_t(kb_avail << 10)
 	 << lowprecision_t(util)
+	 << byte_u_t(kb_used_raw << 10)
+	 << byte_u_t(kb_avail_raw << 10)
 	 << lowprecision_t(var);
 
     if (qi.is_bucket()) {
@@ -7376,6 +7407,8 @@ protected:
 		 int64_t kb_used_meta,
 		 int64_t kb_avail,
 		 double& util,
+		 int64_t kb_used_raw, //FIXME
+		 int64_t kb_avail_raw,
 		 double& var,
 		 const size_t num_pgs,
 		 Formatter *f) override {
@@ -7389,6 +7422,8 @@ protected:
     f->dump_int("kb_used_meta", kb_used_meta);
     f->dump_int("kb_avail", kb_avail);
     f->dump_float("utilization", util);
+    f->dump_int("kb_used_raw", kb_used_raw);
+    f->dump_int("kb_avail_raw", kb_avail_raw);
     f->dump_float("var", var);
     f->dump_unsigned("pgs", num_pgs);
     if (!qi.is_bucket()) {
@@ -7411,12 +7446,14 @@ public:
     auto& s = sum.statfs;
 
     f->dump_int("total_kb", s.kb());
-    f->dump_int("total_kb_used", s.kb_used_raw());
+    f->dump_int("total_kb_used", s.kb_used());
     f->dump_int("total_kb_used_data", s.kb_used_data());
     f->dump_int("total_kb_used_omap", s.kb_used_omap());
     f->dump_int("total_kb_used_meta", s.kb_used_internal_metadata());
     f->dump_int("total_kb_avail", s.kb_avail());
     f->dump_float("average_utilization", average_util);
+    f->dump_int("total_kb_used_raw", s.kb_used_raw());
+    f->dump_int("total_kb_avail_raw", s.kb_avail_raw());
     f->dump_float("min_var", min_var);
     f->dump_float("max_var", max_var);
     f->dump_float("dev", dev());

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2377,32 +2377,14 @@ std::pair<ghobject_t, bool> PG::do_delete_work(
   return {next, running};
 }
 
-int PG::pg_stat_adjust(osd_stat_t *ns)
+int64_t PG::get_pg_stat_adjustment()
 {
-  osd_stat_t &new_stat = *ns;
   if (is_primary()) {
     return 0;
   }
   // Adjust the kb_used by adding pending backfill data
-  uint64_t reserved_num_bytes = get_reserved_num_bytes();
-
-  // For now we don't consider projected space gains here
-  // I suggest we have an optional 2 pass backfill that frees up
-  // space in a first pass.  This could be triggered when at nearfull
-  // or near to backfillfull.
-  if (reserved_num_bytes > 0) {
-    // TODO: Handle compression by adjusting by the PGs average
-    // compression precentage.
-    dout(20) << __func__ << " reserved_num_bytes " << (reserved_num_bytes >> 10) << "KiB"
-             << " Before kb_used " << new_stat.statfs.kb_used() << "KiB" << dendl;
-    if (new_stat.statfs.available > reserved_num_bytes)
-      new_stat.statfs.available -= reserved_num_bytes;
-    else
-      new_stat.statfs.available = 0;
-    dout(20) << __func__ << " After kb_used " << new_stat.statfs.kb_used() << "KiB" << dendl;
-    return 1;
-  }
-  return 0;
+  int64_t reserved_num_bytes = is_primary() ? 0 : (int64_t)get_reserved_num_bytes();
+  return reserved_num_bytes;
 }
 
 void PG::dump_pgstate_history(Formatter *f)

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1270,7 +1270,7 @@ protected:
 
 
 public:
-  int pg_stat_adjust(osd_stat_t *new_stat);
+  int64_t get_pg_stat_adjustment();
   bool is_degraded() const { return recovery_state.is_degraded(); }
 protected:
   bool delete_needs_sleep = false;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -633,6 +633,8 @@ void osd_stat_t::decode(ceph::buffer::list::const_iterator &bl)
     } else {
       statfs.internally_reserved = 0;
     }
+    statfs.total_raw = kb << 10;
+    statfs.avail_raw = kb_avail << 10;
     statfs.allocated = kb_used_data << 10;
     statfs.omap_allocated = kb_used_omap << 10;
     statfs.internal_metadata = kb_used_meta << 10;
@@ -3373,8 +3375,10 @@ bool store_statfs_t::operator==(const store_statfs_t& other) const
 {
   return total == other.total
     && available == other.available
-    && allocated == other.allocated
     && internally_reserved == other.internally_reserved
+    && total_raw == other.total_raw
+    && avail_raw == other.avail_raw
+    && allocated == other.allocated
     && data_stored == other.data_stored
     && data_compressed == other.data_compressed
     && data_compressed_allocated == other.data_compressed_allocated
@@ -3388,6 +3392,8 @@ void store_statfs_t::dump(Formatter *f) const
   f->dump_int("total", total);
   f->dump_int("available", available);
   f->dump_int("internally_reserved", internally_reserved);
+  f->dump_int("total_raw", total_raw);
+  f->dump_int("avail_raw", avail_raw);
   f->dump_int("allocated", allocated);
   f->dump_int("data_stored", data_stored);
   f->dump_int("data_compressed", data_compressed);
@@ -3397,12 +3403,59 @@ void store_statfs_t::dump(Formatter *f) const
   f->dump_int("internal_metadata", internal_metadata);
 }
 
+void store_statfs_t::encode(ceph::buffer::list &bl) const
+{
+  ENCODE_START(2, 1, bl);
+  encode(total, bl);
+  encode(available, bl);
+  encode(internally_reserved, bl);
+
+  encode(allocated, bl);
+  encode(data_stored, bl);
+  encode(data_compressed, bl);
+  encode(data_compressed_allocated, bl);
+  encode(data_compressed_original, bl);
+  encode(omap_allocated, bl);
+  encode(internal_metadata, bl);
+
+  // since struct_v == 2
+  encode(total_raw, bl);
+  encode(avail_raw, bl);
+  ENCODE_FINISH(bl);
+}
+void store_statfs_t::decode(ceph::buffer::list::const_iterator &bl)
+{
+  DECODE_START(2, bl);
+  decode(total, bl);
+  decode(available, bl);
+  decode(internally_reserved, bl);
+
+  decode(allocated, bl);
+  decode(data_stored, bl);
+  decode(data_compressed, bl);
+  decode(data_compressed_allocated, bl);
+  decode(data_compressed_original, bl);
+  decode(omap_allocated, bl);
+  decode(internal_metadata, bl);
+
+  if (struct_v >= 2) {
+    decode(total_raw, bl);
+    decode(avail_raw, bl);
+  } else {
+    total_raw = total;
+    avail_raw = available;
+  }
+  DECODE_FINISH(bl);
+}
+
 ostream& operator<<(ostream& out, const store_statfs_t &s)
 {
   out << std::hex
       << "store_statfs(0x" << s.available
       << "/0x"  << s.internally_reserved
       << "/0x"  << s.total
+      << ", raw 0x" << s.avail_raw
+      << "/0x"  << s.total_raw
       << ", data 0x" << s.data_stored
       << "/0x"  << s.allocated
       << ", compress 0x" << s.data_compressed
@@ -3423,6 +3476,8 @@ list<store_statfs_t> store_statfs_t::generate_test_instances()
   a.total = 234;
   a.available = 123;
   a.internally_reserved = 33;
+  a.total_raw = 234;
+  a.avail_raw = 123;
   a.allocated = 32;
   a.data_stored = 44;
   a.data_compressed = 21;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2464,12 +2464,15 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r);
  */
 struct store_statfs_t
 {
-  uint64_t total = 0;                  ///< Total bytes
+  uint64_t total = 0;                  ///< Total logical bytes
   uint64_t available = 0;              ///< Free bytes available
   uint64_t internally_reserved = 0;    ///< Bytes reserved for internal purposes
 
-  int64_t allocated = 0;               ///< Bytes allocated by the store
+  // physical bytes
+  uint64_t total_raw = 0;              ///< Total physical bytes
+  uint64_t avail_raw = 0;              ///< Physically used bytes
 
+  int64_t allocated = 0;             ///< Bytes allocated for user data
   int64_t data_stored = 0;                ///< Bytes actually stored by the user
   int64_t data_compressed = 0;            ///< Bytes stored after compression
   int64_t data_compressed_allocated = 0;  ///< Bytes allocated for compressed data
@@ -2486,6 +2489,10 @@ struct store_statfs_t
     FLOOR(total);
     FLOOR(available);
     FLOOR(internally_reserved);
+
+    FLOOR(total_raw);
+    FLOOR(avail_raw);
+
     FLOOR(allocated);
     FLOOR(data_stored);
     FLOOR(data_compressed);
@@ -2506,14 +2513,18 @@ struct store_statfs_t
     return total - available - internally_reserved;
   }
 
-  // this accumulates both actually used and statfs's internally_reserved
+  // bytes physically used
   uint64_t get_used_raw() const {
-    return total - available;
+    return total_raw - avail_raw;
+  }
+  // bytes physically available
+  uint64_t get_avail_raw() const {
+    return avail_raw;
   }
 
   float get_used_raw_ratio() const {
-    if (total) {
-      return (float)get_used_raw() / (float)total;
+    if (total_raw) {
+      return (float)get_used_raw() / (float)total_raw;
     } else {
       return 0.0;
     }
@@ -2527,7 +2538,14 @@ struct store_statfs_t
     return total >> 10;
   }
   uint64_t kb_used() const {
-    return (total - available - internally_reserved) >> 10;
+    return get_used() >> 10;
+  }
+
+  uint64_t kb_avail_raw() const {
+    return avail_raw >> 10;
+  }
+  uint64_t kb_total_raw() const {
+    return total_raw >> 10;
   }
   uint64_t kb_used_raw() const {
     return get_used_raw() >> 10;
@@ -2548,6 +2566,10 @@ struct store_statfs_t
     total += o.total;
     available += o.available;
     internally_reserved += o.internally_reserved;
+
+    total_raw += o.total_raw;
+    avail_raw += o.avail_raw;
+
     allocated += o.allocated;
     data_stored += o.data_stored;
     data_compressed += o.data_compressed;
@@ -2560,6 +2582,10 @@ struct store_statfs_t
     total -= o.total;
     available -= o.available;
     internally_reserved -= o.internally_reserved;
+
+    total_raw -= o.total_raw;
+    avail_raw -= o.avail_raw;
+
     allocated -= o.allocated;
     data_stored -= o.data_stored;
     data_compressed -= o.data_compressed;
@@ -2569,23 +2595,12 @@ struct store_statfs_t
     internal_metadata -= o.internal_metadata;
   }
   void dump(ceph::Formatter *f) const;
-  DENC(store_statfs_t, v, p) {
-    DENC_START(1, 1, p);
-    denc(v.total, p);
-    denc(v.available, p);
-    denc(v.internally_reserved, p);
-    denc(v.allocated, p);
-    denc(v.data_stored, p);
-    denc(v.data_compressed, p);
-    denc(v.data_compressed_allocated, p);
-    denc(v.data_compressed_original, p);
-    denc(v.omap_allocated, p);
-    denc(v.internal_metadata, p);
-    DENC_FINISH(p);
-  }
   static std::list<store_statfs_t> generate_test_instances();
+  void encode(ceph::buffer::list &bl) const;
+  void decode(ceph::buffer::list::const_iterator &bl);
+  static void generate_test_instances(std::list<store_statfs_t*>& o);
 };
-WRITE_CLASS_DENC(store_statfs_t)
+WRITE_CLASS_ENCODER(store_statfs_t)
 
 std::ostream &operator<<(std::ostream &lhs, const store_statfs_t &rhs);
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2464,22 +2464,28 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r);
  */
 struct store_statfs_t
 {
-  uint64_t total = 0;                  ///< Total logical bytes
-  uint64_t available = 0;              ///< Free bytes available
-  uint64_t internally_reserved = 0;    ///< Bytes reserved for internal purposes
+  // Primary logical stats
+  uint64_t total = 0;                  ///< Total logical bytes, aka store's capacity.
+  uint64_t available = 0;              ///< Remaining logical bytes available, i.e. how much additional data the store can fit.
 
-  // physical bytes
-  uint64_t total_raw = 0;              ///< Total physical bytes
-  uint64_t avail_raw = 0;              ///< Physically used bytes
+  // Physical device stats, can differ from logical ones
+  // when e.g. thin provisioning is in place.
+  uint64_t total_raw = 0;              ///< Total physical bytes, i.e. underlying disk capacity.
+  uint64_t avail_raw = 0;              ///< Remaining physical bytes available.
 
-  int64_t allocated = 0;             ///< Bytes allocated for user data
-  int64_t data_stored = 0;                ///< Bytes actually stored by the user
-  int64_t data_compressed = 0;            ///< Bytes stored after compression
-  int64_t data_compressed_allocated = 0;  ///< Bytes allocated for compressed data
-  int64_t data_compressed_original = 0;   ///< Bytes that were compressed
+  // Additional user-specific ObjectStore stats
+  int64_t allocated = 0;                  ///< Bytes allocated - how much of logical capacity is occupied by user data
+  int64_t data_stored = 0;                ///< Bytes stored by user - how much data is kept in the store from user's perspective.
+  int64_t data_compressed = 0;            ///< Bytes compressed - how much data is persisted in compressed form.
+  int64_t data_compressed_allocated = 0;  ///< Bytes allocated after compression - how much space occupied for compressed user data.
+  int64_t data_compressed_original = 0;   ///< Bytes passed compression - how much user data has undergone compression.
 
-  int64_t omap_allocated = 0;         ///< approx usage of omap data
-  int64_t internal_metadata = 0;      ///< approx usage of internal metadata
+  // Additional internal ObjectStore stats
+  int64_t omap_allocated = 0;         ///< Bytes for OMAP - how much space used to keep OMAPs (estimation)
+  int64_t internal_metadata = 0;      ///< Bytes for internal metadata - how much space used for internal metadata
+
+  // Obsolete
+  uint64_t internally_reserved = 0;    ///< Bytes reserved for internal purposes, apparently NOT USED anymore.
 
   void reset() {
     *this = store_statfs_t();
@@ -2488,7 +2494,6 @@ struct store_statfs_t
 #define FLOOR(x) if (int64_t(x) < f) x = f
     FLOOR(total);
     FLOOR(available);
-    FLOOR(internally_reserved);
 
     FLOOR(total_raw);
     FLOOR(avail_raw);
@@ -2501,6 +2506,8 @@ struct store_statfs_t
 
     FLOOR(omap_allocated);
     FLOOR(internal_metadata);
+
+    FLOOR(internally_reserved);
 #undef FLOOR
   }
 
@@ -2565,7 +2572,6 @@ struct store_statfs_t
   void add(const store_statfs_t& o) {
     total += o.total;
     available += o.available;
-    internally_reserved += o.internally_reserved;
 
     total_raw += o.total_raw;
     avail_raw += o.avail_raw;
@@ -2575,13 +2581,15 @@ struct store_statfs_t
     data_compressed += o.data_compressed;
     data_compressed_allocated += o.data_compressed_allocated;
     data_compressed_original += o.data_compressed_original;
+
     omap_allocated += o.omap_allocated;
     internal_metadata += o.internal_metadata;
+
+    internally_reserved += o.internally_reserved;
   }
   void sub(const store_statfs_t& o) {
     total -= o.total;
     available -= o.available;
-    internally_reserved -= o.internally_reserved;
 
     total_raw -= o.total_raw;
     avail_raw -= o.avail_raw;
@@ -2593,6 +2601,8 @@ struct store_statfs_t
     data_compressed_original -= o.data_compressed_original;
     omap_allocated -= o.omap_allocated;
     internal_metadata -= o.internal_metadata;
+
+    internally_reserved -= o.internally_reserved;
   }
   void dump(ceph::Formatter *f) const;
   static std::list<store_statfs_t> generate_test_instances();


### PR DESCRIPTION
This allows to use NVMe devices with compression on-board in Ceph and see the utilization stats properly via Ceph means

Apart from high level changes in monitor/osd code this patch relies on EBD plugin infra which was introduced for thin-provisioning devices. New plugin 'thin_nvme' has been introduced.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
