### PR TITLE
blk/spdk/NVMEDevice.cc: apply pci_whitelist only for PCIe transports

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -410,7 +410,7 @@ the following command::
 You may also specify a remote NVMeoF target over the TCP transport, as in the
 following example::
 
-  bluestore_block_path = "spdk:trtype:TCP traddr:10.67.110.197 trsvcid:4420 subnqn:nqn.2019-02.io.spdk:cnode1"
+  bluestore_block_path = "spdk:trtype:TCP adrfam:IPv4 traddr:10.67.110.197 trsvcid:4420 subnqn:nqn.2019-02.io.spdk:cnode1"
 
 To run multiple SPDK instances per node, you must make sure each instance uses
 its own DPDK memory by specifying for each instance the amount of DPDK memory

--- a/src/blk/spdk/NVMEDevice.cc
+++ b/src/blk/spdk/NVMEDevice.cc
@@ -593,13 +593,15 @@ int NVMEManager::try_get(const spdk_nvme_transport_id& trid, SharedDriverData **
         int r;
 
         bool local_pci_device = false;
-        int rc = spdk_pci_addr_parse(&addr, trid.traddr);
-        if (!rc) {
-          local_pci_device = true;
-          opts.pci_whitelist = &addr;
-          opts.num_pci_addr = 1;
+        if (trid.trtype == SPDK_NVME_TRANSPORT_PCIE){
+          int rc = spdk_pci_addr_parse(&addr, trid.traddr);
+          if (!rc) {
+            local_pci_device = true;
+            opts.pci_whitelist = &addr;
+            opts.num_pci_addr = 1;
+          }
         }
-
+        
 	spdk_env_opts_init(&opts);
         opts.name = "nvme-device-manager";
         opts.core_mask = coremask_arg.c_str();


### PR DESCRIPTION
## Fix SPDK NVMe Probe Misclassification for TCP Transport in Ceph OSD Startup

When running Ceph OSD with SPDK NVMe-oF over TCP using the following `vstart.sh` configuration:

```
../src/vstart.sh --debug --new -x --localhost --bluestore \
--bluestore-spdk "trtype:tcp adrfam:IPv4 traddr:127.0.0.1 trsvcid:4420 subnqn:nqn.2019-02.io.spdk:cnode0,\
trtype:tcp adrfam:IPv4 traddr:127.0.0.1 trsvcid:4420 subnqn:nqn.2019-02.io.spdk:cnode1,\
trtype:tcp adrfam:IPv4 traddr:127.0.0.1 trsvcid:4420 subnqn:nqn.2019-02.io.spdk:cnode2"
```

i got error from osds :

```
2025-05-25T06:10:07.459+0000 7f552e7fdf40 -1 bdev() open failed to get nvme device with transport address 127.0.0.1 type 3
2025-05-25T06:10:07.459+0000 7f552e7fdf40 -1 bluestore(/app/build/dev/osd0) mkfs failed, (1) Operation not permitted
2025-05-25T06:10:07.459+0000 7f552e7fdf40 -1 OSD::mkfs: ObjectStore::mkfs failed with error (1) Operation not permitted
2025-05-25T06:10:07.459+0000 7f552e7fdf40 -1 ERROR: error creating empty object store in /app/build/dev/osd0: (1) Operation not permitted
```

The code incorrectly sets local_pci_device = true for a TCP transport address (127.0.0.1) due to this logic:

```
bool local_pci_device = false;
int rc = spdk_pci_addr_parse(&addr, trid.traddr);
if (!rc) {
  local_pci_device = true;
  opts.pci_whitelist = &addr;
  opts.num_pci_addr = 1;
}

```
spdk_pci_addr_parse() does not validate whether the transport is actually PCIe or not. This causes spdk_nvme_probe() to be called with NULL for the first argument even in TCP mode:

`r = spdk_nvme_probe(local_pci_device ? NULL : &trid, ctxt, probe_cb, attach_cb, NULL);`

To ensure correct behavior, the following change was introduced:

```
if (trid.trtype == SPDK_NVME_TRANSPORT_PCIE) {
  // Only classify as local PCIe device if the transport is actually PCIe
  int rc = spdk_pci_addr_parse(&addr, trid.traddr);
  if (!rc) {
    local_pci_device = true;
    opts.pci_whitelist = &addr;
    opts.num_pci_addr = 1;
  }
}

```
This guards against misclassifying TCP transports as local PCIe devices, and ensures that spdk_nvme_probe() is invoked correctly for TCP configurations.

With this fix, the Ceph OSDs bring up successfully as expected.

```
$ ./bin/ceph -s
cluster:
  id: 56e8c6d7-c426-487e-9a09-101ac4c09ab7
  health: HEALTH_OK

services:
  mon: 3 daemons, quorum a,b,c
  mgr: x(active)
  mds: 1/1 daemons up, 2 standby
  osd: 3 osds: 3 up, 3 in

data:
  volumes: 1/1 healthy
  pools: 3 pools, 145 pgs
  objects: 24 objects, 451 KiB
  usage: 82 MiB used, 2.9 GiB / 3 GiB avail
  pgs: 145 active+clean
```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
