### PR TITLE
reef: doc/dev/cephfs-mirroring: edit file 3 of x

### DIFF
--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -237,43 +237,65 @@ distribution are detailed in the `Mirror Daemon Status` section.
 Bootstrap Peers
 ---------------
 
-Adding a peer (via `peer_add`) requires the peer cluster configuration and user keyring
-to be available in the primary cluster (manager host and hosts running the mirror daemon).
-This can be avoided by bootstrapping and importing a peer token. Peer bootstrap involves
-creating a bootstrap token on the peer cluster via::
+Adding a peer (via ``peer_add``) requires that the peer cluster configuration
+and the user keyring be available in the primary cluster (Manager host and
+hosts running the mirror daemon). This requirement can be avoided by
+bootstrapping and importing a peer token. Peer bootstraping involves creating a
+bootstrap token on the peer cluster by running a command of the following form:
 
-  $ ceph fs snapshot mirror peer_bootstrap create <fs_name> <client_entity> <site-name>
+.. prompt:: bash $
 
-e.g.::
+   ceph fs snapshot mirror peer_bootstrap create <fs_name> <client_entity> <site-name>
 
-  $ ceph fs snapshot mirror peer_bootstrap create backup_fs client.mirror_remote site-remote
+For example:
+
+.. prompt:: bash $
+
+   ceph fs snapshot mirror peer_bootstrap create backup_fs client.mirror_remote site-remote
+
+::
+
   {"token": "eyJmc2lkIjogIjBkZjE3MjE3LWRmY2QtNDAzMC05MDc5LTM2Nzk4NTVkNDJlZiIsICJmaWxlc3lzdGVtIjogImJhY2t1cF9mcyIsICJ1c2VyIjogImNsaWVudC5taXJyb3JfcGVlcl9ib290c3RyYXAiLCAic2l0ZV9uYW1lIjogInNpdGUtcmVtb3RlIiwgImtleSI6ICJBUUFhcDBCZ0xtRmpOeEFBVnNyZXozai9YYUV0T2UrbUJEZlJDZz09IiwgIm1vbl9ob3N0IjogIlt2MjoxOTIuMTY4LjAuNTo0MDkxOCx2MToxOTIuMTY4LjAuNTo0MDkxOV0ifQ=="}
 
-`site-name` refers to a user-defined string to identify the remote filesystem. In context
-of `peer_add` interface, `site-name` is the passed in `cluster` name from `remote_cluster_spec`.
+``site-name`` refers to a user-defined string to identify the remote
+filesystem. In the context of the ``peer_add`` interface, ``site-name`` is the
+passed in the ``cluster`` name from ``remote_cluster_spec``.
 
-Import the bootstrap token in the primary cluster via::
+Import the bootstrap token in the primary cluster by running a command of the
+following form:
 
-  $ ceph fs snapshot mirror peer_bootstrap import <fs_name> <token>
+.. prompt:: bash $
 
-e.g.::
+   ceph fs snapshot mirror peer_bootstrap import <fs_name> <token>
 
-  $ ceph fs snapshot mirror peer_bootstrap import cephfs eyJmc2lkIjogIjBkZjE3MjE3LWRmY2QtNDAzMC05MDc5LTM2Nzk4NTVkNDJlZiIsICJmaWxlc3lzdGVtIjogImJhY2t1cF9mcyIsICJ1c2VyIjogImNsaWVudC5taXJyb3JfcGVlcl9ib290c3RyYXAiLCAic2l0ZV9uYW1lIjogInNpdGUtcmVtb3RlIiwgImtleSI6ICJBUUFhcDBCZ0xtRmpOeEFBVnNyZXozai9YYUV0T2UrbUJEZlJDZz09IiwgIm1vbl9ob3N0IjogIlt2MjoxOTIuMTY4LjAuNTo0MDkxOCx2MToxOTIuMTY4LjAuNTo0MDkxOV0ifQ==
+For example:
+
+.. prompt:: bash $
+
+   ceph fs snapshot mirror peer_bootstrap import cephfs eyJmc2lkIjogIjBkZjE3MjE3LWRmY2QtNDAzMC05MDc5LTM2Nzk4NTVkNDJlZiIsICJmaWxlc3lzdGVtIjogImJhY2t1cF9mcyIsICJ1c2VyIjogImNsaWVudC5taXJyb3JfcGVlcl9ib290c3RyYXAiLCAic2l0ZV9uYW1lIjogInNpdGUtcmVtb3RlIiwgImtleSI6ICJBUUFhcDBCZ0xtRmpOeEFBVnNyZXozai9YYUV0T2UrbUJEZlJDZz09IiwgIm1vbl9ob3N0IjogIlt2MjoxOTIuMTY4LjAuNTo0MDkxOCx2MToxOTIuMTY4LjAuNTo0MDkxOV0ifQ==
 
 Mirror Daemon Status
 --------------------
 
-Mirror daemons get asynchronously notified about changes in file system mirroring status
-and/or peer updates.
+Mirror daemons are asynchronously notified about changes in
+file-system-mirroring status and peer updates.
 
-CephFS mirroring module provides `mirror daemon status` interface to check mirror daemon
-status::
+The CephFS mirroring module provides the ``mirror daemon status`` interface for 
+checking the status of the mirror daemon. Run the following command to check
+the status of the mirror daemon:
 
-  $ ceph fs snapshot mirror daemon status
+.. prompt:: bash $
 
-E.g::
+   ceph fs snapshot mirror daemon status
 
-  $ ceph fs snapshot mirror daemon status | jq
+For example:
+
+.. prompt:: bash $
+
+   ceph fs snapshot mirror daemon status | jq
+
+::
+
   [
     {
       "daemon_id": 284167,
@@ -301,14 +323,20 @@ E.g::
     }
   ]
 
-An entry per mirror daemon instance is displayed along with information such as configured
-peers and basic stats. For more detailed stats, use the admin socket interface as detailed
-below.
+One entry per mirror-daemon instance is displayed, along with information
+including configured peers and basic statistics. For more detailed statistics,
+use the admin socket interface as detailed below.
 
-CephFS mirror daemons provide admin socket commands for querying mirror status. To check
-available commands for mirror status use::
+CephFS mirror daemons provide admin socket commands for querying mirror status.
+To list the available commands for ``mirror status``, run the following
+command:
 
-  $ ceph --admin-daemon /path/to/mirror/daemon/admin/socket help
+.. prompt:: bash $
+
+   ceph --admin-daemon /path/to/mirror/daemon/admin/socket help
+
+::
+
   {
       ....
       ....
@@ -317,15 +345,21 @@ available commands for mirror status use::
       ....
   }
 
-Commands with `fs mirror status` prefix provide mirror status for mirror enabled
-file systems. Note that `cephfs@360` is of format `filesystem-name@filesystem-id`.
-This format is required since mirror daemons get asynchronously notified regarding
-file system mirror status (A file system can be deleted and recreated with the same
-name).
+Commands that have the ``fs mirror status`` prefix provide mirror status for
+mirror-enabled file systems. Note that ``cephfs@360`` has the format
+``filesystem-name@filesystem-id``. This format is required because mirror
+daemons are asynchronously notified of file-system mirror status (A file
+system can be deleted and recreated with the same name).
 
-Right now, the command provides minimal information regarding mirror status::
+Currently (May 2025), the command provides minimal information regarding mirror
+status:
 
-  $ ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror status cephfs@360
+.. prompt:: bash $
+
+   ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror status cephfs@360
+
+::
+
   {
     "rados_inst": "192.168.0.5:0/1476644347",
     "peers": {


### PR DESCRIPTION
Add prompts (and perform necessary corrections to glaring grammatical errors) to doc/dev/cephfs-mirroring.rst, as requested by Jos Collin in https://github.com/ceph/ceph/pull/63237/files#r2085886075.

This commit edits the third quarter of the doc/dev/cephfs-mirroring.rst file. This commit edits down to the line beginning "`Peers` section in the command output".


(cherry picked from commit 3915238f21cd82896e6cda9cc90b68fee5d12750)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

