### PR TITLE
node-proxy: address `ceph orch hardware status` cmd

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1709,9 +1709,9 @@ class NodeProxyCache:
                 else:
                     state = 'ok'
                 _result[host]['status'][component] = state
-        _result[host]['sn'] = data['sn']
-        _result[host]['host'] = data['host']
-        _result[host]['status']['firmwares'] = data['firmwares']
+            _result[host]['sn'] = data['sn']
+            _result[host]['host'] = data['host']
+            _result[host]['status']['firmwares'] = data['firmwares']
         return _result
 
     def common(self, endpoint: str, **kw: Any) -> Dict[str, Any]:


### PR DESCRIPTION
ce360a4a introduced a regression.

`ceph orch hardware status` fails when no hostname is passed (global cluster hw status report).

Typical failure:

```
Error EINVAL: Traceback (most recent call last):
  File "/usr/share/ceph/mgr/mgr_module.py", line 1928, in _handle_command
    return self.handle_command(inbuf, cmd)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 186, in handle_command
    return dispatch[cmd['prefix']].call(self, cmd, inbuf)
  File "/usr/share/ceph/mgr/mgr_module.py", line 527, in call
    return self.func(mgr, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 122, in <lambda>
    wrapper_copy = lambda *l_args, **l_kwargs: wrapper(*l_args, **l_kwargs)  # noqa: E731
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 111, in wrapper
    return func(*args, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/module.py", line 553, in _hardware_status
    row = [k, v['sn']]
KeyError: 'sn'
```

Only the last node in the list has the `sn`, `host` and `firmwares` information because of the wrong identation.

Fixes: https://tracker.ceph.com/issues/71472
