### PR TITLE
reef: scrub: use a generic interface for scheduling timer based events

### DIFF
--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -74,7 +74,10 @@ function TEST_scrub_test() {
       local anotherosd="2"
     fi
 
-    objectstore_tool $dir $anotherosd obj1 set-bytes /etc/fstab
+    CORRUPT_DATA="corrupt-data.$$"
+    dd if=/dev/urandom of=$CORRUPT_DATA bs=512 count=1
+    objectstore_tool $dir $anotherosd obj1 set-bytes $CORRUPT_DATA
+    rm -f $CORRUPT_DATA
 
     local pgid="${poolid}.0"
     pg_deep_scrub "$pgid" || return 1

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -558,9 +558,10 @@ ScrubQueue::scrub_schedule_t ScrubQueue::adjust_target_time(
   return sched_n_dead;
 }
 
-double ScrubQueue::scrub_sleep_time(bool must_scrub) const
+std::chrono::milliseconds ScrubQueue::scrub_sleep_time(bool must_scrub) const
 {
-  double regular_sleep_period = conf()->osd_scrub_sleep;
+  std::chrono::milliseconds regular_sleep_period{
+    uint64_t(std::max(0.0, conf()->osd_scrub_sleep) * 1000)};
 
   if (must_scrub || scrub_time_permit(time_now())) {
     return regular_sleep_period;
@@ -568,8 +569,10 @@ double ScrubQueue::scrub_sleep_time(bool must_scrub) const
 
   // relevant if scrubbing started during allowed time, but continued into
   // forbidden hours
-  double extended_sleep = conf()->osd_scrub_extended_sleep;
+  std::chrono::milliseconds extended_sleep{
+    uint64_t(std::max(0.0, conf()->osd_scrub_extended_sleep) * 1000)};
   dout(20) << "w/ extended sleep (" << extended_sleep << ")" << dendl;
+
   return std::max(extended_sleep, regular_sleep_period);
 }
 

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -389,15 +389,16 @@ class ScrubQueue {
   int get_blocked_pgs_count() const;
 
   /**
-   * Pacing the scrub operation by inserting delays (mostly between chunks)
+   * scrub_sleep_time
    *
-   * Special handling for regular scrubs that continued into "no scrub" times.
-   * Scrubbing will continue, but the delays will be controlled by a separate
-   * (read - with higher value) configuration element
-   * (osd_scrub_extended_sleep).
+   * Returns std::chrono::milliseconds indicating how long to wait between
+   * chunks.
+   *
+   * Implementation Note: Returned value will either osd_scrub_sleep or
+   * osd_scrub_extended_sleep depending on must_scrub_param and time
+   * of day (see configs osd_scrub_begin*)
    */
-  double scrub_sleep_time(bool must_scrub) const;  /// \todo (future) return
-						   /// milliseconds
+  std::chrono::milliseconds scrub_sleep_time(bool must_scrub) const;
 
   /**
    *  called every heartbeat to update the "daily" load average

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -683,6 +683,16 @@ void PgScrubber::cancel_callback(scrubber_callback_cancel_token_t token)
   m_osds->sleep_timer.cancel_event(token);
 }
 
+LogChannelRef &PgScrubber::get_clog() const
+{
+  return m_osds->clog;
+}
+
+int PgScrubber::get_whoami() const
+{
+  return m_osds->whoami;
+}
+
 /*
  * The selected range is set directly into 'm_start' and 'm_end'
  * setting:

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -891,9 +891,8 @@ void PgScrubber::add_delayed_scheduling()
 
   milliseconds sleep_time{0ms};
   if (m_needs_sleep) {
-    double scrub_sleep =
-      1000.0 * m_osds->get_scrub_services().scrub_sleep_time(m_flags.required);
-    sleep_time = milliseconds{int64_t(scrub_sleep)};
+    sleep_time = m_osds->get_scrub_services().scrub_sleep_time(
+      m_flags.required);
   }
   dout(15) << __func__ << " sleep: " << sleep_time.count() << "ms. needed? "
 	   << m_needs_sleep << dendl;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -498,6 +498,11 @@ class PgScrubber : public ScrubPgIF,
   // the I/F used by the state-machine (i.e. the implementation of
   // ScrubMachineListener)
 
+  CephContext* get_cct() const final { return m_pg->cct; }
+  LogChannelRef &get_clog() const final;
+  int get_whoami() const final;
+  spg_t get_spgid() const final { return m_pg->get_pgid(); }
+
   scrubber_callback_cancel_token_t schedule_callback_after(
     ceph::timespan duration, scrubber_callback_t &&cb);
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -537,11 +537,9 @@ class PgScrubber : public ScrubPgIF,
   /// services (thus can be called from FSM reactions)
   void clear_pgscrub_state() final;
 
-  /*
-   * Send an 'InternalSchedScrub' FSM event either immediately, or - if
-   * 'm_need_sleep' is asserted - after a configuration-dependent timeout.
-   */
-  void add_delayed_scheduling() final;
+
+  std::chrono::milliseconds get_scrub_sleep_time() const final;
+  void queue_for_scrub_resched(Scrub::scrub_prio_t prio) final;
 
   void get_replicas_maps(bool replica_can_preempt) final;
 
@@ -732,9 +730,6 @@ class PgScrubber : public ScrubPgIF,
   [[nodiscard]] bool check_interval(epoch_t epoch_to_verify);
 
   epoch_t m_last_aborted{};  // last time we've noticed a request to abort
-
-  utime_t m_sleep_started_at;
-
 
   // 'optional', as 'ReplicaReservations' & 'LocalReservation' are
   // 'RAII-designed' to guarantee un-reserving when deleted.

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -123,22 +123,6 @@ class ReplicaReservations {
   using clock = std::chrono::system_clock;
   using tpoint_t = std::chrono::time_point<clock>;
 
-  /// a no-reply timeout handler
-  struct no_reply_t {
-    explicit no_reply_t(
-      OSDService* osds,
-      const ConfigProxy& conf,
-      ReplicaReservations& parent,
-      std::string_view log_prfx);
-
-    ~no_reply_t();
-    OSDService* m_osds;
-    const ConfigProxy& m_conf;
-    ReplicaReservations& m_parent;
-    std::string m_log_prfx;
-    Context* m_abort_callback{nullptr};
-  };
-
   PG* m_pg;
   std::set<pg_shard_t> m_acting_set;
   OSDService* m_osds;
@@ -153,9 +137,6 @@ class ReplicaReservations {
   // detecting slow peers (see 'slow-secondary' above)
   std::chrono::milliseconds m_timeout;
   std::optional<tpoint_t> m_timeout_point;
-
-  // detecting & handling a "no show" of a replica
-  std::unique_ptr<no_reply_t> m_no_reply;
 
   void release_replica(pg_shard_t peer, epoch_t epoch);
 
@@ -398,6 +379,8 @@ class PgScrubber : public ScrubPgIF,
   void discard_replica_reservations() final;
   void clear_scrub_reservations() final;  // PG::clear... fwds to here
   void unreserve_replicas() final;
+  void on_replica_reservation_timeout() final;
+
 
   // managing scrub op registration
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -733,10 +733,6 @@ class PgScrubber : public ScrubPgIF,
 
   epoch_t m_last_aborted{};  // last time we've noticed a request to abort
 
-  bool m_needs_sleep{true};  ///< should we sleep before being rescheduled?
-			     ///< always 'true', unless we just got out of a
-			     ///< sleep period
-
   utime_t m_sleep_started_at;
 
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -508,6 +508,18 @@ class PgScrubber : public ScrubPgIF,
 
   void cancel_callback(scrubber_callback_cancel_token_t);
 
+  ceph::timespan get_range_blocked_grace() {
+    int grace = get_pg_cct()->_conf->osd_blocked_scrub_grace_period;
+    if (grace == 0) {
+      return ceph::timespan{};
+    }
+    ceph::timespan grace_period{
+      m_debug_blockrange ?
+      std::chrono::seconds(4) :
+      std::chrono::seconds{grace}};
+    return grace_period;
+  }
+
   [[nodiscard]] bool is_primary() const final
   {
     return m_pg->recovery_state.is_primary();
@@ -520,7 +532,6 @@ class PgScrubber : public ScrubPgIF,
 
   void select_range_n_notify() final;
 
-  Scrub::BlockedRangeWarning acquire_blocked_alarm() final;
   void set_scrub_blocked(utime_t since) final;
   void clear_scrub_blocked() final;
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -498,6 +498,11 @@ class PgScrubber : public ScrubPgIF,
   // the I/F used by the state-machine (i.e. the implementation of
   // ScrubMachineListener)
 
+  scrubber_callback_cancel_token_t schedule_callback_after(
+    ceph::timespan duration, scrubber_callback_t &&cb);
+
+  void cancel_callback(scrubber_callback_cancel_token_t);
+
   [[nodiscard]] bool is_primary() const final
   {
     return m_pg->recovery_state.is_primary();

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -72,6 +72,11 @@ using BlockedRangeWarning = std::unique_ptr<blocked_range_t>;
 }  // namespace Scrub
 
 struct ScrubMachineListener {
+  virtual CephContext *get_cct() const = 0;
+  virtual LogChannelRef &get_clog() const = 0;
+  virtual int get_whoami() const = 0;
+  virtual spg_t get_spgid() const = 0;
+
   using scrubber_callback_t = std::function<void(void)>;
   using scrubber_callback_cancel_token_t = Context*;
 

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -179,6 +179,8 @@ struct ScrubMachineListener {
 
   virtual void unreserve_replicas() = 0;
 
+  virtual void on_replica_reservation_timeout() = 0;
+
   virtual void set_scrub_begin_time() = 0;
 
   virtual void set_scrub_duration() = 0;

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -118,11 +118,11 @@ struct ScrubMachineListener {
   /// services (thus can be called from FSM reactions)
   virtual void clear_pgscrub_state() = 0;
 
-  /*
-   * Send an 'InternalSchedScrub' FSM event either immediately, or - if
-   * 'm_need_sleep' is asserted - after a configuration-dependent timeout.
-   */
-  virtual void add_delayed_scheduling() = 0;
+  /// Get time to sleep before next scrub
+  virtual std::chrono::milliseconds get_scrub_sleep_time() const = 0;
+
+  /// Queues InternalSchedScrub for later
+  virtual void queue_for_scrub_resched(Scrub::scrub_prio_t prio) = 0;
 
   /**
    * Ask all replicas for their scrub maps for the current chunk.


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/66988
backport of 50199