### PR TITLE
osd/scrub: only periodic_regular scrubs should suffer extended sleeps

### DIFF
--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -348,13 +348,13 @@ bool OsdScrub::scrub_time_permit(utime_t now) const
 
 
 std::chrono::milliseconds OsdScrub::scrub_sleep_time(
-    utime_t t,
-    bool high_priority_scrub) const
+    utime_t t_now,
+    bool scrub_respects_ext_sleep) const
 {
   const milliseconds regular_sleep_period =
       milliseconds{int64_t(std::max(0.0, 1'000 * conf->osd_scrub_sleep))};
 
-  if (high_priority_scrub || scrub_time_permit(t)) {
+  if (!scrub_respects_ext_sleep || scrub_time_permit(t_now)) {
     return regular_sleep_period;
   }
 

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -104,12 +104,16 @@ class OsdScrub {
    * chunks.
    *
    * Implementation Note: Returned value is either osd_scrub_sleep or
-   * osd_scrub_extended_sleep, depending on must_scrub_param and time
-   * of day (see configs osd_scrub_begin*)
+   * osd_scrub_extended_sleep:
+   * - if scrubs are allowed at this point in time - osd_scrub_sleep; otherwise
+   *   (i.e. - the current time is outside of the allowed scrubbing hours/days,
+   *   but the scrub started earlier):
+   * - if the scrub observes "extended sleep" (i.e. - it's a low urgency
+   *   scrub) - osd_scrub_extended_sleep.
    */
   std::chrono::milliseconds scrub_sleep_time(
-      utime_t t,
-      bool high_priority_scrub) const;
+      utime_t t_now,
+      bool scrub_respects_ext_sleep) const;
 
 
   /**

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2565,7 +2565,7 @@ std::chrono::milliseconds PgScrubber::get_scrub_sleep_time() const
 {
   return m_osds->get_scrub_services().scrub_sleep_time(
       ceph_clock_now(),
-      !ScrubJob::observes_allowed_hours(m_active_target->urgency()));
+      ScrubJob::observes_extended_sleep(m_active_target->urgency()));
 }
 
 void PgScrubber::queue_for_scrub_resched(Scrub::scrub_prio_t prio)

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -374,6 +374,11 @@ bool ScrubJob::observes_allowed_hours(urgency_t urgency)
   return urgency < urgency_t::operator_requested;
 }
 
+bool ScrubJob::observes_extended_sleep(urgency_t urgency)
+{
+  return urgency == urgency_t::periodic_regular;
+}
+
 bool ScrubJob::observes_load_limit(urgency_t urgency)
 {
   return urgency < urgency_t::after_repair;

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -336,14 +336,14 @@ class ScrubJob {
  *  | limitation |  must-  | after-repair |repairing| operator | must-repair |
  *  |            |  scrub  |(aft recovery)|(errors) | request  |             |
  *  +------------+---------+--------------+---------+----------+-------------+
- *  | reservation|    yes! |      no      |    no?  +     no   |      no     |
- *  | dow/time   |    yes  |     yes      |    no   +     no   |      no     |
- *  | ext-sleep  |    no   |      no      |    no   +     no   |      no     |
- *  | load       |    yes  |      no      |    no   +     no   |      no     |
- *  | noscrub    |    yes  |      no?     |    Yes  +     no   |      no     |
- *  | max-scrubs |    yes  |      yes     |    Yes  +     no   |      no     |
- *  | backoff    |    yes  |      no      |    no   +     no   |      no     |
- *  | recovery   |    yes  |      yes     |    Yes  +     no   |      no     |
+ *  | reservation|    yes! |      no      |    no?  |     no   |      no     |
+ *  | dow/time   |    yes  |     yes      |    no   |     no   |      no     |
+ *  | ext-sleep  |    no   |      no      |    no   |     no   |      no     |
+ *  | load       |    yes  |      no      |    no   |     no   |      no     |
+ *  | noscrub    |    yes  |      no      |    Yes  |     no   |      no     |
+ *  | max-scrubs |    yes  |      yes     |    Yes  |     no   |      no     |
+ *  | backoff    |    yes  |      no      |    no   |     no   |      no     |
+ *  | recovery   |    yes  |      yes     |    Yes  |     no   |      no     |
  *  +------------+---------+--------------+---------+----------+-------------+
  */
 
@@ -353,6 +353,8 @@ class ScrubJob {
   static bool observes_noscrub_flags(urgency_t urgency);
 
   static bool observes_allowed_hours(urgency_t urgency);
+
+  static bool observes_extended_sleep(urgency_t urgency);
 
   static bool observes_load_limit(urgency_t urgency);
 


### PR DESCRIPTION
fix get_scrub_sleep_time() call parameters, to use the correct
logic (observes_extended_sleep()) for sleep time calculations.