### PR TITLE
rgw/dedup: full object dedup continuous work

### DIFF
--- a/src/rgw/rgw_dedup.h
+++ b/src/rgw/rgw_dedup.h
@@ -95,10 +95,10 @@ namespace rgw::dedup {
       STEP_REMOVE_DUPLICATES
     };
 
-    void ack_notify(uint64_t notify_id, uint64_t cookie, int status);
     void run();
     int  setup(struct dedup_epoch_t*);
     void work_shards_barrier(work_shard_t num_work_shards);
+    void md5_shards_barrier(md5_shard_t num_md5_shards);
     void handle_pause_req(const char* caller);
     const char* dedup_step_name(dedup_step_t step);
     int  read_buckets();
@@ -216,7 +216,7 @@ namespace rgw::dedup {
                      bool                 is_shared_manifest_src);
 #endif
     int  remove_slabs(unsigned worker_id, unsigned md5_shard, uint32_t slab_count);
-    int  init_rados_access_handles();
+    int  init_rados_access_handles(bool init_pool);
 
     // private data members
     rgw::sal::Driver* driver = nullptr;
@@ -244,7 +244,6 @@ namespace rgw::dedup {
 
     std::thread d_runner;
     std::mutex  d_cond_mutex;
-    std::mutex  d_pause_mutex;
     std::condition_variable d_cond;
   };
 

--- a/src/rgw/rgw_dedup_store.cc
+++ b/src/rgw/rgw_dedup_store.cc
@@ -32,8 +32,6 @@
 
 namespace rgw::dedup {
 
-  rgw_pool pool(DEDUP_POOL_NAME);
-
   //---------------------------------------------------------------------------
   disk_record_t::disk_record_t(const rgw::sal::Bucket *p_bucket,
                                const std::string      &obj_name,

--- a/src/rgw/rgw_dedup_table.h
+++ b/src/rgw/rgw_dedup_table.h
@@ -49,6 +49,10 @@ namespace rgw::dedup {
       return this->md5_low;
     }
 
+    bool multipart_object() const {
+      return num_parts > 0;
+    }
+
     uint64_t md5_high;      // High Bytes of the Object Data MD5
     uint64_t md5_low;       // Low  Bytes of the Object Data MD5
     uint32_t size_4k_units; // Object size in 4KB units max out at 16TB (AWS MAX-SIZE is 5TB)
@@ -110,10 +114,10 @@ namespace rgw::dedup {
                                      disk_block_id_t block_id,
                                      record_id_t rec_id);
 
-    void count_duplicates(uint64_t *p_singleton_count,
-                          uint64_t *p_unique_count,
-                          uint64_t *p_duplicate_count,
-                          uint64_t *p_duplicate_bytes_approx);
+    void count_duplicates(dedup_stats_t *p_small_objs_stat,
+                          dedup_stats_t *p_big_objs_stat,
+                          uint64_t *p_duplicate_head_bytes);
+
     void remove_singletons_and_redistribute_keys();
   private:
     // 32 Bytes unified entries

--- a/src/rgw/rgw_dedup_utils.cc
+++ b/src/rgw/rgw_dedup_utils.cc
@@ -35,6 +35,48 @@ namespace rgw::dedup {
     return out;
   }
 
+  //---------------------------------------------------------------------------
+  dedup_stats_t& dedup_stats_t::operator+=(const dedup_stats_t& other)
+  {
+    this->singleton_count += other.singleton_count;
+    this->unique_count += other.unique_count;
+    this->duplicate_count += other.duplicate_count;
+    this->dedup_bytes_estimate += other.dedup_bytes_estimate;
+    return *this;
+  }
+
+  //---------------------------------------------------------------------------
+  std::ostream& operator<<(std::ostream &out, const dedup_stats_t& stats)
+  {
+    out << "::singleton_count="  << stats.singleton_count
+        << "::unique_count="     << stats.unique_count
+        << "::duplicate_count="  << stats.duplicate_count
+        << "::duplicated_bytes=" << stats.dedup_bytes_estimate;
+    return out;
+  }
+
+  //---------------------------------------------------------------------------
+  void encode(const dedup_stats_t& ds, ceph::bufferlist& bl)
+  {
+    ENCODE_START(1, 1, bl);
+    encode(ds.singleton_count, bl);
+    encode(ds.unique_count, bl);
+    encode(ds.duplicate_count, bl);
+    encode(ds.dedup_bytes_estimate, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  //---------------------------------------------------------------------------
+  void decode(dedup_stats_t& ds, ceph::bufferlist::const_iterator& bl)
+  {
+    DECODE_START(1, bl);
+    decode(ds.singleton_count, bl);
+    decode(ds.unique_count, bl);
+    decode(ds.duplicate_count, bl);
+    decode(ds.dedup_bytes_estimate, bl);
+    DECODE_FINISH(bl);
+  }
+
   // convert a hex-string to a 64bit integer (max 16 hex digits)
   //---------------------------------------------------------------------------
   bool hex2int(const char *p, const char *p_end, uint64_t *p_val)
@@ -206,7 +248,8 @@ namespace rgw::dedup {
   };
 
   //---------------------------------------------------------------------------
-  const char* get_urgent_msg_names(int msg) {
+  const char* get_urgent_msg_names(int msg)
+  {
     if (msg <= URGENT_MSG_INVALID && msg >= URGENT_MSG_NONE) {
       return s_urgent_msg_names[msg];
     }
@@ -216,22 +259,34 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
-  std::ostream& operator<<(std::ostream &out, const worker_stats_t &s)
+  worker_stats_t& worker_stats_t::operator+=(const worker_stats_t& other)
   {
-    JSONFormatter formatter(false);
-    s.dump(&formatter);
-    std::stringstream sstream;
-    formatter.flush(sstream);
-    out << sstream.str();
-    return out;
-  }
+    this->ingress_obj += other.ingress_obj;
+    this->ingress_obj_bytes += other.ingress_obj_bytes;
+    this->egress_records += other.egress_records;
+    this->egress_blocks += other.egress_blocks;
+    this->egress_slabs += other.egress_slabs;
+    this->single_part_objs += other.single_part_objs;
+    this->multipart_objs += other.multipart_objs;
+    this->small_multipart_obj += other.small_multipart_obj;
+    this->default_storage_class_objs += other.default_storage_class_objs;
+    this->default_storage_class_objs_bytes += other.default_storage_class_objs_bytes;
+    this->non_default_storage_class_objs += other.non_default_storage_class_objs;
+    this->non_default_storage_class_objs_bytes += other.non_default_storage_class_objs_bytes;
+    this->ingress_corrupted_etag += other.ingress_corrupted_etag;
+    this->ingress_skip_too_small_bytes += other.ingress_skip_too_small_bytes;
+    this->ingress_skip_too_small += other.ingress_skip_too_small;
+    this->ingress_skip_too_small_64KB_bytes += other.ingress_skip_too_small_64KB_bytes;
+    this->ingress_skip_too_small_64KB += other.ingress_skip_too_small_64KB;
 
+    return *this;
+  }
   //---------------------------------------------------------------------------
   void worker_stats_t::dump(Formatter *f) const
   {
     // main section
     {
-      Formatter::ObjectSection notify(*f, "main");
+      Formatter::ObjectSection main(*f, "main");
 
       f->dump_unsigned("Ingress Objs count", this->ingress_obj);
       f->dump_unsigned("Accum byte size Ingress Objs", this->ingress_obj_bytes);
@@ -286,6 +341,122 @@ namespace rgw::dedup {
   }
 
   //---------------------------------------------------------------------------
+  std::ostream& operator<<(std::ostream &out, const worker_stats_t &s)
+  {
+    JSONFormatter formatter(false);
+    s.dump(&formatter);
+    std::stringstream sstream;
+    formatter.flush(sstream);
+    out << sstream.str();
+    return out;
+  }
+
+  //---------------------------------------------------------------------------
+  void encode(const worker_stats_t& w, ceph::bufferlist& bl)
+  {
+    ENCODE_START(1, 1, bl);
+    encode(w.ingress_obj, bl);
+    encode(w.ingress_obj_bytes, bl);
+    encode(w.egress_records, bl);
+    encode(w.egress_blocks, bl);
+    encode(w.egress_slabs, bl);
+
+    encode(w.single_part_objs, bl);
+    encode(w.multipart_objs, bl);
+    encode(w.small_multipart_obj, bl);
+
+    encode(w.default_storage_class_objs, bl);
+    encode(w.default_storage_class_objs_bytes, bl);
+    encode(w.non_default_storage_class_objs, bl);
+    encode(w.non_default_storage_class_objs_bytes, bl);
+
+    encode(w.ingress_corrupted_etag, bl);
+
+    encode(w.ingress_skip_too_small_bytes, bl);
+    encode(w.ingress_skip_too_small, bl);
+
+    encode(w.ingress_skip_too_small_64KB_bytes, bl);
+    encode(w.ingress_skip_too_small_64KB, bl);
+
+    encode(w.duration, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  //---------------------------------------------------------------------------
+  void decode(worker_stats_t& w, ceph::bufferlist::const_iterator& bl)
+  {
+    DECODE_START(1, bl);
+    decode(w.ingress_obj, bl);
+    decode(w.ingress_obj_bytes, bl);
+    decode(w.egress_records, bl);
+    decode(w.egress_blocks, bl);
+    decode(w.egress_slabs, bl);
+    decode(w.single_part_objs, bl);
+    decode(w.multipart_objs, bl);
+    decode(w.small_multipart_obj, bl);
+    decode(w.default_storage_class_objs, bl);
+    decode(w.default_storage_class_objs_bytes, bl);
+    decode(w.non_default_storage_class_objs, bl);
+    decode(w.non_default_storage_class_objs_bytes, bl);
+    decode(w.ingress_corrupted_etag, bl);
+    decode(w.ingress_skip_too_small_bytes, bl);
+    decode(w.ingress_skip_too_small, bl);
+    decode(w.ingress_skip_too_small_64KB_bytes, bl);
+    decode(w.ingress_skip_too_small_64KB, bl);
+
+    decode(w.duration, bl);
+    DECODE_FINISH(bl);
+  }
+
+  //---------------------------------------------------------------------------
+  md5_stats_t& md5_stats_t::operator+=(const md5_stats_t& other)
+  {
+    this->small_objs_stat               += other.small_objs_stat;
+    this->big_objs_stat                 += other.big_objs_stat;
+    this->ingress_failed_load_bucket    += other.ingress_failed_load_bucket;
+    this->ingress_failed_get_object     += other.ingress_failed_get_object;
+    this->ingress_failed_get_obj_attrs  += other.ingress_failed_get_obj_attrs;
+    this->ingress_corrupted_etag        += other.ingress_corrupted_etag;
+    this->ingress_corrupted_obj_attrs   += other.ingress_corrupted_obj_attrs;
+    this->ingress_skip_encrypted        += other.ingress_skip_encrypted;
+    this->ingress_skip_encrypted_bytes  += other.ingress_skip_encrypted_bytes;
+    this->ingress_skip_compressed       += other.ingress_skip_compressed;
+    this->ingress_skip_compressed_bytes += other.ingress_skip_compressed_bytes;
+    this->ingress_skip_changed_objs     += other.ingress_skip_changed_objs;
+    this->shared_manifest_dedup_bytes   += other.shared_manifest_dedup_bytes;
+
+    this->skipped_shared_manifest += other.skipped_shared_manifest;
+    this->skipped_purged_small    += other.skipped_purged_small;
+    this->skipped_singleton       += other.skipped_singleton;
+    this->skipped_singleton_bytes += other.skipped_singleton_bytes;
+    this->skipped_source_record   += other.skipped_source_record;
+    this->duplicate_records       += other.duplicate_records;
+    this->size_mismatch           += other.size_mismatch;
+    this->sha256_mismatch         += other.sha256_mismatch;
+    this->failed_src_load         += other.failed_src_load;
+    this->failed_rec_load         += other.failed_rec_load;
+    this->failed_block_load       += other.failed_block_load;
+
+    this->valid_sha256_attrs      += other.valid_sha256_attrs;
+    this->invalid_sha256_attrs    += other.invalid_sha256_attrs;
+    this->set_sha256_attrs        += other.set_sha256_attrs;
+    this->skip_sha256_cmp         += other.skip_sha256_cmp;
+
+    this->set_shared_manifest_src += other.set_shared_manifest_src;
+    this->loaded_objects          += other.loaded_objects;
+    this->processed_objects       += other.processed_objects;
+    this->dup_head_bytes_estimate += other.dup_head_bytes_estimate;
+    this->deduped_objects         += other.deduped_objects;
+    this->deduped_objects_bytes   += other.deduped_objects_bytes;
+    this->dup_head_bytes          += other.dup_head_bytes;
+
+    this->failed_dedup            += other.failed_dedup;
+    this->failed_table_load       += other.failed_table_load;
+    this->failed_map_overflow     += other.failed_map_overflow;
+    return *this;
+  }
+
+  //---------------------------------------------------------------------------
   std::ostream& operator<<(std::ostream &out, const md5_stats_t &s)
   {
     JSONFormatter formatter(false);
@@ -301,19 +472,37 @@ namespace rgw::dedup {
   {
     // main section
     {
-      Formatter::ObjectSection notify(*f, "main");
+      Formatter::ObjectSection main(*f, "main");
 
       f->dump_unsigned("Total processed objects", this->processed_objects);
       f->dump_unsigned("Loaded objects", this->loaded_objects);
       f->dump_unsigned("Set Shared-Manifest SRC", this->set_shared_manifest_src);
       f->dump_unsigned("Deduped Obj (this cycle)", this->deduped_objects);
       f->dump_unsigned("Deduped Bytes(this cycle)", this->deduped_objects_bytes);
+      f->dump_unsigned("Dup head bytes (not dedup)", this->dup_head_bytes);
       f->dump_unsigned("Already Deduped bytes (prev cycles)",
                        this->shared_manifest_dedup_bytes);
-      f->dump_unsigned("Singleton Obj", this->singleton_count);
-      f->dump_unsigned("Unique Obj", this->unique_count);
-      f->dump_unsigned("Duplicate Obj", this->duplicate_count);
-      f->dump_unsigned("Dedup Bytes Estimate", this->dedup_bytes_estimate);
+
+      const dedup_stats_t &ds = this->big_objs_stat;
+      f->dump_unsigned("Singleton Obj", ds.singleton_count);
+      f->dump_unsigned("Unique Obj", ds.unique_count);
+      f->dump_unsigned("Duplicate Obj", ds.duplicate_count);
+      f->dump_unsigned("Dedup Bytes Estimate", ds.dedup_bytes_estimate);
+    }
+
+    // Potential Dedup Section:
+    // What could be gained by allowing dedup for smaller objects (64KB-4MB)
+    // Space wasted because of duplicated head-object (4MB)
+    {
+      Formatter::ObjectSection potential(*f, "Potential Dedup");
+      const dedup_stats_t &ds = this->small_objs_stat;
+      f->dump_unsigned("Singleton Obj (64KB-4MB)", ds.singleton_count);
+      f->dump_unsigned("Unique Obj (64KB-4MB)", ds.unique_count);
+      f->dump_unsigned("Duplicate Obj (64KB-4MB)", ds.duplicate_count);
+      f->dump_unsigned("Dedup Bytes Estimate (64KB-4MB)", ds.dedup_bytes_estimate);
+      f->dump_unsigned("Duplicated Head Bytes Estimate",
+                       this->dup_head_bytes_estimate);
+      f->dump_unsigned("Duplicated Head Bytes", this->dup_head_bytes);
     }
 
     {
@@ -340,6 +529,7 @@ namespace rgw::dedup {
     {
       Formatter::ObjectSection skipped(*f, "skipped");
       f->dump_unsigned("Skipped shared_manifest", this->skipped_shared_manifest);
+      f->dump_unsigned("Skipped purged small objs", this->skipped_purged_small);
       f->dump_unsigned("Skipped singleton objs", this->skipped_singleton);
       if (this->skipped_singleton) {
         f->dump_unsigned("Skipped singleton Bytes", this->skipped_singleton_bytes);
@@ -402,5 +592,106 @@ namespace rgw::dedup {
         f->dump_unsigned("Size mismatch SRC/TGT", this->size_mismatch);
       }
     }
+  }
+
+  //---------------------------------------------------------------------------
+  void encode(const md5_stats_t& m, ceph::bufferlist& bl)
+  {
+    ENCODE_START(1, 1, bl);
+
+    encode(m.small_objs_stat, bl);
+    encode(m.big_objs_stat, bl);
+    encode(m.ingress_failed_load_bucket, bl);
+    encode(m.ingress_failed_get_object, bl);
+    encode(m.ingress_failed_get_obj_attrs, bl);
+    encode(m.ingress_corrupted_etag, bl);
+    encode(m.ingress_corrupted_obj_attrs, bl);
+    encode(m.ingress_skip_encrypted, bl);
+    encode(m.ingress_skip_encrypted_bytes, bl);
+    encode(m.ingress_skip_compressed, bl);
+    encode(m.ingress_skip_compressed_bytes, bl);
+    encode(m.ingress_skip_changed_objs, bl);
+    encode(m.shared_manifest_dedup_bytes, bl);
+
+    encode(m.skipped_shared_manifest, bl);
+    encode(m.skipped_purged_small, bl);
+    encode(m.skipped_singleton, bl);
+    encode(m.skipped_singleton_bytes, bl);
+    encode(m.skipped_source_record, bl);
+    encode(m.duplicate_records, bl);
+    encode(m.size_mismatch, bl);
+    encode(m.sha256_mismatch, bl);
+    encode(m.failed_src_load, bl);
+    encode(m.failed_rec_load, bl);
+    encode(m.failed_block_load, bl);
+
+    encode(m.valid_sha256_attrs, bl);
+    encode(m.invalid_sha256_attrs, bl);
+    encode(m.set_sha256_attrs, bl);
+    encode(m.skip_sha256_cmp, bl);
+    encode(m.set_shared_manifest_src, bl);
+
+    encode(m.loaded_objects, bl);
+    encode(m.processed_objects, bl);
+    encode(m.dup_head_bytes_estimate, bl);
+    encode(m.deduped_objects, bl);
+    encode(m.deduped_objects_bytes, bl);
+    encode(m.dup_head_bytes, bl);
+    encode(m.failed_dedup, bl);
+    encode(m.failed_table_load, bl);
+    encode(m.failed_map_overflow, bl);
+
+    encode(m.duration, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  //---------------------------------------------------------------------------
+  void decode(md5_stats_t& m, ceph::bufferlist::const_iterator& bl)
+  {
+    DECODE_START(1, bl);
+    decode(m.small_objs_stat, bl);
+    decode(m.big_objs_stat, bl);
+    decode(m.ingress_failed_load_bucket, bl);
+    decode(m.ingress_failed_get_object, bl);
+    decode(m.ingress_failed_get_obj_attrs, bl);
+    decode(m.ingress_corrupted_etag, bl);
+    decode(m.ingress_corrupted_obj_attrs, bl);
+    decode(m.ingress_skip_encrypted, bl);
+    decode(m.ingress_skip_encrypted_bytes, bl);
+    decode(m.ingress_skip_compressed, bl);
+    decode(m.ingress_skip_compressed_bytes, bl);
+    decode(m.ingress_skip_changed_objs, bl);
+    decode(m.shared_manifest_dedup_bytes, bl);
+
+    decode(m.skipped_shared_manifest, bl);
+    decode(m.skipped_purged_small, bl);
+    decode(m.skipped_singleton, bl);
+    decode(m.skipped_singleton_bytes, bl);
+    decode(m.skipped_source_record, bl);
+    decode(m.duplicate_records, bl);
+    decode(m.size_mismatch, bl);
+    decode(m.sha256_mismatch, bl);
+    decode(m.failed_src_load, bl);
+    decode(m.failed_rec_load, bl);
+    decode(m.failed_block_load, bl);
+
+    decode(m.valid_sha256_attrs, bl);
+    decode(m.invalid_sha256_attrs, bl);
+    decode(m.set_sha256_attrs, bl);
+    decode(m.skip_sha256_cmp, bl);
+    decode(m.set_shared_manifest_src, bl);
+
+    decode(m.loaded_objects, bl);
+    decode(m.processed_objects, bl);
+    decode(m.dup_head_bytes_estimate, bl);
+    decode(m.deduped_objects, bl);
+    decode(m.deduped_objects_bytes, bl);
+    decode(m.dup_head_bytes, bl);
+    decode(m.failed_dedup, bl);
+    decode(m.failed_table_load, bl);
+    decode(m.failed_map_overflow, bl);
+
+    decode(m.duration, bl);
+    DECODE_FINISH(bl);
   }
 } //namespace rgw::dedup

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -150,6 +150,7 @@ void RGWZoneParams::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("name", name, obj);
   JSONDecoder::decode_json("domain_root", domain_root, obj);
   JSONDecoder::decode_json("control_pool", control_pool, obj);
+  JSONDecoder::decode_json("dedup_pool", dedup_pool, obj);
   JSONDecoder::decode_json("gc_pool", gc_pool, obj);
   JSONDecoder::decode_json("lc_pool", lc_pool, obj);
   JSONDecoder::decode_json("log_pool", log_pool, obj);
@@ -178,6 +179,7 @@ void RGWZoneParams::dump(Formatter *f) const
   encode_json("name", name, f);
   encode_json("domain_root", domain_root, f);
   encode_json("control_pool", control_pool, f);
+  encode_json("dedup_pool", dedup_pool, f);
   encode_json("gc_pool", gc_pool, f);
   encode_json("lc_pool", lc_pool, f);
   encode_json("log_pool", log_pool, f);
@@ -237,6 +239,7 @@ void add_zone_pools(const RGWZoneParams& info,
 {
   pools.insert(info.domain_root);
   pools.insert(info.control_pool);
+  pools.insert(info.dedup_pool);
   pools.insert(info.gc_pool);
   pools.insert(info.log_pool);
   pools.insert(info.intent_log_pool);
@@ -808,6 +811,7 @@ int init_zone_pool_names(const DoutPrefixProvider *dpp, optional_yield y,
 {
   info.domain_root = fix_zone_pool_dup(pools, info.name, ".rgw.meta:root", info.domain_root);
   info.control_pool = fix_zone_pool_dup(pools, info.name, ".rgw.control", info.control_pool);
+  info.dedup_pool = fix_zone_pool_dup(pools, info.name, ".rgw.dedup", info.dedup_pool);
   info.gc_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:gc", info.gc_pool);
   info.lc_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log:lc", info.lc_pool);
   info.log_pool = fix_zone_pool_dup(pools, info.name, ".rgw.log", info.log_pool);

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -32,6 +32,7 @@ struct RGWZoneParams {
   rgw_pool topics_pool;
   rgw_pool account_pool;
   rgw_pool group_pool;
+  rgw_pool dedup_pool;
 
   RGWAccessKey system_key;
 
@@ -59,7 +60,7 @@ struct RGWZoneParams {
   const std::string& get_compression_type(const rgw_placement_rule& placement_rule) const;
   
   void encode(bufferlist& bl) const {
-    ENCODE_START(15, 1, bl);
+    ENCODE_START(16, 1, bl);
     encode(domain_root, bl);
     encode(control_pool, bl);
     encode(gc_pool, bl);
@@ -95,11 +96,12 @@ struct RGWZoneParams {
     encode(topics_pool, bl);
     encode(account_pool, bl);
     encode(group_pool, bl);
+    encode(dedup_pool, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(15, bl);
+    DECODE_START(16, bl);
     decode(domain_root, bl);
     decode(control_pool, bl);
     decode(gc_pool, bl);
@@ -183,6 +185,11 @@ struct RGWZoneParams {
       topics_pool = name + ".rgw.meta:topics";
       account_pool = name + ".rgw.meta:accounts";
       group_pool = name + ".rgw.meta:groups";
+    }
+    if (struct_v >= 16) {
+      decode(dedup_pool, bl);
+    } else {
+      dedup_pool = name + ".rgw.dedup";
     }
     DECODE_FINISH(bl);
   }

--- a/src/test/rgw/dedup/pytest.ini
+++ b/src/test/rgw/dedup/pytest.ini
@@ -3,5 +3,5 @@ markers =
   basic_test
 
 log_cli=true
-log_cli_level=WARNING
-#log_cli_level=INFO
+#log_cli_level=WARNING
+log_cli_level=INFO


### PR DESCRIPTION
Moved all control objects (EPOCH, WATCH, Tokens) to default.rgw.control pool.
rgw.dedup pool is created on dedup start and removed when the scan is over

report duplicated space after dedup because of the head-object
report potential dedup for smaller objects (64KB-4MB)
code cleanup 




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
