### PR TITLE
script: ceph-backport.sh adds redmine key to api requests

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -917,7 +917,7 @@ function number_to_url {
 
 function populate_original_issue {
     if [ -z "$original_issue" ] ; then
-        original_issue=$(curl --silent "${redmine_url}.json?include=relations" |
+        original_issue=$(curl --silent "${redmine_url}.json?include=relations&key=$redmine_key" |
             jq '.issue.relations[] | select(.relation_type | contains("copied_to")) | .issue_id')
         original_issue_url="$(number_to_url "redmine" "${original_issue}")"
     fi
@@ -926,7 +926,7 @@ function populate_original_issue {
 function populate_original_pr {
     if [ "$original_issue" ] ; then
         if [ -z "$original_pr" ] ; then
-            original_pr=$(curl --silent "${original_issue_url}.json" |
+            original_pr=$(curl --silent "${original_issue_url}.json?key=$redmine_key" |
                           jq -r '.issue.custom_fields[] | select(.id | contains(21)) | .value')
             original_pr_url="$(number_to_url "github" "${original_pr}")"
         fi
@@ -1553,7 +1553,7 @@ fi
 redmine_url="$(number_to_url "redmine" "${issue}")"
 debug "Considering Redmine issue: $redmine_url - is it in the Backport tracker?"
 
-remote_api_output="$(curl --silent "${redmine_url}.json")"
+remote_api_output="$(curl --silent "${redmine_url}.json?key=$redmine_key")"
 debug $remote_api_output
 tracker="$(echo "$remote_api_output" | jq -r '.issue.tracker.name')"
 if [ "$tracker" = "Backport" ]; then


### PR DESCRIPTION
the ceph-backport.sh script recently started failing with:

> ceph-backport.sh: DEBUG: Considering Redmine issue: https://tracker.ceph.com/issues/70374 - is it in the Backport tracker?
> ceph-backport.sh: DEBUG:
> ceph-backport.sh: ERROR: Issue https://tracker.ceph.com/issues/70374 is not a Backport

because the command `curl --silent https://tracker.ceph.com/issues/70374.json` now fails with `HTTP/2 401` (Unauthorized) and returns an empty string

the command succeeds after adding my redmine key as a query param like some of the other redmine requests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
