### PR TITLE
tentacle: doc/mgr: edit rgw.rst

### DIFF
--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -9,9 +9,11 @@ the different related entities.
 Enabling
 --------
 
-The *rgw* module is enabled with::
+To enable the ``rgw`` module, run the following command:
 
-  ceph mgr module enable rgw
+.. prompt:: bash #
+
+   ceph mgr module enable rgw
 
 
 RGW Realm Operations
@@ -25,13 +27,13 @@ supports both passing the arguments through the cmd line or as a spec file:
 
 .. prompt:: bash #
 
-  ceph rgw realm bootstrap [--realm-name] [--zonegroup-name] [--zone-name] [--port] [--placement] [--start-radosgw]
+   ceph rgw realm bootstrap [--realm-name] [--zonegroup-name] [--zone-name] [--port] [--placement] [--start-radosgw]
 
 The command supports providing the configuration through a spec file (`-i option`):
 
 .. prompt:: bash #
 
-  ceph rgw realm bootstrap -i myrgw.yaml
+   ceph rgw realm bootstrap -i myrgw.yaml
 
 Following is an example of RGW multisite spec file:
 
@@ -68,11 +70,11 @@ Realm Credentials Token
 Users can list the available tokens for the created (or already existing) realms.
 The token is a base64 string that encapsulates the realm information and its
 master zone endpoint authentication data. Following is an example of
-the `ceph rgw realm tokens` output:
+the ``ceph rgw realm tokens`` output:
 
 .. prompt:: bash #
 
-  ceph rgw realm tokens | jq
+   ceph rgw realm tokens | jq
 
 .. code-block:: json
 
@@ -115,28 +117,29 @@ Following is an example of zone spec file:
 
 Commands
 --------
-::
 
-  ceph rgw realm bootstrap -i spec.yaml
+.. prompt:: bash #
+
+   ceph rgw realm bootstrap -i spec.yaml
 
 Create a new realm + zonegroup + zone and deploy rgw daemons via the
 orchestrator using the information specified in the YAML file.
 
-::
+.. prompt:: bash #
 
-  ceph rgw realm tokens
+   ceph rgw realm tokens
 
 List the tokens of all the available realms
 
-::
+.. prompt:: bash #
 
-  ceph rgw zone create -i spec.yaml
+   ceph rgw zone create -i spec.yaml
 
 Join an existing realm by creating a new secondary zone (using the realm token)
 
-::
+.. prompt:: bash #
 
-  ceph rgw admin [*]
+   ceph rgw admin [*]
 
 RGW admin command
 
@@ -176,6 +179,6 @@ Upgrading root ca certificates
 #. From the primary node, ensure that the ``curl`` command can be run by the
    user:
 
-   .. prompt:: bash [root@primary-node]# 
+   .. prompt:: bash [user@primary-node]$ 
 
       curl https://<host_ip>:443


### PR DESCRIPTION
Edit doc/mgr/rgw.rst.

This is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.


(cherry picked from commit e7f2a4b5b22280b32800930a5707791360e68f59)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

