### PR TITLE
test/common: fix memory leak in librados completion tests

### DIFF
--- a/src/test/common/test_librados_completion.cc
+++ b/src/test/common/test_librados_completion.cc
@@ -37,12 +37,12 @@ namespace async = ceph::async;
 
 TEST(CoroSucc, AioComplete)
 {
-  auto lrc = librados::Rados::aio_create_completion();
+  std::unique_ptr<librados::AioCompletion> lrc{librados::Rados::aio_create_completion()};
   asio::io_context c;
   asio::co_spawn(c.get_executor(),
                  []() -> asio::awaitable<void> {
                    co_return;
-                 }(), lrc);
+                 }(), lrc.get());
   c.run();
   lrc->wait_for_complete();
   auto r = lrc->get_return_value();
@@ -51,13 +51,13 @@ TEST(CoroSucc, AioComplete)
 
 TEST(CoroExcept, AioComplete)
 {
-  auto lrc = librados::Rados::aio_create_completion();
+  std::unique_ptr<librados::AioCompletion> lrc{librados::Rados::aio_create_completion()};
   asio::io_context c;
   asio::co_spawn(c.get_executor(),
                  []() -> asio::awaitable<void> {
                    throw sys::system_error{ENOENT, sys::generic_category()};
                    co_return;
-                 }(), lrc);
+                 }(), lrc.get());
   c.run();
   lrc->wait_for_complete();
   auto r = lrc->get_return_value();
@@ -66,13 +66,13 @@ TEST(CoroExcept, AioComplete)
 
 TEST(CoroUnknownExcept, AioComplete)
 {
-  auto lrc = librados::Rados::aio_create_completion();
+  std::unique_ptr<librados::AioCompletion> lrc{librados::Rados::aio_create_completion()};
   asio::io_context c;
   asio::co_spawn(c.get_executor(),
                  []() -> asio::awaitable<void> {
                    throw std::exception{};
                    co_return;
-                 }(), lrc);
+                 }(), lrc.get());
   c.run();
   lrc->wait_for_complete();
   auto r = lrc->get_return_value();
@@ -81,12 +81,12 @@ TEST(CoroUnknownExcept, AioComplete)
 
 TEST(Int, AioComplete)
 {
-  auto lrc = librados::Rados::aio_create_completion();
+  std::unique_ptr<librados::AioCompletion> lrc{librados::Rados::aio_create_completion()};
   asio::io_context c;
   async::async_dispatch(c.get_executor(),
                         []() {
                          return -42;
-                       }, lrc);
+                       }, lrc.get());
   c.run();
   lrc->wait_for_complete();
   auto r = lrc->get_return_value();
@@ -95,13 +95,13 @@ TEST(Int, AioComplete)
 
 TEST(EC, AioComplete)
 {
-  auto lrc = librados::Rados::aio_create_completion();
+  std::unique_ptr<librados::AioCompletion> lrc{librados::Rados::aio_create_completion()};
   asio::io_context c;
   async::async_dispatch(c.get_executor(),
                         []() {
                           return sys::error_code(ENOENT,
                                                  sys::generic_category());
-                        }, lrc);
+                        }, lrc.get());
   c.run();
   lrc->wait_for_complete();
   auto r = lrc->get_return_value();


### PR DESCRIPTION
Replace raw pointers with unique_ptr for AioCompletion instances in test_librados_completion to prevent memory leaks. Previously, each test case allocated AioCompletion objects but never freed them, causing AddressSanitizer to report leaks.

The unique_ptr automatically manages the object lifecycle, ensuring cleanup when the pointer goes out of scope.

Fixes ASan error:

```
`==1199357==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x5602d9f0eaad in operator new(unsigned long) (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/unittest_librados_completion+0x1f2aad) (BuildId: ef5b4b8f0a479e21b6a2686519ff4c3ef71b9f94)
    #1 0x7f3ac9b776f4 in librados::v14_2_0::Rados::aio_create_completion() /home/jenkins-build/build/workspace/ceph-pull-requests/src/librados/librados_cxx.cc:2892:10
    #2 0x5602d9f11a0a in CoroExcept_AioComplete_Test::TestBody() /home/jenkins-build/build/workspace/ceph-pull-requests/src/test/common/test_librados_completion.cc:54:14
    #3 0x5602da01d69d in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/jenkins-build/build/workspace/ceph-pull-requests/src/googletest/googletest/src/gtest.cc:2653:10
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
