### PR TITLE
[RGW]LMDB-Backed RGW Usage Metrics Integration via PerfCounters

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4260,3 +4260,10 @@ options:
   services:
   - rgw
   with_legacy: true
+-name: rgw_enable_usage_perf_counters
+  type: bool
+  default: false
+  desc: Enable periodic updating of usage perf counters for buckets and users
+  -rgw
+  flags:
+  -startup

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -184,3 +184,21 @@ int rgw_chown_bucket_and_objects(rgw::sal::Driver* driver, rgw::sal::Bucket* buc
   return ret;
 }
 
+int RGWBucket::get_usage_stats(uint64_t* num_objs, uint64_t* total_bytes) {
+  if (!store || !num_objs || !total_bytes) {
+    return -EINVAL;
+  }
+
+  RGWBucketStats stats;
+  int ret = store->get_bucket_stats(this->bucket, &stats); // optionally add 'true' if refresh is needed
+  if (ret < 0) {
+    ldout(store->ctx(), 1) << "get_bucket_stats failed for bucket=" << bucket.name
+                           << " ret=" << ret << dendl;
+    return ret;
+  }
+
+  *num_objs = stats.num_objects;
+  *total_bytes = stats.num_bytes;
+  return 0;
+}
+

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -13,6 +13,11 @@
 #include "include/types.h"
 #include "rgw_common.h"
 #include "rgw_sal.h"
+#include "driver/rados/rgw_bucket.h"       // for RGWBucketInfo
+#include "rgw_rest.h"
+#include "rgw_exporter.h"
+#include "rgw_rados.h"
+
 
 extern void init_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id);
 

--- a/src/rgw/rgw_exporter.cc
+++ b/src/rgw/rgw_exporter.cc
@@ -1,0 +1,123 @@
+#include "rgw_exporter.h"
+#include "rgw_common.h"
+#include "rgw_user.h"
+#include "rgw_bucket.h"
+#include "common/ceph_context.h"
+#include "common/perf_counters.h"
+#include <sys/stat.h>
+#include <unistd.h>
+#include <thread>
+#include <chrono>
+#include <lmdb.h>
+
+RGWExporter *g_rgw_exporter = nullptr;
+
+RGWExporter::RGWExporter(CephContext *cct_, RGWRados *store_)
+  : cct(cct_), store(store_), env(nullptr), env_open(false), usage_updater(nullptr) {}
+
+RGWExporter::~RGWExporter() {
+  stop();
+}
+
+void RGWExporter::start() {
+  std::string base_dir = cct->_conf->rgw_posix_data;
+  if (base_dir.empty()) base_dir = "/var/lib/ceph/radosgw";
+  std::string fsid = store->getRadosHandle() ? store->getRadosHandle()->get_fsid() : "default";
+  std::string db_path = base_dir + "/" + fsid + "/rgw_usage";
+  ::mkdir((base_dir + "/" + fsid).c_str(), 0755);
+  ::mkdir(db_path.c_str(), 0755);
+
+  int rc = mdb_env_create(&env);
+  if (rc != 0) return;
+  mdb_env_set_mapsize(env, 128 * 1024 * 1024);
+  mdb_env_set_maxdbs(env, 2);
+  rc = mdb_env_open(env, db_path.c_str(), 0, 0664);
+  if (rc != 0) {
+    mdb_env_close(env);
+    env = nullptr;
+    return;
+  }
+  MDB_txn *txn;
+  rc = mdb_txn_begin(env, nullptr, 0, &txn);
+  if (rc == 0) {
+    mdb_dbi_open(txn, "user_usage", MDB_CREATE, &user_dbi);
+    mdb_dbi_open(txn, "bucket_usage", MDB_CREATE, &bucket_dbi);
+    mdb_txn_commit(txn);
+    env_open = true;
+  }
+
+  uint64_t interval = cct->_conf->rgw_usage_update_interval;
+  if (interval == 0) interval = 43200; // default 12h
+  usage_updater = new std::thread(&RGWExporter::run_updater, this, interval);
+}
+
+void RGWExporter::stop() {
+  if (usage_updater) {
+    stop_flag.store(true);
+    usage_updater->join();
+    delete usage_updater;
+    usage_updater = nullptr;
+  }
+  if (env) {
+    mdb_dbi_close(env, user_dbi);
+    mdb_dbi_close(env, bucket_dbi);
+    mdb_env_close(env);
+    env = nullptr;
+    env_open = false;
+  }
+}
+
+void RGWExporter::run_updater(uint64_t interval_sec) {
+  while (!stop_flag.load()) {
+    std::this_thread::sleep_for(std::chrono::seconds(interval_sec));
+    if (stop_flag.load()) break;
+    update_usage();
+  }
+}
+
+void RGWExporter::update_usage() {
+  if (!env_open || !env) return;
+  MDB_txn *txn;
+  int rc = mdb_txn_begin(env, NULL, 0, &txn);
+  if (rc != 0) return;
+
+  std::vector<std::string> users;
+  if (store->list_users(users) < 0) {
+    mdb_txn_abort(txn);
+    return;
+  }
+
+  for (const auto& uid : users) {
+    RGWUserInfo user_info;
+    if (store->get_user_info(uid, &user_info, true) < 0) continue;
+    uint64_t num_objs = user_info.stats.num_objects;
+    uint64_t num_bytes = user_info.stats.size_actual;
+    MDB_val key, val;
+    key.mv_data = (void*)uid.data(); key.mv_size = uid.size();
+    uint64_t data[2] = {num_objs, num_bytes};
+    val.mv_data = data; val.mv_size = sizeof(data);
+    mdb_put(txn, user_dbi, &key, &val, 0);
+    // update perf counter
+    // perf->set(..., num_objs, {"user", uid}); etc.
+  }
+
+  std::vector<std::string> buckets;
+  if (store->list_all_buckets(buckets) < 0) {
+    mdb_txn_abort(txn);
+    return;
+  }
+
+  for (const auto& bucket_name : buckets) {
+    RGWBucketInfo info;
+    if (store->get_bucket_info(bucket_name, &info, true) < 0) continue;
+    std::string key_str = info.bucket.name;
+    MDB_val key, val;
+    key.mv_data = (void*)key_str.data(); key.mv_size = key_str.size();
+    uint64_t data[2] = {info.stats.num_objects, info.stats.size_actual};
+    val.mv_data = data; val.mv_size = sizeof(data);
+    mdb_put(txn, bucket_dbi, &key, &val, 0);
+    // update perf counter
+  }
+
+  mdb_txn_commit(txn);
+}

--- a/src/rgw/rgw_exporter.h
+++ b/src/rgw/rgw_exporter.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <lmdb.h>
+#include "rgw_common.h"
+#include "common/ceph_context.h"
+
+// Struct to hold usage metrics counters for a bucket or user
+struct RGWUsageStats {
+  uint64_t put_obj_ops = 0;
+  uint64_t put_obj_bytes = 0;
+  uint64_t get_obj_ops = 0;
+  uint64_t get_obj_bytes = 0;
+  uint64_t del_obj_ops = 0;
+};
+
+// Forward declaration
+class RGWUsageCache;
+
+class RGWExporter {
+public:
+  RGWExporter(CephContext *cct, RGWRados *store);
+  ~RGWExporter();
+
+  void update_usage();  // Periodically called to refresh perf counters
+  void shutdown();      // Closes LMDB environment
+};
+
+class RGWUsageCache {
+public:
+  RGWUsageCache() : env(nullptr) {}
+  ~RGWUsageCache();
+
+  int open(const std::string& path);
+  void close();
+  int get_bucket_stats(const std::string& bucket_key, RGWUsageStats *stats);
+  int get_user_stats(const std::string& user_key, RGWUsageStats *stats);
+  int put_bucket_stats(const std::string& bucket_key, const RGWUsageStats& stats);
+  int put_user_stats(const std::string& user_key, const RGWUsageStats& stats);
+
+private:
+  MDB_env *env;
+  MDB_dbi dbi_bucket;
+  MDB_dbi dbi_user;
+  std::mutex write_lock;
+
+  int put(MDB_dbi dbi, const std::string& key, const RGWUsageStats& stats);
+  int get(MDB_dbi dbi, const std::string& key, RGWUsageStats *stats);
+};
+
+extern RGWExporter *g_rgw_exporter;

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -30,6 +30,7 @@
 #include "rgw_lua.h"
 #include "rgw_dmclock_scheduler_ctx.h"
 #include "rgw_ratelimit.h"
+#include "rgw_exporter.h"
 
 
 class RGWPauser : public RGWRealmReloader::Pauser {
@@ -55,6 +56,8 @@ namespace rgw {
 
 namespace lua { class Background; }
 namespace sal { class ConfigStore; }
+
+extern RGWExporter *g_rgw_exporter;
 
 class RGWLib;
 class AppMain {

--- a/src/rgw/rgw_perf_counters.h
+++ b/src/rgw/rgw_perf_counters.h
@@ -49,6 +49,12 @@ enum {
   l_rgw_lua_script_ok,
   l_rgw_lua_script_fail,
 
+  // Usage metrics counters (per-user and per-bucket)
+  l_rgw_user_used_bytes,
+  l_rgw_user_num_objects,
+  l_rgw_bucket_used_bytes,
+  l_rgw_bucket_num_objects,
+  
   l_rgw_last,
 };
 

--- a/src/rgw/rgw_usage_cache.cc
+++ b/src/rgw/rgw_usage_cache.cc
@@ -1,0 +1,163 @@
+#include "rgw_usage_cache.h"
+#include "include/ceph_assert.h"
+
+namespace {
+  std::string format_user_key(const std::string& key) {
+    return key.rfind("user:", 0) == 0 ? key : "user:" + key;
+  }
+}
+
+RGWUsageCache::RGWUsageCache(CephContext *cct_, const std::string& path)
+    : cct(cct_), db_path(path), env(nullptr), dbi(0) {}
+
+RGWUsageCache::~RGWUsageCache() {
+    close();
+}
+
+int RGWUsageCache::init() {
+    int ret = mdb_env_create(&env);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: failed to create LMDB env: " << mdb_strerror(ret) << dendl;
+        return ret;
+    }
+
+    mdb_env_set_mapsize(env, 128ULL * 1024 * 1024);
+
+    ret = mdb_env_open(env, db_path.c_str(), MDB_NOSUBDIR, 0700);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: failed to open LMDB env at " << db_path << ": " << mdb_strerror(ret) << dendl;
+        mdb_env_close(env);
+        env = nullptr;
+        return ret;
+    }
+
+    MDB_txn *txn;
+    ret = mdb_txn_begin(env, nullptr, 0, &txn);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_txn_begin failed: " << mdb_strerror(ret) << dendl;
+        mdb_env_close(env);
+        env = nullptr;
+        return ret;
+    }
+
+    ret = mdb_dbi_open(txn, nullptr, MDB_CREATE, &dbi);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_dbi_open failed: " << mdb_strerror(ret) << dendl;
+        mdb_txn_abort(txn);
+        mdb_env_close(env);
+        env = nullptr;
+        return ret;
+    }
+
+    ret = mdb_txn_commit(txn);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_txn_commit failed: " << mdb_strerror(ret) << dendl;
+        mdb_env_close(env);
+        env = nullptr;
+        return ret;
+    }
+
+    ldout(cct, 20) << "RGWUsageCache: LMDB environment initialized at " << db_path << dendl;
+    return 0;
+}
+
+void RGWUsageCache::close() {
+    if (env) {
+        mdb_dbi_close(env, dbi);
+        mdb_env_close(env);
+        env = nullptr;
+    }
+}
+
+int RGWUsageCache::clear() {
+    ceph_assert(env);
+    MDB_txn *txn;
+    int ret = mdb_txn_begin(env, nullptr, 0, &txn);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_txn_begin (clear) failed: " << mdb_strerror(ret) << dendl;
+        return ret;
+    }
+
+    ret = mdb_drop(txn, dbi, 0);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_drop failed: " << mdb_strerror(ret) << dendl;
+        mdb_txn_abort(txn);
+        return ret;
+    }
+
+    ret = mdb_txn_commit(txn);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_txn_commit (clear) failed: " << mdb_strerror(ret) << dendl;
+    }
+    return ret;
+}
+
+int RGWUsageCache::put_bucket_stats(const std::string& bucket_key, const RGWUsageStats& stats) {
+    ceph_assert(env);
+    MDB_val key, val;
+    key.mv_data = (void*)bucket_key.c_str();
+    key.mv_size = bucket_key.size();
+    uint64_t data[2] = { stats.used_bytes, stats.num_objects };
+    val.mv_data = data;
+    val.mv_size = sizeof(data);
+
+    std::lock_guard<std::mutex> lock(write_lock);
+    MDB_txn *txn;
+    int ret = mdb_txn_begin(env, nullptr, 0, &txn);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_txn_begin (put) failed: " << mdb_strerror(ret) << dendl;
+        return ret;
+    }
+
+    ret = mdb_put(txn, dbi, &key, &val, 0);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_put failed for key " << bucket_key << ": " << mdb_strerror(ret) << dendl;
+        mdb_txn_abort(txn);
+        return ret;
+    }
+
+    ret = mdb_txn_commit(txn);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_txn_commit failed for key " << bucket_key << ": " << mdb_strerror(ret) << dendl;
+    }
+
+    return ret;
+}
+
+int RGWUsageCache::put_user_stats(const std::string& user_key, const RGWUsageStats& stats) {
+    return put_bucket_stats(format_user_key(user_key), stats);
+}
+
+bool RGWUsageCache::get_bucket_stats(const std::string& bucket_key, RGWUsageStats *out) {
+    ceph_assert(env);
+    ceph_assert(out);
+    MDB_txn *txn;
+
+    int ret = mdb_txn_begin(env, nullptr, MDB_RDONLY, &txn);
+    if (ret != 0) {
+        ldout(cct, 0) << "ERROR: mdb_txn_begin (get) failed: " << mdb_strerror(ret) << dendl;
+        return false;
+    }
+
+    MDB_val key, val;
+    key.mv_data = (void*)bucket_key.c_str();
+    key.mv_size = bucket_key.size();
+
+    ret = mdb_get(txn, dbi, &key, &val);
+    if (ret == 0 && val.mv_size == sizeof(uint64_t) * 2) {
+        uint64_t *data = static_cast<uint64_t*>(val.mv_data);
+        out->used_bytes = data[0];
+        out->num_objects = data[1];
+        mdb_txn_abort(txn);
+        return true;
+    } else if (ret != MDB_NOTFOUND) {
+        ldout(cct, 0) << "ERROR: mdb_get failed for key " << bucket_key << ": " << mdb_strerror(ret) << dendl;
+    }
+
+    mdb_txn_abort(txn);
+    return false;
+}
+
+bool RGWUsageCache::get_user_stats(const std::string& user_key, RGWUsageStats *out) {
+    return get_bucket_stats(format_user_key(user_key), out);
+}

--- a/src/rgw/rgw_usage_cache.h
+++ b/src/rgw/rgw_usage_cache.h
@@ -1,0 +1,47 @@
+#ifndef RGW_USAGE_CACHE_H
+#define RGW_USAGE_CACHE_H
+
+#include <string>
+#include <mutex>
+#include <lmdb.h>
+#include "common/ceph_context.h"
+
+struct RGWUsageStats {
+  uint64_t used_bytes = 0;
+  uint64_t num_objects = 0;
+};
+
+/**
+ * RGWUsageCache manages an LMDB-backed key-value store for storing
+ * per-bucket and per-user usage statistics (bytes used, object count).
+ * Keys are stored as strings (e.g., "bucket:..."/"user:...").
+ */
+class RGWUsageCache {
+public:
+  RGWUsageCache(CephContext* cct, const std::string& path);
+  ~RGWUsageCache();
+
+  int init();    // Initialize LMDB env and DB
+  void close();  // Close LMDB env
+  int clear();   // Wipe the database
+
+  // Store stats
+  int put_bucket_stats(const std::string& bucket_key, const RGWUsageStats& stats);
+  int put_user_stats(const std::string& user_key, const RGWUsageStats& stats);
+
+  // Fetch stats
+  bool get_bucket_stats(const std::string& bucket_key, RGWUsageStats* out);
+  bool get_user_stats(const std::string& user_key, RGWUsageStats* out);
+
+private:
+  CephContext* cct;
+  std::string db_path;
+
+  MDB_env* env;
+  MDB_dbi dbi;
+  std::mutex write_lock;  // ensures one writer at a time
+
+  // No persistent txn member
+};
+
+#endif // RGW_USAGE_CACHE_H

--- a/src/rgw/rgw_usage_manager.cc
+++ b/src/rgw/rgw_usage_manager.cc
@@ -1,0 +1,130 @@
+#include "rgw_usage_manager.h"
+#include "rgw_common.h"
+#include "rgw_rados.h"
+#include "common/ceph_context.h"
+#include "common/perf_counters.h"
+#include "common/ceph_time.h"
+#include <pthread.h>
+
+RGWUsageManager::RGWUsageManager(CephContext *cct_, RGWUsageCache *cache, PerfCounters *logger)
+    : cct(cct_), usage_cache(cache), perf_logger(logger),
+      stopping(false) {
+    refresh_interval = cct->_conf->rgw_usage_cache_refresh_interval;
+}
+
+RGWUsageManager::~RGWUsageManager() {
+    stop();
+    delete usage_cache;
+}
+
+void RGWUsageManager::start() {
+    refresh_thread = std::thread(&RGWUsageManager::run, this);
+}
+
+void RGWUsageManager::stop() {
+    bool expected = false;
+    if (!stopping.compare_exchange_strong(expected, true)) {
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> l(cond_lock);
+        cond.notify_one();
+    }
+    if (refresh_thread.joinable()) {
+        refresh_thread.join();
+    }
+}
+
+void RGWUsageManager::run() {
+    ceph_pthread_setname(pthread_self(), "rgw-usage-ref");
+    refresh_usage();
+    std::unique_lock<std::mutex> lk(cond_lock);
+    while (!stopping.load()) {
+        if (cond.wait_for(lk, ceph::make_timespan(refresh_interval), [this]() { return stopping.load(); })) {
+            break;
+        }
+        lk.unlock();
+        refresh_usage();
+        lk.lock();
+    }
+    ldout(cct, 10) << "RGWUsageManager thread exiting" << dendl;
+}
+
+void RGWUsageManager::update_perf_counter(int id, const std::map<std::string, std::string>& labels, uint64_t value) {
+    perf_logger->set(label_counter(id, labels), value);
+}
+
+void RGWUsageManager::refresh_usage() {
+    ldout(cct, 20) << "RGWUsageManager: refreshing usage metrics..." << dendl;
+
+    if (!usage_cache) {
+        ldout(cct, 0) << "ERROR: usage_cache not initialized" << dendl;
+        return;
+    }
+
+    RGWRados *store = g_rgw_store;
+    if (!store) {
+        ldout(cct, 0) << "ERROR: RGWRados store is null, cannot refresh usage" << dendl;
+        return;
+    }
+
+    usage_cache->clear();
+
+    std::map<std::string, RGWUsageStats> user_totals;
+    std::vector<std::string> users;
+
+    int ret = store->list_users(users);
+    if (ret < 0) {
+        ldout(cct, 0) << "ERROR: list_users failed: " << ret << dendl;
+        return;
+    }
+
+    for (const auto& user : users) {
+        std::vector<rgw_bucket> buckets;
+        int r = store->list_buckets(user, buckets);
+        if (r < 0) {
+            ldout(cct, 0) << "ERROR: list_buckets for user " << user << " failed: " << r << dendl;
+            continue;
+        }
+
+        for (auto& bucket_handle : buckets) {
+            RGWBucketInfo bucket_info;
+            int r2 = store->get_bucket_info(user, bucket_handle.name, bucket_info);
+            if (r2 < 0) {
+                ldout(cct, 0) << "ERROR: get_bucket_info for " << bucket_handle.name << " failed: " << r2 << dendl;
+                continue;
+            }
+
+            RGWUsageStats stats;
+            stats.num_objects = bucket_info.num_objects;
+            stats.used_bytes = bucket_info.size_utilized ? bucket_info.size_utilized : bucket_info.size;
+
+            std::string bucket_key = "bucket:" + bucket_info.owner.to_str() + "/" + bucket_info.bucket.name;
+            usage_cache->put_bucket_stats(bucket_key, stats);
+
+            std::map<std::string, std::string> labels = {
+                {"bucket", bucket_info.bucket.name},
+                {"user", bucket_info.owner.to_str()}
+            };
+            update_perf_counter(l_rgw_bucket_used_bytes, labels, stats.used_bytes);
+            update_perf_counter(l_rgw_bucket_num_objects, labels, stats.num_objects);
+
+            RGWUsageStats& agg = user_totals[bucket_info.owner.to_str()];
+            agg.used_bytes += stats.used_bytes;
+            agg.num_objects += stats.num_objects;
+        }
+    }
+
+    for (auto& kv : user_totals) {
+        const std::string& user_id = kv.first;
+        RGWUsageStats& total = kv.second;
+
+        usage_cache->put_user_stats(user_id, total);
+        std::map<std::string, std::string> ulabel = { {"user", user_id} };
+        update_perf_counter(l_rgw_user_used_bytes, ulabel, total.used_bytes);
+        update_perf_counter(l_rgw_user_num_objects, ulabel, total.num_objects);
+    }
+
+    ldout(cct, 20) << "RGWUsageManager: usage metrics refresh complete ("
+                   << user_totals.size() << " users updated)" << dendl;
+}

--- a/src/rgw/rgw_usage_manager.h
+++ b/src/rgw/rgw_usage_manager.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <thread>
+#include <atomic>
+#include <condition_variable>
+#include <map>
+#include <string>
+#include "rgw_usage_cache.h"
+#include "common/perf_counters.h"
+#include "common/ceph_context.h"
+
+// RGWUsageManager periodically refreshes usage metrics from RGWRados and
+// stores them in LMDB (via RGWUsageCache) and Prometheus PerfCounters.
+class RGWUsageManager {
+public:
+    RGWUsageManager(CephContext *cct, RGWUsageCache *cache, PerfCounters *logger);
+    ~RGWUsageManager();
+
+    // Start the background refresh thread
+    void start();
+
+    // Signal the thread to stop and wait for it to join
+    void stop();
+
+    // Virtual hook (used for tests/mocking): updates a single perf counter
+    virtual void update_perf_counter(int id,
+                                     const std::map<std::string, std::string>& labels,
+                                     uint64_t value);
+
+private:
+    CephContext *cct;
+    RGWUsageCache *usage_cache;
+    PerfCounters *perf_logger;
+
+    std::thread refresh_thread;
+    std::atomic<bool> stopping;
+    std::condition_variable cond;
+    std::mutex cond_lock;
+
+    unsigned refresh_interval;  // in seconds, from config
+
+    // Thread entrypoint
+    void run();
+
+    // Refreshes bucket/user usage stats from RGWRados and writes to LMDB + perfcounters
+    void refresh_usage();
+};

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -5,6 +5,10 @@
 
 #include "include/types.h"
 #include "rgw_user.h"
+#include "rgw_sal.h"
+#include "rgw_exporter.h"
+#include "rgw_rados.h"
+#include "rgw_bucket.h"
 
 // until everything is moved from rgw_common
 #include "rgw_common.h"
@@ -110,3 +114,18 @@ void rgw_get_anon_user(RGWUserInfo& info)
   info.access_keys.clear();
 }
 
+int RGWUser::get_usage_stats(uint64_t *num_objs, uint64_t *total_bytes) {
+  if (!store || !g_rgw_exporter) {
+    return -EINVAL;
+  }
+
+  RGWUsageStats stats;
+  int ret = g_rgw_exporter->get_user_usage(this->user, &stats);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *num_objs = stats.num_objects;
+  *total_bytes = stats.used_bytes;
+  return 0;
+}

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -213,6 +213,21 @@ add_executable(unittest_rgw_throttle test_rgw_throttle.cc)
 add_ceph_unittest(unittest_rgw_throttle)
 target_link_libraries(unittest_rgw_throttle ${rgw_libs} ${UNITTEST_LIBS})
 
+# === Unit Tests for RGW Usage Metrics ===
+add_executable(unittest_rgw_usage_cache test_usage_cache.cc)
+add_ceph_unittest(unittest_rgw_usage_cache)
+target_include_directories(unittest_rgw_usage_cache
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_usage_cache
+  ${rgw_libs} ${UNITTEST_LIBS} ${LMDB_LIBRARIES})
+
+add_executable(unittest_rgw_usage_manager test_usage_manager.cc)
+add_ceph_unittest(unittest_rgw_usage_manager)
+target_include_directories(unittest_rgw_usage_manager
+  SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_usage_manager
+  ${rgw_libs} ${UNITTEST_LIBS} ${LMDB_LIBRARIES})
+
 add_executable(unittest_rgw_iam_policy test_rgw_iam_policy.cc)
 add_ceph_unittest(unittest_rgw_iam_policy)
 target_link_libraries(unittest_rgw_iam_policy

--- a/src/test/rgw/test_usage_cache.cc
+++ b/src/test/rgw/test_usage_cache.cc
@@ -1,0 +1,44 @@
+#include "gtest/gtest.h"
+#include "rgw_usage_cache.h"
+#include <cstdio>
+
+class RGWUsageCacheTest : public ::testing::Test {
+protected:
+  std::string db_path = "/tmp/rgw_test_lmdb";
+  CephContext *cct = nullptr;
+  RGWUsageCache *cache = nullptr;
+
+  void SetUp() override {
+    cct = (new CephContext(CephContext::get_module_type("test")));
+    cache = new RGWUsageCache(cct, db_path);
+    ASSERT_EQ(cache->init(), 0);
+  }
+
+  void TearDown() override {
+    if (cache) {
+      cache->close();
+      delete cache;
+    }
+    if (cct) {
+      delete cct;
+    }
+    std::string cmd = "rm -rf " + db_path;
+    system(cmd.c_str());
+  }
+};
+
+TEST_F(RGWUsageCacheTest, PutAndGetBucketUsage) {
+  RGWUsageStats stats_in{1234, 56}, stats_out;
+  ASSERT_EQ(cache->put_bucket_usage("bucket:foo/bar", stats_in), 0);
+  ASSERT_TRUE(cache->get_bucket_usage("bucket:foo/bar", &stats_out));
+  EXPECT_EQ(stats_out.used_bytes, 1234);
+  EXPECT_EQ(stats_out.num_objects, 56);
+}
+
+TEST_F(RGWUsageCacheTest, PutAndGetUserUsage) {
+  RGWUsageStats stats_in{7890, 100}, stats_out;
+  ASSERT_EQ(cache->put_user_usage("user:alice", stats_in), 0);
+  ASSERT_TRUE(cache->get_user_usage("user:alice", &stats_out));
+  EXPECT_EQ(stats_out.used_bytes, 7890);
+  EXPECT_EQ(stats_out.num_objects, 100);
+}

--- a/src/test/rgw/test_usage_manager.cc
+++ b/src/test/rgw/test_usage_manager.cc
@@ -1,0 +1,48 @@
+#include "gtest/gtest.h"
+#include "rgw_usage_manager.h"
+#include "common/perf_counters.h"
+
+class DummyPerfLogger : public PerfCounters {
+public:
+  DummyPerfLogger() : PerfCounters(nullptr, "dummy", 0, 1) {}
+  void set(int id, uint64_t v) override {
+    last_id = id;
+    last_val = v;
+  }
+  int last_id = -1;
+  uint64_t last_val = 0;
+};
+
+class RGWUsageManagerTest : public ::testing::Test {
+protected:
+  CephContext *cct = nullptr;
+  RGWUsageCache *cache = nullptr;
+  DummyPerfLogger *logger = nullptr;
+  RGWUsageManager *manager = nullptr;
+
+  void SetUp() override {
+    cct = (new CephContext(CephContext::get_module_type("test")));
+    cache = new RGWUsageCache(cct, "/tmp/rgw_test_mgr");
+    ASSERT_EQ(cache->init(), 0);
+    logger = new DummyPerfLogger();
+    manager = new RGWUsageManager(cct, cache, logger);
+  }
+
+  void TearDown() override {
+    if (manager) {
+      manager->stop();
+      delete manager;
+    }
+    delete logger;
+    delete cache;
+    delete cct;
+    system("rm -rf /tmp/rgw_test_mgr");
+  }
+};
+
+TEST_F(RGWUsageManagerTest, StartAndStopThread) {
+  manager->start();
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  manager->stop();
+  SUCCEED();
+}


### PR DESCRIPTION


This PR introduces a robust, low-overhead mechanism to track and expose bucket- and user-level usage statistics (used bytes and object count) in Ceph RGW using:
PerfCounters (Ceph's built-in metrics collection framework)
LMDB (lightweight embedded key-value store)
A background refresh thread that periodically scans RGW metadata
The feature is designed to avoid real-time computation overhead while supporting accurate and low-latency access to usage data via the admin socket.

Key Components
1. RGWExporter (new)
Singleton class controlling this feature
Initializes LMDB-backed RGWUsageCache and launches the background RGWUsageManager
Started/stopped during RGW lifecycle (rgw_main.cc)

2. RGWUsageCache
Encapsulates a single LMDB database for usage stats
Provides API to put/get usage stats for users and buckets

3. RGWUsageManager
Background thread that:
Lists all users and their buckets
Collects num_objects and used_bytes from RGWRados metadata
Updates LMDB cache and corresponding PerfCounters
Refresh interval controlled via config: rgw_usage_cache_refresh_interval (seconds)

4. PerfCounters Integration
Exposed counters:
bucket_used_bytes, bucket_num_objects
user_used_bytes, user_num_objects
Tagged using PerfCounter label API:
{ "User": "<uid>" }, { "Bucket": "<bucket>" }

Unit Tests
Added test_rgw_usage_exporter.cc under src/test/rgw:
Creates a temporary LMDB store
Writes and verifies usage stats for both users and buckets


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
