### PR TITLE
doc/cephadm: edit host-management.rst

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -228,34 +228,35 @@ The following host labels have a special meaning to cephadm.  All start with ``_
 Maintenance Mode
 ================
 
-Putting a host into "maintenance mode" stops all Ceph daemons on the host. Run
-a command of the following form to put a host into maintenance mode or to take
-a host out of maintenance mode: 
+Putting a host into *maintenance mode* stops all Ceph daemons on the host.
+Run a command of the following form to put a host into maintenance mode or
+to take a host out of maintenance mode: 
 
 .. prompt:: bash #
 
    ceph orch host maintenance enter <hostname> [--force] [--yes-i-really-mean-it]
    ceph orch host maintenance exit <hostname> [--force] [--offline]
 
-* Adding the ``--force`` flag to the ``enter`` command allows the user to bypass
-  warnings (but not alerts). 
-* Adding the ``--yes-i-really-mean-it`` flag to the ``enter`` command bypasses
-  all safety checks and makes an attempt to force the host into maintenance
-  mode.
-* Adding the ``--force`` and ``--offline`` flags to the ``exit`` command cause
-  cephadm to mark hosts that are in maintenance mode and offline as no longer
-  in maintenance mode. Note that if the host comes online, the Ceph daemons on
-  the host will remain in the stopped state. The ``--force`` and ``--offline``
-  flags of the ``exit`` command are meant to be run on hosts that are in
-  maintenance mode and that are permanently offline prior to the removal of
-  those hosts from cephadm management by running the ``ceph orch host rm``
-  command.
+* Adding the ``--force`` flag to the ``enter`` command allows the user to
+  bypass warnings (but not alerts). 
+* Adding the ``--yes-i-really-mean-it`` flag to the ``enter`` command
+  bypasses all safety checks and makes an attempt to force the host into
+  maintenance mode.
+* Adding the ``--force`` and ``--offline`` flags to the ``exit`` command
+  causes cephadm to mark hosts that are in maintenance mode and offline as
+  no longer in maintenance mode. Note that if the host comes online, the
+  Ceph daemons on the host will remain in the stopped state. The ``--force``
+  and ``--offline`` flags of the ``exit`` command are meant to be run on
+  hosts that are in maintenance mode and that are permanently offline prior
+  to the removal of those hosts from cephadm management by running the
+  ``ceph orch host rm`` command.
 
 .. warning:: Using the ``--yes-i-really-mean-it`` flag to force the host to
-   enter maintenance mode can cause loss of data availability, breakdown of the
-   mon quorum due to too few running monitors, unresponsive mgr module commands
-   (such as ``ceph orch . . .`` commands), and other issues. Use this flag only
-   if you're absolutely certain that you know what you're doing.
+   enter maintenance mode can cause loss of data availability, breakdown of
+   the mon quorum due to too few running monitors, unresponsive Manager
+   module commands (such as ``ceph orch . . .`` commands), and other issues.
+   Use this flag only if you're absolutely certain that you know what you're
+   doing.
 
 See also :ref:`cephadm-fqdn`
 


### PR DESCRIPTION
Make the improvements to doc/cephadm/host-management.rst that Anthony D'Atri suggested in https://github.com/ceph/ceph/pull/62600.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

