### PR TITLE
reef: .github: Fix RTD build retrigger

### DIFF
--- a/.github/workflows/retrigger-rtd.yml
+++ b/.github/workflows/retrigger-rtd.yml
@@ -1,0 +1,42 @@
+name: Retrigger Read the Docs Build
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  retrigger-rtd:
+    if: github.event.issue.pull_request &&
+        (contains(github.event.comment.body, 'jenkins test docs') || 
+         contains(github.event.comment.body, 'jenkins rebuild docs') || 
+         contains(github.event.comment.body, 'jenkins retrigger docs'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract PR Branch Name
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_BRANCH=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${PR_URL}" | jq -r .head.ref)
+          echo "PR_BRANCH=${PR_BRANCH}" >> $GITHUB_ENV
+          echo "Detected PR Branch: ${PR_BRANCH}"
+
+      - name: Send Webhook to Read the Docs
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg ref "refs/heads/${{ env.PR_BRANCH }}" \
+            --arg repo "${{ github.event.repository.name }}" \
+            --arg owner "${{ github.repository_owner }}" \
+            '{event: "push", ref: $ref, repository: {name: $repo, owner: {login: $owner}}}')
+
+          SECRET="${{ secrets.READTHEDOCS_API_TOKEN }}"
+          SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
+
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
+            -d "$PAYLOAD" \
+            ${{ secrets.READTHEDOCS_WEBHOOK_URL }}

--- a/.github/workflows/retrigger-rtd.yml
+++ b/.github/workflows/retrigger-rtd.yml
@@ -1,4 +1,4 @@
-name: Retrigger Read the Docs Build
+name: Retrigger RTD build on PR comment
 
 on:
   issue_comment:
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  issues: read
   pull-requests: read
 
 jobs:
@@ -16,27 +15,11 @@ jobs:
          contains(github.event.comment.body, 'jenkins rebuild docs') || 
          contains(github.event.comment.body, 'jenkins retrigger docs'))
     runs-on: ubuntu-latest
+
     steps:
-      - name: Extract PR Branch Name
+      - name: Trigger Read the Docs build
         run: |
-          PR_URL="${{ github.event.issue.pull_request.url }}"
-          PR_BRANCH=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${PR_URL}" | jq -r .head.ref)
-          echo "PR_BRANCH=${PR_BRANCH}" >> $GITHUB_ENV
-          echo "Detected PR Branch: ${PR_BRANCH}"
-
-      - name: Send Webhook to Read the Docs
-        run: |
-          PAYLOAD=$(jq -n \
-            --arg ref "refs/heads/${{ env.PR_BRANCH }}" \
-            --arg repo "${{ github.event.repository.name }}" \
-            --arg owner "${{ github.repository_owner }}" \
-            '{event: "push", ref: $ref, repository: {name: $repo, owner: {login: $owner}}}')
-
-          SECRET="${{ secrets.READTHEDOCS_API_TOKEN }}"
-          SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
-
           curl -X POST \
-            -H "Content-Type: application/json" \
-            -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
-            -d "$PAYLOAD" \
-            ${{ secrets.READTHEDOCS_WEBHOOK_URL }}
+            "https://readthedocs.org/api/v3/projects/ceph/versions/${{ github.event.issue.number }}/builds/" \
+            -H "Authorization: Token ${{ secrets.READTHEDOCS_API_TOKEN }}" \
+            -H "Content-Type: application/json"


### PR DESCRIPTION

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
