### PR TITLE
mgr/cephadm: During upgrade if NFS cluster is using old nodeids, keep using old node ids

### DIFF
--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -1,11 +1,13 @@
 import json
 import re
 import logging
-from typing import TYPE_CHECKING, Iterator, Optional, Dict, Any, List
+from typing import TYPE_CHECKING, Iterator, Optional, Dict, Any, List, cast
 
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec, RGWSpec, CertificateSource
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec, RGWSpec, CertificateSource, NFSServiceSpec
 from cephadm.schedule import HostAssignment
 from cephadm.utils import SpecialHostLabels
+from cephadm.services.nfs import NFSService
+from cephadm.services.service_registry import service_registry
 import rados
 from mgr_util import get_cert_issuer_info
 
@@ -15,7 +17,7 @@ from orchestrator import OrchestratorError, DaemonDescription
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 8
+LAST_MIGRATION = 9
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +123,11 @@ class Migrations:
             logger.info('Running migration 7 -> 8')
             if self.migrate_7_8():
                 self.set(8)
+
+        if self.mgr.migration_current == 8 and not startup:
+            logger.info('Running migration 8 -> 9')
+            if self.migrate_8_9():
+                self.set(9)
 
     def migrate_0_1(self) -> bool:
         """
@@ -529,6 +536,30 @@ class Migrations:
         except Exception as e:
             logger.error(f"Promtail -> Alloy migration failed: {e}")
             return False
+
+    def migrate_8_9(self) -> bool:
+        # For NFS, check if nfs cluster is using old types of node ids (service_name.0)
+        # if yes, then store those daemons in mon store, to continue using old node ids for those daemons
+        nfs_services = []
+        service_specs = self.mgr.spec_store.get_specs_by_type('nfs')
+        nfs_service = cast(NFSService, service_registry.get_service('nfs'))
+        try:
+            for service_name, spec in service_specs.items():
+                # get grace tool dump
+                out = nfs_service.run_grace_tool(cast(NFSServiceSpec, spec), 'dump')
+                if service_name in out:
+                    nfs_services.append(service_name)
+                    logger.info(f'NFS service {nfs_service} needs to maintain old node ids after upgrade')
+        except Exception as e:
+            logger.exception(f'Got error while executing grace tool: {e}')
+            self.mgr.set_health_warning('CEPHADM_MIGRATION_FAILURE',
+                                        f'Cephadm migration failed: {e}',
+                                        1, [str(e)])
+            return False
+        if nfs_services:
+            self.mgr.set_store('nfs_services_with_old_nodeid', ','.join(nfs_services))
+        self.mgr.remove_health_warning('CEPHADM_MIGRATION_FAILURE')
+        return True
 
 
 def queue_migrate_rgw_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]) -> None:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3265,9 +3265,16 @@ Then run the following:
                 for h, ls in osds_msg.items():
                     msg += f'\thost {h}: {" ".join([f"osd.{id}" for id in ls])}'
                 raise OrchestratorError(
-                    f'If {service_name} is removed then the following OSDs '
-                    f'will remain, --force to proceed anyway\n{msg}'
-                )
+                    f'If {service_name} is removed then the following OSDs will remain, --force to proceed anyway\n{msg}')
+        elif service_name.startswith('nfs.'):
+            # check if its using old node id style and remove from mon store
+            nfs_services = self.get_store('nfs_services_with_old_nodeid')
+            if nfs_services:
+                nfs_services = nfs_services.split(',')
+                if service_name in nfs_services:
+                    nfs_services.remove(service_name)
+                    val = ','.join(nfs_services) if nfs_services else None
+                    self.set_store('nfs_services_with_old_nodeid', val)
 
         spec = self.spec_store[service_name].spec
         CephadmServe(self)._remove_service_config(spec)

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -92,7 +92,7 @@ class NFSService(CephService):
                 for daemon_id in m.values():
                     if daemon_id is not None:
                         self.fence(daemon_id)
-                nodeid = f'{rank}'
+                nodeid = self.get_daemon_nodeid(spec.service_name(), rank)
                 self.mgr.log.info(
                     "Removing %s from the ganesha grace table for service %s", nodeid, service_name
                 )
@@ -144,6 +144,12 @@ class NFSService(CephService):
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         return daemon_spec
 
+    def get_daemon_nodeid(self, service_name: str, rank: Optional[int]) -> str:
+        out = self.mgr.get_store('nfs_services_with_old_nodeid')
+        if out and service_name in out.split(','):
+            return f'{service_name}.{rank}'
+        return str(rank)
+
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         super().prepare_certificates(daemon_spec)
@@ -152,7 +158,7 @@ class NFSService(CephService):
         host = daemon_spec.host
         spec = cast(NFSServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
 
-        nodeid = f'{daemon_spec.rank}'
+        nodeid = self.get_daemon_nodeid(spec.service_name(), daemon_spec.rank)
 
         nfs_idmap_conf = '/etc/ganesha/idmap.conf'
 
@@ -266,7 +272,8 @@ class NFSService(CephService):
                 "tls_ktls": spec.tls_ktls,
                 "tls_debug": spec.tls_debug,
                 "ceph_nodes": ceph_nodes,
-                "protocols": "3, 4" if spec.enable_nfsv3 else "4"
+                "protocols": "3, 4" if spec.enable_nfsv3 else "4",
+                "use_old_nodeid": False if nodeid.isdigit() else True
             }
             if spec.enable_haproxy_protocol:
                 context["haproxy_hosts"] = self._haproxy_hosts()
@@ -403,7 +410,7 @@ class NFSService(CephService):
     def run_grace_tool(self,
                        spec: NFSServiceSpec,
                        action: str,
-                       nodeid: str) -> None:
+                       nodeid: str = '') -> str:
         # write a temp keyring and referencing config file.  this is a kludge
         # because the ganesha-grace-tool can only authenticate as a client (and
         # not a mgr).  Also, it doesn't allow you to pass a keyring location via
@@ -445,9 +452,10 @@ class NFSService(CephService):
                         'Ignore ganesha-rados-grace tool remove failure as %s does not exists for %s service',
                         nodeid, spec.service_name()
                     )
-                    return
+                    return ''
 
                 raise RuntimeError(f'grace tool failed for service {spec.service_name()}: {stderr}')
+            return result.stdout.decode("utf-8")
 
         finally:
             self.mgr.check_mon_command({

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -43,7 +43,7 @@ NFSv4 {
 
 RADOS_KV {
         UserId = "{{ user }}";
-        nodeid = {{ nodeid }};
+        nodeid = "{{ nodeid }}";
         pool = "{{ pool }}";
         namespace = "{{ namespace }}";
 }
@@ -74,6 +74,12 @@ RGW {
         name = "client.{{ rgw_user }}";
 }
 
+{% if use_old_nodeid %}
+Ceph {
+	Use_old_uuid = true;
+}
+
+{% endif %}
 {% if tls_add %}
 TLS_CONFIG{
         Enable_TLS = {{ tls_add }};

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -1210,7 +1210,7 @@ class TestIngressService:
             '\n'
             'RADOS_KV {\n'
             '        UserId = "nfs.foo.test.0.0";\n'
-            '        nodeid = 0;\n'
+            '        nodeid = "0";\n'
             '        pool = ".nfs";\n'
             '        namespace = "foo";\n'
             '}\n'

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -216,6 +216,7 @@ def test_migrate_service_id_mds_one(cephadm_module: CephadmOrchestrator):
         assert len(cephadm_module.spec_store.all_specs) == 0
 
 
+@mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
 def test_migrate_nfs_initial(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1'):
@@ -249,6 +250,7 @@ def test_migrate_nfs_initial(cephadm_module: CephadmOrchestrator):
         assert cephadm_module.migration_current == LAST_MIGRATION
 
 
+@mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
 def test_migrate_nfs_initial_octopus(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1'):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/71509
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph nfs cluster create mynfs '*'
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS   RUNNING  REFRESHED  AGE  PLACEMENT  
crash                                  3/3  5s ago     10m  *          
mgr                                    2/2  5s ago     10m  count:2    
mon                                    3/5  5s ago     10m  count:5    
nfs.mynfs                  ?:2049      3/3  5s ago     21s  *          
osd.all-available-devices                6  5s ago     9m   *          
[ceph: root@ceph-node-0 /]#  ganesha-rados-grace --pool '.nfs' --ns mynfs dump
cur=4 rec=0
======================================================
nfs.mynfs.0	  
nfs.mynfs.1	  
nfs.mynfs.2	  
[ceph: root@ceph-node-0 /]#

[ceph: root@ceph-node-0 /]# ceph orch upgrade status
{
    "in_progress": true,
    "target_image": "quay.io/rh-ee-shbhosal/ceph@sha256:e4cce2111686132df4a452a5e2cbc5f06c15630355265703fbc0fe1cc2e58f65",
    "services_complete": [
        "mgr",
        "nfs",
        "mon",
        "crash",
        "mds",
        "osd"
    ],
    "which": "Upgrading all daemon types on all hosts",
    "progress": "19/19 daemons upgraded",
    "message": "Currently upgrading nfs daemons",
    "is_paused": false
}

RADOS_KV {
        UserId = "nfs.mynfs.0.1.ceph-node-0.qiimud";
        nodeid = "nfs.mynfs.0";
        pool = ".nfs";
        namespace = "mynfs";
}
Ceph {
        Use_old_uuid = true;
}

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
