### PR TITLE
reef: doc/mgr: Small improvements in rgw.rst

### DIFF
--- a/doc/mgr/rgw.rst
+++ b/doc/mgr/rgw.rst
@@ -2,7 +2,7 @@
 
 RGW Module
 ============
-The rgw module provides a simple interface to deploy RGW multisite.
+The ``rgw`` module provides a simple interface to deploy RGW :ref:`multisite`.
 It helps with bootstrapping and configuring RGW realm, zonegroup and
 the different related entities.
 
@@ -17,19 +17,19 @@ To enable the ``rgw`` module, run the following command:
 
 
 RGW Realm Operations
------------------------
+--------------------
 
 Bootstrapping RGW realm creates a new RGW realm entity, a new zonegroup,
 and a new zone. It configures a new system user that can be used for
 multisite sync operations. Under the hood this module instructs the
 orchestrator to create and deploy the corresponding RGW daemons. The module
-supports both passing the arguments through the cmd line or as a spec file:
+supports passing the arguments through the command line or as a spec file:
 
 .. prompt:: bash #
 
    ceph rgw realm bootstrap [--realm-name] [--zonegroup-name] [--zone-name] [--port] [--placement] [--start-radosgw]
 
-The command supports providing the configuration through a spec file (`-i option`):
+The command supports configuration through a spec file (``-i`` option):
 
 .. prompt:: bash #
 
@@ -49,11 +49,12 @@ Following is an example of RGW multisite spec file:
   spec:
     rgw_frontend_port: 5500
 
-.. note:: The spec file used by RGW has the same format as the one used by the orchestrator. Thus,
-          the user can provide any orchestration supported rgw parameters including advanced
-          configuration features such as SSL certificates etc.
+.. note:: RGW multisite spec files follow the same format as cephadm
+          orchestrator spec files. Thus the user can specify any supported RGW
+          parameters including advanced configuration features such as SSL
+          certificates etc.
 
-Users can also specify custom zone endpoints in the spec (or through the cmd line). In this case, no
+Users can also specify custom zone endpoints in the spec (or through the command line). In this case, no
 cephadm daemons will be launched. Following is an example RGW spec file with zone endpoints:
 
 .. code-block:: yaml
@@ -91,7 +92,7 @@ the ``ceph rgw realm tokens`` output:
 
 User can use the token to pull a realm to create secondary zone on a
 different cluster that syncs with the master zone on the primary cluster
-by using `ceph rgw zone create` command and providing the corresponding token.
+by using ``ceph rgw zone create`` command and providing the corresponding token.
 
 Following is an example of zone spec file:
 
@@ -112,7 +113,7 @@ Following is an example of zone spec file:
   ceph rgw zone create -i zone-spec.yaml
 
 .. note:: The spec file used by RGW has the same format as the one used by the orchestrator. Thus,
-          the user can provide any orchestration supported rgw parameters including advanced
+          the user can provide any orchestration supported RGW parameters including advanced
           configuration features such as SSL certificates etc.
 
 Commands
@@ -122,7 +123,7 @@ Commands
 
    ceph rgw realm bootstrap -i spec.yaml
 
-Create a new realm + zonegroup + zone and deploy rgw daemons via the
+Create a new realm + zonegroup + zone and deploy RGW daemons via the
 orchestrator using the information specified in the YAML file.
 
 .. prompt:: bash #
@@ -141,21 +142,19 @@ Join an existing realm by creating a new secondary zone (using the realm token)
 
    ceph rgw admin [*]
 
-RGW admin command
-
-Upgrading root ca certificates
+Upgrading Root CA Certificates
 ------------------------------
 
 #. Make sure that the RGW service is running.
 #. Make sure that the RGW service is up.
 #. Make sure that the RGW service has been upgraded to the latest release.
-#. From the Primary cluster on the Manager node, run the following command:
+#. From the primary cluster on the Manager node, run the following command:
 
    .. prompt:: bash #
 
       ceph orch cert-store get cert cephadm_root_ca_cert
 
-#. On the node where the RGW service is running, store the certificate on the
+#. On the nodes where the RGW service is running, store the certificate on the
    following path::
 
       /etc/pki/ca-trust/source/anchors/<cert_name>.crt
@@ -166,8 +165,8 @@ Upgrading root ca certificates
 
       openssl x509 -in <cert_name>.crt -noout -text
 
-#. Perform the above steps on the MGR node and on the RGW node of all secondary
-   clusters.
+#. Perform the above steps on the Manager node and on the RGW nodes of all
+   secondary clusters.
 
 #. After the certificates have been validated on all clusters, run the
    following command on all clusters that generate certificates: 
@@ -176,7 +175,7 @@ Upgrading root ca certificates
 
       update-ca-trust
 
-#. From the primary node, ensure that the ``curl`` command can be run by the
+#. From the primary cluster, ensure that the ``curl`` command can be run by the
    user:
 
    .. prompt:: bash [user@primary-node]$ 


### PR DESCRIPTION
Use double backticks consistently for module name, CLI commands and parameters etc.

Use title case in section titles and underline them only until end of title text.

Use "command line" instead of "cmd line" in text.

Capitalize RGW consistently.

Delete one paragraph that included a strange out of place text fragment.

Call it "Manager" consistently instead of "MGR" in text one time.

Improve language in CA cert upgrade.


(cherry picked from commit 7a3c6b563bb39e2adde4d3211cb603161fd46f02)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

