### PR TITLE
crimson/common/fatal_signal: Rework signals

### DIFF
--- a/src/crimson/common/assert.cc
+++ b/src/crimson/common/assert.cc
@@ -8,6 +8,8 @@
 
 #include "crimson/common/log.h"
 
+SET_SUBSYS(osd);
+
 namespace ceph {
   [[gnu::cold]] void __ceph_assert_fail(const ceph::assert_data &ctx)
   {
@@ -18,12 +20,8 @@ namespace ceph {
                                         const char* file, int line,
                                         const char* func)
   {
-    seastar::logger& logger = crimson::get_logger(0);
-    logger.error("{}:{} : In function '{}', ceph_assert(%s)\n"
-                 "{}",
-                 file, line, func, assertion,
-                 seastar::current_backtrace());
-    std::cout << std::flush;
+    GENERIC_ERROR("{}:{} : In function '{}', ceph_assert({})\n",
+                  file, line, func, assertion);
     abort();
   }
   [[gnu::cold]] void __ceph_assertf_fail(const char *assertion,
@@ -37,25 +35,15 @@ namespace ceph {
     std::vsnprintf(buf, sizeof(buf), msg, args);
     va_end(args);
 
-    seastar::logger& logger = crimson::get_logger(0);
-    logger.error("{}:{} : In function '{}', ceph_assert(%s)\n"
-                 "{}\n{}\n",
-                 file, line, func, assertion,
-                 buf,
-                 seastar::current_backtrace());
-    std::cout << std::flush;
+    GENERIC_ERROR("{}:{} : In function '{}', ceph_assert({})\n {}\n",
+                 file, line, func, assertion, buf);
     abort();
   }
 
   [[gnu::cold]] void __ceph_abort(const char* file, int line,
                                   const char* func, const std::string& msg)
   {
-    seastar::logger& logger = crimson::get_logger(0);
-    logger.error("{}:{} : In function '{}', abort(%s)\n"
-                 "{}",
-                 file, line, func, msg,
-                 seastar::current_backtrace());
-    std::cout << std::flush;
+    GENERIC_ERROR("{}:{} : In function '{}', abort({})\n", file, line, func, msg);
     abort();
   }
 
@@ -69,12 +57,8 @@ namespace ceph {
     std::vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
 
-    seastar::logger& logger = crimson::get_logger(0);
-    logger.error("{}:{} : In function '{}', abort()\n"
-                 "{}\n{}\n",
-                 file, line, func,
-                 buf,
-                 seastar::current_backtrace());
+    GENERIC_ERROR("{}:{} : In function '{}', abort()\n {}\n",
+                  file, line, func, buf);
     std::cout << std::flush;
     abort();
   }

--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -110,7 +110,7 @@ void FatalSignal::install_oneshot_signal_handler()
   //       see handle_fatal_signal()
 }
 
-static void print_segv_info(const siginfo_t& siginfo)
+[[maybe_unused]] static void print_segv_info(const siginfo_t& siginfo)
 {
   std::cerr \
      << "Dump of siginfo:" << std::endl
@@ -139,7 +139,7 @@ static void print_segv_info(const siginfo_t& siginfo)
   std::cerr << std::flush;
 }
 
-static void print_proc_maps()
+[[maybe_unused]] static void print_proc_maps()
 {
   const int fd = ::open("/proc/self/maps", O_RDONLY);
   if (fd < 0) {
@@ -168,17 +168,20 @@ static void print_proc_maps()
 [[gnu::noinline]] void FatalSignal::signaled(const int signum,
                                              const siginfo_t& siginfo)
 {
+  // Commented out for clean backtrace logs,
+  // can be used if needed:
+  // print_proc_maps();
+  // print_segv_info(siginfo);
+
   switch (signum) {
   case SIGSEGV:
-    print_backtrace("Segmentation fault");
-    print_segv_info(siginfo);
+    print_backtrace("Got SIGSEGV");
     break;
   case SIGABRT:
-    print_backtrace("Aborting");
+    print_backtrace("Got SIGABRT");
     break;
   default:
-    print_backtrace(fmt::format("Signal {}", signum));
+    print_backtrace(fmt::format("Got signal {}", signum));
     break;
   }
-  print_proc_maps();
 }

--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -7,12 +7,22 @@
 #include <iostream>
 #include <string_view>
 
+// boost is able to translate addresses
+// to lines with the following definition.
+// Similar to Seastar's seastar-addr2line
 #define BOOST_STACKTRACE_USE_ADDR2LINE
+
+// Consider std once C++23 is available
 #include <boost/stacktrace.hpp>
+
 #include <seastar/core/reactor.hh>
+
+#include "crimson/common/log.h"
 
 #include "common/safe_io.h"
 #include "include/scope_guard.h"
+
+SET_SUBSYS(osd);
 
 FatalSignal::FatalSignal()
 {
@@ -78,22 +88,24 @@ void FatalSignal::install_oneshot_signal_handler()
   assert(r == 0);
 }
 
-
 [[gnu::noinline]] static void print_backtrace(std::string_view cause) {
-  std::cerr << cause;
-  if (seastar::engine_is_ready()) {
-    std::cerr << " on shard " << seastar::this_shard_id();
-  }
   // nobody wants to see things like `FatalSignal::signaled()` or
   // `print_backtrace()` in our backtraces. `+ 1` is for the extra
   // frame created by kernel (signal trampoline, it will take care
   // about e.g. sigreturn(2) calling; see the man page).
-  constexpr std::size_t FRAMES_TO_SKIP = 3 + 1;
-  std::cerr << ".\nBacktrace:\n";
-  std::cerr << boost::stacktrace::stacktrace(
+  constexpr std::size_t FRAMES_TO_SKIP = 2 + 1;
+
+  std::string backtrace = fmt::format("{} on shard {}  \nBacktrace:\n {}",
+    cause,
+    seastar::engine_is_ready() ? std::to_string(seastar::this_shard_id()) : "no shard",
+    boost::stacktrace::to_string(boost::stacktrace::stacktrace(
     FRAMES_TO_SKIP,
-    static_cast<std::size_t>(-1)/* max depth same as the default one */);
-  std::cerr << std::flush;
+    static_cast<std::size_t>(-1)/* max depth same as the default one */)));
+
+  // Print backtrace in log and in std out
+  GENERIC_ERROR("{}", backtrace);
+  std::cerr << backtrace << std::flush;
+
   // TODO: dump crash related meta data to $crash_dir
   //       see handle_fatal_signal()
 }

--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -95,6 +95,17 @@ void FatalSignal::install_oneshot_signal_handler()
   // about e.g. sigreturn(2) calling; see the man page).
   constexpr std::size_t FRAMES_TO_SKIP = 2 + 1;
 
+  // Let's inform regarding the abort before getting the stacktrace
+   std::string pre_backtrace = fmt::format(
+    "Aborting {} on shard {} - Stopping all shards",
+    cause,
+    seastar::engine_is_ready() ? std::to_string(seastar::this_shard_id()) : "no shard");
+
+  GENERIC_ERROR("{}", pre_backtrace);
+  std::cerr << pre_backtrace << std::flush;
+
+  seastar::engine().exit(1);
+
   std::string backtrace = fmt::format("{} on shard {}  \nBacktrace:\n {}",
     cause,
     seastar::engine_is_ready() ? std::to_string(seastar::this_shard_id()) : "no shard",

--- a/src/crimson/common/log.h
+++ b/src/crimson/common/log.h
@@ -48,6 +48,8 @@ static inline seastar::log_level to_log_level(int level) {
 #define LOGGER(subname_) crimson::get_logger(ceph_subsys_##subname_)
 #define LOG_PREFIX(x) constexpr auto FNAME = #x
 
+#define GENERIC_LOG(level_, MSG, ...) \
+  LOCAL_LOGGER.log(level_, MSG , ##__VA_ARGS__)
 #define LOG(level_, MSG, ...) \
   LOCAL_LOGGER.log(level_, "{}: " MSG, FNAME , ##__VA_ARGS__)
 #define SUBLOG(subname_, level_, MSG, ...) \
@@ -80,6 +82,7 @@ static inline seastar::log_level to_log_level(int level) {
 #define SUBWARNI(subname_, ...) SUBLOGI(subname_, seastar::log_level::warn, __VA_ARGS__)
 
 #define ERROR(...) LOG(seastar::log_level::error, __VA_ARGS__)
+#define GENERIC_ERROR(...) GENERIC_LOG(seastar::log_level::error, __VA_ARGS__)
 #define ERRORI(...) LOGI(seastar::log_level::error, __VA_ARGS__)
 #define SUBERROR(subname_, ...) SUBLOG(subname_, seastar::log_level::error, __VA_ARGS__)
 #define SUBERRORI(subname_, ...) SUBLOGI(subname_, seastar::log_level::error, __VA_ARGS__)


### PR DESCRIPTION
Currently  crashes caused by signals are *very* hard to detect, we only get a "Segmentation fault" which gets hidden in random log lines from other shards due to missing newlines:
```
Segmentation faultDEBUG 2025-05-29 12:03:35,878 [shard 2:main]
seastore_t - ...
```

Rework aborting from signals path to be more informative. 

See segfaults trackers examples below:
https://tracker.ceph.com/issues/66818
https://tracker.ceph.com/issues/71457





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
