### PR TITLE
rgw: add new zone filter support for bucket notifications

### DIFF
--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -515,20 +515,29 @@ Parameters are XML encoded in the body of the request, in the following format:
                    <FilterRule>
                        <Name></Name>
                        <Value></Value>
+                       <Exclude></Exclude>
                    </FilterRule>
                 </S3Key>
                 <S3Metadata>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Exclude></Exclude>
                     </FilterRule>
                 </S3Metadata>
                 <S3Tags>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Exclude></Exclude>
                     </FilterRule>
                 </S3Tags>
+                <S3Zones>
+                    <FilterRule>
+                        <Name></Name>
+                        <Exclude></Exclude>
+                    </FilterRule>
+                </S3Zones>
             </Filter>
        </TopicConfiguration>
    </NotificationConfiguration>
@@ -563,19 +572,30 @@ Parameters are XML encoded in the body of the request, in the following format:
 |                               |           | All filter rules in the list must match the tags defined on the object. However,     |          |
 |                               |           | the object still match it it has other tags not listed in the filter.                |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Key.FilterRule``          | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would  be: ``prefix``, ``suffix``  | Yes      |
-|                               |           | or ``regex``. The ``Value`` would hold the key prefix, key suffix or a regular       |          |
-|                               |           | expression for matching the key, accordingly.                                        |          |
+| ``S3Key.FilterRule``          | Container | Holding ``Name``, ``Value`` and ``Exclude`` entities. ``Name`` would  be: ``prefix``,| Yes      |
+|                               |           | ``suffix``, or ``regex``. The ``Value`` would hold the key prefix, key suffix        |          |
+|                               |           | or a regular expression for matching the key, accordingly. The ``Exclude`` entity is |          |
+|                               |           | optional, and can hold ``true`` or ``false``. It defaults to ``false`` if            |          |
+|                               |           | unspecified. ``false`` means the key must match the rule, ``true`` means the key     |          |
+|                               |           | must not match the rule.                                                             |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Metadata.FilterRule``     | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would be the name of the metadata  | Yes      |
-|                               |           | attribute (e.g. ``x-amz-meta-xxx``). The ``Value`` would be the expected value for   |          |
-|                               |           | this attribute.                                                                      |          |
+| ``S3Metadata.FilterRule``     | Container | Holding ``Name``, ``Value`` and ``Exclude`` entities. ``Name`` would be the name of  | Yes      |
+|                               |           | the metadata attribute (e.g., ``x-amz-meta-xxx``). The ``Value`` would be the        |          |
+|                               |           | expected value for this attribute. The ``Exclude`` entity is  optional, and can hold |          |
+|                               |           | ``true`` or ``false``. It defaults to ``false`` if unspecified. ``false``            |          |
+|                               |           | means the key must match the rule,  ``true`` means the key must not match the rule.  |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-| ``S3Tags.FilterRule``         | Container | Holding ``Name`` and ``Value`` entities. ``Name`` would be the tag key,              |  Yes     |
-|                               |           | and ``Value`` would be the tag value.                                                |          |
+| ``S3Tags.FilterRule``         | Container | Holding ``Name``, ``Value`` and ``Exclude`` entities. ``Name`` would be the tag key, | Yes      |
+|                               |           | and ``Value`` would be the tag value. The ``Exclude`` entity is  optional, and can   |          |
+|                               |           | hold ``true`` or ``false``. It defaults to ``false`` if unspecified. ``false``       |          |
+|                               |           | means the key must match the rule,  ``true`` means the key must not match the rule.  |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
-
-
+| ``S3Zones.FilterRule``        | Container | Holding ``Name`` and ``Exclude`` entities. ``Name`` would be the zone name,          |  Yes     |
+|                               |           | ``Exclude`` determines if a zone is to be exclude. The ``Exclude`` entity is         |          |
+|                               |           | optional, and can  hold ``true`` or ``false``. It defaults to ``false``              |          |
+|                               |           | if unspecified. ``false`` means the zone is not honored,  ``true`` means             |          |
+|                               |           | the zone is honored.                                                                 |          |
++-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
 HTTP Response
 ~~~~~~~~~~~~~
 
@@ -668,20 +688,29 @@ The response is XML encoded in the body of the request, in the following format:
                    <FilterRule>
                        <Name></Name>
                        <Value></Value>
+                       <Exclude></Exclude>
                    </FilterRule>
                 </S3Key>
                 <S3Metadata>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Exclude></Exclude>
                     </FilterRule>
                 </S3Metadata>
                 <S3Tags>
                     <FilterRule>
                         <Name></Name>
                         <Value></Value>
+                        <Exclude></Exclude>
                     </FilterRule>
                 </S3Tags>
+                <S3Zones>
+                    <FilterRule>
+                        <Name></Name>
+                        <Exclude></Exclude>
+                    </FilterRule>
+                </S3Zones>
             </Filter>
        </TopicConfiguration>
    </NotificationConfiguration>

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -81,7 +81,7 @@
 	"S3RepSource": {
 	    "type": "structure",
 	    "members": {
-                "Zones": {
+                "S3Zones": {
                     "shape":"ZoneList",
                     "documentation":"<p>Array of replication source zone names.</p>",
 		    "locationName":"Zone"
@@ -90,7 +90,7 @@
         },
 	"Destination": {
 	    "members": {
-                "Zones": {
+                "S3Zones": {
                     "shape":"ZoneList",
                     "documentation":"<p>Array of replication destination zone names.</p>",
 		    "locationName":"Zone"
@@ -193,6 +193,10 @@
                 "Value":{
                     "shape":"FilterRuleValue",
                     "documentation":"<p>The value that the filter searches for in object key names.</p>"
+                }, 
+                "Exclude": {
+                    "shape":"FilterRuleExclude",
+                    "documentation":"<p>Exclude Flag for filter rule. If true, acts as negative filter. Defaults to false.</p>"
                 }
             },
             "documentation":"<p>Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix, prefix or regex of the key name.</p>"
@@ -204,6 +208,9 @@
                 "suffix",
                 "regex"
             ]
+        },
+        "FilterRuleExclude":{
+            "type":"boolean"
         },
         "NotificationConfigurationFilter":{
             "type":"structure",
@@ -222,8 +229,12 @@
                     "shape":"S3TagsFilter",
                     "documentation":"<p/>",
                     "locationName":"S3Tags"
+                }, 
+                "S3Zones":{
+                    "shape":"S3ZonesFilter",
+                    "documentation":"<p/>",
+                    "locationName":"S3Zones"
                 }
-
             },
             "documentation":"<p>Specifies object key name filtering rules. For information about key name filtering, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html\">Configuring Event Notifications</a> in the <i>Amazon Simple Storage Service Developer Guide</i>.</p>"
         },
@@ -259,6 +270,16 @@
                 }
             },
             "documentation":"<p>A container for object tags filtering rules.</p>"
+        },
+        "S3ZonesFilter": {
+            "type":"structure",
+            "members":{
+                "FilterRules":{
+                    "shape":"FilterRuleList",
+                    "documentation":"<p/>",
+                    "locationName":"FilterRule"
+                }
+            }
         },
         "GetUsageStatsOutput": {
             "type": "structure",

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -1049,7 +1049,7 @@ static inline bool notification_match(reservation_t& res,
     return false;
   }
 
-  if (!filter.s3_filter.metadata_filter.kv.empty()) {
+  if (filter.s3_filter.metadata_filter.has_content()) {
     // metadata filter exists
     if (res.s) {
       filter_amz_meta(res.x_meta_map, res.s->info.x_meta_map);
@@ -1060,7 +1060,7 @@ static inline bool notification_match(reservation_t& res,
     }
   }
 
-  if (!filter.s3_filter.tag_filter.kv.empty()) {
+  if (filter.s3_filter.tag_filter.has_content()) {
     // tag filter exists
     if (req_tags) {
       // tags in the request
@@ -1079,6 +1079,14 @@ static inline bool notification_match(reservation_t& res,
       if (!match(filter.s3_filter.tag_filter, tags)) {
         return false;
       }
+    }
+  }
+
+  if (filter.s3_filter.zone_filter.has_content()) {
+    //zone filter exists
+    const std::string &zone_name = res.store->get_zone()->get_name();
+    if(!match(filter.s3_filter.zone_filter, zone_name)) {
+      return false;
     }
   }
 

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -26,18 +26,21 @@ struct rgw_pubsub_topic_filter;
         <FilterRule>
           <Name>suffix</Name>
           <Value>jpg</Value>
+          <Exclude></Exclude>
         </FilterRule>
       </S3Key>
       <S3Metadata>
         <FilterRule>
           <Name></Name>
           <Value></Value>
+          <Exclude></Exclude>
         </FilterRule>
       </S3Metadata>
       <S3Tags>
         <FilterRule>
           <Name></Name>
           <Value></Value>
+          <Exclude></Exclude>
         </FilterRule>
       </S3Tags>
     </Filter>

--- a/src/rgw/rgw_s3_filter.h
+++ b/src/rgw/rgw_s3_filter.h
@@ -14,59 +14,9 @@ struct rgw_s3_key_filter {
   std::string suffix_rule;
   std::string regex_rule;
 
-  bool has_content() const;
-
-  void dump(Formatter *f) const;
-  bool decode_xml(XMLObj *obj);
-  void dump_xml(Formatter *f) const;
-
-  void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
-      encode(prefix_rule, bl);
-      encode(suffix_rule, bl);
-      encode(regex_rule, bl);
-    ENCODE_FINISH(bl);
-  }
-
-  void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
-      decode(prefix_rule, bl);
-      decode(suffix_rule, bl);
-      decode(regex_rule, bl);
-    DECODE_FINISH(bl);
-  }
-};
-WRITE_CLASS_ENCODER(rgw_s3_key_filter)
-
-using KeyValueMap = boost::container::flat_map<std::string, std::string>;
-using KeyMultiValueMap = std::multimap<std::string, std::string>;
-
-struct rgw_s3_key_value_filter {
-  KeyValueMap kv;
-
-  bool has_content() const;
-
-  void dump(Formatter *f) const;
-  bool decode_xml(XMLObj *obj);
-  void dump_xml(Formatter *f) const;
-
-  void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
-      encode(kv, bl);
-    ENCODE_FINISH(bl);
-  }
-  void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
-      decode(kv, bl);
-    DECODE_FINISH(bl);
-  }
-};
-WRITE_CLASS_ENCODER(rgw_s3_key_value_filter)
-
-struct rgw_s3_filter {
-  rgw_s3_key_filter key_filter;
-  rgw_s3_key_value_filter metadata_filter;
-  rgw_s3_key_value_filter tag_filter;
+  bool is_prefix_negative{false};
+  bool is_suffix_negative{false};
+  bool is_regex_negative{false};
 
   bool has_content() const;
 
@@ -76,18 +26,133 @@ struct rgw_s3_filter {
 
   void encode(bufferlist& bl) const {
     ENCODE_START(2, 1, bl);
-      encode(key_filter, bl);
-      encode(metadata_filter, bl);
-      encode(tag_filter, bl);
+      encode(prefix_rule, bl);
+      encode(suffix_rule, bl);
+      encode(regex_rule, bl);
+      encode(is_prefix_negative, bl);
+      encode(is_suffix_negative, bl);
+      encode(is_regex_negative, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
     DECODE_START(2, bl);
+      decode(prefix_rule, bl);
+      decode(suffix_rule, bl);
+      decode(regex_rule, bl);
+      if(struct_v >= 2) {
+        decode(is_prefix_negative, bl); 
+        decode(is_suffix_negative, bl); 
+        decode(is_regex_negative, bl);
+      }
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(rgw_s3_key_filter)
+
+using KeyValueMap = boost::container::flat_map<std::string, std::string>;
+//add this type for negative filter support - ensure v2 structs encoded as (key, (value, is_negative)) 
+using KeyValueExcludePairMap = boost::container::flat_map<std::string, std::pair<std::string,bool>>;
+using KeyMultiValueMap = std::multimap<std::string, std::string>;
+
+struct rgw_s3_key_value_filter {
+  // key -> {value, is_negative} ; Exclude -> true; is_negative is true, else false
+  KeyValueExcludePairMap kve; 
+  bool has_content() const;
+
+  void dump(Formatter *f) const;
+  bool decode_xml(XMLObj *obj);
+  void dump_xml(Formatter *f) const;
+
+  void encode(bufferlist& bl) const {
+    KeyValueMap kv; 
+    for(const auto& it: kve){
+      //pa => stores is_negative flag -> emplace to kv only if is_negative is false
+      if(!it.second.second) {
+        kv.emplace(it.first, it.second.first);
+      }
+    }
+    ENCODE_START(2, 1, bl);
+    encode(kv, bl);
+    encode(kve, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    KeyValueMap kv;
+    DECODE_START(2, bl);
+      decode(kv, bl);
+      if(struct_v >= 2) {
+        decode(kve, bl);
+      }
+      else {   
+        // convert kv to kvt for correct matching based on type for v1 structs
+        //type stores is_negative flag
+        for (const auto& it : kv) {
+          kve.emplace(it.first, std::make_pair(it.second, false));
+        }
+      }
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(rgw_s3_key_value_filter)
+
+struct rgw_s3_zone_filter {
+  std::vector<std::string> in_list; 
+  std::vector<std::string> out_list; 
+
+  bool has_content() const;
+
+  void dump(Formatter *f) const;
+  bool decode_xml(XMLObj *obj);
+  void dump_xml(Formatter *f) const;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+      encode(in_list, bl);
+      encode(out_list, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+      decode(in_list, bl);
+      decode(out_list, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(rgw_s3_zone_filter)
+
+struct rgw_s3_filter {
+  rgw_s3_key_filter key_filter;
+  rgw_s3_key_value_filter metadata_filter;
+  rgw_s3_key_value_filter tag_filter;
+  rgw_s3_zone_filter zone_filter;
+
+  bool has_content() const;
+
+  void dump(Formatter *f) const;
+  bool decode_xml(XMLObj *obj);
+  void dump_xml(Formatter *f) const;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(3, 1, bl);
+      encode(key_filter, bl);
+      encode(metadata_filter, bl);
+      encode(tag_filter, bl);
+      encode(zone_filter, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(3, bl);
       decode(key_filter, bl);
       decode(metadata_filter, bl);
       if (struct_v >= 2) {
         decode(tag_filter, bl);
+      }
+      if (struct_v >= 3) {
+        decode(zone_filter, bl);
       }
     DECODE_FINISH(bl);
   }
@@ -99,5 +164,7 @@ bool match(const rgw_s3_key_filter& filter, const std::string& key);
 bool match(const rgw_s3_key_value_filter& filter, const KeyValueMap& kv);
 
 bool match(const rgw_s3_key_value_filter& filter, const KeyMultiValueMap& kv);
+
+bool match(const rgw_s3_zone_filter& filter, const std::string& zone);
 
 bool match(const rgw_s3_filter& filter, const rgw::sal::Object* obj);

--- a/src/test/rgw/bucket_notification/__init__.py
+++ b/src/test/rgw/bucket_notification/__init__.py
@@ -29,6 +29,9 @@ def setup():
     global default_zonegroup
     default_zonegroup = defaults.get("zonegroup")
 
+    global default_zonename
+    default_zonename = defaults.get("zonename")
+
     global default_cluster
     default_cluster = defaults.get("cluster")
 
@@ -60,6 +63,10 @@ def get_config_port():
 def get_config_zonegroup():
     global default_zonegroup
     return default_zonegroup
+
+def get_config_zonename():
+    global default_zonename
+    return default_zonename
 
 def get_config_cluster():
     global default_cluster

--- a/src/test/rgw/bucket_notification/bntests.conf.SAMPLE
+++ b/src/test/rgw/bucket_notification/bntests.conf.SAMPLE
@@ -2,6 +2,7 @@
 port = 8000
 host = localhost
 zonegroup = default
+zonename = default
 cluster = noname
 version = v2
 


### PR DESCRIPTION
this fix adds support for zone filter for bucket notifications. 

changes introduced: 
- add new struct `rgw_s3_zone_filter` for filtering based on zone, add relevant struct  methods and match function for zone filter
- add condition to match notification based on zone filter in `notification_match` method in `rgw_notify.cc`. 

Fixes: https://tracker.ceph.com/issues/68789
Signed-off-by: Adarsh Ashokan [dev.9401adarsh@gmail.com](mailto:dev.9401adarsh@gmail.com)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
