### PR TITLE
reef: doc/mgr: edit telemetry.rst

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -64,35 +64,45 @@ the way Ceph is used.
 
 Data is sent secured to *https://telemetry.ceph.com*.
 
-Individual channels can be enabled or disabled with::
+Individual channels can be enabled or disabled with:
 
-  ceph telemetry enable channel basic
-  ceph telemetry enable channel crash
-  ceph telemetry enable channel device
-  ceph telemetry enable channel ident
-  ceph telemetry enable channel perf
+.. prompt:: bash #
 
-  ceph telemetry disable channel basic
-  ceph telemetry disable channel crash
-  ceph telemetry disable channel device
-  ceph telemetry disable channel ident
-  ceph telemetry disable channel perf
+   ceph telemetry enable channel basic
+   ceph telemetry enable channel crash
+   ceph telemetry enable channel device
+   ceph telemetry enable channel ident
+   ceph telemetry enable channel perf
+  
+   ceph telemetry disable channel basic
+   ceph telemetry disable channel crash
+   ceph telemetry disable channel device
+   ceph telemetry disable channel ident
+   ceph telemetry disable channel perf
 
-Multiple channels can be enabled or disabled with::
+Multiple channels can be enabled or disabled with:
 
-  ceph telemetry enable channel basic crash device ident perf
-  ceph telemetry disable channel basic crash device ident perf
+.. prompt:: bash #
 
-Channels can be enabled or disabled all at once with::
+   ceph telemetry enable channel basic crash device ident perf
+   ceph telemetry disable channel basic crash device ident perf
 
-  ceph telemetry enable channel all
-  ceph telemetry disable channel all
+Channels can be enabled or disabled all at once with:
+
+.. prompt:: bash #
+
+   ceph telemetry enable channel all
+   ceph telemetry disable channel all
 
 Please note that telemetry should be on for these commands to take effect.
 
-List all channels with::
+List all channels with:
+
+.. prompt:: bash #
 
   ceph telemetry channel ls
+
+::
 
   NAME      ENABLED    DEFAULT    DESC
   basic     ON         ON         Share basic cluster information (size, version)
@@ -105,32 +115,40 @@ List all channels with::
 Enabling Telemetry
 ------------------
 
-To allow the *telemetry* module to start sharing data::
+To allow the *telemetry* module to start sharing data:
 
-  ceph telemetry on
+.. prompt:: bash #
+
+   ceph telemetry on
 
 Please note: Telemetry data is licensed under the Community Data License
 Agreement - Sharing - Version 1.0 (https://cdla.io/sharing-1-0/). Hence,
-telemetry module can be enabled only after you add '--license sharing-1-0' to
-the 'ceph telemetry on' command.
-Once telemetry is on, please consider enabling channels which are off by
-default, such as the 'perf' channel. 'ceph telemetry on' output will list the
-exact command to enable these channels.
+telemetry module can be enabled only after you add ``--license sharing-1-0`` to
+the ``ceph telemetry on`` command.  Once telemetry is on, please consider
+enabling channels which are off by default, such as the ``perf`` channel.
+``ceph telemetry on`` output will list the exact command to enable these
+channels.
 
-Telemetry can be disabled at any time with::
+Telemetry can be disabled at any time with:
 
-  ceph telemetry off
+.. prompt:: bash #
+
+   ceph telemetry off
 
 Sample report
 -------------
 
-You can look at what data is reported at any time with the command::
+You can look at what data is reported at any time with the command:
 
-  ceph telemetry show
+.. prompt:: bash #
 
-If telemetry is off, you can preview a sample report with::
+   ceph telemetry show
 
-  ceph telemetry preview
+If telemetry is off, you can preview a sample report with:
+
+.. prompt:: bash #
+
+   ceph telemetry preview
 
 Generating a sample report might take a few moments in big clusters (clusters
 with hundreds of OSDs or more).
@@ -138,50 +156,69 @@ with hundreds of OSDs or more).
 To protect your privacy, device reports are generated separately, and data such
 as hostname and device serial number is anonymized. The device telemetry is
 sent to a different endpoint and does not associate the device data with a
-particular cluster. To see a preview of the device report use the command::
+particular cluster. To see a preview of the device report use the command:
 
-  ceph telemetry show-device
+.. prompt:: bash #
 
-If telemetry is off, you can preview a sample device report with::
+   ceph telemetry show-device
 
-  ceph telemetry preview-device
+If telemetry is off, you can preview a sample device report with:
+
+.. prompt:: bash #
+
+   ceph telemetry preview-device
 
 Please note: In order to generate the device report we use Smartmontools
-version 7.0 and up, which supports JSON output. 
-If you have any concerns about privacy with regard to the information included in
-this report, please contact the Ceph developers.
+version 7.0 and up, which supports JSON output.  If you have any concerns about
+privacy with regard to the information included in this report, please contact
+the Ceph developers.
 
-In case you prefer to have a single output of both reports, and telemetry is on, use::
+In case you prefer to have a single output of both reports, and telemetry is
+on, use:
 
-  ceph telemetry show-all
+.. prompt:: bash #
 
-If you would like to view a single output of both reports, and telemetry is off, use::
+   ceph telemetry show-all
 
-  ceph telemetry preview-all
+If you would like to view a single output of both reports, and telemetry is
+off, use:
+
+.. prompt:: bash #
+
+   ceph telemetry preview-all
 
 **Sample report by channel**
 
-When telemetry is on you can see what data is reported by channel with::
+When telemetry is on you can see what data is reported by channel with:
 
-  ceph telemetry show <channel_name>
+.. prompt:: bash #
 
-Please note: If telemetry is on, and <channel_name> is disabled, the command
-above will output a sample report by that channel, according to the collections
-the user is enrolled to. However this data is not reported, since the channel
-is disabled.
+   ceph telemetry show <channel_name>
 
-If telemetry is off you can preview a sample report by channel with::
+Please note: If telemetry is on, and ``<channel_name>`` is disabled, the
+command above will output a sample report by that channel, according to the
+collections the user is enrolled to. However this data is not reported, since
+the channel is disabled.
+
+If telemetry is off you can preview a sample report by channel with:
+
+.. prompt:: bash #
 
   ceph telemetry preview <channel_name>
 
 Collections
 -----------
 
-Collections represent different aspects of data that we collect within a channel.
+Collections represent different aspects of data that we collect within a
+channel.
 
-List all collections with::
+List all collections with:
 
-  ceph telemetry collection ls
+.. prompt:: bash #
+
+   ceph telemetry collection ls
+
+::
 
   NAME                            STATUS                                               DESC
   basic_base                      NOT REPORTING: NOT OPTED-IN                          Basic information about the cluster (capacity, number and type of daemons, version, etc.)
@@ -208,66 +245,84 @@ is opted-in to this collection).
 **DESC**: General description of the collection.
 
 See the diff between the collections you are enrolled to, and the new,
-available collections with::
+available collections with:
 
-  ceph telemetry diff
+.. prompt:: bash #
 
-Enroll to the most recent collections with::
+   ceph telemetry diff
 
-  ceph telemetry on
+Enroll to the most recent collections with:
 
-Then enable new channels that are off with::
+.. prompt:: bash #
 
-  ceph telemetry enable channel <channel_name>
+   ceph telemetry on
+
+Then enable new channels that are off with:
+
+.. prompt:: bash #
+
+   ceph telemetry enable channel <channel_name>
 
 Interval
 --------
 
 The module compiles and sends a new report every 24 hours by default.
-You can adjust this interval with::
+You can adjust this interval with:
 
-  ceph config set mgr mgr/telemetry/interval 72    # report every three days
+.. prompt:: bash #
+
+   ceph config set mgr mgr/telemetry/interval 72    # report every three days
 
 Status
 --------
 
-The see the current configuration::
+The see the current configuration:
 
-  ceph telemetry status
+.. prompt:: bash #
+
+   ceph telemetry status
 
 Manually sending telemetry
 --------------------------
 
-To ad hoc send telemetry data::
+To ad hoc send telemetry data:
 
-  ceph telemetry send
+.. prompt:: bash #
 
-In case telemetry is not enabled (with 'ceph telemetry on'), you need to add
-'--license sharing-1-0' to 'ceph telemetry send' command.
+   ceph telemetry send
+
+In case telemetry is not enabled (with ``ceph telemetry on``), you need to add
+``--license sharing-1-0`` to the ``ceph telemetry send`` command.
 
 Sending telemetry through a proxy
 ---------------------------------
 
 If the cluster cannot directly connect to the configured telemetry
-endpoint (default *telemetry.ceph.com*), you can configure a HTTP/HTTPS
-proxy server with::
+endpoint (default ``telemetry.ceph.com``), you can configure a HTTP/HTTPS
+proxy server with:
 
-  ceph config set mgr mgr/telemetry/proxy https://10.0.0.1:8080
+.. prompt:: bash #
 
-You can also include a *user:pass* if needed::
+   ceph config set mgr mgr/telemetry/proxy https://10.0.0.1:8080
 
-  ceph config set mgr mgr/telemetry/proxy https://ceph:telemetry@10.0.0.1:8080
+You can also include a ``user:pass`` if needed:
+
+.. prompt:: bash #
+
+   ceph config set mgr mgr/telemetry/proxy https://ceph:telemetry@10.0.0.1:8080
 
 
 Contact and Description
 -----------------------
 
 A contact and description can be added to the report.  This is
-completely optional, and disabled by default.::
+completely optional, and disabled by default:
 
-  ceph config set mgr mgr/telemetry/contact 'John Doe <john.doe@example.com>'
-  ceph config set mgr mgr/telemetry/description 'My first Ceph cluster'
-  ceph config set mgr mgr/telemetry/channel_ident true
+.. prompt:: bash #
+
+   ceph config set mgr mgr/telemetry/contact 'John Doe <john.doe@example.com>'
+   ceph config set mgr mgr/telemetry/description 'My first Ceph cluster'
+   ceph config set mgr mgr/telemetry/channel_ident true
 
 Leaderboard
 -----------
@@ -275,7 +330,7 @@ Leaderboard
 To participate in a leaderboard in the `public dashboards
 <https://telemetry-public.ceph.com/>`_, run the following command:
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/telemetry/leaderboard true
 
@@ -283,7 +338,7 @@ The leaderboard displays basic information about the cluster. This includes the
 total storage capacity and the number of OSDs. To add a description of the
 cluster, run a command of the following form: 
 
-.. prompt:: bash $
+.. prompt:: bash #
 
    ceph config set mgr mgr/telemetry/leaderboard_description 'Ceph cluster for Computational Biology at the University of XYZ'
 


### PR DESCRIPTION
Edit doc/mgr/telemetry.rst.

The English in this file is unacceptably demotic and exhibits a curious but all-too-familiar lack here and there of definite articles.

This is part of a project to separate out the twenty-five files that were committed to https://github.com/ceph/ceph/pull/62782.


(cherry picked from commit be67afcfcb51d07251f8a2be86de8dd7f45c713f)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

