### PR TITLE
libcephfs: Bump API major version

### DIFF
--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -39,9 +39,9 @@ using CephContext = ceph::common::CephContext;
 extern "C" {
 #endif
 
-#define LIBCEPHFS_VER_MAJOR 10
-#define LIBCEPHFS_VER_MINOR 1
-#define LIBCEPHFS_VER_EXTRA 3
+#define LIBCEPHFS_VER_MAJOR 11
+#define LIBCEPHFS_VER_MINOR 0
+#define LIBCEPHFS_VER_EXTRA 0
 
 #define LIBCEPHFS_VERSION(maj, min, extra) ((maj << 16) + (min << 8) + extra)
 #define LIBCEPHFS_VERSION_CODE LIBCEPHFS_VERSION(LIBCEPHFS_VER_MAJOR, LIBCEPHFS_VER_MINOR, LIBCEPHFS_VER_EXTRA)


### PR DESCRIPTION
We recently had ABI changes https://github.com/ceph/ceph/pull/62934 with respect to APIs from _chown()_ family which calls for a change in major version. Native users of the library may not have to change their code but expected sizes differ when data type for parameters are changed. However go-ceph, Go bindings for ceph, couldn't build https://github.com/ceph/go-ceph/issues/1119 unless the ABI change is made visible to the consumers of the API. Following the Semantic Versioning [guidelines](https://semver.org/#spec-item-8) we reset minor and patch (extra) versions to 0.

Fixes: https://tracker.ceph.com/issues/71519