### PR TITLE
squid: qa/suites: wait longer before stopping OSDs with valgrind

### DIFF
--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -31,5 +31,6 @@ overrides:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
       mds: [--tool=memcheck]
+    stop-daemons-timeout: 1200
 # https://tracker.ceph.com/issues/38621
 #      mgr: [--tool=memcheck]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71542

---

backport of https://github.com/ceph/ceph/pull/62823
parent tracker: https://tracker.ceph.com/issues/62713

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh