### PR TITLE
tentacle: debian: radosgw: add media-types packages as alternative for mime-support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1044,7 +1044,7 @@ Package: radosgw
 Architecture: linux-any
 Depends: ceph-common (= ${binary:Version}),
          librgw2 (= ${binary:Version}),
-         mime-support,
+         media-types | mime-support,
          ${misc:Depends},
          ${shlibs:Depends},
 Suggests: gawk,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71564

---

backport of https://github.com/ceph/ceph/pull/63702
parent tracker: https://tracker.ceph.com/issues/71545

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh