### PR TITLE
doc/mgr: edit telemetry (1 of x)

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -4,26 +4,27 @@ Telemetry Module
 ================
 
 The telemetry module sends anonymous data about the cluster back to the Ceph
-developers to help understand how Ceph is used and what problems users may
-be experiencing.
+developers to report how Ceph is used and to report problems experienced by
+users. 
 
-This data is visualized on `public dashboards <https://telemetry-public.ceph.com/>`_
-that allow the community to quickly see summary statistics on how many clusters
-are reporting, their total capacity and OSD count, and version distribution
-trends.
+This data is visualized on `public dashboards
+<https://telemetry-public.ceph.com/>`_ that allow the community to see a
+summary of statistics including how many clusters are reporting, their total
+capacity and OSD count, and version distribution trends.
 
 Channels
 --------
 
 The telemetry report is broken down into several "channels", each with
-a different type of information.  Assuming telemetry has been enabled,
-individual channels can be turned on and off.  (If telemetry is off,
+a different type of information. If telemetry has been enabled,
+individual channels can be turned on and off. (If telemetry is off,
 the per-channel setting has no effect.)
 
 * **basic** (default: on): Basic information about the cluster
 
     - capacity of the cluster
-    - number of monitors, managers, OSDs, MDSs, object gateways, or other daemons
+    - number of monitors, managers, OSDs, MDSs, object gateways, or other
+      daemons
     - software version currently being used
     - number and types of RADOS pools and CephFS file systems
     - names of configuration options that have been changed from their
@@ -34,7 +35,7 @@ the per-channel setting has no effect.)
     - type of daemon
     - version of the daemon
     - operating system (OS distribution, kernel version)
-    - stack trace identifying where in the Ceph code the crash occurred
+    - stack trace, identifying where in the Ceph code the crash occurred
 
 * **device** (default: on): Information about device metrics, including
 
@@ -46,25 +47,28 @@ the per-channel setting has no effect.)
     - cluster description
     - contact email address
 
-* **perf** (default: off): Various performance metrics of a cluster, which can be used to
+* **perf** (default: off): Various performance metrics of a cluster, which can
+  be used to
 
     - reveal overall cluster health
     - identify workload patterns
     - troubleshoot issues with latency, throttling, memory management, etc.
     - monitor cluster performance by daemon
 
-The data being reported does *not* contain any sensitive
-data like pool names, object names, object contents, hostnames, or device
-serial numbers.
+The reported data does *not* contain any sensitive data. This means that the
+reported data does not include pool names, object names, object contents,
+hostnames, or device serial numbers.
 
-It contains counters and statistics on how the cluster has been
-deployed, the version of Ceph, the distribution of the hosts and other
-parameters which help the project to gain a better understanding of
+The reported data contains counters and statistics pertaining to how the
+cluster has been deployed, the version of Ceph, the distribution of the hosts,
+and other parameters that help the project develop a better understanding of
 the way Ceph is used.
 
-Data is sent secured to *https://telemetry.ceph.com*.
+Data is sent secured to
+`https://telemetry.ceph.com<https://telemetry.ceph.com>`_.
 
-Individual channels can be enabled or disabled with:
+Individual channels can be enabled or disabled by running the following
+commands:
 
 .. prompt:: bash #
 
@@ -80,21 +84,23 @@ Individual channels can be enabled or disabled with:
    ceph telemetry disable channel ident
    ceph telemetry disable channel perf
 
-Multiple channels can be enabled or disabled with:
+Multiple channels can be enabled or disabled at the same time by running the
+following commands:
 
 .. prompt:: bash #
 
    ceph telemetry enable channel basic crash device ident perf
    ceph telemetry disable channel basic crash device ident perf
 
-Channels can be enabled or disabled all at once with:
+All channels can be enabled or disabled at once by running the following
+commands:
 
 .. prompt:: bash #
 
    ceph telemetry enable channel all
    ceph telemetry disable channel all
 
-Please note that telemetry should be on for these commands to take effect.
+Note that telemetry must be on for these commands to take effect.
 
 List all channels with:
 


### PR DESCRIPTION
Improve the English and the formatting in doc/mgr/telemetry.rst. This follows up on https://github.com/ceph/ceph/pull/63476.

This commit edits down to the line "Note that telemetry must be on for these commands to take effect.", inclusive.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
