### PR TITLE
doc/mgr: edit telemetry (3 of x)

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -209,10 +209,10 @@ If telemetry is off you can preview a sample report by channel with:
 Collections
 -----------
 
-Collections represent different aspects of data that we collect within a
+Collections represent different aspects of data collected within a
 channel.
 
-List all collections with:
+To list all collections, run the following command:
 
 .. prompt:: bash #
 
@@ -237,29 +237,38 @@ List all collections with:
 
 Where:
 
-**NAME**: Collection name; prefix indicates the channel the collection belongs to.
+.. glossary:: 
 
-**STATUS**: Indicates whether the collection metrics are reported; this is
-determined by the status (enabled / disabled) of the channel the collection
-belongs to, along with the enrollment status of the collection (whether the user
-is opted-in to this collection).
+        NAME
+                Collection name; prefix indicates the channel the collection
+                belongs to.
 
-**DESC**: General description of the collection.
+        STATUS
+                Indicates whether the collection metrics are reported; this is
+                determined by the status (enabled / disabled) of the channel
+                the collection belongs to, along with the enrollment status of
+                the collection (whether the user is opted-in to this
+                collection).
 
-See the diff between the collections you are enrolled to, and the new,
-available collections with:
+        DESC
+                General description of the collection.
+
+To print the diff that displays the differences between (1) the collections you
+are enrolled to and (2) the new, available collections, run the following
+command:
 
 .. prompt:: bash #
 
    ceph telemetry diff
 
-Enroll to the most recent collections with:
+To enroll to the most recent collections, run the following command:
 
 .. prompt:: bash #
 
    ceph telemetry on
 
-Then enable new channels that are off with:
+Enable a new channel that is disabled by running a command of the following
+form:
 
 .. prompt:: bash #
 
@@ -268,8 +277,8 @@ Then enable new channels that are off with:
 Interval
 --------
 
-The module compiles and sends a new report every 24 hours by default.
-You can adjust this interval with:
+The telemetry module compiles and sends a new report every 24 hours by default.
+Adjust this interval by running a command of the following form:
 
 .. prompt:: bash #
 
@@ -278,7 +287,8 @@ You can adjust this interval with:
 Status
 --------
 
-The see the current configuration:
+To print the current configuration of the telemetry module, run a command of
+the following form:
 
 .. prompt:: bash #
 
@@ -287,7 +297,7 @@ The see the current configuration:
 Manually sending telemetry
 --------------------------
 
-To ad hoc send telemetry data:
+To ad hoc [fixme] send telemetry data:
 
 .. prompt:: bash #
 


### PR DESCRIPTION
Improve the English and the formatting in doc/mgr/telemetry.rst. This follows up on https://github.com/ceph/ceph/pull/63476.

This commit edits the third hundred lines in doc/mgr/telemetry.rst.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

