### PR TITLE
qa/rgw: fix perl tests missing Amazon::S3 module 

### DIFF
--- a/qa/suites/rgw/multifs/0-install.yaml
+++ b/qa/suites/rgw/multifs/0-install.yaml
@@ -1,5 +1,8 @@
 tasks:
 - install:
+    extra_system_packages:
+      deb: ['cpanminus', 'libxml-simple-perl']
+      rpm: ['cpanminus', 'perl-XML-Simple', 'perl-LWP-Protocol-https', 'perl-ExtUtils-Config', 'perl-ExtUtils-Helpers', 'perl-ExtUtils-InstallPaths', 'perl-Module-Build-Tiny']
 - ceph:
 - rgw: [client.0]
 - tox: [client.0]

--- a/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
@@ -2,4 +2,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_bucket_quota.pl
+        - rgw/s3_bucket_quota-run.sh

--- a/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
@@ -2,4 +2,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_multipart_upload.pl
+        - rgw/s3_multipart_upload-run.sh

--- a/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
@@ -2,4 +2,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_user_quota.pl
+        - rgw/s3_user_quota-run.sh

--- a/qa/suites/rgw/thrash/install.yaml
+++ b/qa/suites/rgw/thrash/install.yaml
@@ -1,5 +1,8 @@
 tasks:
 - install:
+    extra_system_packages:
+      deb: ['cpanminus', 'libxml-simple-perl']
+      rpm: ['cpanminus', 'perl-XML-Simple', 'perl-LWP-Protocol-https', 'perl-ExtUtils-Config', 'perl-ExtUtils-Helpers', 'perl-ExtUtils-InstallPaths', 'perl-Module-Build-Tiny']
 - ceph:
 - rgw: [client.0]
 

--- a/qa/suites/rgw/thrash/workload/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_bucket_quota.yaml
@@ -2,7 +2,7 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_bucket_quota.pl
+        - rgw/s3_bucket_quota-run.sh
 overrides:
   ceph:
     conf:

--- a/qa/suites/rgw/thrash/workload/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_multipart_upload.yaml
@@ -2,7 +2,7 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_multipart_upload.pl
+        - rgw/s3_multipart_upload-run.sh
 overrides:
   ceph:
     conf:

--- a/qa/suites/rgw/thrash/workload/rgw_user_quota.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_user_quota.yaml
@@ -2,7 +2,7 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_user_quota.pl
+        - rgw/s3_user_quota-run.sh
 overrides:
   ceph:
     conf:

--- a/qa/workunits/rgw/s3_bucket_quota-run.sh
+++ b/qa/workunits/rgw/s3_bucket_quota-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+cpanm --sudo Amazon::S3
+exec perl $(dirname $0)/s3_bucket_quota.pl

--- a/qa/workunits/rgw/s3_multipart_upload-run.sh
+++ b/qa/workunits/rgw/s3_multipart_upload-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+cpanm --sudo Amazon::S3
+exec perl $(dirname $0)/s3_multipart_upload.pl

--- a/qa/workunits/rgw/s3_user_quota-run.sh
+++ b/qa/workunits/rgw/s3_user_quota-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+cpanm --sudo Amazon::S3
+exec perl $(dirname $0)/s3_user_quota.pl

--- a/qa/workunits/rgw/s3_utilities.pm
+++ b/qa/workunits/rgw/s3_utilities.pm
@@ -32,6 +32,7 @@ sub get_status {
     if ($status =~ /\d+/ ){
         return 0;
     }
+    warn "ERROR: $service is not running\n";
     return 1;
 }
 


### PR DESCRIPTION
and a second case where perl tests can fail without error output

1. fix errors like: `Can't locate Amazon/S3.pm in @INC (you may need to
   install the Amazon::S3 module)`
by priming the perl tests with installing the Amazon::S3 module from cpan 

ex:
```
2025-06-23T19:18:40.162 INFO:tasks.workunit.client.0.smithi090.stderr:Can't locate Amazon/S3.pm in @INC (you may need to install the Amazon::S3 module) (@INC contains: /usr/local/lib64/perl5/5.32 ...
```

2. log an error when RGW process is not detected


Fixes: https://tracker.ceph.com/issues/71577



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
