### PR TITLE
squid: doc/mgr: edit telemetry (2 of x)

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -115,21 +115,22 @@ List all channels with:
 Enabling Telemetry
 ------------------
 
-To allow the *telemetry* module to start sharing data:
+To allow the *telemetry* module to start sharing data, run the following
+command:
 
 .. prompt:: bash #
 
    ceph telemetry on
 
-Please note: Telemetry data is licensed under the Community Data License
-Agreement - Sharing - Version 1.0 (https://cdla.io/sharing-1-0/). Hence,
-telemetry module can be enabled only after you add ``--license sharing-1-0`` to
-the ``ceph telemetry on`` command.  Once telemetry is on, please consider
-enabling channels which are off by default, such as the ``perf`` channel.
-``ceph telemetry on`` output will list the exact command to enable these
-channels.
+Please note: Telemetry data is licensed under the `Community Data License
+Agreement - Sharing - Version 1.0 <https://cdla.io/sharing-1-0/>`_.  This means
+that telemetry module can be enabled only after you add ``--license
+sharing-1-0`` to the ``ceph telemetry on`` command. After telemetry is on,
+consider enabling channels which are off by default, such as the
+``perf`` channel.  ``ceph telemetry on`` output will list the exact command to
+enable these channels.
 
-Telemetry can be disabled at any time with:
+Telemetry can be disabled at any time by running the following command:
 
 .. prompt:: bash #
 
@@ -138,50 +139,52 @@ Telemetry can be disabled at any time with:
 Sample report
 -------------
 
-You can look at what data is reported at any time with the command:
+Show reported data by running the following command: 
 
 .. prompt:: bash #
 
    ceph telemetry show
 
-If telemetry is off, you can preview a sample report with:
+If telemetry is disabled, run the following command to preview a sample report:
 
 .. prompt:: bash #
 
    ceph telemetry preview
 
-Generating a sample report might take a few moments in big clusters (clusters
-with hundreds of OSDs or more).
+The generation of a sample report might take a few moments in big clusters
+(clusters with hundreds of OSDs or more).
 
-To protect your privacy, device reports are generated separately, and data such
-as hostname and device serial number is anonymized. The device telemetry is
-sent to a different endpoint and does not associate the device data with a
-particular cluster. To see a preview of the device report use the command:
+To protect your privacy, device reports are generated separately. Data
+including  hostnames and device serial numbers are anonymized. The device
+telemetry is sent to a different endpoint and does not associate the device
+data with a particular cluster. To see a preview of the device report, run the
+following command: 
 
 .. prompt:: bash #
 
    ceph telemetry show-device
 
-If telemetry is off, you can preview a sample device report with:
+If telemetry is disabled, run the following command to preview a sample device
+report:
 
 .. prompt:: bash #
 
    ceph telemetry preview-device
 
-Please note: In order to generate the device report we use Smartmontools
-version 7.0 and up, which supports JSON output.  If you have any concerns about
-privacy with regard to the information included in this report, please contact
-the Ceph developers.
+.. note:: In order to generate the device report we use Smartmontools version
+   7.0 and up, which supports JSON output. If you have any concerns about
+   privacy with regard to the information included in this report, contact the
+   Ceph developers.
 
-In case you prefer to have a single output of both reports, and telemetry is
-on, use:
+When telemetry is enabled, run the following command to generate both reports
+in a single output: 
 
 .. prompt:: bash #
 
    ceph telemetry show-all
 
-If you would like to view a single output of both reports, and telemetry is
-off, use:
+When telemetry is disabled, run the following command to view both reports in a
+single output:
 
 .. prompt:: bash #
 
@@ -189,7 +192,8 @@ off, use:
 
 **Sample report by channel**
 
-When telemetry is on you can see what data is reported by channel with:
+Run the following command when telemetry is enabled to show the data reported
+by a specified channel:
 
 .. prompt:: bash #
 


### PR DESCRIPTION
Improve the English and the formatting in doc/mgr/telemetry.rst. This follows up on https://github.com/ceph/ceph/pull/63476.

This commit edits the second hundred lines in doc/mgr/telemetry.rst.


(cherry picked from commit f8975b05a6cff674ad5fb6ce93c839ca1856464c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

