### PR TITLE
squid: node-proxy: address `ceph orch hardware status` cmd

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1637,9 +1637,9 @@ class NodeProxyCache:
                 else:
                     state = 'ok'
                 _result[host]['status'][component] = state
-        _result[host]['sn'] = data['sn']
-        _result[host]['host'] = data['host']
-        _result[host]['status']['firmwares'] = data['firmwares']
+            _result[host]['sn'] = data['sn']
+            _result[host]['host'] = data['host']
+            _result[host]['status']['firmwares'] = data['firmwares']
         return _result
 
     def common(self, endpoint: str, **kw: Any) -> Dict[str, Any]:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71535

---

backport of https://github.com/ceph/ceph/pull/63556
parent tracker: https://tracker.ceph.com/issues/71472

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh