### PR TITLE
tentacle: os/bluestore: Set of various fixes to bluefs

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -4693,7 +4693,6 @@ void BlueFS::_drain_writer(FileWriter *h)
     if (bdev[i]) {
       if (h->iocv[i]) {
 	h->iocv[i]->aio_wait();
-	delete h->iocv[i];
       }
     }
   }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -434,6 +434,9 @@ public:
     // NOTE: caller must call BlueFS::close_writer()
     ~FileWriter() {
       --file->num_writers;
+      for (unsigned i = 0; i < MAX_BDEV; ++i) {
+        delete iocv[i];
+      }
     }
 
     // note: BlueRocksEnv uses this append exclusively, so it's safe

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -190,9 +190,6 @@ void bluefs_super_t::encode(bufferlist& bl) const
   encode(block_size, bl);
   encode(log_fnode, bl);
   encode(memorized_layout, bl);
-  if (_version >= 3) {
-    encode(wal_version, bl);
-  }
   ENCODE_FINISH(bl);
 }
 
@@ -207,9 +204,6 @@ void bluefs_super_t::decode(bufferlist::const_iterator& p)
   decode(log_fnode, p);
   if (struct_v >= 2) {
     decode(memorized_layout, p);
-  }
-  if (struct_v >= 3) {
-    decode(wal_version, p);
   }
   DECODE_FINISH(p);
 }

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -328,8 +328,6 @@ struct bluefs_super_t {
 
   std::optional<bluefs_layout_t> memorized_layout;
 
-  uint8_t wal_version;
-
   bluefs_super_t();
 
   uint64_t block_mask() const {

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1663,7 +1663,7 @@ TEST(BlueFS, test_shared_alloc) {
                       size, shared_alloc_unit, "test shared allocator"),
     shared_alloc_unit);
   shared_alloc.a->init_add_free(0, size);
-
+  auto sg = make_scope_guard([&shared_alloc] { delete shared_alloc.a; });
   BlueFS fs(g_ceph_context);
   // DB device is fully utilized
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev_db.path, false));
@@ -1747,6 +1747,7 @@ TEST(BlueFS, test_shared_alloc_sparse) {
   for(uint64_t i = 5 * bluefs_alloc_unit; i < size; i += 2 * main_unit) {
     shared_alloc.a->init_add_free(i, main_unit);
   }
+  auto sg = make_scope_guard([&shared_alloc] { delete shared_alloc.a; });
 
   BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev_slow.path, false,
@@ -1823,6 +1824,7 @@ TEST(BlueFS, test_4k_shared_alloc) {
                       size, main_unit, "test shared allocator"),
     main_unit);
   shared_alloc.a->init_add_free(bluefs_alloc_unit, size - bluefs_alloc_unit);
+  auto sg = make_scope_guard([&shared_alloc] { delete shared_alloc.a; });
 
   BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, bdev_slow.path, false,

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1137,7 +1137,7 @@ TEST(BlueFS, test_wal_migrate) {
   gen_debugable(70000, bl1);
   fs.append_try_flush(writer, bl1.c_str(), bl1.length());
   fs.fsync(writer);
-
+  fs.close_writer(writer);
   // WAL files don't update internal extents while writing to save memory, only on _replay
   fs.umount();
   fs.mount();
@@ -1392,6 +1392,7 @@ TEST(BlueFS, test_wal_read_after_rollback_to_v1) {
   gen_debugable(70000, bl1);
   fs.append_try_flush(writer, bl1.c_str(), bl1.length());
   fs.fsync(writer);
+  fs.close_writer(writer);
 
   g_ceph_context->_conf.set_val("bluefs_wal_envelope_mode", "false");
   fs.umount();
@@ -1411,6 +1412,7 @@ TEST(BlueFS, test_wal_read_after_rollback_to_v1) {
     ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
     ASSERT_NE(nullptr, writer);
     ASSERT_EQ(writer->file->fnode.encoding, bluefs_node_encoding::PLAIN);
+    fs.close_writer(writer);
   }
   fs.umount();
 }
@@ -1628,6 +1630,7 @@ TEST(BlueFS, truncate_fsync) {
         fs.fsync(h);
         fs.close_writer(h);
       }
+      fs.umount();
     }
     {
       //this was broken due to https://tracker.ceph.com/issues/55307
@@ -2082,6 +2085,7 @@ TEST(BlueFS, test_log_runway) {
   utime_t mtime;
   fs.stat("dir", "file", &file_size, &mtime);
   ASSERT_EQ(file_size, 9);
+  fs.umount();
 }
 
 TEST(BlueFS, test_log_runway_2) {
@@ -2139,6 +2143,7 @@ TEST(BlueFS, test_log_runway_2) {
   std::vector<std::string> ls_longdir;
   fs.readdir(longdir, &ls_longdir);
   ASSERT_EQ(ls_longdir.front(), longfile);
+  fs.umount();
 }
 
 TEST(BlueFS, test_log_runway_3) {
@@ -2199,6 +2204,7 @@ TEST(BlueFS, test_log_runway_3) {
     fs.stat(longdir, longfile, &file_size, &mtime);
     ASSERT_EQ(file_size, 6);
   }
+  fs.umount();
 }
 
 TEST(BlueFS, test_log_runway_advance_seq) {
@@ -2223,6 +2229,7 @@ TEST(BlueFS, test_log_runway_advance_seq) {
   std::string longdir(max_log_runway*2, 'A');
   ASSERT_EQ(fs.mkdir(longdir), 0);
   fs.compact_log();
+  fs.umount();
 }
 
 TEST(BlueFS, test_69481_truncate_corrupts_log) {


### PR DESCRIPTION
backport of #63761


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
