### PR TITLE
tentacle: mds: log meaningful error message when entering damaged state

### DIFF
--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -176,10 +176,6 @@ bool DamageTable::notify_dentry(
     inodeno_t ino, frag_t frag,
     snapid_t snap_id, std::string_view dname, std::string_view path)
 {
-  if (oversized()) {
-    return true;
-  }
-
   // Special cases: damage to these dirfrags is considered fatal to
   // the MDS rank that owns them.
   if (
@@ -188,7 +184,14 @@ bool DamageTable::notify_dentry(
       (MDS_INO_IS_STRAY(ino) && MDS_INO_STRAY_OWNER(ino) == rank)
      ) {
     derr << "Damage to dentries in fragment " << frag << " of ino " << ino
-         << "is fatal because it is a system directory for this rank" << dendl;
+         << " is fatal because it is a system directory for this rank" << dendl;
+    return true;
+  }
+
+  if (oversized()) {
+    derr << "Damage to dentries in fragment " << frag << " of ino " << ino
+         << " is fatal because maximum number of damage table entries "
+         << " has been reached" << dendl;
     return true;
   }
 
@@ -216,6 +219,9 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag,
   }
 
   if (oversized()) {
+    derr << "Damage to fragment " << frag << " of ino " << ino
+         << " is fatal because maximum number of damage table entries"
+         << " has been reached" << dendl;
     return true;
   }
 
@@ -232,6 +238,9 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag,
 bool DamageTable::notify_remote_damaged(inodeno_t ino, std::string_view path)
 {
   if (oversized()) {
+    derr << "Damage to remote " << path << " of ino " << ino
+         << " is fatal because maximum number of damage table entries"
+         << " has been reached" << dendl;
     return true;
   }
 
@@ -280,6 +289,9 @@ bool DamageTable::notify_uninline_failed(
   std::string_view path)
 {
   if (oversized()) {
+    derr << "Uninline failure for " << path << " of ino " << ino
+         << " is fatal because maximum number of damage table entries"
+         << " has been reached" << dendl;
     return true;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71486

---

backport of https://github.com/ceph/ceph/pull/63220
parent tracker: https://tracker.ceph.com/issues/71270

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh