### PR TITLE
tentacle: osd/scrub: move m_session_started_at out of Session ctor

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2377,7 +2377,7 @@ pg_scrubbing_status_t PgScrubber::get_schedule() const
 
     } else {
       int32_t dur_seconds =
-	  duration_cast<seconds>(m_fsm->get_time_scrubbing()).count();
+	  ceil<seconds>(m_fsm->get_time_scrubbing()).count();
       return pg_scrubbing_status_t{
 	  utime_t{},
 	  dur_seconds,

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -284,7 +284,6 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
  public:
   friend class PgScrubber;
 
- public:
   explicit ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub);
   virtual ~ScrubMachine();
 
@@ -309,10 +308,14 @@ class ScrubMachine : public ScrubFsmIf, public sc::state_machine<ScrubMachine, N
     sc::state_machine<ScrubMachine, NotActive>::process_event(evt);
   }
 
-// ///////////////// aux declarations & functions //////////////////////// //
+  /// the time when the session was initiated
+  std::optional<ScrubTimePoint> m_session_started_at;
 
+
+  // ///////////////// aux declarations & functions //////////////////////// //
 
 private:
+
   /**
    * scheduled_event_state_t
    *
@@ -572,9 +575,6 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
   /// the set of performance counters for this session (relevant, i.e. for
   /// this pool type)
   const ScrubCounterSet* m_counters_idx{nullptr};
-
-  /// the time when the session was initiated
-  ScrubTimePoint m_session_started_at{ScrubClock::now()};
 
   /// abort reason - if known. Determines the delay time imposed on the
   /// failed scrub target.


### PR DESCRIPTION
ScrubMachine::get_time_scrubbing() must access the Session object to compute the scrub duration. But the State data is not externally accessible before its ctor has completed.

As we always happen to try to access that data inside the ctor, this always results in a warning log message.

Here we move m_session_started_at into the outer state, simplifying the logic required to access it.

Fixes: https://tracker.ceph.com/issues/71586
Original tracker: https://tracker.ceph.com/issues/64955
Backport of https://github.com/ceph/ceph/pull/63758
(cherry picked from commit 38057ce2c14ca9a6b81617399480510fb0eae951)

