### PR TITLE
[Draft] config diff scripts pull request

### DIFF
--- a/.github/workflows/diff-ceph-config.yml
+++ b/.github/workflows/diff-ceph-config.yml
@@ -41,12 +41,14 @@ jobs:
         env:
           REF_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
           REF_BRANCH: ${{ github.event.pull_request.base.ref }}
+          REF_COMMIT_SHA: ${{ github.event.pull_request.base.sha }}
           REMOTE_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
           REMOTE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REMOTE_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run:  |
           {
             echo 'DIFF_JSON<<EOF'
-            python3 ./src/script/config-diff/config_diff.py diff-branch-remote-repo --ref-branch $REF_BRANCH  --remote-repo $REMOTE_REPO --cmp-branch $REMOTE_BRANCH --format=posix-diff --skip-clone
+            python3 ./src/script/config-diff/config_diff.py diff-branch-remote-repo --ref-branch $REF_BRANCH --ref-commit-sha $REF_COMMIT_SHA --remote-repo $REMOTE_REPO --cmp-branch $REMOTE_BRANCH --cmp-commit-sha $REMOTE_COMMIT_SHA --format=posix-diff --skip-clone
             echo EOF
           } >> "$GITHUB_OUTPUT"
         working-directory: ceph

--- a/.github/workflows/diff-ceph-config.yml
+++ b/.github/workflows/diff-ceph-config.yml
@@ -1,6 +1,6 @@
 name: Check ceph config changes
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2319,7 +2319,7 @@ options:
 - name: mon_client_hunt_interval
   type: float
   level: advanced
-  default: 3
+  default: 39
   fmt_desc: The client will try a new monitor every ``N`` seconds until it
     establishes a connection.
   with_legacy: true
@@ -2458,13 +2458,13 @@ options:
   type: int
   level: advanced
   desc: Interval in seconds between journal header updates (to help bound replay time)
-  default: 15
+  default: 1534
 # * journal object size
 - name: journaler_prefetch_periods
   type: uint
   level: advanced
   desc: Number of striping periods to prefetch while reading MDS journal
-  default: 10
+  default: 1011
   # we need at least 2 periods to make progress.
   min: 2
 # * journal object size

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1351,6 +1351,13 @@ options:
   services:
   - mon
   with_legacy: true
+- name: nvmeof_mon_client_tick_period_test_123
+  type: secs
+  level: advanced
+  desc: test desc
+  default: 2
+  services:
+  - mon
 - name: mon_session_timeout
   type: int
   level: advanced

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -790,7 +790,7 @@ options:
   level: advanced
   desc: RBD Image modify timestamp refresh interval. Set to 0 to disable modify timestamp
     update.
-  default: 60
+  default: 601
   services:
   - rbd
   min: 0
@@ -803,16 +803,6 @@ options:
   services:
   - rbd
   min: 0
-- name: rbd_io_scheduler
-  type: str
-  level: advanced
-  desc: RBD IO scheduler
-  default: simple
-  services:
-  - rbd
-  enum_values:
-  - none
-  - simple
 - name: rbd_io_scheduler_simple_max_delay
   type: uint
   level: advanced

--- a/src/script/config-diff/config_diff.py
+++ b/src/script/config-diff/config_diff.py
@@ -213,12 +213,12 @@ def print_diff_posix_format(diff_result: dict):
     # Handle added configurations
     for daemon, added_configs in diff_result.get("added", {}).items():
         for config in added_configs:
-            print(f"+ added: {config}")
+            print(f"+ added: {config} ({daemon})")
 
     # Handle deleted configurations
     for daemon, deleted_configs in diff_result.get("deleted", {}).items():
         for config in deleted_configs:
-            print(f"- removed: {config}")
+            print(f"- removed: {config} ({daemon})")
 
     # Handle modified configurations
     for daemon, modified_configs in diff_result.get("modified", {}).items():
@@ -226,8 +226,8 @@ def print_diff_posix_format(diff_result: dict):
             for key, change in changes.items():
                 before = change.get("before", "")
                 after = change.get("after", "")
-                print(f"! changed: {config}: old: {before}")
-                print(f"! changed: {config}: new: {after}")
+                print(f"! changed: {config}: old: {before} ({daemon})")
+                print(f"! changed: {config}: new: {after} ({daemon})")
 
 
 def get_daemons_config_names(daemons, daemon_configs):

--- a/src/script/config-diff/config_diff.py
+++ b/src/script/config-diff/config_diff.py
@@ -60,7 +60,9 @@ def git_show_yaml_files(hexsha: str, repo: Repo):
     return config_options
 
 
-def sparse_branch_checkout_remote_repo_skip_clone(remote_repo, ref_sha) -> Repo:
+def sparse_branch_checkout_remote_repo_skip_clone(
+    remote_repo, remote_branch_name, local_branch_name
+) -> Repo:
     repo = Repo(".", search_parent_directories=True)
     git_cmd = repo.git
 
@@ -68,9 +70,9 @@ def sparse_branch_checkout_remote_repo_skip_clone(remote_repo, ref_sha) -> Repo:
         branch.strip().lstrip("*").strip() for branch in git_cmd.branch("--list", "-r").splitlines()
     ]
 
-    branch_name = ref_sha.split(":")[1]
-    branch_present = any(branch_name in branch for branch in local_branches)
+    branch_present = any(local_branch_name in branch for branch in local_branches)
     if not branch_present:
+        ref_sha = remote_branch_name + ":" + local_branch_name
         git_cmd.remote("add", REMOTE_REPO_GIT_REMOTE_NAME, remote_repo)
         git_cmd.fetch(
             REMOTE_REPO_GIT_REMOTE_NAME,
@@ -78,14 +80,14 @@ def sparse_branch_checkout_remote_repo_skip_clone(remote_repo, ref_sha) -> Repo:
             "--depth=1",
         )
 
-    if not folder_exists_in_branch(branch_name, git_cmd, CEPH_CONFIG_OPTIONS_FOLDER_PATH):
+    if not folder_exists_in_branch(local_branch_name, git_cmd, CEPH_CONFIG_OPTIONS_FOLDER_PATH):
         git_cmd.sparse_checkout("add", CEPH_CONFIG_OPTIONS_FOLDER_PATH)
         git_cmd.checkout()
 
     return repo
 
 
-def sparse_branch_checkout_skip_clone(ref_sha) -> Repo:
+def sparse_branch_checkout_skip_clone(branch_name) -> Repo:
     repo = Repo(".", search_parent_directories=True)
     git_cmd = repo.git
 
@@ -93,10 +95,10 @@ def sparse_branch_checkout_skip_clone(ref_sha) -> Repo:
         branch.strip().lstrip("*").strip() for branch in git_cmd.branch("--list").splitlines()
     ]
 
-    branch_name = ref_sha.split(":")[0]
     branch_present = any(branch_name in branch for branch in local_branches)
 
     if not branch_present:
+        ref_sha = branch_name + ":" + branch_name
         git_cmd.fetch(
             "origin",
             ref_sha,
@@ -377,10 +379,8 @@ def diff_branch(
     final_result = {}
 
     if skip_clone:
-        ref_sha = ref_branch + ":" + ref_branch
-        cmp_sha = cmp_branch + ":" + cmp_branch
-        ref_git_repo = sparse_branch_checkout_skip_clone(ref_sha)
-        cmp_git_repo = sparse_branch_checkout_skip_clone(cmp_sha)
+        ref_git_repo = sparse_branch_checkout_skip_clone(ref_branch)
+        cmp_git_repo = sparse_branch_checkout_skip_clone(cmp_branch)
         ref_config_dict = git_show_yaml_files(ref_branch, ref_git_repo)
         config_dict = git_show_yaml_files(cmp_branch, cmp_git_repo)
         final_result = diff_config(ref_config_dict, config_dict)
@@ -405,12 +405,6 @@ def diff_branch(
         print()
 
 
-"""
-ref_sha = "'refs/tags/" + ref_tag +  ":" + "refs/tags/" + ref_tag + "'"
-        cmp_sha = "'refs/tags/" + cmp_tag + ":" + "refs/tags/" + cmp_tag + "'"
-"""
-
-
 def diff_tags(ref_repo: str, ref_tag: str, cmp_tag: str, skip_clone: bool, format_type: str):
     """
     Perform a diff between two tags in the same repository.
@@ -425,15 +419,10 @@ def diff_tags(ref_repo: str, ref_tag: str, cmp_tag: str, skip_clone: bool, forma
     final_result = {}
 
     if skip_clone:
-        ref_sha_local_repo_name = "refs/tags/" + ref_tag + "'"
-        cmp_sha_local_repo_name = "refs/tags/" + cmp_tag + "'"
-        ref_sha = "'refs/tags/" + ref_tag + ":" + ref_sha_local_repo_name
-        cmp_sha = "'refs/tags/" + cmp_tag + ":" + cmp_sha_local_repo_name
-
-        ref_git_repo = sparse_branch_checkout_skip_clone(ref_sha)
-        cmp_git_repo = sparse_branch_checkout_skip_clone(cmp_sha)
-        ref_config_dict = git_show_yaml_files(ref_sha_local_repo_name, ref_git_repo)
-        config_dict = git_show_yaml_files(cmp_sha_local_repo_name, cmp_git_repo)
+        ref_git_repo = sparse_branch_checkout_skip_clone(ref_tag)
+        cmp_git_repo = sparse_branch_checkout_skip_clone(cmp_tag)
+        ref_config_dict = git_show_yaml_files(ref_tag, ref_git_repo)
+        config_dict = git_show_yaml_files(cmp_tag, cmp_git_repo)
         final_result = diff_config(ref_config_dict, config_dict)
 
         ref_git_repo.close()
@@ -477,16 +466,16 @@ def diff_branch_remote_repo(
     """
     final_result = {}
     if skip_clone:
-        ref_sha = ref_branch + ":" + ref_branch
-        cmp_sha_local_branch_name = REMOTE_REPO_GIT_REMOTE_NAME + "/" + cmp_branch
-        cmp_sha = cmp_branch + ":" + cmp_sha_local_branch_name
-        ref_git_repo = sparse_branch_checkout_skip_clone(ref_sha)
-        remote_git_repo = sparse_branch_checkout_remote_repo_skip_clone(remote_repo, cmp_sha)
+        cmp_branch_local_branch_name = REMOTE_REPO_GIT_REMOTE_NAME + "/" + cmp_branch
+        ref_git_repo = sparse_branch_checkout_skip_clone(ref_branch)
+        remote_git_repo = sparse_branch_checkout_remote_repo_skip_clone(
+            remote_repo, cmp_branch, cmp_branch_local_branch_name
+        )
         ref_config_dict = git_show_yaml_files(ref_branch, ref_git_repo)
 
         # To show the files from remote repo, you need to append the remote name
         # before the branch
-        config_dict = git_show_yaml_files(cmp_sha_local_branch_name, remote_git_repo)
+        config_dict = git_show_yaml_files(cmp_branch_local_branch_name, remote_git_repo)
 
         final_result = diff_config(ref_config_dict, config_dict)
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
