### PR TITLE
mgr/dashboard: support size parameters

### DIFF
--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -5,3 +5,4 @@ python3-saml~=1.4
 requests~=2.26
 Routes~=2.4
 cheroot~=10.0
+xmlsec==1.3.9

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import cherrypy
 from orchestrator import OrchestratorError
@@ -386,8 +386,8 @@ else:
             rbd_image_name: str,
             rbd_pool: str = "rbd",
             create_image: Optional[bool] = False,
-            size: Optional[str] = 1024,
-            rbd_image_size: Optional[str] = None,
+            size: Optional[Union[str, int]] = 1024,
+            rbd_image_size: Optional[Union[str, int]] = None,
             trash_image: Optional[bool] = False,
             block_size: int = 512,
             load_balancing_group: Optional[int] = None,

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -376,7 +376,8 @@ else:
                 )
             },
         )
-        @NvmeofCLICommand("nvmeof ns add", model.NamespaceCreation)
+        @NvmeofCLICommand("nvmeof ns add", model.NamespaceCreation,
+                          size_params=['size', 'rbd_image_size'])
         @convert_to_model(model.NamespaceCreation)
         @handle_nvmeof_error
         def create(
@@ -385,8 +386,8 @@ else:
             rbd_image_name: str,
             rbd_pool: str = "rbd",
             create_image: Optional[bool] = False,
-            size: Optional[int] = 1024,
-            rbd_image_size: Optional[int] = None,
+            size: Optional[str] = 1024,
+            rbd_image_size: Optional[str] = None,
             trash_image: Optional[bool] = False,
             block_size: int = 512,
             load_balancing_group: Optional[int] = None,
@@ -402,7 +403,7 @@ else:
                     rbd_pool_name=rbd_pool,
                     block_size=block_size,
                     create_image=create_image,
-                    size=rbd_image_size or size,
+                    size=int(rbd_image_size or size),
                     trash_image=trash_image,
                     anagrpid=load_balancing_group,
                     force=force,

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -55,6 +55,33 @@ def remove_nvmeof_gateway(_, name: str, daemon_name: str = ''):
         return -errno.EINVAL, '', str(ex)
 
 
+MULTIPLES = ['', "K", "M", "G", "T", "P"]
+UNITS = {
+    f"{prefix}{suffix}": 1024 ** mult
+    for mult, prefix in enumerate(MULTIPLES)
+    for suffix in ['', 'B', 'iB']
+    if not (prefix == '' and suffix == 'iB')
+}
+
+
+def convert_to_bytes(size: Union[int, str], default_unit=None):
+    if isinstance(size, int):
+        number = size
+        size = str(size)
+    else:
+        num_str = ''.join(filter(str.isdigit, size))
+        number = int(num_str)
+    unit_str = ''.join(filter(str.isalpha, size))
+    if not unit_str:
+        if not default_unit:
+            raise ValueError("default unit was not provided")
+        unit_str = default_unit
+
+    if unit_str in UNITS:
+        return number * UNITS[unit_str]
+    raise ValueError(f"Invalid unit: {unit_str}")
+
+
 def convert_from_bytes(num_in_bytes):
     units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
     size = float(num_in_bytes)
@@ -198,10 +225,12 @@ class AnnotatedDataTextOutputFormatter(OutputFormatter):
 
 
 class NvmeofCLICommand(CLICommand):
-    def __init__(self, prefix, model: Type[NamedTuple], perm='rw', poll=False):
+    def __init__(self, prefix, model: Type[NamedTuple],
+                 size_params: Optional[List[str]] = None, perm='rw', poll=False):
         super().__init__(prefix, perm, poll)
         self._output_formatter = AnnotatedDataTextOutputFormatter()
         self._model = model
+        self._size_params = size_params
 
     def __call__(self, func) -> HandlerFuncType:  # type: ignore
         # pylint: disable=useless-super-delegation
@@ -218,6 +247,11 @@ class NvmeofCLICommand(CLICommand):
              cmd_dict: Dict[str, Any],
              inbuf: Optional[str] = None) -> HandleCommandResult:
         try:
+            if self._size_params:
+                for param in self._size_params:
+                    if val := cmd_dict.get(param):
+                        cmd_dict[param] = convert_to_bytes(val, default_unit='MB')
+
             ret = super().call(mgr, cmd_dict, inbuf)
             out_format = cmd_dict.get('format')
             if ret is None:


### PR DESCRIPTION
support param values of number + unit (e.g. 5GB) rather than an integer of bytes (e.g. 5*10^9)

```
[root@cephnvme-vm29 ~]# ceph nvmeof ns add --nqn=nqn.2016-06.io.spdk:cnode2.mygroup1 --rbd-pool=mypool --rbd-image-name=myimage9 --rbd-image-size=10MB --create-image=true
Success
[root@cephnvme-vm29 ~]# ceph nvmeof ns list --nqn=nqn.2016-06.io.spdk:cnode2.mygroup1
+-----------------------------------------+---------+--------+--------+--------------+----------+-----------+-----------+------------+-------------+------------+-----+----+------------------------------------+-----------------------------------+-----------+
|Bdev Name                                |Rbd Image|Rbd Pool|Lb Group|Rbd Image Size|Block Size|R/W Ios/Sec|R/W Mbs/Sec|Read Mbs/Sec|Write Mbs/Sec|Auto Visible|Hosts|Nsid|Uuid                                |Ns Subsystem Nqn                   |Trash Image|
+-----------------------------------------+---------+--------+--------+--------------+----------+-----------+-----------+------------+-------------+------------+-----+----+------------------------------------+-----------------------------------+-----------+
|bdev_686e808e-ce75-4f3b-8b3d-7c663af2c2c8|myimage5 |mypool  |1       |200MB         |512B      |0          |0          |0           |0            |True        |[]   |1   |686e808e-ce75-4f3b-8b3d-7c663af2c2c8|nqn.2016-06.io.spdk:cnode2.mygroup1|False      |
|bdev_a73bd6c2-2cfb-49d3-b527-d0e5f43d2bc3|myimage6 |mypool  |2       |200MB         |512B      |0          |0          |0           |0            |True        |[]   |2   |a73bd6c2-2cfb-49d3-b527-d0e5f43d2bc3|nqn.2016-06.io.spdk:cnode2.mygroup1|False      |
|bdev_4bd15748-5a5a-4621-96bb-e64d2cebf450|myimage7 |mypool  |3       |200MB         |512B      |0          |0          |0           |0            |True        |[]   |3   |4bd15748-5a5a-4621-96bb-e64d2cebf450|nqn.2016-06.io.spdk:cnode2.mygroup1|False      |
|bdev_ae59301b-c322-4c24-ac79-d429e9dab0fd|myimage8 |mypool  |4       |200MB         |512B      |0          |0          |0           |0            |True        |[]   |4   |ae59301b-c322-4c24-ac79-d429e9dab0fd|nqn.2016-06.io.spdk:cnode2.mygroup1|False      |
|bdev_f4549513-07a1-4722-8388-b0e69e9fbe53|myimage9 |mypool  |4       |10MB          |512B      |0          |0          |0           |0            |True        |[]   |5   |f4549513-07a1-4722-8388-b0e69e9fbe53|nqn.2016-06.io.spdk:cnode2.mygroup1|False      |
+-----------------------------------------+---------+--------+--------+--------------+----------+-----------+-----------+------------+-------------+------------+-----+----+------------------------------------+-----------------------------------+-----------+
```

fixes: https://tracker.ceph.com/issues/71589


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
