### PR TITLE
tentacle: Wip libcephfs perf dump

### DIFF
--- a/qa/workunits/libcephfs/test.sh
+++ b/qa/workunits/libcephfs/test.sh
@@ -8,5 +8,6 @@ ceph_test_libcephfs_newops
 ceph_test_libcephfs_suidsgid
 ceph_test_libcephfs_snapdiff
 ceph_test_libcephfs_vxattr
+ceph_test_libcephfs_perfcounters
 
 exit 0

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -670,7 +670,7 @@ void Client::_finish_init()
     plb.add_u64(l_c_rd_ops, "rdops", "Total read IO operations");
     plb.add_time(l_c_wr_avg, "writeavg", "Average latency for processing write requests");
     plb.add_u64(l_c_wr_sqsum, "writesqsum", "Sum of squares ((to calculate variability/stdev) for write requests");
-    plb.add_u64(l_c_wr_ops, "rdops", "Total write IO operations");
+    plb.add_u64(l_c_wr_ops, "wrops", "Total write IO operations");
     logger.reset(plb.create_perf_counters());
     cct->get_perfcounters_collection()->add(logger.get());
   }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -17483,6 +17483,23 @@ void Client::set_cap_epoch_barrier(epoch_t e)
   cap_epoch_barrier = e;
 }
 
+int Client::get_perf_counters(bufferlist *outbl) {
+  RWRef_t iref_reader(initialize_state, CLIENT_INITIALIZED);
+  if (!iref_reader.is_state_satisfied()) {
+    return -ENOTCONN;
+  }
+
+  ceph::bufferlist inbl;
+  std::ostringstream err;
+  std::vector<std::string> cmd{
+    "{\"prefix\": \"perf dump\"}",
+    "{\"format\": \"json\"}"
+  };
+
+  ldout(cct, 10) << __func__ << ": perf cmd=" << cmd << dendl;
+  return cct->get_admin_socket()->execute_command(cmd, inbl, err, outbl);
+}
+
 std::vector<std::string> Client::get_tracked_keys() const noexcept
 {
   static constexpr auto as_sv = std::to_array<std::string_view>({

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -380,6 +380,8 @@ public:
 		     std::vector<std::pair<uint64_t,uint64_t>> *blocks);
   int file_blockdiff_finish(struct scan_state_t *state);
 
+  int get_perf_counters(bufferlist *outbl);
+
   /*
    * Get the next snapshot delta entry.
    *

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 #define LIBCEPHFS_VER_MAJOR 10
-#define LIBCEPHFS_VER_MINOR 0
+#define LIBCEPHFS_VER_MINOR 1
 #define LIBCEPHFS_VER_EXTRA 3
 
 #define LIBCEPHFS_VERSION(maj, min, extra) ((maj << 16) + (min << 8) + extra)

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -2285,6 +2285,23 @@ int ceph_get_snap_info(struct ceph_mount_info *cmount,
  * @param snap_info snapshot info struct (fetched via call to ceph_get_snap_info()).
  */
 void ceph_free_snap_info_buffer(struct snap_info *snap_info);
+
+/**
+ * perf counters via libcephfs API.
+ */
+
+/**
+ * Get a json string of performance counters
+ *
+ * @param cmount the ceph mount handle to use.
+ * @param perf_dump buffer holding the perf dump
+ *
+ * Returns 0 success with the performance counters populated in the
+ * passed in perf_dump buffer. Caller is responsible for freeing the
+ * @perf_dump buffer using free().
+ */
+int ceph_get_perf_counters(struct ceph_mount_info *cmount, char **perf_dump);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2540,3 +2540,14 @@ extern "C" void ceph_free_snap_info_buffer(struct snap_info *snap_info) {
   }
   free(snap_info->snap_metadata);
 }
+
+extern "C" int ceph_get_perf_counters(struct ceph_mount_info *cmount, char **perf_dump) {
+  bufferlist outbl;
+  int r = cmount->get_client()->get_perf_counters(&outbl);
+  if (r != 0) {
+    return r;
+  }
+
+  do_out_buffer(outbl, perf_dump, NULL);
+  return outbl.length();
+}

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -122,4 +122,19 @@ target_link_libraries(ceph_test_libcephfs_lazyio
     )
   install(TARGETS ceph_test_libcephfs_access
     DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  add_executable(ceph_test_libcephfs_perfcounters
+    perfcounters.cc
+    main.cc
+  )
+  target_link_libraries(ceph_test_libcephfs_perfcounters
+    ceph-common
+    cephfs
+    librados
+    ${UNITTEST_LIBS}
+    ${EXTRALIBS}
+    ${CMAKE_DL_LIBS}
+    )
+  install(TARGETS ceph_test_libcephfs_perfcounters
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(WITH_LIBCEPHFS)

--- a/src/test/libcephfs/perfcounters.cc
+++ b/src/test/libcephfs/perfcounters.cc
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "include/compat.h"
+#include "gtest/gtest.h"
+#include "include/cephfs/libcephfs.h"
+#include "common/ceph_json.h"
+#include "include/utime.h"
+
+#include <string>
+
+using namespace std;
+
+TEST(LibCephFS, ValidatePerfCounters) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(0, ceph_create(&cmount, NULL));
+  ASSERT_EQ(0, ceph_conf_read_file(cmount, NULL));
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(0, ceph_mount(cmount, "/"));
+
+  char *perf_dump;
+  int len = ceph_get_perf_counters(cmount, &perf_dump);
+  ASSERT_GT(len, 0);
+
+  JSONParser jp;
+  ASSERT_TRUE(jp.parse(perf_dump, len));
+
+  JSONObj *jo = jp.find_obj("client");
+
+  // basic verification to chek if we have (some) fields in
+  // the json object.
+  utime_t val;
+  JSONDecoder::decode_json("mdavg", val, jo);
+  JSONDecoder::decode_json("readavg", val, jo);
+  JSONDecoder::decode_json("writeavg", val, jo);
+
+  int count;
+  JSONDecoder::decode_json("mdops", count, jo);
+  JSONDecoder::decode_json("rdops", count, jo);
+  JSONDecoder::decode_json("wrops", count, jo);
+
+  free(perf_dump);
+  ceph_shutdown(cmount);
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71377

---

backport of https://github.com/ceph/ceph/pull/62632
parent tracker: https://tracker.ceph.com/issues/71233

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh