### PR TITLE
mgr/cephadm: handle possibly undefined template variable in haproxy.cfg.j2

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
@@ -67,7 +67,7 @@ frontend frontend
 backend backend
 {% if mode == 'http' %}
     option forwardfor
-{% if backend_spec.ssl %}
+{% if backend_spec.ssl is defined and backend_spec.ssl %}
     default-server ssl
     default-server verify none
 {% endif %}


### PR DESCRIPTION
This PR updates the `haproxy.cfg` Jinja2 template to better handle the `backend_spec` object, which may not always have the `ssl` property inside it.

In my specific use case, I was trying to setup a ingress for a Grafana backend service, but the Grafana spec doesn't have an `ssl` property. 