### PR TITLE
qa/suites/crimson-rados: Accommodate to new crimson flavors

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -144,7 +144,7 @@ rbd-mirror" \
 >> packages.txt
 
 # Optional crimson package(s)
-RUN if [ "${OSD_FLAVOR}" == "crimson" ]; then \
+RUN if [[ "${OSD_FLAVOR}" == "crimson-debug" || "${OSD_FLAVOR}" == "crimson-release" ]]; then \
     echo "ceph-crimson-osd" >> packages.txt ; \
 fi
 

--- a/container/build.sh
+++ b/container/build.sh
@@ -174,7 +174,7 @@ if [[ ${CI_CONTAINER} == "true" ]] ; then
     podman tag ${image_id} ${branch_repo_tag}
     podman tag ${image_id} ${sha1_repo_tag}
 
-    if [[ ${FLAVOR} == "crimson" && ${ARCH} == "x86_64" ]] ; then
+    if [[ (${FLAVOR} == "crimson-debug" || ${FLAVOR} == "crimson-release") && ${ARCH} == "x86_64" ]] ; then
         sha1_flavor_repo_tag=${sha1_repo_tag}-${FLAVOR}
         podman tag ${image_id} ${sha1_flavor_repo_tag}
         if [[ -z "${NO_PUSH}" ]] ; then

--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -12,7 +12,6 @@ overrides:
         debug ms: 20
         seastore cache lru size: 64M
         seastore max concurrent transactions: 8
-    flavor: crimson
   workunit:
     env:
       CRIMSON_COMPAT: '1'

--- a/qa/suites/crimson-rados-experimental/thrash/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados-experimental/thrash/deploy/ceph.yaml
@@ -1,11 +1,6 @@
-overrides:
-  install:
-    ceph:
-      flavor: crimson
 tasks:
 - install:
 - ceph:
     conf:
       osd:
         debug monc: 20
-    flavor: crimson

--- a/qa/suites/crimson-rados/basic/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/basic/deploy/ceph.yaml
@@ -1,7 +1,3 @@
-overrides:
-  install:
-    ceph:
-      flavor: crimson
 tasks:
 - install:
 - ceph:
@@ -15,4 +11,3 @@ tasks:
         mon osdmap full prune min: 15
         mon osdmap full prune interval: 2
         mon osdmap full prune txsize: 2
-    flavor: crimson

--- a/qa/suites/crimson-rados/perf/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/perf/deploy/ceph.yaml
@@ -1,7 +1,3 @@
-overrides:
-  install:
-    ceph:
-      flavor: crimson
 tasks:
 - install:
 - ceph:
@@ -9,5 +5,4 @@ tasks:
     conf:
       osd:
         debug monc: 20
-    flavor: crimson
 - ssh_keys:

--- a/qa/suites/crimson-rados/rbd/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/rbd/deploy/ceph.yaml
@@ -1,7 +1,3 @@
-overrides:
-  install:
-    ceph:
-      flavor: crimson
 tasks:
 - install:
 - ceph:
@@ -15,4 +11,3 @@ tasks:
         mon osdmap full prune min: 15
         mon osdmap full prune interval: 2
         mon osdmap full prune txsize: 2
-    flavor: crimson

--- a/qa/suites/crimson-rados/singleton/all/osd-backfill.yaml
+++ b/qa/suites/crimson-rados/singleton/all/osd-backfill.yaml
@@ -11,8 +11,6 @@ openstack:
       count: 3
       size: 10 # GB
 tasks:
-- install:
-    flavor: crimson
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force

--- a/qa/suites/crimson-rados/singleton/all/osd-pg-splitting.yaml
+++ b/qa/suites/crimson-rados/singleton/all/osd-pg-splitting.yaml
@@ -12,8 +12,6 @@ openstack:
       count: 3
       size: 10 # GB
 tasks:
-- install:
-    flavor: crimson
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force

--- a/qa/suites/crimson-rados/thrash/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/thrash/deploy/ceph.yaml
@@ -1,11 +1,6 @@
-overrides:
-  install:
-    ceph:
-      flavor: crimson
 tasks:
 - install:
 - ceph:
     conf:
       osd:
         debug monc: 20
-    flavor: crimson

--- a/qa/suites/crimson-rados/thrash_seastore_radosbench/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/thrash_seastore_radosbench/deploy/ceph.yaml
@@ -1,11 +1,6 @@
-overrides:
-  install:
-    ceph:
-      flavor: crimson
 tasks:
 - install:
 - ceph:
     conf:
       osd:
         debug monc: 20
-    flavor: crimson

--- a/qa/suites/crimson-rados/thrash_simple/deploy/ceph.yaml
+++ b/qa/suites/crimson-rados/thrash_simple/deploy/ceph.yaml
@@ -1,11 +1,6 @@
-overrides:
-  install:
-    ceph:
-      flavor: crimson
 tasks:
 - install:
 - ceph:
     conf:
       osd:
         debug monc: 20
-    flavor: crimson

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -666,7 +666,8 @@ def create_simple_monmap(ctx, remote, conf, mons,
 
 
 def is_crimson(config):
-    return config.get('flavor', 'default') == 'crimson'
+    return config.get('flavor', 'default') == 'crimson-debug' or \
+        config.get('flavor', 'default') == 'crimson-release'
 
 
 def maybe_redirect_stderr(config, type_, args, log_path):

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -2352,7 +2352,7 @@ def task(ctx, config):
         flavor = config.get('flavor', 'default')
 
         if sha1:
-            if flavor == "crimson":
+            if flavor == "crimson-debug" or flavor == "crimson-release":
                 ctx.ceph[cluster_name].image = container_image_name + ':' + sha1 + '-' + flavor
             else:
                 ctx.ceph[cluster_name].image = container_image_name + ':' + sha1

--- a/qa/tasks/rook.py
+++ b/qa/tasks/rook.py
@@ -626,7 +626,7 @@ def task(ctx, config):
         sha1 = config.get('sha1')
         flavor = config.get('flavor', 'default')
         if sha1:
-            if flavor == "crimson":
+            if flavor == "crimson-debug" or flavor == "crimson-release":
                 ctx.rook[cluster_name].image = container_image_name + ':' + sha1 + '-' + flavor
             else:
                 ctx.rook[cluster_name].image = container_image_name + ':' + sha1


### PR DESCRIPTION
flavor crimson is deprecated, let the flavor to be set when passing --flavor/-f when scheduling jobs instead.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
