### PR TITLE
doc/rados/operations: Address suggestions for stretch-mode.rst

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -18,8 +18,9 @@ one-third to one-half of the total cluster).
 
 Ceph is designed with the expectation that all parts of its network and cluster
 will be reliable and that failures will be distributed randomly across the
-CRUSH topology. If a host or network switch goes down and causes the loss of many OSDs, Ceph is
-designed so that the remaining OSDs and monitors will route around such a loss. 
+CRUSH topology. When a host or network switch goes down, many OSDs will
+become unavailable. Ceph is designed so that the remaining OSDs and
+Monitors will maintain access to data.
 
 Sometimes this cannot be relied upon. If you have a "stretched-cluster"
 deployment in which much of your cluster is behind a single network component,
@@ -30,12 +31,12 @@ data centers (or, in clouds, two availability zones), and a configuration with
 three data centers.
 
 In the two-site configuration, Ceph arranges for each site to hold a copy of
-the data, with a third site that has a tiebreaker (arbiter, witness)
-monitor. This tiebreaker monitor picks a winner when a network connection
+the data. A third site houses a tiebreaker (arbiter, witness)
+Monitor. This tiebreaker Monitor picks a winner when a network connection
 between sites fails and both data centers remain alive.
 
 The tiebreaker monitor can be a VM. It can also have higher network latency
-to the two main sites.
+to the OSD site(s) than OSD site(s) can have to each other.
 
 The standard Ceph configuration is able to survive many network failures or
 data-center failures without compromising data availability. When enough
@@ -57,7 +58,7 @@ without human intervention.
 
 Ceph does not permit the compromise of data integrity or data consistency, but
 there are situations in which *data availability* is compromised. These
-situations can occur even though there are sufficient replias of data available to satisfy
+situations can occur even though there are sufficient replicas of data available to satisfy
 consistency and sizing constraints. In some situations, you might
 discover that your cluster does not satisfy those constraints.
 
@@ -87,8 +88,7 @@ Individual Stretch Pools
 ========================
 Setting individual ``stretch pool`` attributes allows for
 specific pools to be distributed across two or more data centers.
-This is done by executing the ``ceph osd pool stretch set`` command on each desired pool,
-contrasted with a cluster-wide strategy with *stretch mode*.
+This is done by executing the ``ceph osd pool stretch set`` command on each desired pool.
 See :ref:`setting_values_for_a_stretch_pool`
 
 Use stretch mode when you have exactly two data centers and require a uniform
@@ -185,8 +185,8 @@ with the CRUSH topology.
              step emit
      }
 
-   .. warning:: If a CRUSH rule is defined in stretch mode cluster and the
-      rule has multiple ``take`` steps, then ``MAX AVAIL`` for the pools
+   .. warning:: When a CRUSH rule is defined in a stretch mode cluster and the
+      rule has multiple ``take`` steps, ``MAX AVAIL`` for the pools
       associated with the CRUSH rule will report that the available size is all
       of the available space from the datacenter, not the available space for
       the pools associated with the CRUSH rule.
@@ -264,7 +264,7 @@ with the CRUSH topology.
 When stretch mode is enabled, PGs will become active only when they peer
 across CRUSH ``datacenter``s (or across whichever CRUSH bucket type was specified),
 assuming both are available. Pools will increase in size from the default ``3`` to
-``4``, and two replicas will be place at each site. OSDs will be allowed to
+``4``, and two replicas will be placed at each site. OSDs will be allowed to
 connect to Monitors only if they are in the same data center as the Monitors.
 New Monitors will not be allowed to join the cluster if they do not specify a
 CRUSH location.
@@ -302,20 +302,20 @@ To exit stretch mode, run the following command:
 
 .. describe:: {crush_rule}
 
-   The CRUSH rule to now use for all pools. If this
+   The non-stretch CRUSH rule to use for all pools. If this
    is not specified, the pools will move to the default CRUSH rule.
 
    :Type: String
    :Required: No.
 
-This command will move the cluster back to normal mode;
+This command moves the cluster back to normal mode;
 the cluster will no longer be in stretch mode.
 All pools will be set with their prior ``size`` and ``min_size``
 values. At this point the user is responsible for scaling down the cluster
 to the desired number of OSDs if they choose to operate with fewer OSDs.
 
-Please note that the command will not execute when the cluster is in
-recovery stretch mode. The command will only execute when the cluster
+Note that the command will not execute when the cluster is in
+recovery stretch mode. The command executes only when the cluster
 is in degraded stretch mode or healthy stretch mode.
 
 Limitations of Stretch Mode 


### PR DESCRIPTION
doc/rados/operations: Address suggestions for stretch-mode.rst


(cherry picked from commit 3f5bf8dedd18f2f6d4afc0583be124be879667f2)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
