### PR TITLE
[Draft] config diff scripts pull request - TEST

### DIFF
--- a/.github/workflows/diff-ceph-config.yml
+++ b/.github/workflows/diff-ceph-config.yml
@@ -20,11 +20,29 @@ jobs:
       - name: checkout ceph.git
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           path: ceph
           sparse-checkout: |
             src/script
             src/common/options
             .github/workflows
+
+      - name:  'Get common ancestor between PR and ceph upstream main branch'
+        id: get_common_ancestor
+        env:
+          branch_pr: origin/${{ github.event.pull_request.head.ref }}
+          refspec_pr: +${{ github.event.pull_request.head.sha }}:remotes/origin/${{ github.event.pull_request.head.ref }}
+        working-directory: ceph
+        run: |
+          # Fetch enough history to find a common ancestor commit (aka merge-base):
+          git fetch origin ${{ env.refspec_pr }} --depth=$(( ${{ github.event.pull_request.commits }} + 1 )) \
+            --no-tags --prune --no-recurse-submodules
+
+          # This should get the oldest commit in the local fetched history (the commit in ceph upstream from which PR branched from):
+          COMMON_ANCESTOR=$( git rev-list --first-parent --max-parents=0 --max-count=1 ${{ env.branch_pr }} )
+          COMMON_ANCESTOR_SHA=$( git log --format=%H "${COMMON_ANCESTOR}" )
+
+          echo "COMMON_ANCESTOR_SHA=${COMMON_ANCESTOR_SHA}" >> $GITHUB_ENV
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
@@ -41,12 +59,14 @@ jobs:
         env:
           REF_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
           REF_BRANCH: ${{ github.event.pull_request.base.ref }}
+          REF_COMMIT_SHA: ${{ env.COMMON_ANCESTOR_SHA }}
           REMOTE_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
           REMOTE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REMOTE_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run:  |
           {
             echo 'DIFF_JSON<<EOF'
-            python3 ./src/script/config-diff/config_diff.py diff-branch-remote-repo --ref-branch $REF_BRANCH  --remote-repo $REMOTE_REPO --cmp-branch $REMOTE_BRANCH --format=posix-diff --skip-clone
+            python3 ./src/script/config-diff/config_diff.py diff-branch-remote-repo --ref-branch $REF_BRANCH --ref-commit-sha $REF_COMMIT_SHA --remote-repo $REMOTE_REPO --cmp-branch $REMOTE_BRANCH --cmp-commit-sha $REMOTE_COMMIT_SHA --format=posix-diff --skip-clone
             echo EOF
           } >> "$GITHUB_OUTPUT"
         working-directory: ceph

--- a/.github/workflows/test-diff-ceph-config.yml
+++ b/.github/workflows/test-diff-ceph-config.yml
@@ -1,0 +1,83 @@
+name: TEST Check ceph config changes
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+
+# The following permissions are needed to write a comment to repo
+permissions:
+    issues: write
+    contents: read
+    pull-requests: write
+
+jobs:
+  pull_request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout ceph.git
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ceph
+          sparse-checkout: |
+            src/script
+            src/common/options
+            .github/workflows
+
+      - name:  'Get common ancestor between PR and ceph upstream main branch'
+        id: get_common_ancestor
+        env:
+          branch_pr: origin/${{ github.event.pull_request.head.ref }}
+          refspec_pr: +${{ github.event.pull_request.head.sha }}:remotes/origin/${{ github.event.pull_request.head.ref }}
+        working-directory: ceph
+        run: |
+          # Fetch enough history to find a common ancestor commit (aka merge-base):
+          git fetch origin ${{ env.refspec_pr }} --depth=$(( ${{ github.event.pull_request.commits }} + 1 )) \
+            --no-tags --prune --no-recurse-submodules
+
+          # This should get the oldest commit in the local fetched history (the commit in ceph upstream from which PR branched from):
+          COMMON_ANCESTOR=$( git rev-list --first-parent --max-parents=0 --max-count=1 ${{ env.branch_pr }} )
+          COMMON_ANCESTOR_SHA=$( git log --format=%H "${COMMON_ANCESTOR}" )
+
+          echo "COMMON_ANCESTOR_SHA=${COMMON_ANCESTOR_SHA}" >> $GITHUB_ENV
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
+        with:
+          python-version: '3.13'
+
+      - name: Install python packages
+        run: |
+          pip3 install -r ./src/script/config-diff/requirements.txt
+        working-directory: ceph
+
+      - name: execute config diff tool
+        id: diff_tool
+        env:
+          REF_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
+          REF_BRANCH: ${{ github.event.pull_request.base.ref }}
+          REF_COMMIT_SHA: ${{ env.COMMON_ANCESTOR_SHA }}
+          REMOTE_REPO: ${{ github.event.pull_request.head.repo.clone_url }}
+          REMOTE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          REMOTE_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run:  |
+          {
+            echo 'DIFF_JSON<<EOF'
+            python3 ./src/script/config-diff/config_diff.py diff-branch-remote-repo --ref-branch $REF_BRANCH --ref-commit-sha $REF_COMMIT_SHA --remote-repo $REMOTE_REPO --cmp-branch $REMOTE_BRANCH --cmp-commit-sha $REMOTE_COMMIT_SHA --format=posix-diff --skip-clone
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+        working-directory: ceph
+
+      - name: Post output as a comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIFF_JSON_OUTPUT: ${{ steps.diff_tool.outputs.DIFF_JSON }}
+        with:
+          script: |
+            const configDiff = process.env.DIFF_JSON_OUTPUT;
+            const postComment = require('./ceph/.github/workflows/scripts/config-diff-post-comment.js');
+            postComment({ github, context, core, configDiff });

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -302,7 +302,7 @@ options:
   level: advanced
   desc: whether to daemonize (background) after startup
   default: false
-  daemon_default: true
+  daemon_default: false
   tags:
   - service
   services:
@@ -4779,7 +4779,7 @@ options:
     state) media
   fmt_desc: Default value of ``bluestore compression max blob size``
     for non-rotational (SSD, NVMe) media.
-  default: 64_K
+  default: 64_GB
   see_also:
   - bluestore_compression_max_blob_size
   flags:

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1549,11 +1549,6 @@ options:
   flags:
   - startup
 # minimum number of peers
-- name: osd_heartbeat_min_peers
-  type: int
-  level: advanced
-  default: 10
-  with_legacy: true
 - name: osd_delete_sleep
   type: float
   level: advanced
@@ -1587,7 +1582,7 @@ options:
   desc: Time in seconds to sleep before next removal transaction when OSD data is on HDD
     and OSD journal or WAL+DB is on SSD
   note: This setting is ignored when the mClock scheduler is used.
-  default: 1
+  default: 10000
   flags:
   - runtime
 - name: osd_rocksdb_iterator_bounds_enabled

--- a/src/common/options/rbd.yaml.in
+++ b/src/common/options/rbd.yaml.in
@@ -874,6 +874,12 @@ options:
   desc: comma-delimited list of librbd plugins to enable
   services:
   - rbd
+- name: rbd_plugins_test
+  type: str
+  level: advanced
+  desc: comma-delimited list of librbd plugins to enable
+  services:
+  - rbd
 - name: rbd_config_pool_override_update_timestamp
   type: uint
   level: dev

--- a/src/script/config-diff/README.md
+++ b/src/script/config-diff/README.md
@@ -52,6 +52,8 @@ python3 config_diff.py <mode> [options]
     - `--cmp-branch`: The branch to compare.
     - `--remote-repo`: The remote repository URL for the branch to compare.
     - `--ref-repo`: (Optional) The repository URL for the reference branch. Defaults to the Ceph upstream repository.
+    - `--ref-commit-sha`: (Optional) The commit sha for the reference branch that is used for reference
+    - `--cmp-commit-sha`: (Optional) The commit sha of the comparing branch
     - `--skip-clone`: (Optional) Skips cloning repositories for diff. **Note**: When using this flag, the script must be run from a valid Ceph upstream repository or a forked repository that has access to the branches present in the upstream repository or already contains those branches.
     - `--format`: (Optional) Specify the output format for the configuration diff. Options are `json` or `posix-diff`. Default is `json`.
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
