### PR TITLE
osd: Multiple fixes to optimized EC and peering

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -478,9 +478,13 @@ public:
     void trim(const pg_log_entry_t &entry) override {
       // TODO
     }
-    void partial_write(pg_info_t *info, const pg_log_entry_t &entry) override {
+    void partial_write(pg_info_t *info,
+                       eversion_t previous_version,
+                       const pg_log_entry_t &entry
+      ) override {
       // TODO
-      ceph_assert(entry.written_shards.empty() && info->partial_writes_last_complete.empty());
+      ceph_assert(entry.written_shards.empty() &&
+                  info->partial_writes_last_complete.empty());
     }
   };
   PGLog::LogEntryHandlerRef get_log_handler(

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1524,9 +1524,11 @@ void OSDMonitor::prime_pg_temp(
   {
     std::lock_guard l(prime_pg_temp_lock);
     // do not touch a mapping if a change is pending
+    std::vector<int> pg_temp = pool ? next.pgtemp_primaryfirst(*pool, acting) :
+                                      acting;
     pending_inc.new_pg_temp.emplace(
       pgid,
-      mempool::osdmap::vector<int>(acting.begin(), acting.end()));
+      mempool::osdmap::vector<int>(pg_temp.begin(), pg_temp.end()));
   }
 }
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1622,7 +1622,7 @@ void ECBackend::objects_read_async(
   extent_set es;
   for (const auto &[read, ctx]: to_read) {
     pair<uint64_t, uint64_t> tmp;
-    if (!cct->_conf->osd_ec_partial_reads || fast_read) {
+    if (!cct->_conf->osd_ec_partial_reads) {
       tmp = sinfo.ro_offset_len_to_stripe_ro_offset_len(read.offset, read.size);
     } else {
       tmp.first = read.offset;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -373,7 +373,7 @@ void ECBackend::RecoveryBackend::handle_recovery_read_complete(
     }
   }
 
-  uint64_t aligned_size = ECUtil::align_page_next(op.obc->obs.oi.size);
+  uint64_t aligned_size = ECUtil::align_next(op.obc->obs.oi.size);
 
   int r = op.returned_data->decode(ec_impl, shard_want_to_read, aligned_size);
   ceph_assert(r == 0);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1246,6 +1246,9 @@ void ECBackend::handle_sub_read_reply(
       rop.complete.emplace(hoid, &sinfo);
     }
     auto &complete = rop.complete.at(hoid);
+    if (!req.shard_reads.contains(from.shard)) {
+      continue;
+    }
     const shard_read_t &read = req.shard_reads.at(from.shard);
     if (!complete.errors.contains(from)) {
       dout(20) << __func__ <<" read:" << read << dendl;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -252,7 +252,7 @@ class ECBackend : public ECCommon {
       hobject_t hoid;
       eversion_t v;
       std::set<pg_shard_t> missing_on;
-      std::set<shard_id_t> missing_on_shards;
+      shard_id_set missing_on_shards;
 
       ObjectRecoveryInfo recovery_info;
       ObjectRecoveryProgress recovery_progress;

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -280,7 +280,7 @@ int ECCommon::ReadPipeline::get_min_avail_to_read_shards(
       extents.union_of(read_request.shard_want_to_read.at(shard));
     }
 
-    extents.align(CEPH_PAGE_SIZE);
+    extents.align(EC_ALIGN_SIZE);
     if (read_mask.contains(shard)) {
       shard_read.extents.intersection_of(extents, read_mask.at(shard));
     }

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -615,7 +615,7 @@ int ECCommon::ReadPipeline::send_all_remaining_reads(
   // reset the old shard reads, we are going to read them again.
   read_request.shard_reads.clear();
   return get_remaining_shards(hoid, rop.complete.at(hoid), read_request,
-                              rop.do_redundant_reads, want_attrs);
+                              rop.for_recovery, want_attrs);
 }
 
 void ECCommon::ReadPipeline::kick_reads() {

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -181,7 +181,8 @@ struct ECCommon {
       } else {
         os << ", noattrs";
       }
-      os << ", buffers_read=" << buffers_read << ")";
+      os << ", buffers_read=" << buffers_read;
+      os << ", processed_read_requests=" << processed_read_requests << ")";
     }
   };
 

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -532,7 +532,7 @@ struct ECCommon {
             << " temp_cleared=" << temp_cleared
             << " remote_read_result=" << remote_shard_extent_map
             << " pending_commits=" << pending_commits
-            << " plan.to_read=" << plan
+            << " plans=" << plan
             << ")";
       }
     };

--- a/src/osd/ECExtentCache.cc
+++ b/src/osd/ECExtentCache.cc
@@ -331,10 +331,6 @@ void ECExtentCache::on_change2() const {
 
 void ECExtentCache::execute(list<OpRef> &op_list) {
   for (auto &op : op_list) {
-    if (op->projected_size < op->object.projected_size) {
-      // Invalidate the object's cache when we see any object reduce in size.
-      op->invalidates_cache = true;
-    }
     op->object.request(op);
   }
   waiting_ops.insert(waiting_ops.end(), op_list.begin(), op_list.end());

--- a/src/osd/ECExtentCache.cc
+++ b/src/osd/ECExtentCache.cc
@@ -173,7 +173,6 @@ void ECExtentCache::Object::erase_line(uint64_t offset) {
   check_seset_empty_for_range(requesting, offset, line_size);
   do_not_read.erase_stripe(offset, line_size);
   lines.erase(offset);
-  delete_maybe();
 }
 
 void ECExtentCache::Object::invalidate(const OpRef &invalidating_op) {

--- a/src/osd/ECExtentCache.cc
+++ b/src/osd/ECExtentCache.cc
@@ -334,18 +334,11 @@ void ECExtentCache::execute(list<OpRef> &op_list) {
     op->object.request(op);
   }
   waiting_ops.insert(waiting_ops.end(), op_list.begin(), op_list.end());
-  counter++;
   cache_maybe_ready();
 }
 
 bool ECExtentCache::idle() const {
   return active_ios == 0;
-}
-
-uint32_t ECExtentCache::get_and_reset_counter() {
-  uint32_t ret = counter;
-  counter = 0;
-  return ret;
 }
 
 list<ECExtentCache::LRU::Key>::iterator ECExtentCache::LRU::erase(

--- a/src/osd/ECExtentCache.h
+++ b/src/osd/ECExtentCache.h
@@ -304,7 +304,6 @@ private:
   const ECUtil::stripe_info_t &sinfo;
   std::list<OpRef> waiting_ops;
   void cache_maybe_ready();
-  uint32_t counter = 0;
   uint32_t active_ios = 0;
   CephContext *cct;
 
@@ -360,7 +359,6 @@ private:
 
   void execute(std::list<OpRef> &op_list);
   [[nodiscard]] bool idle() const;
-  uint32_t get_and_reset_counter();
 
   void add_on_write(std::function<void(void)> &&cb) const {
     if (waiting_ops.empty()) {

--- a/src/osd/ECExtentCache.h
+++ b/src/osd/ECExtentCache.h
@@ -155,6 +155,7 @@ class ECExtentCache {
     ECUtil::shard_extent_map_t result;
     bool complete = false;
     bool invalidates_cache = false;
+    bool did_invalidate_cache = false;
     bool reading = false;
     bool read_done = false;
     uint64_t projected_size = 0;
@@ -225,7 +226,6 @@ private:
     uint64_t projected_size = 0;
     uint64_t line_size = 0;
     bool reading = false;
-    bool cache_invalidated = false;
     bool cache_invalidate_expected = false;
 
     void request(OpRef &op);

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -137,7 +137,12 @@ ECTransaction::WritePlanObj::WritePlanObj(
 {
   extent_set unaligned_ro_writes;
   hobject_t source;
-  invalidates_cache = op.has_source(&source) || op.is_delete();
+  /* Certain transactions mean that the cache is invalid:
+   * 1. Clone operations invalidate the *target*
+   * 2. ALL delete operations (do NOT use is_delete() here!!!)
+   * 3. Truncates that reduce size.
+   */
+  invalidates_cache = op.has_source(&source) || op.delete_first || projected_size < orig_size;
 
   op.buffer_updates.to_interval_set(unaligned_ro_writes);
 

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -132,16 +132,10 @@ ECTransaction::WritePlanObj::WritePlanObj(
   will_write(sinfo.get_k_plus_m()),
   hinfo(hinfo),
   shinfo(shinfo),
-  orig_size(orig_size) // On-disk object sizes are rounded up to the next page.
+  orig_size(orig_size), // On-disk object sizes are rounded up to the next page.
+  projected_size(soi?soi->size:(oi?oi->size:0))
 {
   extent_set unaligned_ro_writes;
-
-  projected_size = oi ? oi->size : 0;
-
-  if (soi) {
-    projected_size = soi->size;
-  }
-
   hobject_t source;
   invalidates_cache = op.has_source(&source) || op.is_delete();
 

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -29,7 +29,7 @@ class WritePlanObj {
   const ECUtil::HashInfoRef hinfo;
   const ECUtil::HashInfoRef shinfo;
   const uint64_t orig_size;
-  uint64_t projected_size;
+  const uint64_t projected_size;
   bool invalidates_cache;
   bool do_parity_delta_write = false;
 
@@ -74,7 +74,7 @@ struct WritePlan {
       } else {
         os << ", ";
       }
-      os << p;
+      os << "{" << p << "}";
     }
    os << "]";
   }

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -99,6 +99,7 @@ class Generate {
   std::vector<std::pair<uint64_t, uint64_t>> rollback_extents;
   std::vector<shard_id_set> rollback_shards;
   uint32_t fadvise_flags = 0;
+  bool written_shards_final{false};
 
   void all_shards_written();
   void shard_written(const shard_id_t shard);

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -48,14 +48,16 @@ class WritePlanObj {
       const unsigned pdw_write_mode);
 
   void print(std::ostream &os) const {
-    os << "to_read: " << to_read
+    os << "{hoid: " << hoid
+       << " to_read: " << to_read
        << " will_write: " << will_write
        << " hinfo: " << hinfo
        << " shinfo: " << shinfo
        << " orig_size: " << orig_size
        << " projected_size: " << projected_size
        << " invalidates_cache: " << invalidates_cache
-       << " do_pdw: " << do_parity_delta_write;
+       << " do_pdw: " << do_parity_delta_write
+       << "}";
   }
 };
 
@@ -64,7 +66,7 @@ struct WritePlan {
   std::list<WritePlanObj> plans;
 
   void print(std::ostream &os) const {
-    os << " { plans : ";
+    os << " plans: [";
     bool first = true;
     for (auto && p : plans) {
       if (first) {
@@ -74,7 +76,7 @@ struct WritePlan {
       }
       os << p;
     }
-    os << "}";
+   os << "]";
   }
 };
 

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -206,12 +206,11 @@ void shard_extent_map_t::erase_after_ro_offset(uint64_t ro_offset) {
                                       ro_to_erase);
   for (auto &&[shard, eset] : ro_to_erase) {
     if (extent_maps.contains(shard)) {
-      extent_maps[shard].erase(eset.range_start(), eset.range_end());
-    }
-
-    // If the result is empty, delete the extent map.
-    if (extent_maps[shard].empty()) {
-      extent_maps.erase(shard);
+      auto &emap = extent_maps.at(shard);
+      emap.erase(eset.range_start(), eset.range_end());
+      if (emap.empty()) {
+        extent_maps.erase(shard);
+      }
     }
   }
 

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -354,7 +354,7 @@ void shard_extent_map_t::insert_in_shard(shard_id_t shard, uint64_t off,
   extent_maps[shard].insert(off, bl.length(), bl);
   raw_shard_id_t raw_shard = sinfo->get_raw_shard(shard);
 
-  if (raw_shard > sinfo->get_k()) {
+  if (raw_shard >= sinfo->get_k()) {
     return;
   }
 

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -137,6 +137,10 @@ class slice_iterator {
           if (emap_iter == input[shard].end()) {
             erase = true;
           } else {
+            if (out_set.contains(shard)) {
+              bufferlist bl = emap_iter.get_val();
+              bl.invalidate_crc();
+            }
             iters.at(shard).second = emap_iter.get_val().begin();
           }
         }

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -209,10 +209,6 @@ public:
   }
 };
 
-// Setting to 1 turns on very large amounts of level 0 debug containing the
-// contents of buffers. Even on level 20 this is not really wanted.
-#define DEBUG_EC_BUFFERS 1
-
 namespace ECUtil {
 class shard_extent_map_t;
 
@@ -314,7 +310,9 @@ struct shard_extent_set_t {
   /** return the sum of extent_set.size */
   uint64_t size() const {
     uint64_t size = 0;
-    for (auto &&[_, e] : map) size += e.size();
+    for (auto &&[_, e] : map) {
+      size += e.size();
+    }
 
     return size;
   }

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -950,6 +950,8 @@ public:
                      const shard_id_set &shards);
   void pad_on_shards(const extent_set &pad_to,
                      const shard_id_set &shards);
+  void pad_on_shard(const extent_set &pad_to,
+                    const shard_id_t shard);
   void trim(const shard_extent_set_t &trim_to);
   int decode(const ErasureCodeInterfaceRef &ec_impl,
              const shard_extent_set_t &want,

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7672,7 +7672,8 @@ void OSD::dispatch_session_waiting(const ceph::ref_t<Session>& session, OSDMapRe
     op->put();
 
     spg_t pgid;
-    if (m->get_type() == CEPH_MSG_OSD_OP) {
+    if (m->get_type() == CEPH_MSG_OSD_OP &&
+	!m->get_connection()->has_features(CEPH_FEATUREMASK_RESEND_ON_SPLIT)) {
       pg_t actual_pgid = osdmap->raw_pg_to_pg(
 	static_cast<const MOSDOp*>(m)->get_pg());
       if (!osdmap->get_primary_shard(actual_pgid, &pgid)) {
@@ -7680,6 +7681,12 @@ void OSD::dispatch_session_waiting(const ceph::ref_t<Session>& session, OSDMapRe
       }
     } else {
       pgid = m->get_spg();
+      //Pre-tentacle clients encode the shard_id_t incorrectly for optimized EC
+      //pools with pg_temp set. Correct the mistake here.
+      if (!m->get_connection()->has_features(CEPH_FEATUREMASK_SERVER_TENTACLE)) {
+        auto pi = osdmap->get_pg_pool(pgid.pool());
+	pgid.reset_shard(osdmap->pgtemp_undo_primaryfirst(*pi, pgid.pgid, pgid.shard));
+      }
     }
     enqueue_op(pgid, std::move(op), m->get_map_epoch());
   }
@@ -7765,11 +7772,25 @@ void OSD::ms_fast_dispatch(Message *m)
 
   service.maybe_inject_dispatch_delay();
 
-  if (m->get_connection()->has_features(CEPH_FEATUREMASK_RESEND_ON_SPLIT) ||
-      m->get_type() != CEPH_MSG_OSD_OP) {
+  // Pre-tentacle clients sending requests to EC shards other than 0 may
+  // set the shard incorrectly because of how pg_temp encodes primary
+  // shards first. These requests need to be routed through
+  // dispatch_session_waiting which uses the OSDMap to correct the shard.
+  bool legacy = !m->get_connection()->has_features(CEPH_FEATUREMASK_SERVER_TENTACLE);
+  spg_t spg = static_cast<MOSDFastDispatchOp*>(m)->get_spg();
+  if (legacy) {
+    // Optimization - replica pools and EC shard 0 are never remapped
+    if ((spg.shard == shard_id_t::NO_SHARD) ||
+	(spg.shard == shard_id_t(0))) {
+      legacy = false;
+    }
+  }
+  if (!legacy &&
+      (m->get_connection()->has_features(CEPH_FEATUREMASK_RESEND_ON_SPLIT) ||
+       m->get_type() != CEPH_MSG_OSD_OP)) {
     // queue it directly
     enqueue_op(
-      static_cast<MOSDFastDispatchOp*>(m)->get_spg(),
+      spg,
       std::move(op),
       static_cast<MOSDFastDispatchOp*>(m)->get_map_epoch());
   } else {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2026,7 +2026,9 @@ void OSDMap::clean_temps(CephContext *cct,
     int primary;
     nextmap.pg_to_raw_up(pg.first, &raw_up, &primary);
     bool remove = false;
-    if (raw_up == pg.second) {
+    const pg_pool_t *pool = nextmap.get_pg_pool(pg.first.pool());
+    auto acting_set = nextmap.pgtemp_undo_primaryfirst(*pool, pg.first, pg.second);
+    if (raw_up == acting_set) {
       ldout(cct, 10) << __func__ << "  removing pg_temp " << pg.first << " "
 		     << pg.second << " that matches raw_up mapping" << dendl;
       remove = true;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2034,13 +2034,9 @@ void OSDMap::clean_temps(CephContext *cct,
       // force a change of primary shard - do not remove pg_temp
       // if it is being used for this purpose
       if (pool->allows_ecoptimizations()) {
-	for (uint8_t i = 0; i < acting_set.size(); ++i) {
-	  if (acting_set[i] == primary) {
-	    if (pool->is_nonprimary_shard(shard_id_t(i))) {
-	      // pg_temp still required
-	      keep = true;
-	    }
-	  }
+	if (nextmap._pick_primary(pg.second) != primary) {
+	  // pg_temp still required
+	  keep = true;
 	}
       }
       if (!keep) {
@@ -2919,7 +2915,7 @@ const std::vector<int> OSDMap::pgtemp_undo_primaryfirst(const pg_pool_t& pool,
   // Only perform the transform for pools with allow_ec_optimizations set
   // that also have pg_temp set
   if (pool.allows_ecoptimizations()) {
-    if (pg_temp->find(pool.raw_pg_to_pg(pg)) != pg_temp->end()) {
+    if (has_pgtemp(pool.raw_pg_to_pg(pg))) {
       std::vector<int> result;
       int primaryshard = 0;
       int nonprimaryshard = pool.size - pool.nonprimary_shards.size();
@@ -2946,7 +2942,7 @@ const shard_id_t OSDMap::pgtemp_primaryfirst(const pg_pool_t& pool,
   }
   shard_id_t result = shard;
   if (pool.allows_ecoptimizations()) {
-    if (pg_temp->find(pool.raw_pg_to_pg(pg)) != pg_temp->end()) {
+    if (has_pgtemp(pool.raw_pg_to_pg(pg))) {
       int num_parity_shards = pool.size - pool.nonprimary_shards.size() - 1;
       if (shard >= pool.size - num_parity_shards) {
 	result = shard_id_t(result + num_parity_shards + 1 - pool.size);
@@ -2967,7 +2963,7 @@ shard_id_t OSDMap::pgtemp_undo_primaryfirst(const pg_pool_t& pool,
   }
   shard_id_t result = shard;
   if (pool.allows_ecoptimizations()) {
-    if (pg_temp->find(pool.raw_pg_to_pg(pg)) != pg_temp->end()) {
+    if (has_pgtemp(pool.raw_pg_to_pg(pg))) {
       int num_parity_shards = pool.size - pool.nonprimary_shards.size() - 1;
       if (shard > num_parity_shards) {
 	result = shard_id_t(result - num_parity_shards);
@@ -2982,6 +2978,7 @@ shard_id_t OSDMap::pgtemp_undo_primaryfirst(const pg_pool_t& pool,
 void OSDMap::_get_temp_osds(const pg_pool_t& pool, pg_t pg,
                             vector<int> *temp_pg, int *temp_primary) const
 {
+  vector<int> temp;
   pg = pool.raw_pg_to_pg(pg);
   const auto p = pg_temp->find(pg);
   temp_pg->clear();
@@ -2991,21 +2988,22 @@ void OSDMap::_get_temp_osds(const pg_pool_t& pool, pg_t pg,
 	if (pool.can_shift_osds()) {
 	  continue;
 	} else {
-	  temp_pg->push_back(CRUSH_ITEM_NONE);
+	  temp.push_back(CRUSH_ITEM_NONE);
 	}
       } else {
-	temp_pg->push_back(p->second[i]);
+	temp.push_back(p->second[i]);
       }
     }
+    *temp_pg = pgtemp_undo_primaryfirst(pool, pg, temp);
   }
   const auto &pp = primary_temp->find(pg);
   *temp_primary = -1;
   if (pp != primary_temp->end()) {
     *temp_primary = pp->second;
-  } else if (!temp_pg->empty()) { // apply pg_temp's primary
-    for (unsigned i = 0; i < temp_pg->size(); ++i) {
-      if ((*temp_pg)[i] != CRUSH_ITEM_NONE) {
-	*temp_primary = (*temp_pg)[i];
+  } else if (!temp.empty()) { // apply pg_temp's primary
+    for (unsigned i = 0; i < temp.size(); ++i) {
+      if (temp[i] != CRUSH_ITEM_NONE) {
+	*temp_primary = temp[i];
 	break;
       }
     }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1338,16 +1338,16 @@ public:
     return false;
   }
   bool get_primary_shard(const pg_t& pgid, int *primary, spg_t *out) const {
-    auto i = get_pools().find(pgid.pool());
-    if (i == get_pools().end()) {
+    auto poolit = get_pools().find(pgid.pool());
+    if (poolit == get_pools().end()) {
       return false;
     }
     std::vector<int> acting;
     pg_to_acting_osds(pgid, &acting, primary);
-    if (i->second.is_erasure()) {
+    if (poolit->second.is_erasure()) {
       for (uint8_t i = 0; i < acting.size(); ++i) {
 	if (acting[i] == *primary) {
-	  *out = spg_t(pgid, shard_id_t(i));
+	  *out = spg_t(pgid, pgtemp_undo_primaryfirst(poolit->second, pgid, shard_id_t(i)));
 	  return true;
 	}
       }
@@ -1363,6 +1363,12 @@ public:
   const std::vector<int> pgtemp_undo_primaryfirst(const pg_pool_t& pool,
 			   const pg_t pg,
 			   const std::vector<int>& acting) const;
+  const shard_id_t pgtemp_primaryfirst(const pg_pool_t& pool,
+				       const pg_t pg,
+				       const shard_id_t shard) const;
+  shard_id_t pgtemp_undo_primaryfirst(const pg_pool_t& pool,
+					    const pg_t pg,
+					    const shard_id_t shard) const;
 
   bool in_removed_snaps_queue(int64_t pool, snapid_t snap) const {
     auto p = removed_snaps_queue.find(pool);

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1358,6 +1358,9 @@ public:
     return false;
   }
 
+  bool has_pgtemp(const pg_t pg) const {
+    return (pg_temp->find(pg) != pg_temp->end());
+  }
   const std::vector<int> pgtemp_primaryfirst(const pg_pool_t& pool,
 			   const std::vector<int>& pg_temp) const;
   const std::vector<int> pgtemp_undo_primaryfirst(const pg_pool_t& pool,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1102,6 +1102,7 @@ void PG::read_state(ObjectStore *store)
 	info,
 	oss,
 	cct->_conf->osd_ignore_stale_divergent_priors,
+	pool.info.allows_ecoptimizations(),
 	cct->_conf->osd_debug_verify_missing_on_start);
 
       if (oss.tellp())

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1144,8 +1144,10 @@ protected:
     void trim(const pg_log_entry_t &entry) override {
       pg->get_pgbackend()->trim(entry, t);
     }
-    void partial_write(pg_info_t *info, const pg_log_entry_t &entry) override {
-      pg->get_pgbackend()->partial_write(info, entry);
+    void partial_write(pg_info_t *info, eversion_t previous_version,
+                       const pg_log_entry_t &entry
+      ) override {
+      pg->get_pgbackend()->partial_write(info, previous_version, entry);
     }
   };
 

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -413,51 +413,53 @@ void PGBackend::try_stash(
 
 void PGBackend::partial_write(
    pg_info_t *info,
+   eversion_t previous_version,
    const pg_log_entry_t &entry)
 {
   ceph_assert(info != nullptr);
-  auto dpp = get_parent()->get_dpp();
-  if (!entry.written_shards.empty()) {
-    ldpp_dout(dpp, 20) << __func__ << " version=" << entry.version
-		       << " written_shards=" << entry.written_shards
-		       << " present_shards=" << entry.present_shards
-		       << " pwlc=" << info->partial_writes_last_complete
-		       << dendl;
-    const pg_pool_t &pool = get_parent()->get_pool();
-    for (unsigned int shard = 0;
-	 shard < get_parent()->get_pool().size;
-	 shard++) {
-      if (pool.is_nonprimary_shard(shard_id_t(shard))) {
-        if (!entry.is_written_shard(shard_id_t(shard))) {
-	  if (!info->partial_writes_last_complete.contains(shard_id_t(shard))) {
-	    // 1st partial write since all logs were updated
-	    info->partial_writes_last_complete[shard_id_t(shard)] =
-	      std::pair(entry.prior_version, entry.version);
-	  } else if (info->partial_writes_last_complete[shard_id_t(shard)]
-		     .second.version + 1 == entry.version.version) {
-	    // Subsequent partial write, version is sequential
-	    info->partial_writes_last_complete[shard_id_t(shard)].second =
-	      entry.version;
-	  } else {
-	    // Subsequent partial write, discontiguous versions
-	    ldpp_dout(dpp, 20) << __func__ << " cannot update shard " << shard
-			       << dendl;
-	  }
-        } else {
-	  // Log updated or shard absent, partial write entry not required
-          info->partial_writes_last_complete.erase(shard_id_t(shard));
-	}
-      }
-    }
-    ldpp_dout(dpp, 20) << __func__ << " after pwlc="
-		       << info->partial_writes_last_complete << dendl;
-  } else {
-    // All shard updated - clear partial write data
-    if (!info->partial_writes_last_complete.empty()) {
-      ldpp_dout(dpp, 20) << __func__ << " clear pwlc" << dendl;
-    }
-    info->partial_writes_last_complete.clear();
+  if (entry.written_shards.empty() && info->partial_writes_last_complete.empty()) {
+    return;
   }
+  auto dpp = get_parent()->get_dpp();
+  ldpp_dout(dpp, 20) << __func__ << " version=" << entry.version
+		     << " written_shards=" << entry.written_shards
+		     << " present_shards=" << entry.present_shards
+		     << " pwlc=" << info->partial_writes_last_complete
+		     << " previous_version=" << previous_version
+		     << dendl;
+  const pg_pool_t &pool = get_parent()->get_pool();
+  for (shard_id_t shard : pool.nonprimary_shards) {
+    auto pwlc_iter = info->partial_writes_last_complete.find(shard);
+    if (!entry.is_written_shard(shard)) {
+      if (pwlc_iter == info->partial_writes_last_complete.end()) {
+	// 1st partial write since all logs were updated
+	info->partial_writes_last_complete[shard] =
+	  std::pair(previous_version, entry.version);
+
+	continue;
+      }
+      auto &&[old_v,  new_v] = pwlc_iter->second;
+      if (old_v == new_v) {
+	old_v = previous_version;
+	new_v = entry.version;
+      } else if (new_v == previous_version) {
+	// Subsequent partial write, contiguous versions
+	new_v = entry.version;
+      } else {
+	// Subsequent partial write, discontiguous versions
+	ldpp_dout(dpp, 20) << __func__ << " cannot update shard " << shard
+			   << dendl;
+      }
+    } else if (pwlc_iter != info->partial_writes_last_complete.end()) {
+      auto &&[old_v,  new_v] = pwlc_iter->second;
+      // Log updated or shard absent, partial write entry is a no-op
+      // FIXME: In a later commit (or later PR) we should look at other ways of
+      //        actually clearing the PWLC once all shards have seen the update.
+      old_v = new_v = entry.version;
+    }
+  }
+  ldpp_dout(dpp, 20) << __func__ << " after pwlc="
+		     << info->partial_writes_last_complete << dendl;
 }
 
 void PGBackend::remove(

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -504,6 +504,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
 
    void partial_write(
      pg_info_t *info,
+     eversion_t previous_version,
      const pg_log_entry_t &entry);
 
    void remove(

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -133,6 +133,11 @@ struct PGLog : DoutPrefixProvider {
     return cct;
   }
 
+  enum NonPrimary : bool {
+    NonPrimaryFalse = false,
+    NonPrimaryTrue = true
+  };
+
   ////////////////////////////// sub classes //////////////////////////////
   struct LogEntryHandler {
     virtual void rollback(
@@ -611,9 +616,13 @@ public:
     }
 
     // actors
-    void add(const pg_log_entry_t& e, bool applied = true) {
+    void add(const pg_log_entry_t& e, enum NonPrimary nonprimary, bool applied) {
       if (!applied) {
-	ceph_assert(get_can_rollback_to() == head);
+        if (!nonprimary) {
+          ceph_assert(get_can_rollback_to() == head);
+        } else {
+          ceph_assert(get_can_rollback_to() >= head);
+        }
       }
 
       // make sure our buffers don't pin bigger buffers
@@ -652,6 +661,12 @@ public:
 	skip_can_rollback_to_to_head();
       }
     } // add
+
+    // nonprimary and applied must either both be provided or neither. If
+    // neither is provided applied = true and the nonprimary is irrelevant.
+    void add(const pg_log_entry_t& e) {
+      add(e, NonPrimaryFalse, true);
+    }
 
     void trim(
       CephContext* cct,
@@ -820,9 +835,13 @@ public:
 
   void unindex() { log.unindex(); }
 
-  void add(const pg_log_entry_t& e, bool applied = true) {
+  void add(const pg_log_entry_t& e, enum NonPrimary nonprimary, bool applied) {
     mark_writeout_from(e.version);
-    log.add(e, applied);
+    log.add(e, nonprimary, applied);
+  }
+
+  void add(const pg_log_entry_t& e) {
+    add(e, NonPrimaryFalse, true);
   }
 
   void reset_recovery_pointers() { log.reset_recovery_pointers(); }

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1614,6 +1614,10 @@ public:
 	    continue;
 	  if (i->is_error())
 	    continue;
+	  if (!i->is_written_shard(info.pgid.shard)) {
+	    // optimized EC - partial write that this shard didn't participate in
+	    continue;
+	  }
 	  if (did.count(i->soid)) continue;
 	  did.insert(i->soid);
 

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -626,7 +626,7 @@ public:
     }
 
     // actors
-    void add(const pg_log_entry_t& e, enum NonPrimary nonprimary, bool applied) {
+    void add(const pg_log_entry_t& e, enum NonPrimary nonprimary, bool applied, pg_info_t *info, LogEntryHandler *h) {
       if (!applied) {
         if (!nonprimary) {
           ceph_assert(get_can_rollback_to() == head);
@@ -668,14 +668,14 @@ public:
       }
 
       if (!applied) {
-	skip_can_rollback_to_to_head();
+	skip_can_rollback_to_to_head(info, h);
       }
     } // add
 
     // nonprimary and applied must either both be provided or neither. If
     // neither is provided applied = true and the nonprimary is irrelevant.
     void add(const pg_log_entry_t& e) {
-      add(e, NonPrimaryFalse, true);
+      add(e, NonPrimaryFalse, true, nullptr, nullptr);
     }
 
     void trim(
@@ -845,13 +845,13 @@ public:
 
   void unindex() { log.unindex(); }
 
-  void add(const pg_log_entry_t& e, enum NonPrimary nonprimary, bool applied) {
+  void add(const pg_log_entry_t& e, enum NonPrimary nonprimary, bool applied, pg_info_t *info, LogEntryHandler *h) {
     mark_writeout_from(e.version);
-    log.add(e, nonprimary, applied);
+    log.add(e, nonprimary, applied, info, h);
   }
 
   void add(const pg_log_entry_t& e) {
-    add(e, NonPrimaryFalse, true);
+    add(e, NonPrimaryFalse, true, nullptr, nullptr);
   }
 
   void reset_recovery_pointers() { log.reset_recovery_pointers(); }

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1009,7 +1009,7 @@ public:
         ++log.complete_to;
 	// partial writes allow a shard which did not participate in a write to
 	// have a missing version that is newer that the most recent log entry
-	if (ec_optimizations_enabled && (log.complete_to == log.log.end())) {
+	if (log.complete_to == log.log.end()) {
 	  // keep complete_to one entry behind the end of the log to stop
 	  // code incorrectly using it to deduce that recovery has completed
 	  --log.complete_to;

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1010,6 +1010,9 @@ public:
 	// partial writes allow a shard which did not participate in a write to
 	// have a missing version that is newer that the most recent log entry
 	if (ec_optimizations_enabled && (log.complete_to == log.log.end())) {
+	  // keep complete_to one entry behind the end of the log to stop
+	  // code incorrectly using it to deduce that recovery has completed
+	  --log.complete_to;
 	  break;
 	}
         ceph_assert(log.complete_to != log.log.end());

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4488,7 +4488,8 @@ void PeeringState::add_log_entry(const pg_log_entry_t& e, bool applied)
     info.last_user_version = e.user_version;
 
   // log mutation
-  pg_log.add(e, applied);
+  enum PGLog::NonPrimary nonprimary{pool.info.is_nonprimary_shard(info.pgid.shard)};
+  pg_log.add(e, nonprimary, applied);
   psdout(10) << "add_log_entry " << e << dendl;
 }
 

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3603,7 +3603,10 @@ void PeeringState::split_into(
 
   child->info.last_user_version = info.last_user_version;
 
+  // fix up pwlc - it may refer to log entries that are no longer in the log
   child->info.partial_writes_last_complete = info.partial_writes_last_complete;
+  pg_log.split_pwlc(info);
+  child->pg_log.split_pwlc(child->info);
 
   info.log_tail = pg_log.get_tail();
   child->info.log_tail = child->pg_log.get_tail();

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -2685,7 +2685,7 @@ bool PeeringState::search_for_missing(
     tinfo.partial_writes_last_complete = info.partial_writes_last_complete;
     if (!tinfo.partial_writes_last_complete.empty()) {
       psdout(20) << "sending info to " << from
-		 << " pwcl=" << tinfo.partial_writes_last_complete
+		 << " pwlc=" << tinfo.partial_writes_last_complete
 		 << " info=" << tinfo
 		 << dendl;
     }

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1787,7 +1787,7 @@ private:
   void update_blocked_by();
   void update_calc_stats();
 
-  void add_log_entry(const pg_log_entry_t& e, bool applied);
+  void add_log_entry(const pg_log_entry_t& e, ObjectStore::Transaction &t, bool applied);
 
   void calc_trim_to();
   void calc_trim_to_aggressive();

--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -109,6 +109,9 @@ struct formatter<object_info_t> {
     if (oi.has_manifest()) {
       fmt::format_to(ctx.out(), " {}", oi.manifest);
     }
+    if (!oi.shard_versions.empty()) {
+      fmt::format_to(ctx.out(), " shard_versions={}", oi.shard_versions);
+    }
     return fmt::format_to(ctx.out(), ")");
   }
 };

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3020,7 +3020,7 @@ int Objecter::_calc_target(op_target_t *t, Connection *con, bool any_change)
     if (pi->is_erasure()) {
       for (uint8_t i = 0; i < t->acting.size(); ++i) {
         if (t->acting[i] == acting_primary) {
-          spgid.reset_shard(shard_id_t(i));
+	  spgid.reset_shard(osdmap->pgtemp_undo_primaryfirst(*pi, actual_pgid, shard_id_t(i)));
           break;
         }
       }

--- a/src/test/osd/TestECBackend.cc
+++ b/src/test/osd/TestECBackend.cc
@@ -765,8 +765,8 @@ TEST(ECCommon, get_min_want_to_read_shards)
 }
 
 TEST(ECCommon, get_min_avail_to_read_shards) {
-  const uint64_t page_size = CEPH_PAGE_SIZE;
-  const uint64_t swidth = 64*page_size;
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
   const unsigned int k = 4;
   const unsigned int m = 2;
   const int nshards = 6;
@@ -807,7 +807,7 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     hobject_t hoid;
 
     for (shard_id_t i; i<k; ++i) {
-      to_read_list[i].insert(int(i) * 2 * page_size, page_size);
+      to_read_list[i].insert(int(i) * 2 * align_size, align_size);
     }
 
     ECCommon::read_request_t read_request(to_read_list, false, object_size);
@@ -828,7 +828,7 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     ECUtil::shard_extent_set_t to_read_list(s.get_k_plus_m());
     hobject_t hoid;
     for (shard_id_t i; i<k; ++i) {
-      to_read_list[i].insert(int(i) * 2 * page_size, page_size);
+      to_read_list[i].insert(int(i) * 2 * align_size, align_size);
     }
 
     ECCommon::read_request_t read_request(to_read_list, false, object_size);
@@ -854,7 +854,7 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     hobject_t hoid;
 
     for (shard_id_t i; i < (int)k; ++i) {
-      to_read_list[i].insert(int(i) * 2 * page_size + int(i) + 1, int(i) + 1);
+      to_read_list[i].insert(int(i) * 2 * align_size + int(i) + 1, int(i) + 1);
     }
     ECCommon::read_request_t ref(to_read_list, false, object_size);
     ECCommon::read_request_t read_request(to_read_list, false, object_size);
@@ -862,7 +862,7 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
       shard_id_t shard_id(i);
       ECCommon::shard_read_t &ref_shard_read = ref.shard_reads[shard_id];
       ref_shard_read.subchunk = ecode->default_sub_chunk;
-      ref_shard_read.extents.insert(i*2*page_size, page_size);
+      ref_shard_read.extents.insert(i*2*align_size, align_size);
       ref_shard_read.pg_shard = pg_shard_t(i, shard_id_t(i));
     }
 
@@ -876,7 +876,7 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     hobject_t hoid;
 
     for (shard_id_t i; i<k; ++i) {
-      to_read_list[i].insert(int(i) * 2 * page_size, page_size);
+      to_read_list[i].insert(int(i) * 2 * align_size, align_size);
     }
 
     ECCommon::read_request_t read_request(to_read_list, false, object_size);
@@ -916,19 +916,19 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     hobject_t hoid;
     unsigned int missing_shard = 1;
 
-    to_read_list[shard_id_t(0)].insert(0, page_size);
-    to_read_list[shard_id_t(1)].insert(page_size, page_size);
-    to_read_list[shard_id_t(2)].insert(2*page_size, page_size);
-    to_read_list[shard_id_t(3)].insert(3*page_size, page_size);
+    to_read_list[shard_id_t(0)].insert(0, align_size);
+    to_read_list[shard_id_t(1)].insert(align_size, align_size);
+    to_read_list[shard_id_t(2)].insert(2*align_size, align_size);
+    to_read_list[shard_id_t(3)].insert(3*align_size, align_size);
     ECCommon::read_request_t read_request(to_read_list, false, object_size);
     ECCommon::read_request_t ref(to_read_list, false, object_size);
 
     // Populating reference manually to check that adjacent shards get correctly combined.
-    ref.shard_reads[shard_id_t(0)].extents.insert(0, page_size*2);
-    ref.shard_reads[shard_id_t(2)].extents.insert(page_size, page_size*2);
-    ref.shard_reads[shard_id_t(3)].extents.insert(page_size, page_size);
-    ref.shard_reads[shard_id_t(3)].extents.insert(3*page_size, page_size);
-    ref.shard_reads[shard_id_t(4)].extents.insert(page_size, page_size);
+    ref.shard_reads[shard_id_t(0)].extents.insert(0, align_size*2);
+    ref.shard_reads[shard_id_t(2)].extents.insert(align_size, align_size*2);
+    ref.shard_reads[shard_id_t(3)].extents.insert(align_size, align_size);
+    ref.shard_reads[shard_id_t(3)].extents.insert(3*align_size, align_size);
+    ref.shard_reads[shard_id_t(4)].extents.insert(align_size, align_size);
     ref.shard_reads[shard_id_t(0)].pg_shard = pg_shard_t(0, shard_id_t(0));
     ref.shard_reads[shard_id_t(2)].pg_shard = pg_shard_t(2, shard_id_t(2));
     ref.shard_reads[shard_id_t(3)].pg_shard = pg_shard_t(3, shard_id_t(3));
@@ -956,8 +956,8 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
 
     extent_set extents_to_read;
     for (shard_id_t i; i<k; ++i) {
-      to_read_list[i].insert(int(i) * 2 * page_size, page_size);
-      extents_to_read.insert(int(i) * 2 * page_size, page_size);
+      to_read_list[i].insert(int(i) * 2 * align_size, align_size);
+      extents_to_read.insert(int(i) * 2 * align_size, align_size);
     }
     ECCommon::read_request_t read_request(to_read_list, false, object_size);
 
@@ -981,7 +981,7 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
     hobject_t hoid;
 
     for (shard_id_t i; i<k; ++i) {
-      to_read_list[i].insert(int(i) * 2 * page_size, page_size);
+      to_read_list[i].insert(int(i) * 2 * align_size, align_size);
     }
     ECCommon::read_request_t read_request(to_read_list, false, object_size);
 
@@ -1019,8 +1019,8 @@ TEST(ECCommon, get_min_avail_to_read_shards) {
 
 TEST(ECCommon, shard_read_combo_tests)
 {
-  const uint64_t page_size = CEPH_PAGE_SIZE;
-  const uint64_t swidth = 2*page_size;
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 2*align_size;
   const unsigned int k = 2;
   const unsigned int m = 2;
   const int nshards = 4;
@@ -1140,8 +1140,8 @@ TEST(ECCommon, get_min_want_to_read_shards_bug67087)
 
 TEST(ECCommon, get_remaining_shards)
 {
-  const uint64_t page_size = CEPH_PAGE_SIZE;
-  const uint64_t swidth = 64*page_size;
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 64*align_size;
   const unsigned int k = 4;
   const unsigned int m = 2;
   const int nshards = 6;
@@ -1202,7 +1202,7 @@ TEST(ECCommon, get_remaining_shards)
     hobject_t hoid;
 
     ECUtil::shard_extent_set_t to_read(s.get_k_plus_m());
-    s.ro_range_to_shard_extent_set(chunk_size/2, chunk_size+page_size, to_read);
+    s.ro_range_to_shard_extent_set(chunk_size/2, chunk_size+align_size, to_read);
     ECCommon::read_request_t read_request(to_read, false, object_size);
     unsigned int missing_shard = 1;
 
@@ -1228,11 +1228,11 @@ TEST(ECCommon, get_remaining_shards)
     }
     ref.shard_reads[shard_id_t(0)].extents.insert(0, chunk_size/2);
     ref.shard_reads[shard_id_t(0)].pg_shard = pg_shards[0];
-    ref.shard_reads[shard_id_t(2)].extents.insert(0, chunk_size/2+page_size);
+    ref.shard_reads[shard_id_t(2)].extents.insert(0, chunk_size/2+align_size);
     ref.shard_reads[shard_id_t(2)].pg_shard = pg_shards[2];
-    ref.shard_reads[shard_id_t(3)].extents.insert(0, chunk_size/2+page_size);
+    ref.shard_reads[shard_id_t(3)].extents.insert(0, chunk_size/2+align_size);
     ref.shard_reads[shard_id_t(3)].pg_shard = pg_shards[3];
-    ref.shard_reads[shard_id_t(4)].extents.insert(0, chunk_size/2+page_size);
+    ref.shard_reads[shard_id_t(4)].extents.insert(0, chunk_size/2+align_size);
     ref.shard_reads[shard_id_t(4)].pg_shard = pg_shards[4];
     ASSERT_EQ(read_request,  ref);
   }
@@ -1240,8 +1240,8 @@ TEST(ECCommon, get_remaining_shards)
 
 TEST(ECCommon, encode)
 {
-  const uint64_t page_size = CEPH_PAGE_SIZE;
-  const uint64_t swidth = 2*page_size;
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 2*align_size;
   const unsigned int k = 2;
   const unsigned int m = 2;
 
@@ -1267,8 +1267,8 @@ TEST(ECCommon, encode)
 
 TEST(ECCommon, decode)
 {
-  const uint64_t page_size = CEPH_PAGE_SIZE;
-  const uint64_t swidth = 3*page_size;
+  const uint64_t align_size = EC_ALIGN_SIZE;
+  const uint64_t swidth = 3*align_size;
   const unsigned int k = 3;
   const unsigned int m = 2;
 

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2487,7 +2487,7 @@ public:
     clear();
     ostringstream err;
     read_log_and_missing(store.get(), ch, log_oid,
-			 pg_info_t(), err, false);
+			 pg_info_t(), err, false, false);
     ASSERT_EQ(orig_dups.size(), log.dups.size());
     ASSERT_EQ(orig_dups, log.dups);
     auto dups_it = log.dups.begin();

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -234,8 +234,10 @@ public:
     void trim(
       const pg_log_entry_t &entry) override {}
     void partial_write(
-      pg_info_t *info,
-      const pg_log_entry_t &entry) override {}
+        pg_info_t *info,
+        eversion_t previous_version,
+        const pg_log_entry_t &entry
+      ) override {}
   };
 
   template <typename missing_t>
@@ -360,8 +362,10 @@ struct TestHandler : public PGLog::LogEntryHandler {
   void trim(
     const pg_log_entry_t &entry) override {}
   void partial_write(
-    pg_info_t *info,
-    const pg_log_entry_t &entry) override {}
+      pg_info_t *info,
+      eversion_t previous_version,
+      const pg_log_entry_t &entry
+    ) override {}
 };
 
 TEST_F(PGLogTest, rewind_divergent_log) {

--- a/src/test/osd/test_extent_cache.cc
+++ b/src/test/osd/test_extent_cache.cc
@@ -597,7 +597,7 @@ TEST(ECExtentCache, test_invalidate)
     ASSERT_FALSE(result++->empty());
     ASSERT_TRUE(result++->empty());
     ASSERT_TRUE(result++->empty());
-    ASSERT_TRUE(result++->empty());
+    ASSERT_FALSE(result++->empty());
     cl.complete_write(*op1);
     cl.complete_write(*op2);
     cl.complete_write(*op3);
@@ -629,7 +629,7 @@ TEST(ECExtentCache, test_invalidate_lru)
     auto io2 = iset_from_vector({{{align_prev(18*bs), align_next(19*bs) - align_prev(18*bs)}}}, cl.get_stripe_info());
     io2[shard_id_t(k)].insert(io1.get_extent_superset());
     io2[shard_id_t(k+1)].insert(io1.get_extent_superset());
-    // io 3 is the truncate
+    // io 3 is the truncate (This does the invalidate)
     auto io3 = shard_extent_set_t(cl.sinfo.get_k_plus_m());
     auto io4 = iset_from_vector({{{align_prev(30*bs), align_next(31*bs) - align_prev(30*bs)}}}, cl.get_stripe_info());
     io3[shard_id_t(k)].insert(io1.get_extent_superset());
@@ -662,7 +662,7 @@ TEST(ECExtentCache, test_invalidate_lru)
     cl.complete_write(*op2);
     op2.reset();
 
-    optional op3 = cl.cache.prepare(cl.oid, nullopt, io3, align_next(36*bs), 0, false,
+    optional op3 = cl.cache.prepare(cl.oid, nullopt, io3, align_next(36*bs), 0, true,
       [&cl](ECExtentCache::OpRef &op)
       {
         cl.cache_ready(op->get_hoid(), op->get_result());

--- a/src/test/osd/test_extent_cache.cc
+++ b/src/test/osd/test_extent_cache.cc
@@ -623,22 +623,22 @@ TEST(ECExtentCache, test_invalidate_lru)
   /* Populate the cache LRU and then invalidate the cache. */
   {
     uint64_t bs = 3767;
-    auto io1 = iset_from_vector({{{align_page_prev(35*bs), align_page_next(36*bs) - align_page_prev(35*bs)}}}, cl.get_stripe_info());
+    auto io1 = iset_from_vector({{{align_prev(35*bs), align_next(36*bs) - align_prev(35*bs)}}}, cl.get_stripe_info());
     io1[shard_id_t(k)].insert(io1.get_extent_superset());
     io1[shard_id_t(k+1)].insert(io1.get_extent_superset());
-    auto io2 = iset_from_vector({{{align_page_prev(18*bs), align_page_next(19*bs) - align_page_prev(18*bs)}}}, cl.get_stripe_info());
+    auto io2 = iset_from_vector({{{align_prev(18*bs), align_next(19*bs) - align_prev(18*bs)}}}, cl.get_stripe_info());
     io2[shard_id_t(k)].insert(io1.get_extent_superset());
     io2[shard_id_t(k+1)].insert(io1.get_extent_superset());
     // io 3 is the truncate
     auto io3 = shard_extent_set_t(cl.sinfo.get_k_plus_m());
-    auto io4 = iset_from_vector({{{align_page_prev(30*bs), align_page_next(31*bs) - align_page_prev(30*bs)}}}, cl.get_stripe_info());
+    auto io4 = iset_from_vector({{{align_prev(30*bs), align_next(31*bs) - align_prev(30*bs)}}}, cl.get_stripe_info());
     io3[shard_id_t(k)].insert(io1.get_extent_superset());
     io3[shard_id_t(k+1)].insert(io1.get_extent_superset());
-    auto io5 = iset_from_vector({{{align_page_prev(18*bs), align_page_next(19*bs) - align_page_prev(18*bs)}}}, cl.get_stripe_info());
+    auto io5 = iset_from_vector({{{align_prev(18*bs), align_next(19*bs) - align_prev(18*bs)}}}, cl.get_stripe_info());
     io4[shard_id_t(k)].insert(io1.get_extent_superset());
     io4[shard_id_t(k+1)].insert(io1.get_extent_superset());
 
-    optional op1 = cl.cache.prepare(cl.oid, nullopt, io1, 0, align_page_next(36*bs), false,
+    optional op1 = cl.cache.prepare(cl.oid, nullopt, io1, 0, align_next(36*bs), false,
       [&cl](ECExtentCache::OpRef &op)
       {
         cl.cache_ready(op->get_hoid(), op->get_result());
@@ -649,7 +649,7 @@ TEST(ECExtentCache, test_invalidate_lru)
     cl.complete_write(*op1);
     op1.reset();
 
-    optional op2 = cl.cache.prepare(cl.oid, io2, io2, align_page_next(36*bs), align_page_next(36*bs), false,
+    optional op2 = cl.cache.prepare(cl.oid, io2, io2, align_next(36*bs), align_next(36*bs), false,
       [&cl](ECExtentCache::OpRef &op)
       {
         cl.cache_ready(op->get_hoid(), op->get_result());
@@ -662,7 +662,7 @@ TEST(ECExtentCache, test_invalidate_lru)
     cl.complete_write(*op2);
     op2.reset();
 
-    optional op3 = cl.cache.prepare(cl.oid, nullopt, io3, align_page_next(36*bs), 0, false,
+    optional op3 = cl.cache.prepare(cl.oid, nullopt, io3, align_next(36*bs), 0, false,
       [&cl](ECExtentCache::OpRef &op)
       {
         cl.cache_ready(op->get_hoid(), op->get_result());
@@ -672,7 +672,7 @@ TEST(ECExtentCache, test_invalidate_lru)
     cl.complete_write(*op3);
     op3.reset();
 
-    optional op4 = cl.cache.prepare(cl.oid, nullopt, io4, 0, align_page_next(30*bs), false,
+    optional op4 = cl.cache.prepare(cl.oid, nullopt, io4, 0, align_next(30*bs), false,
       [&cl](ECExtentCache::OpRef &op)
       {
         cl.cache_ready(op->get_hoid(), op->get_result());
@@ -682,7 +682,7 @@ TEST(ECExtentCache, test_invalidate_lru)
     cl.complete_write(*op4);
     op4.reset();
 
-    optional op5 = cl.cache.prepare(cl.oid, io5, io5, align_page_next(30*bs), align_page_next(30*bs), false,
+    optional op5 = cl.cache.prepare(cl.oid, io5, io5, align_next(30*bs), align_next(30*bs), false,
       [&cl](ECExtentCache::OpRef &op)
       {
         cl.cache_ready(op->get_hoid(), op->get_result());

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1183,7 +1183,7 @@ int expand_log(
     for (; e <= target_version; e.version++) {
       entry.version = e;
       std::cout << "adding " << e << std::endl;
-      log.add(entry, true);
+      log.add(entry);
     }
     info.last_complete = target_version;
     info.last_update = target_version;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -453,7 +453,8 @@ int get_log(CephContext *cct, ObjectStore *fs, __u8 struct_ver,
       pgid.make_pgmeta_oid(),
       info, log, missing,
       oss,
-      g_ceph_context->_conf->osd_ignore_stale_divergent_priors);
+      g_ceph_context->_conf->osd_ignore_stale_divergent_priors,
+      true); // Always use relaxed asserts for this tool.
     if (debug && oss.str().size())
       cerr << oss.str() << std::endl;
   }
@@ -1173,6 +1174,7 @@ int expand_log(
       info,
       oss,
       cct->_conf->osd_ignore_stale_divergent_priors,
+      true, // Always use relaxed asserts for this tool.
       cct->_conf->osd_debug_verify_missing_on_start);
     if (debug && oss.str().size())
       cerr << oss.str() << std::endl;


### PR DESCRIPTION
This PR is a result of several weeks/months of teuthology tests for EC, running in a branch where the optimised EC is always on. 

The commits themselves describe the individual problems that are being fixed and each fix is relatively self contained.  Where multiple attempts at a fix were made, these have been squashed, but largely each commit reflects the result of a teuthology test failure. 

There is one commit which is a collection of cosmetic/debug/typos, rather than spreading these out over other commits. 

Tracker: https://tracker.ceph.com/issues/71814

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
