### PR TITLE
cephadm/services/ingress.py: fixed _get_valid_interface_and_ip

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -312,13 +312,18 @@ class IngressService(CephService):
                 if ifaces and ipaddress.ip_address(bare_ip) in ipaddress.ip_network(subnet):
                     interface = list(ifaces.keys())[0]
                     for ip_addr in ifaces[interface]:
-                        if ip_addr != str(bare_ip):
-                            host_ip = ip_addr
-                            break
+                        # Ignore if the IP is the VIP
+                        if ip_addr == str(bare_ip):
+                            continue
+                        host_ip = ip_addr
+                        break
+
+                if host_ip:
                     logger.info(
                         f'{bare_ip} is in {subnet} on {host} interface {interface}'
                     )
                     break
+
             # try to find interface by matching spec.virtual_interface_networks
             if not interface and spec.virtual_interface_networks:
                 for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():


### PR DESCRIPTION
Function was returning a bad IP or an empty string when using IPv6.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
