### PR TITLE
RGW/D4N : adding Redis connection pool 

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4487,3 +4487,16 @@ options:
   default: false
   services:
   - rgw
+- name: rgw_redis_connection_pool_size
+  type: int
+  level: basic
+  desc: RGW connection pool size for Redis operation per D4N
+  long_desc: This option sets the size of the connection pool for Redis operations
+    in D4N. It is used to manage the number of concurrent connections to Redis.
+    A larger pool size can improve performance when multiple threads are accessing
+    Redis simultaneously, but it also increases resource usage.
+  fmt_desc: The size of the redis connection pool.
+  default: 512
+  services:
+  - rgw
+  with_legacy: true

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -130,12 +130,12 @@ void redis_exec_connection_pool(const DoutPrefixProvider* dpp,
 				boost::redis::generic_response& resp,
 				optional_yield y)
 {
-    if(redis_pool==nullptr)
+    if(!redis_pool)[[unlikely]]
     {
 	redis_exec(conn, ec, req, resp, y);
 	ldpp_dout(dpp, 0) << "Directory::" << __func__ << " not using connection-pool, it's using the shared connection " << dendl;
     }
-    else
+    else[[likely]]
     	redis_exec_cp(redis_pool, ec, req, resp, y);
 }
 
@@ -148,12 +148,12 @@ void redis_exec_connection_pool(const DoutPrefixProvider* dpp,
 				boost::redis::response<Types...>& resp,
 				optional_yield y)
 {
-    if(redis_pool==nullptr)
+    if(!redis_pool)[[unlikely]]
     {
 	redis_exec(conn, ec, req, resp, y);
 	ldpp_dout(dpp, 0) << "Directory::" << __func__ << " not using connection-pool, it's using the shared connection " << dendl;
     }
-    else
+    else[[likely]]
     	redis_exec_cp(redis_pool, ec, req, resp, y);
 }
 

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -4,8 +4,73 @@
 
 #include <boost/asio/detached.hpp>
 #include <boost/redis/connection.hpp>
+#include <condition_variable>
+#include <deque>
+#include <memory>
 
 namespace rgw { namespace d4n {
+
+using boost::redis::connection;
+class RedisPool {
+public:
+    RedisPool(boost::asio::io_context* ioc, const boost::redis::config& cfg, std::size_t size)
+        :  m_ioc(ioc),m_cfg(cfg) {
+        for (std::size_t i = 0; i < size; ++i) {
+            // Each connection gets its own strand
+            auto strand = boost::asio::make_strand(*m_ioc);
+            auto conn = std::make_shared<connection>(strand);
+            m_pool.push_back(conn);
+        }
+    }
+
+    std::shared_ptr<connection> acquire() {
+        std::unique_lock<std::mutex> lock(m_aquire_release_mtx);
+
+	if (!m_is_pool_connected) {
+		for(auto& it:m_pool) {
+	    		auto conn = it;
+	    		conn->async_run(m_cfg, {}, boost::asio::consign(boost::asio::detached, conn));
+		}
+	    m_is_pool_connected = true;
+	}
+
+        if (m_pool.empty()) {
+		//wait until m_pool is not empty
+		m_cond_var.wait(lock, [this] { return !m_pool.empty(); });
+        } 
+        auto conn = m_pool.front();
+        m_pool.pop_front();
+        return conn;
+    }
+
+    void release(std::shared_ptr<connection> conn) {
+        std::unique_lock<std::mutex> lock(m_aquire_release_mtx);
+        m_pool.push_back(conn);
+	// Notify one waiting thread that a connection is available
+	m_cond_var.notify_one();
+    }
+
+    int current_pool_size() const {
+        std::unique_lock<std::mutex> lock(m_aquire_release_mtx);
+        return m_pool.size();
+    }
+
+    void cancel_all() {
+        std::unique_lock<std::mutex> lock(m_aquire_release_mtx);
+	for(auto& conn : m_pool) {
+		conn->cancel();
+        }
+    }
+
+private:
+    boost::asio::io_context* m_ioc;
+    boost::redis::config m_cfg;
+    std::deque<std::shared_ptr<connection>> m_pool;
+    mutable std::mutex m_aquire_release_mtx;
+    std::condition_variable m_cond_var;
+    bool m_is_pool_connected{false};
+};
+
 
 namespace net = boost::asio;
 using boost::redis::config;
@@ -67,6 +132,10 @@ struct CacheBlock {
 
 class Directory {
   public:
+	std::shared_ptr<RedisPool> redis_pool{nullptr}; // Redis connection pool
+    	void set_redis_pool(std::shared_ptr<RedisPool> pool) {
+      	redis_pool = pool;
+    }
     Directory() {}
 };
 

--- a/src/rgw/driver/d4n/d4n_directory.h
+++ b/src/rgw/driver/d4n/d4n_directory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rgw_common.h"
+#include "rgw_asio_thread.h"
 
 #include <boost/asio/detached.hpp>
 #include <boost/redis/connection.hpp>
@@ -35,6 +36,7 @@ public:
 	}
 
         if (m_pool.empty()) {
+		maybe_warn_about_blocking(nullptr);
 		//wait until m_pool is not empty
 		m_cond_var.wait(lock, [this] { return !m_pool.empty(); });
         } 

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -62,6 +62,9 @@ class D4NFilterDriver : public FilterDriver {
     boost::asio::io_context& io_context;
     optional_yield y;
 
+    // Redis connection pool
+    std::shared_ptr<rgw::d4n::RedisPool> redis_pool;
+
   public:
     D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context, bool admin);
     virtual ~D4NFilterDriver();


### PR DESCRIPTION
the current connection setup is single and shared connection, this connection is guarded by a strand, which effectively serializes access: only one coroutine can use the connection at a time for both sending a request and reading the response.
 
Because of this serialization, under a steady workload of 100 concurrent S3 requests, each coroutine must wait for the preceding 99 Redis operations to finish their round-trip communication with the Redis server. This wait becomes more significant when certain Redis operations take longer than others.

To address this, a Redis connection pool has been introduced. The pool provides a thread-safe acquire/release API, allowing each Redis operation to obtain an independent, strand-guarded connection from the pool. This eliminates the serialization caused by the single shared connection, enabling concurrent Redis operations to proceed.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
