### PR TITLE
tentacle: mgr/vol: some improvements for stats_util.py and async_cloner.py

### DIFF
--- a/src/pybind/mgr/volumes/fs/async_cloner.py
+++ b/src/pybind/mgr/volumes/fs/async_cloner.py
@@ -177,12 +177,20 @@ def set_quota_on_clone(fs_handle, clone_volumes_pair):
         quota = int(fs_handle.getxattr(src_path, 'ceph.quota.max_bytes').decode('utf-8'))
     except cephfs.NoData:
         pass
+    except cephfs.ObjectNotFound:
+        log.info('set_quota_on_clone(): getxattr failed because source path '
+                 f'"{src_path}" has gone missing')
+        raise
 
     if quota is not None:
         try:
             fs_handle.setxattr(dst_path, 'ceph.quota.max_bytes', str(quota).encode('utf-8'), 0)
         except cephfs.InvalidValue:
             raise VolumeException(-errno.EINVAL, "invalid size specified: '{0}'".format(quota))
+        except cephfs.ObjectNotFound:
+            log.info('set_quota_on_clone(): getxattr failed because destination path '
+                     f'"{dst_path}" has gone missing')
+            raise
         except cephfs.Error as e:
              raise VolumeException(-e.args[0], e.args[1])
 
@@ -191,12 +199,20 @@ def set_quota_on_clone(fs_handle, clone_volumes_pair):
         quota_files = int(fs_handle.getxattr(src_path, 'ceph.quota.max_files').decode('utf-8'))
     except cephfs.NoData:
         pass
+    except cephfs.ObjectNotFound:
+        log.info('set_quota_on_clone(): getxattr failed because source path '
+                 f'"{src_path}" has gone missing')
+        raise
 
     if quota_files is not None:
         try:
             fs_handle.setxattr(dst_path, 'ceph.quota.max_files', str(quota_files).encode('utf-8'), 0)
         except cephfs.InvalidValue:
             raise VolumeException(-errno.EINVAL, "invalid file count specified: '{0}'".format(quota_files))
+        except cephfs.ObjectNotFound:
+            log.info('set_quota_on_clone(): getxattr failed because destination path '
+                     f'"{dst_path}" has gone missing')
+            raise
         except cephfs.Error as e:
              raise VolumeException(-e.args[0], e.args[1])
 

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -1035,7 +1035,8 @@ class VolumeClient(CephfsClient["Module"]):
             return None
 
         stats = get_stats(src_path, dst_path, vol_handle)
-        stats['percentage cloned'] = str(stats['percentage cloned']) + '%'
+        if stats:
+            stats['percentage cloned'] = str(stats['percentage cloned']) + '%'
         return stats
 
     def _get_clone_status(self, vol_handle, group, subvol):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71188

---

backport of https://github.com/ceph/ceph/pull/62638
parent tracker: https://tracker.ceph.com/issues/71019

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh