### PR TITLE
rgw/logging: refactoring of canonical_names()

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -496,6 +496,7 @@ public:
   int get_lua_filter(std::unique_ptr<RGWGetObj_Filter>* filter,
       RGWGetObj_Filter* cb);
 
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
 };
 
@@ -524,6 +525,7 @@ class RGWGetObjTags : public RGWOp {
   const char* name() const override { return "get_obj_tags"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_TAGGING; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 
 };
 
@@ -539,6 +541,7 @@ class RGWPutObjTags : public RGWOp {
   const char* name() const override { return "put_obj_tags"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ_TAGGING; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 
 };
 
@@ -551,6 +554,7 @@ class RGWDeleteObjTags: public RGWOp {
   const char* name() const override { return "delete_obj_tags"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
   RGWOpType get_type() override { return RGW_OP_DELETE_OBJ_TAGGING;}
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 };
 
 class RGWGetBucketTags : public RGWOp {
@@ -566,6 +570,7 @@ public:
   const char* name() const override { return "get_bucket_tags"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_TAGGING; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_TAGGING", s->info.method); }
 };
 
 class RGWPutBucketTags : public RGWOp {
@@ -581,6 +586,7 @@ public:
   const char* name() const override { return "put_bucket_tags"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_TAGGING; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_TAGGING", s->info.method); }
 };
 
 class RGWDeleteBucketTags : public RGWOp {
@@ -902,6 +908,7 @@ public:
   const char* name() const override { return "list_buckets"; }
   RGWOpType get_type() override { return RGW_OP_LIST_BUCKETS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKETS", s->info.method); }
 }; // class RGWListBuckets
 
 class RGWGetUsage : public RGWOp {
@@ -931,6 +938,7 @@ public:
 
   const char* name() const override { return "get_self_usage"; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.USER_USAGE", s->info.method); }
 };
 
 class RGWStatAccount : public RGWOp {
@@ -948,6 +956,7 @@ public:
   const char* name() const override { return "stat_account"; }
   RGWOpType get_type() override { return RGW_OP_STAT_ACCOUNT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_STATUS", s->info.method); }
 };
 
 class RGWListBucket : public RGWOp {
@@ -987,6 +996,7 @@ public:
   RGWOpType get_type() override { return RGW_OP_LIST_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   virtual bool need_container_stats() { return false; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWGetBucketLocation : public RGWOp {
@@ -1060,6 +1070,7 @@ public:
   const char* name() const override { return "get_bucket_website"; }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_WEBSITE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
 };
 
 class RGWSetBucketWebsite : public RGWOp {
@@ -1079,6 +1090,7 @@ public:
   const char* name() const override { return "set_bucket_website"; }
   RGWOpType get_type() override { return RGW_OP_SET_BUCKET_WEBSITE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
 };
 
 class RGWDeleteBucketWebsite : public RGWOp {
@@ -1093,6 +1105,7 @@ public:
   const char* name() const override { return "delete_bucket_website"; }
   RGWOpType get_type() override { return RGW_OP_SET_BUCKET_WEBSITE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
 };
 
 class RGWStatBucket : public RGWOp {
@@ -1110,6 +1123,7 @@ public:
   const char* name() const override { return "stat_bucket"; }
   RGWOpType get_type() override { return RGW_OP_STAT_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_STATUS", s->info.method); }
 };
 
 class RGWCreateBucket : public RGWOp {
@@ -1142,6 +1156,7 @@ class RGWCreateBucket : public RGWOp {
   const char* name() const override { return "create_bucket"; }
   RGWOpType get_type() override { return RGW_OP_CREATE_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWDeleteBucket : public RGWOp {
@@ -1159,6 +1174,7 @@ public:
   const char* name() const override { return "delete_bucket"; }
   RGWOpType get_type() override { return RGW_OP_DELETE_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 struct rgw_slo_entry {
@@ -1328,6 +1344,10 @@ public:
   const char* name() const override { return "put_obj"; }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override {
+    const bool multipart = !multipart_upload_id.empty();
+    return fmt::format("REST.{}.{}", s->info.method, multipart ? "PART" : "OBJECT");
+  }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
   bool always_do_bucket_logging() const override { return false; }
 };
@@ -1467,6 +1487,7 @@ public:
   RGWOpType get_type() override { return RGW_OP_PUT_METADATA_OBJECT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   virtual bool need_object_expiration() { return false; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_METADATA", s->info.method); }
 };
 
 class RGWRestoreObj : public RGWOp {
@@ -1486,6 +1507,7 @@ public:
   const char* name() const override { return "restore_obj"; }
   RGWOpType get_type() override { return RGW_OP_RESTORE_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class RGWDeleteObj : public RGWOp {
@@ -1521,6 +1543,7 @@ public:
   RGWOpType get_type() override { return RGW_OP_DELETE_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
   virtual bool need_object_expiration() { return false; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
 };
 
@@ -1617,6 +1640,7 @@ public:
   const char* name() const override { return "copy_obj"; }
   RGWOpType get_type() override { return RGW_OP_COPY_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
 };
 
@@ -1635,6 +1659,7 @@ public:
   const char* name() const override { return "get_acls"; }
   RGWOpType get_type() override { return RGW_OP_GET_ACLS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
 };
 
 class RGWPutACLs : public RGWOp {
@@ -1656,6 +1681,7 @@ public:
   const char* name() const override { return "put_acls"; }
   RGWOpType get_type() override { return RGW_OP_PUT_ACLS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
 };
 
 class RGWGetObjAttrs : public RGWGetObj {
@@ -1717,6 +1743,7 @@ public:
   const char* name() const override { return "get_lifecycle"; }
   RGWOpType get_type() override { return RGW_OP_GET_LC; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWPutLC : public RGWOp {
@@ -1749,6 +1776,7 @@ public:
   const char* name() const override { return "put_lifecycle"; }
   RGWOpType get_type() override { return RGW_OP_PUT_LC; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWDeleteLC : public RGWOp {
@@ -1761,6 +1789,7 @@ public:
   void send_response() override = 0;
   const char* name() const override { return "delete_lifecycle"; }
   RGWOpType get_type() override { return RGW_OP_DELETE_LC; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
 
@@ -1777,6 +1806,7 @@ public:
   const char* name() const override { return "get_cors"; }
   RGWOpType get_type() override { return RGW_OP_GET_CORS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWPutCORS : public RGWOp {
@@ -2539,6 +2569,7 @@ public:
   const char* name() const override { return "put_obj_retention"; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ_RETENTION; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.RETENTION", s->info.method); }
 };
 
 class RGWGetObjRetention : public RGWOp {
@@ -2567,6 +2598,7 @@ public:
   const char* name() const override { return "put_obj_legal_hold"; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ_LEGAL_HOLD; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LEGAL_HOLD", s->info.method); }
 };
 
 class RGWGetObjLegalHold : public RGWOp {
@@ -2597,6 +2629,7 @@ public:
   const char* name() const override { return "config_bucket_meta_search"; }
   virtual RGWOpType get_type() override { return RGW_OP_CONFIG_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
 };
 
 class RGWGetBucketMetaSearch : public RGWOp {
@@ -2610,6 +2643,7 @@ public:
   const char* name() const override { return "get_bucket_meta_search"; }
   virtual RGWOpType get_type() override { return RGW_OP_GET_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
 };
 
 class RGWDelBucketMetaSearch : public RGWOp {
@@ -2623,6 +2657,7 @@ public:
   const char* name() const override { return "delete_bucket_meta_search"; }
   virtual RGWOpType delete_type() { return RGW_OP_DEL_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
 };
 
 class RGWGetClusterStat : public RGWOp {

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -129,39 +129,30 @@ public:
   }
 
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class RGWGetObjTags_ObjStore : public RGWGetObjTags {
 public:
   RGWGetObjTags_ObjStore() {};
   ~RGWGetObjTags_ObjStore() {};
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 };
 
 class RGWPutObjTags_ObjStore: public RGWPutObjTags {
 public:
   RGWPutObjTags_ObjStore() {};
   ~RGWPutObjTags_ObjStore() {};
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 };
 
 class RGWGetBucketTags_ObjStore : public RGWGetBucketTags {
 public:
   RGWGetBucketTags_ObjStore() = default;
   virtual ~RGWGetBucketTags_ObjStore() = default;
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_TAGGING", s->info.method); }
 };
 
 class RGWPutBucketTags_ObjStore: public RGWPutBucketTags {
 public:
   RGWPutBucketTags_ObjStore() = default;
   virtual ~RGWPutBucketTags_ObjStore() = default;
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_TAGGING", s->info.method); }
 };
 
 class RGWGetBucketReplication_ObjStore : public RGWGetBucketReplication {
@@ -186,56 +177,42 @@ class RGWListBuckets_ObjStore : public RGWListBuckets {
 public:
   RGWListBuckets_ObjStore() {}
   ~RGWListBuckets_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKETS", s->info.method); }
 };
 
 class RGWGetUsage_ObjStore : public RGWGetUsage {
 public:
   RGWGetUsage_ObjStore() {}
   ~RGWGetUsage_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.USER_USAGE", s->info.method); }
 };
 
 class RGWListBucket_ObjStore : public RGWListBucket {
 public:
   RGWListBucket_ObjStore() {}
   ~RGWListBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWStatAccount_ObjStore : public RGWStatAccount {
 public:
   RGWStatAccount_ObjStore() {}
   ~RGWStatAccount_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_STATUS", s->info.method); }
 };
 
 class RGWStatBucket_ObjStore : public RGWStatBucket {
 public:
   RGWStatBucket_ObjStore() {}
   ~RGWStatBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_STATUS", s->info.method); }
 };
 
 class RGWCreateBucket_ObjStore : public RGWCreateBucket {
 public:
   RGWCreateBucket_ObjStore() {}
   ~RGWCreateBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWDeleteBucket_ObjStore : public RGWDeleteBucket {
 public:
   RGWDeleteBucket_ObjStore() {}
   ~RGWDeleteBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWPutObj_ObjStore : public RGWPutObj
@@ -248,10 +225,6 @@ public:
   int get_params(optional_yield y) override;
   int get_data(bufferlist& bl) override;
 
-  virtual std::string canonical_name() const override {
-    const bool multipart = !multipart_upload_id.empty();
-    return fmt::format("REST.{}.{}", s->info.method, multipart ? "PART" : "OBJECT");
-  }
 };
 
 class RGWPostObj_ObjStore : public RGWPostObj
@@ -322,7 +295,6 @@ public:
   ~RGWPostObj_ObjStore() override {}
 
   int verify_params() override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 
@@ -332,7 +304,6 @@ public:
   RGWPutMetadataAccount_ObjStore() {}
   ~RGWPutMetadataAccount_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_METADATA", s->info.method); }
 };
 
 class RGWPutMetadataBucket_ObjStore : public RGWPutMetadataBucket
@@ -341,7 +312,6 @@ public:
   RGWPutMetadataBucket_ObjStore() {}
   ~RGWPutMetadataBucket_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_METADATA", s->info.method); }
 };
 
 class RGWPutMetadataObject_ObjStore : public RGWPutMetadataObject
@@ -350,23 +320,18 @@ public:
   RGWPutMetadataObject_ObjStore() {}
   ~RGWPutMetadataObject_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_METADATA", s->info.method); }
 };
 
 class RGWRestoreObj_ObjStore : public RGWRestoreObj {
 public:
   RGWRestoreObj_ObjStore() {}
   ~RGWRestoreObj_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class RGWDeleteObj_ObjStore : public RGWDeleteObj {
 public:
   RGWDeleteObj_ObjStore() {}
   ~RGWDeleteObj_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class  RGWGetCrossDomainPolicy_ObjStore : public RGWGetCrossDomainPolicy {
@@ -385,16 +350,12 @@ class RGWCopyObj_ObjStore : public RGWCopyObj {
 public:
   RGWCopyObj_ObjStore() {}
   ~RGWCopyObj_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class RGWGetACLs_ObjStore : public RGWGetACLs {
 public:
   RGWGetACLs_ObjStore() {}
   ~RGWGetACLs_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
 };
 
 class RGWPutACLs_ObjStore : public RGWPutACLs {
@@ -403,7 +364,6 @@ public:
   ~RGWPutACLs_ObjStore() override {}
 
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
 };
 
 class RGWGetObjAttrs_ObjStore : public RGWGetObjAttrs {
@@ -422,7 +382,6 @@ public:
   RGWGetLC_ObjStore() {}
   ~RGWGetLC_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWPutLC_ObjStore : public RGWPutLC {
@@ -431,7 +390,6 @@ public:
   ~RGWPutLC_ObjStore() override {}
 
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWDeleteLC_ObjStore : public RGWDeleteLC {
@@ -439,7 +397,6 @@ public:
   RGWDeleteLC_ObjStore() {}
   ~RGWDeleteLC_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWGetCORS_ObjStore : public RGWGetCORS {
@@ -447,7 +404,6 @@ public:
   RGWGetCORS_ObjStore() {}
   ~RGWGetCORS_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWPutCORS_ObjStore : public RGWPutCORS {
@@ -455,7 +411,6 @@ public:
   RGWPutCORS_ObjStore() {}
   ~RGWPutCORS_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWDeleteCORS_ObjStore : public RGWDeleteCORS {
@@ -463,7 +418,6 @@ public:
   RGWDeleteCORS_ObjStore() {}
   ~RGWDeleteCORS_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWOptionsCORS_ObjStore : public RGWOptionsCORS {
@@ -471,7 +425,6 @@ public:
   RGWOptionsCORS_ObjStore() {}
   ~RGWOptionsCORS_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWGetBucketEncryption_ObjStore : public RGWGetBucketEncryption {
@@ -497,7 +450,6 @@ public:
   RGWInitMultipart_ObjStore() {}
   ~RGWInitMultipart_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOADS", s->info.method); }
 };
 
 class RGWCompleteMultipart_ObjStore : public RGWCompleteMultipart {
@@ -505,7 +457,6 @@ public:
   RGWCompleteMultipart_ObjStore() {}
   ~RGWCompleteMultipart_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
   int get_params(optional_yield y) override;
 };
 
@@ -514,7 +465,6 @@ public:
   RGWAbortMultipart_ObjStore() {}
   ~RGWAbortMultipart_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
 };
 
 class RGWListMultipart_ObjStore : public RGWListMultipart {
@@ -522,7 +472,6 @@ public:
   RGWListMultipart_ObjStore() {}
   ~RGWListMultipart_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
   int get_params(optional_yield y) override;
 };
 
@@ -531,7 +480,6 @@ public:
   RGWListBucketMultiparts_ObjStore() {}
   ~RGWListBucketMultiparts_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOADS", s->info.method); }
   int get_params(optional_yield y) override;
 };
 
@@ -540,7 +488,6 @@ public:
   RGWBulkDelete_ObjStore() {}
   ~RGWBulkDelete_ObjStore() override {}
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BULK_DELETE", s->info.method); }
 };
 
 class RGWBulkUploadOp_ObjStore : public RGWBulkUploadOp {
@@ -548,7 +495,6 @@ public:
   RGWBulkUploadOp_ObjStore() = default;
   ~RGWBulkUploadOp_ObjStore() = default;
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BULK_UPLOAD", s->info.method); }
 };
 
 class RGWDeleteMultiObj_ObjStore : public RGWDeleteMultiObj {
@@ -557,7 +503,6 @@ public:
   ~RGWDeleteMultiObj_ObjStore() override {}
 
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.DELETE_MULTI_OBJECT", s->info.method); }
 };
 
 class RGWInfo_ObjStore : public RGWInfo {
@@ -583,14 +528,12 @@ class RGWPutObjRetention_ObjStore : public RGWPutObjRetention {
 public:
   RGWPutObjRetention_ObjStore() = default;
   ~RGWPutObjRetention_ObjStore() override = default;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.RETENTION", s->info.method); }
 };
 
 class RGWGetObjRetention_ObjStore : public RGWGetObjRetention {
 public:
   RGWGetObjRetention_ObjStore() = default;
   ~RGWGetObjRetention_ObjStore() = default;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.RETENTION", s->info.method); }
 };
 
 class RGWPutObjLegalHold_ObjStore : public RGWPutObjLegalHold {
@@ -598,13 +541,11 @@ public:
   RGWPutObjLegalHold_ObjStore() = default;
   ~RGWPutObjLegalHold_ObjStore() override = default;
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LEGAL_HOLD", s->info.method); }
 };
 
 class RGWGetObjLegalHold_ObjStore : public RGWGetObjLegalHold {
 public:
   RGWGetObjLegalHold_ObjStore() = default;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LEGAL_HOLD", s->info.method); }
   ~RGWGetObjLegalHold_ObjStore() = default;
 };
 
@@ -622,6 +563,7 @@ public:
   virtual int check_caps(const RGWUserCaps& caps)
     { return -EPERM; } /* should to be implemented! */
   int verify_permission(optional_yield y) override;
+  std::string canonical_name() const override { return fmt::format("REST.{}.{}", s->info.method, name()); }
   dmc::client_id dmclock_client() override { return dmc::client_id::admin; }
 };
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -83,7 +83,6 @@ class RGWDeleteObjTags_ObjStore_S3 : public RGWDeleteObjTags
 public:
   ~RGWDeleteObjTags_ObjStore_S3() override {}
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 };
 
 class RGWGetBucketTags_ObjStore_S3 : public RGWGetBucketTags_ObjStore
@@ -215,7 +214,6 @@ public:
   ~RGWGetBucketWebsite_ObjStore_S3() override {}
 
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
 };
 
 class RGWSetBucketWebsite_ObjStore_S3 : public RGWSetBucketWebsite {
@@ -225,7 +223,6 @@ public:
 
   int get_params(optional_yield y) override;
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
 };
 
 class RGWDeleteBucketWebsite_ObjStore_S3 : public RGWDeleteBucketWebsite {
@@ -234,7 +231,6 @@ public:
   ~RGWDeleteBucketWebsite_ObjStore_S3() override {}
 
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
 };
 
 class RGWStatBucket_ObjStore_S3 : public RGWStatBucket_ObjStore {
@@ -604,7 +600,6 @@ class RGWConfigBucketMetaSearch_ObjStore_S3 : public RGWConfigBucketMetaSearch {
 public:
   RGWConfigBucketMetaSearch_ObjStore_S3() {}
   ~RGWConfigBucketMetaSearch_ObjStore_S3() {}
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
 
   int get_params(optional_yield y) override;
   void send_response() override;
@@ -622,7 +617,6 @@ class RGWDelBucketMetaSearch_ObjStore_S3 : public RGWDelBucketMetaSearch {
 public:
   RGWDelBucketMetaSearch_ObjStore_S3() {}
   ~RGWDelBucketMetaSearch_ObjStore_S3() {}
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
 
   void send_response() override;
 };


### PR DESCRIPTION
move them into the base class when possible

analysis of cost in time and tokens of the work:
https://gist.github.com/yuvalif/98ec4690532bea31276fc31ca55826bb



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
