### PR TITLE
rgw/logging: fix canonical names

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -481,6 +481,7 @@ public:
   virtual int send_response_data(bufferlist& bl, off_t ofs, off_t len) = 0;
 
   const char* name() const override { return "get_obj"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   virtual bool need_object_expiration() { return false; }
@@ -522,6 +523,7 @@ class RGWGetObjTags : public RGWOp {
 
   virtual void send_response_data(bufferlist& bl) = 0;
   const char* name() const override { return "get_obj_tags"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_TAGGING; }
 
@@ -537,6 +539,7 @@ class RGWPutObjTags : public RGWOp {
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_obj_tags"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ_TAGGING; }
 
@@ -549,6 +552,7 @@ class RGWDeleteObjTags: public RGWOp {
   void execute(optional_yield y) override;
 
   const char* name() const override { return "delete_obj_tags"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
   RGWOpType get_type() override { return RGW_OP_DELETE_OBJ_TAGGING;}
 };
@@ -564,6 +568,7 @@ public:
 
   virtual void send_response_data(bufferlist& bl) = 0;
   const char* name() const override { return "get_bucket_tags"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.TAGGING", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_TAGGING; }
 };
@@ -579,6 +584,7 @@ public:
   virtual void send_response() override = 0;
   virtual int get_params(const DoutPrefixProvider *dpp, optional_yield y) = 0;
   const char* name() const override { return "put_bucket_tags"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.TAGGING", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_TAGGING; }
 };
@@ -710,6 +716,7 @@ public:
   void send_response() override = 0;
 
   const char* name() const override { return "bulk_delete"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BULK_DELETE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_BULK_DELETE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
@@ -781,6 +788,7 @@ public:
   void execute(optional_yield y) override;
 
   const char* name() const override { return "bulk_upload"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BULK_UPLOAD", s->info.method); }
 
   RGWOpType get_type() override {
     return RGW_OP_BULK_UPLOAD;
@@ -903,6 +911,7 @@ public:
   virtual bool supports_account_metadata() { return false; }
 
   const char* name() const override { return "list_buckets"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKETS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_LIST_BUCKETS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 }; // class RGWListBuckets
@@ -933,6 +942,7 @@ public:
   virtual bool should_get_stats() { return false; }
 
   const char* name() const override { return "get_self_usage"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.USER_USAGE", s->info.method); }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
 
@@ -949,6 +959,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "stat_account"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_STATUS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_STAT_ACCOUNT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -987,6 +998,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "list_bucket"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_LIST_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   virtual bool need_container_stats() { return false; }
@@ -1063,6 +1075,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "get_bucket_website"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_WEBSITE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1082,6 +1095,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "set_bucket_website"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_SET_BUCKET_WEBSITE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1096,6 +1110,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "delete_bucket_website"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_SET_BUCKET_WEBSITE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1113,6 +1128,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "stat_bucket"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_STATUS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_STAT_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1145,6 +1161,7 @@ class RGWCreateBucket : public RGWOp {
   virtual int get_params(optional_yield y) { return 0; }
   void send_response() override = 0;
   const char* name() const override { return "create_bucket"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_CREATE_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1162,6 +1179,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "delete_bucket"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_DELETE_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
 };
@@ -1331,6 +1349,10 @@ public:
   virtual int get_data(bufferlist& bl) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_obj"; }
+  std::string canonical_name() const override {
+    const bool multipart = !multipart_upload_id.empty();
+    return fmt::format("REST.{}.{}", s->info.method, multipart ? "PART" : "OBJECT");
+  }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
@@ -1383,6 +1405,7 @@ public:
   virtual int get_data(ceph::bufferlist& bl, bool& again) = 0;
   void send_response() override = 0;
   const char* name() const override { return "post_obj"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_POST_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
@@ -1416,6 +1439,7 @@ public:
                                    const std::set<std::string>& rmattr_names,
                                    std::map<int, std::string>& temp_url_keys);
   const char* name() const override { return "put_account_metadata"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_METADATA", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_METADATA_ACCOUNT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1447,6 +1471,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_bucket_metadata"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_METADATA", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_METADATA_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1469,6 +1494,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_obj_metadata"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_METADATA", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_METADATA_OBJECT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   virtual bool need_object_expiration() { return false; }
@@ -1489,6 +1515,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "restore_obj"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_RESTORE_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1523,6 +1550,7 @@ public:
   virtual int get_params(optional_yield y) { return 0; }
   void send_response() override = 0;
   const char* name() const override { return "delete_obj"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_DELETE_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
   virtual bool need_object_expiration() { return false; }
@@ -1620,6 +1648,7 @@ public:
   virtual void send_partial_response(off_t ofs) {}
   void send_response() override = 0;
   const char* name() const override { return "copy_obj"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_COPY_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   dmc::client_id dmclock_client() override { return dmc::client_id::data; }
@@ -1638,6 +1667,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "get_acls"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_ACLS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1659,6 +1689,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_acls"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_ACLS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1720,6 +1751,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "get_lifecycle"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_LC; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1752,6 +1784,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_lifecycle"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_LC; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1765,6 +1798,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "delete_lifecycle"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_DELETE_LC; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1780,6 +1814,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "get_cors"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_CORS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1799,6 +1834,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_cors"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_CORS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1814,6 +1850,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "delete_cors"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_DELETE_CORS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1947,6 +1984,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "init_multipart"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.UPLOADS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_INIT_MULTIPART; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   virtual int prepare_encryption(std::map<std::string, bufferlist>& attrs) { return 0; }
@@ -1980,6 +2018,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "complete_multipart"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_COMPLETE_MULTIPART; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   bool always_do_bucket_logging() const override { return false; }
@@ -1997,6 +2036,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "abort_multipart"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_ABORT_MULTIPART; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
 };
@@ -2026,6 +2066,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "list_multipart"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_LIST_MULTIPART; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -2065,6 +2106,7 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "list_bucket_multiparts"; }
+  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOADS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_LIST_BUCKET_MULTIPARTS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -2156,6 +2198,7 @@ public:
                                      int ret) = 0;
   virtual void end_response() = 0;
   const char* name() const override { return "multi_object_delete"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.DELETE_MULTI_OBJECT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_DELETE_MULTI_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
 
@@ -2550,6 +2593,7 @@ public:
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_obj_retention"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.RETENTION", s->info.method); }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ_RETENTION; }
 };
@@ -2563,6 +2607,7 @@ public:
   void execute(optional_yield y) override;
   virtual void send_response() override = 0;
   const char* name() const override {return "get_obj_retention"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.RETENTION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_RETENTION; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -2578,6 +2623,7 @@ public:
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_obj_legal_hold"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LEGAL_HOLD", s->info.method); }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_OBJ_LEGAL_HOLD; }
 };
@@ -2591,6 +2637,7 @@ public:
   void execute(optional_yield y) override;
   virtual void send_response() override = 0;
   const char* name() const override {return "get_obj_legal_hold"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LEGAL_HOLD", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_LEGAL_HOLD; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -2608,6 +2655,7 @@ public:
 
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "config_bucket_meta_search"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
   virtual RGWOpType get_type() override { return RGW_OP_CONFIG_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -2621,6 +2669,7 @@ public:
   void execute(optional_yield) override {}
 
   const char* name() const override { return "get_bucket_meta_search"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
   virtual RGWOpType get_type() override { return RGW_OP_GET_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -2634,6 +2683,7 @@ public:
   void execute(optional_yield y) override;
 
   const char* name() const override { return "delete_bucket_meta_search"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
   virtual RGWOpType delete_type() { return RGW_OP_DEL_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -604,6 +604,7 @@ public:
 
   virtual void send_response_data() = 0;
   const char* name() const override { return "get_bucket_replication"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.REPLICATION", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_REPLICATION; }
 };
@@ -619,6 +620,7 @@ public:
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_bucket_replication"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.REPLICATION", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_REPLICATION; }
 };
@@ -632,6 +634,7 @@ public:
   void execute(optional_yield y) override;
 
   const char* name() const override { return "delete_bucket_replication"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.REPLICATION", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
   RGWOpType get_type() override { return RGW_OP_DELETE_BUCKET_REPLICATION;}
 };
@@ -1016,6 +1019,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "get_bucket_versioning"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.VERSIONING", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_VERSIONING; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1044,6 +1048,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "set_bucket_versioning"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.VERSIONING", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_SET_BUCKET_VERSIONING; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1845,6 +1850,7 @@ public:
   int verify_permission(optional_yield y) override;
   void execute(optional_yield y) override;
   const char* name() const override { return "put_bucket_encryption"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ENCRYPTION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_ENCRYPTION; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1859,6 +1865,7 @@ public:
   int verify_permission(optional_yield y) override;
   void execute(optional_yield y) override;
   const char* name() const override { return "get_bucket_encryption"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ENCRYPTION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_ENCRYPTION; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1873,6 +1880,7 @@ public:
   int verify_permission(optional_yield y) override;
   void execute(optional_yield y) override;
   const char* name() const override { return "delete_bucket_encryption"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.ENCRYPTION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_DELETE_BUCKET_ENCRYPTION; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1890,6 +1898,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "get_request_payment"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.REQUEST_PAYMENT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_REQUEST_PAYMENT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1909,6 +1918,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "set_request_payment"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.REQUEST_PAYMENT", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_SET_REQUEST_PAYMENT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -2457,6 +2467,7 @@ public:
   void execute(optional_yield y) override;
   int get_params(optional_yield y);
   const char* name() const override { return "put_bucket_policy"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKETPOLICY", s->info.method); }
   RGWOpType get_type() override {
     return RGW_OP_PUT_BUCKET_POLICY;
   }
@@ -2473,6 +2484,7 @@ public:
   }
   void execute(optional_yield y) override;
   const char* name() const override { return "get_bucket_policy"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKETPOLICY", s->info.method); }
   RGWOpType get_type() override {
     return RGW_OP_GET_BUCKET_POLICY;
   }
@@ -2489,6 +2501,7 @@ public:
   void execute(optional_yield y) override;
   int get_params(optional_yield y);
   const char* name() const override { return "delete_bucket_policy"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKETPOLICY", s->info.method); }
   RGWOpType get_type() override {
     return RGW_OP_DELETE_BUCKET_POLICY;
   }
@@ -2662,6 +2675,7 @@ public:
   int verify_permission(optional_yield y) override;
   const char* name() const override { return "put_bucket_public_access_block";}
   virtual RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_PUBLIC_ACCESS_BLOCK; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.PUBLIC_ACCESS_BLOCK", s->info.method); }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   int get_params(optional_yield y);
   void execute(optional_yield y) override;
@@ -2674,6 +2688,7 @@ protected:
 public:
   int verify_permission(optional_yield y) override;
   const char* name() const override { return "get_bucket_public_access_block";}
+  std::string canonical_name() const override { return fmt::format("REST.{}.PUBLIC_ACCESS_BLOCK", s->info.method); }
   virtual RGWOpType get_type() override { return RGW_OP_GET_BUCKET_PUBLIC_ACCESS_BLOCK; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   int get_params(optional_yield y);
@@ -2687,6 +2702,7 @@ protected:
 public:
   int verify_permission(optional_yield y) override;
   const char* name() const override { return "delete_bucket_public_access_block";}
+  std::string canonical_name() const override { return fmt::format("REST.{}.PUBLIC_ACCESS_BLOCK", s->info.method); }
   virtual RGWOpType get_type() override { return RGW_OP_DELETE_BUCKET_PUBLIC_ACCESS_BLOCK; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   int get_params(optional_yield y);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -481,7 +481,12 @@ public:
   virtual int send_response_data(bufferlist& bl, off_t ofs, off_t len) = 0;
 
   const char* name() const override { return "get_obj"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
+  std::string canonical_name() const override {
+    if (get_torrent) {
+      return fmt::format("REST.{}.TORRENT", s->info.method);
+    }
+    return fmt::format("REST.{}.OBJECT", s->info.method);
+  }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   virtual bool need_object_expiration() { return false; }
@@ -942,7 +947,6 @@ public:
   virtual bool should_get_stats() { return false; }
 
   const char* name() const override { return "get_self_usage"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.USER_USAGE", s->info.method); }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
 
@@ -959,7 +963,6 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "stat_account"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_STATUS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_STAT_ACCOUNT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1013,6 +1016,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "get_bucket_location"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LOCATION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_LOCATION; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1128,7 +1132,6 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "stat_bucket"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_STATUS", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_STAT_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -1439,7 +1442,6 @@ public:
                                    const std::set<std::string>& rmattr_names,
                                    std::map<int, std::string>& temp_url_keys);
   const char* name() const override { return "put_account_metadata"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_METADATA", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_METADATA_ACCOUNT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1471,7 +1473,6 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_bucket_metadata"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_METADATA", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_METADATA_BUCKET; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1494,7 +1495,6 @@ public:
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_obj_metadata"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_METADATA", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_METADATA_OBJECT; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   virtual bool need_object_expiration() { return false; }
@@ -1515,7 +1515,7 @@ public:
 
   void send_response() override = 0;
   const char* name() const override { return "restore_obj"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
+  std::string canonical_name() const override { return fmt::format("REST.{}.RESTORE", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_RESTORE_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -1734,6 +1734,7 @@ public:
   void execute(optional_yield y) override;
   void send_response() override = 0;
   const char* name() const override { return "get_obj_attrs"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_ATTRIBUTES", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_ATTRS; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 }; /* RGWGetObjAttrs */
@@ -2564,6 +2565,7 @@ public:
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_bucket_object_lock"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_LOCK", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_OBJ_LOCK; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -2575,6 +2577,7 @@ public:
   void execute(optional_yield y) override;
   virtual void send_response() override = 0;
   const char* name() const override {return "get_bucket_object_lock"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_LOCK", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_OBJ_LOCK; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -2655,7 +2658,6 @@ public:
 
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "config_bucket_meta_search"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
   virtual RGWOpType get_type() override { return RGW_OP_CONFIG_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
@@ -2669,7 +2671,6 @@ public:
   void execute(optional_yield) override {}
 
   const char* name() const override { return "get_bucket_meta_search"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
   virtual RGWOpType get_type() override { return RGW_OP_GET_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -2683,7 +2684,6 @@ public:
   void execute(optional_yield y) override;
 
   const char* name() const override { return "delete_bucket_meta_search"; }
-  std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
   virtual RGWOpType delete_type() { return RGW_OP_DEL_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -129,39 +129,30 @@ public:
   }
 
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class RGWGetObjTags_ObjStore : public RGWGetObjTags {
 public:
   RGWGetObjTags_ObjStore() {};
   ~RGWGetObjTags_ObjStore() {};
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 };
 
 class RGWPutObjTags_ObjStore: public RGWPutObjTags {
 public:
   RGWPutObjTags_ObjStore() {};
   ~RGWPutObjTags_ObjStore() {};
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 };
 
 class RGWGetBucketTags_ObjStore : public RGWGetBucketTags {
 public:
   RGWGetBucketTags_ObjStore() = default;
   virtual ~RGWGetBucketTags_ObjStore() = default;
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.TAGGING", s->info.method); }
 };
 
 class RGWPutBucketTags_ObjStore: public RGWPutBucketTags {
 public:
   RGWPutBucketTags_ObjStore() = default;
   virtual ~RGWPutBucketTags_ObjStore() = default;
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.TAGGING", s->info.method); }
 };
 
 class RGWGetBucketReplication_ObjStore : public RGWGetBucketReplication {
@@ -186,56 +177,42 @@ class RGWListBuckets_ObjStore : public RGWListBuckets {
 public:
   RGWListBuckets_ObjStore() {}
   ~RGWListBuckets_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKETS", s->info.method); }
 };
 
 class RGWGetUsage_ObjStore : public RGWGetUsage {
 public:
   RGWGetUsage_ObjStore() {}
   ~RGWGetUsage_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.USER_USAGE", s->info.method); }
 };
 
 class RGWListBucket_ObjStore : public RGWListBucket {
 public:
   RGWListBucket_ObjStore() {}
   ~RGWListBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWStatAccount_ObjStore : public RGWStatAccount {
 public:
   RGWStatAccount_ObjStore() {}
   ~RGWStatAccount_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_STATUS", s->info.method); }
 };
 
 class RGWStatBucket_ObjStore : public RGWStatBucket {
 public:
   RGWStatBucket_ObjStore() {}
   ~RGWStatBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_STATUS", s->info.method); }
 };
 
 class RGWCreateBucket_ObjStore : public RGWCreateBucket {
 public:
   RGWCreateBucket_ObjStore() {}
   ~RGWCreateBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWDeleteBucket_ObjStore : public RGWDeleteBucket {
 public:
   RGWDeleteBucket_ObjStore() {}
   ~RGWDeleteBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET", s->info.method); }
 };
 
 class RGWPutObj_ObjStore : public RGWPutObj
@@ -247,11 +224,6 @@ public:
   int verify_params() override;
   int get_params(optional_yield y) override;
   int get_data(bufferlist& bl) override;
-
-  virtual std::string canonical_name() const override {
-    const bool multipart = !multipart_upload_id.empty();
-    return fmt::format("REST.{}.{}", s->info.method, multipart ? "PART" : "OBJECT");
-  }
 };
 
 class RGWPostObj_ObjStore : public RGWPostObj
@@ -322,7 +294,6 @@ public:
   ~RGWPostObj_ObjStore() override {}
 
   int verify_params() override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 
@@ -331,8 +302,6 @@ class RGWPutMetadataAccount_ObjStore : public RGWPutMetadataAccount
 public:
   RGWPutMetadataAccount_ObjStore() {}
   ~RGWPutMetadataAccount_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACCOUNT_METADATA", s->info.method); }
 };
 
 class RGWPutMetadataBucket_ObjStore : public RGWPutMetadataBucket
@@ -340,8 +309,6 @@ class RGWPutMetadataBucket_ObjStore : public RGWPutMetadataBucket
 public:
   RGWPutMetadataBucket_ObjStore() {}
   ~RGWPutMetadataBucket_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_METADATA", s->info.method); }
 };
 
 class RGWPutMetadataObject_ObjStore : public RGWPutMetadataObject
@@ -349,24 +316,18 @@ class RGWPutMetadataObject_ObjStore : public RGWPutMetadataObject
 public:
   RGWPutMetadataObject_ObjStore() {}
   ~RGWPutMetadataObject_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_METADATA", s->info.method); }
 };
 
 class RGWRestoreObj_ObjStore : public RGWRestoreObj {
 public:
   RGWRestoreObj_ObjStore() {}
   ~RGWRestoreObj_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class RGWDeleteObj_ObjStore : public RGWDeleteObj {
 public:
   RGWDeleteObj_ObjStore() {}
   ~RGWDeleteObj_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class  RGWGetCrossDomainPolicy_ObjStore : public RGWGetCrossDomainPolicy {
@@ -385,25 +346,19 @@ class RGWCopyObj_ObjStore : public RGWCopyObj {
 public:
   RGWCopyObj_ObjStore() {}
   ~RGWCopyObj_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT", s->info.method); }
 };
 
 class RGWGetACLs_ObjStore : public RGWGetACLs {
 public:
   RGWGetACLs_ObjStore() {}
   ~RGWGetACLs_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
 };
 
 class RGWPutACLs_ObjStore : public RGWPutACLs {
 public:
   RGWPutACLs_ObjStore() {}
   ~RGWPutACLs_ObjStore() override {}
-
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.ACL", s->info.method); }
 };
 
 class RGWGetObjAttrs_ObjStore : public RGWGetObjAttrs {
@@ -421,8 +376,6 @@ class RGWGetLC_ObjStore : public RGWGetLC {
 public:
   RGWGetLC_ObjStore() {}
   ~RGWGetLC_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWPutLC_ObjStore : public RGWPutLC {
@@ -431,47 +384,36 @@ public:
   ~RGWPutLC_ObjStore() override {}
 
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWDeleteLC_ObjStore : public RGWDeleteLC {
 public:
   RGWDeleteLC_ObjStore() {}
   ~RGWDeleteLC_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LIFECYCLE", s->info.method); }
 };
 
 class RGWGetCORS_ObjStore : public RGWGetCORS {
 public:
   RGWGetCORS_ObjStore() {}
   ~RGWGetCORS_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWPutCORS_ObjStore : public RGWPutCORS {
 public:
   RGWPutCORS_ObjStore() {}
   ~RGWPutCORS_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWDeleteCORS_ObjStore : public RGWDeleteCORS {
 public:
   RGWDeleteCORS_ObjStore() {}
   ~RGWDeleteCORS_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWOptionsCORS_ObjStore : public RGWOptionsCORS {
 public:
   RGWOptionsCORS_ObjStore() {}
   ~RGWOptionsCORS_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.CORS", s->info.method); }
 };
 
 class RGWGetBucketEncryption_ObjStore : public RGWGetBucketEncryption {
@@ -496,16 +438,12 @@ class RGWInitMultipart_ObjStore : public RGWInitMultipart {
 public:
   RGWInitMultipart_ObjStore() {}
   ~RGWInitMultipart_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOADS", s->info.method); }
 };
 
 class RGWCompleteMultipart_ObjStore : public RGWCompleteMultipart {
 public:
   RGWCompleteMultipart_ObjStore() {}
   ~RGWCompleteMultipart_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
   int get_params(optional_yield y) override;
 };
 
@@ -513,16 +451,12 @@ class RGWAbortMultipart_ObjStore : public RGWAbortMultipart {
 public:
   RGWAbortMultipart_ObjStore() {}
   ~RGWAbortMultipart_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
 };
 
 class RGWListMultipart_ObjStore : public RGWListMultipart {
 public:
   RGWListMultipart_ObjStore() {}
   ~RGWListMultipart_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOAD", s->info.method); }
   int get_params(optional_yield y) override;
 };
 
@@ -530,8 +464,6 @@ class RGWListBucketMultiparts_ObjStore : public RGWListBucketMultiparts {
 public:
   RGWListBucketMultiparts_ObjStore() {}
   ~RGWListBucketMultiparts_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.UPLOADS", s->info.method); }
   int get_params(optional_yield y) override;
 };
 
@@ -539,16 +471,12 @@ class RGWBulkDelete_ObjStore : public RGWBulkDelete {
 public:
   RGWBulkDelete_ObjStore() {}
   ~RGWBulkDelete_ObjStore() override {}
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BULK_DELETE", s->info.method); }
 };
 
 class RGWBulkUploadOp_ObjStore : public RGWBulkUploadOp {
 public:
   RGWBulkUploadOp_ObjStore() = default;
   ~RGWBulkUploadOp_ObjStore() = default;
-
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BULK_UPLOAD", s->info.method); }
 };
 
 class RGWDeleteMultiObj_ObjStore : public RGWDeleteMultiObj {
@@ -557,7 +485,6 @@ public:
   ~RGWDeleteMultiObj_ObjStore() override {}
 
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.DELETE_MULTI_OBJECT", s->info.method); }
 };
 
 class RGWInfo_ObjStore : public RGWInfo {
@@ -583,14 +510,12 @@ class RGWPutObjRetention_ObjStore : public RGWPutObjRetention {
 public:
   RGWPutObjRetention_ObjStore() = default;
   ~RGWPutObjRetention_ObjStore() override = default;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.RETENTION", s->info.method); }
 };
 
 class RGWGetObjRetention_ObjStore : public RGWGetObjRetention {
 public:
   RGWGetObjRetention_ObjStore() = default;
   ~RGWGetObjRetention_ObjStore() = default;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.RETENTION", s->info.method); }
 };
 
 class RGWPutObjLegalHold_ObjStore : public RGWPutObjLegalHold {
@@ -598,13 +523,11 @@ public:
   RGWPutObjLegalHold_ObjStore() = default;
   ~RGWPutObjLegalHold_ObjStore() override = default;
   int get_params(optional_yield y) override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LEGAL_HOLD", s->info.method); }
 };
 
 class RGWGetObjLegalHold_ObjStore : public RGWGetObjLegalHold {
 public:
   RGWGetObjLegalHold_ObjStore() = default;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.LEGAL_HOLD", s->info.method); }
   ~RGWGetObjLegalHold_ObjStore() = default;
 };
 

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -153,7 +153,7 @@ public:
   RGWGetBucketTags_ObjStore() = default;
   virtual ~RGWGetBucketTags_ObjStore() = default;
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_TAGGING", s->info.method); }
+  virtual std::string canonical_name() const override { return fmt::format("REST.{}.TAGGING", s->info.method); }
 };
 
 class RGWPutBucketTags_ObjStore: public RGWPutBucketTags {
@@ -161,7 +161,7 @@ public:
   RGWPutBucketTags_ObjStore() = default;
   virtual ~RGWPutBucketTags_ObjStore() = default;
 
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_TAGGING", s->info.method); }
+  virtual std::string canonical_name() const override { return fmt::format("REST.{}.TAGGING", s->info.method); }
 };
 
 class RGWGetBucketReplication_ObjStore : public RGWGetBucketReplication {

--- a/src/rgw/rgw_rest_bucket_logging.cc
+++ b/src/rgw/rgw_rest_bucket_logging.cc
@@ -124,6 +124,7 @@ public:
     rgw_flush_formatter_and_reset(s, s->formatter);
   }
   const char* name() const override { return "get_bucket_logging"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LOGGING", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_LOGGING; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
@@ -215,6 +216,7 @@ class RGWPutBucketLoggingOp : public RGWDefaultResponseOp {
   }
 
   const char* name() const override { return "put_bucket_logging"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LOGGING", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_LOGGING; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 
@@ -372,6 +374,7 @@ class RGWPostBucketLoggingOp : public RGWDefaultResponseOp {
   }
 
   const char* name() const override { return "post_bucket_logging"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.LOGGING", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_POST_BUCKET_LOGGING; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -1189,6 +1189,7 @@ public:
   }
 
   const char* name() const override { return "pubsub_notification_create_s3"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.NOTIFICATION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_NOTIF_CREATE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 
@@ -1444,6 +1445,7 @@ class RGWPSDeleteNotifOp : public RGWDefaultResponseOp {
   }
   
   const char* name() const override { return "pubsub_notification_delete_s3"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.NOTIFICATION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_NOTIF_DELETE; }
   uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
 
@@ -1548,6 +1550,7 @@ public:
   }
 
   const char* name() const override { return "pubsub_notifications_get_s3"; }
+  std::string canonical_name() const override { return fmt::format("REST.{}.NOTIFICATION", s->info.method); }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_NOTIF_LIST; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -215,7 +215,7 @@ public:
   ~RGWGetBucketWebsite_ObjStore_S3() override {}
 
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
+  virtual std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
 };
 
 class RGWSetBucketWebsite_ObjStore_S3 : public RGWSetBucketWebsite {
@@ -225,7 +225,7 @@ public:
 
   int get_params(optional_yield y) override;
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
+  virtual std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
 };
 
 class RGWDeleteBucketWebsite_ObjStore_S3 : public RGWDeleteBucketWebsite {
@@ -234,7 +234,7 @@ public:
   ~RGWDeleteBucketWebsite_ObjStore_S3() override {}
 
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("WEBSITE.{}.BUCKET_WEBSITE", s->info.method); }
+  virtual std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
 };
 
 class RGWStatBucket_ObjStore_S3 : public RGWStatBucket_ObjStore {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -83,7 +83,6 @@ class RGWDeleteObjTags_ObjStore_S3 : public RGWDeleteObjTags
 public:
   ~RGWDeleteObjTags_ObjStore_S3() override {}
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.OBJECT_TAGGING", s->info.method); }
 };
 
 class RGWGetBucketTags_ObjStore_S3 : public RGWGetBucketTags_ObjStore
@@ -215,7 +214,6 @@ public:
   ~RGWGetBucketWebsite_ObjStore_S3() override {}
 
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
 };
 
 class RGWSetBucketWebsite_ObjStore_S3 : public RGWSetBucketWebsite {
@@ -225,7 +223,6 @@ public:
 
   int get_params(optional_yield y) override;
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
 };
 
 class RGWDeleteBucketWebsite_ObjStore_S3 : public RGWDeleteBucketWebsite {
@@ -234,7 +231,6 @@ public:
   ~RGWDeleteBucketWebsite_ObjStore_S3() override {}
 
   void send_response() override;
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.WEBSITE", s->info.method); }
 };
 
 class RGWStatBucket_ObjStore_S3 : public RGWStatBucket_ObjStore {
@@ -604,7 +600,6 @@ class RGWConfigBucketMetaSearch_ObjStore_S3 : public RGWConfigBucketMetaSearch {
 public:
   RGWConfigBucketMetaSearch_ObjStore_S3() {}
   ~RGWConfigBucketMetaSearch_ObjStore_S3() {}
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
 
   int get_params(optional_yield y) override;
   void send_response() override;
@@ -622,7 +617,6 @@ class RGWDelBucketMetaSearch_ObjStore_S3 : public RGWDelBucketMetaSearch {
 public:
   RGWDelBucketMetaSearch_ObjStore_S3() {}
   ~RGWDelBucketMetaSearch_ObjStore_S3() {}
-  virtual std::string canonical_name() const override { return fmt::format("REST.{}.BUCKET_MDSEARCH", s->info.method); }
 
   void send_response() override;
 };

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -97,4 +97,5 @@ public:
         return RGWGetObj_ObjStore_S3::get_params(y);
       }
   }
+  std::string canonical_name() const override { return fmt::format("WEBSITE.{}.OBJECT", s->info.method); }
 };


### PR DESCRIPTION

Fixes: https://tracker.ceph.com/issues/71638

> split to 3 commits so it is easier to review. will squash into one before merge

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
