### PR TITLE
src: Fix memory leaks in generate_test_instance() by returning values instead of pointers

### DIFF
--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -74,8 +74,10 @@ struct EntityAuth {
     encode_json("caps", caps, f);
     f->dump_object("pending_key", pending_key);
   }
-  static void generate_test_instances(std::list<EntityAuth*>& ls) {
-    ls.push_back(new EntityAuth);
+  static std::list<EntityAuth> generate_test_instances() {
+    std::list<EntityAuth> ls;
+    ls.push_back(EntityAuth{});
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(EntityAuth)
@@ -118,13 +120,15 @@ struct AuthCapsInfo {
     encode_json("caps", caps, f);
     f->dump_unsigned("caps_len", caps.length());
   }
-  static void generate_test_instances(std::list<AuthCapsInfo*>& ls) {
-    ls.push_back(new AuthCapsInfo);
-    ls.push_back(new AuthCapsInfo);
-    ls.back()->allow_all = true;
-    ls.push_back(new AuthCapsInfo);
-    ls.back()->caps.append("foo");
-    ls.back()->caps.append("bar");
+  static std::list<AuthCapsInfo> generate_test_instances() {
+    std::list<AuthCapsInfo> ls;
+    ls.push_back(AuthCapsInfo{});
+    ls.push_back(AuthCapsInfo{});
+    ls.back().allow_all = true;
+    ls.push_back(AuthCapsInfo{});
+    ls.back().caps.append("foo");
+    ls.back().caps.append("bar");
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(AuthCapsInfo)
@@ -184,15 +188,17 @@ struct AuthTicket {
     f->dump_object("caps", caps);
     f->dump_unsigned("flags", flags);
   }
-  static void generate_test_instances(std::list<AuthTicket*>& ls) {
-    ls.push_back(new AuthTicket);
-    ls.push_back(new AuthTicket);
-    ls.back()->name.set_id("client.123");
-    ls.back()->global_id = 123;
-    ls.back()->init_timestamps(utime_t(123, 456), 7);
-    ls.back()->caps.caps.append("foo");
-    ls.back()->caps.caps.append("bar");
-    ls.back()->flags = 0x12345678;
+  static std::list<AuthTicket> generate_test_instances() {
+    std::list<AuthTicket> ls;
+    ls.push_back(AuthTicket{});
+    ls.push_back(AuthTicket{});
+    ls.back().name.set_id("client.123");
+    ls.back().global_id = 123;
+    ls.back().init_timestamps(utime_t(123, 456), 7);
+    ls.back().caps.caps.append("foo");
+    ls.back().caps.caps.append("bar");
+    ls.back().flags = 0x12345678;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(AuthTicket)
@@ -282,11 +288,13 @@ struct ExpiringCryptoKey {
     f->dump_object("key", key);
     f->dump_stream("expiration") << expiration;
   }
-  static void generate_test_instances(std::list<ExpiringCryptoKey*>& ls) {
-    ls.push_back(new ExpiringCryptoKey);
-    ls.push_back(new ExpiringCryptoKey);
-    ls.back()->key.set_secret(
+  static std::list<ExpiringCryptoKey> generate_test_instances() {
+    std::list<ExpiringCryptoKey> ls;
+    ls.push_back(ExpiringCryptoKey{});
+    ls.push_back(ExpiringCryptoKey{});
+    ls.back().key.set_secret(
       CEPH_CRYPTO_AES, bufferptr("1234567890123456", 16), utime_t(123, 456));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(ExpiringCryptoKey)
@@ -355,11 +363,13 @@ struct RotatingSecrets {
   void dump(ceph::Formatter *f) const {
     encode_json("secrets", secrets, f);
   }
-  static void generate_test_instances(std::list<RotatingSecrets*>& ls) {
-    ls.push_back(new RotatingSecrets);
-    ls.push_back(new RotatingSecrets);
-    auto eck = new ExpiringCryptoKey;
-    ls.back()->add(*eck);
+  static std::list<RotatingSecrets> generate_test_instances() {
+    std::list<RotatingSecrets> ls;
+    ls.push_back(RotatingSecrets{});
+    ls.push_back(RotatingSecrets{});
+    ExpiringCryptoKey eck{};
+    ls.back().add(eck);
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(RotatingSecrets)

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -519,14 +519,16 @@ void CryptoKey::dump(Formatter *f) const
   f->dump_int("secret.length", secret.length());
 }
 
-void CryptoKey::generate_test_instances(std::list<CryptoKey*>& ls)
+std::list<CryptoKey> CryptoKey::generate_test_instances()
 {
-  ls.push_back(new CryptoKey);
-  ls.push_back(new CryptoKey);
-  ls.back()->type = CEPH_CRYPTO_AES;
-  ls.back()->set_secret(
+  std::list<CryptoKey> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().type = CEPH_CRYPTO_AES;
+  ls.back().set_secret(
     CEPH_CRYPTO_AES, bufferptr("1234567890123456", 16), utime_t(123, 456));
-  ls.back()->created = utime_t(123, 456);
+  ls.back().created = utime_t(123, 456);
+  return ls;
 }
 
 int CryptoKey::set_secret(int type, const bufferptr& s, utime_t c)

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -112,7 +112,7 @@ public:
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<CryptoKey*>& ls);
+  static std::list<CryptoKey> generate_test_instances();
 
   void clear() {
     *this = CryptoKey();

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -263,9 +263,11 @@ void KeyServer::dump(Formatter *f) const
   f->dump_object("data", data);
 }
 
-void KeyServer::generate_test_instances(std::list<KeyServer*>& ls)
+std::list<KeyServer> KeyServer::generate_test_instances()
 {
-  ls.push_back(new KeyServer(nullptr, nullptr));
+  std::list<KeyServer> ls;
+  ls.emplace_back(nullptr, nullptr);
+  return ls;
 }
 
 bool KeyServer::generate_secret(CryptoKey& secret)

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -78,10 +78,12 @@ struct KeyServerData {
     encode_json("secrets", secrets, f);
     encode_json("rotating_secrets", rotating_secrets, f);
   }
-  static void generate_test_instances(std::list<KeyServerData*>& ls) {
-    ls.push_back(new KeyServerData);
-    ls.push_back(new KeyServerData);
-    ls.back()->version = 1;
+  static std::list<KeyServerData> generate_test_instances() {
+    std::list<KeyServerData> ls;
+    ls.push_back(KeyServerData{});
+    ls.push_back(KeyServerData{});
+    ls.back().version = 1;
+    return ls;
   }
   bool contains(const EntityName& name) const {
     return (secrets.find(name) != secrets.end());
@@ -176,13 +178,15 @@ struct KeyServerData {
       f->dump_object("name", name);
       f->dump_object("auth", auth);
     }
-    static void generate_test_instances(std::list<Incremental*>& ls) {
-      ls.push_back(new Incremental);
-      ls.back()->op = AUTH_INC_DEL;
-      ls.push_back(new Incremental);
-      ls.back()->op = AUTH_INC_ADD;
-      ls.push_back(new Incremental);
-      ls.back()->op = AUTH_INC_SET_ROTATING;
+    static std::list<Incremental> generate_test_instances() {
+      std::list<Incremental> ls;
+      ls.push_back(Incremental{});
+      ls.back().op = AUTH_INC_DEL;
+      ls.push_back(Incremental{});
+      ls.back().op = AUTH_INC_ADD;
+      ls.push_back(Incremental{});
+      ls.back().op = AUTH_INC_SET_ROTATING;
+      return ls;
     }
   };
   
@@ -274,7 +278,7 @@ public:
     decode(data, bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<KeyServer*>& ls);
+  static std::list<KeyServer> generate_test_instances();
   bool contains(const EntityName& name) const;
   int encode_secrets(ceph::Formatter *f, std::stringstream *ds) const;
   void encode_formatted(std::string label, ceph::Formatter *f, ceph::buffer::list &bl);

--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -58,9 +58,11 @@ struct CephXServerChallenge {
   void dump(ceph::Formatter *f) const {
     f->dump_unsigned("server_challenge", server_challenge);
   }
-  static void generate_test_instances(std::list<CephXServerChallenge*>& ls) {
-    ls.push_back(new CephXServerChallenge);
-    ls.back()->server_challenge = 1;
+  static std::list<CephXServerChallenge> generate_test_instances() {
+    std::list<CephXServerChallenge> ls;
+    ls.push_back(CephXServerChallenge{});
+    ls.back().server_challenge = 1;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXServerChallenge)
@@ -82,9 +84,11 @@ struct CephXRequestHeader {
   void dump(ceph::Formatter *f) const {
     f->dump_unsigned("request_type", request_type);
   }
-  static void generate_test_instances(std::list<CephXRequestHeader*>& ls) {
-    ls.push_back(new CephXRequestHeader);
-    ls.back()->request_type = 1;
+  static std::list<CephXRequestHeader> generate_test_instances() {
+    std::list<CephXRequestHeader> ls;
+    ls.push_back(CephXRequestHeader{});
+    ls.back().request_type = 1;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXRequestHeader)
@@ -107,10 +111,12 @@ struct CephXResponseHeader {
     f->dump_unsigned("request_type", request_type);
     f->dump_int("status", status);
   }
-  static void generate_test_instances(std::list<CephXResponseHeader*>& ls) {
-    ls.push_back(new CephXResponseHeader);
-    ls.back()->request_type = 1;
-    ls.back()->status = 0;
+  static std::list<CephXResponseHeader> generate_test_instances() {
+    std::list<CephXResponseHeader> ls;
+    ls.push_back(CephXResponseHeader{});
+    ls.back().request_type = 1;
+    ls.back().status = 0;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXResponseHeader)
@@ -142,10 +148,12 @@ struct CephXTicketBlob {
     f->dump_unsigned("blob_len", blob.length());
   }
 
-  static void generate_test_instances(std::list<CephXTicketBlob*>& ls) {
-    ls.push_back(new CephXTicketBlob);
-    ls.back()->secret_id = 123;
-    ls.back()->blob.append(std::string_view("this is a blob"));
+  static std::list<CephXTicketBlob> generate_test_instances() {
+    std::list<CephXTicketBlob> ls;
+    ls.push_back(CephXTicketBlob{});
+    ls.back().secret_id = 123;
+    ls.back().blob.append(std::string_view("this is a blob"));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXTicketBlob)
@@ -194,16 +202,18 @@ struct CephXAuthenticate {
     f->close_section();
     f->dump_unsigned("other_keys", other_keys);
   }
-  static void generate_test_instances(std::list<CephXAuthenticate*>& ls) {
-    ls.push_back(new CephXAuthenticate);
-    ls.back()->client_challenge = 0;
-    ls.back()->key = 0;
-    ls.push_back(new CephXAuthenticate);
-    ls.back()->client_challenge = 1;
-    ls.back()->key = 2;
-    ls.back()->old_ticket.secret_id = 3;
-    ls.back()->old_ticket.blob.append(std::string_view("this is a blob"));
-    ls.back()->other_keys = 4;
+  static std::list<CephXAuthenticate> generate_test_instances() {
+    std::list<CephXAuthenticate> ls;
+    ls.push_back(CephXAuthenticate{});
+    ls.back().client_challenge = 0;
+    ls.back().key = 0;
+    ls.push_back(CephXAuthenticate{});
+    ls.back().client_challenge = 1;
+    ls.back().key = 2;
+    ls.back().old_ticket.secret_id = 3;
+    ls.back().old_ticket.blob.append(std::string_view("this is a blob"));
+    ls.back().other_keys = 4;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXAuthenticate)
@@ -225,10 +235,12 @@ struct CephXChallengeBlob {
     f->dump_unsigned("server_challenge", server_challenge);
     f->dump_unsigned("client_challenge", client_challenge);
   }
-  static void generate_test_instances(std::list<CephXChallengeBlob*>& ls) {
-    ls.push_back(new CephXChallengeBlob);
-    ls.back()->server_challenge = 123;
-    ls.back()->client_challenge = 456;
+  static std::list<CephXChallengeBlob> generate_test_instances() {
+    std::list<CephXChallengeBlob> ls;
+    ls.push_back(CephXChallengeBlob{});
+    ls.back().server_challenge = 123;
+    ls.back().client_challenge = 456;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXChallengeBlob)
@@ -285,9 +297,11 @@ struct CephXServiceTicketRequest {
     f->dump_unsigned("keys", keys);
   }
 
-  static void generate_test_instances(std::list<CephXServiceTicketRequest*>& ls) {
-    ls.push_back(new CephXServiceTicketRequest);
-    ls.back()->keys = 123;
+  static std::list<CephXServiceTicketRequest> generate_test_instances() {
+    std::list<CephXServiceTicketRequest> ls;
+    ls.push_back(CephXServiceTicketRequest{});
+    ls.back().keys = 123;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXServiceTicketRequest)
@@ -326,12 +340,14 @@ struct CephXAuthorizeReply {
     f->dump_unsigned("nonce_plus_one", nonce_plus_one);
     f->dump_string("connection_secret", connection_secret);
   }
-  static void generate_test_instances(std::list<CephXAuthorizeReply*>& ls) {
-    ls.push_back(new CephXAuthorizeReply);
-    ls.back()->nonce_plus_one = 0;
-    ls.push_back(new CephXAuthorizeReply);
-    ls.back()->nonce_plus_one = 123;
-    ls.back()->connection_secret = "secret";
+  static std::list<CephXAuthorizeReply> generate_test_instances() {
+    std::list<CephXAuthorizeReply> ls;
+    ls.push_back(CephXAuthorizeReply{});
+    ls.back().nonce_plus_one = 0;
+    ls.push_back(CephXAuthorizeReply{});
+    ls.back().nonce_plus_one = 123;
+    ls.back().connection_secret = "secret";
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXAuthorizeReply)
@@ -439,12 +455,14 @@ struct CephXServiceTicket {
     session_key.dump(f);
     validity.dump(f);
   }
-  static void generate_test_instances(std::list<CephXServiceTicket*>& ls) {
-    ls.push_back(new CephXServiceTicket);
-    ls.push_back(new CephXServiceTicket);
-    ls.back()->session_key.set_secret(
+  static std::list<CephXServiceTicket> generate_test_instances() {
+    std::list<CephXServiceTicket> ls;
+    ls.push_back(CephXServiceTicket{});
+    ls.push_back(CephXServiceTicket{});
+    ls.back().session_key.set_secret(
       CEPH_CRYPTO_AES, bufferptr("1234567890123456", 16), utime_t(123, 456));
-    ls.back()->validity = utime_t(123, 456);
+    ls.back().validity = utime_t(123, 456);
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXServiceTicket)
@@ -472,13 +490,15 @@ struct CephXServiceTicketInfo {
     ticket.dump(f);
     session_key.dump(f);
   }
-  static void generate_test_instances(std::list<CephXServiceTicketInfo*>& ls) {
-    ls.push_back(new CephXServiceTicketInfo);
-    ls.push_back(new CephXServiceTicketInfo);
-    ls.back()->ticket.global_id = 1234;
-    ls.back()->ticket.init_timestamps(utime_t(123, 456), utime_t(123, 456));
-    ls.back()->session_key.set_secret(
+  static std::list<CephXServiceTicketInfo> generate_test_instances() {
+    std::list<CephXServiceTicketInfo> ls;
+    ls.push_back(CephXServiceTicketInfo{});
+    ls.push_back(CephXServiceTicketInfo{});
+    ls.back().ticket.global_id = 1234;
+    ls.back().ticket.init_timestamps(utime_t(123, 456), utime_t(123, 456));
+    ls.back().session_key.set_secret(
       CEPH_CRYPTO_AES, bufferptr("1234567890123456", 16), utime_t(123, 456));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXServiceTicketInfo)
@@ -500,9 +520,11 @@ struct CephXAuthorizeChallenge : public AuthAuthorizerChallenge {
   void dump(ceph::Formatter *f) const {
     f->dump_unsigned("server_challenge", server_challenge);
   }
-  static void generate_test_instances(std::list<CephXAuthorizeChallenge*>& ls) {
-    ls.push_back(new CephXAuthorizeChallenge);
-    ls.back()->server_challenge = 1234;
+  static std::list<CephXAuthorizeChallenge> generate_test_instances() {
+    std::list<CephXAuthorizeChallenge> ls;
+    ls.push_back(CephXAuthorizeChallenge{});
+    ls.back().server_challenge = 1234;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXAuthorizeChallenge)
@@ -534,12 +556,14 @@ struct CephXAuthorize {
     f->dump_unsigned("have_challenge", have_challenge);
     f->dump_unsigned("server_challenge_plus_one", server_challenge_plus_one);
   }
-  static void generate_test_instances(std::list<CephXAuthorize*>& ls) {
-    ls.push_back(new CephXAuthorize);
-    ls.push_back(new CephXAuthorize);
-    ls.back()->nonce = 1234;
-    ls.back()->have_challenge = true;
-    ls.back()->server_challenge_plus_one = 1234;
+  static std::list<CephXAuthorize> generate_test_instances() {
+    std::list<CephXAuthorize> ls;
+    ls.push_back(CephXAuthorize{});
+    ls.push_back(CephXAuthorize{});
+    ls.back().nonce = 1234;
+    ls.back().have_challenge = true;
+    ls.back().server_challenge_plus_one = 1234;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(CephXAuthorize)

--- a/src/cls/2pc_queue/cls_2pc_queue_ops.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_ops.h
@@ -30,12 +30,14 @@ struct cls_2pc_queue_reserve_op {
     f->dump_unsigned("entries", entries);
   }
 
-  static void generate_test_instances(std::list<cls_2pc_queue_reserve_op*>& ls) {
-    ls.push_back(new cls_2pc_queue_reserve_op);
-    ls.back()->size = 0;
-    ls.push_back(new cls_2pc_queue_reserve_op);
-    ls.back()->size = 123;
-    ls.back()->entries = 456;
+  static std::list<cls_2pc_queue_reserve_op> generate_test_instances() {
+    std::list<cls_2pc_queue_reserve_op> ls;
+    ls.push_back(cls_2pc_queue_reserve_op{});
+    ls.back().size = 0;
+    ls.push_back(cls_2pc_queue_reserve_op{});
+    ls.back().size = 123;
+    ls.back().entries = 456;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_reserve_op)
@@ -59,9 +61,11 @@ struct cls_2pc_queue_reserve_ret {
     f->dump_unsigned("id", id);
   }
 
-  static void generate_test_instances(std::list<cls_2pc_queue_reserve_ret*>& ls) {
-    ls.push_back(new cls_2pc_queue_reserve_ret);
-    ls.back()->id = 123;
+  static std::list<cls_2pc_queue_reserve_ret> generate_test_instances() {
+    std::list<cls_2pc_queue_reserve_ret> ls;
+    ls.push_back(cls_2pc_queue_reserve_ret{});
+    ls.back().id = 123;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_reserve_ret)
@@ -89,13 +93,15 @@ struct cls_2pc_queue_commit_op {
     encode_json("bl_data_vec", bl_data_vec, f);
   }
 
-  static void generate_test_instances(std::list<cls_2pc_queue_commit_op*>& ls) {
-    ls.push_back(new cls_2pc_queue_commit_op);
-    ls.back()->id = 123;
-    ls.back()->bl_data_vec.push_back(ceph::buffer::list());
-    ls.back()->bl_data_vec.back().append("foo");
-    ls.back()->bl_data_vec.push_back(ceph::buffer::list());
-    ls.back()->bl_data_vec.back().append("bar");
+  static std::list<cls_2pc_queue_commit_op> generate_test_instances() {
+    std::list<cls_2pc_queue_commit_op> ls;
+    ls.push_back(cls_2pc_queue_commit_op{});
+    ls.back().id = 123;
+    ls.back().bl_data_vec.push_back(ceph::buffer::list());
+    ls.back().bl_data_vec.back().append("foo");
+    ls.back().bl_data_vec.push_back(ceph::buffer::list());
+    ls.back().bl_data_vec.back().append("bar");
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_commit_op)
@@ -117,9 +123,11 @@ struct cls_2pc_queue_abort_op {
   void dump(ceph::Formatter *f) const {
     f->dump_unsigned("id", id);
   }
-  static void generate_test_instances(std::list<cls_2pc_queue_abort_op*>& ls) {
-    ls.push_back(new cls_2pc_queue_abort_op);
-    ls.back()->id = 1;
+  static std::list<cls_2pc_queue_abort_op> generate_test_instances() {
+    std::list<cls_2pc_queue_abort_op> ls;
+    ls.push_back(cls_2pc_queue_abort_op{});
+    ls.back().id = 1;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_abort_op)
@@ -142,10 +150,12 @@ struct cls_2pc_queue_expire_op {
   void dump(ceph::Formatter *f) const {
     f->dump_stream("stale_time") << stale_time;
   }
-  static void generate_test_instances(std::list<cls_2pc_queue_expire_op*>& ls) {
-    ls.push_back(new cls_2pc_queue_expire_op);
-    ls.push_back(new cls_2pc_queue_expire_op);
-    ls.back()->stale_time = ceph::coarse_real_time::min();
+  static std::list<cls_2pc_queue_expire_op> generate_test_instances() {
+    std::list<cls_2pc_queue_expire_op> ls;
+    ls.push_back(cls_2pc_queue_expire_op{});
+    ls.push_back(cls_2pc_queue_expire_op{});
+    ls.back().stale_time = ceph::coarse_real_time::min();
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_expire_op)
@@ -175,11 +185,13 @@ struct cls_2pc_queue_reservations_ret {
     f->close_section();
   }
 
-  static void generate_test_instances(std::list<cls_2pc_queue_reservations_ret*>& ls) {
-    ls.push_back(new cls_2pc_queue_reservations_ret);
-    ls.push_back(new cls_2pc_queue_reservations_ret);
-    ls.back()->reservations[1] = cls_2pc_reservation();
-    ls.back()->reservations[2] = cls_2pc_reservation();
+  static std::list<cls_2pc_queue_reservations_ret> generate_test_instances() {
+    std::list<cls_2pc_queue_reservations_ret> ls;
+    ls.push_back(cls_2pc_queue_reservations_ret{});
+    ls.push_back(cls_2pc_queue_reservations_ret{});
+    ls.back().reservations[1] = cls_2pc_reservation();
+    ls.back().reservations[2] = cls_2pc_reservation();
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_reservations_ret)

--- a/src/cls/2pc_queue/cls_2pc_queue_types.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_types.h
@@ -42,12 +42,14 @@ struct cls_2pc_reservation
     f->dump_stream("timestamp") << timestamp;
   }
 
-  static void generate_test_instances(std::list<cls_2pc_reservation*>& ls) {
-    ls.push_back(new cls_2pc_reservation);
-    ls.back()->size = 0;
-    ls.push_back(new cls_2pc_reservation);
-    ls.back()->size = 123;
-    ls.back()->timestamp = ceph::coarse_real_clock::zero();
+  static std::list<cls_2pc_reservation> generate_test_instances() {
+    std::list<cls_2pc_reservation> ls;
+    ls.push_back(cls_2pc_reservation{});
+    ls.back().size = 0;
+    ls.push_back(cls_2pc_reservation{});
+    ls.back().size = 123;
+    ls.back().timestamp = ceph::coarse_real_clock::zero();
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_reservation)
@@ -98,13 +100,15 @@ struct cls_2pc_urgent_data
     f->dump_bool("has_xattrs", has_xattrs);
   }
 
-  static void generate_test_instances(std::list<cls_2pc_urgent_data*>& ls) {
-    ls.push_back(new cls_2pc_urgent_data);
-    ls.push_back(new cls_2pc_urgent_data);
-    ls.back()->reserved_size = 123;
-    ls.back()->last_id = 456;
-    ls.back()->reservations.emplace(789, cls_2pc_reservation(1, ceph::coarse_real_clock::zero(), 2));
-    ls.back()->has_xattrs = true;
+  static std::list<cls_2pc_urgent_data> generate_test_instances() {
+    std::list<cls_2pc_urgent_data> ls;
+    ls.push_back(cls_2pc_urgent_data{});
+    ls.push_back(cls_2pc_urgent_data{});
+    ls.back().reserved_size = 123;
+    ls.back().last_id = 456;
+    ls.back().reservations.emplace(789, cls_2pc_reservation(1, ceph::coarse_real_clock::zero(), 2));
+    ls.back().has_xattrs = true;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_urgent_data)

--- a/src/cls/cas/cls_cas_internal.h
+++ b/src/cls/cas/cls_cas_internal.h
@@ -93,8 +93,10 @@ struct chunk_refs_t {
   void dump(Formatter *f) const {
     r->dump(f);
   }
-  static void generate_test_instances(std::list<chunk_refs_t*>& ls) {
-    ls.push_back(new chunk_refs_t());
+  static std::list<chunk_refs_t> generate_test_instances() {
+    std::list<chunk_refs_t> ls;
+    ls.push_back(chunk_refs_t{});
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(chunk_refs_t)
@@ -145,11 +147,13 @@ struct chunk_refs_by_object_t : public chunk_refs_t::refs_t {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<chunk_refs_by_object_t*>& ls) {
-    ls.push_back(new chunk_refs_by_object_t());
-    ls.push_back(new chunk_refs_by_object_t());
-    ls.back()->by_object.insert(hobject_t(sobject_t("foo", CEPH_NOSNAP)));
-    ls.back()->by_object.insert(hobject_t(sobject_t("bar", CEPH_NOSNAP)));
+  static std::list<chunk_refs_by_object_t> generate_test_instances() {
+    std::list<chunk_refs_by_object_t> ls;
+    ls.push_back(chunk_refs_by_object_t{});
+    ls.push_back(chunk_refs_by_object_t{});
+    ls.back().by_object.insert(hobject_t(sobject_t("foo", CEPH_NOSNAP)));
+    ls.back().by_object.insert(hobject_t(sobject_t("bar", CEPH_NOSNAP)));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(chunk_refs_by_object_t)
@@ -392,10 +396,12 @@ struct chunk_refs_count_t : public chunk_refs_t::refs_t {
     f->dump_string("type", "count");
     f->dump_unsigned("count", total);
   }
-  static void generate_test_instances(std::list<chunk_refs_count_t*>& o) {
-    o.push_back(new chunk_refs_count_t);
-    o.push_back(new chunk_refs_count_t);
-    o.back()->total = 123;
+  static std::list<chunk_refs_count_t> generate_test_instances() {
+    std::list<chunk_refs_count_t> o;
+    o.push_back(chunk_refs_count_t{});
+    o.push_back(chunk_refs_count_t{});
+    o.back().total = 123;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(chunk_refs_count_t)

--- a/src/cls/cas/cls_cas_ops.h
+++ b/src/cls/cas/cls_cas_ops.h
@@ -39,8 +39,10 @@ struct cls_cas_chunk_create_or_get_ref_op {
     f->dump_unsigned("flags", flags);
     f->dump_unsigned("data_len", data.length());
   }
-  static void generate_test_instances(std::list<cls_cas_chunk_create_or_get_ref_op*>& ls) {
-    ls.push_back(new cls_cas_chunk_create_or_get_ref_op());
+  static std::list<cls_cas_chunk_create_or_get_ref_op> generate_test_instances() {
+    std::list<cls_cas_chunk_create_or_get_ref_op> ls;
+    ls.push_back(cls_cas_chunk_create_or_get_ref_op{});
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_cas_chunk_create_or_get_ref_op)
@@ -65,8 +67,10 @@ struct cls_cas_chunk_get_ref_op {
   void dump(ceph::Formatter *f) const {
     f->dump_object("source", source);
   }
-  static void generate_test_instances(std::list<cls_cas_chunk_get_ref_op*>& ls) {
-    ls.push_back(new cls_cas_chunk_get_ref_op());
+  static std::list<cls_cas_chunk_get_ref_op> generate_test_instances() {
+    std::list<cls_cas_chunk_get_ref_op> ls;
+    ls.push_back(cls_cas_chunk_get_ref_op{});
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_cas_chunk_get_ref_op)
@@ -92,8 +96,10 @@ struct cls_cas_chunk_put_ref_op {
   void dump(ceph::Formatter *f) const {
     f->dump_object("source", source);
   }
-  static void generate_test_instances(std::list<cls_cas_chunk_put_ref_op*>& ls) {
-    ls.push_back(new cls_cas_chunk_put_ref_op());
+  static std::list<cls_cas_chunk_put_ref_op> generate_test_instances() {
+    std::list<cls_cas_chunk_put_ref_op> ls;
+    ls.push_back(cls_cas_chunk_put_ref_op{});
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_cas_chunk_put_ref_op)

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -57,10 +57,12 @@ struct entry_header {
   void dump(ceph::Formatter *f) const {
     f->dump_stream("mtime") << mtime;
   }
-  static void generate_test_instances(std::list<entry_header*>& ls) {
-    ls.push_back(new entry_header);
-    ls.push_back(new entry_header);
-    ls.back()->mtime = ceph::real_clock::now();
+  static std::list<entry_header> generate_test_instances() {
+    std::list<entry_header> ls;
+    ls.push_back(entry_header{});
+    ls.push_back(entry_header{});
+    ls.back().mtime = ceph::real_clock::now();
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(entry_header)

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -77,20 +77,22 @@ struct create_meta
     f->dump_unsigned("max_entry_size", max_entry_size);
     f->dump_bool("exclusive", exclusive);
   }
-  static void generate_test_instances(std::list<create_meta*>& o) {
-    o.push_back(new create_meta);
-    o.push_back(new create_meta);
-    o.back()->id = "id";
+  static std::list<create_meta> generate_test_instances() {
+    std::list<create_meta> o;
+    o.push_back(create_meta{});
+    o.push_back(create_meta{});
+    o.back().id = "id";
     objv v1;
     v1.instance = "inst1";
     v1.ver = 1;
-    o.back()->version = v1;
-    o.back()->pool.name = "pool";
-    o.back()->pool.ns = "ns";
-    o.back()->oid_prefix = "prefix";
-    o.back()->max_part_size = 1024;
-    o.back()->max_entry_size = 1024;
-    o.back()->exclusive = true;
+    o.back().version = v1;
+    o.back().pool.name = "pool";
+    o.back().pool.ns = "ns";
+    o.back().oid_prefix = "prefix";
+    o.back().max_part_size = 1024;
+    o.back().max_entry_size = 1024;
+    o.back().exclusive = true;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(create_meta)
@@ -112,13 +114,15 @@ struct get_meta
   void dump(ceph::Formatter *f) const {
     f->dump_object("version", version.value_or(objv()));
   }
-  static void generate_test_instances(std::list<get_meta*>& o) {
-    o.push_back(new get_meta);
-    o.push_back(new get_meta);
+  static std::list<get_meta> generate_test_instances() {
+    std::list<get_meta> o;
+    o.push_back(get_meta{});
+    o.push_back(get_meta{});
     objv v1;
     v1.instance = "inst1";
     v1.ver = 1;
-    o.back()->version = v1;
+    o.back().version = v1;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(get_meta)
@@ -149,12 +153,14 @@ struct get_meta_reply
     f->dump_unsigned("part_header_size", part_header_size);
     f->dump_unsigned("part_entry_overhead", part_entry_overhead);
   }
-  static void generate_test_instances(std::list<get_meta_reply*>& o) {
-    o.push_back(new get_meta_reply);
-    o.push_back(new get_meta_reply);
-    o.back()->info = fifo::info();
-    o.back()->part_header_size = 1024;
-    o.back()->part_entry_overhead = 1024;
+  static std::list<get_meta_reply> generate_test_instances() {
+    std::list<get_meta_reply> o;
+    o.push_back(get_meta_reply{});
+    o.push_back(get_meta_reply{});
+    o.back().info = fifo::info();
+    o.back().part_header_size = 1024;
+    o.back().part_entry_overhead = 1024;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(get_meta_reply)

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -58,11 +58,13 @@ struct objv {
     f->dump_string("instance", instance);
     f->dump_unsigned("ver", ver);
   }
-  static void generate_test_instances(std::list<objv*>& o) {
-    o.push_back(new objv);
-    o.push_back(new objv);
-    o.back()->instance = "instance";
-    o.back()->ver = 1;
+  static std::list<objv> generate_test_instances() {
+    std::list<objv> o;
+    o.emplace_back();
+    o.emplace_back();
+    o.back().instance = "instance";
+    o.back().ver = 1;
+    return o;
   }
   void decode_json(JSONObj* obj);
 
@@ -117,12 +119,14 @@ struct data_params {
     f->dump_unsigned("max_entry_size", max_entry_size);
     f->dump_unsigned("full_size_threshold", full_size_threshold);
   }
-  static void generate_test_instances(std::list<data_params*>& o) {
-    o.push_back(new data_params);
-    o.push_back(new data_params);
-    o.back()->max_part_size = 1;
-    o.back()->max_entry_size = 2;
-    o.back()->full_size_threshold = 3;
+  static std::list<data_params> generate_test_instances() {
+    std::list<data_params> o;
+    o.push_back(data_params{});
+    o.push_back(data_params{});
+    o.back().max_part_size = 1;
+    o.back().max_entry_size = 2;
+    o.back().full_size_threshold = 3;
+    return o;
   }
   void decode_json(JSONObj* obj);
 
@@ -437,20 +441,22 @@ struct info {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<info*>& o) {
-    o.push_back(new info);
-    o.push_back(new info);
-    o.back()->id = "myid";
-    o.back()->version = objv();
-    o.back()->oid_prefix = "myprefix";
-    o.back()->params = data_params();
-    o.back()->tail_part_num = 123;
-    o.back()->head_part_num = 456;
-    o.back()->min_push_part_num = 789;
-    o.back()->max_push_part_num = 101112;
-    o.back()->journal.insert(journal_entry(journal_entry::Op::create, 1));
-    o.back()->journal.insert(journal_entry(journal_entry::Op::create, 2));
-    o.back()->journal.insert(journal_entry(journal_entry::Op::create, 3));
+  static std::list<info> generate_test_instances() {
+    std::list<info> o;
+    o.push_back(info{});
+    o.push_back(info{});
+    o.back().id = "myid";
+    o.back().version = objv();
+    o.back().oid_prefix = "myprefix";
+    o.back().params = data_params();
+    o.back().tail_part_num = 123;
+    o.back().head_part_num = 456;
+    o.back().min_push_part_num = 789;
+    o.back().max_push_part_num = 101112;
+    o.back().journal.insert(journal_entry(journal_entry::Op::create, 1));
+    o.back().journal.insert(journal_entry(journal_entry::Op::create, 2));
+    o.back().journal.insert(journal_entry(journal_entry::Op::create, 3));
+    return o;
   }
   void decode_json(JSONObj* obj);
 

--- a/src/cls/journal/cls_journal_types.cc
+++ b/src/cls/journal/cls_journal_types.cc
@@ -33,9 +33,11 @@ void ObjectPosition::dump(Formatter *f) const {
   f->dump_unsigned("entry_tid", entry_tid);
 }
 
-void ObjectPosition::generate_test_instances(std::list<ObjectPosition *> &o) {
-  o.push_back(new ObjectPosition());
-  o.push_back(new ObjectPosition(1, 2, 3));
+std::list<ObjectPosition> ObjectPosition::generate_test_instances() {
+  std::list<ObjectPosition> o;
+  o.push_back(ObjectPosition{});
+  o.push_back(ObjectPosition(1, 2, 3));
+  return o;
 }
 
 void ObjectSetPosition::encode(bufferlist& bl) const {
@@ -60,10 +62,11 @@ void ObjectSetPosition::dump(Formatter *f) const {
   f->close_section();
 }
 
-void ObjectSetPosition::generate_test_instances(
-    std::list<ObjectSetPosition *> &o) {
-  o.push_back(new ObjectSetPosition());
-  o.push_back(new ObjectSetPosition({{0, 1, 120}, {121, 2, 121}}));
+std::list<ObjectSetPosition> ObjectSetPosition::generate_test_instances() {
+  std::list<ObjectSetPosition> o;
+  o.push_back(ObjectSetPosition{});
+  o.push_back(ObjectSetPosition({{0, 1, 120}, {121, 2, 121}}));
+  return o;
 }
 
 void Client::encode(bufferlist& bl) const {
@@ -101,13 +104,15 @@ void Client::dump(Formatter *f) const {
   f->dump_string("state", stringify(state));
 }
 
-void Client::generate_test_instances(std::list<Client *> &o) {
+std::list<Client> Client::generate_test_instances() {
+  std::list<Client> o;
   bufferlist data;
   data.append(std::string(128, '1'));
 
-  o.push_back(new Client());
-  o.push_back(new Client("id", data));
-  o.push_back(new Client("id", data, {{{1, 2, 120}, {2, 3, 121}}}));
+  o.push_back(Client());
+  o.push_back(Client("id", data));
+  o.push_back(Client("id", data, {{{1, 2, 120}, {2, 3, 121}}}));
+  return o;
 }
 
 void Tag::encode(bufferlist& bl) const {
@@ -135,12 +140,14 @@ void Tag::dump(Formatter *f) const {
   f->dump_string("data", data_ss.str());
 }
 
-void Tag::generate_test_instances(std::list<Tag *> &o) {
-  o.push_back(new Tag());
+std::list<Tag> Tag::generate_test_instances() {
+  std::list<Tag> o;
+  o.push_back(Tag{});
 
   bufferlist data;
   data.append(std::string(128, '1'));
-  o.push_back(new Tag(123, 234, data));
+  o.push_back(Tag(123, 234, data));
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &os, const ClientState &state) {

--- a/src/cls/journal/cls_journal_types.h
+++ b/src/cls/journal/cls_journal_types.h
@@ -52,7 +52,7 @@ struct ObjectPosition {
     return entry_tid < rhs.entry_tid;
   }
 
-  static void generate_test_instances(std::list<ObjectPosition *> &o);
+  static std::list<ObjectPosition> generate_test_instances();
 };
 
 typedef std::list<ObjectPosition> ObjectPositions;
@@ -73,7 +73,7 @@ struct ObjectSetPosition {
     return (object_positions == rhs.object_positions);
   }
 
-  static void generate_test_instances(std::list<ObjectSetPosition *> &o);
+  static std::list<ObjectSetPosition> generate_test_instances();
 };
 
 enum ClientState {
@@ -107,7 +107,7 @@ struct Client {
   void decode(ceph::buffer::list::const_iterator& iter);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<Client *> &o);
+  static std::list<Client> generate_test_instances();
 };
 
 struct Tag {
@@ -134,7 +134,7 @@ struct Tag {
   void decode(ceph::buffer::list::const_iterator& iter);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<Tag *> &o);
+  static std::list<Tag> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(ObjectPosition);

--- a/src/cls/lock/cls_lock_ops.cc
+++ b/src/cls/lock/cls_lock_ops.cc
@@ -39,18 +39,20 @@ void cls_lock_lock_op::dump(Formatter *f) const
   f->dump_int("flags", (int)flags);
 }
 
-void cls_lock_lock_op::generate_test_instances(list<cls_lock_lock_op*>& o)
+list<cls_lock_lock_op> cls_lock_lock_op::generate_test_instances()
 {
-  cls_lock_lock_op *i = new cls_lock_lock_op;
-  i->name = "name";
-  i->type = ClsLockType::SHARED;
-  i->cookie = "cookie";
-  i->tag = "tag";
-  i->description = "description";
-  i->duration = utime_t(5, 0);
-  i->flags = LOCK_FLAG_MAY_RENEW;
-  o.push_back(i);
-  o.push_back(new cls_lock_lock_op);
+  list<cls_lock_lock_op> o;
+  cls_lock_lock_op i;
+  i.name = "name";
+  i.type = ClsLockType::SHARED;
+  i.cookie = "cookie";
+  i.tag = "tag";
+  i.description = "description";
+  i.duration = utime_t(5, 0);
+  i.flags = LOCK_FLAG_MAY_RENEW;
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_lock_op{});
+  return o;
 }
 
 void cls_lock_unlock_op::dump(Formatter *f) const
@@ -59,13 +61,15 @@ void cls_lock_unlock_op::dump(Formatter *f) const
   f->dump_string("cookie", cookie);
 }
 
-void cls_lock_unlock_op::generate_test_instances(list<cls_lock_unlock_op*>& o)
+list<cls_lock_unlock_op> cls_lock_unlock_op::generate_test_instances()
 {
-  cls_lock_unlock_op *i = new cls_lock_unlock_op;
-  i->name = "name";
-  i->cookie = "cookie";
-  o.push_back(i);
-  o.push_back(new cls_lock_unlock_op);
+  list<cls_lock_unlock_op> o;
+  cls_lock_unlock_op i;
+  i.name = "name";
+  i.cookie = "cookie";
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_unlock_op{});
+  return o;
 }
 
 void cls_lock_break_op::dump(Formatter *f) const
@@ -75,14 +79,16 @@ void cls_lock_break_op::dump(Formatter *f) const
   f->dump_stream("locker") << locker;
 }
 
-void cls_lock_break_op::generate_test_instances(list<cls_lock_break_op*>& o)
+list<cls_lock_break_op> cls_lock_break_op::generate_test_instances()
 {
-  cls_lock_break_op *i = new cls_lock_break_op;
-  i->name = "name";
-  i->cookie = "cookie";
-  i->locker =  entity_name_t::CLIENT(1);
-  o.push_back(i);
-  o.push_back(new cls_lock_break_op);
+  list<cls_lock_break_op> o;
+  cls_lock_break_op i;
+  i.name = "name";
+  i.cookie = "cookie";
+  i.locker =  entity_name_t::CLIENT(1);
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_break_op{});
+  return o;
 }
 
 void cls_lock_get_info_op::dump(Formatter *f) const
@@ -90,12 +96,14 @@ void cls_lock_get_info_op::dump(Formatter *f) const
   f->dump_string("name", name);
 }
 
-void cls_lock_get_info_op::generate_test_instances(list<cls_lock_get_info_op*>& o)
+list<cls_lock_get_info_op> cls_lock_get_info_op::generate_test_instances()
 {
-  cls_lock_get_info_op *i = new cls_lock_get_info_op;
-  i->name = "name";
-  o.push_back(i);
-  o.push_back(new cls_lock_get_info_op);
+  list<cls_lock_get_info_op> o;
+  cls_lock_get_info_op i;
+  i.name = "name";
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_get_info_op{});
+  return o;
 }
 
 static void generate_test_addr(entity_addr_t& a, int nonce, int port)
@@ -130,22 +138,24 @@ void cls_lock_get_info_reply::dump(Formatter *f) const
   f->close_section();
 }
 
-void cls_lock_get_info_reply::generate_test_instances(list<cls_lock_get_info_reply*>& o)
+list<cls_lock_get_info_reply> cls_lock_get_info_reply::generate_test_instances()
 {
-  cls_lock_get_info_reply *i = new cls_lock_get_info_reply;
-  i->lock_type = ClsLockType::SHARED;
-  i->tag = "tag";
+  list<cls_lock_get_info_reply> o;
+  cls_lock_get_info_reply i;
+  i.lock_type = ClsLockType::SHARED;
+  i.tag = "tag";
   locker_id_t id1, id2;
   entity_addr_t addr1, addr2;
   generate_lock_id(id1, 1, "cookie1");
   generate_test_addr(addr1, 10, 20);
-  i->lockers[id1] = locker_info_t(utime_t(10, 0), addr1, "description1");
+  i.lockers[id1] = locker_info_t(utime_t(10, 0), addr1, "description1");
   generate_lock_id(id2, 2, "cookie2");
   generate_test_addr(addr2, 30, 40);
-  i->lockers[id2] = locker_info_t(utime_t(20, 0), addr2, "description2");
+  i.lockers[id2] = locker_info_t(utime_t(20, 0), addr2, "description2");
 
-  o.push_back(i);
-  o.push_back(new cls_lock_get_info_reply);
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_get_info_reply{});
+  return o;
 }
 
 void cls_lock_list_locks_reply::dump(Formatter *f) const
@@ -160,15 +170,17 @@ void cls_lock_list_locks_reply::dump(Formatter *f) const
   f->close_section();
 }
 
-void cls_lock_list_locks_reply::generate_test_instances(list<cls_lock_list_locks_reply*>& o)
+list<cls_lock_list_locks_reply> cls_lock_list_locks_reply::generate_test_instances()
 {
-  cls_lock_list_locks_reply *i = new cls_lock_list_locks_reply;
-  i->locks.push_back("lock1");
-  i->locks.push_back("lock2");
-  i->locks.push_back("lock3");
+  list<cls_lock_list_locks_reply> o;
+  cls_lock_list_locks_reply i;
+  i.locks.push_back("lock1");
+  i.locks.push_back("lock2");
+  i.locks.push_back("lock3");
 
-  o.push_back(i);
-  o.push_back(new cls_lock_list_locks_reply);
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_list_locks_reply{});
+  return o;
 }
 
 void cls_lock_assert_op::dump(Formatter *f) const
@@ -179,15 +191,17 @@ void cls_lock_assert_op::dump(Formatter *f) const
   f->dump_string("tag", tag);
 }
 
-void cls_lock_assert_op::generate_test_instances(list<cls_lock_assert_op*>& o)
+list<cls_lock_assert_op> cls_lock_assert_op::generate_test_instances()
 {
-  cls_lock_assert_op *i = new cls_lock_assert_op;
-  i->name = "name";
-  i->type = ClsLockType::SHARED;
-  i->cookie = "cookie";
-  i->tag = "tag";
-  o.push_back(i);
-  o.push_back(new cls_lock_assert_op);
+  list<cls_lock_assert_op> o;
+  cls_lock_assert_op i;
+  i.name = "name";
+  i.type = ClsLockType::SHARED;
+  i.cookie = "cookie";
+  i.tag = "tag";
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_assert_op{});
+  return o;
 }
 
 void cls_lock_set_cookie_op::dump(Formatter *f) const
@@ -199,15 +213,17 @@ void cls_lock_set_cookie_op::dump(Formatter *f) const
   f->dump_string("new_cookie", new_cookie);
 }
 
-void cls_lock_set_cookie_op::generate_test_instances(list<cls_lock_set_cookie_op*>& o)
+list<cls_lock_set_cookie_op> cls_lock_set_cookie_op::generate_test_instances()
 {
-  cls_lock_set_cookie_op *i = new cls_lock_set_cookie_op;
-  i->name = "name";
-  i->type = ClsLockType::SHARED;
-  i->cookie = "cookie";
-  i->tag = "tag";
-  i->new_cookie = "new cookie";
-  o.push_back(i);
-  o.push_back(new cls_lock_set_cookie_op);
+  list<cls_lock_set_cookie_op> o;
+  cls_lock_set_cookie_op i;
+  i.name = "name";
+  i.type = ClsLockType::SHARED;
+  i.cookie = "cookie";
+  i.tag = "tag";
+  i.new_cookie = "new cookie";
+  o.push_back(std::move(i));
+  o.push_back(cls_lock_set_cookie_op{});
+  return o;
 }
 

--- a/src/cls/lock/cls_lock_ops.h
+++ b/src/cls/lock/cls_lock_ops.h
@@ -46,7 +46,7 @@ struct cls_lock_lock_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_lock_op*>& o);
+  static std::list<cls_lock_lock_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_lock_lock_op)
 
@@ -70,7 +70,7 @@ struct cls_lock_unlock_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_unlock_op*>& o);
+  static std::list<cls_lock_unlock_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_lock_unlock_op)
 
@@ -97,7 +97,7 @@ struct cls_lock_break_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_break_op*>& o);
+  static std::list<cls_lock_break_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_lock_break_op)
 
@@ -118,7 +118,7 @@ struct cls_lock_get_info_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_get_info_op*>& o);
+  static std::list<cls_lock_get_info_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_lock_get_info_op)
 
@@ -148,7 +148,7 @@ struct cls_lock_get_info_reply
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_get_info_reply*>& o);
+  static std::list<cls_lock_get_info_reply> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(cls_lock_get_info_reply)
 
@@ -169,7 +169,7 @@ struct cls_lock_list_locks_reply
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_list_locks_reply*>& o);
+  static std::list<cls_lock_list_locks_reply> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_lock_list_locks_reply)
 
@@ -202,7 +202,7 @@ struct cls_lock_assert_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_assert_op*>& o);
+  static std::list<cls_lock_assert_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_lock_assert_op)
 
@@ -238,7 +238,7 @@ struct cls_lock_set_cookie_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_lock_set_cookie_op*>& o);
+  static std::list<cls_lock_set_cookie_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_lock_set_cookie_op)
 

--- a/src/cls/lock/cls_lock_types.cc
+++ b/src/cls/lock/cls_lock_types.cc
@@ -30,12 +30,14 @@ void locker_id_t::dump(ceph::Formatter *f) const
   f->dump_string("cookie", cookie);
 }
 
-void locker_id_t::generate_test_instances(std::list<locker_id_t*>& o)
+std::list<locker_id_t> locker_id_t::generate_test_instances()
 {
-  locker_id_t *i = new locker_id_t;
-  generate_lock_id(*i, 1, "cookie");
-  o.push_back(i);
-  o.push_back(new locker_id_t);
+  std::list<locker_id_t> o;
+  locker_id_t i;
+  generate_lock_id(i, 1, "cookie");
+  o.push_back(std::move(i));
+  o.push_back(locker_id_t{});
+  return o;
 }
 
 void locker_info_t::dump(ceph::Formatter *f) const
@@ -57,14 +59,16 @@ static void generate_test_addr(entity_addr_t& a, int nonce, int port)
   a.set_port(port);
 }
 
-void locker_info_t::generate_test_instances(std::list<locker_info_t*>& o)
+std::list<locker_info_t> locker_info_t::generate_test_instances()
 {
-  locker_info_t *i = new locker_info_t;
-  i->expiration = utime_t(5, 0);
-  generate_test_addr(i->addr, 1, 2);
-  i->description = "description";
-  o.push_back(i);
-  o.push_back(new locker_info_t);
+  std::list<locker_info_t> o;
+  locker_info_t i;
+  i.expiration = utime_t(5, 0);
+  generate_test_addr(i.addr, 1, 2);
+  i.description = "description";
+  o.push_back(std::move(i));
+  o.push_back(locker_info_t{});
+  return o;
 }
 
 void lock_info_t::dump(ceph::Formatter *f) const
@@ -81,18 +85,20 @@ void lock_info_t::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void lock_info_t::generate_test_instances(std::list<lock_info_t *>& o)
+std::list<lock_info_t> lock_info_t::generate_test_instances()
 {
-  lock_info_t *i = new lock_info_t;
+  std::list<lock_info_t> o;
+  lock_info_t i;
   locker_id_t id;
   locker_info_t info;
   generate_lock_id(id, 1, "cookie");
   info.expiration = utime_t(5, 0);
   generate_test_addr(info.addr, 1, 2);
   info.description = "description";
-  i->lockers[id] = info;
-  i->lock_type = ClsLockType::EXCLUSIVE;
-  i->tag = "tag";
-  o.push_back(i);
-  o.push_back(new lock_info_t);
+  i.lockers[id] = info;
+  i.lock_type = ClsLockType::EXCLUSIVE;
+  i.tag = "tag";
+  o.push_back(std::move(i));
+  o.push_back(lock_info_t{});
+  return o;
 }

--- a/src/cls/lock/cls_lock_types.h
+++ b/src/cls/lock/cls_lock_types.h
@@ -90,7 +90,7 @@ namespace rados {
 	  out << data.locker;
 	  return out;
 	}
-        static void generate_test_instances(std::list<locker_id_t*>& o);
+        static std::list<locker_id_t> generate_test_instances();
       };
       WRITE_CLASS_ENCODER(locker_id_t)
 
@@ -133,7 +133,7 @@ namespace rados {
 
 	  return out;
 	}
-        static void generate_test_instances(std::list<locker_info_t *>& o);
+        static std::list<locker_info_t > generate_test_instances();
       };
       WRITE_CLASS_ENCODER_FEATURES(locker_info_t)
 
@@ -164,7 +164,7 @@ namespace rados {
 
         lock_info_t() : lock_type(ClsLockType::NONE) {}
         void dump(ceph::Formatter *f) const;
-        static void generate_test_instances(std::list<lock_info_t *>& o);
+        static std::list<lock_info_t > generate_test_instances();
       };
       WRITE_CLASS_ENCODER_FEATURES(lock_info_t);
     }

--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -40,17 +40,19 @@ struct add_op {
     encode_json("monotonic_inc", monotonic_inc, f);
   }
 
-  static void generate_test_instances(std::list<add_op *>& l) {
+  static std::list<add_op> generate_test_instances() {
     using namespace std::literals;
-    l.push_back(new add_op);
-    l.push_back(new add_op);
-    l.back()->entries.push_back(entry{});
-    l.back()->entries.push_back(entry{});
-    l.back()->entries.back().section = "section";
-    l.back()->entries.back().name = "name";
-    l.back()->entries.back().timestamp = ceph::real_time{1s + 2ns};
-    l.back()->entries.back().data.append("data");
-    l.back()->entries.back().id = "id";
+    std::list<add_op> l;
+    l.emplace_back();
+    l.emplace_back();
+    l.back().entries.push_back(entry{});
+    l.back().entries.push_back(entry{});
+    l.back().entries.back().section = "section";
+    l.back().entries.back().name = "name";
+    l.back().entries.back().timestamp = ceph::real_time{1s + 2ns};
+    l.back().entries.back().data.append("data");
+    l.back().entries.back().id = "id";
+    return l;
   }
 };
 WRITE_CLASS_ENCODER(add_op)
@@ -88,14 +90,16 @@ struct list_op {
     f->dump_stream("to_time") << to_time;
     f->dump_int("max_entries", max_entries);
   }
-  static void generate_test_instances(std::list<list_op*>& ls) {
+  static std::list<list_op> generate_test_instances() {
     using namespace std::literals;
-    ls.push_back(new list_op);
-    ls.push_back(new list_op);
-    ls.back()->from_time = ceph::real_time{1s + 2ns};
-    ls.back()->marker = "marker";
-    ls.back()->to_time = ceph::real_time{3s + 4ns};
-    ls.back()->max_entries = 5;
+    std::list<list_op> ls;
+    ls.emplace_back();
+    ls.emplace_back();
+    ls.back().from_time = ceph::real_time{1s + 2ns};
+    ls.back().marker = "marker";
+    ls.back().to_time = ceph::real_time{3s + 4ns};
+    ls.back().max_entries = 5;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(list_op)
@@ -128,19 +132,21 @@ struct list_ret {
     f->dump_string("marker", marker);
     f->dump_bool("truncated", truncated);
   }
-  static void generate_test_instances(std::list<list_ret*>& ls) {
+  static std::list<list_ret> generate_test_instances() {
     using namespace std::literals;
-    ls.push_back(new list_ret);
-    ls.push_back(new list_ret);
-    ls.back()->entries.push_back(entry{});
-    ls.back()->entries.push_back(entry{});
-    ls.back()->entries.back().section = "section";
-    ls.back()->entries.back().name = "name";
-    ls.back()->entries.back().timestamp = ceph::real_time{1s + 2ns};
-    ls.back()->entries.back().data.append("data");
-    ls.back()->entries.back().id = "id";
-    ls.back()->marker = "marker";
-    ls.back()->truncated = true;
+    std::list<list_ret> ls;
+    ls.emplace_back();
+    ls.emplace_back();
+    ls.back().entries.push_back(entry{});
+    ls.back().entries.push_back(entry{});
+    ls.back().entries.back().section = "section";
+    ls.back().entries.back().name = "name";
+    ls.back().entries.back().timestamp = ceph::real_time{1s + 2ns};
+    ls.back().entries.back().data.append("data");
+    ls.back().entries.back().id = "id";
+    ls.back().marker = "marker";
+    ls.back().truncated = true;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(list_ret)
@@ -182,14 +188,16 @@ struct trim_op {
     f->dump_string("from_marker", from_marker);
     f->dump_string("to_marker", to_marker);
   }
-  static void generate_test_instances(std::list<trim_op*>& ls) {
+  static std::list<trim_op> generate_test_instances() {
     using namespace std::literals;
-    ls.push_back(new trim_op);
-    ls.push_back(new trim_op);
-    ls.back()->from_time = ceph::real_time{1s + 2ns};
-    ls.back()->to_time = ceph::real_time(3s + 4ns);
-    ls.back()->from_marker = "from_marker";
-    ls.back()->to_marker = "to_marker";
+    std::list<trim_op> ls;
+    ls.emplace_back();
+    ls.emplace_back();
+    ls.back().from_time = ceph::real_time{1s + 2ns};
+    ls.back().to_time = ceph::real_time(3s + 4ns);
+    ls.back().from_marker = "from_marker";
+    ls.back().to_marker = "to_marker";
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(trim_op)
@@ -212,8 +220,10 @@ struct info_op {
   void dump(ceph::Formatter* f) const {
   }
 
-  static void generate_test_instances(std::list<info_op*>& ls) {
-    ls.push_back(new info_op);
+  static std::list<info_op> generate_test_instances() {
+    std::list<info_op> ls;
+    ls.emplace_back();
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(info_op)

--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -69,16 +69,18 @@ struct entry {
     JSONDecoder::decode_json("id", id, obj);
   }
 
-  static void generate_test_instances(std::list<cls::log::entry *>& l) {
-    l.push_back(new cls::log::entry{});
-    l.push_back(new cls::log::entry);
-    l.back()->id = "test_id";
-    l.back()->section = "test_section";
-    l.back()->name = "test_name";
-    l.back()->timestamp = ceph::real_time{};
+  static std::list<cls::log::entry> generate_test_instances() {
+    std::list<cls::log::entry> l;
+    l.push_back(cls::log::entry{});
+    l.push_back(cls::log::entry{});
+    l.back().id = "test_id";
+    l.back().section = "test_section";
+    l.back().name = "test_name";
+    l.back().timestamp = ceph::real_time{};
     ceph::buffer::list bl;
     ceph::encode(std::string("Test"), bl, 0);
-    l.back()->data = bl;
+    l.back().data = bl;
+    return l;
   }
 };
 WRITE_CLASS_ENCODER(entry)
@@ -105,11 +107,13 @@ struct header {
     f->dump_string("max_marker", max_marker);
     f->dump_stream("max_time") << max_time;
   }
-  static void generate_test_instances(std::list<header*>& o) {
-    o.push_back(new header);
-    o.push_back(new header);
-    o.back()->max_marker = "test_marker";
-    o.back()->max_time = ceph::real_clock::zero();
+  static std::list<header> generate_test_instances() {
+    std::list<header> o;
+    o.push_back(header{});
+    o.push_back(header{});
+    o.back().max_marker = "test_marker";
+    o.back().max_time = ceph::real_clock::zero();
+    return o;
   }
   friend auto operator <=>(const header&, const header&) = default;
 };

--- a/src/cls/queue/cls_queue_ops.h
+++ b/src/cls/queue/cls_queue_ops.h
@@ -36,12 +36,14 @@ struct cls_queue_init_op {
     f->dump_unsigned("urgent_data_len", bl_urgent_data.length());
   }
 
-  static void generate_test_instances(std::list<cls_queue_init_op*>& o) {
-    o.push_back(new cls_queue_init_op);
-    o.push_back(new cls_queue_init_op);
-    o.back()->queue_size = 1024;
-    o.back()->max_urgent_data_size = 1024;
-    o.back()->bl_urgent_data.append(std::string_view("data"));
+  static std::list<cls_queue_init_op> generate_test_instances() {
+    std::list<cls_queue_init_op> o;
+    o.push_back(cls_queue_init_op{});
+    o.push_back(cls_queue_init_op{});
+    o.back().queue_size = 1024;
+    o.back().max_urgent_data_size = 1024;
+    o.back().bl_urgent_data.append(std::string_view("data"));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_init_op)
@@ -67,11 +69,13 @@ struct cls_queue_enqueue_op {
     f->dump_unsigned("data_vec_len", bl_data_vec.size());
   }
 
-  static void generate_test_instances(std::list<cls_queue_enqueue_op*>& o) {
-    o.push_back(new cls_queue_enqueue_op);
-    o.push_back(new cls_queue_enqueue_op);
-    o.back()->bl_data_vec.push_back(ceph::buffer::list());
-    o.back()->bl_data_vec.back().append(std::string_view("data"));
+  static std::list<cls_queue_enqueue_op> generate_test_instances() {
+    std::list<cls_queue_enqueue_op> o;
+    o.push_back(cls_queue_enqueue_op{});
+    o.push_back(cls_queue_enqueue_op{});
+    o.back().bl_data_vec.push_back(ceph::buffer::list());
+    o.back().bl_data_vec.back().append(std::string_view("data"));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_enqueue_op)
@@ -106,11 +110,13 @@ struct cls_queue_list_op {
     f->dump_string("start_marker", start_marker);
   }
 
-  static void generate_test_instances(std::list<cls_queue_list_op*>& o) {
-    o.push_back(new cls_queue_list_op);
-    o.push_back(new cls_queue_list_op);
-    o.back()->max = 123;
-    o.back()->start_marker = "foo";
+  static std::list<cls_queue_list_op> generate_test_instances() {
+    std::list<cls_queue_list_op> o;
+    o.push_back(cls_queue_list_op{});
+    o.push_back(cls_queue_list_op{});
+    o.back().max = 123;
+    o.back().start_marker = "foo";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_list_op)
@@ -144,14 +150,16 @@ struct cls_queue_list_ret {
     encode_json("entries", entries, f);
   }
 
-  static void generate_test_instances(std::list<cls_queue_list_ret*>& o) {
-    o.push_back(new cls_queue_list_ret);
-    o.back()->is_truncated = true;
-    o.back()->next_marker = "foo";
-    o.back()->entries.push_back(cls_queue_entry());
-    o.back()->entries.push_back(cls_queue_entry());
-    o.back()->entries.back().marker = "id";
-    o.back()->entries.back().data.append(std::string_view("data"));
+  static std::list<cls_queue_list_ret> generate_test_instances() {
+    std::list<cls_queue_list_ret> o;
+    o.push_back(cls_queue_list_ret{});
+    o.back().is_truncated = true;
+    o.back().next_marker = "foo";
+    o.back().entries.push_back(cls_queue_entry());
+    o.back().entries.push_back(cls_queue_entry());
+    o.back().entries.back().marker = "id";
+    o.back().entries.back().data.append(std::string_view("data"));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_list_ret)
@@ -176,10 +184,12 @@ struct cls_queue_remove_op {
   void dump(ceph::Formatter *f) const {
     f->dump_string("end_marker", end_marker);
   }
-  static void generate_test_instances(std::list<cls_queue_remove_op*>& o) {
-    o.push_back(new cls_queue_remove_op);
-    o.push_back(new cls_queue_remove_op);
-    o.back()->end_marker = "foo";
+  static std::list<cls_queue_remove_op> generate_test_instances() {
+    std::list<cls_queue_remove_op> o;
+    o.push_back(cls_queue_remove_op{});
+    o.push_back(cls_queue_remove_op{});
+    o.back().end_marker = "foo";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_remove_op)
@@ -204,9 +214,11 @@ struct cls_queue_get_capacity_ret {
   void dump(ceph::Formatter *f) const {
     f->dump_unsigned("queue_capacity", queue_capacity);
   }
-  static void generate_test_instances(std::list<cls_queue_get_capacity_ret*>& o) {
-    o.push_back(new cls_queue_get_capacity_ret);
-    o.back()->queue_capacity = 123;
+  static std::list<cls_queue_get_capacity_ret> generate_test_instances() {
+    std::list<cls_queue_get_capacity_ret> o;
+    o.push_back(cls_queue_get_capacity_ret{});
+    o.back().queue_capacity = 123;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_get_capacity_ret)

--- a/src/cls/queue/cls_queue_types.h
+++ b/src/cls/queue/cls_queue_types.h
@@ -39,11 +39,13 @@ struct cls_queue_entry
     f->dump_string("marker", marker);
     f->dump_unsigned("data_len", data.length());
   }
-  static void generate_test_instances(std::list<cls_queue_entry*>& o) {
-    o.push_back(new cls_queue_entry);
-    o.push_back(new cls_queue_entry);
-    o.back()->data.append(std::string_view("data"));
-    o.back()->marker = "marker";
+  static std::list<cls_queue_entry> generate_test_instances() {
+    std::list<cls_queue_entry> o;
+    o.push_back(cls_queue_entry{});
+    o.push_back(cls_queue_entry{});
+    o.back().data.append(std::string_view("data"));
+    o.back().marker = "marker";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_entry)
@@ -95,11 +97,13 @@ struct cls_queue_marker
     f->dump_unsigned("offset", offset);
     f->dump_unsigned("gen", gen);
   }
-  static void generate_test_instances(std::list<cls_queue_marker*>& o) {
-    o.push_back(new cls_queue_marker);
-    o.push_back(new cls_queue_marker);
-    o.back()->offset = 1024;
-    o.back()->gen = 0;
+  static std::list<cls_queue_marker> generate_test_instances() {
+    std::list<cls_queue_marker> o;
+    o.push_back(cls_queue_marker{});
+    o.push_back(cls_queue_marker{});
+    o.back().offset = 1024;
+    o.back().gen = 0;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_marker)
@@ -144,16 +148,18 @@ struct cls_queue_head
     f->dump_unsigned("tail_offset", tail.offset);
     f->dump_unsigned("tail_gen", tail.gen);
   }
-  static void generate_test_instances(std::list<cls_queue_head*>& o) {
-    o.push_back(new cls_queue_head);
-    o.push_back(new cls_queue_head);
-    o.back()->max_head_size = 1024;
-    o.back()->front.offset = 1024;
-    o.back()->front.gen = 0;
-    o.back()->tail.offset = 1024;
-    o.back()->tail.gen = 0;
-    o.back()->queue_size = 1024;
-    o.back()->max_urgent_data_size = 0;
+  static std::list<cls_queue_head> generate_test_instances() {
+    std::list<cls_queue_head> o;
+    o.push_back(cls_queue_head{});
+    o.push_back(cls_queue_head{});
+    o.back().max_head_size = 1024;
+    o.back().front.offset = 1024;
+    o.back().front.gen = 0;
+    o.back().tail.offset = 1024;
+    o.back().tail.gen = 0;
+    o.back().queue_size = 1024;
+    o.back().max_urgent_data_size = 0;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_queue_head)

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -93,11 +93,13 @@ struct cls_rbd_parent {
     }
   }
 
-  static void generate_test_instances(std::list<cls_rbd_parent*>& o) {
-    o.push_back(new cls_rbd_parent{});
-    o.push_back(new cls_rbd_parent{{1, "", "image id", 234}, {}});
-    o.push_back(new cls_rbd_parent{{1, "", "image id", 234}, {123}});
-    o.push_back(new cls_rbd_parent{{1, "ns", "image id", 234}, {123}});
+  static std::list<cls_rbd_parent> generate_test_instances() {
+    std::list<cls_rbd_parent> o;
+    o.push_back(cls_rbd_parent{});
+    o.push_back(cls_rbd_parent{{1, "", "image id", 234}, {}});
+    o.push_back(cls_rbd_parent{{1, "", "image id", 234}, {123}});
+    o.push_back(cls_rbd_parent{{1, "ns", "image id", 234}, {123}});
+    return o;
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(cls_rbd_parent)
@@ -225,21 +227,22 @@ struct cls_rbd_snap {
     }
   }
 
-  static void generate_test_instances(std::list<cls_rbd_snap*>& o) {
-    o.push_back(new cls_rbd_snap{});
+  static std::list<cls_rbd_snap> generate_test_instances() {
+    std::list<cls_rbd_snap> o;
+    o.emplace_back();
     // the parent field is ignored in v8 and up, so let's avoid setting it.
     // otherwise check-generated.sh would fail due to the disprepancies between
     // the original dump and re-encoded dump
-    o.push_back(new cls_rbd_snap{1, "snap", 123456,
-                                 RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
-                                 cls::rbd::UserSnapshotNamespace{}, 543, {}});
-    o.push_back(new cls_rbd_snap{1, "snap", 123456,
-                                 RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
-                                 cls::rbd::UserSnapshotNamespace{}, 543, {0}});
-    o.push_back(new cls_rbd_snap{1, "snap", 123456,
-                                 RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
-                                 cls::rbd::UserSnapshotNamespace{}, 543,
-                                 {123}});
+    o.push_back(cls_rbd_snap{1, "snap", 123456,
+                             RBD_PROTECTION_STATUS_PROTECTED, cls_rbd_parent{}, 31, {},
+                             cls::rbd::UserSnapshotNamespace{}, 543, {}});
+    o.push_back(cls_rbd_snap{1, "snap", 123456,
+                             RBD_PROTECTION_STATUS_PROTECTED, cls_rbd_parent{}, 31, utime_t{},
+                             cls::rbd::UserSnapshotNamespace{}, 543, std::optional<uint64_t>{0}});
+    o.push_back(cls_rbd_snap{1, "snap", 123456,
+                             RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
+                             cls::rbd::UserSnapshotNamespace{}, 543, {123}});
+    return o;
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(cls_rbd_snap)

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -79,14 +79,16 @@ void MirrorPeer::dump(Formatter *f) const {
   f->dump_stream("last_seen") << last_seen;
 }
 
-void MirrorPeer::generate_test_instances(std::list<MirrorPeer*> &o) {
-  o.push_back(new MirrorPeer());
-  o.push_back(new MirrorPeer("uuid-123", MIRROR_PEER_DIRECTION_RX, "site A",
-                             "client name", ""));
-  o.push_back(new MirrorPeer("uuid-234", MIRROR_PEER_DIRECTION_TX, "site B",
-                             "", "mirror_uuid"));
-  o.push_back(new MirrorPeer("uuid-345", MIRROR_PEER_DIRECTION_RX_TX, "site C",
-                             "client name", "mirror_uuid"));
+std::list<MirrorPeer> MirrorPeer::generate_test_instances() {
+  std::list<MirrorPeer> o;
+  o.push_back(MirrorPeer());
+  o.push_back(MirrorPeer("uuid-123", MIRROR_PEER_DIRECTION_RX, "site A",
+                         "client name", ""));
+  o.push_back(MirrorPeer("uuid-234", MIRROR_PEER_DIRECTION_TX, "site B",
+                         "", "mirror_uuid"));
+  o.push_back(MirrorPeer("uuid-345", MIRROR_PEER_DIRECTION_RX_TX, "site C",
+                         "client name", "mirror_uuid"));
+  return o;
 }
 
 bool MirrorPeer::operator==(const MirrorPeer &rhs) const {
@@ -159,12 +161,14 @@ void MirrorImage::dump(Formatter *f) const {
   f->dump_stream("state") << state;
 }
 
-void MirrorImage::generate_test_instances(std::list<MirrorImage*> &o) {
-  o.push_back(new MirrorImage());
-  o.push_back(new MirrorImage(MIRROR_IMAGE_MODE_JOURNAL, "uuid-123",
-                              MIRROR_IMAGE_STATE_ENABLED));
-  o.push_back(new MirrorImage(MIRROR_IMAGE_MODE_SNAPSHOT, "uuid-abc",
-                              MIRROR_IMAGE_STATE_DISABLING));
+std::list<MirrorImage> MirrorImage::generate_test_instances() {
+  std::list<MirrorImage> o;
+  o.push_back(MirrorImage());
+  o.push_back(MirrorImage(MIRROR_IMAGE_MODE_JOURNAL, "uuid-123",
+                          MIRROR_IMAGE_STATE_ENABLED));
+  o.push_back(MirrorImage(MIRROR_IMAGE_MODE_SNAPSHOT, "uuid-abc",
+                          MIRROR_IMAGE_STATE_DISABLING));
+  return o;
 }
 
 bool MirrorImage::operator==(const MirrorImage &rhs) const {
@@ -306,15 +310,16 @@ std::string MirrorImageSiteStatus::state_to_string() const {
   return ss.str();
 }
 
-void MirrorImageSiteStatus::generate_test_instances(
-  std::list<MirrorImageSiteStatus*> &o) {
-  o.push_back(new MirrorImageSiteStatus());
-  o.push_back(new MirrorImageSiteStatus("", MIRROR_IMAGE_STATUS_STATE_REPLAYING,
-                                        ""));
-  o.push_back(new MirrorImageSiteStatus("", MIRROR_IMAGE_STATUS_STATE_ERROR,
-                                        "error"));
-  o.push_back(new MirrorImageSiteStatus("2fb68ca9-1ba0-43b3-8cdf-8c5a9db71e65",
-                                        MIRROR_IMAGE_STATUS_STATE_STOPPED, ""));
+std::list<MirrorImageSiteStatus> MirrorImageSiteStatus::generate_test_instances() {
+  std::list<MirrorImageSiteStatus> o;
+  o.push_back(MirrorImageSiteStatus());
+  o.push_back(MirrorImageSiteStatus("", MIRROR_IMAGE_STATUS_STATE_REPLAYING,
+                                    ""));
+  o.push_back(MirrorImageSiteStatus("", MIRROR_IMAGE_STATUS_STATE_ERROR,
+                                    "error"));
+  o.push_back(MirrorImageSiteStatus("2fb68ca9-1ba0-43b3-8cdf-8c5a9db71e65",
+                                    MIRROR_IMAGE_STATUS_STATE_STOPPED, ""));
+  return o;
 }
 
 bool MirrorImageSiteStatus::operator==(const MirrorImageSiteStatus &rhs) const {
@@ -357,13 +362,14 @@ void MirrorImageSiteStatusOnDisk::decode(bufferlist::const_iterator &it) {
   cls::rbd::MirrorImageSiteStatus::decode(it);
 }
 
-void MirrorImageSiteStatusOnDisk::generate_test_instances(
-    std::list<MirrorImageSiteStatusOnDisk*> &o) {
-  o.push_back(new MirrorImageSiteStatusOnDisk());
-  o.push_back(new MirrorImageSiteStatusOnDisk(
+std::list<MirrorImageSiteStatusOnDisk> MirrorImageSiteStatusOnDisk::generate_test_instances() {
+  std::list<MirrorImageSiteStatusOnDisk> o;
+  o.push_back(MirrorImageSiteStatusOnDisk());
+  o.push_back(MirrorImageSiteStatusOnDisk(
     {"", MIRROR_IMAGE_STATUS_STATE_ERROR, "error"}));
-  o.push_back(new MirrorImageSiteStatusOnDisk(
+  o.push_back(MirrorImageSiteStatusOnDisk(
     {"siteA", MIRROR_IMAGE_STATUS_STATE_STOPPED, ""}));
+  return o;
 }
 
 int MirrorImageStatus::get_local_mirror_image_site_status(
@@ -469,12 +475,13 @@ bool MirrorImageStatus::operator==(const MirrorImageStatus &rhs) const {
   return (mirror_image_site_statuses == rhs.mirror_image_site_statuses);
 }
 
-void MirrorImageStatus::generate_test_instances(
-    std::list<MirrorImageStatus*> &o) {
-  o.push_back(new MirrorImageStatus());
-  o.push_back(new MirrorImageStatus({{"", MIRROR_IMAGE_STATUS_STATE_ERROR, ""}}));
-  o.push_back(new MirrorImageStatus({{"", MIRROR_IMAGE_STATUS_STATE_STOPPED, ""},
-                                     {"siteA", MIRROR_IMAGE_STATUS_STATE_REPLAYING, ""}}));
+std::list<MirrorImageStatus> MirrorImageStatus::generate_test_instances() {
+  std::list<MirrorImageStatus> o;
+  o.push_back(MirrorImageStatus());
+  o.push_back(MirrorImageStatus({{"", MIRROR_IMAGE_STATUS_STATE_ERROR, ""}}));
+  o.push_back(MirrorImageStatus({{"", MIRROR_IMAGE_STATUS_STATE_STOPPED, ""},
+                                 {"siteA", MIRROR_IMAGE_STATUS_STATE_REPLAYING, ""}}));
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& os,
@@ -530,10 +537,12 @@ void ParentImageSpec::dump(Formatter *f) const {
   f->dump_unsigned("snap_id", snap_id);
 }
 
-void ParentImageSpec::generate_test_instances(std::list<ParentImageSpec*>& o) {
-  o.push_back(new ParentImageSpec{});
-  o.push_back(new ParentImageSpec{1, "", "foo", 3});
-  o.push_back(new ParentImageSpec{1, "ns", "foo", 3});
+std::list<ParentImageSpec> ParentImageSpec::generate_test_instances() {
+  std::list<ParentImageSpec> o;
+  o.push_back(ParentImageSpec{});
+  o.push_back(ParentImageSpec{1, "", "foo", 3});
+  o.push_back(ParentImageSpec{1, "ns", "foo", 3});
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& os, const ParentImageSpec& rhs) {
@@ -570,10 +579,12 @@ void ChildImageSpec::dump(Formatter *f) const {
   f->dump_string("image_id", image_id);
 }
 
-void ChildImageSpec::generate_test_instances(std::list<ChildImageSpec*> &o) {
-  o.push_back(new ChildImageSpec());
-  o.push_back(new ChildImageSpec(123, "", "abc"));
-  o.push_back(new ChildImageSpec(123, "ns", "abc"));
+std::list<ChildImageSpec> ChildImageSpec::generate_test_instances() {
+  std::list<ChildImageSpec> o;
+  o.push_back(ChildImageSpec());
+  o.push_back(ChildImageSpec(123, "", "abc"));
+  o.push_back(ChildImageSpec(123, "ns", "abc"));
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& os, const ChildImageSpec& rhs) {
@@ -637,9 +648,11 @@ std::string GroupImageSpec::image_key() {
   }
 }
 
-void GroupImageSpec::generate_test_instances(std::list<GroupImageSpec*> &o) {
-  o.push_back(new GroupImageSpec("10152ae8944a", 0));
-  o.push_back(new GroupImageSpec("1018643c9869", 3));
+std::list<GroupImageSpec> GroupImageSpec::generate_test_instances() {
+  std::list<GroupImageSpec> o;
+  o.push_back(GroupImageSpec("10152ae8944a", 0));
+  o.push_back(GroupImageSpec("1018643c9869", 3));
+  return o;
 }
 
 void GroupImageStatus::encode(bufferlist &bl) const {
@@ -672,11 +685,13 @@ void GroupImageStatus::dump(Formatter *f) const {
   f->dump_string("state", state_to_string());
 }
 
-void GroupImageStatus::generate_test_instances(std::list<GroupImageStatus*> &o) {
-  o.push_back(new GroupImageStatus(GroupImageSpec("10152ae8944a", 0), GROUP_IMAGE_LINK_STATE_ATTACHED));
-  o.push_back(new GroupImageStatus(GroupImageSpec("1018643c9869", 3), GROUP_IMAGE_LINK_STATE_ATTACHED));
-  o.push_back(new GroupImageStatus(GroupImageSpec("10152ae8944a", 0), GROUP_IMAGE_LINK_STATE_INCOMPLETE));
-  o.push_back(new GroupImageStatus(GroupImageSpec("1018643c9869", 3), GROUP_IMAGE_LINK_STATE_INCOMPLETE));
+std::list<GroupImageStatus> GroupImageStatus::generate_test_instances() {
+  std::list<GroupImageStatus> o;
+  o.push_back(GroupImageStatus(GroupImageSpec("10152ae8944a", 0), GROUP_IMAGE_LINK_STATE_ATTACHED));
+  o.push_back(GroupImageStatus(GroupImageSpec("1018643c9869", 3), GROUP_IMAGE_LINK_STATE_ATTACHED));
+  o.push_back(GroupImageStatus(GroupImageSpec("10152ae8944a", 0), GROUP_IMAGE_LINK_STATE_INCOMPLETE));
+  o.push_back(GroupImageStatus(GroupImageSpec("1018643c9869", 3), GROUP_IMAGE_LINK_STATE_INCOMPLETE));
+  return o;
 }
 
 
@@ -703,9 +718,11 @@ bool GroupSpec::is_valid() const {
   return (!group_id.empty()) && (pool_id != -1);
 }
 
-void GroupSpec::generate_test_instances(std::list<GroupSpec *> &o) {
-  o.push_back(new GroupSpec("10152ae8944a", 0));
-  o.push_back(new GroupSpec("1018643c9869", 3));
+std::list<GroupSpec> GroupSpec::generate_test_instances() {
+  std::list<GroupSpec> o;
+  o.push_back(GroupSpec("10152ae8944a", 0));
+  o.push_back(GroupSpec("1018643c9869", 3));
+  return o;
 }
 
 void GroupSnapshotNamespace::encode(bufferlist& bl) const {
@@ -881,24 +898,26 @@ void SnapshotInfo::dump(Formatter *f) const {
   f->dump_stream("timestamp") << timestamp;
 }
 
-void SnapshotInfo::generate_test_instances(std::list<SnapshotInfo*> &o) {
-  o.push_back(new SnapshotInfo(1ULL, UserSnapshotNamespace{}, "snap1", 123,
-                               {123456, 0}, 12));
-  o.push_back(new SnapshotInfo(2ULL,
-                               GroupSnapshotNamespace{567, "group1", "snap1"},
-                               "snap1", 123, {123456, 0}, 987));
-  o.push_back(new SnapshotInfo(3ULL,
-                               TrashSnapshotNamespace{
-                                 SNAPSHOT_NAMESPACE_TYPE_USER, "snap1"},
-                               "12345", 123, {123456, 0}, 429));
-  o.push_back(new SnapshotInfo(1ULL,
-                               MirrorSnapshotNamespace{MIRROR_SNAPSHOT_STATE_PRIMARY,
-                                                       {"1", "2"}, "", CEPH_NOSNAP},
-                               "snap1", 123, {123456, 0}, 12));
-  o.push_back(new SnapshotInfo(1ULL,
-                               MirrorSnapshotNamespace{MIRROR_SNAPSHOT_STATE_NON_PRIMARY,
-                                                       {"1", "2"}, "uuid", 123},
-                               "snap1", 123, {123456, 0}, 12));
+std::list<SnapshotInfo> SnapshotInfo::generate_test_instances() {
+  std::list<SnapshotInfo> o;
+  o.push_back(SnapshotInfo(1ULL, UserSnapshotNamespace{}, "snap1", 123,
+                           {123456, 0}, 12));
+  o.push_back(SnapshotInfo(2ULL,
+                           GroupSnapshotNamespace{567, "group1", "snap1"},
+                           "snap1", 123, {123456, 0}, 987));
+  o.push_back(SnapshotInfo(3ULL,
+                           TrashSnapshotNamespace{
+                             SNAPSHOT_NAMESPACE_TYPE_USER, "snap1"},
+                           "12345", 123, {123456, 0}, 429));
+  o.push_back(SnapshotInfo(1ULL,
+                           MirrorSnapshotNamespace{MIRROR_SNAPSHOT_STATE_PRIMARY,
+                                                   {"1", "2"}, "", CEPH_NOSNAP},
+                           "snap1", 123, {123456, 0}, 12));
+  o.push_back(SnapshotInfo(1ULL,
+                           MirrorSnapshotNamespace{MIRROR_SNAPSHOT_STATE_NON_PRIMARY,
+                                                   {"1", "2"}, "uuid", 123},
+                           "snap1", 123, {123456, 0}, 12));
+  return o;
 }
 
 void SnapshotNamespace::encode(bufferlist& bl) const {
@@ -937,25 +956,27 @@ void SnapshotNamespace::dump(Formatter *f) const {
   visit(DumpSnapshotNamespaceVisitor(f, "snapshot_namespace_type"));
 }
 
-void SnapshotNamespace::generate_test_instances(std::list<SnapshotNamespace*> &o) {
-  o.push_back(new SnapshotNamespace(UserSnapshotNamespace()));
-  o.push_back(new SnapshotNamespace(GroupSnapshotNamespace(0, "10152ae8944a",
-                                                           "2118643c9732")));
-  o.push_back(new SnapshotNamespace(GroupSnapshotNamespace(5, "1018643c9869",
-                                                           "33352be8933c")));
-  o.push_back(new SnapshotNamespace(TrashSnapshotNamespace()));
-  o.push_back(new SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_PRIMARY,
-                                                            {"peer uuid"},
-                                                            "", CEPH_NOSNAP)));
-  o.push_back(new SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED,
-                                                            {"peer uuid"},
-                                                            "", CEPH_NOSNAP)));
-  o.push_back(new SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_NON_PRIMARY,
-                                                            {"peer uuid"},
-                                                            "uuid", 123)));
-  o.push_back(new SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED,
-                                                            {"peer uuid"},
-                                                            "uuid", 123)));
+std::list<SnapshotNamespace> SnapshotNamespace::generate_test_instances() {
+  std::list<SnapshotNamespace> o;
+  o.push_back(SnapshotNamespace(UserSnapshotNamespace()));
+  o.push_back(SnapshotNamespace(GroupSnapshotNamespace(0, "10152ae8944a",
+                                                       "2118643c9732")));
+  o.push_back(SnapshotNamespace(GroupSnapshotNamespace(5, "1018643c9869",
+                                                       "33352be8933c")));
+  o.push_back(SnapshotNamespace(TrashSnapshotNamespace()));
+  o.push_back(SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_PRIMARY,
+                                                        {"peer uuid"},
+                                                        "", CEPH_NOSNAP)));
+  o.push_back(SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_PRIMARY_DEMOTED,
+                                                        {"peer uuid"},
+                                                        "", CEPH_NOSNAP)));
+  o.push_back(SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_NON_PRIMARY,
+                                                        {"peer uuid"},
+                                                        "uuid", 123)));
+  o.push_back(SnapshotNamespace(MirrorSnapshotNamespace(MIRROR_SNAPSHOT_STATE_NON_PRIMARY_DEMOTED,
+                                                        {"peer uuid"},
+                                                        "uuid", 123)));
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& os, const SnapshotNamespace& ns) {
@@ -1073,9 +1094,11 @@ void ImageSnapshotSpec::dump(Formatter *f) const {
   f->dump_int("snap_id", snap_id);
 }
 
-void ImageSnapshotSpec::generate_test_instances(std::list<ImageSnapshotSpec *> &o) {
-  o.push_back(new ImageSnapshotSpec(0, "myimage", 2));
-  o.push_back(new ImageSnapshotSpec(1, "testimage", 7));
+std::list<ImageSnapshotSpec> ImageSnapshotSpec::generate_test_instances() {
+  std::list<ImageSnapshotSpec> o;
+  o.push_back(ImageSnapshotSpec(0, "myimage", 2));
+  o.push_back(ImageSnapshotSpec(1, "testimage", 7));
+  return o;
 }
 
 void GroupSnapshot::encode(bufferlist& bl) const {
@@ -1104,9 +1127,11 @@ void GroupSnapshot::dump(Formatter *f) const {
   f->dump_int("state", state);
 }
 
-void GroupSnapshot::generate_test_instances(std::list<GroupSnapshot *> &o) {
-  o.push_back(new GroupSnapshot("10152ae8944a", "groupsnapshot1", GROUP_SNAPSHOT_STATE_INCOMPLETE));
-  o.push_back(new GroupSnapshot("1018643c9869", "groupsnapshot2", GROUP_SNAPSHOT_STATE_COMPLETE));
+std::list<GroupSnapshot> GroupSnapshot::generate_test_instances() {
+  std::list<GroupSnapshot> o;
+  o.push_back(GroupSnapshot("10152ae8944a", "groupsnapshot1", GROUP_SNAPSHOT_STATE_INCOMPLETE));
+  o.push_back(GroupSnapshot("1018643c9869", "groupsnapshot2", GROUP_SNAPSHOT_STATE_COMPLETE));
+  return o;
 }
 void TrashImageSpec::encode(bufferlist& bl) const {
   ENCODE_START(2, 1, bl);
@@ -1162,13 +1187,14 @@ void MirrorImageMap::dump(Formatter *f) const {
   f->dump_string("data", data_ss.str());
 }
 
-void MirrorImageMap::generate_test_instances(
-  std::list<MirrorImageMap*> &o) {
+std::list<MirrorImageMap> MirrorImageMap::generate_test_instances() {
+  std::list<MirrorImageMap> o;
   bufferlist data;
   data.append(std::string(128, '1'));
 
-  o.push_back(new MirrorImageMap("uuid-123", utime_t(), data));
-  o.push_back(new MirrorImageMap("uuid-abc", utime_t(), data));
+  o.push_back(MirrorImageMap("uuid-123", utime_t(), data));
+  o.push_back(MirrorImageMap("uuid-abc", utime_t(), data));
+  return o;
 }
 
 bool MirrorImageMap::operator==(const MirrorImageMap &rhs) const {
@@ -1307,16 +1333,18 @@ void MigrationSpec::dump(Formatter *f) const {
   f->dump_stream("mirror_image_mode") << mirror_image_mode;
 }
 
-void MigrationSpec::generate_test_instances(std::list<MigrationSpec*> &o) {
-  o.push_back(new MigrationSpec());
-  o.push_back(new MigrationSpec(MIGRATION_HEADER_TYPE_SRC, 1, "ns",
-                                "image_name", "image_id", "", {{1, 2}}, 123,
-                                true, MIRROR_IMAGE_MODE_SNAPSHOT, true,
-                                MIGRATION_STATE_PREPARED, "description"));
-  o.push_back(new MigrationSpec(MIGRATION_HEADER_TYPE_DST, -1, "", "", "",
-                                "{\"format\": \"raw\"}", {{1, 2}}, 123,
-                                true, MIRROR_IMAGE_MODE_SNAPSHOT, true,
-                                MIGRATION_STATE_PREPARED, "description"));
+std::list<MigrationSpec> MigrationSpec::generate_test_instances() {
+  std::list<MigrationSpec> o;
+  o.push_back(MigrationSpec());
+  o.push_back(MigrationSpec(MIGRATION_HEADER_TYPE_SRC, 1, "ns",
+                            "image_name", "image_id", "", {{1, 2}}, 123,
+                            true, MIRROR_IMAGE_MODE_SNAPSHOT, true,
+                            MIGRATION_STATE_PREPARED, "description"));
+  o.push_back(MigrationSpec(MIGRATION_HEADER_TYPE_DST, -1, "", "", "",
+                            "{\"format\": \"raw\"}", {{1, 2}}, 123,
+                            true, MIRROR_IMAGE_MODE_SNAPSHOT, true,
+                            MIGRATION_STATE_PREPARED, "description"));
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& os,

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -122,7 +122,7 @@ struct MirrorPeer {
   void decode(ceph::buffer::list::const_iterator &it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<MirrorPeer*> &o);
+  static std::list<MirrorPeer> generate_test_instances();
 
   bool operator==(const MirrorPeer &rhs) const;
   bool operator!=(const MirrorPeer &rhs) const {
@@ -163,7 +163,7 @@ struct MirrorImage {
   void decode(ceph::buffer::list::const_iterator &it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<MirrorImage*> &o);
+  static std::list<MirrorImage> generate_test_instances();
 
   bool operator==(const MirrorImage &rhs) const;
   bool operator<(const MirrorImage &rhs) const;
@@ -230,7 +230,7 @@ struct MirrorImageSiteStatus {
 
   bool operator==(const MirrorImageSiteStatus &rhs) const;
 
-  static void generate_test_instances(std::list<MirrorImageSiteStatus*> &o);
+  static std::list<MirrorImageSiteStatus> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(MirrorImageSiteStatus);
 
@@ -251,8 +251,7 @@ struct MirrorImageSiteStatusOnDisk : cls::rbd::MirrorImageSiteStatus {
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &it);
 
-  static void generate_test_instances(
-      std::list<MirrorImageSiteStatusOnDisk*> &o);
+  static std::list<MirrorImageSiteStatusOnDisk> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(MirrorImageSiteStatusOnDisk)
 
@@ -274,7 +273,7 @@ struct MirrorImageStatus {
 
   bool operator==(const MirrorImageStatus& rhs) const;
 
-  static void generate_test_instances(std::list<MirrorImageStatus*> &o);
+  static std::list<MirrorImageStatus> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(MirrorImageStatus);
 
@@ -313,7 +312,7 @@ struct ParentImageSpec {
   void decode(ceph::buffer::list::const_iterator &it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<ParentImageSpec*> &o);
+  static std::list<ParentImageSpec> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(ParentImageSpec);
@@ -335,7 +334,7 @@ struct ChildImageSpec {
   void decode(ceph::buffer::list::const_iterator &it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<ChildImageSpec*> &o);
+  static std::list<ChildImageSpec> generate_test_instances();
 
   inline bool operator==(const ChildImageSpec& rhs) const {
     return (pool_id == rhs.pool_id &&
@@ -373,7 +372,7 @@ struct GroupImageSpec {
   void decode(ceph::buffer::list::const_iterator &it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<GroupImageSpec*> &o);
+  static std::list<GroupImageSpec> generate_test_instances();
 
   std::string image_key();
 
@@ -399,7 +398,7 @@ struct GroupImageStatus {
   void decode(ceph::buffer::list::const_iterator &it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<GroupImageStatus*> &o);
+  static std::list<GroupImageStatus> generate_test_instances();
 
   std::string state_to_string() const;
 };
@@ -419,7 +418,7 @@ struct GroupSpec {
   void dump(ceph::Formatter *f) const;
   bool is_valid() const;
 
-  static void generate_test_instances(std::list<GroupSpec *> &o);
+  static std::list<GroupSpec> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(GroupSpec);
@@ -700,7 +699,7 @@ struct SnapshotNamespace : public SnapshotNamespaceVariant {
   decltype(auto) visit(F&& f) & {
     return std::visit(std::forward<F>(f), static_cast<SnapshotNamespaceVariant&>(*this));
   }
-  static void generate_test_instances(std::list<SnapshotNamespace*> &o);
+  static std::list<SnapshotNamespace> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(SnapshotNamespace);
 
@@ -732,7 +731,7 @@ struct SnapshotInfo {
   void decode(ceph::buffer::list::const_iterator& it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<SnapshotInfo*> &o);
+  static std::list<SnapshotInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(SnapshotInfo);
 
@@ -772,7 +771,7 @@ struct ImageSnapshotSpec {
 
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<ImageSnapshotSpec *> &o);
+  static std::list<ImageSnapshotSpec> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ImageSnapshotSpec);
 
@@ -794,7 +793,7 @@ struct GroupSnapshot {
   void decode(ceph::buffer::list::const_iterator& it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<GroupSnapshot *> &o);
+  static std::list<GroupSnapshot> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(GroupSnapshot);
 enum TrashImageSource {
@@ -911,7 +910,7 @@ struct MirrorImageMap {
   void decode(ceph::buffer::list::const_iterator &it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<MirrorImageMap*> &o);
+  static std::list<MirrorImageMap> generate_test_instances();
 
   bool operator==(const MirrorImageMap &rhs) const;
   bool operator<(const MirrorImageMap &rhs) const;
@@ -998,7 +997,7 @@ struct MigrationSpec {
   void decode(ceph::buffer::list::const_iterator& it);
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<MigrationSpec*> &o);
+  static std::list<MigrationSpec> generate_test_instances();
 
   inline bool operator==(const MigrationSpec& ms) const {
     return header_type == ms.header_type && pool_id == ms.pool_id &&

--- a/src/cls/refcount/cls_refcount_ops.cc
+++ b/src/cls/refcount/cls_refcount_ops.cc
@@ -13,12 +13,14 @@ void cls_refcount_get_op::dump(ceph::Formatter *f) const
   f->dump_int("implicit_ref", (int)implicit_ref);
 }
 
-void cls_refcount_get_op::generate_test_instances(list<cls_refcount_get_op*>& ls)
+list<cls_refcount_get_op> cls_refcount_get_op::generate_test_instances()
 {
-  ls.push_back(new cls_refcount_get_op);
-  ls.push_back(new cls_refcount_get_op);
-  ls.back()->tag = "foo";
-  ls.back()->implicit_ref = true;
+  list<cls_refcount_get_op> ls;
+  ls.push_back(cls_refcount_get_op{});
+  ls.push_back(cls_refcount_get_op{});
+  ls.back().tag = "foo";
+  ls.back().implicit_ref = true;
+  return ls;
 }
 
 
@@ -28,12 +30,14 @@ void cls_refcount_put_op::dump(ceph::Formatter *f) const
   f->dump_int("implicit_ref", (int)implicit_ref);
 }
 
-void cls_refcount_put_op::generate_test_instances(list<cls_refcount_put_op*>& ls)
+list<cls_refcount_put_op> cls_refcount_put_op::generate_test_instances()
 {
-  ls.push_back(new cls_refcount_put_op);
-  ls.push_back(new cls_refcount_put_op);
-  ls.back()->tag = "foo";
-  ls.back()->implicit_ref = true;
+  list<cls_refcount_put_op> ls;
+  ls.push_back(cls_refcount_put_op{});
+  ls.push_back(cls_refcount_put_op{});
+  ls.back().tag = "foo";
+  ls.back().implicit_ref = true;
+  return ls;
 }
 
 
@@ -43,12 +47,14 @@ void cls_refcount_set_op::dump(ceph::Formatter *f) const
   encode_json("refs", refs, f);
 }
 
-void cls_refcount_set_op::generate_test_instances(list<cls_refcount_set_op*>& ls)
+list<cls_refcount_set_op> cls_refcount_set_op::generate_test_instances()
 {
-  ls.push_back(new cls_refcount_set_op);
-  ls.push_back(new cls_refcount_set_op);
-  ls.back()->refs.push_back("foo");
-  ls.back()->refs.push_back("bar");
+  list<cls_refcount_set_op> ls;
+  ls.push_back(cls_refcount_set_op{});
+  ls.push_back(cls_refcount_set_op{});
+  ls.back().refs.push_back("foo");
+  ls.back().refs.push_back("bar");
+  return ls;
 }
 
 
@@ -57,11 +63,12 @@ void cls_refcount_read_op::dump(ceph::Formatter *f) const
   f->dump_int("implicit_ref", (int)implicit_ref);
 }
 
-void cls_refcount_read_op::generate_test_instances(list<cls_refcount_read_op*>& ls)
+list<cls_refcount_read_op> cls_refcount_read_op::generate_test_instances()
 {
-  ls.push_back(new cls_refcount_read_op);
-  ls.push_back(new cls_refcount_read_op);
-  ls.back()->implicit_ref = true;
+  list<cls_refcount_read_op> ls;
+  ls.push_back(cls_refcount_read_op{});
+  ls.push_back(cls_refcount_read_op{});
+  return ls;
 }
 
 
@@ -73,12 +80,14 @@ void cls_refcount_read_ret::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void cls_refcount_read_ret::generate_test_instances(list<cls_refcount_read_ret*>& ls)
+list<cls_refcount_read_ret> cls_refcount_read_ret::generate_test_instances()
 {
-  ls.push_back(new cls_refcount_read_ret);
-  ls.push_back(new cls_refcount_read_ret);
-  ls.back()->refs.push_back("foo");
-  ls.back()->refs.push_back("bar");
+  list<cls_refcount_read_ret> ls;
+  ls.push_back(cls_refcount_read_ret{});
+  ls.push_back(cls_refcount_read_ret{});
+  ls.back().refs.push_back("foo");
+  ls.back().refs.push_back("bar");
+  return ls;
 }
 
 void obj_refcount::dump(ceph::Formatter *f) const
@@ -98,9 +107,11 @@ void obj_refcount::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void obj_refcount::generate_test_instances(list<obj_refcount*>& ls)
+list<obj_refcount> obj_refcount::generate_test_instances()
 {
-  ls.push_back(new obj_refcount);
-  ls.back()->refs.emplace("foo",true);
-  ls.back()->retired_refs.emplace("bar");
+  list<obj_refcount> ls;
+  ls.push_back(obj_refcount{});
+  ls.back().refs.emplace("foo",true);
+  ls.back().retired_refs.emplace("bar");
+  return ls;
 }

--- a/src/cls/refcount/cls_refcount_ops.h
+++ b/src/cls/refcount/cls_refcount_ops.h
@@ -27,7 +27,7 @@ struct cls_refcount_get_op {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_refcount_get_op*>& ls);
+  static std::list<cls_refcount_get_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_refcount_get_op)
 
@@ -53,7 +53,7 @@ struct cls_refcount_put_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_refcount_put_op*>& ls);
+  static std::list<cls_refcount_put_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_refcount_put_op)
 
@@ -75,7 +75,7 @@ struct cls_refcount_set_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_refcount_set_op*>& ls);
+  static std::list<cls_refcount_set_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_refcount_set_op)
 
@@ -98,7 +98,7 @@ struct cls_refcount_read_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_refcount_read_op*>& ls);
+  static std::list<cls_refcount_read_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_refcount_read_op)
 
@@ -120,7 +120,7 @@ struct cls_refcount_read_ret {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_refcount_read_ret*>& ls);
+  static std::list<cls_refcount_read_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_refcount_read_ret)
 
@@ -147,7 +147,7 @@ struct obj_refcount {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<obj_refcount*>& ls);
+  static std::list<obj_refcount> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(obj_refcount)
 

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -17,11 +17,13 @@ void rgw_cls_tag_timeout_op::dump(Formatter *f) const
   f->dump_int("tag_timeout", tag_timeout);
 }
 
-void rgw_cls_tag_timeout_op::generate_test_instances(list<rgw_cls_tag_timeout_op*>& ls)
+list<rgw_cls_tag_timeout_op> rgw_cls_tag_timeout_op::generate_test_instances()
 {
-  ls.push_back(new rgw_cls_tag_timeout_op);
-  ls.push_back(new rgw_cls_tag_timeout_op);
-  ls.back()->tag_timeout = 23323;
+  list<rgw_cls_tag_timeout_op> ls;
+  ls.push_back(rgw_cls_tag_timeout_op{});
+  ls.push_back(rgw_cls_tag_timeout_op{});
+  ls.back().tag_timeout = 23323;
+  return ls;
 }
 
 void cls_rgw_gc_set_entry_op::dump(Formatter *f) const
@@ -32,11 +34,13 @@ void cls_rgw_gc_set_entry_op::dump(Formatter *f) const
   f->close_section();
 }
 
-void cls_rgw_gc_set_entry_op::generate_test_instances(list<cls_rgw_gc_set_entry_op*>& ls)
+list<cls_rgw_gc_set_entry_op> cls_rgw_gc_set_entry_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_gc_set_entry_op);
-  ls.push_back(new cls_rgw_gc_set_entry_op);
-  ls.back()->expiration_secs = 123;
+  list<cls_rgw_gc_set_entry_op> ls;
+  ls.push_back(cls_rgw_gc_set_entry_op{});
+  ls.push_back(cls_rgw_gc_set_entry_op{});
+  ls.back().expiration_secs = 123;
+  return ls;
 }
 
 void cls_rgw_gc_defer_entry_op::dump(Formatter *f) const
@@ -45,12 +49,14 @@ void cls_rgw_gc_defer_entry_op::dump(Formatter *f) const
   f->dump_string("tag", tag);
 }
 
-void cls_rgw_gc_defer_entry_op::generate_test_instances(list<cls_rgw_gc_defer_entry_op*>& ls)
+list<cls_rgw_gc_defer_entry_op> cls_rgw_gc_defer_entry_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_gc_defer_entry_op);
-  ls.push_back(new cls_rgw_gc_defer_entry_op);
-  ls.back()->expiration_secs = 123;
-  ls.back()->tag = "footag";
+  list<cls_rgw_gc_defer_entry_op> ls;
+  ls.push_back(cls_rgw_gc_defer_entry_op{});
+  ls.push_back(cls_rgw_gc_defer_entry_op{});
+  ls.back().expiration_secs = 123;
+  ls.back().tag = "footag";
+  return ls;
 }
 
 void cls_rgw_gc_list_op::dump(Formatter *f) const
@@ -60,12 +66,14 @@ void cls_rgw_gc_list_op::dump(Formatter *f) const
   f->dump_bool("expired_only", expired_only);
 }
 
-void cls_rgw_gc_list_op::generate_test_instances(list<cls_rgw_gc_list_op*>& ls)
+list<cls_rgw_gc_list_op> cls_rgw_gc_list_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_gc_list_op);
-  ls.push_back(new cls_rgw_gc_list_op);
-  ls.back()->marker = "mymarker";
-  ls.back()->max = 2312;
+  list<cls_rgw_gc_list_op> ls;
+  ls.push_back(cls_rgw_gc_list_op{});
+  ls.push_back(cls_rgw_gc_list_op{});
+  ls.back().marker = "mymarker";
+  ls.back().max = 2312;
+  return ls;
 }
 
 void cls_rgw_gc_list_ret::dump(Formatter *f) const
@@ -75,12 +83,14 @@ void cls_rgw_gc_list_ret::dump(Formatter *f) const
   f->dump_int("truncated", (int)truncated);
 }
 
-void cls_rgw_gc_list_ret::generate_test_instances(list<cls_rgw_gc_list_ret*>& ls)
+list<cls_rgw_gc_list_ret> cls_rgw_gc_list_ret::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_gc_list_ret);
-  ls.push_back(new cls_rgw_gc_list_ret);
-  ls.back()->entries.push_back(cls_rgw_gc_obj_info());
-  ls.back()->truncated = true;
+  list<cls_rgw_gc_list_ret> ls;
+  ls.push_back(cls_rgw_gc_list_ret{});
+  ls.push_back(cls_rgw_gc_list_ret{});
+  ls.back().entries.push_back(cls_rgw_gc_obj_info());
+  ls.back().truncated = true;
+  return ls;
 }
 
 void cls_rgw_gc_remove_op::dump(Formatter *f) const
@@ -88,12 +98,14 @@ void cls_rgw_gc_remove_op::dump(Formatter *f) const
   encode_json("tags", tags, f);
 }
 
-void cls_rgw_gc_remove_op::generate_test_instances(list<cls_rgw_gc_remove_op*>& ls)
+list<cls_rgw_gc_remove_op> cls_rgw_gc_remove_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_gc_remove_op);
-  ls.push_back(new cls_rgw_gc_remove_op);
-  ls.back()->tags.push_back("tag1");
-  ls.back()->tags.push_back("tag2");
+  list<cls_rgw_gc_remove_op> ls;
+  ls.push_back(cls_rgw_gc_remove_op{});
+  ls.push_back(cls_rgw_gc_remove_op{});
+  ls.back().tags.push_back("tag1");
+  ls.back().tags.push_back("tag2");
+  return ls;
 }
 
 void cls_rgw_lc_get_entry_ret::dump(Formatter *f) const
@@ -101,22 +113,26 @@ void cls_rgw_lc_get_entry_ret::dump(Formatter *f) const
   encode_json("entry", entry, f);
 }
 
-void cls_rgw_lc_get_entry_ret::generate_test_instances(list<cls_rgw_lc_get_entry_ret*>& ls)
+list<cls_rgw_lc_get_entry_ret> cls_rgw_lc_get_entry_ret::generate_test_instances()
 {
+  list<cls_rgw_lc_get_entry_ret> ls;
   cls_rgw_lc_entry entry("bucket1", 6000, 0);
-  ls.push_back(new cls_rgw_lc_get_entry_ret);
-  ls.back()->entry = entry;
+  ls.push_back(cls_rgw_lc_get_entry_ret{});
+  ls.back().entry = entry;
+  return ls;
 }
 
-void rgw_cls_obj_prepare_op::generate_test_instances(list<rgw_cls_obj_prepare_op*>& o)
+list<rgw_cls_obj_prepare_op> rgw_cls_obj_prepare_op::generate_test_instances()
 {
-  rgw_cls_obj_prepare_op *op = new rgw_cls_obj_prepare_op;
-  op->op = CLS_RGW_OP_ADD;
-  op->key.name = "name";
-  op->tag = "tag";
-  op->locator = "locator";
-  o.push_back(op);
-  o.push_back(new rgw_cls_obj_prepare_op);
+  list<rgw_cls_obj_prepare_op> o;
+  rgw_cls_obj_prepare_op op;
+  op.op = CLS_RGW_OP_ADD;
+  op.key.name = "name";
+  op.tag = "tag";
+  op.locator = "locator";
+  o.push_back(std::move(op));
+  o.push_back(rgw_cls_obj_prepare_op{});
+  return o;
 }
 
 void rgw_cls_obj_prepare_op::dump(Formatter *f) const
@@ -127,24 +143,24 @@ void rgw_cls_obj_prepare_op::dump(Formatter *f) const
   f->dump_string("locator", locator);
 }
 
-void rgw_cls_obj_complete_op::generate_test_instances(list<rgw_cls_obj_complete_op*>& o)
+list<rgw_cls_obj_complete_op> rgw_cls_obj_complete_op::generate_test_instances()
 {
-  rgw_cls_obj_complete_op *op = new rgw_cls_obj_complete_op;
-  op->op = CLS_RGW_OP_DEL;
-  op->key.name = "name";
-  op->locator = "locator";
-  op->ver.pool = 2;
-  op->ver.epoch = 100;
-  op->tag = "tag";
+  list<rgw_cls_obj_complete_op> o;
+  rgw_cls_obj_complete_op op;
+  op.op = CLS_RGW_OP_DEL;
+  op.key.name = "name";
+  op.locator = "locator";
+  op.ver.pool = 2;
+  op.ver.epoch = 100;
+  op.tag = "tag";
 
-  list<rgw_bucket_dir_entry_meta *> l;
-  rgw_bucket_dir_entry_meta::generate_test_instances(l);
+  list<rgw_bucket_dir_entry_meta> l = rgw_bucket_dir_entry_meta::generate_test_instances();
   auto iter = l.begin();
-  op->meta = *(*iter);
+  op.meta = *iter;
 
-  o.push_back(op);
-
-  o.push_back(new rgw_cls_obj_complete_op);
+  o.push_back(std::move(op));
+  o.push_back(rgw_cls_obj_complete_op{});
+  return o;
 }
 
 void rgw_cls_obj_complete_op::dump(Formatter *f) const
@@ -165,23 +181,24 @@ void rgw_cls_obj_complete_op::dump(Formatter *f) const
   encode_json("zones_trace", zones_trace, f);
 }
 
-void rgw_cls_link_olh_op::generate_test_instances(list<rgw_cls_link_olh_op*>& o)
+list<rgw_cls_link_olh_op> rgw_cls_link_olh_op::generate_test_instances()
 {
-  rgw_cls_link_olh_op *op = new rgw_cls_link_olh_op;
-  op->key.name = "name";
-  op->olh_tag = "olh_tag";
-  op->delete_marker = true;
-  op->op_tag = "op_tag";
-  op->olh_epoch = 123;
-  list<rgw_bucket_dir_entry_meta *> l;
-  rgw_bucket_dir_entry_meta::generate_test_instances(l);
+  list<rgw_cls_link_olh_op> o;
+  rgw_cls_link_olh_op op;
+  op.key.name = "name";
+  op.olh_tag = "olh_tag";
+  op.delete_marker = true;
+  op.op_tag = "op_tag";
+  op.olh_epoch = 123;
+  list<rgw_bucket_dir_entry_meta> l = rgw_bucket_dir_entry_meta::generate_test_instances();
   auto iter = l.begin();
-  op->meta = *(*iter);
-  op->log_op = true;
+  op.meta = *iter;
+  op.log_op = true;
 
-  o.push_back(op);
+  o.push_back(std::move(op));
 
-  o.push_back(new rgw_cls_link_olh_op);
+  o.push_back(rgw_cls_link_olh_op{});
+  return o;
 }
 
 void rgw_cls_link_olh_op::dump(Formatter *f) const
@@ -200,17 +217,19 @@ void rgw_cls_link_olh_op::dump(Formatter *f) const
   encode_json("zones_trace", zones_trace, f);
 }
 
-void rgw_cls_unlink_instance_op::generate_test_instances(list<rgw_cls_unlink_instance_op*>& o)
+list<rgw_cls_unlink_instance_op> rgw_cls_unlink_instance_op::generate_test_instances()
 {
-  rgw_cls_unlink_instance_op *op = new rgw_cls_unlink_instance_op;
-  op->key.name = "name";
-  op->op_tag = "op_tag";
-  op->olh_epoch = 124;
-  op->log_op = true;
+  list<rgw_cls_unlink_instance_op> o;
+  rgw_cls_unlink_instance_op op;
+  op.key.name = "name";
+  op.op_tag = "op_tag";
+  op.olh_epoch = 124;
+  op.log_op = true;
 
-  o.push_back(op);
+  o.push_back(std::move(op));
 
-  o.push_back(new rgw_cls_unlink_instance_op);
+  o.push_back(rgw_cls_unlink_instance_op{});
+  return o;
 }
 
 void rgw_cls_unlink_instance_op::dump(Formatter *f) const
@@ -223,16 +242,17 @@ void rgw_cls_unlink_instance_op::dump(Formatter *f) const
   encode_json("zones_trace", zones_trace, f);
 }
 
-void rgw_cls_read_olh_log_op::generate_test_instances(list<rgw_cls_read_olh_log_op*>& o)
+list<rgw_cls_read_olh_log_op> rgw_cls_read_olh_log_op::generate_test_instances()
 {
-  rgw_cls_read_olh_log_op *op = new rgw_cls_read_olh_log_op;
-  op->olh.name = "name";
-  op->ver_marker = 123;
-  op->olh_tag = "olh_tag";
+  list<rgw_cls_read_olh_log_op> o;
+  rgw_cls_read_olh_log_op op;
+  op.olh.name = "name";
+  op.ver_marker = 123;
+  op.olh_tag = "olh_tag";
 
-  o.push_back(op);
-
-  o.push_back(new rgw_cls_read_olh_log_op);
+  o.push_back(std::move(op));
+  o.push_back(rgw_cls_read_olh_log_op{});
+  return o;
 }
 
 void rgw_cls_read_olh_log_op::dump(Formatter *f) const
@@ -242,18 +262,18 @@ void rgw_cls_read_olh_log_op::dump(Formatter *f) const
   encode_json("olh_tag", olh_tag, f);
 }
 
-void rgw_cls_read_olh_log_ret::generate_test_instances(list<rgw_cls_read_olh_log_ret*>& o)
+list<rgw_cls_read_olh_log_ret> rgw_cls_read_olh_log_ret::generate_test_instances()
 {
-  rgw_cls_read_olh_log_ret *r = new rgw_cls_read_olh_log_ret;
-  r->is_truncated = true;
-  list<rgw_bucket_olh_log_entry *> l;
-  rgw_bucket_olh_log_entry::generate_test_instances(l);
+  list<rgw_cls_read_olh_log_ret> o;
+  rgw_cls_read_olh_log_ret r;
+  r.is_truncated = true;
+  list<rgw_bucket_olh_log_entry> l = rgw_bucket_olh_log_entry::generate_test_instances();
   auto iter = l.begin();
-  r->log[1].push_back(*(*iter));
+  r.log[1].push_back(*iter);
 
-  o.push_back(r);
-
-  o.push_back(new rgw_cls_read_olh_log_ret);
+  o.push_back(std::move(r));
+  o.push_back(rgw_cls_read_olh_log_ret{});
+  return o;
 }
 
 void rgw_cls_read_olh_log_ret::dump(Formatter *f) const
@@ -262,16 +282,17 @@ void rgw_cls_read_olh_log_ret::dump(Formatter *f) const
   encode_json("is_truncated", is_truncated, f);
 }
 
-void rgw_cls_trim_olh_log_op::generate_test_instances(list<rgw_cls_trim_olh_log_op*>& o)
+list<rgw_cls_trim_olh_log_op> rgw_cls_trim_olh_log_op::generate_test_instances()
 {
-  rgw_cls_trim_olh_log_op *op = new rgw_cls_trim_olh_log_op;
-  op->olh.name = "olh.name";
-  op->ver = 100;
-  op->olh_tag = "olh_tag";
+  list<rgw_cls_trim_olh_log_op> o;
+  rgw_cls_trim_olh_log_op op;
+  op.olh.name = "olh.name";
+  op.ver = 100;
+  op.olh_tag = "olh_tag";
 
-  o.push_back(op);
-
-  o.push_back(new rgw_cls_trim_olh_log_op);
+  o.push_back(std::move(op));
+  o.push_back(rgw_cls_trim_olh_log_op{});
+  return o;
 }
 
 void rgw_cls_trim_olh_log_op::dump(Formatter *f) const
@@ -281,15 +302,16 @@ void rgw_cls_trim_olh_log_op::dump(Formatter *f) const
   encode_json("olh_tag", olh_tag, f);
 }
 
-void rgw_cls_bucket_clear_olh_op::generate_test_instances(list<rgw_cls_bucket_clear_olh_op *>& o)
+list<rgw_cls_bucket_clear_olh_op> rgw_cls_bucket_clear_olh_op::generate_test_instances()
 {
+  list<rgw_cls_bucket_clear_olh_op> o;
+  rgw_cls_bucket_clear_olh_op op;
+  op.key.name = "key.name";
+  op.olh_tag = "olh_tag";
 
-  rgw_cls_bucket_clear_olh_op *op = new rgw_cls_bucket_clear_olh_op;
-  op->key.name = "key.name";
-  op->olh_tag = "olh_tag";
-
-  o.push_back(op);
-  o.push_back(new rgw_cls_bucket_clear_olh_op);
+  o.push_back(std::move(op));
+  o.push_back(rgw_cls_bucket_clear_olh_op{});
+  return o;
 }
 
 void rgw_cls_bucket_clear_olh_op::dump(Formatter *f) const
@@ -298,14 +320,16 @@ void rgw_cls_bucket_clear_olh_op::dump(Formatter *f) const
   encode_json("olh_tag", olh_tag, f);
 }
 
-void rgw_cls_list_op::generate_test_instances(list<rgw_cls_list_op*>& o)
+list<rgw_cls_list_op> rgw_cls_list_op::generate_test_instances()
 {
-  rgw_cls_list_op *op = new rgw_cls_list_op;
-  op->start_obj.name = "start_obj";
-  op->num_entries = 100;
-  op->filter_prefix = "filter_prefix";
-  o.push_back(op);
-  o.push_back(new rgw_cls_list_op);
+  list<rgw_cls_list_op> o;
+  rgw_cls_list_op op;
+  op.start_obj.name = "start_obj";
+  op.num_entries = 100;
+  op.filter_prefix = "filter_prefix";
+  o.push_back(std::move(op));
+  o.push_back(rgw_cls_list_op{});
+  return o;
 }
 
 void rgw_cls_list_op::dump(Formatter *f) const
@@ -314,23 +338,19 @@ void rgw_cls_list_op::dump(Formatter *f) const
   f->dump_unsigned("num_entries", num_entries);
 }
 
-void rgw_cls_list_ret::generate_test_instances(list<rgw_cls_list_ret*>& o)
+list<rgw_cls_list_ret> rgw_cls_list_ret::generate_test_instances()
 {
- list<rgw_bucket_dir *> l;
-  rgw_bucket_dir::generate_test_instances(l);
-  for (auto iter = l.begin(); iter != l.end(); ++iter) {
-    rgw_bucket_dir *d = *iter;
+  list<rgw_cls_list_ret> o;
+  for (auto& d : rgw_bucket_dir::generate_test_instances()) {
+    rgw_cls_list_ret ret;
+    ret.dir = d;
+    ret.is_truncated = true;
 
-    rgw_cls_list_ret *ret = new rgw_cls_list_ret;
-    ret->dir = *d;
-    ret->is_truncated = true;
-
-    o.push_back(ret);
-
-    delete d;
+    o.push_back(std::move(ret));
   }
 
-  o.push_back(new rgw_cls_list_ret);
+  o.push_back(rgw_cls_list_ret{});
+  return o;
 }
 
 void rgw_cls_list_ret::dump(Formatter *f) const
@@ -341,19 +361,18 @@ void rgw_cls_list_ret::dump(Formatter *f) const
   f->dump_int("is_truncated", (int)is_truncated);
 }
 
-void rgw_cls_check_index_ret::generate_test_instances(list<rgw_cls_check_index_ret*>& o)
+list<rgw_cls_check_index_ret> rgw_cls_check_index_ret::generate_test_instances()
 {
-  list<rgw_bucket_dir_header *> h;
-  rgw_bucket_dir_header::generate_test_instances(h);
-  rgw_cls_check_index_ret *r = new rgw_cls_check_index_ret;
-  r->existing_header = *(h.front());
-  r->calculated_header = *(h.front());
-  o.push_back(r);
+  list<rgw_cls_check_index_ret> o;
 
-  for (auto iter = h.begin(); iter != h.end(); ++iter) {
-    delete *iter;
-  }
-  o.push_back(new rgw_cls_check_index_ret);
+  list<rgw_bucket_dir_header> h = rgw_bucket_dir_header::generate_test_instances();
+  rgw_cls_check_index_ret r;
+  r.existing_header = h.front();
+  r.calculated_header = h.front();
+  o.push_back(std::move(r));
+
+  o.push_back(rgw_cls_check_index_ret{});
+  return o;
 }
 
 void rgw_cls_check_index_ret::dump(Formatter *f) const
@@ -362,21 +381,23 @@ void rgw_cls_check_index_ret::dump(Formatter *f) const
   encode_json("calculated_header", calculated_header, f);
 }
 
-void rgw_cls_bucket_update_stats_op::generate_test_instances(list<rgw_cls_bucket_update_stats_op*>& o)
+list<rgw_cls_bucket_update_stats_op> rgw_cls_bucket_update_stats_op::generate_test_instances()
 {
-  rgw_cls_bucket_update_stats_op *r = new rgw_cls_bucket_update_stats_op;
-  r->absolute = true;
-  rgw_bucket_category_stats& s = r->stats[RGWObjCategory::None];
+  list<rgw_cls_bucket_update_stats_op> o;
+
+  rgw_cls_bucket_update_stats_op r;
+  r.absolute = true;
+  rgw_bucket_category_stats& s = r.stats[RGWObjCategory::None];
   s.total_size = 1;
   s.total_size_rounded = 4096;
   s.num_entries = 1;
-  rgw_bucket_category_stats& dec_s = r->dec_stats[RGWObjCategory::None];
+  rgw_bucket_category_stats& dec_s = r.dec_stats[RGWObjCategory::None];
   dec_s.total_size = 1;
   dec_s.total_size_rounded = 4096;
   dec_s.num_entries = 1;
-  o.push_back(r);
-
-  o.push_back(new rgw_cls_bucket_update_stats_op);
+  o.push_back(std::move(r));
+  o.push_back(rgw_cls_bucket_update_stats_op{});
+  return o;
 }
 
 void rgw_cls_bucket_update_stats_op::dump(Formatter *f) const
@@ -400,12 +421,14 @@ void cls_rgw_bi_log_list_op::dump(Formatter *f) const
   f->dump_unsigned("max", max);
 }
 
-void cls_rgw_bi_log_list_op::generate_test_instances(list<cls_rgw_bi_log_list_op*>& ls)
+list<cls_rgw_bi_log_list_op> cls_rgw_bi_log_list_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_bi_log_list_op);
-  ls.push_back(new cls_rgw_bi_log_list_op);
-  ls.back()->marker = "mark";
-  ls.back()->max = 123;
+  list<cls_rgw_bi_log_list_op> ls;
+  ls.push_back(cls_rgw_bi_log_list_op{});
+  ls.push_back(cls_rgw_bi_log_list_op{});
+  ls.back().marker = "mark";
+  ls.back().max = 123;
+  return ls;
 }
 
 void cls_rgw_bi_log_trim_op::dump(Formatter *f) const
@@ -414,12 +437,14 @@ void cls_rgw_bi_log_trim_op::dump(Formatter *f) const
   f->dump_string("end_marker", end_marker);
 }
 
-void cls_rgw_bi_log_trim_op::generate_test_instances(list<cls_rgw_bi_log_trim_op*>& ls)
+list<cls_rgw_bi_log_trim_op> cls_rgw_bi_log_trim_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_bi_log_trim_op);
-  ls.push_back(new cls_rgw_bi_log_trim_op);
-  ls.back()->start_marker = "foo";
-  ls.back()->end_marker = "bar";
+  list<cls_rgw_bi_log_trim_op> ls;
+  ls.push_back(cls_rgw_bi_log_trim_op{});
+  ls.push_back(cls_rgw_bi_log_trim_op{});
+  ls.back().start_marker = "foo";
+  ls.back().end_marker = "bar";
+  return ls;
 }
 
 void cls_rgw_bi_log_list_ret::dump(Formatter *f) const
@@ -428,20 +453,24 @@ void cls_rgw_bi_log_list_ret::dump(Formatter *f) const
   f->dump_unsigned("truncated", (int)truncated);
 }
 
-void cls_rgw_bi_log_list_ret::generate_test_instances(list<cls_rgw_bi_log_list_ret*>& ls)
+list<cls_rgw_bi_log_list_ret> cls_rgw_bi_log_list_ret::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_bi_log_list_ret);
-  ls.push_back(new cls_rgw_bi_log_list_ret);
-  ls.back()->entries.push_back(rgw_bi_log_entry());
-  ls.back()->truncated = true;
+  list<cls_rgw_bi_log_list_ret> ls;
+  ls.push_back(cls_rgw_bi_log_list_ret{});
+  ls.push_back(cls_rgw_bi_log_list_ret{});
+  ls.back().entries.push_back(rgw_bi_log_entry());
+  ls.back().truncated = true;
+  return ls;
 }
 
-void cls_rgw_mp_upload_part_info_update_op::generate_test_instances(std::list<cls_rgw_mp_upload_part_info_update_op*>& ls)
+std::list<cls_rgw_mp_upload_part_info_update_op> cls_rgw_mp_upload_part_info_update_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_mp_upload_part_info_update_op);
-  ls.back()->part_key = "part1";
-  ls.push_back(new cls_rgw_mp_upload_part_info_update_op);
-  ls.back()->part_key = "part2";
+  std::list<cls_rgw_mp_upload_part_info_update_op> ls;
+  ls.push_back(cls_rgw_mp_upload_part_info_update_op{});
+  ls.back().part_key = "part1";
+  ls.push_back(cls_rgw_mp_upload_part_info_update_op{});
+  ls.back().part_key = "part2";
+  return ls;
 }
 
 void cls_rgw_mp_upload_part_info_update_op::dump(Formatter* f) const
@@ -451,14 +480,15 @@ void cls_rgw_mp_upload_part_info_update_op::dump(Formatter* f) const
   encode_json("part_prefix", info.manifest.get_prefix(), f);
 }
 
-void cls_rgw_reshard_add_op::generate_test_instances(list<cls_rgw_reshard_add_op*>& ls)
+list<cls_rgw_reshard_add_op> cls_rgw_reshard_add_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_reshard_add_op);
-  ls.push_back(new cls_rgw_reshard_add_op);
-  list<cls_rgw_reshard_entry *> l;
-  cls_rgw_reshard_entry::generate_test_instances(l);
+  list<cls_rgw_reshard_add_op> ls;
+  ls.push_back(cls_rgw_reshard_add_op{});
+  ls.push_back(cls_rgw_reshard_add_op{});
+  list<cls_rgw_reshard_entry> l = cls_rgw_reshard_entry::generate_test_instances();
   auto iter = l.begin();
-  ls.back()->entry = *(*iter);
+  ls.back().entry = *iter;
+  return ls;
 }
 
 void cls_rgw_reshard_add_op::dump(Formatter *f) const
@@ -466,12 +496,14 @@ void cls_rgw_reshard_add_op::dump(Formatter *f) const
   encode_json("entry", entry, f);
 }
 
-void cls_rgw_reshard_list_op::generate_test_instances(list<cls_rgw_reshard_list_op*>& ls)
+list<cls_rgw_reshard_list_op> cls_rgw_reshard_list_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_reshard_list_op);
-  ls.push_back(new cls_rgw_reshard_list_op);
-  ls.back()->max = 1000;
-  ls.back()->marker = "foo";
+  list<cls_rgw_reshard_list_op> ls;
+  ls.push_back(cls_rgw_reshard_list_op{});
+  ls.push_back(cls_rgw_reshard_list_op{});
+  ls.back().max = 1000;
+  ls.back().marker = "foo";
+  return ls;
 }
 
 void cls_rgw_reshard_list_op::dump(Formatter *f) const
@@ -480,12 +512,14 @@ void cls_rgw_reshard_list_op::dump(Formatter *f) const
   encode_json("marker", marker, f);
 }
 
-void cls_rgw_reshard_list_ret::generate_test_instances(list<cls_rgw_reshard_list_ret*>& ls)
+list<cls_rgw_reshard_list_ret> cls_rgw_reshard_list_ret::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_reshard_list_ret);
-  ls.push_back(new cls_rgw_reshard_list_ret);
-  ls.back()->entries.push_back(cls_rgw_reshard_entry());
-  ls.back()->is_truncated = true;
+  list<cls_rgw_reshard_list_ret> ls;
+  ls.push_back(cls_rgw_reshard_list_ret{});
+  ls.push_back(cls_rgw_reshard_list_ret{});
+  ls.back().entries.push_back(cls_rgw_reshard_entry());
+  ls.back().is_truncated = true;
+  return ls;
 }
 
 void cls_rgw_reshard_list_ret::dump(Formatter *f) const
@@ -494,10 +528,12 @@ void cls_rgw_reshard_list_ret::dump(Formatter *f) const
   encode_json("is_truncated", is_truncated, f);
 }
 
-void cls_rgw_reshard_get_op::generate_test_instances(list<cls_rgw_reshard_get_op*>& ls)
+list<cls_rgw_reshard_get_op> cls_rgw_reshard_get_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_reshard_get_op);
-  ls.push_back(new cls_rgw_reshard_get_op);
+  list<cls_rgw_reshard_get_op> ls;
+  ls.push_back(cls_rgw_reshard_get_op{});
+  ls.push_back(cls_rgw_reshard_get_op{});
+  return ls;
 }
 
 void cls_rgw_reshard_get_op::dump(Formatter *f) const
@@ -505,10 +541,12 @@ void cls_rgw_reshard_get_op::dump(Formatter *f) const
   encode_json("entry", entry, f);
 }
 
-void cls_rgw_reshard_get_ret::generate_test_instances(list<cls_rgw_reshard_get_ret*>& ls)
+list<cls_rgw_reshard_get_ret> cls_rgw_reshard_get_ret::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_reshard_get_ret);
-  ls.push_back(new cls_rgw_reshard_get_ret);
+  list<cls_rgw_reshard_get_ret> ls;
+  ls.push_back(cls_rgw_reshard_get_ret{});
+  ls.push_back(cls_rgw_reshard_get_ret{});
+  return ls;
 }
 
 void cls_rgw_reshard_get_ret::dump(Formatter *f) const
@@ -516,12 +554,14 @@ void cls_rgw_reshard_get_ret::dump(Formatter *f) const
   encode_json("entry", entry, f);
 }
 
-void cls_rgw_reshard_remove_op::generate_test_instances(list<cls_rgw_reshard_remove_op*>& ls)
+list<cls_rgw_reshard_remove_op> cls_rgw_reshard_remove_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_reshard_remove_op);
-  ls.push_back(new cls_rgw_reshard_remove_op);
-  ls.back()->bucket_name = "foo";
-  ls.back()->bucket_id = "bucket_id";
+  list<cls_rgw_reshard_remove_op> ls;
+  ls.push_back(cls_rgw_reshard_remove_op{});
+  ls.push_back(cls_rgw_reshard_remove_op{});
+  ls.back().bucket_name = "foo";
+  ls.back().bucket_id = "bucket_id";
+  return ls;
 }
 
 void cls_rgw_reshard_remove_op::dump(Formatter *f) const
@@ -531,11 +571,12 @@ void cls_rgw_reshard_remove_op::dump(Formatter *f) const
 }
 
 
-void cls_rgw_set_bucket_resharding_op::generate_test_instances(
-  list<cls_rgw_set_bucket_resharding_op*>& ls)
+list<cls_rgw_set_bucket_resharding_op> cls_rgw_set_bucket_resharding_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_set_bucket_resharding_op);
-  ls.push_back(new cls_rgw_set_bucket_resharding_op);
+  list<cls_rgw_set_bucket_resharding_op> ls;
+  ls.push_back(cls_rgw_set_bucket_resharding_op{});
+  ls.push_back(cls_rgw_set_bucket_resharding_op{});
+  return ls;
 }
 
 void cls_rgw_set_bucket_resharding_op::dump(Formatter *f) const
@@ -543,22 +584,24 @@ void cls_rgw_set_bucket_resharding_op::dump(Formatter *f) const
   encode_json("entry", entry, f);
 }
 
-void cls_rgw_clear_bucket_resharding_op::generate_test_instances(
-  list<cls_rgw_clear_bucket_resharding_op*>& ls)
+list<cls_rgw_clear_bucket_resharding_op> cls_rgw_clear_bucket_resharding_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_clear_bucket_resharding_op);
-  ls.push_back(new cls_rgw_clear_bucket_resharding_op);
+  list<cls_rgw_clear_bucket_resharding_op> ls;
+  ls.push_back(cls_rgw_clear_bucket_resharding_op{});
+  ls.push_back(cls_rgw_clear_bucket_resharding_op{});
+  return ls;
 }
 
 void cls_rgw_clear_bucket_resharding_op::dump(Formatter *f) const
 {
 }
 
-void cls_rgw_guard_bucket_resharding_op::generate_test_instances(
-  list<cls_rgw_guard_bucket_resharding_op*>& ls)
+list<cls_rgw_guard_bucket_resharding_op> cls_rgw_guard_bucket_resharding_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_guard_bucket_resharding_op);
-  ls.push_back(new cls_rgw_guard_bucket_resharding_op);
+  list<cls_rgw_guard_bucket_resharding_op> ls;
+  ls.push_back(cls_rgw_guard_bucket_resharding_op{});
+  ls.push_back(cls_rgw_guard_bucket_resharding_op{});
+  return ls;
 }
 
 void cls_rgw_guard_bucket_resharding_op::dump(Formatter *f) const
@@ -567,11 +610,12 @@ void cls_rgw_guard_bucket_resharding_op::dump(Formatter *f) const
 }
 
 
-void cls_rgw_get_bucket_resharding_op::generate_test_instances(
-  list<cls_rgw_get_bucket_resharding_op*>& ls)
+list<cls_rgw_get_bucket_resharding_op> cls_rgw_get_bucket_resharding_op::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_get_bucket_resharding_op);
-  ls.push_back(new cls_rgw_get_bucket_resharding_op);
+  list<cls_rgw_get_bucket_resharding_op> ls;
+  ls.push_back(cls_rgw_get_bucket_resharding_op{});
+  ls.push_back(cls_rgw_get_bucket_resharding_op{});
+  return ls;
 }
 
 void cls_rgw_get_bucket_resharding_op::dump(Formatter *f) const

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -20,7 +20,7 @@ struct rgw_cls_tag_timeout_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_cls_tag_timeout_op*>& ls);
+  static std::list<rgw_cls_tag_timeout_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_cls_tag_timeout_op)
 
@@ -75,7 +75,7 @@ struct rgw_cls_obj_prepare_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_cls_obj_prepare_op*>& o);
+  static std::list<rgw_cls_obj_prepare_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_prepare_op)
 
@@ -158,7 +158,7 @@ struct rgw_cls_obj_complete_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_cls_obj_complete_op*>& o);
+  static std::list<rgw_cls_obj_complete_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_complete_op)
 
@@ -224,7 +224,7 @@ struct rgw_cls_link_olh_op {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_link_olh_op *>& o);
+  static std::list<rgw_cls_link_olh_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_link_olh_op)
@@ -268,7 +268,7 @@ struct rgw_cls_unlink_instance_op {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_unlink_instance_op *>& o);
+  static std::list<rgw_cls_unlink_instance_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_unlink_instance_op)
@@ -295,7 +295,7 @@ struct rgw_cls_read_olh_log_op
     decode(olh_tag, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<rgw_cls_read_olh_log_op *>& o);
+  static std::list<rgw_cls_read_olh_log_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_read_olh_log_op)
@@ -320,7 +320,7 @@ struct rgw_cls_read_olh_log_ret
     decode(is_truncated, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<rgw_cls_read_olh_log_ret *>& o);
+  static std::list<rgw_cls_read_olh_log_ret> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_read_olh_log_ret)
@@ -347,7 +347,7 @@ struct rgw_cls_trim_olh_log_op
     decode(olh_tag, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<rgw_cls_trim_olh_log_op *>& o);
+  static std::list<rgw_cls_trim_olh_log_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_trim_olh_log_op)
@@ -372,7 +372,7 @@ struct rgw_cls_bucket_clear_olh_op {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_bucket_clear_olh_op *>& o);
+  static std::list<rgw_cls_bucket_clear_olh_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(rgw_cls_bucket_clear_olh_op)
@@ -417,7 +417,7 @@ struct rgw_cls_list_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_cls_list_op*>& o);
+  static std::list<rgw_cls_list_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_cls_list_op)
 
@@ -459,7 +459,7 @@ struct rgw_cls_list_ret {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_cls_list_ret*>& o);
+  static std::list<rgw_cls_list_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_cls_list_ret)
 
@@ -483,7 +483,7 @@ struct rgw_cls_check_index_ret
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_cls_check_index_ret *>& o);
+  static std::list<rgw_cls_check_index_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_cls_check_index_ret)
 
@@ -511,7 +511,7 @@ struct rgw_cls_bucket_update_stats_op
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_cls_bucket_update_stats_op *>& o);
+  static std::list<rgw_cls_bucket_update_stats_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_cls_bucket_update_stats_op)
 
@@ -534,11 +534,13 @@ struct rgw_cls_obj_remove_op {
     encode_json("keep_attr_prefixes", keep_attr_prefixes, f);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_obj_remove_op*>& o) {
-    o.push_back(new rgw_cls_obj_remove_op);
-    o.back()->keep_attr_prefixes.push_back("keep_attr_prefixes1");
-    o.back()->keep_attr_prefixes.push_back("keep_attr_prefixes2");
-    o.back()->keep_attr_prefixes.push_back("keep_attr_prefixes3");
+  static std::list<rgw_cls_obj_remove_op> generate_test_instances() {
+    std::list<rgw_cls_obj_remove_op> o;
+    o.push_back(rgw_cls_obj_remove_op{});
+    o.back().keep_attr_prefixes.push_back("keep_attr_prefixes1");
+    o.back().keep_attr_prefixes.push_back("keep_attr_prefixes2");
+    o.back().keep_attr_prefixes.push_back("keep_attr_prefixes3");
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_remove_op)
@@ -562,9 +564,11 @@ struct rgw_cls_obj_store_pg_ver_op {
     f->dump_string("attr", attr);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_obj_store_pg_ver_op*>& o) {
-    o.push_back(new rgw_cls_obj_store_pg_ver_op);
-    o.back()->attr = "attr";
+  static std::list<rgw_cls_obj_store_pg_ver_op> generate_test_instances() {
+    std::list<rgw_cls_obj_store_pg_ver_op> o;
+    o.push_back(rgw_cls_obj_store_pg_ver_op{});
+    o.back().attr = "attr";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_store_pg_ver_op)
@@ -594,10 +598,12 @@ struct rgw_cls_obj_check_attrs_prefix {
     f->dump_bool("fail_if_exist", fail_if_exist);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_obj_check_attrs_prefix*>& o) {
-    o.push_back(new rgw_cls_obj_check_attrs_prefix);
-    o.back()->check_prefix = "prefix";
-    o.back()->fail_if_exist = true;
+  static std::list<rgw_cls_obj_check_attrs_prefix> generate_test_instances() {
+    std::list<rgw_cls_obj_check_attrs_prefix> o;
+    o.push_back(rgw_cls_obj_check_attrs_prefix{});
+    o.back().check_prefix = "prefix";
+    o.back().fail_if_exist = true;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_check_attrs_prefix)
@@ -658,8 +664,10 @@ struct rgw_cls_usage_log_add_op {
     f->dump_string("user", user.to_str());
   }
 
-  static void generate_test_instances(std::list<rgw_cls_usage_log_add_op*>& o) {
-    o.push_back(new rgw_cls_usage_log_add_op);
+  static std::list<rgw_cls_usage_log_add_op> generate_test_instances() {
+    std::list<rgw_cls_usage_log_add_op> o;
+    o.push_back(rgw_cls_usage_log_add_op{});
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_add_op)
@@ -691,12 +699,14 @@ struct rgw_cls_bi_get_op {
     f->dump_int("type", (int)type);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_bi_get_op*>& o) {
-    o.push_back(new rgw_cls_bi_get_op);
-    o.push_back(new rgw_cls_bi_get_op);
-    o.back()->key.name = "key";
-    o.back()->key.instance = "instance";
-    o.back()->type = BIIndexType::Plain;
+  static std::list<rgw_cls_bi_get_op> generate_test_instances() {
+    std::list<rgw_cls_bi_get_op> o;
+    o.push_back(rgw_cls_bi_get_op{});
+    o.push_back(rgw_cls_bi_get_op{});
+    o.back().key.name = "key";
+    o.back().key.instance = "instance";
+    o.back().type = BIIndexType::Plain;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_get_op)
@@ -722,9 +732,11 @@ struct rgw_cls_bi_get_ret {
     f->dump_string("entry", entry.idx);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_bi_get_ret*>& o) {
-    o.push_back(new rgw_cls_bi_get_ret);
-    o.back()->entry.idx = "entry";
+  static std::list<rgw_cls_bi_get_ret> generate_test_instances() {
+    std::list<rgw_cls_bi_get_ret> o;
+    o.push_back(rgw_cls_bi_get_ret{});
+    o.back().entry.idx = "entry";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_get_ret)
@@ -750,10 +762,12 @@ struct rgw_cls_bi_put_op {
     f->dump_string("entry", entry.idx);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_bi_put_op*>& o) {
-    o.push_back(new rgw_cls_bi_put_op);
-    o.push_back(new rgw_cls_bi_put_op);
-    o.back()->entry.idx = "entry";
+  static std::list<rgw_cls_bi_put_op> generate_test_instances() {
+    std::list<rgw_cls_bi_put_op> o;
+    o.push_back(rgw_cls_bi_put_op{});
+    o.push_back(rgw_cls_bi_put_op{});
+    o.back().entry.idx = "entry";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_put_op)
@@ -778,11 +792,13 @@ struct rgw_cls_bi_put_entries_op {
 
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<rgw_cls_bi_put_entries_op*>& o) {
-    o.push_back(new rgw_cls_bi_put_entries_op);
-    o.push_back(new rgw_cls_bi_put_entries_op);
-    o.back()->entries.push_back({.idx = "entry"});
-    o.back()->check_existing = true;
+  static std::list<rgw_cls_bi_put_entries_op> generate_test_instances() {
+    std::list<rgw_cls_bi_put_entries_op> o;
+    o.push_back(rgw_cls_bi_put_entries_op{});
+    o.push_back(rgw_cls_bi_put_entries_op{});
+    o.back().entries.push_back({.idx = "entry"});
+    o.back().check_existing = true;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_put_entries_op)
@@ -822,13 +838,15 @@ struct rgw_cls_bi_list_op {
     f->dump_bool("reshardlog", reshardlog);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_bi_list_op*>& o) {
-    o.push_back(new rgw_cls_bi_list_op);
-    o.push_back(new rgw_cls_bi_list_op);
-    o.back()->max = 100;
-    o.back()->name_filter = "name_filter";
-    o.back()->marker = "marker";
-    o.back()->reshardlog = true;
+  static std::list<rgw_cls_bi_list_op> generate_test_instances() {
+    std::list<rgw_cls_bi_list_op> o;
+    o.push_back(rgw_cls_bi_list_op{});
+    o.push_back(rgw_cls_bi_list_op{});
+    o.back().max = 100;
+    o.back().name_filter = "name_filter";
+    o.back().marker = "marker";
+    o.back().reshardlog = true;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_list_op)
@@ -858,13 +876,15 @@ struct rgw_cls_bi_list_ret {
     encode_json("entries", entries, f);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_bi_list_ret*>& o) {
-    o.push_back(new rgw_cls_bi_list_ret);
-    o.push_back(new rgw_cls_bi_list_ret);
-    o.back()->entries.push_back(rgw_cls_bi_entry());
-    o.back()->entries.push_back(rgw_cls_bi_entry());
-    o.back()->entries.back().idx = "entry";
-    o.back()->is_truncated = true;
+  static std::list<rgw_cls_bi_list_ret> generate_test_instances() {
+    std::list<rgw_cls_bi_list_ret> o;
+    o.push_back(rgw_cls_bi_list_ret{});
+    o.push_back(rgw_cls_bi_list_ret{});
+    o.back().entries.push_back(rgw_cls_bi_entry());
+    o.back().entries.push_back(rgw_cls_bi_entry());
+    o.back().entries.back().idx = "entry";
+    o.back().is_truncated = true;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_bi_list_ret)
@@ -911,14 +931,16 @@ struct rgw_cls_usage_log_read_op {
     f->dump_unsigned("max_entries", max_entries);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_usage_log_read_op*>& o) {
-    o.push_back(new rgw_cls_usage_log_read_op);
-    o.back()->start_epoch = 1;
-    o.back()->end_epoch = 2;
-    o.back()->owner = "owner";
-    o.back()->bucket = "bucket";
-    o.back()->iter = "iter";
-    o.back()->max_entries = 100;
+  static std::list<rgw_cls_usage_log_read_op> generate_test_instances() {
+    std::list<rgw_cls_usage_log_read_op> o;
+    o.push_back(rgw_cls_usage_log_read_op{});
+    o.back().start_epoch = 1;
+    o.back().end_epoch = 2;
+    o.back().owner = "owner";
+    o.back().bucket = "bucket";
+    o.back().iter = "iter";
+    o.back().max_entries = 100;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_read_op)
@@ -950,16 +972,18 @@ struct rgw_cls_usage_log_read_ret {
     encode_json("usage", usage, f);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_usage_log_read_ret*>& o) {
-    o.push_back(new rgw_cls_usage_log_read_ret);
-    o.back()->next_iter = "123";
-    o.back()->truncated = true;
-    o.back()->usage.clear();
-    o.push_back(new rgw_cls_usage_log_read_ret);
-    o.back()->usage[rgw_user_bucket("user1", "bucket1")] = rgw_usage_log_entry();
-    o.back()->usage[rgw_user_bucket("user2", "bucket2")] = rgw_usage_log_entry();
-    o.back()->truncated = true;
-    o.back()->next_iter = "next_iter";
+  static std::list<rgw_cls_usage_log_read_ret> generate_test_instances() {
+    std::list<rgw_cls_usage_log_read_ret> o;
+    o.push_back(rgw_cls_usage_log_read_ret{});
+    o.back().next_iter = "123";
+    o.back().truncated = true;
+    o.back().usage.clear();
+    o.push_back(rgw_cls_usage_log_read_ret{});
+    o.back().usage[rgw_user_bucket("user1", "bucket1")] = rgw_usage_log_entry();
+    o.back().usage[rgw_user_bucket("user2", "bucket2")] = rgw_usage_log_entry();
+    o.back().truncated = true;
+    o.back().next_iter = "next_iter";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_read_ret)
@@ -997,13 +1021,15 @@ struct rgw_cls_usage_log_trim_op {
     f->dump_string("bucket", bucket);
   }
 
-  static void generate_test_instances(std::list<rgw_cls_usage_log_trim_op*>& ls) {
-    rgw_cls_usage_log_trim_op *m = new rgw_cls_usage_log_trim_op;
-    m->start_epoch = 1;
-    m->end_epoch = 2;
-    m->user = "user";
-    m->bucket = "bucket";
-    ls.push_back(m);
+  static std::list<rgw_cls_usage_log_trim_op> generate_test_instances() {
+    std::list<rgw_cls_usage_log_trim_op> ls;
+    rgw_cls_usage_log_trim_op m;
+    m.start_epoch = 1;
+    m.end_epoch = 2;
+    m.user = "user";
+    m.bucket = "bucket";
+    ls.push_back(std::move(m));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(rgw_cls_usage_log_trim_op)
@@ -1028,7 +1054,7 @@ struct cls_rgw_gc_set_entry_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_gc_set_entry_op*>& ls);
+  static std::list<cls_rgw_gc_set_entry_op> generate_test_instances();
 
   size_t estimate_encoded_size() const {
     constexpr size_t start_overhead = sizeof(__u8) + sizeof(__u8) + sizeof(ceph_le32); // version and length prefix
@@ -1058,7 +1084,7 @@ struct cls_rgw_gc_defer_entry_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_gc_defer_entry_op*>& ls);
+  static std::list<cls_rgw_gc_defer_entry_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_defer_entry_op)
 
@@ -1088,7 +1114,7 @@ struct cls_rgw_gc_list_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_gc_list_op*>& ls);
+  static std::list<cls_rgw_gc_list_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_list_op)
 
@@ -1117,7 +1143,7 @@ struct cls_rgw_gc_list_ret {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_gc_list_ret*>& ls);
+  static std::list<cls_rgw_gc_list_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_list_ret)
 
@@ -1139,7 +1165,7 @@ struct cls_rgw_gc_remove_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_gc_remove_op*>& ls);
+  static std::list<cls_rgw_gc_remove_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_remove_op)
 
@@ -1164,7 +1190,7 @@ struct cls_rgw_bi_log_list_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_bi_log_list_op*>& ls);
+  static std::list<cls_rgw_bi_log_list_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_bi_log_list_op)
 
@@ -1189,7 +1215,7 @@ struct cls_rgw_bi_log_trim_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_bi_log_trim_op*>& ls);
+  static std::list<cls_rgw_bi_log_trim_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_bi_log_trim_op)
 
@@ -1214,7 +1240,7 @@ struct cls_rgw_bi_log_list_ret {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_bi_log_list_ret*>& ls);
+  static std::list<cls_rgw_bi_log_list_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_bi_log_list_ret)
 
@@ -1316,7 +1342,7 @@ struct cls_rgw_lc_get_entry_ret {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_lc_get_entry_ret*>& ls);
+  static std::list<cls_rgw_lc_get_entry_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_entry_ret)
 
@@ -1372,12 +1398,14 @@ struct cls_rgw_lc_set_entry_op {
     f->dump_int("status", entry.status);
   }
 
-  static void generate_test_instances(std::list<cls_rgw_lc_set_entry_op*>& ls) {
-    ls.push_back(new cls_rgw_lc_set_entry_op);
-    ls.push_back(new cls_rgw_lc_set_entry_op);
-    ls.back()->entry.bucket = "foo";
-    ls.back()->entry.start_time = 123;
-    ls.back()->entry.status = 456;
+  static std::list<cls_rgw_lc_set_entry_op> generate_test_instances() {
+    std::list<cls_rgw_lc_set_entry_op> ls;
+    ls.push_back(cls_rgw_lc_set_entry_op{});
+    ls.push_back(cls_rgw_lc_set_entry_op{});
+    ls.back().entry.bucket = "foo";
+    ls.back().entry.start_time = 123;
+    ls.back().entry.status = 456;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_set_entry_op)
@@ -1512,7 +1540,7 @@ struct cls_rgw_mp_upload_part_info_update_op {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(std::list<cls_rgw_mp_upload_part_info_update_op*>& ls);
+  static std::list<cls_rgw_mp_upload_part_info_update_op> generate_test_instances();
   void dump(Formatter* f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_mp_upload_part_info_update_op)
@@ -1541,7 +1569,7 @@ struct cls_rgw_reshard_add_op {
     }
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_reshard_add_op*>& o);
+  static std::list<cls_rgw_reshard_add_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_add_op)
@@ -1565,7 +1593,7 @@ struct cls_rgw_reshard_list_op {
     decode(marker, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_reshard_list_op*>& o);
+  static std::list<cls_rgw_reshard_list_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_list_op)
@@ -1590,7 +1618,7 @@ struct cls_rgw_reshard_list_ret {
     decode(is_truncated, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_reshard_list_ret*>& o);
+  static std::list<cls_rgw_reshard_list_ret> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_list_ret)
@@ -1611,7 +1639,7 @@ struct cls_rgw_reshard_get_op {
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_reshard_get_op*>& o);
+  static std::list<cls_rgw_reshard_get_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_get_op)
@@ -1632,7 +1660,7 @@ struct cls_rgw_reshard_get_ret {
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_reshard_get_ret*>& o);
+  static std::list<cls_rgw_reshard_get_ret> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_get_ret)
@@ -1659,7 +1687,7 @@ struct cls_rgw_reshard_remove_op {
     decode(bucket_id, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_reshard_remove_op*>& o);
+  static std::list<cls_rgw_reshard_remove_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_remove_op)
@@ -1678,7 +1706,7 @@ struct cls_rgw_set_bucket_resharding_op  {
     decode(entry, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_set_bucket_resharding_op*>& o);
+  static std::list<cls_rgw_set_bucket_resharding_op> generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_set_bucket_resharding_op)
@@ -1693,7 +1721,7 @@ struct cls_rgw_clear_bucket_resharding_op {
     DECODE_START(1, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<cls_rgw_clear_bucket_resharding_op*>& o);
+  static std::list<cls_rgw_clear_bucket_resharding_op>generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_clear_bucket_resharding_op)
@@ -1713,7 +1741,7 @@ struct cls_rgw_guard_bucket_resharding_op  {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(std::list<cls_rgw_guard_bucket_resharding_op*>& o);
+  static std::list<cls_rgw_guard_bucket_resharding_op>generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_guard_bucket_resharding_op)
@@ -1730,7 +1758,7 @@ struct cls_rgw_get_bucket_resharding_op  {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(std::list<cls_rgw_get_bucket_resharding_op*>& o);
+  static std::list<cls_rgw_get_bucket_resharding_op>generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_op)
@@ -1750,7 +1778,7 @@ struct cls_rgw_get_bucket_resharding_ret  {
     DECODE_FINISH(bl);
   }
 
-  static void generate_test_instances(std::list<cls_rgw_get_bucket_resharding_ret*>& o);
+  static std::list<cls_rgw_get_bucket_resharding_ret>generate_test_instances();
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -61,14 +61,16 @@ void rgw_zone_set::dump(Formatter *f) const
   encode_json("entries", entries, f);
 }
 
-void rgw_zone_set::generate_test_instances(list<rgw_zone_set*>& o)
+list<rgw_zone_set> rgw_zone_set::generate_test_instances()
 {
-  o.push_back(new rgw_zone_set);
-  o.push_back(new rgw_zone_set);
+  list<rgw_zone_set> o;
+  o.push_back(rgw_zone_set{});
+  o.push_back(rgw_zone_set{});
   std::optional<string> loc_key = "loc_key";
-  o.back()->insert("zone1", loc_key);
-  o.back()->insert("zone2", loc_key);
-  o.back()->insert("zone3", loc_key);
+  o.back().insert("zone1", loc_key);
+  o.back().insert("zone2", loc_key);
+  o.back().insert("zone3", loc_key);
+  return o;
 }
 
 void rgw_zone_set::insert(const string& zone, std::optional<string> location_key)
@@ -142,13 +144,15 @@ std::string_view to_string(RGWObjCategory c)
   }
 }
 
-void rgw_bucket_pending_info::generate_test_instances(list<rgw_bucket_pending_info*>& o)
+list<rgw_bucket_pending_info> rgw_bucket_pending_info::generate_test_instances()
 {
-  rgw_bucket_pending_info *i = new rgw_bucket_pending_info;
-  i->state = CLS_RGW_STATE_COMPLETE;
-  i->op = CLS_RGW_OP_DEL;
-  o.push_back(i);
-  o.push_back(new rgw_bucket_pending_info);
+  list<rgw_bucket_pending_info> o;
+  rgw_bucket_pending_info i;
+  i.state = CLS_RGW_STATE_COMPLETE;
+  i.op = CLS_RGW_OP_DEL;
+  o.push_back(std::move(i));
+  o.push_back(rgw_bucket_pending_info{});
+  return o;
 }
 
 void rgw_bucket_pending_info::dump(Formatter *f) const
@@ -174,17 +178,19 @@ void cls_rgw_obj_key::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("instance", instance, obj);
 }
 
-void rgw_bucket_dir_entry_meta::generate_test_instances(list<rgw_bucket_dir_entry_meta*>& o)
+list<rgw_bucket_dir_entry_meta> rgw_bucket_dir_entry_meta::generate_test_instances()
 {
-  rgw_bucket_dir_entry_meta *m = new rgw_bucket_dir_entry_meta;
-  m->category = RGWObjCategory::Main;
-  m->size = 100;
-  m->etag = "etag";
-  m->owner = "owner";
-  m->owner_display_name = "display name";
-  m->content_type = "content/type";
-  o.push_back(m);
-  o.push_back(new rgw_bucket_dir_entry_meta);
+  list<rgw_bucket_dir_entry_meta> o;
+  rgw_bucket_dir_entry_meta m;
+  m.category = RGWObjCategory::Main;
+  m.size = 100;
+  m.etag = "etag";
+  m.owner = "owner";
+  m.owner_display_name = "display name";
+  m.content_type = "content/type";
+  o.push_back(std::move(m));
+  o.push_back(rgw_bucket_dir_entry_meta{});
+  return o;
 }
 
 void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
@@ -223,27 +229,24 @@ void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("appendable", appendable, obj);
 }
 
-void rgw_bucket_dir_entry::generate_test_instances(list<rgw_bucket_dir_entry*>& o)
+list<rgw_bucket_dir_entry> rgw_bucket_dir_entry::generate_test_instances()
 {
-  list<rgw_bucket_dir_entry_meta *> l;
-  rgw_bucket_dir_entry_meta::generate_test_instances(l);
+  list<rgw_bucket_dir_entry> o;
 
-  for (auto iter = l.begin(); iter != l.end(); ++iter) {
-    rgw_bucket_dir_entry_meta *m = *iter;
-    rgw_bucket_dir_entry *e = new rgw_bucket_dir_entry;
-    e->key.name = "name";
-    e->ver.pool = 1;
-    e->ver.epoch = 1234;
-    e->locator = "locator";
-    e->exists = true;
-    e->meta = *m;
-    e->tag = "tag";
+  for (auto& m : rgw_bucket_dir_entry_meta::generate_test_instances()) {
+    rgw_bucket_dir_entry e;
+    e.key.name = "name";
+    e.ver.pool = 1;
+    e.ver.epoch = 1234;
+    e.locator = "locator";
+    e.exists = true;
+    e.meta = m;
+    e.tag = "tag";
 
-    o.push_back(e);
-
-    delete m;
+    o.push_back(std::move(e));
   }
-  o.push_back(new rgw_bucket_dir_entry);
+  o.push_back(rgw_bucket_dir_entry{});
+  return o;
 }
 
 void rgw_bucket_entry_ver::dump(Formatter *f) const
@@ -257,12 +260,14 @@ void rgw_bucket_entry_ver::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("epoch", epoch, obj);
 }
 
-void rgw_bucket_entry_ver::generate_test_instances(list<rgw_bucket_entry_ver*>& ls)
+list<rgw_bucket_entry_ver> rgw_bucket_entry_ver::generate_test_instances()
 {
-  ls.push_back(new rgw_bucket_entry_ver);
-  ls.push_back(new rgw_bucket_entry_ver);
-  ls.back()->pool = 123;
-  ls.back()->epoch = 12322;
+  list<rgw_bucket_entry_ver> ls;
+  ls.push_back(rgw_bucket_entry_ver{});
+  ls.push_back(rgw_bucket_entry_ver{});
+  ls.back().pool = 123;
+  ls.back().epoch = 12322;
+  return ls;
 }
 
 
@@ -441,10 +446,11 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
   return false;
 }
 
-void rgw_cls_bi_entry::generate_test_instances(list<rgw_cls_bi_entry*>& o)
+list<rgw_cls_bi_entry> rgw_cls_bi_entry::generate_test_instances()
 {
   using ceph::encode;
-  rgw_cls_bi_entry *m = new rgw_cls_bi_entry;
+  list<rgw_cls_bi_entry> o;
+  rgw_cls_bi_entry m;
   rgw_bucket_olh_entry entry;
   entry.delete_marker = true;
   entry.epoch = 1234;
@@ -453,11 +459,12 @@ void rgw_cls_bi_entry::generate_test_instances(list<rgw_cls_bi_entry*>& o)
   entry.key.instance = "key.instance";
   entry.exists = true;
   entry.pending_removal = true;
-  m->type = BIIndexType::OLH;
-  m->idx = "idx";
-  encode(entry,m->data);
-  o.push_back(m);
-  o.push_back(new rgw_cls_bi_entry);
+  m.type = BIIndexType::OLH;
+  m.idx = "idx";
+  encode(entry, m.data);
+  o.push_back(std::move(m));
+  o.push_back(rgw_cls_bi_entry{});
+  return o;
 }
 
 void rgw_bucket_olh_entry::dump(Formatter *f) const
@@ -482,18 +489,20 @@ void rgw_bucket_olh_entry::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("pending_removal", pending_removal, obj);
 }
 
-void rgw_bucket_olh_entry::generate_test_instances(list<rgw_bucket_olh_entry*>& o)
+list<rgw_bucket_olh_entry> rgw_bucket_olh_entry::generate_test_instances()
 {
-  rgw_bucket_olh_entry *entry = new rgw_bucket_olh_entry;
-  entry->delete_marker = true;
-  entry->epoch = 1234;
-  entry->tag = "tag";
-  entry->key.name = "key.name";
-  entry->key.instance = "key.instance";
-  entry->exists = true;
-  entry->pending_removal = true;
-  o.push_back(entry);
-  o.push_back(new rgw_bucket_olh_entry);
+  list<rgw_bucket_olh_entry> o;
+  rgw_bucket_olh_entry entry;
+  entry.delete_marker = true;
+  entry.epoch = 1234;
+  entry.tag = "tag";
+  entry.key.name = "key.name";
+  entry.key.instance = "key.instance";
+  entry.exists = true;
+  entry.pending_removal = true;
+  o.push_back(std::move(entry));
+  o.push_back(rgw_bucket_olh_entry{});
+  return o;
 }
 
 void rgw_bucket_deleted_entry::dump(Formatter *f) const
@@ -506,26 +515,30 @@ void rgw_bucket_deleted_entry::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("key", key, obj);
 }
 
-void rgw_bucket_deleted_entry::generate_test_instances(list<rgw_bucket_deleted_entry*>& o)
+list<rgw_bucket_deleted_entry> rgw_bucket_deleted_entry::generate_test_instances()
 {
-  rgw_bucket_deleted_entry *entry = new rgw_bucket_deleted_entry;
-  entry->key.name = "key.name";
-  entry->key.instance = "key.instance";
-  o.push_back(entry);
-  o.push_back(new rgw_bucket_deleted_entry);
+  list<rgw_bucket_deleted_entry> o;
+  rgw_bucket_deleted_entry entry;
+  entry.key.name = "key.name";
+  entry.key.instance = "key.instance";
+  o.push_back(std::move(entry));
+  o.push_back(rgw_bucket_deleted_entry{});
+  return o;
 }
 
-void rgw_bucket_olh_log_entry::generate_test_instances(list<rgw_bucket_olh_log_entry*>& o)
+list<rgw_bucket_olh_log_entry> rgw_bucket_olh_log_entry::generate_test_instances()
 {
-  rgw_bucket_olh_log_entry *entry = new rgw_bucket_olh_log_entry;
-  entry->epoch = 1234;
-  entry->op = CLS_RGW_OLH_OP_LINK_OLH;
-  entry->op_tag = "op_tag";
-  entry->key.name = "key.name";
-  entry->key.instance = "key.instance";
-  entry->delete_marker = true;
-  o.push_back(entry);
-  o.push_back(new rgw_bucket_olh_log_entry);
+  list<rgw_bucket_olh_log_entry> o;
+  rgw_bucket_olh_log_entry entry;
+  entry.epoch = 1234;
+  entry.op = CLS_RGW_OLH_OP_LINK_OLH;
+  entry.op_tag = "op_tag";
+  entry.key.name = "key.name";
+  entry.key.instance = "key.instance";
+  entry.delete_marker = true;
+  o.push_back(std::move(entry));
+  o.push_back(rgw_bucket_olh_log_entry{});
+  return o;
 }
 
 void rgw_bucket_olh_log_entry::dump(Formatter *f) const
@@ -634,28 +647,32 @@ void rgw_bi_log_entry::dump(Formatter *f) const
   encode_json("zones_trace", zones_trace, f);
 }
 
-void rgw_bi_log_entry::generate_test_instances(list<rgw_bi_log_entry*>& ls)
+list<rgw_bi_log_entry> rgw_bi_log_entry::generate_test_instances()
 {
-  ls.push_back(new rgw_bi_log_entry);
-  ls.push_back(new rgw_bi_log_entry);
-  ls.back()->id = "midf";
-  ls.back()->object = "obj";
-  ls.back()->timestamp = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
-  ls.back()->index_ver = 4323;
-  ls.back()->tag = "tagasdfds";
-  ls.back()->op = CLS_RGW_OP_DEL;
-  ls.back()->state = CLS_RGW_STATE_PENDING_MODIFY;
+  list<rgw_bi_log_entry> ls;
+  ls.push_back(rgw_bi_log_entry{});
+  ls.push_back(rgw_bi_log_entry{});
+  ls.back().id = "midf";
+  ls.back().object = "obj";
+  ls.back().timestamp = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
+  ls.back().index_ver = 4323;
+  ls.back().tag = "tagasdfds";
+  ls.back().op = CLS_RGW_OP_DEL;
+  ls.back().state = CLS_RGW_STATE_PENDING_MODIFY;
+  return ls;
 }
 
-void rgw_bucket_category_stats::generate_test_instances(list<rgw_bucket_category_stats*>& o)
+list<rgw_bucket_category_stats> rgw_bucket_category_stats::generate_test_instances()
 {
-  rgw_bucket_category_stats *s = new rgw_bucket_category_stats;
-  s->total_size = 1024;
-  s->total_size_rounded = 4096;
-  s->num_entries = 2;
-  s->actual_size = 1024;
-  o.push_back(s);
-  o.push_back(new rgw_bucket_category_stats);
+  list<rgw_bucket_category_stats> o;
+  rgw_bucket_category_stats s;
+  s.total_size = 1024;
+  s.total_size_rounded = 4096;
+  s.num_entries = 2;
+  s.actual_size = 1024;
+  o.push_back(std::move(s));
+  o.push_back(rgw_bucket_category_stats{});
+  return o;
 }
 
 void rgw_bucket_category_stats::dump(Formatter *f) const
@@ -666,24 +683,24 @@ void rgw_bucket_category_stats::dump(Formatter *f) const
   f->dump_unsigned("actual_size", actual_size);
 }
 
-void rgw_bucket_dir_header::generate_test_instances(list<rgw_bucket_dir_header*>& o)
+list<rgw_bucket_dir_header> rgw_bucket_dir_header::generate_test_instances()
 {
-  list<rgw_bucket_category_stats *> l;
-  rgw_bucket_category_stats::generate_test_instances(l);
+  list<rgw_bucket_dir_header> o;
+  list<rgw_bucket_category_stats> l = rgw_bucket_category_stats::generate_test_instances();
+
 
   uint8_t i = 0;
   for (auto iter = l.begin(); iter != l.end(); ++iter, ++i) {
     RGWObjCategory c = static_cast<RGWObjCategory>(i);
-    rgw_bucket_dir_header *h = new rgw_bucket_dir_header;
-    rgw_bucket_category_stats *s = *iter;
-    h->stats[c] = *s;
+    rgw_bucket_dir_header h;
+    rgw_bucket_category_stats& s = *iter;
+    h.stats[c] = s;
 
-    o.push_back(h);
-
-    delete s;
+    o.push_back(std::move(h));
   }
 
-  o.push_back(new rgw_bucket_dir_header);
+  o.push_back(rgw_bucket_dir_header{});
+  return o;
 }
 
 void rgw_bucket_dir_header::dump(Formatter *f) const
@@ -702,31 +719,31 @@ void rgw_bucket_dir_header::dump(Formatter *f) const
   f->dump_int("reshardlog_entries", reshardlog_entries);
 }
 
-void rgw_bucket_dir::generate_test_instances(list<rgw_bucket_dir*>& o)
+list<rgw_bucket_dir> rgw_bucket_dir::generate_test_instances()
 {
-  list<rgw_bucket_dir_header *> l;
-  rgw_bucket_dir_header::generate_test_instances(l);
+  list<rgw_bucket_dir> o;
+
+  list<rgw_bucket_dir_header> l = rgw_bucket_dir_header::generate_test_instances();
 
   uint8_t i = 0;
   for (auto iter = l.begin(); iter != l.end(); ++iter, ++i) {
-    rgw_bucket_dir *d = new rgw_bucket_dir;
-    rgw_bucket_dir_header *h = *iter;
-    d->header = *h;
+    rgw_bucket_dir d;
+    rgw_bucket_dir_header& h = *iter;
+    d.header = h;
 
     list<rgw_bucket_dir_entry *> el;
     for (auto eiter = el.begin(); eiter != el.end(); ++eiter) {
       rgw_bucket_dir_entry *e = *eiter;
-      d->m[e->key.name] = *e;
+      d.m[e->key.name] = *e;
 
       delete e;
     }
 
-    o.push_back(d);
-
-    delete h;
+    o.push_back(std::move(d));
   }
 
-  o.push_back(new rgw_bucket_dir);
+  o.push_back(rgw_bucket_dir{});
+  return o;
 }
 
 void rgw_bucket_dir::dump(Formatter *f) const
@@ -745,13 +762,15 @@ void rgw_bucket_dir::dump(Formatter *f) const
   f->close_section();
 }
 
-void rgw_s3select_usage_data::generate_test_instances(list<rgw_s3select_usage_data*>& o)
+list<rgw_s3select_usage_data> rgw_s3select_usage_data::generate_test_instances()
 {
-  rgw_s3select_usage_data *s = new rgw_s3select_usage_data;
-  s->bytes_processed = 1024;
-  s->bytes_returned = 512;
-  o.push_back(s);
-  o.push_back(new rgw_s3select_usage_data);
+  list<rgw_s3select_usage_data> o;
+  rgw_s3select_usage_data s;
+  s.bytes_processed = 1024;
+  s.bytes_returned = 512;
+  o.push_back(std::move(s));
+  o.push_back(rgw_s3select_usage_data{});
+  return o;
 }
 
 void rgw_s3select_usage_data::dump(Formatter *f) const
@@ -760,15 +779,17 @@ void rgw_s3select_usage_data::dump(Formatter *f) const
   f->dump_unsigned("bytes_returned", bytes_returned);
 }
 
-void rgw_usage_data::generate_test_instances(list<rgw_usage_data*>& o)
+list<rgw_usage_data> rgw_usage_data::generate_test_instances()
 {
-  rgw_usage_data *s = new rgw_usage_data;
-  s->bytes_sent = 1024;
-  s->bytes_received = 1024;
-  s->ops = 2;
-  s->successful_ops = 1;
-  o.push_back(s);
-  o.push_back(new rgw_usage_data);
+  list<rgw_usage_data> o;
+  rgw_usage_data s;
+  s.bytes_sent = 1024;
+  s.bytes_received = 1024;
+  s.ops = 2;
+  s.successful_ops = 1;
+  o.push_back(std::move(s));
+  o.push_back(rgw_usage_data{});
+  return o;
 }
 
 void rgw_usage_data::dump(Formatter *f) const
@@ -779,17 +800,19 @@ void rgw_usage_data::dump(Formatter *f) const
   f->dump_int("successful_ops", successful_ops);
 }
 
-void rgw_usage_log_info::generate_test_instances(list<rgw_usage_log_info*>& o)
+list<rgw_usage_log_info> rgw_usage_log_info::generate_test_instances()
 {
-  rgw_usage_log_info *s = new rgw_usage_log_info;
+  list<rgw_usage_log_info> o;
+  rgw_usage_log_info s;
   std::string owner = "owner";
   std::string payer = "payer";
   std::string bucket = "bucket";
 
   rgw_usage_log_entry r(owner, payer, bucket);
-  s->entries.push_back(r);
-  o.push_back(s);
-  o.push_back(new rgw_usage_log_info);
+  s.entries.push_back(r);
+  o.push_back(std::move(s));
+  o.push_back(rgw_usage_log_info{});
+  return o;
 }
 
 void rgw_usage_log_info::dump(Formatter *f) const
@@ -797,13 +820,15 @@ void rgw_usage_log_info::dump(Formatter *f) const
   encode_json("entries", entries, f);
 }
 
-void rgw_user_bucket::generate_test_instances(list<rgw_user_bucket*>& o)
+list<rgw_user_bucket> rgw_user_bucket::generate_test_instances()
 {
-  rgw_user_bucket *s = new rgw_user_bucket;
-  s->user = "user";
-  s->bucket = "bucket";
-  o.push_back(s);
-  o.push_back(new rgw_user_bucket);
+  list<rgw_user_bucket> o;
+  rgw_user_bucket s;
+  s.user = "user";
+  s.bucket = "bucket";
+  o.push_back(std::move(s));
+  o.push_back(rgw_user_bucket{});
+  return o;
 }
 
 void rgw_user_bucket::dump(Formatter *f) const
@@ -847,23 +872,25 @@ void rgw_usage_log_entry::dump(Formatter *f) const
   f->close_section();
 }
 
-void rgw_usage_log_entry::generate_test_instances(list<rgw_usage_log_entry *> &o)
+list<rgw_usage_log_entry> rgw_usage_log_entry::generate_test_instances()
 {
-  rgw_usage_log_entry *entry = new rgw_usage_log_entry;
+  list<rgw_usage_log_entry> o;
+  rgw_usage_log_entry entry;
   rgw_usage_data usage_data{1024, 2048};
   rgw_s3select_usage_data s3select_usage_data{8192, 4096};
-  entry->owner = rgw_user("owner");
-  entry->payer = rgw_user("payer");
-  entry->bucket = "bucket";
-  entry->epoch = 1234;
-  entry->total_usage.bytes_sent = usage_data.bytes_sent;
-  entry->total_usage.bytes_received = usage_data.bytes_received;
-  entry->total_usage.ops = usage_data.ops;
-  entry->total_usage.successful_ops = usage_data.successful_ops;
-  entry->usage_map["get_obj"] = usage_data;
-  entry->s3select_usage = s3select_usage_data;
-  o.push_back(entry);
-  o.push_back(new rgw_usage_log_entry);
+  entry.owner = rgw_user("owner");
+  entry.payer = rgw_user("payer");
+  entry.bucket = "bucket";
+  entry.epoch = 1234;
+  entry.total_usage.bytes_sent = usage_data.bytes_sent;
+  entry.total_usage.bytes_received = usage_data.bytes_received;
+  entry.total_usage.ops = usage_data.ops;
+  entry.total_usage.successful_ops = usage_data.successful_ops;
+  entry.usage_map["get_obj"] = usage_data;
+  entry.s3select_usage = s3select_usage_data;
+  o.push_back(std::move(entry));
+  o.push_back(rgw_usage_log_entry{});
+  return o;
 }
 
 std::string to_string(cls_rgw_reshard_initiator i) {
@@ -901,16 +928,18 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("initiator", to_string(initiator), f);
 }
 
-void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>& ls)
+list<cls_rgw_reshard_entry> cls_rgw_reshard_entry::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_reshard_entry);
-  ls.push_back(new cls_rgw_reshard_entry);
-  ls.back()->time = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
-  ls.back()->tenant = "tenant";
-  ls.back()->bucket_name = "bucket1""";
-  ls.back()->bucket_id = "bucket_id";
-  ls.back()->old_num_shards = 8;
-  ls.back()->new_num_shards = 64;
+  list<cls_rgw_reshard_entry> ls;
+  ls.push_back(cls_rgw_reshard_entry{});
+  ls.push_back(cls_rgw_reshard_entry{});
+  ls.back().time = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
+  ls.back().tenant = "tenant";
+  ls.back().bucket_name = "bucket1""";
+  ls.back().bucket_id = "bucket_id";
+  ls.back().old_num_shards = 8;
+  ls.back().new_num_shards = 64;
+  return ls;
 }
 
 void cls_rgw_bucket_instance_entry::dump(Formatter *f) const
@@ -918,12 +947,13 @@ void cls_rgw_bucket_instance_entry::dump(Formatter *f) const
   encode_json("reshard_status", to_string(reshard_status), f);
 }
 
-void cls_rgw_bucket_instance_entry::generate_test_instances(
-list<cls_rgw_bucket_instance_entry*>& ls)
+list<cls_rgw_bucket_instance_entry> cls_rgw_bucket_instance_entry::generate_test_instances()
 {
-  ls.push_back(new cls_rgw_bucket_instance_entry);
-  ls.push_back(new cls_rgw_bucket_instance_entry);
-  ls.back()->reshard_status = RESHARD_STATUS::IN_PROGRESS;
+  list<cls_rgw_bucket_instance_entry> ls;
+  ls.push_back(cls_rgw_bucket_instance_entry{});
+  ls.push_back(cls_rgw_bucket_instance_entry{});
+  ls.back().reshard_status = RESHARD_STATUS::IN_PROGRESS;
+  return ls;
 }
 
 void cls_rgw_lc_entry::dump(Formatter *f) const
@@ -933,14 +963,16 @@ void cls_rgw_lc_entry::dump(Formatter *f) const
   encode_json("status", status, f);
 }
 
-void cls_rgw_lc_entry::generate_test_instances(list<cls_rgw_lc_entry*>& o)
+list<cls_rgw_lc_entry> cls_rgw_lc_entry::generate_test_instances()
 {
-  cls_rgw_lc_entry *s = new cls_rgw_lc_entry;
-  s->bucket = "bucket";
-  s->start_time = 10;
-  s->status = 1;
-  o.push_back(s);
-  o.push_back(new cls_rgw_lc_entry);
+  list<cls_rgw_lc_entry> o;
+  cls_rgw_lc_entry s;
+  s.bucket = "bucket";
+  s.start_time = 10;
+  s.status = 1;
+  o.push_back(std::move(s));
+  o.push_back(cls_rgw_lc_entry{});
+  return o;
 }
 
 void cls_rgw_lc_obj_head::dump(Formatter *f) const 
@@ -949,8 +981,9 @@ void cls_rgw_lc_obj_head::dump(Formatter *f) const
   encode_json("marker", marker, f);
 }
 
-void cls_rgw_lc_obj_head::generate_test_instances(list<cls_rgw_lc_obj_head*>& ls)
+list<cls_rgw_lc_obj_head> cls_rgw_lc_obj_head::generate_test_instances()
 {
+  return {};
 }
 
 std::ostream& operator<<(std::ostream& out, cls_rgw_reshard_status status) {

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -76,7 +76,7 @@ struct rgw_zone_set {
     ceph::decode(entries, bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_zone_set*>& o);
+  static std::list<rgw_zone_set> generate_test_instances();
   void insert(const std::string& zone, std::optional<std::string> location_key);
   bool exists(const std::string& zone, std::optional<std::string> location_key) const;
 };
@@ -170,7 +170,7 @@ struct rgw_bucket_pending_info {
   }
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bucket_pending_info*>& o);
+  static std::list<rgw_bucket_pending_info> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_pending_info)
 
@@ -252,7 +252,7 @@ struct rgw_bucket_dir_entry_meta {
   }
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bucket_dir_entry_meta*>& o);
+  static std::list<rgw_bucket_dir_entry_meta> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_dir_entry_meta)
 
@@ -352,7 +352,7 @@ struct rgw_bucket_entry_ver {
   }
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bucket_entry_ver*>& o);
+  static std::list<rgw_bucket_entry_ver> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_entry_ver)
 
@@ -464,7 +464,7 @@ struct rgw_bucket_dir_entry {
 
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bucket_dir_entry*>& o);
+  static std::list<rgw_bucket_dir_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_dir_entry)
 
@@ -503,7 +503,7 @@ struct rgw_cls_bi_entry {
 
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj, cls_rgw_obj_key *effective_key = NULL);
-  static void generate_test_instances(std::list<rgw_cls_bi_entry*>& o);
+  static std::list<rgw_cls_bi_entry> generate_test_instances();
   bool get_info(cls_rgw_obj_key *key, RGWObjCategory *category,
 		rgw_bucket_category_stats *accounted_stats) const;
 };
@@ -546,7 +546,7 @@ struct rgw_bucket_olh_log_entry {
     decode(delete_marker, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<rgw_bucket_olh_log_entry*>& o);
+  static std::list<rgw_bucket_olh_log_entry> generate_test_instances();
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
@@ -587,7 +587,7 @@ struct rgw_bucket_olh_entry {
   }
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bucket_olh_entry*>& o);
+  static std::list<rgw_bucket_olh_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_olh_entry)
 
@@ -606,7 +606,7 @@ struct rgw_bucket_deleted_entry {
   }
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bucket_deleted_entry*>& o);
+  static std::list<rgw_bucket_deleted_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_deleted_entry)
 
@@ -674,7 +674,7 @@ struct rgw_bi_log_entry {
   }
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bi_log_entry*>& o);
+  static std::list<rgw_bi_log_entry> generate_test_instances();
 
   bool is_versioned() {
     return ((bilog_flags & RGW_BILOG_FLAG_VERSIONED_OP) != 0);
@@ -716,7 +716,7 @@ struct rgw_bucket_category_stats {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_bucket_category_stats*>& o);
+  static std::list<rgw_bucket_category_stats> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_category_stats)
 
@@ -787,7 +787,7 @@ struct cls_rgw_bucket_instance_entry {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_bucket_instance_entry*>& o);
+  static std::list<cls_rgw_bucket_instance_entry> generate_test_instances();
 
   void clear() {
     reshard_status = RESHARD_STATUS::NOT_RESHARDING;
@@ -876,7 +876,7 @@ struct rgw_bucket_dir_header {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_bucket_dir_header*>& o);
+  static std::list<rgw_bucket_dir_header> generate_test_instances();
 
   bool resharding() const {
     return new_instance.resharding();
@@ -910,7 +910,7 @@ struct rgw_bucket_dir {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_bucket_dir*>& o);
+  static std::list<rgw_bucket_dir> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_bucket_dir)
 
@@ -942,7 +942,7 @@ struct rgw_s3select_usage_data {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_s3select_usage_data*>& o);
+  static std::list<rgw_s3select_usage_data> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_s3select_usage_data)
 
@@ -980,7 +980,7 @@ struct rgw_usage_data {
     successful_ops += usage.successful_ops;
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_usage_data*>& o);
+  static std::list<rgw_usage_data> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_usage_data)
 
@@ -1077,7 +1077,7 @@ struct rgw_usage_log_entry {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<rgw_usage_log_entry*>& o);
+  static std::list<rgw_usage_log_entry> generate_test_instances();
 
 };
 WRITE_CLASS_ENCODER(rgw_usage_log_entry)
@@ -1097,7 +1097,7 @@ struct rgw_usage_log_info {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<rgw_usage_log_info*>& o);
+  static std::list<rgw_usage_log_info> generate_test_instances();
 
   rgw_usage_log_info() {}
 };
@@ -1134,7 +1134,7 @@ struct rgw_user_bucket {
     return false;
   }
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<rgw_user_bucket*>& o);
+  static std::list<rgw_user_bucket> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_user_bucket)
 
@@ -1177,12 +1177,14 @@ struct cls_rgw_obj {
     f->dump_string("key", loc);
     f->dump_string("instance", key.instance);
   }
-  static void generate_test_instances(std::list<cls_rgw_obj*>& ls) {
-    ls.push_back(new cls_rgw_obj);
-    ls.push_back(new cls_rgw_obj);
-    ls.back()->pool = "mypool";
-    ls.back()->key.name = "myoid";
-    ls.back()->loc = "mykey";
+  static std::list<cls_rgw_obj> generate_test_instances() {
+    std::list<cls_rgw_obj> ls;
+    ls.push_back(cls_rgw_obj{});
+    ls.push_back(cls_rgw_obj{});
+    ls.back().pool = "mypool";
+    ls.back().key.name = "myoid";
+    ls.back().loc = "mykey";
+    return ls;
   }
 
   size_t estimate_encoded_size() const {
@@ -1229,8 +1231,10 @@ struct cls_rgw_obj_chain {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<cls_rgw_obj_chain*>& ls) {
-    ls.push_back(new cls_rgw_obj_chain);
+  static std::list<cls_rgw_obj_chain> generate_test_instances() {
+    std::list<cls_rgw_obj_chain> ls;
+    ls.push_back(cls_rgw_obj_chain{});
+    return ls;
   }
 
   bool empty() {
@@ -1280,12 +1284,14 @@ struct cls_rgw_gc_obj_info
     f->close_section();
     f->dump_stream("time") << time;
   }
-  static void generate_test_instances(std::list<cls_rgw_gc_obj_info*>& ls) {
-    ls.push_back(new cls_rgw_gc_obj_info);
-    ls.push_back(new cls_rgw_gc_obj_info);
-    ls.back()->tag = "footag";
+  static std::list<cls_rgw_gc_obj_info> generate_test_instances() {
+    std::list<cls_rgw_gc_obj_info> ls;
+    ls.push_back(cls_rgw_gc_obj_info{});
+    ls.push_back(cls_rgw_gc_obj_info{});
+    ls.back().tag = "footag";
     ceph_timespec ts{ceph_le32(21), ceph_le32(32)};
-    ls.back()->time = ceph::real_clock::from_ceph_timespec(ts);
+    ls.back().time = ceph::real_clock::from_ceph_timespec(ts);
+    return ls;
   }
 
   size_t estimate_encoded_size() const {
@@ -1331,7 +1337,7 @@ struct cls_rgw_lc_obj_head
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_lc_obj_head*>& ls);
+  static std::list<cls_rgw_lc_obj_head> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_obj_head)
 
@@ -1364,7 +1370,7 @@ struct cls_rgw_lc_entry {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_lc_entry*>& ls);
+  static std::list<cls_rgw_lc_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_entry);
 
@@ -1426,7 +1432,7 @@ struct cls_rgw_reshard_entry
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_rgw_reshard_entry*>& o);
+  static std::list<cls_rgw_reshard_entry> generate_test_instances();
 
   static void generate_key(const std::string& tenant, const std::string& bucket_name, std::string *key);
   void get_key(std::string *key) const;

--- a/src/cls/rgw_gc/cls_rgw_gc_ops.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_ops.h
@@ -30,10 +30,12 @@ struct cls_rgw_gc_queue_init_op {
     f->dump_unsigned("num_deferred_entries", num_deferred_entries);
   }
 
-  static void generate_test_instances(std::list<cls_rgw_gc_queue_init_op*>& o) {
-    o.push_back(new cls_rgw_gc_queue_init_op);
-    o.back()->size = 1024;
-    o.back()->num_deferred_entries = 512;
+  static std::list<cls_rgw_gc_queue_init_op> generate_test_instances() {
+    std::list<cls_rgw_gc_queue_init_op> o;
+    o.push_back(cls_rgw_gc_queue_init_op{});
+    o.back().size = 1024;
+    o.back().num_deferred_entries = 512;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_queue_init_op)

--- a/src/cls/rgw_gc/cls_rgw_gc_types.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_types.h
@@ -40,12 +40,14 @@ struct cls_rgw_gc_urgent_data
     f->dump_unsigned("num_head_urgent_entries", num_head_urgent_entries);
     f->dump_unsigned("num_xattr_urgent_entries", num_xattr_urgent_entries);
   }
-  static void generate_test_instances(std::list<cls_rgw_gc_urgent_data*>& o) {
-    o.push_back(new cls_rgw_gc_urgent_data);
-    o.push_back(new cls_rgw_gc_urgent_data);
-    o.back()->num_urgent_data_entries = 1024;
-    o.back()->num_head_urgent_entries = 512;
-    o.back()->num_xattr_urgent_entries = 512;
+  static std::list<cls_rgw_gc_urgent_data> generate_test_instances() {
+    std::list<cls_rgw_gc_urgent_data> o;
+    o.push_back(cls_rgw_gc_urgent_data{});
+    o.push_back(cls_rgw_gc_urgent_data{});
+    o.back().num_urgent_data_entries = 1024;
+    o.back().num_head_urgent_entries = 512;
+    o.back().num_xattr_urgent_entries = 512;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_urgent_data)

--- a/src/cls/timeindex/cls_timeindex_ops.h
+++ b/src/cls/timeindex/cls_timeindex_ops.h
@@ -64,13 +64,15 @@ struct cls_timeindex_list_op {
     f->dump_int("max_entries", max_entries);
   }
 
-  static void generate_test_instances(std::list<cls_timeindex_list_op*>& o) {
-    o.push_back(new cls_timeindex_list_op);
-    o.push_back(new cls_timeindex_list_op);
-    o.back()->from_time = utime_t(1, 2);
-    o.back()->marker = "marker";
-    o.back()->to_time = utime_t(3, 4);
-    o.back()->max_entries = 5;
+  static std::list<cls_timeindex_list_op> generate_test_instances() {
+    std::list<cls_timeindex_list_op> o;
+    o.push_back(cls_timeindex_list_op{});
+    o.push_back(cls_timeindex_list_op{});
+    o.back().from_time = utime_t(1, 2);
+    o.back().marker = "marker";
+    o.back().to_time = utime_t(3, 4);
+    o.back().max_entries = 5;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_timeindex_list_op)
@@ -104,15 +106,17 @@ struct cls_timeindex_list_ret {
     f->dump_bool("truncated", truncated);
   }
 
-  static void generate_test_instances(std::list<cls_timeindex_list_ret*>& o) {
-    o.push_back(new cls_timeindex_list_ret);
-    o.push_back(new cls_timeindex_list_ret);
-    o.back()->entries.push_back(cls_timeindex_entry());
-    o.back()->entries.back().key_ts = utime_t(1, 2);
-    o.back()->entries.back().key_ext = "key_ext";
-    o.back()->entries.back().value.append("value");
-    o.back()->marker = "marker";
-    o.back()->truncated = true;
+  static std::list<cls_timeindex_list_ret> generate_test_instances() {
+    std::list<cls_timeindex_list_ret> o;
+    o.push_back(cls_timeindex_list_ret{});
+    o.push_back(cls_timeindex_list_ret{});
+    o.back().entries.push_back(cls_timeindex_entry());
+    o.back().entries.back().key_ts = utime_t(1, 2);
+    o.back().entries.back().key_ext = "key_ext";
+    o.back().entries.back().value.append("value");
+    o.back().marker = "marker";
+    o.back().truncated = true;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_timeindex_list_ret)

--- a/src/cls/timeindex/cls_timeindex_types.cc
+++ b/src/cls/timeindex/cls_timeindex_types.cc
@@ -8,14 +8,16 @@ void cls_timeindex_entry::dump(Formatter *f) const
   f->dump_string("value", value.to_str());
 }
 
-void cls_timeindex_entry::generate_test_instances(std::list<cls_timeindex_entry*>& o)
+std::list<cls_timeindex_entry> cls_timeindex_entry::generate_test_instances()
 {
-  cls_timeindex_entry *i = new cls_timeindex_entry;
-  i->key_ts = utime_t(0,0);
-  i->key_ext = "foo";
+  std::list<cls_timeindex_entry> o;
+  cls_timeindex_entry i;
+  i.key_ts = utime_t(0,0);
+  i.key_ext = "foo";
   bufferlist bl;
   bl.append("bar");
-  i->value = bl;
-  o.push_back(i);
-  o.push_back(new cls_timeindex_entry);
+  i.value = bl;
+  o.push_back(std::move(i));
+  o.push_back(cls_timeindex_entry{});
+  return o;
 }

--- a/src/cls/timeindex/cls_timeindex_types.h
+++ b/src/cls/timeindex/cls_timeindex_types.h
@@ -39,7 +39,7 @@ struct cls_timeindex_entry {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_timeindex_entry*>& o);
+  static std::list<cls_timeindex_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_timeindex_entry)
 

--- a/src/cls/user/cls_user_ops.cc
+++ b/src/cls/user/cls_user_ops.cc
@@ -16,18 +16,20 @@ void cls_user_set_buckets_op::dump(Formatter *f) const
   encode_json("time", utime_t(time), f);
 }
 
-void cls_user_set_buckets_op::generate_test_instances(list<cls_user_set_buckets_op*>& ls)
+list<cls_user_set_buckets_op> cls_user_set_buckets_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_set_buckets_op);
-  cls_user_set_buckets_op *op = new cls_user_set_buckets_op;
+  list<cls_user_set_buckets_op> ls;
+  ls.push_back(cls_user_set_buckets_op{});
+  cls_user_set_buckets_op op;
   for (int i = 0; i < 3; i++) {
     cls_user_bucket_entry e;
     cls_user_gen_test_bucket_entry(&e, i);
-    op->entries.push_back(e);
+    op.entries.push_back(e);
   }
-  op->add = true;
-  op->time = utime_t(1, 0).to_real_time();
+  op.add = true;
+  op.time = utime_t(1, 0).to_real_time();
   ls.push_back(op);
+  return ls;
 }
 
 void cls_user_remove_bucket_op::dump(Formatter *f) const
@@ -35,12 +37,14 @@ void cls_user_remove_bucket_op::dump(Formatter *f) const
   encode_json("bucket", bucket, f);
 }
 
-void cls_user_remove_bucket_op::generate_test_instances(list<cls_user_remove_bucket_op*>& ls)
+list<cls_user_remove_bucket_op> cls_user_remove_bucket_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_remove_bucket_op);
-  cls_user_remove_bucket_op *op = new cls_user_remove_bucket_op;
-  cls_user_gen_test_bucket(&op->bucket, 0);
-  ls.push_back(op);
+  list<cls_user_remove_bucket_op> ls;
+  ls.push_back(cls_user_remove_bucket_op{});
+  cls_user_remove_bucket_op op;
+  cls_user_gen_test_bucket(&op.bucket, 0);
+  ls.push_back(std::move(op));
+  return ls;
 }
 
 void cls_user_list_buckets_op::dump(Formatter *f) const
@@ -49,13 +53,15 @@ void cls_user_list_buckets_op::dump(Formatter *f) const
   encode_json("max_entries", max_entries, f);
 }
 
-void cls_user_list_buckets_op::generate_test_instances(list<cls_user_list_buckets_op*>& ls)
+list<cls_user_list_buckets_op> cls_user_list_buckets_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_list_buckets_op);
-  cls_user_list_buckets_op *op = new cls_user_list_buckets_op;
-  op->marker = "marker";
-  op->max_entries = 1000;
-  ls.push_back(op);
+  list<cls_user_list_buckets_op> ls;
+  ls.push_back(cls_user_list_buckets_op{});
+  cls_user_list_buckets_op op;;
+  op.marker = "marker";
+  op.max_entries = 1000;
+  ls.push_back(std::move(op));
+  return ls;
 }
 
 void cls_user_list_buckets_ret::dump(Formatter *f) const
@@ -65,18 +71,20 @@ void cls_user_list_buckets_ret::dump(Formatter *f) const
   encode_json("truncated", truncated, f);
 }
 
-void cls_user_list_buckets_ret::generate_test_instances(list<cls_user_list_buckets_ret*>& ls)
+list<cls_user_list_buckets_ret> cls_user_list_buckets_ret::generate_test_instances()
 {
-  ls.push_back(new cls_user_list_buckets_ret);
-  cls_user_list_buckets_ret *ret = new cls_user_list_buckets_ret;
+  list<cls_user_list_buckets_ret> ls;
+  ls.push_back(cls_user_list_buckets_ret{});
+  cls_user_list_buckets_ret ret;;
   for (int i = 0; i < 3; i++) {
     cls_user_bucket_entry e;
     cls_user_gen_test_bucket_entry(&e, i);
-    ret->entries.push_back(e);
+    ret.entries.push_back(e);
   }
-  ret->marker = "123";
-  ret->truncated = true;
-  ls.push_back(ret);
+  ret.marker = "123";
+  ret.truncated = true;
+  ls.push_back(std::move(ret));
+  return ls;
 }
 
 void cls_user_get_header_op::dump(Formatter *f) const
@@ -84,9 +92,11 @@ void cls_user_get_header_op::dump(Formatter *f) const
   // empty!
 }
 
-void cls_user_get_header_op::generate_test_instances(list<cls_user_get_header_op*>& ls)
+list<cls_user_get_header_op> cls_user_get_header_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_get_header_op);
+  list<cls_user_get_header_op> ls;
+  ls.push_back(cls_user_get_header_op{});
+  return ls;
 }
 
 void cls_user_get_header_ret::dump(Formatter *f) const
@@ -94,12 +104,14 @@ void cls_user_get_header_ret::dump(Formatter *f) const
   encode_json("header", header, f);
 }
 
-void cls_user_get_header_ret::generate_test_instances(list<cls_user_get_header_ret*>& ls)
+list<cls_user_get_header_ret> cls_user_get_header_ret::generate_test_instances()
 {
-  ls.push_back(new cls_user_get_header_ret);
-  cls_user_get_header_ret *ret = new cls_user_get_header_ret;
-  cls_user_gen_test_header(&ret->header);
-  ls.push_back(ret);
+  list<cls_user_get_header_ret> ls;
+  ls.push_back(cls_user_get_header_ret{});
+  cls_user_get_header_ret ret;
+  cls_user_gen_test_header(&ret.header);
+  ls.push_back(std::move(ret));
+  return ls;
 }
 
 void cls_user_complete_stats_sync_op::dump(Formatter *f) const
@@ -107,12 +119,14 @@ void cls_user_complete_stats_sync_op::dump(Formatter *f) const
   encode_json("time", utime_t(time), f);
 }
 
-void cls_user_complete_stats_sync_op::generate_test_instances(list<cls_user_complete_stats_sync_op*>& ls)
+list<cls_user_complete_stats_sync_op> cls_user_complete_stats_sync_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_complete_stats_sync_op);
-  cls_user_complete_stats_sync_op *op = new cls_user_complete_stats_sync_op;
-  op->time = utime_t(12345, 0).to_real_time();
-  ls.push_back(op);
+  list<cls_user_complete_stats_sync_op> ls;
+  ls.push_back(cls_user_complete_stats_sync_op{});
+  cls_user_complete_stats_sync_op op;
+  op.time = utime_t(12345, 0).to_real_time();
+  ls.push_back(std::move(op));
+  return ls;
 }
 
 
@@ -123,12 +137,14 @@ void cls_user_account_resource_add_op::dump(Formatter *f) const
   encode_json("limit", limit, f);
 }
 
-void cls_user_account_resource_add_op::generate_test_instances(std::list<cls_user_account_resource_add_op*>& ls)
+std::list<cls_user_account_resource_add_op> cls_user_account_resource_add_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_resource_add_op);
-  cls_user_account_resource_add_op *op = new cls_user_account_resource_add_op;
-  cls_user_gen_test_resource(op->entry);
-  ls.push_back(op);
+  std::list<cls_user_account_resource_add_op> ls;
+  ls.push_back(cls_user_account_resource_add_op{});
+  cls_user_account_resource_add_op op;
+  cls_user_gen_test_resource(op.entry);
+  ls.push_back(std::move(op));
+  return ls;
 }
 
 void cls_user_account_resource_get_op::dump(Formatter *f) const
@@ -136,12 +152,14 @@ void cls_user_account_resource_get_op::dump(Formatter *f) const
   encode_json("name", name, f);
 }
 
-void cls_user_account_resource_get_op::generate_test_instances(std::list<cls_user_account_resource_get_op*>& ls)
+std::list<cls_user_account_resource_get_op> cls_user_account_resource_get_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_resource_get_op);
-  cls_user_account_resource_get_op *op = new cls_user_account_resource_get_op;
-  op->name = "name";
-  ls.push_back(op);
+  std::list<cls_user_account_resource_get_op> ls;
+  ls.push_back(cls_user_account_resource_get_op{});
+  cls_user_account_resource_get_op op;
+  op.name = "name";
+  ls.push_back(std::move(op));
+  return ls;
 }
 
 void cls_user_account_resource_get_ret::dump(Formatter *f) const
@@ -149,12 +167,14 @@ void cls_user_account_resource_get_ret::dump(Formatter *f) const
   encode_json("entry", entry, f);
 }
 
-void cls_user_account_resource_get_ret::generate_test_instances(std::list<cls_user_account_resource_get_ret*>& ls)
+std::list<cls_user_account_resource_get_ret> cls_user_account_resource_get_ret::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_resource_get_ret);
-  cls_user_account_resource_get_ret *ret = new cls_user_account_resource_get_ret;
-  cls_user_gen_test_resource(ret->entry);
-  ls.push_back(ret);
+  std::list<cls_user_account_resource_get_ret> ls;
+  ls.push_back(cls_user_account_resource_get_ret{});
+  cls_user_account_resource_get_ret ret;
+  cls_user_gen_test_resource(ret.entry);
+  ls.push_back(std::move(ret));
+  return ls;
 }
 
 void cls_user_account_resource_rm_op::dump(Formatter *f) const
@@ -162,12 +182,14 @@ void cls_user_account_resource_rm_op::dump(Formatter *f) const
   encode_json("name", name, f);
 }
 
-void cls_user_account_resource_rm_op::generate_test_instances(std::list<cls_user_account_resource_rm_op*>& ls)
+std::list<cls_user_account_resource_rm_op> cls_user_account_resource_rm_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_resource_rm_op);
-  cls_user_account_resource_rm_op *op = new cls_user_account_resource_rm_op;
-  op->name = "name";
-  ls.push_back(op);
+  std::list<cls_user_account_resource_rm_op> ls;
+  ls.push_back(cls_user_account_resource_rm_op{});
+  cls_user_account_resource_rm_op op;
+  op.name = "name";
+  ls.push_back(std::move(op));
+  return ls;
 }
 
 void cls_user_account_resource_list_op::dump(Formatter *f) const
@@ -177,14 +199,16 @@ void cls_user_account_resource_list_op::dump(Formatter *f) const
   encode_json("max_entries", max_entries, f);
 }
 
-void cls_user_account_resource_list_op::generate_test_instances(std::list<cls_user_account_resource_list_op*>& ls)
+std::list<cls_user_account_resource_list_op> cls_user_account_resource_list_op::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_resource_list_op);
-  cls_user_account_resource_list_op *op = new cls_user_account_resource_list_op;
-  op->marker = "marker";
-  op->path_prefix = "path";
-  op->max_entries = 20;
-  ls.push_back(op);
+  std::list<cls_user_account_resource_list_op> ls;
+  ls.push_back(cls_user_account_resource_list_op{});
+  cls_user_account_resource_list_op op;
+  op.marker = "marker";
+  op.path_prefix = "path";
+  op.max_entries = 20;
+  ls.push_back(std::move(op));
+  return ls;
 }
 
 void cls_user_account_resource_list_ret::dump(Formatter *f) const
@@ -194,11 +218,13 @@ void cls_user_account_resource_list_ret::dump(Formatter *f) const
   encode_json("marker", marker, f);
 }
 
-void cls_user_account_resource_list_ret::generate_test_instances(std::list<cls_user_account_resource_list_ret*>& ls)
+std::list<cls_user_account_resource_list_ret> cls_user_account_resource_list_ret::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_resource_list_ret);
-  cls_user_account_resource_list_ret *ret = new cls_user_account_resource_list_ret;
-  cls_user_gen_test_resource(ret->entries.emplace_back());
-  ret->truncated = true;
-  ls.push_back(ret);
+  std::list<cls_user_account_resource_list_ret> ls;
+  ls.push_back(cls_user_account_resource_list_ret{});
+  cls_user_account_resource_list_ret ret;
+  cls_user_gen_test_resource(ret.entries.emplace_back());
+  ret.truncated = true;
+  ls.push_back(std::move(ret));
+  return ls;
 }

--- a/src/cls/user/cls_user_ops.h
+++ b/src/cls/user/cls_user_ops.h
@@ -30,7 +30,7 @@ struct cls_user_set_buckets_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_set_buckets_op*>& ls);
+  static std::list<cls_user_set_buckets_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_set_buckets_op)
 
@@ -52,7 +52,7 @@ struct cls_user_remove_bucket_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_remove_bucket_op*>& ls);
+  static std::list<cls_user_remove_bucket_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_remove_bucket_op)
 
@@ -84,7 +84,7 @@ struct cls_user_list_buckets_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_list_buckets_op*>& ls);
+  static std::list<cls_user_list_buckets_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_list_buckets_op)
 
@@ -112,7 +112,7 @@ struct cls_user_list_buckets_ret {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_list_buckets_ret*>& ls);
+  static std::list<cls_user_list_buckets_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_list_buckets_ret)
 
@@ -131,7 +131,7 @@ struct cls_user_get_header_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_get_header_op*>& ls);
+  static std::list<cls_user_get_header_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_get_header_op)
 
@@ -152,7 +152,7 @@ struct cls_user_reset_stats_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_reset_stats_op*>& ls);
+  static std::list<cls_user_reset_stats_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_reset_stats_op);
 
@@ -180,7 +180,7 @@ struct cls_user_reset_stats2_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_reset_stats2_op*>& ls);
+  static std::list<cls_user_reset_stats2_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_reset_stats2_op);
 
@@ -214,8 +214,7 @@ struct cls_user_reset_stats2_ret {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(
-    std::list<cls_user_reset_stats2_ret*>& ls);
+  static std::list<cls_user_reset_stats2_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_reset_stats2_ret);
 
@@ -237,7 +236,7 @@ struct cls_user_get_header_ret {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_get_header_ret*>& ls);
+  static std::list<cls_user_get_header_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_get_header_ret)
 
@@ -259,7 +258,7 @@ struct cls_user_complete_stats_sync_op {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_complete_stats_sync_op*>& ls);
+  static std::list<cls_user_complete_stats_sync_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_complete_stats_sync_op)
 
@@ -285,7 +284,7 @@ struct cls_user_account_resource_add_op {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_resource_add_op*>& ls);
+  static std::list<cls_user_account_resource_add_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_resource_add_op)
 
@@ -304,7 +303,7 @@ struct cls_user_account_resource_get_op {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_resource_get_op*>& ls);
+  static std::list<cls_user_account_resource_get_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_resource_get_op)
 
@@ -323,7 +322,7 @@ struct cls_user_account_resource_get_ret {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_resource_get_ret*>& ls);
+  static std::list<cls_user_account_resource_get_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_resource_get_ret)
 
@@ -342,7 +341,7 @@ struct cls_user_account_resource_rm_op {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_resource_rm_op*>& ls);
+  static std::list<cls_user_account_resource_rm_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_resource_rm_op)
 
@@ -367,7 +366,7 @@ struct cls_user_account_resource_list_op {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_resource_list_op*>& ls);
+  static std::list<cls_user_account_resource_list_op> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_resource_list_op)
 
@@ -392,7 +391,7 @@ struct cls_user_account_resource_list_ret {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_resource_list_ret*>& ls);
+  static std::list<cls_user_account_resource_list_ret> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_resource_list_ret)
 

--- a/src/cls/user/cls_user_types.cc
+++ b/src/cls/user/cls_user_types.cc
@@ -30,12 +30,14 @@ void cls_user_bucket::dump(Formatter *f) const
   encode_json("bucket_id", bucket_id,f);
 }
 
-void cls_user_bucket::generate_test_instances(list<cls_user_bucket*>& ls)
+list<cls_user_bucket> cls_user_bucket::generate_test_instances()
 {
-  ls.push_back(new cls_user_bucket);
-  cls_user_bucket *b = new cls_user_bucket;
-  cls_user_gen_test_bucket(b, 0);
-  ls.push_back(b);
+  list<cls_user_bucket> ls;
+  ls.push_back(cls_user_bucket{});
+  cls_user_bucket b;
+  cls_user_gen_test_bucket(&b, 0);
+  ls.push_back(std::move(b));
+  return ls;
 }
 
 void cls_user_bucket_entry::dump(Formatter *f) const
@@ -58,12 +60,14 @@ void cls_user_gen_test_bucket_entry(cls_user_bucket_entry *entry, int i)
   entry->user_stats_sync = true;
 }
 
-void cls_user_bucket_entry::generate_test_instances(list<cls_user_bucket_entry*>& ls)
+list<cls_user_bucket_entry> cls_user_bucket_entry::generate_test_instances()
 {
-  ls.push_back(new cls_user_bucket_entry);
-  cls_user_bucket_entry *entry = new cls_user_bucket_entry;
-  cls_user_gen_test_bucket_entry(entry, 0);
-  ls.push_back(entry);
+  list<cls_user_bucket_entry> ls;
+  ls.push_back(cls_user_bucket_entry{});
+  cls_user_bucket_entry entry;
+  cls_user_gen_test_bucket_entry(&entry, 0);
+  ls.push_back(std::move(entry));
+  return ls;
 }
 
 void cls_user_gen_test_stats(cls_user_stats *s)
@@ -80,12 +84,14 @@ void cls_user_stats::dump(Formatter *f) const
   f->dump_int("total_bytes_rounded", total_bytes_rounded);
 }
 
-void cls_user_stats::generate_test_instances(list<cls_user_stats*>& ls)
+list<cls_user_stats> cls_user_stats::generate_test_instances()
 {
-  ls.push_back(new cls_user_stats);
-  cls_user_stats *s = new cls_user_stats;
-  cls_user_gen_test_stats(s);
-  ls.push_back(s);
+  list<cls_user_stats> ls;
+  ls.push_back(cls_user_stats{});
+  cls_user_stats s;
+  cls_user_gen_test_stats(&s);
+  ls.push_back(std::move(s));
+  return ls;
 }
 
 void cls_user_gen_test_header(cls_user_header *h)
@@ -102,12 +108,14 @@ void cls_user_header::dump(Formatter *f) const
   encode_json("last_stats_update", utime_t(last_stats_update), f);
 }
 
-void cls_user_header::generate_test_instances(list<cls_user_header*>& ls)
+list<cls_user_header> cls_user_header::generate_test_instances()
 {
-  ls.push_back(new cls_user_header);
-  cls_user_header *h = new cls_user_header;
-  cls_user_gen_test_header(h);
-  ls.push_back(h);
+  list<cls_user_header> ls;
+  ls.push_back(cls_user_header{});
+  cls_user_header h;
+  cls_user_gen_test_header(&h);
+  ls.push_back(std::move(h));
+  return ls;
 }
 
 
@@ -116,9 +124,11 @@ void cls_user_account_header::dump(ceph::Formatter* f) const
   encode_json("count", count, f);
 }
 
-void cls_user_account_header::generate_test_instances(std::list<cls_user_account_header*>& ls)
+std::list<cls_user_account_header> cls_user_account_header::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_header);
+  std::list<cls_user_account_header> ls;
+  ls.push_back(cls_user_account_header{});
+  return ls;
 }
 
 void cls_user_account_resource::dump(ceph::Formatter* f) const
@@ -134,10 +144,12 @@ void cls_user_gen_test_resource(cls_user_account_resource& r)
   r.path = "path";
 }
 
-void cls_user_account_resource::generate_test_instances(std::list<cls_user_account_resource*>& ls)
+std::list<cls_user_account_resource> cls_user_account_resource::generate_test_instances()
 {
-  ls.push_back(new cls_user_account_resource);
-  auto p = new cls_user_account_resource;
-  cls_user_gen_test_resource(*p);
-  ls.push_back(p);
+  std::list<cls_user_account_resource> ls;
+  ls.push_back(cls_user_account_resource{});
+  cls_user_account_resource p;
+  cls_user_gen_test_resource(p);
+  ls.push_back(std::move(p));
+  return ls;
 }

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -90,7 +90,7 @@ struct cls_user_bucket {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_bucket*>& ls);
+  static std::list<cls_user_bucket> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_bucket)
 
@@ -154,7 +154,7 @@ struct cls_user_bucket_entry {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_bucket_entry*>& ls);
+  static std::list<cls_user_bucket_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_bucket_entry)
 
@@ -184,7 +184,7 @@ struct cls_user_stats {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_stats*>& ls);
+  static std::list<cls_user_stats> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_stats)
 
@@ -212,7 +212,7 @@ struct cls_user_header {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cls_user_header*>& ls);
+  static std::list<cls_user_header> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_header)
 
@@ -231,7 +231,7 @@ struct cls_user_account_header {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_header*>& ls);
+  static std::list<cls_user_account_header> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_header)
 
@@ -259,7 +259,7 @@ struct cls_user_account_resource {
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<cls_user_account_resource*>& ls);
+  static std::list<cls_user_account_resource> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(cls_user_account_resource)
 

--- a/src/cls/version/cls_version_ops.h
+++ b/src/cls/version/cls_version_ops.h
@@ -28,11 +28,13 @@ struct cls_version_set_op {
     f->dump_object("objv", objv);
   }
 
-  static void generate_test_instances(std::list<cls_version_set_op*>& o) {
-    o.push_back(new cls_version_set_op);
-    o.push_back(new cls_version_set_op);
-    o.back()->objv.ver = 123;
-    o.back()->objv.tag = "foo";
+  static std::list<cls_version_set_op> generate_test_instances() {
+    std::list<cls_version_set_op> o;
+    o.push_back(cls_version_set_op{});
+    o.push_back(cls_version_set_op{});
+    o.back().objv.ver = 123;
+    o.back().objv.tag = "foo";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_version_set_op)
@@ -62,15 +64,17 @@ struct cls_version_inc_op {
     encode_json("conds", conds, f);
   }
 
-  static void generate_test_instances(std::list<cls_version_inc_op*>& o) {
-    o.push_back(new cls_version_inc_op);
-    o.push_back(new cls_version_inc_op);
-    o.back()->objv.ver = 123;
-    o.back()->objv.tag = "foo";
-    o.back()->conds.push_back(obj_version_cond());
-    o.back()->conds.back().ver.ver = 123;
-    o.back()->conds.back().ver.tag = "foo";
-    o.back()->conds.back().cond = VER_COND_GE;
+  static std::list<cls_version_inc_op> generate_test_instances() {
+    std::list<cls_version_inc_op> o;
+    o.push_back(cls_version_inc_op{});
+    o.push_back(cls_version_inc_op{});
+    o.back().objv.ver = 123;
+    o.back().objv.tag = "foo";
+    o.back().conds.push_back(obj_version_cond());
+    o.back().conds.back().ver.ver = 123;
+    o.back().conds.back().ver.tag = "foo";
+    o.back().conds.back().cond = VER_COND_GE;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_version_inc_op)
@@ -100,15 +104,17 @@ struct cls_version_check_op {
     encode_json("conds", conds, f);
   }
 
-  static void generate_test_instances(std::list<cls_version_check_op*>& o) {
-    o.push_back(new cls_version_check_op);
-    o.push_back(new cls_version_check_op);
-    o.back()->objv.ver = 123;
-    o.back()->objv.tag = "foo";
-    o.back()->conds.push_back(obj_version_cond());
-    o.back()->conds.back().ver.ver = 123;
-    o.back()->conds.back().ver.tag = "foo";
-    o.back()->conds.back().cond = VER_COND_GE;
+  static std::list<cls_version_check_op> generate_test_instances() {
+    std::list<cls_version_check_op> o;
+    o.push_back(cls_version_check_op{});
+    o.push_back(cls_version_check_op{});
+    o.back().objv.ver = 123;
+    o.back().objv.tag = "foo";
+    o.back().conds.push_back(obj_version_cond());
+    o.back().conds.back().ver.ver = 123;
+    o.back().conds.back().ver.tag = "foo";
+    o.back().conds.back().cond = VER_COND_GE;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_version_check_op)
@@ -134,11 +140,13 @@ struct cls_version_read_ret {
     f->dump_object("objv", objv);
   }
 
-  static void generate_test_instances(std::list<cls_version_read_ret*>& o) {
-    o.push_back(new cls_version_read_ret);
-    o.push_back(new cls_version_read_ret);
-    o.back()->objv.ver = 123;
-    o.back()->objv.tag = "foo";
+  static std::list<cls_version_read_ret> generate_test_instances() {
+    std::list<cls_version_read_ret> o;
+    o.push_back(cls_version_read_ret{});
+    o.push_back(cls_version_read_ret{});
+    o.back().objv.ver = 123;
+    o.back().objv.tag = "foo";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(cls_version_read_ret)

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -67,7 +67,7 @@ struct obj_version {
   }
 
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<obj_version*>& o);
+  static std::list<obj_version> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(obj_version)
 
@@ -112,12 +112,14 @@ struct obj_version_cond {
     f->dump_unsigned("cond", cond);
   }
 
-  static void generate_test_instances(std::list<obj_version_cond*>& o) {
-    o.push_back(new obj_version_cond);
-    o.push_back(new obj_version_cond);
-    o.back()->ver.ver = 1;
-    o.back()->ver.tag = "foo";
-    o.back()->cond = VER_COND_EQ;
+  static std::list<obj_version_cond> generate_test_instances() {
+    std::list<obj_version_cond> o;
+    o.push_back(obj_version_cond{});
+    o.push_back(obj_version_cond{});
+    o.back().ver.ver = 1;
+    o.back().ver.tag = "foo";
+    o.back().cond = VER_COND_EQ;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(obj_version_cond)

--- a/src/common/CompatSet.cc
+++ b/src/common/CompatSet.cc
@@ -81,13 +81,15 @@ void CompatSet::dump(ceph::Formatter *f) const {
   f->close_section();
 }
 
-void CompatSet::generate_test_instances(std::list<CompatSet*>& o) {
-  o.push_back(new CompatSet);
-  o.push_back(new CompatSet);
-  o.back()->compat.insert(Feature(1, "one"));
-  o.back()->compat.insert(Feature(2, "two"));
-  o.back()->ro_compat.insert(Feature(4, "four"));
-  o.back()->incompat.insert(Feature(3, "three"));
+std::list<CompatSet> CompatSet::generate_test_instances() {
+  std::list<CompatSet> o;
+  o.push_back(CompatSet{});
+  o.push_back(CompatSet{});
+  o.back().compat.insert(Feature(1, "one"));
+  o.back().compat.insert(Feature(2, "two"));
+  o.back().ro_compat.insert(Feature(4, "four"));
+  o.back().incompat.insert(Feature(3, "three"));
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& out, const CompatSet::Feature& f)

--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -55,13 +55,16 @@ void DecayCounter::dump(ceph::Formatter *f) const
   f->dump_float("halflife", rate.get_halflife());
 }
 
-void DecayCounter::generate_test_instances(std::list<DecayCounter*>& ls)
+std::list<DecayCounter> DecayCounter::generate_test_instances()
 {
-  DecayCounter *counter = new DecayCounter();
-  counter->val = 3.0;
-  ls.push_back(counter);
-  counter = new DecayCounter();
-  ls.push_back(counter);
+  std::list<DecayCounter>ls;
+
+  DecayCounter counter;
+  counter.val = 3.0;
+  ls.push_back(std::move(counter));
+  counter = DecayCounter();
+  ls.push_back(std::move(counter));
+  return ls;
 }
 
 void DecayCounter::decay(double delta) const

--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -63,7 +63,7 @@ public:
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<DecayCounter*>& ls);
+  static std::list<DecayCounter> generate_test_instances();
 
   /**
    * reading

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -29,10 +29,12 @@ void LogEntryKey::dump(Formatter *f) const
   f->dump_unsigned("seq", seq);
 }
 
-void LogEntryKey::generate_test_instances(list<LogEntryKey*>& o)
+list<LogEntryKey> LogEntryKey::generate_test_instances()
 {
-  o.push_back(new LogEntryKey);
-  o.push_back(new LogEntryKey(entity_name_t::CLIENT(1234), utime_t(1,2), 34));
+  list<LogEntryKey> o;
+  o.push_back(LogEntryKey{});
+  o.push_back(LogEntryKey(entity_name_t::CLIENT(1234), utime_t(1,2), 34));
+  return o;
 }
 
 clog_type LogEntry::str_to_level(std::string const &str)
@@ -269,9 +271,11 @@ void LogEntry::dump(Formatter *f) const
   f->dump_string("message", msg);
 }
 
-void LogEntry::generate_test_instances(list<LogEntry*>& o)
+list<LogEntry> LogEntry::generate_test_instances()
 {
-  o.push_back(new LogEntry);
+  list<LogEntry> o;
+  o.push_back(LogEntry{});
+  return o;
 }
 
 
@@ -352,8 +356,10 @@ void LogSummary::dump(Formatter *f) const
   f->close_section();
 }
 
-void LogSummary::generate_test_instances(list<LogSummary*>& o)
+list<LogSummary> LogSummary::generate_test_instances()
 {
-  o.push_back(new LogSummary);
+  list<LogSummary> o;
+  o.push_back(LogSummary{});
   // more!
+  return o;
 }

--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -83,7 +83,7 @@ public:
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<LogEntryKey*>& o);
+  static std::list<LogEntryKey> generate_test_instances();
 
   friend bool operator==(const LogEntryKey& l, const LogEntryKey& r) {
     return l.rank == r.rank && l.stamp == r.stamp && l.seq == r.seq;
@@ -132,7 +132,7 @@ struct LogEntry {
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<LogEntry*>& o);
+  static std::list<LogEntry> generate_test_instances();
   static clog_type str_to_level(std::string const &str);
   static std::string_view level_to_str(clog_type t) {
     switch (t) {
@@ -191,7 +191,7 @@ struct LogSummary {
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<LogSummary*>& o);
+  static std::list<LogSummary> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(LogSummary)
 

--- a/src/common/SloppyCRCMap.cc
+++ b/src/common/SloppyCRCMap.cc
@@ -171,13 +171,15 @@ void SloppyCRCMap::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void SloppyCRCMap::generate_test_instances(list<SloppyCRCMap*>& ls)
+list<SloppyCRCMap> SloppyCRCMap::generate_test_instances()
 {
-  ls.push_back(new SloppyCRCMap);
-  ls.push_back(new SloppyCRCMap(2));
+  list<SloppyCRCMap> ls;
+  ls.push_back(SloppyCRCMap{});
+  ls.push_back(SloppyCRCMap(2));
   bufferlist bl;
   bl.append("some data");
-  ls.back()->write(1, bl.length(), bl);
-  ls.back()->write(10, bl.length(), bl);
-  ls.back()->zero(4, 2);
+  ls.back().write(1, bl.length(), bl);
+  ls.back().write(10, bl.length(), bl);
+  ls.back().zero(4, 2);
+  return ls;
 }

--- a/src/common/SloppyCRCMap.h
+++ b/src/common/SloppyCRCMap.h
@@ -71,7 +71,7 @@ public:
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SloppyCRCMap*>& ls);
+  static std::list<SloppyCRCMap> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(SloppyCRCMap)
 

--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -219,7 +219,7 @@ public:
 
   bool operator==(const BitVector &b) const;
 
-  static void generate_test_instances(std::list<BitVector *> &o);
+  static std::list<BitVector> generate_test_instances();
 private:
   bufferlist m_data;
   uint64_t m_size;
@@ -616,18 +616,21 @@ typename BitVector<_b>::Reference& BitVector<_b>::Reference::operator=(uint8_t v
 }
 
 template <uint8_t _b>
-void BitVector<_b>::generate_test_instances(std::list<BitVector *> &o) {
-  o.push_back(new BitVector());
+auto BitVector<_b>::generate_test_instances() -> std::list<BitVector> {
+  std::list<BitVector> o;
 
-  BitVector *b = new BitVector();
-  const uint64_t radix = 1 << b->BIT_COUNT;
+  o.push_back(BitVector{});
+
+  BitVector b;
+  const uint64_t radix = 1 << b.BIT_COUNT;
   const uint64_t size = 1024;
 
-  b->resize(size, false);
+  b.resize(size, false);
   for (uint64_t i = 0; i < size; ++i) {
-    (*b)[i] = rand() % radix;
+    b[i] = rand() % radix;
   }
-  o.push_back(b);
+  o.push_back(std::move(b));
+  return o;
 }
 
 

--- a/src/common/bloom_filter.cc
+++ b/src/common/bloom_filter.cc
@@ -72,18 +72,20 @@ void bloom_filter::dump(Formatter *f) const
   f->close_section();
 }
 
-void bloom_filter::generate_test_instances(std::list<bloom_filter*>& ls)
+std::list<bloom_filter> bloom_filter::generate_test_instances()
 {
-  ls.push_back(new bloom_filter(10, .5, 1));
-  ls.push_back(new bloom_filter(10, .5, 1));
-  ls.back()->insert("foo");
-  ls.back()->insert("bar");
-  ls.push_back(new bloom_filter(50, .5, 1));
-  ls.back()->insert("foo");
-  ls.back()->insert("bar");
-  ls.back()->insert("baz");
-  ls.back()->insert("boof");
-  ls.back()->insert("boogggg");
+  std::list<bloom_filter> ls;
+  ls.push_back(bloom_filter(10, .5, 1));
+  ls.push_back(bloom_filter(10, .5, 1));
+  ls.back().insert("foo");
+  ls.back().insert("bar");
+  ls.push_back(bloom_filter(50, .5, 1));
+  ls.back().insert("foo");
+  ls.back().insert("bar");
+  ls.back().insert("baz");
+  ls.back().insert("boof");
+  ls.back().insert("boogggg");
+  return ls;
 }
 
 
@@ -129,17 +131,19 @@ void compressible_bloom_filter::dump(Formatter *f) const
   f->close_section();
 }
 
-void compressible_bloom_filter::generate_test_instances(std::list<compressible_bloom_filter*>& ls)
+std::list<compressible_bloom_filter> compressible_bloom_filter::generate_test_instances()
 {
-  ls.push_back(new compressible_bloom_filter(10, .5, 1));
-  ls.push_back(new compressible_bloom_filter(10, .5, 1));
-  ls.back()->insert("foo");
-  ls.back()->insert("bar");
-  ls.push_back(new compressible_bloom_filter(50, .5, 1));
-  ls.back()->insert("foo");
-  ls.back()->insert("bar");
-  ls.back()->insert("baz");
-  ls.back()->insert("boof");
-  ls.back()->compress(20);
-  ls.back()->insert("boogggg");
+  std::list<compressible_bloom_filter> ls;
+  ls.push_back(compressible_bloom_filter(10, .5, 1));
+  ls.push_back(compressible_bloom_filter(10, .5, 1));
+  ls.back().insert("foo");
+  ls.back().insert("bar");
+  ls.push_back(compressible_bloom_filter(50, .5, 1));
+  ls.back().insert("foo");
+  ls.back().insert("bar");
+  ls.back().insert("baz");
+  ls.back().insert("boof");
+  ls.back().compress(20);
+  ls.back().insert("boogggg");
+  return ls;
 }

--- a/src/common/bloom_filter.hpp
+++ b/src/common/bloom_filter.hpp
@@ -468,7 +468,7 @@ public:
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bloom_filter*>& ls);
+  static std::list<bloom_filter> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(bloom_filter)
 
@@ -565,7 +565,7 @@ public:
   void encode(ceph::bufferlist& bl) const;
   void decode(ceph::bufferlist::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<compressible_bloom_filter*>& ls);
+  static std::list<compressible_bloom_filter> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(compressible_bloom_filter)
 

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -856,32 +856,34 @@ public:
         break;
     }
   }
-  static void generate_test_instances(std::list<JSONFormattable*>& o) {
-    o.push_back(new JSONFormattable);
-    o.push_back(new JSONFormattable);
-    o.back()->set_type(FMT_VALUE);
-    o.back()->value.str = "foo";
-    o.back()->value.quoted = true;
-    o.push_back(new JSONFormattable);
-    o.back()->set_type(FMT_VALUE);
-    o.back()->value.str = "foo";
-    o.back()->value.quoted = false;
-    o.push_back(new JSONFormattable);
-    o.back()->set_type(FMT_ARRAY);
-    o.back()->arr.push_back(JSONFormattable());
-    o.back()->arr.back().set_type(FMT_VALUE);
-    o.back()->arr.back().value.str = "foo";
-    o.back()->arr.back().value.quoted = true;
-    o.back()->arr.push_back(JSONFormattable());
-    o.back()->arr.back().set_type(FMT_VALUE);
-    o.back()->arr.back().value.str = "bar";
-    o.back()->arr.back().value.quoted = true;
-    o.push_back(new JSONFormattable);
-    o.back()->set_type(FMT_OBJ);
-    o.back()->obj["foo"] = JSONFormattable();
-    o.back()->obj["foo"].set_type(FMT_VALUE);
-    o.back()->obj["foo"].value.str = "bar";
-    o.back()->obj["foo"].value.quoted = true;
+  static std::list<JSONFormattable> generate_test_instances() {
+    std::list<JSONFormattable> o;
+    o.push_back(JSONFormattable{});
+    o.push_back(JSONFormattable{});
+    o.back().set_type(FMT_VALUE);
+    o.back().value.str = "foo";
+    o.back().value.quoted = true;
+    o.push_back(JSONFormattable{});
+    o.back().set_type(FMT_VALUE);
+    o.back().value.str = "foo";
+    o.back().value.quoted = false;
+    o.push_back(JSONFormattable{});
+    o.back().set_type(FMT_ARRAY);
+    o.back().arr.push_back(JSONFormattable());
+    o.back().arr.back().set_type(FMT_VALUE);
+    o.back().arr.back().value.str = "foo";
+    o.back().arr.back().value.quoted = true;
+    o.back().arr.push_back(JSONFormattable());
+    o.back().arr.back().set_type(FMT_VALUE);
+    o.back().arr.back().value.str = "bar";
+    o.back().arr.back().value.quoted = true;
+    o.push_back(JSONFormattable{});
+    o.back().set_type(FMT_OBJ);
+    o.back().obj["foo"] = JSONFormattable();
+    o.back().obj["foo"].set_type(FMT_VALUE);
+    o.back().obj["foo"].value.str = "bar";
+    o.back().obj["foo"].value.quoted = true;
+    return o;
   }
 
   const std::string& val() const {

--- a/src/common/entity_name.cc
+++ b/src/common/entity_name.cc
@@ -50,14 +50,16 @@ void EntityName::dump(ceph::Formatter *f) const {
   f->dump_string("id", id);
 }
 
-void EntityName::generate_test_instances(std::list<EntityName*>& ls) {
-  ls.push_back(new EntityName);
-  ls.push_back(new EntityName);
-  ls.back()->set_type(CEPH_ENTITY_TYPE_OSD);
-  ls.back()->set_id("0");
-  ls.push_back(new EntityName);
-  ls.back()->set_type(CEPH_ENTITY_TYPE_MDS);
-  ls.back()->set_id("a");
+std::list<EntityName> EntityName::generate_test_instances() {
+  std::list<EntityName> ls;
+  ls.push_back(EntityName{});
+  ls.push_back(EntityName{});
+  ls.back().set_type(CEPH_ENTITY_TYPE_OSD);
+  ls.back().set_id("0");
+  ls.push_back(EntityName{});
+  ls.back().set_type(CEPH_ENTITY_TYPE_MDS);
+  ls.back().set_id("a");
+  return ls;
 }
 
 const std::string& EntityName::to_str() const {

--- a/src/common/entity_name.h
+++ b/src/common/entity_name.h
@@ -37,7 +37,7 @@ struct EntityName
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<EntityName*>& ls);
+  static std::list<EntityName> generate_test_instances();
   const std::string& to_str() const;
   const char *to_cstr() const;
   bool from_str(std::string_view s);

--- a/src/common/frag.cc
+++ b/src/common/frag.cc
@@ -45,10 +45,12 @@ void frag_t::dump(ceph::Formatter *f) const {
   f->dump_unsigned("bits", bits());
 }
 
-void frag_t::generate_test_instances(std::list<frag_t*>& ls) {
-  ls.push_back(new frag_t);
-  ls.push_back(new frag_t(10, 2));
-  ls.push_back(new frag_t(11, 3));
+std::list<frag_t> frag_t::generate_test_instances() {
+  std::list<frag_t> ls;
+  ls.push_back(frag_t{});
+  ls.push_back(frag_t(10, 2));
+  ls.push_back(frag_t(11, 3));
+  return ls;
 }
 
 std::ostream& operator<<(std::ostream& out, const frag_t& hb)
@@ -185,9 +187,11 @@ void fragtree_t::dump(ceph::Formatter *f) const {
   f->close_section(); // splits
 }
 
-void fragtree_t::generate_test_instances(std::list<fragtree_t*>& ls) {
-  ls.push_back(new fragtree_t);
-  ls.push_back(new fragtree_t);
+std::list<fragtree_t> fragtree_t::generate_test_instances() {
+  std::list<fragtree_t> ls;
+  ls.push_back(fragtree_t{});
+  ls.push_back(fragtree_t{});
+  return ls;
 }
 
 std::ostream& operator<<(std::ostream& out, const fragtree_t& ft)

--- a/src/common/fs_types.cc
+++ b/src/common/fs_types.cc
@@ -143,15 +143,17 @@ void file_layout_t::decode_json(JSONObj *obj){
     JSONDecoder::decode_json("pool_ns", pool_ns, obj, true);
 }
 
-void file_layout_t::generate_test_instances(std::list<file_layout_t*>& o)
+std::list<file_layout_t> file_layout_t::generate_test_instances()
 {
-  o.push_back(new file_layout_t);
-  o.push_back(new file_layout_t);
-  o.back()->stripe_unit = 4096;
-  o.back()->stripe_count = 16;
-  o.back()->object_size = 1048576;
-  o.back()->pool_id = 3;
-  o.back()->pool_ns = "myns";
+  std::list<file_layout_t> o;
+  o.push_back(file_layout_t{});
+  o.push_back(file_layout_t{});
+  o.back().stripe_unit = 4096;
+  o.back().stripe_count = 16;
+  o.back().object_size = 1048576;
+  o.back().pool_id = 3;
+  o.back().pool_ns = "myns";
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& out, const file_layout_t &layout)

--- a/src/common/histogram.cc
+++ b/src/common/histogram.cc
@@ -39,14 +39,16 @@ void pow2_hist_t::decode(ceph::buffer::list::const_iterator& p)
   DECODE_FINISH(p);
 }
 
-void pow2_hist_t::generate_test_instances(std::list<pow2_hist_t*>& ls)
+std::list<pow2_hist_t> pow2_hist_t::generate_test_instances()
 {
-  ls.push_back(new pow2_hist_t);
-  ls.push_back(new pow2_hist_t);
-  ls.back()->h.push_back(1);
-  ls.back()->h.push_back(3);
-  ls.back()->h.push_back(0);
-  ls.back()->h.push_back(2);
+  std::list<pow2_hist_t> ls;
+  ls.push_back(pow2_hist_t{});
+  ls.push_back(pow2_hist_t{});
+  ls.back().h.push_back(1);
+  ls.back().h.push_back(3);
+  ls.back().h.push_back(0);
+  ls.back().h.push_back(2);
+  return ls;
 }
 
 void pow2_hist_t::decay(int bits)

--- a/src/common/histogram.h
+++ b/src/common/histogram.h
@@ -121,7 +121,7 @@ public:
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
-  static void generate_test_instances(std::list<pow2_hist_t*>& o);
+  static std::list<pow2_hist_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pow2_hist_t)
 

--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -194,16 +194,18 @@ void hobject_t::dump(Formatter *f) const
   f->dump_string("namespace", nspace);
 }
 
-void hobject_t::generate_test_instances(list<hobject_t*>& o)
+list<hobject_t> hobject_t::generate_test_instances()
 {
-  o.push_back(new hobject_t);
-  o.push_back(new hobject_t);
-  o.back()->max = true;
-  o.push_back(new hobject_t(object_t("oname"), string(), 1, 234, -1, ""));
-  o.push_back(new hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
+  list<hobject_t> o;
+  o.push_back(hobject_t{});
+  o.push_back(hobject_t{});
+  o.back().max = true;
+  o.push_back(hobject_t(object_t("oname"), string(), 1, 234, -1, ""));
+  o.push_back(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
 	67, 0, "n1"));
-  o.push_back(new hobject_t(object_t("oname3"), string("oname3"),
+  o.push_back(hobject_t(object_t("oname3"), string("oname3"),
 	CEPH_SNAPDIR, 910, 1, "n2"));
+  return o;
 }
 
 static void append_out_escaped(const string &in, string *out)
@@ -495,29 +497,31 @@ void ghobject_t::dump(Formatter *f) const
   f->dump_int("max", (int)max);
 }
 
-void ghobject_t::generate_test_instances(list<ghobject_t*>& o)
+list<ghobject_t> ghobject_t::generate_test_instances()
 {
-  o.push_back(new ghobject_t);
-  o.push_back(new ghobject_t);
-  o.back()->hobj.max = true;
-  o.push_back(new ghobject_t(hobject_t(object_t("oname"), string(), 1, 234, -1, "")));
+  list<ghobject_t> o;
+  o.push_back(ghobject_t{});
+  o.push_back(ghobject_t{});
+  o.back().hobj.max = true;
+  o.push_back(ghobject_t(hobject_t(object_t("oname"), string(), 1, 234, -1, "")));
 
-  o.push_back(new ghobject_t(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
+  o.push_back(ghobject_t(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
         67, 0, "n1"), 1, shard_id_t(0)));
-  o.push_back(new ghobject_t(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
+  o.push_back(ghobject_t(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
         67, 0, "n1"), 1, shard_id_t(1)));
-  o.push_back(new ghobject_t(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
+  o.push_back(ghobject_t(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
         67, 0, "n1"), 1, shard_id_t(2)));
-  o.push_back(new ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
+  o.push_back(ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
         CEPH_SNAPDIR, 910, 1, "n2"), 1, shard_id_t(0)));
-  o.push_back(new ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
+  o.push_back(ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
         CEPH_SNAPDIR, 910, 1, "n2"), 2, shard_id_t(0)));
-  o.push_back(new ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
+  o.push_back(ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
         CEPH_SNAPDIR, 910, 1, "n2"), 3, shard_id_t(0)));
-  o.push_back(new ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
+  o.push_back(ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
         CEPH_SNAPDIR, 910, 1, "n2"), 3, shard_id_t(1)));
-  o.push_back(new ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
+  o.push_back(ghobject_t(hobject_t(object_t("oname3"), string("oname3"),
         CEPH_SNAPDIR, 910, 1, "n2"), 3, shard_id_t(2)));
+  return o;
 }
 
 ostream& operator<<(ostream& out, const ghobject_t& o)

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -344,7 +344,7 @@ public:
   void decode(ceph::bufferlist::const_iterator& bl);
   void decode(json_spirit::Value& v);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<hobject_t*>& o);
+  static std::list<hobject_t> generate_test_instances();
   friend int cmp(const hobject_t& l, const hobject_t& r);
   constexpr auto operator<=>(const hobject_t &rhs) const noexcept {
     auto cmp = max <=> rhs.max;
@@ -594,7 +594,7 @@ struct ghobject_t {
   void decode(json_spirit::Value& v);
   size_t encoded_size() const;
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ghobject_t*>& o);
+  static std::list<ghobject_t> generate_test_instances();
   friend int cmp(const ghobject_t& l, const ghobject_t& r);
   constexpr auto operator<=>(const ghobject_t&) const = default;
   bool operator==(const ghobject_t&) const = default;

--- a/src/common/snap_types.cc
+++ b/src/common/snap_types.cc
@@ -42,16 +42,18 @@ void SnapRealmInfo::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void SnapRealmInfo::generate_test_instances(std::list<SnapRealmInfo*>& o)
+std::list<SnapRealmInfo> SnapRealmInfo::generate_test_instances()
 {
-  o.push_back(new SnapRealmInfo);
-  o.push_back(new SnapRealmInfo(1, 10, 10, 0));
-  o.push_back(new SnapRealmInfo(1, 10, 10, 0));
-  o.back()->my_snaps.push_back(10);
-  o.push_back(new SnapRealmInfo(1, 10, 10, 5));
-  o.back()->my_snaps.push_back(10);
-  o.back()->prior_parent_snaps.push_back(3);
-  o.back()->prior_parent_snaps.push_back(5);
+  std::list<SnapRealmInfo> o;
+  o.push_back(SnapRealmInfo{});
+  o.push_back(SnapRealmInfo(1, 10, 10, 0));
+  o.push_back(SnapRealmInfo(1, 10, 10, 0));
+  o.back().my_snaps.push_back(10);
+  o.push_back(SnapRealmInfo(1, 10, 10, 5));
+  o.back().my_snaps.push_back(10);
+  o.back().prior_parent_snaps.push_back(3);
+  o.back().prior_parent_snaps.push_back(5);
+  return o;
 }
 
 // -- "new" SnapRealmInfo --
@@ -83,16 +85,18 @@ void SnapRealmInfoNew::dump(ceph::Formatter *f) const
   f->dump_unsigned("change_attr", change_attr);
 }
 
-void SnapRealmInfoNew::generate_test_instances(std::list<SnapRealmInfoNew*>& o)
+std::list<SnapRealmInfoNew> SnapRealmInfoNew::generate_test_instances()
 {
-  o.push_back(new SnapRealmInfoNew);
-  o.push_back(new SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 0), utime_t(), 0));
-  o.push_back(new SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 0), utime_t(), 1));
-  o.back()->info.my_snaps.push_back(10);
-  o.push_back(new SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 5), utime_t(), 2));
-  o.back()->info.my_snaps.push_back(10);
-  o.back()->info.prior_parent_snaps.push_back(3);
-  o.back()->info.prior_parent_snaps.push_back(5);
+  std::list<SnapRealmInfoNew> o;
+  o.push_back(SnapRealmInfoNew{});
+  o.push_back(SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 0), utime_t(), 0));
+  o.push_back(SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 0), utime_t(), 1));
+  o.back().info.my_snaps.push_back(10);
+  o.push_back(SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 5), utime_t(), 2));
+  o.back().info.my_snaps.push_back(10);
+  o.back().info.prior_parent_snaps.push_back(3);
+  o.back().info.prior_parent_snaps.push_back(5);
+  return o;
 }
 
 // -----
@@ -138,15 +142,17 @@ void SnapContext::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void SnapContext::generate_test_instances(std::list<SnapContext*>& o)
+std::list<SnapContext> SnapContext::generate_test_instances()
 {
-  o.push_back(new SnapContext);
+  std::list<SnapContext> o;
+  o.push_back(SnapContext{});
   std::vector<snapid_t> v;
-  o.push_back(new SnapContext(10, v));
+  o.push_back(SnapContext(10, v));
   v.push_back(18);
   v.push_back(3);
   v.push_back(1);
-  o.push_back(new SnapContext(20, v));
+  o.push_back(SnapContext(20, v));
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& out, const SnapContext& snapc) {

--- a/src/common/snap_types.h
+++ b/src/common/snap_types.h
@@ -41,7 +41,7 @@ struct SnapRealmInfo {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SnapRealmInfo*>& o);
+  static std::list<SnapRealmInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(SnapRealmInfo)
 
@@ -71,7 +71,7 @@ struct SnapRealmInfoNew {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SnapRealmInfoNew*>& o);
+  static std::list<SnapRealmInfoNew> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(SnapRealmInfoNew)
 
@@ -93,7 +93,7 @@ struct SnapContext {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SnapContext*>& o);
+  static std::list<SnapContext> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(SnapContext)
 

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -3966,10 +3966,12 @@ void CrushWrapper::dump_tree(
   }
 }
 
-void CrushWrapper::generate_test_instances(list<CrushWrapper*>& o)
+list<CrushWrapper> CrushWrapper::generate_test_instances()
 {
-  o.push_back(new CrushWrapper);
+  list<CrushWrapper> o;
+  o.emplace_back();
   // fixme
+  return o;
 }
 
 /**

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1659,7 +1659,7 @@ public:
   }
   void dump_tree(ceph::Formatter *f,
 		 const CrushTreeDumper::name_map_t& ws) const;
-  static void generate_test_instances(std::list<CrushWrapper*>& o);
+  static std::list<CrushWrapper> generate_test_instances();
 
   int get_osd_pool_default_crush_replicated_rule(CephContext *cct);
 

--- a/src/include/CompatSet.h
+++ b/src/include/CompatSet.h
@@ -201,7 +201,7 @@ struct CompatSet {
 
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<CompatSet*>& o);
+  static std::list<CompatSet> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(CompatSet)
 

--- a/src/include/cephfs/metrics/Types.h
+++ b/src/include/cephfs/metrics/Types.h
@@ -688,8 +688,10 @@ public:
     std::visit(DumpPayloadVisitor(f), payload);
   }
 
-  static void generate_test_instances(std::list<ClientMetricMessage*>& ls) {
-    ls.push_back(new ClientMetricMessage(CapInfoPayload(1, 2, 3)));
+  static std::list<ClientMetricMessage> generate_test_instances() {
+    std::list<ClientMetricMessage> ls;
+    ls.push_back(ClientMetricMessage(CapInfoPayload(1, 2, 3)));
+    return ls;
   }
 
   void print(std::ostream *out) const {

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -117,7 +117,7 @@ struct frag_info_t : public scatter_info_t {
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<frag_info_t*>& ls);
+  static std::list<frag_info_t>  generate_test_instances();
 
   // this frag
   utime_t mtime;
@@ -177,7 +177,7 @@ struct nest_info_t : public scatter_info_t {
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<nest_info_t*>& ls);
+  static std::list<nest_info_t> generate_test_instances();
 
   // this frag + children
   utime_t rctime;
@@ -212,9 +212,11 @@ struct vinodeno_t {
     decode(snapid, p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<vinodeno_t*>& ls) {
-    ls.push_back(new vinodeno_t);
-    ls.push_back(new vinodeno_t(1, 2));
+  static std::list<vinodeno_t> generate_test_instances() {
+    std::list<vinodeno_t> ls;
+    ls.push_back(vinodeno_t{});
+    ls.push_back(vinodeno_t(1, 2));
+    return ls;
   }
   inodeno_t ino;
   snapid_t snapid;
@@ -338,7 +340,7 @@ struct quota_info_t
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<quota_info_t *>& ls);
+  static std::list<quota_info_t> generate_test_instances();
 
   bool is_valid() const {
     return max_bytes >=0 && max_files >=0;
@@ -377,7 +379,7 @@ struct client_writeable_range_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<client_writeable_range_t*>& ls);
+  static std::list<client_writeable_range_t> generate_test_instances();
 
   byte_range_t range;
   snapid_t follows = 0;     // aka "data+metadata flushed thru"
@@ -442,7 +444,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<inline_data_t*>& ls);
+  static std::list<inline_data_t> generate_test_instances();
   version_t version = 1;
 
 private:
@@ -825,7 +827,7 @@ struct inode_t {
   static void client_ranges_cb(client_range_map& c, JSONObj *obj);
   static void old_pools_cb(compact_set<int64_t, std::less<int64_t>, Allocator<int64_t> >& c, JSONObj *obj);
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<inode_t*>& ls);
+  static std::list<inode_t> generate_test_instances();
   /**
    * Compare this inode_t with another that represent *the same inode*
    * at different points in time.
@@ -1129,12 +1131,14 @@ void inode_t<Allocator>::decode(ceph::buffer::list::const_iterator &p)
 }
 
 template<template<typename> class Allocator>
-void inode_t<Allocator>::generate_test_instances(std::list<inode_t*>& ls)
+auto inode_t<Allocator>::generate_test_instances() -> std::list<inode_t>
 {
-  ls.push_back(new inode_t<Allocator>);
-  ls.push_back(new inode_t<Allocator>);
-  ls.back()->ino = 1;
+  std::list<inode_t> ls;
+  ls.push_back(inode_t<Allocator>{});
+  ls.push_back(inode_t<Allocator>{});
+  ls.back().ino = 1;
   // i am lazy.
+  return ls;
 }
 
 template<template<typename> class Allocator>

--- a/src/include/filepath.cc
+++ b/src/include/filepath.cc
@@ -116,12 +116,14 @@ void filepath::dump(ceph::Formatter *f) const {
   f->dump_string("relative_path", path);
 }
 
-void filepath::generate_test_instances(std::list<filepath*>& o) {
-  o.push_back(new filepath);
-  o.push_back(new filepath("/usr/bin", 0));
-  o.push_back(new filepath("/usr/sbin", 1));
-  o.push_back(new filepath("var/log", 1));
-  o.push_back(new filepath("foo/bar", 101));
+std::list<filepath> filepath::generate_test_instances() {
+  std::list<filepath> o;
+  o.push_back(filepath{});
+  o.push_back(filepath("/usr/bin", 0));
+  o.push_back(filepath("/usr/sbin", 1));
+  o.push_back(filepath("var/log", 1));
+  o.push_back(filepath("foo/bar", 101));
+  return o;
 }
 
 bool filepath::is_last_dot_or_dotdot() const {

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -151,7 +151,7 @@ class filepath {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& blp);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<filepath*>& o);
+  static std::list<filepath> generate_test_instances();
 
   bool is_last_dot_or_dotdot() const;
 

--- a/src/include/frag.h
+++ b/src/include/frag.h
@@ -149,7 +149,7 @@ public:
 
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<frag_t*>& ls);
+  static std::list<frag_t> generate_test_instances() ;
 
   bool operator<(const frag_t& b) const
   {
@@ -399,7 +399,7 @@ public:
 
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<fragtree_t*>& ls);
+  static std::list<fragtree_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(fragtree_t)
 

--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -46,9 +46,11 @@ struct inodeno_t {
     decode(val, p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<inodeno_t*>& ls) {
-    ls.push_back(new inodeno_t(1));
-    ls.push_back(new inodeno_t(123456789));
+  static std::list<inodeno_t> generate_test_instances() {
+    std::list<inodeno_t> ls;
+    ls.push_back(inodeno_t(1));
+    ls.push_back(inodeno_t(123456789));
+    return ls;
   }
 } __attribute__ ((__may_alias__));
 WRITE_CLASS_ENCODER(inodeno_t)
@@ -136,7 +138,7 @@ struct file_layout_t {
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<file_layout_t*>& o);
+  static std::list<file_layout_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(file_layout_t)
 

--- a/src/include/object.cc
+++ b/src/include/object.cc
@@ -31,9 +31,11 @@ void object_t::dump(ceph::Formatter *f) const {
   f->dump_string("name", name);
 }
 
-void object_t::generate_test_instances(std::list<object_t*>& o) {
-  o.push_back(new object_t);
-  o.push_back(new object_t("myobject"));
+std::list<object_t> object_t::generate_test_instances() {
+  std::list<object_t> o;
+  o.push_back(object_t{});
+  o.push_back(object_t{"myobject"});
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& out, const object_t& o) {
@@ -60,9 +62,11 @@ void sobject_t::dump(ceph::Formatter *f) const {
   f->dump_stream("snap") << snap;
 }
 
-void sobject_t::generate_test_instances(std::list<sobject_t*>& o) {
-  o.push_back(new sobject_t);
-  o.push_back(new sobject_t(object_t("myobject"), 123));
+std::list<sobject_t> sobject_t::generate_test_instances() {
+  std::list<sobject_t> o;
+  o.push_back(sobject_t{});
+  o.push_back(sobject_t{object_t("myobject"), 123});
+  return o;
 }
 
 std::ostream& operator<<(std::ostream& out, const sobject_t &o) {

--- a/src/include/object.h
+++ b/src/include/object.h
@@ -58,7 +58,7 @@ struct object_t {
 
   void dump(ceph::Formatter *f) const;
 
-  static void generate_test_instances(std::list<object_t*>& o);
+  static std::list<object_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(object_t)
 
@@ -178,7 +178,7 @@ struct sobject_t {
     decode(snap, bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<sobject_t*>& o);
+  static std::list<sobject_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(sobject_t)
 

--- a/src/include/types.cc
+++ b/src/include/types.cc
@@ -52,10 +52,12 @@ void client_t::dump(ceph::Formatter *f) const {
   f->dump_int("id", v);
 }
 
-void client_t::generate_test_instances(std::list<client_t*>& ls) {
-  ls.push_back(new client_t);
-  ls.push_back(new client_t(1));
-  ls.push_back(new client_t(123));
+std::list<client_t> client_t::generate_test_instances() {
+  std::list<client_t> ls;
+  ls.push_back(client_t{});
+  ls.push_back(client_t(1));
+  ls.push_back(client_t(123));
+  return ls;
 }
 
 std::ostream& operator<<(std::ostream& out, const client_t& c) {
@@ -114,16 +116,20 @@ void shard_id_t::dump(ceph::Formatter *f) const {
   f->dump_int("id", id);
 }
 
-void shard_id_t::generate_test_instances(std::list<shard_id_t*>& ls) {
-  ls.push_back(new shard_id_t(1));
-  ls.push_back(new shard_id_t(2));
+std::list<shard_id_t> shard_id_t::generate_test_instances() {
+  std::list<shard_id_t> ls;
+  ls.push_back(shard_id_t(1));
+  ls.push_back(shard_id_t(2));
+  return ls;
 }
 
 void errorcode32_t::dump(ceph::Formatter *f) const {
   f->dump_int("code", code);
 }
 
-void errorcode32_t::generate_test_instances(std::list<errorcode32_t*>& ls) {
-  ls.push_back(new errorcode32_t(1));
-  ls.push_back(new errorcode32_t(2));
+std::list<errorcode32_t> errorcode32_t::generate_test_instances() {
+  std::list<errorcode32_t> ls;
+  ls.push_back(errorcode32_t(1));
+  ls.push_back(errorcode32_t(2));
+  return ls;
 }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -412,7 +412,7 @@ struct client_t {
     decode(v, bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<client_t*>& ls);
+  static std::list<client_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(client_t)
 
@@ -490,7 +490,7 @@ struct shard_id_t {
     decode(id, bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<shard_id_t*>& ls);
+  static std::list<shard_id_t> generate_test_instances();
   shard_id_t& operator++() { ++id; return *this; }
   friend constexpr std::strong_ordering operator<=>(const shard_id_t &lhs,
                                                     const shard_id_t &rhs) {
@@ -563,7 +563,7 @@ struct errorcode32_t {
     set_wire_to_host(newcode);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<errorcode32_t*>& ls);
+  static std::list<errorcode32_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(errorcode32_t)
 
@@ -608,12 +608,14 @@ struct sha_digest_t {
   void dump(ceph::Formatter *f) const {
     f->dump_string("sha1", to_str());
   }
-  static void generate_test_instances(std::list<sha_digest_t*>& ls) {
-    ls.push_back(new sha_digest_t);
-    ls.push_back(new sha_digest_t);
-    ls.back()->v[0] = 1;
-    ls.push_back(new sha_digest_t);
-    ls.back()->v[0] = 2;
+  static std::list<sha_digest_t> generate_test_instances() {
+    std::list<sha_digest_t> ls;
+    ls.push_back(sha_digest_t{});
+    ls.push_back(sha_digest_t{});
+    ls.back().v[0] = 1;
+    ls.push_back(sha_digest_t{});
+    ls.back().v[0] = 2;
+    return ls;
   }
 };
 

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -63,13 +63,15 @@ struct ceph_data_stats
     DECODE_FINISH(p);
   }
 
-  static void generate_test_instances(std::list<ceph_data_stats*>& ls) {
-    ls.push_back(new ceph_data_stats);
-    ls.push_back(new ceph_data_stats);
-    ls.back()->byte_total = 1024*1024;
-    ls.back()->byte_used = 512*1024;
-    ls.back()->byte_avail = 512*1024;
-    ls.back()->avail_percent = 50;
+  static std::list<ceph_data_stats> generate_test_instances() {
+    std::list<ceph_data_stats> ls;
+    ls.push_back(ceph_data_stats{});
+    ls.push_back(ceph_data_stats{});
+    ls.back().byte_total = 1024*1024;
+    ls.back().byte_used = 512*1024;
+    ls.back().byte_avail = 512*1024;
+    ls.back().avail_percent = 50;
+    return ls;
   }
 };
 typedef struct ceph_data_stats ceph_data_stats_t;

--- a/src/include/utime.cc
+++ b/src/include/utime.cc
@@ -27,13 +27,15 @@ void utime_t::dump(ceph::Formatter *f) const
   f->dump_int("nanoseconds", tv.tv_nsec);
 }
 
-void utime_t::generate_test_instances(std::list<utime_t*>& o)
+std::list<utime_t> utime_t::generate_test_instances()
 {
-  o.push_back(new utime_t());
-  o.push_back(new utime_t());
-  o.back()->tv.tv_sec = static_cast<__u32>((1L << 32) - 1);
-  o.push_back(new utime_t());
-  o.back()->tv.tv_nsec = static_cast<__u32>((1L << 32) - 1);
+  std::list<utime_t> o;
+  o.push_back(utime_t());
+  o.push_back(utime_t());
+  o.back().tv.tv_sec = static_cast<__u32>((1L << 32) - 1);
+  o.push_back(utime_t());
+  o.back().tv.tv_nsec = static_cast<__u32>((1L << 32) - 1);
+  return o;
 }
 
 std::ostream& utime_t::gmtime(std::ostream& out, bool legacy_form) const {

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -183,7 +183,7 @@ public:
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<utime_t*>& o);
+  static std::list<utime_t> generate_test_instances();
   
   void encode_timeval(struct ceph_timespec *t) const {
     t->tv_sec = tv.tv_sec;

--- a/src/include/uuid.cc
+++ b/src/include/uuid.cc
@@ -51,17 +51,19 @@ void uuid_d::dump(ceph::Formatter *f) const
   f->dump_stream("uuid") << to_string();
 }
 
-void uuid_d::generate_test_instances(std::list<uuid_d*>& o)
+std::list<uuid_d> uuid_d::generate_test_instances()
 {
+  std::list<uuid_d> o;
   // these are sourced from examples at
   // https://www.boost.org/doc/libs/1_62_0/libs/uuid/uuid.html#Synopsis_generators
   boost::uuids::string_generator gen;
-  o.push_back(new uuid_d());
-  o.back()->uuid = gen("{01234567-89ab-cdef-0123-456789abcdef}");
-  o.push_back(new uuid_d());
-  o.back()->uuid = gen(L"01234567-89ab-cdef-0123-456789abcdef");
-  o.push_back(new uuid_d());
-  o.back()->uuid = gen(std::string("0123456789abcdef0123456789abcdef"));
-  o.push_back(new uuid_d());
-  o.back()->uuid = gen(std::wstring(L"01234567-89ab-cdef-0123-456789abcdef"));
+  o.push_back(uuid_d());
+  o.back().uuid = gen("{01234567-89ab-cdef-0123-456789abcdef}");
+  o.push_back(uuid_d());
+  o.back().uuid = gen(L"01234567-89ab-cdef-0123-456789abcdef");
+  o.push_back(uuid_d());
+  o.back().uuid = gen(std::string("0123456789abcdef0123456789abcdef"));
+  o.push_back(uuid_d());
+  o.back().uuid = gen(std::wstring(L"01234567-89ab-cdef-0123-456789abcdef"));
+  return o;
 }

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -64,7 +64,7 @@ struct uuid_d {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<uuid_d*>& o);
+  static std::list<uuid_d> generate_test_instances();
 };
 WRITE_CLASS_DENC_BOUNDED(uuid_d)
 

--- a/src/journal/Entry.cc
+++ b/src/journal/Entry.cc
@@ -136,12 +136,16 @@ bool Entry::is_readable(bufferlist::const_iterator iter, uint32_t *bytes_needed)
   return true;
 }
 
-void Entry::generate_test_instances(std::list<Entry *> &o) {
-  o.push_back(new Entry(1, 123, bufferlist()));
+std::list<Entry> Entry::generate_test_instances() {
+  std::list<Entry> o;
+
+  o.push_back(Entry(1, 123, bufferlist()));
 
   bufferlist bl;
   bl.append("data");
-  o.push_back(new Entry(2, 123, bl));
+  o.push_back(Entry(2, 123, bl));
+
+  return o;
 }
 
 bool Entry::operator==(const Entry& rhs) const {

--- a/src/journal/Entry.h
+++ b/src/journal/Entry.h
@@ -45,7 +45,7 @@ public:
   bool operator==(const Entry& rhs) const;
 
   static bool is_readable(bufferlist::const_iterator iter, uint32_t *bytes_needed);
-  static void generate_test_instances(std::list<Entry *> &o);
+  static std::list<Entry> generate_test_instances();
 
 private:
   static const uint64_t preamble = 0x3141592653589793;

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -424,34 +424,36 @@ NotifyOp NotifyMessage::get_notify_op() const {
   return payload->get_notify_op();
 }
 
-void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
-  o.push_back(new NotifyMessage(new AcquiredLockPayload(ClientId(1, 2))));
-  o.push_back(new NotifyMessage(new ReleasedLockPayload(ClientId(1, 2))));
-  o.push_back(new NotifyMessage(new RequestLockPayload(ClientId(1, 2), true)));
-  o.push_back(new NotifyMessage(new HeaderUpdatePayload()));
-  o.push_back(new NotifyMessage(new AsyncProgressPayload(AsyncRequestId(ClientId(0, 1), 2), 3, 4)));
-  o.push_back(new NotifyMessage(new AsyncCompletePayload(AsyncRequestId(ClientId(0, 1), 2), 3)));
-  o.push_back(new NotifyMessage(new FlattenPayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(new ResizePayload(AsyncRequestId(ClientId(0, 1), 2), 123, true)));
-  o.push_back(new NotifyMessage(new SnapCreatePayload(AsyncRequestId(ClientId(0, 1), 2),
-                                                      cls::rbd::UserSnapshotNamespace(),
-                                                      "foo", 1)));
-  o.push_back(new NotifyMessage(new SnapRemovePayload(AsyncRequestId(ClientId(0, 1), 2),
-                                                      cls::rbd::UserSnapshotNamespace(), "foo")));
-  o.push_back(new NotifyMessage(new SnapProtectPayload(AsyncRequestId(ClientId(0, 1), 2),
-                                                       cls::rbd::UserSnapshotNamespace(), "foo")));
-  o.push_back(new NotifyMessage(new SnapUnprotectPayload(AsyncRequestId(ClientId(0, 1), 2),
-                                                         cls::rbd::UserSnapshotNamespace(), "foo")));
-  o.push_back(new NotifyMessage(new RebuildObjectMapPayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(new RenamePayload(AsyncRequestId(ClientId(0, 1), 2), "foo")));
-  o.push_back(new NotifyMessage(new UpdateFeaturesPayload(AsyncRequestId(ClientId(0, 1), 2),
-                                                          1, true)));
-  o.push_back(new NotifyMessage(new MigratePayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(new SparsifyPayload(AsyncRequestId(ClientId(0, 1), 2), 1)));
-  o.push_back(new NotifyMessage(new QuiescePayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(new UnquiescePayload(AsyncRequestId(ClientId(0, 1), 2))));
-  o.push_back(new NotifyMessage(new MetadataUpdatePayload(AsyncRequestId(ClientId(0, 1), 2),
-                                                          "foo", std::optional<std::string>{"xyz"})));
+std::list<NotifyMessage> NotifyMessage::generate_test_instances() {
+  std::list<NotifyMessage> o;
+  o.push_back(NotifyMessage(new AcquiredLockPayload(ClientId(1, 2))));
+  o.push_back(NotifyMessage(new ReleasedLockPayload(ClientId(1, 2))));
+  o.push_back(NotifyMessage(new RequestLockPayload(ClientId(1, 2), true)));
+  o.push_back(NotifyMessage(new HeaderUpdatePayload()));
+  o.push_back(NotifyMessage(new AsyncProgressPayload(AsyncRequestId(ClientId(0, 1), 2), 3, 4)));
+  o.push_back(NotifyMessage(new AsyncCompletePayload(AsyncRequestId(ClientId(0, 1), 2), 3)));
+  o.push_back(NotifyMessage(new FlattenPayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(NotifyMessage(new ResizePayload(AsyncRequestId(ClientId(0, 1), 2), 123, true)));
+  o.push_back(NotifyMessage(new SnapCreatePayload(AsyncRequestId(ClientId(0, 1), 2),
+						  cls::rbd::UserSnapshotNamespace(),
+						  "foo", 1)));
+  o.push_back(NotifyMessage(new SnapRemovePayload(AsyncRequestId(ClientId(0, 1), 2),
+						  cls::rbd::UserSnapshotNamespace(), "foo")));
+  o.push_back(NotifyMessage(new SnapProtectPayload(AsyncRequestId(ClientId(0, 1), 2),
+						   cls::rbd::UserSnapshotNamespace(), "foo")));
+  o.push_back(NotifyMessage(new SnapUnprotectPayload(AsyncRequestId(ClientId(0, 1), 2),
+						     cls::rbd::UserSnapshotNamespace(), "foo")));
+  o.push_back(NotifyMessage(new RebuildObjectMapPayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(NotifyMessage(new RenamePayload(AsyncRequestId(ClientId(0, 1), 2), "foo")));
+  o.push_back(NotifyMessage(new UpdateFeaturesPayload(AsyncRequestId(ClientId(0, 1), 2),
+						      1, true)));
+  o.push_back(NotifyMessage(new MigratePayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(NotifyMessage(new SparsifyPayload(AsyncRequestId(ClientId(0, 1), 2), 1)));
+  o.push_back(NotifyMessage(new QuiescePayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(NotifyMessage(new UnquiescePayload(AsyncRequestId(ClientId(0, 1), 2))));
+  o.push_back(NotifyMessage(new MetadataUpdatePayload(AsyncRequestId(ClientId(0, 1), 2),
+						      "foo", std::optional<std::string>{"xyz"})));
+  return o;
 }
 
 void ResponseMessage::encode(bufferlist& bl) const {
@@ -470,8 +472,10 @@ void ResponseMessage::dump(Formatter *f) const {
   f->dump_int("result", result);
 }
 
-void ResponseMessage::generate_test_instances(std::list<ResponseMessage *> &o) {
-  o.push_back(new ResponseMessage(1));
+std::list<ResponseMessage> ResponseMessage::generate_test_instances() {
+  std::list<ResponseMessage> o;
+  o.push_back(ResponseMessage(1));
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &out,

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -499,7 +499,7 @@ struct NotifyMessage {
   void dump(Formatter *f) const;
   NotifyOp get_notify_op() const;
 
-  static void generate_test_instances(std::list<NotifyMessage *> &o);
+  static std::list<NotifyMessage>  generate_test_instances();
 };
 
 struct ResponseMessage {
@@ -512,7 +512,7 @@ struct ResponseMessage {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<ResponseMessage *> &o);
+  static std::list<ResponseMessage> generate_test_instances();
 };
 
 std::ostream &operator<<(std::ostream &out,

--- a/src/librbd/cache/pwl/Types.cc
+++ b/src/librbd/cache/pwl/Types.cc
@@ -71,22 +71,24 @@ void WriteLogCacheEntry::dump(Formatter *f) const {
   f->dump_unsigned("entry_index", entry_index);
 }
 
-void WriteLogCacheEntry::generate_test_instances(std::list<WriteLogCacheEntry*>& ls) {
-  ls.push_back(new WriteLogCacheEntry());
-  ls.push_back(new WriteLogCacheEntry);
-  ls.back()->sync_gen_number = 1;
-  ls.back()->write_sequence_number = 1;
-  ls.back()->image_offset_bytes = 1;
-  ls.back()->write_bytes = 1;
-  ls.back()->write_data_pos = 1;
-  ls.back()->set_entry_valid(true);
-  ls.back()->set_sync_point(true);
-  ls.back()->set_sequenced(true);
-  ls.back()->set_has_data(true);
-  ls.back()->set_discard(true);
-  ls.back()->set_writesame(true);
-  ls.back()->ws_datalen = 1;
-  ls.back()->entry_index = 1;
+std::list<WriteLogCacheEntry> WriteLogCacheEntry::generate_test_instances() {
+  std::list<WriteLogCacheEntry> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().sync_gen_number = 1;
+  ls.back().write_sequence_number = 1;
+  ls.back().image_offset_bytes = 1;
+  ls.back().write_bytes = 1;
+  ls.back().write_data_pos = 1;
+  ls.back().set_entry_valid(true);
+  ls.back().set_sync_point(true);
+  ls.back().set_sequenced(true);
+  ls.back().set_has_data(true);
+  ls.back().set_discard(true);
+  ls.back().set_writesame(true);
+  ls.back().ws_datalen = 1;
+  ls.back().entry_index = 1;
+  return ls;
 }
 
 void WriteLogPoolRoot::dump(Formatter *f) const {
@@ -100,17 +102,19 @@ void WriteLogPoolRoot::dump(Formatter *f) const {
   f->dump_unsigned("first_valid_entry", first_valid_entry);
 }
 
-void WriteLogPoolRoot::generate_test_instances(std::list<WriteLogPoolRoot*>& ls) {
-  ls.push_back(new WriteLogPoolRoot());
-  ls.push_back(new WriteLogPoolRoot);
-  ls.back()->layout_version = 2;
-  ls.back()->cur_sync_gen = 1;
-  ls.back()->pool_size = 1024;
-  ls.back()->flushed_sync_gen = 1;
-  ls.back()->block_size = 4096;
-  ls.back()->num_log_entries = 10000000;
-  ls.back()->first_free_entry = 1;
-  ls.back()->first_valid_entry = 0;
+std::list<WriteLogPoolRoot> WriteLogPoolRoot::generate_test_instances() {
+  std::list<WriteLogPoolRoot> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().layout_version = 2;
+  ls.back().cur_sync_gen = 1;
+  ls.back().pool_size = 1024;
+  ls.back().flushed_sync_gen = 1;
+  ls.back().block_size = 4096;
+  ls.back().num_log_entries = 10000000;
+  ls.back().first_free_entry = 1;
+  ls.back().first_valid_entry = 0;
+  return ls;
 }
 #endif
 

--- a/src/librbd/cache/pwl/Types.h
+++ b/src/librbd/cache/pwl/Types.h
@@ -325,7 +325,7 @@ struct WriteLogCacheEntry {
   }
   #endif
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<WriteLogCacheEntry*>& ls);
+  static std::list<WriteLogCacheEntry> generate_test_instances();
 };
 
 struct WriteLogPoolRoot {
@@ -367,7 +367,7 @@ struct WriteLogPoolRoot {
   #endif
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<WriteLogPoolRoot*>& ls);
+  static std::list<WriteLogPoolRoot> generate_test_instances();
 };
 
 struct WriteBufferAllocation {

--- a/src/librbd/cache/pwl/ssd/Types.h
+++ b/src/librbd/cache/pwl/ssd/Types.h
@@ -27,17 +27,19 @@ struct SuperBlock{
     f->dump_object("super", root);
   }
 
-  static void generate_test_instances(std::list<SuperBlock*>& ls) {
-    ls.push_back(new SuperBlock());
-    ls.push_back(new SuperBlock);
-    ls.back()->root.layout_version = 3;
-    ls.back()->root.cur_sync_gen = 1;
-    ls.back()->root.pool_size = 10737418240;
-    ls.back()->root.flushed_sync_gen = 1;
-    ls.back()->root.block_size = 4096;
-    ls.back()->root.num_log_entries = 0;
-    ls.back()->root.first_free_entry = 30601;
-    ls.back()->root.first_valid_entry = 2;
+  static std::list<SuperBlock> generate_test_instances() {
+    std::list<SuperBlock> ls;
+    ls.emplace_back();
+    ls.emplace_back();
+    ls.back().root.layout_version = 3;
+    ls.back().root.cur_sync_gen = 1;
+    ls.back().root.pool_size = 10737418240;
+    ls.back().root.flushed_sync_gen = 1;
+    ls.back().root.block_size = 4096;
+    ls.back().root.num_log_entries = 0;
+    ls.back().root.first_free_entry = 30601;
+    ls.back().root.first_valid_entry = 2;
+    return ls;
   }
 };
 

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -518,56 +518,60 @@ void EventEntry::decode_metadata(bufferlist::const_iterator& it) {
   DECODE_FINISH(it);
 }
 
-void EventEntry::generate_test_instances(std::list<EventEntry *> &o) {
-  o.push_back(new EventEntry(AioDiscardEvent()));
-  o.push_back(new EventEntry(AioDiscardEvent(123, 345, 4096), utime_t(1, 1)));
+std::list<EventEntry> EventEntry::generate_test_instances() {
+  std::list<EventEntry> o;
+
+  o.push_back(EventEntry(AioDiscardEvent()));
+  o.push_back(EventEntry(AioDiscardEvent(123, 345, 4096), utime_t(1, 1)));
 
   bufferlist bl;
   bl.append(std::string(32, '1'));
-  o.push_back(new EventEntry(AioWriteEvent()));
-  o.push_back(new EventEntry(AioWriteEvent(123, 456, bl), utime_t(1, 1)));
+  o.push_back(EventEntry(AioWriteEvent()));
+  o.push_back(EventEntry(AioWriteEvent(123, 456, bl), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(AioFlushEvent()));
+  o.push_back(EventEntry(AioFlushEvent()));
 
-  o.push_back(new EventEntry(OpFinishEvent(123, -1), utime_t(1, 1)));
+  o.push_back(EventEntry(OpFinishEvent(123, -1), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(SnapCreateEvent(), utime_t(1, 1)));
-  o.push_back(new EventEntry(SnapCreateEvent(234, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
+  o.push_back(EventEntry(SnapCreateEvent(), utime_t(1, 1)));
+  o.push_back(EventEntry(SnapCreateEvent(234, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(SnapRemoveEvent()));
-  o.push_back(new EventEntry(SnapRemoveEvent(345, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
+  o.push_back(EventEntry(SnapRemoveEvent()));
+  o.push_back(EventEntry(SnapRemoveEvent(345, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(SnapRenameEvent()));
-  o.push_back(new EventEntry(SnapRenameEvent(456, 1, "src snap", "dest snap"),
+  o.push_back(EventEntry(SnapRenameEvent()));
+  o.push_back(EventEntry(SnapRenameEvent(456, 1, "src snap", "dest snap"),
                              utime_t(1, 1)));
 
-  o.push_back(new EventEntry(SnapProtectEvent()));
-  o.push_back(new EventEntry(SnapProtectEvent(567, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
+  o.push_back(EventEntry(SnapProtectEvent()));
+  o.push_back(EventEntry(SnapProtectEvent(567, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(SnapUnprotectEvent()));
-  o.push_back(new EventEntry(SnapUnprotectEvent(678, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
+  o.push_back(EventEntry(SnapUnprotectEvent()));
+  o.push_back(EventEntry(SnapUnprotectEvent(678, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(SnapRollbackEvent()));
-  o.push_back(new EventEntry(SnapRollbackEvent(789, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
+  o.push_back(EventEntry(SnapRollbackEvent()));
+  o.push_back(EventEntry(SnapRollbackEvent(789, cls::rbd::UserSnapshotNamespace(), "snap"), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(RenameEvent()));
-  o.push_back(new EventEntry(RenameEvent(890, "image name"), utime_t(1, 1)));
+  o.push_back(EventEntry(RenameEvent()));
+  o.push_back(EventEntry(RenameEvent(890, "image name"), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(ResizeEvent()));
-  o.push_back(new EventEntry(ResizeEvent(901, 1234), utime_t(1, 1)));
+  o.push_back(EventEntry(ResizeEvent()));
+  o.push_back(EventEntry(ResizeEvent(901, 1234), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(FlattenEvent(123), utime_t(1, 1)));
+  o.push_back(EventEntry(FlattenEvent(123), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(DemotePromoteEvent()));
+  o.push_back(EventEntry(DemotePromoteEvent()));
 
-  o.push_back(new EventEntry(UpdateFeaturesEvent()));
-  o.push_back(new EventEntry(UpdateFeaturesEvent(123, 127, true), utime_t(1, 1)));
+  o.push_back(EventEntry(UpdateFeaturesEvent()));
+  o.push_back(EventEntry(UpdateFeaturesEvent(123, 127, true), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(MetadataSetEvent()));
-  o.push_back(new EventEntry(MetadataSetEvent(123, "key", "value"), utime_t(1, 1)));
+  o.push_back(EventEntry(MetadataSetEvent()));
+  o.push_back(EventEntry(MetadataSetEvent(123, "key", "value"), utime_t(1, 1)));
 
-  o.push_back(new EventEntry(MetadataRemoveEvent()));
-  o.push_back(new EventEntry(MetadataRemoveEvent(123, "key"), utime_t(1, 1)));
+  o.push_back(EventEntry(MetadataRemoveEvent()));
+  o.push_back(EventEntry(MetadataRemoveEvent(123, "key"), utime_t(1, 1)));
+
+  return o;
 }
 
 // Journal Client
@@ -728,14 +732,16 @@ void ClientData::dump(Formatter *f) const {
   std::visit(DumpVisitor(f, "client_meta_type"), client_meta);
 }
 
-void ClientData::generate_test_instances(std::list<ClientData *> &o) {
-  o.push_back(new ClientData(ImageClientMeta()));
-  o.push_back(new ClientData(ImageClientMeta(123)));
-  o.push_back(new ClientData(MirrorPeerClientMeta()));
-  o.push_back(new ClientData(MirrorPeerClientMeta("image_id",
-                                                  {{{}, "snap 2", "snap 1", 123}},
-                                                  {{1, 2}, {3, 4}})));
-  o.push_back(new ClientData(CliClientMeta()));
+std::list<ClientData> ClientData::generate_test_instances() {
+  std::list<ClientData> o;
+  o.push_back(ClientData(ImageClientMeta()));
+  o.push_back(ClientData(ImageClientMeta(123)));
+  o.push_back(ClientData(MirrorPeerClientMeta()));
+  o.push_back(ClientData(MirrorPeerClientMeta("image_id",
+					      {{{}, "snap 2", "snap 1", 123}},
+					      {{1, 2}, {3, 4}})));
+  o.push_back(ClientData(CliClientMeta()));
+  return o;
 }
 
 // Journal Tag
@@ -782,10 +788,12 @@ void TagData::dump(Formatter *f) const {
   f->close_section();
 }
 
-void TagData::generate_test_instances(std::list<TagData *> &o) {
-  o.push_back(new TagData());
-  o.push_back(new TagData("mirror-uuid"));
-  o.push_back(new TagData("mirror-uuid", "remote-mirror-uuid", true, 123, 234));
+std::list<TagData> TagData::generate_test_instances() {
+  std::list<TagData> o;
+  o.push_back(TagData());
+  o.push_back(TagData("mirror-uuid"));
+  o.push_back(TagData("mirror-uuid", "remote-mirror-uuid", true, 123, 234));
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &out, const EventType &type) {

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -452,7 +452,7 @@ struct EventEntry {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<EventEntry *> &o);
+  static std::list<EventEntry> generate_test_instances();
 
 private:
   static const uint32_t EVENT_FIXED_SIZE = 14; /// version encoding, type
@@ -593,7 +593,7 @@ struct ClientData {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<ClientData *> &o);
+  static std::list<ClientData> generate_test_instances();
 };
 
 // Journal Tag data structures
@@ -648,7 +648,7 @@ struct TagData {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<TagData *> &o);
+  static std::list<TagData> generate_test_instances();
 };
 
 std::ostream &operator<<(std::ostream &out, const EventType &type);

--- a/src/librbd/mirroring_watcher/Types.cc
+++ b/src/librbd/mirroring_watcher/Types.cc
@@ -111,10 +111,12 @@ void NotifyMessage::dump(Formatter *f) const {
   std::visit(DumpPayloadVisitor(f), payload);
 }
 
-void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
-  o.push_back(new NotifyMessage(ModeUpdatedPayload(cls::rbd::MIRROR_MODE_DISABLED)));
-  o.push_back(new NotifyMessage(ImageUpdatedPayload(cls::rbd::MIRROR_IMAGE_STATE_DISABLING,
-                                                    "image id", "global image id")));
+std::list<NotifyMessage> NotifyMessage::generate_test_instances() {
+  std::list<NotifyMessage> o;
+  o.push_back(NotifyMessage(ModeUpdatedPayload(cls::rbd::MIRROR_MODE_DISABLED)));
+  o.push_back(NotifyMessage(ImageUpdatedPayload(cls::rbd::MIRROR_IMAGE_STATE_DISABLING,
+					       "image id", "global image id")));
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &out, const NotifyOp &op) {

--- a/src/librbd/mirroring_watcher/Types.h
+++ b/src/librbd/mirroring_watcher/Types.h
@@ -86,7 +86,7 @@ struct NotifyMessage {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<NotifyMessage *> &o);
+  static std::list<NotifyMessage> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(NotifyMessage);

--- a/src/librbd/trash_watcher/Types.cc
+++ b/src/librbd/trash_watcher/Types.cc
@@ -105,10 +105,12 @@ void NotifyMessage::dump(Formatter *f) const {
   std::visit(DumpPayloadVisitor(f), payload);
 }
 
-void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
-  o.push_back(new NotifyMessage{ImageAddedPayload{
+std::list<NotifyMessage> NotifyMessage::generate_test_instances() {
+  std::list<NotifyMessage> o;
+  o.push_back(NotifyMessage{ImageAddedPayload{
     "id", {cls::rbd::TRASH_IMAGE_SOURCE_USER, "name", {}, {}}}});
-  o.push_back(new NotifyMessage{ImageRemovedPayload{"id"}});
+  o.push_back(NotifyMessage{ImageRemovedPayload{"id"}});
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &out, const NotifyOp &op) {

--- a/src/librbd/trash_watcher/Types.h
+++ b/src/librbd/trash_watcher/Types.h
@@ -81,7 +81,7 @@ struct NotifyMessage {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<NotifyMessage *> &o);
+  static std::list<NotifyMessage> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(NotifyMessage);

--- a/src/mds/Anchor.cc
+++ b/src/mds/Anchor.cc
@@ -50,14 +50,16 @@ void Anchor::dump(Formatter *f) const
   f->dump_unsigned("d_type", d_type);
 }
 
-void Anchor::generate_test_instances(std::list<Anchor*>& ls)
+std::list<Anchor> Anchor::generate_test_instances()
 {
-  ls.push_back(new Anchor);
-  ls.push_back(new Anchor);
-  ls.back()->ino = 1;
-  ls.back()->dirino = 2;
-  ls.back()->d_name = "hello";
-  ls.back()->d_type = DT_DIR;
+  std::list<Anchor> ls;
+  ls.push_back(Anchor{});
+  ls.push_back(Anchor{});
+  ls.back().ino = 1;
+  ls.back().dirino = 2;
+  ls.back().d_name = "hello";
+  ls.back().d_type = DT_DIR;
+  return ls;
 }
 
 std::ostream& operator<<(std::ostream& out, const Anchor &a)

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -35,7 +35,7 @@ public:
   void encode(bufferlist &bl) const;
   void decode(bufferlist::const_iterator &bl);
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<Anchor*>& ls);
+  static std::list<Anchor> generate_test_instances();
   bool operator==(const Anchor &r) const {
     return ino == r.ino && dirino == r.dirino &&
 	   d_name == r.d_name && d_type == r.d_type &&

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4795,22 +4795,26 @@ void InodeStoreBase::old_indoes_cb(InodeStoreBase::mempool_old_inode_map& c, JSO
   c[s] = i;
 }
 
-void InodeStore::generate_test_instances(std::list<InodeStore*> &ls)
+std::list<InodeStore> InodeStore::generate_test_instances()
 {
-  InodeStore *populated = new InodeStore;
-  populated->get_inode()->ino = 0xdeadbeef;
-  populated->get_inode()->mode = S_IFLNK | 0777;
-  populated->symlink = "rhubarb";
-  ls.push_back(populated);
+  std::list<InodeStore> ls;
+  InodeStore populated;
+  populated.get_inode()->ino = 0xdeadbeef;
+  populated.get_inode()->mode = S_IFLNK | 0777;
+  populated.symlink = "rhubarb";
+  ls.push_back(std::move(populated));
+  return ls;
 }
 
-void InodeStoreBare::generate_test_instances(std::list<InodeStoreBare*> &ls)
+std::list<InodeStoreBare> InodeStoreBare::generate_test_instances()
 {
-  InodeStoreBare *populated = new InodeStoreBare;
-  populated->get_inode()->ino = 0xdeadbeef;
-  populated->get_inode()->mode = S_IFLNK | 0777;
-  populated->symlink = "rhubarb";
-  ls.push_back(populated);
+  std::list<InodeStoreBare> ls;
+  InodeStoreBare populated;
+  populated.get_inode()->ino = 0xdeadbeef;
+  populated.get_inode()->mode = S_IFLNK | 0777;
+  populated.symlink = "rhubarb";
+  ls.push_back(std::move(populated));
+  return ls;
 }
 
 void CInode::validate_disk_state(CInode::validated_data *results,

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -221,7 +221,7 @@ public:
     InodeStoreBase::decode_bare(bl, snap_blob);
   }
 
-  static void generate_test_instances(std::list<InodeStore*>& ls);
+  static std::list<InodeStore> generate_test_instances();
 
   using InodeStoreBase::inode;
   using InodeStoreBase::xattrs;
@@ -242,7 +242,7 @@ public:
   void decode(ceph::buffer::list::const_iterator &bl) {
     InodeStore::decode_bare(bl);
   }
-  static void generate_test_instances(std::list<InodeStoreBare*>& ls);
+  static std::list<InodeStoreBare> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(InodeStoreBare)
 

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -73,10 +73,12 @@ void Capability::Export::dump(ceph::Formatter *f) const
   f->dump_stream("last_issue_stamp") << last_issue_stamp;
 }
 
-void Capability::Export::generate_test_instances(std::list<Capability::Export*>& ls)
+std::list<Capability::Export> Capability::Export::generate_test_instances()
 {
-  ls.push_back(new Export());
-  ls.push_back(new Export(1, 2, 3, 4, 5, 6, 7, utime_t(8, 9), 10));
+  std::list<Capability::Export> ls;
+  ls.push_back(Export());
+  ls.push_back(Export(1, 2, 3, 4, 5, 6, 7, utime_t(8, 9), 10));
+  return ls;
 }
 
 void Capability::Import::encode(ceph::buffer::list &bl) const
@@ -104,10 +106,12 @@ void Capability::Import::dump(ceph::Formatter *f) const
   f->dump_unsigned("migrate_seq", mseq);
 }
 
-void Capability::Import::generate_test_instances(std::list<Capability::Import*>& ls)
+std::list<Capability::Import> Capability::Import::generate_test_instances()
 {
-  ls.push_back(new Import());
-  ls.push_back(new Import(1, 2, 3));
+  std::list<Capability::Import> ls;
+  ls.push_back(Import());
+  ls.push_back(Import(1, 2, 3));
+  return ls;
 }
 /*
  * Capability::revoke_info
@@ -138,13 +142,15 @@ void Capability::revoke_info::dump(ceph::Formatter *f) const
   f->dump_unsigned("last_issue", last_issue);
 }
 
-void Capability::revoke_info::generate_test_instances(std::list<Capability::revoke_info*>& ls)
+std::list<Capability::revoke_info> Capability::revoke_info::generate_test_instances()
 {
-  ls.push_back(new revoke_info);
-  ls.push_back(new revoke_info);
-  ls.back()->before = 1;
-  ls.back()->seq = 2;
-  ls.back()->last_issue = 3;
+  std::list<Capability::revoke_info> ls;
+  ls.push_back(revoke_info{});
+  ls.push_back(revoke_info{});
+  ls.back().before = 1;
+  ls.back().seq = 2;
+  ls.back().last_issue = 3;
+  return ls;
 }
 
 
@@ -315,26 +321,28 @@ void Capability::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void Capability::generate_test_instances(std::list<Capability*>& ls)
+std::list<Capability> Capability::generate_test_instances()
 {
-  ls.push_back(new Capability);
-  ls.push_back(new Capability);
-  ls.back()->last_sent = 11;
-  ls.back()->last_issue_stamp = utime_t(12, 13);
-  ls.back()->set_wanted(14);
-  ls.back()->_pending = 15;
+  std::list<Capability> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().last_sent = 11;
+  ls.back().last_issue_stamp = utime_t(12, 13);
+  ls.back().set_wanted(14);
+  ls.back()._pending = 15;
   {
-    auto &r = ls.back()->_revokes.emplace_back();
+    auto &r = ls.back()._revokes.emplace_back();
     r.before = 16;
     r.seq = 17;
     r.last_issue = 18;
   }
   {
-    auto &r = ls.back()->_revokes.emplace_back();
+    auto &r = ls.back()._revokes.emplace_back();
     r.before = 19;
     r.seq = 20;
     r.last_issue = 21;
   }
+  return ls;
 }
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(Capability, co_cap, mds_co);

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -80,7 +80,7 @@ public:
     void encode(ceph::buffer::list &bl) const;
     void decode(ceph::buffer::list::const_iterator &p);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<Export*>& ls);
+    static std::list<Export> generate_test_instances();
 
     int64_t cap_id = 0;
     int32_t wanted = 0;
@@ -98,7 +98,7 @@ public:
     void encode(ceph::buffer::list &bl) const;
     void decode(ceph::buffer::list::const_iterator &p);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<Import*>& ls);
+    static std::list<Import> generate_test_instances();
 
     int64_t cap_id = 0;
     ceph_seq_t issue_seq = 0;
@@ -110,7 +110,7 @@ public:
     void encode(ceph::buffer::list& bl) const;
     void decode(ceph::buffer::list::const_iterator& bl);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<revoke_info*>& ls);
+    static std::list<revoke_info> generate_test_instances();
 
     __u32 before = 0;
     ceph_seq_t seq = 0;
@@ -324,7 +324,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<Capability*>& ls);
+  static std::list<Capability> generate_test_instances();
 
   snapid_t client_follows = 0;
   version_t client_xattr_version = 0;

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -116,12 +116,14 @@ void MirrorInfo::dump(ceph::Formatter *f) const {
   f->close_section(); // peers
 }
 
-void MirrorInfo::generate_test_instances(std::list<MirrorInfo*>& ls) {
-  ls.push_back(new MirrorInfo());
-  ls.push_back(new MirrorInfo());
-  ls.back()->mirrored = true;
-  ls.back()->peers.insert(Peer());
-  ls.back()->peers.insert(Peer());
+std::list<MirrorInfo> MirrorInfo::generate_test_instances() {
+  std::list<MirrorInfo> ls;
+  ls.push_back(MirrorInfo());
+  ls.push_back(MirrorInfo());
+  ls.back().mirrored = true;
+  ls.back().peers.insert(Peer());
+  ls.back().peers.insert(Peer());
+  return ls;
 }
 
 void MirrorInfo::print(std::ostream& out) const {
@@ -195,23 +197,23 @@ FSMap &FSMap::operator=(const FSMap &rhs)
   return *this;
 }
 
-void FSMap::generate_test_instances(std::list<FSMap*>& ls)
+std::list<FSMap> FSMap::generate_test_instances()
 {
-  FSMap* fsmap = new FSMap();
+  std::list<FSMap> ls;
 
-  std::list<MDSMap*> mds_map_instances;
-  MDSMap::generate_test_instances(mds_map_instances);
+  FSMap fsmap;
 
   int k = 20;
-  for (auto& mdsmap : mds_map_instances) {
+  for (auto& mdsmap : MDSMap::generate_test_instances()) {
     auto fs = Filesystem();
     fs.fscid = k++;
-    fs.mds_map = *mdsmap;
-    fsmap->filesystems[fs.fscid] = fs;
-    delete mdsmap;
+    fs.mds_map = mdsmap;
+    fsmap.filesystems[fs.fscid] = fs;
   }
 
-  ls.push_back(fsmap);
+  ls.push_back(std::move(fsmap));
+
+  return ls;
 }
 
 void FSMap::print(ostream& out) const

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -169,7 +169,7 @@ struct MirrorInfo {
   Peers peers;
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<MirrorInfo*>& ls);
+  static std::list<MirrorInfo> generate_test_instances();
   void print(std::ostream& out) const;
 
   void encode(ceph::buffer::list &bl) const;
@@ -676,7 +676,7 @@ public:
   void print_fs_summary(std::ostream& out) const;
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<FSMap*>& ls);
+  static std::list<FSMap> generate_test_instances();
 
 protected:
   iterator begin() {

--- a/src/mds/FSMapUser.cc
+++ b/src/mds/FSMapUser.cc
@@ -41,16 +41,18 @@ void FSMapUser::fs_info_t::decode(ceph::buffer::list::const_iterator& p)
   DECODE_FINISH(p);
 }
 
-void FSMapUser::generate_test_instances(std::list<FSMapUser*>& ls)
+std::list<FSMapUser> FSMapUser::generate_test_instances()
 {
-  FSMapUser *m = new FSMapUser();
-  m->epoch = 2;
-  m->legacy_client_fscid = 1;
-  m->filesystems[1].cid = 1;
-  m->filesystems[2].name = "cephfs2";
-  m->filesystems[2].cid = 2;
-  m->filesystems[1].name = "cephfs1";
-  ls.push_back(m);
+  std::list<FSMapUser> ls;
+  FSMapUser m;
+  m.epoch = 2;
+  m.legacy_client_fscid = 1;
+  m.filesystems[1].cid = 1;
+  m.filesystems[2].name = "cephfs2";
+  m.filesystems[2].cid = 2;
+  m.filesystems[1].name = "cephfs1";
+  ls.push_back(std::move(m));
+  return ls;
 }
 
 

--- a/src/mds/FSMapUser.h
+++ b/src/mds/FSMapUser.h
@@ -48,7 +48,7 @@ public:
   void print(std::ostream& out) const;
   void print_summary(ceph::Formatter *f, std::ostream *out) const;
 
-  static void generate_test_instances(std::list<FSMapUser*>& ls);
+  static std::list<FSMapUser> generate_test_instances();
 
   std::map<fs_cluster_id_t, fs_info_t> filesystems;
   fs_cluster_id_t legacy_client_fscid = FS_CLUSTER_ID_NONE;

--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -186,9 +186,11 @@ void InoTable::dump(Formatter *f) const
 }
 
 
-void InoTable::generate_test_instances(std::list<InoTable*>& ls)
+std::list<InoTable> InoTable::generate_test_instances()
 {
-  ls.push_back(new InoTable());
+  std::list<InoTable> ls;
+  ls.push_back(InoTable());
+  return ls;
 }
 
 

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -66,7 +66,7 @@ class InoTable : public MDSTable {
     decode_state(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<InoTable*>& ls);
+  static std::list<InoTable> generate_test_instances();
 
   void skip_inos(inodeno_t i);
 

--- a/src/mds/JournalPointer.h
+++ b/src/mds/JournalPointer.h
@@ -60,12 +60,14 @@ class JournalPointer {
     f->close_section(); // journal_header
   }
 
-  static void generate_test_instances(std::list<JournalPointer*> &ls)
+  static std::list<JournalPointer> generate_test_instances()
   {
-    ls.push_back(new JournalPointer());
-    ls.push_back(new JournalPointer());
-    ls.back()->front = 0xdeadbeef;
-    ls.back()->back = 0xfeedbead;
+    std::list<JournalPointer> ls;
+    ls.push_back(JournalPointer());
+    ls.push_back(JournalPointer());
+    ls.back().front = 0xdeadbeef;
+    ls.back().back = 0xfeedbead;
+    return ls;
   }
 
   // The currently active journal

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -177,15 +177,17 @@ void MDSMap::mds_info_t::dump(std::ostream& o) const
   o << "]";
 }
 
-void MDSMap::mds_info_t::generate_test_instances(std::list<mds_info_t*>& ls)
+auto MDSMap::mds_info_t::generate_test_instances() -> std::list<mds_info_t>
 {
-  mds_info_t *sample = new mds_info_t();
-  ls.push_back(sample);
-  sample = new mds_info_t();
-  sample->global_id = 1;
-  sample->name = "test_instance";
-  sample->rank = 0;
-  ls.push_back(sample);
+  std::list<mds_info_t> ls;
+  mds_info_t sample;
+  ls.push_back(std::move(sample));
+  sample = mds_info_t();
+  sample.global_id = 1;
+  sample.name = "test_instance";
+  sample.rank = 0;
+  ls.push_back(std::move(sample));
+  return ls;
 }
 
 void MDSMap::dump(Formatter *f) const
@@ -276,20 +278,23 @@ void MDSMap::dump_flags_state(Formatter *f) const
     f->close_section();
 }
 
-void MDSMap::generate_test_instances(std::list<MDSMap*>& ls)
+std::list<MDSMap> MDSMap::generate_test_instances()
 {
-  MDSMap *m = new MDSMap();
-  m->max_mds = 1;
-  m->data_pools.push_back(0);
-  m->metadata_pool = 1;
-  m->cas_pool = 2;
-  m->compat = get_compat_set_all();
+  std::list<MDSMap> ls;
+  MDSMap m;
+  m.max_mds = 1;
+  m.data_pools.push_back(0);
+  m.metadata_pool = 1;
+  m.cas_pool = 2;
+  m.compat = get_compat_set_all();
 
   // these aren't the defaults, just in case anybody gets confused
-  m->session_timeout = 61;
-  m->session_autoclose = 301;
-  m->max_file_size = 1<<24;
-  ls.push_back(m);
+  m.session_timeout = 61;
+  m.session_autoclose = 301;
+  m.max_file_size = 1<<24;
+  ls.push_back(std::move(m));
+
+  return ls;
 }
 
 void MDSMap::print(ostream& out) const

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -150,7 +150,7 @@ public:
     // The long form name for use in cluster log messages`
     std::string human_name() const;
 
-    static void generate_test_instances(std::list<mds_info_t*>& ls);
+    static std::list<mds_info_t> generate_test_instances();
 
     mds_gid_t global_id = MDS_GID_NONE;
     std::string name;
@@ -584,7 +584,7 @@ public:
 
   void dump(ceph::Formatter *f) const;
   void dump_flags_state(Formatter *f) const;
-  static void generate_test_instances(std::list<MDSMap*>& ls);
+  static std::list<MDSMap> generate_test_instances();
 
   static bool state_transition_valid(DaemonState prev, DaemonState next);
 

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -119,16 +119,18 @@ void PurgeItem::dump(Formatter *f) const
   f->close_section();
 }
 
-void PurgeItem::generate_test_instances(std::list<PurgeItem*>& ls) {
-  ls.push_back(new PurgeItem());
-  ls.push_back(new PurgeItem());
-  ls.back()->action = PurgeItem::PURGE_FILE;
-  ls.back()->ino = 1;
-  ls.back()->size = 2;
-  ls.back()->layout = file_layout_t();
-  ls.back()->old_pools = {1, 2};
-  ls.back()->snapc = SnapContext();
-  ls.back()->stamp = utime_t(3, 4);
+std::list<PurgeItem> PurgeItem::generate_test_instances() {
+  std::list<PurgeItem> ls;
+  ls.push_back(PurgeItem());
+  ls.push_back(PurgeItem());
+  ls.back().action = PurgeItem::PURGE_FILE;
+  ls.back().ino = 1;
+  ls.back().size = 2;
+  ls.back().layout = file_layout_t();
+  ls.back().old_pools = {1, 2};
+  ls.back().snapc = SnapContext();
+  ls.back().stamp = utime_t(3, 4);
+  return ls;
 }
 
 // if Objecter has any slow requests, take that as a hint and

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -58,7 +58,7 @@ public:
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<PurgeItem*>& ls);
+  static std::list<PurgeItem> generate_test_instances();
 
   std::string_view get_type_str() const;
 

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -700,10 +700,12 @@ Session* SessionMapStore::get_or_add_session(const entity_inst_t& i) {
   return s;
 }
 
-void SessionMapStore::generate_test_instances(std::list<SessionMapStore*>& ls)
+std::list<SessionMapStore> SessionMapStore::generate_test_instances()
 {
+  std::list<SessionMapStore> ls;
   // pretty boring for now
-  ls.push_back(new SessionMapStore());
+  ls.push_back(SessionMapStore());
+  return ls;
 }
 
 void SessionMap::wipe()

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -559,7 +559,7 @@ public:
 
   Session* get_or_add_session(const entity_inst_t& i);
 
-  static void generate_test_instances(std::list<SessionMapStore*>& ls);
+  static std::list<SessionMapStore> generate_test_instances();
   void reset_state()
   {
     session_map.clear();

--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -93,10 +93,12 @@ void SimpleLock::dump(ceph::Formatter *f) const {
   f->close_section();
 }
 
-void SimpleLock::generate_test_instances(std::list<SimpleLock*>& ls) {
-  ls.push_back(new SimpleLock);
-  ls.push_back(new SimpleLock);
-  ls.back()->set_state(LOCK_SYNC);
+std::list<SimpleLock> SimpleLock::generate_test_instances() {
+  std::list<SimpleLock> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().set_state(LOCK_SYNC);
+  return ls;
 }
 
 

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -579,7 +579,7 @@ public:
    * to formatter, or nothing if is_sync_and_unlocked.
    */
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SimpleLock*>& ls);
+  static std::list<SimpleLock> generate_test_instances();
 
   virtual void print(std::ostream& out) const {
     out << "(";

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -454,28 +454,28 @@ void SnapServer::dump(Formatter *f) const
   f->close_section();
 }
 
-void SnapServer::generate_test_instances(std::list<SnapServer*>& ls)
+std::list<SnapServer> SnapServer::generate_test_instances()
 {
-  list<SnapInfo*> snapinfo_instances;
-  SnapInfo::generate_test_instances(snapinfo_instances);
-  SnapInfo populated_snapinfo = *(snapinfo_instances.back());
-  for (auto& info : snapinfo_instances) {
-    delete info;
-    info = nullptr;
-  }
+  std::list<SnapServer> ls;
+  list<SnapInfo> snapinfo_instances = SnapInfo::generate_test_instances();
 
-  SnapServer *blank = new SnapServer();
-  ls.push_back(blank);
-  SnapServer *populated = new SnapServer();
-  populated->last_snap = 123;
-  populated->snaps[456] = populated_snapinfo;
-  populated->need_to_purge[2].insert(012);
-  populated->pending_update[234] = populated_snapinfo;
-  populated->pending_destroy[345].first = 567;
-  populated->pending_destroy[345].second = 768;
-  populated->pending_noop.insert(890);
+  SnapInfo populated_snapinfo = snapinfo_instances.back();
 
-  ls.push_back(populated);
+  SnapServer blank;
+  ls.push_back(std::move(blank));
+
+  SnapServer populated;
+  populated.last_snap = 123;
+  populated.snaps[456] = populated_snapinfo;
+  populated.need_to_purge[2].insert(012);
+  populated.pending_update[234] = populated_snapinfo;
+  populated.pending_destroy[345].first = 567;
+  populated.pending_destroy[345].second = 768;
+  populated.pending_noop.insert(890);
+
+  ls.push_back(std::move(populated));
+
+  return ls;
 }
 
 bool SnapServer::force_update(snapid_t last, snapid_t v2_since,

--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -64,7 +64,7 @@ public:
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<SnapServer*>& ls);
+  static std::list<SnapServer> generate_test_instances();
 
   bool force_update(snapid_t last, snapid_t v2_since,
 		    std::map<snapid_t, SnapInfo>& _snaps);

--- a/src/mds/events/ECommitted.h
+++ b/src/mds/events/ECommitted.h
@@ -33,7 +33,7 @@ public:
   void encode(bufferlist &bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator &bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<ECommitted*>& ls);
+  static std::list<ECommitted> generate_test_instances();
 
   void update_segment() override {}
   void replay(MDSRank *mds) override;

--- a/src/mds/events/EExport.h
+++ b/src/mds/events/EExport.h
@@ -49,7 +49,7 @@ public:
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator &bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EExport*>& ls);
+  static std::list<EExport> generate_test_instances();
   void replay(MDSRank *mds) override;
 
 };

--- a/src/mds/events/EFragment.h
+++ b/src/mds/events/EFragment.h
@@ -73,7 +73,7 @@ public:
   void encode(bufferlist &bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator &bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EFragment*>& ls);
+  static std::list<EFragment> generate_test_instances();
   void replay(MDSRank *mds) override;
 };
 WRITE_CLASS_ENCODER_FEATURES(EFragment)

--- a/src/mds/events/EImportFinish.h
+++ b/src/mds/events/EImportFinish.h
@@ -43,7 +43,7 @@ class EImportFinish : public LogEvent {
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator &bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EImportFinish*>& ls);
+  static std::list<EImportFinish> generate_test_instances();
   
   void replay(MDSRank *mds) override;
 

--- a/src/mds/events/EImportStart.h
+++ b/src/mds/events/EImportStart.h
@@ -50,7 +50,7 @@ public:
   void encode(bufferlist &bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator &bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EImportStart*>& ls);
+  static std::list<EImportStart> generate_test_instances();
   
   void update_segment() override;
   void replay(MDSRank *mds) override;

--- a/src/mds/events/ELid.h
+++ b/src/mds/events/ELid.h
@@ -37,7 +37,7 @@ public:
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
   void replay(MDSRank *mds) override;
-  static void generate_test_instances(std::list<ELid*>& ls);
+  static std::list<ELid> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(ELid)
 

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -104,7 +104,7 @@ public:
     void encode(bufferlist& bl, uint64_t features) const;
     void decode(bufferlist::const_iterator &bl);
     void dump(Formatter *f) const;
-    static void generate_test_instances(std::list<EMetaBlob::fullbit*>& ls);
+    static std::list<EMetaBlob::fullbit> generate_test_instances();
 
     void update_inode(MDSRank *mds, CInode *in);
     bool is_dirty() const { return (state & STATE_DIRTY); }
@@ -174,7 +174,7 @@ public:
       out << std::endl;
     }
     void dump(Formatter *f) const;
-    static void generate_test_instances(std::list<remotebit*>& ls);
+    static std::list<remotebit> generate_test_instances();
   };
   WRITE_CLASS_ENCODER_FEATURES(remotebit)
 
@@ -195,7 +195,7 @@ public:
     void encode(bufferlist& bl) const;
     void decode(bufferlist::const_iterator &bl);
     void dump(Formatter *f) const;
-    static void generate_test_instances(std::list<nullbit*>& ls);
+    static std::list<nullbit> generate_test_instances();
     void print(std::ostream& out) const {
       out << " nullbit dn " << dn << " [" << dnfirst << "," << dnlast << "] dnv " << dnv
 	  << " dirty=" << dirty << std::endl;
@@ -313,7 +313,7 @@ public:
     void encode(bufferlist& bl, uint64_t features) const;
     void decode(bufferlist::const_iterator &bl);
     void dump(Formatter *f) const;
-    static void generate_test_instances(std::list<dirlump*>& ls);
+    static std::list<dirlump> generate_test_instances();
   };
   WRITE_CLASS_ENCODER_FEATURES(dirlump)
 
@@ -363,7 +363,7 @@ private:
   entity_name_t get_client_name() const {return client_name;}
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<EMetaBlob*>& ls);
+  static std::list<EMetaBlob> generate_test_instances();
 
   // for replay, in certain cases
   //LogSegment *_segment;

--- a/src/mds/events/EOpen.h
+++ b/src/mds/events/EOpen.h
@@ -51,7 +51,7 @@ public:
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EOpen*>& ls);
+  static std::list<EOpen> generate_test_instances();
 
   void update_segment() override;
   void replay(MDSRank *mds) override;

--- a/src/mds/events/EPeerUpdate.h
+++ b/src/mds/events/EPeerUpdate.h
@@ -40,7 +40,7 @@ struct link_rollback {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<link_rollback*>& ls);
+  static std::list<link_rollback> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(link_rollback)
 
@@ -61,7 +61,7 @@ struct rmdir_rollback {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<rmdir_rollback*>& ls);
+  static std::list<rmdir_rollback> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rmdir_rollback)
 
@@ -81,7 +81,7 @@ struct rename_rollback {
     void encode(bufferlist& bl) const;
     void decode(bufferlist::const_iterator& bl);
     void dump(Formatter *f) const;
-    static void generate_test_instances(std::list<drec*>& ls);
+    static std::list<drec> generate_test_instances();
   };
   WRITE_CLASS_MEMBER_ENCODER(drec)
 
@@ -95,7 +95,7 @@ struct rename_rollback {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<rename_rollback*>& ls);
+  static std::list<rename_rollback> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rename_rollback::drec)
 WRITE_CLASS_ENCODER(rename_rollback)
@@ -150,7 +150,7 @@ public:
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EPeerUpdate*>& ls);
+  static std::list<EPeerUpdate> generate_test_instances();
 
   void replay(MDSRank *mds) override;
 };

--- a/src/mds/events/EResetJournal.h
+++ b/src/mds/events/EResetJournal.h
@@ -32,7 +32,7 @@ class EResetJournal : public LogEvent, public SegmentBoundary {
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EResetJournal*>& ls);
+  static std::list<EResetJournal> generate_test_instances();
   void print(std::ostream& out) const override {
     out << "EResetJournal";
   }

--- a/src/mds/events/ESegment.h
+++ b/src/mds/events/ESegment.h
@@ -33,7 +33,7 @@ public:
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
   void replay(MDSRank *mds) override;
-  static void generate_test_instances(std::list<ESegment*>& ls);
+  static std::list<ESegment> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(ESegment)
 

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -50,7 +50,7 @@ class ESession : public LogEvent {
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<ESession*>& ls);
+  static std::list<ESession> generate_test_instances();
 
   void print(std::ostream& out) const override {
     if (open)

--- a/src/mds/events/ESessions.h
+++ b/src/mds/events/ESessions.h
@@ -47,7 +47,7 @@ public:
     else decode_new(bl);
   }
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<ESessions*>& ls);
+  static std::list<ESessions> generate_test_instances();
 
   void print(std::ostream& out) const override {
     out << "ESessions " << client_map.size() << " opens cmapv " << cmapv;

--- a/src/mds/events/ESubtreeMap.h
+++ b/src/mds/events/ESubtreeMap.h
@@ -39,7 +39,7 @@ public:
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<ESubtreeMap*>& ls);
+  static std::list<ESubtreeMap> generate_test_instances();
 
   void replay(MDSRank *mds) override;
   bool is_major_segment_boundary() const override {

--- a/src/mds/events/ETableClient.h
+++ b/src/mds/events/ETableClient.h
@@ -34,7 +34,7 @@ struct ETableClient : public LogEvent {
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<ETableClient*>& ls);
+  static std::list<ETableClient> generate_test_instances();
 
   void print(std::ostream& out) const override {
     out << "ETableClient " << get_mdstable_name(table) << " " << get_mdstableserver_opname(op);

--- a/src/mds/events/ETableServer.h
+++ b/src/mds/events/ETableServer.h
@@ -39,7 +39,7 @@ struct ETableServer : public LogEvent {
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<ETableServer*>& ls);
+  static std::list<ETableServer> generate_test_instances();
 
   void print(std::ostream& out) const override {
     out << "ETableServer " << get_mdstable_name(table) 

--- a/src/mds/events/EUpdate.h
+++ b/src/mds/events/EUpdate.h
@@ -45,7 +45,7 @@ public:
   void encode(bufferlist& bl, uint64_t features) const override;
   void decode(bufferlist::const_iterator& bl) override;
   void dump(Formatter *f) const override;
-  static void generate_test_instances(std::list<EUpdate*>& ls);
+  static std::list<EUpdate> generate_test_instances();
 
   void update_segment() override;
   void replay(MDSRank *mds) override;

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -84,13 +84,15 @@ void ceph_lock_state_t::dump(ceph::Formatter *f) const {
 }
 
 
-void ceph_lock_state_t::generate_test_instances(std::list<ceph_lock_state_t*>& ls) {
-  ls.push_back(new ceph_lock_state_t(NULL, 0));
-  ls.push_back(new ceph_lock_state_t(NULL, 1));
-  ls.back()->held_locks.insert(std::make_pair(1, ceph_filelock()));
-  ls.back()->waiting_locks.insert(std::make_pair(1, ceph_filelock()));
-  ls.back()->client_held_lock_counts.insert(std::make_pair(1, 1));
-  ls.back()->client_waiting_lock_counts.insert(std::make_pair(1, 1));
+std::list<ceph_lock_state_t> ceph_lock_state_t::generate_test_instances() {
+  std::list<ceph_lock_state_t> ls;
+  ls.push_back(ceph_lock_state_t(NULL, 0));
+  ls.push_back(ceph_lock_state_t(NULL, 1));
+  ls.back().held_locks.insert(std::make_pair(1, ceph_filelock()));
+  ls.back().waiting_locks.insert(std::make_pair(1, ceph_filelock()));
+  ls.back().client_held_lock_counts.insert(std::make_pair(1, 1));
+  ls.back().client_waiting_lock_counts.insert(std::make_pair(1, 1));
+  return ls;
 }
 
 bool ceph_lock_state_t::is_waiting(const ceph_filelock &fl) const

--- a/src/mds/flock.h
+++ b/src/mds/flock.h
@@ -123,7 +123,7 @@ public:
   void encode(ceph::bufferlist& bl) const;
   void decode(ceph::bufferlist::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ceph_lock_state_t*>& ls);
+  static std::list<ceph_lock_state_t> generate_test_instances();
   bool empty() const {
     return held_locks.empty() && waiting_locks.empty() &&
 	   client_held_lock_counts.empty() &&

--- a/src/mds/inode_backtrace.cc
+++ b/src/mds/inode_backtrace.cc
@@ -40,13 +40,15 @@ void inode_backpointer_t::dump(ceph::Formatter *f) const
   f->dump_unsigned("version", version);
 }
 
-void inode_backpointer_t::generate_test_instances(std::list<inode_backpointer_t*>& ls)
+std::list<inode_backpointer_t> inode_backpointer_t::generate_test_instances()
 {
-  ls.push_back(new inode_backpointer_t);
-  ls.push_back(new inode_backpointer_t);
-  ls.back()->dirino = 1;
-  ls.back()->dname = "foo";
-  ls.back()->version = 123;
+  std::list<inode_backpointer_t> ls;
+  ls.push_back(inode_backpointer_t{});
+  ls.push_back(inode_backpointer_t{});
+  ls.back().dirino = 1;
+  ls.back().dname = "foo";
+  ls.back().version = 123;
+  return ls;
 }
 
 
@@ -105,18 +107,20 @@ void inode_backtrace_t::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void inode_backtrace_t::generate_test_instances(std::list<inode_backtrace_t*>& ls)
+std::list<inode_backtrace_t> inode_backtrace_t::generate_test_instances()
 {
-  ls.push_back(new inode_backtrace_t);
-  ls.push_back(new inode_backtrace_t);
-  ls.back()->ino = 1;
-  ls.back()->ancestors.push_back(inode_backpointer_t());
-  ls.back()->ancestors.back().dirino = 123;
-  ls.back()->ancestors.back().dname = "bar";
-  ls.back()->ancestors.back().version = 456;
-  ls.back()->pool = 0;
-  ls.back()->old_pools.push_back(10);
-  ls.back()->old_pools.push_back(7);
+  std::list<inode_backtrace_t> ls;
+  ls.push_back(inode_backtrace_t{});
+  ls.push_back(inode_backtrace_t{});
+  ls.back().ino = 1;
+  ls.back().ancestors.push_back(inode_backpointer_t());
+  ls.back().ancestors.back().dirino = 123;
+  ls.back().ancestors.back().dname = "bar";
+  ls.back().ancestors.back().version = 456;
+  ls.back().pool = 0;
+  ls.back().old_pools.push_back(10);
+  ls.back().old_pools.push_back(7);
+  return ls;
 }
 
 int inode_backtrace_t::compare(const inode_backtrace_t& other,

--- a/src/mds/inode_backtrace.h
+++ b/src/mds/inode_backtrace.h
@@ -35,7 +35,7 @@ struct inode_backpointer_t {
   void decode(ceph::buffer::list::const_iterator &bl);
   void decode_old(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<inode_backpointer_t*>& ls);
+  static std::list<inode_backpointer_t> generate_test_instances();
 
   inodeno_t dirino;    // containing directory ino
   std::string dname;        // linking dentry name
@@ -60,7 +60,7 @@ struct inode_backtrace_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<inode_backtrace_t*>& ls);
+  static std::list<inode_backtrace_t> generate_test_instances();
 
   /**
    * Compare two backtraces *for the same inode*.

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -615,16 +615,17 @@ void EMetaBlob::fullbit::dump(Formatter *f) const
   f->dump_string("alternate_name", alternate_name);
 }
 
-void EMetaBlob::fullbit::generate_test_instances(std::list<EMetaBlob::fullbit*>& ls)
+std::list<EMetaBlob::fullbit> EMetaBlob::fullbit::generate_test_instances()
 {
+  std::list<EMetaBlob::fullbit> ls;
   auto _inode = CInode::allocate_inode();
   fragtree_t fragtree;
   auto _xattrs = CInode::allocate_xattr_map();
   bufferlist empty_snapbl;
-  fullbit *sample = new fullbit("/testdn", "", 0, 0, 0,
-                                _inode, fragtree, _xattrs, "", 0, empty_snapbl,
-                                false, NULL);
-  ls.push_back(sample);
+  ls.emplace_back("/testdn", "", 0, 0, 0,
+		  _inode, fragtree, _xattrs, "", 0, empty_snapbl,
+		  false, nullptr);
+  return ls;
 }
 
 void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
@@ -794,14 +795,15 @@ void EMetaBlob::remotebit::dump(Formatter *f) const
   f->dump_int("referentino", referent_ino);
 }
 
-void EMetaBlob::remotebit::
-generate_test_instances(std::list<EMetaBlob::remotebit*>& ls)
+std::list<EMetaBlob::remotebit> EMetaBlob::remotebit::generate_test_instances()
 {
+  std::list<EMetaBlob::remotebit> ls;
   auto _inode = CInode::allocate_inode();
-  remotebit *remote = new remotebit("/test/dn", "", 0, 10, 15, 1, IFTODT(S_IFREG), 2, _inode, false);
+  auto remote = remotebit("/test/dn", "", 0, 10, 15, 1, IFTODT(S_IFREG), 2, _inode, false);
+  ls.push_back(std::move(remote));
+  remote = remotebit("/test/dn2", "foo", 0, 10, 15, 1, IFTODT(S_IFREG), 2, _inode, false);
   ls.push_back(remote);
-  remote = new remotebit("/test/dn2", "foo", 0, 10, 15, 1, IFTODT(S_IFREG), 2, _inode, false);
-  ls.push_back(remote);
+  return ls;
 }
 
 // EMetaBlob::nullbit
@@ -839,12 +841,14 @@ void EMetaBlob::nullbit::dump(Formatter *f) const
   f->dump_string("dirty", dirty ? "true" : "false");
 }
 
-void EMetaBlob::nullbit::generate_test_instances(std::list<nullbit*>& ls)
+auto EMetaBlob::nullbit::generate_test_instances() -> std::list<nullbit>
 {
-  nullbit *sample = new nullbit("/test/dentry", 0, 10, 15, false);
-  nullbit *sample2 = new nullbit("/test/dirty", 10, 20, 25, true);
-  ls.push_back(sample);
-  ls.push_back(sample2);
+  std::list<nullbit> ls;
+  nullbit sample("/test/dentry", 0, 10, 15, false);
+  nullbit sample2("/test/dirty", 10, 20, 25, true);
+  ls.push_back(std::move(sample));
+  ls.push_back(std::move(sample2));
+  return ls;
 }
 
 // EMetaBlob::dirlump
@@ -918,11 +922,13 @@ void EMetaBlob::dirlump::dump(Formatter *f) const
   f->close_section(); // null bits
 }
 
-void EMetaBlob::dirlump::generate_test_instances(std::list<dirlump*>& ls)
+auto EMetaBlob::dirlump::generate_test_instances() -> std::list<dirlump>
 {
-  auto dl = new dirlump();
-  dl->fnode = CDir::allocate_fnode();
-  ls.push_back(dl);
+  std::list<dirlump> ls;
+  ls.emplace_back();
+  dirlump& dl = ls.back();
+  dl.fnode = CDir::allocate_fnode();
+  return ls;
 }
 
 /**
@@ -1257,9 +1263,11 @@ void EMetaBlob::dump(Formatter *f) const
   f->close_section(); // client requests
 }
 
-void EMetaBlob::generate_test_instances(std::list<EMetaBlob*>& ls)
+std::list<EMetaBlob> EMetaBlob::generate_test_instances()
 {
-  ls.push_back(new EMetaBlob());
+  std::list<EMetaBlob> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void EMetaBlob::replay(MDSRank *mds, LogSegmentRef const& logseg, int type, MDPeerUpdate *peerup)
@@ -2096,9 +2104,11 @@ void ESession::dump(Formatter *f) const
   f->close_section();  // client_metadata
 }
 
-void ESession::generate_test_instances(std::list<ESession*>& ls)
+std::list<ESession> ESession::generate_test_instances()
 {
-  ls.push_back(new ESession);
+  std::list<ESession> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 // -----------------------
@@ -2149,9 +2159,11 @@ void ESessions::dump(Formatter *f) const
   f->close_section(); // client map
 }
 
-void ESessions::generate_test_instances(std::list<ESessions*>& ls)
+std::list<ESessions> ESessions::generate_test_instances()
 {
-  ls.push_back(new ESessions());
+  std::list<ESessions> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void ESessions::update_segment()
@@ -2215,9 +2227,11 @@ void ETableServer::dump(Formatter *f) const
   f->dump_int("version", version);
 }
 
-void ETableServer::generate_test_instances(std::list<ETableServer*>& ls)
+std::list<ETableServer> ETableServer::generate_test_instances()
 {
-  ls.push_back(new ETableServer());
+  std::list<ETableServer> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 
@@ -2307,9 +2321,11 @@ void ETableClient::dump(Formatter *f) const
   f->dump_int("tid", tid);
 }
 
-void ETableClient::generate_test_instances(std::list<ETableClient*>& ls)
+std::list<ETableClient> ETableClient::generate_test_instances()
 {
-  ls.push_back(new ETableClient());
+  std::list<ETableClient> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void ETableClient::replay(MDSRank *mds)
@@ -2405,9 +2421,11 @@ void EUpdate::dump(Formatter *f) const
   f->dump_string("had peers", had_peers ? "true" : "false");
 }
 
-void EUpdate::generate_test_instances(std::list<EUpdate*>& ls)
+std::list<EUpdate> EUpdate::generate_test_instances()
 {
-  ls.push_back(new EUpdate());
+  std::list<EUpdate> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 
@@ -2494,11 +2512,13 @@ void EOpen::dump(Formatter *f) const
   f->close_section(); // inos
 }
 
-void EOpen::generate_test_instances(std::list<EOpen*>& ls)
+std::list<EOpen> EOpen::generate_test_instances()
 {
-  ls.push_back(new EOpen());
-  ls.push_back(new EOpen());
-  ls.back()->add_ino(0);
+  std::list<EOpen> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().add_ino(0);
+  return ls;
 }
 
 void EOpen::update_segment()
@@ -2568,12 +2588,14 @@ void ECommitted::dump(Formatter *f) const {
   f->dump_stream("reqid") << reqid;
 }
 
-void ECommitted::generate_test_instances(std::list<ECommitted*>& ls)
+std::list<ECommitted> ECommitted::generate_test_instances()
 {
-  ls.push_back(new ECommitted);
-  ls.push_back(new ECommitted);
-  ls.back()->stamp = utime_t(1, 2);
-  ls.back()->reqid = metareqid_t(entity_name_t::CLIENT(123), 456);
+  std::list<ECommitted> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().stamp = utime_t(1, 2);
+  ls.back().reqid = metareqid_t(entity_name_t::CLIENT(123), 456);
+  return ls;
 }
 
 // -----------------------
@@ -2620,9 +2642,11 @@ void link_rollback::dump(Formatter *f) const
   f->dump_stream("referent_ino") << referent_ino;
 }
 
-void link_rollback::generate_test_instances(std::list<link_rollback*>& ls)
+std::list<link_rollback> link_rollback::generate_test_instances()
 {
-  ls.push_back(new link_rollback());
+  std::list<link_rollback> ls;
+  ls.push_back(link_rollback());
+  return ls;
 }
 
 void rmdir_rollback::encode(bufferlist& bl) const
@@ -2659,9 +2683,11 @@ void rmdir_rollback::dump(Formatter *f) const
   f->dump_string("destination dname", dest_dname);
 }
 
-void rmdir_rollback::generate_test_instances(std::list<rmdir_rollback*>& ls)
+std::list<rmdir_rollback> rmdir_rollback::generate_test_instances()
 {
-  ls.push_back(new rmdir_rollback());
+  std::list<rmdir_rollback> ls;
+  ls.push_back(rmdir_rollback());
+  return ls;
 }
 
 void rename_rollback::drec::encode(bufferlist &bl) const
@@ -2720,10 +2746,12 @@ void rename_rollback::drec::dump(Formatter *f) const
   f->dump_stream("old ctime") << old_ctime;
 }
 
-void rename_rollback::drec::generate_test_instances(std::list<drec*>& ls)
+auto rename_rollback::drec::generate_test_instances() -> std::list<drec>
 {
-  ls.push_back(new drec());
-  ls.back()->remote_d_type = IFTODT(S_IFREG);
+  std::list<drec> ls;
+  ls.push_back(drec());
+  ls.back().remote_d_type = IFTODT(S_IFREG);
+  return ls;
 }
 
 void rename_rollback::encode(bufferlist &bl) const
@@ -2769,12 +2797,14 @@ void rename_rollback::dump(Formatter *f) const
   f->dump_stream("ctime") << ctime;
 }
 
-void rename_rollback::generate_test_instances(std::list<rename_rollback*>& ls)
+std::list<rename_rollback> rename_rollback::generate_test_instances()
 {
-  ls.push_back(new rename_rollback());
-  ls.back()->orig_src.remote_d_type = IFTODT(S_IFREG);
-  ls.back()->orig_dest.remote_d_type = IFTODT(S_IFREG);
-  ls.back()->stray.remote_d_type = IFTODT(S_IFREG);
+  std::list<rename_rollback> ls;
+  ls.push_back(rename_rollback());
+  ls.back().orig_src.remote_d_type = IFTODT(S_IFREG);
+  ls.back().orig_dest.remote_d_type = IFTODT(S_IFREG);
+  ls.back().stray.remote_d_type = IFTODT(S_IFREG);
+  return ls;
 }
 
 void EPeerUpdate::encode(bufferlist &bl, uint64_t features) const
@@ -2820,9 +2850,11 @@ void EPeerUpdate::dump(Formatter *f) const
   f->dump_int("original op", origop);
 }
 
-void EPeerUpdate::generate_test_instances(std::list<EPeerUpdate*>& ls)
+std::list<EPeerUpdate> EPeerUpdate::generate_test_instances()
 {
-  ls.push_back(new EPeerUpdate());
+  std::list<EPeerUpdate> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void EPeerUpdate::replay(MDSRank *mds)
@@ -2918,9 +2950,11 @@ void ESubtreeMap::dump(Formatter *f) const
   f->dump_int("expire position", expire_pos);
 }
 
-void ESubtreeMap::generate_test_instances(std::list<ESubtreeMap*>& ls)
+std::list<ESubtreeMap> ESubtreeMap::generate_test_instances()
 {
-  ls.push_back(new ESubtreeMap());
+  std::list<ESubtreeMap> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void ESubtreeMap::replay(MDSRank *mds) 
@@ -3146,13 +3180,15 @@ void EFragment::dump(Formatter *f) const
   f->dump_int("bits", bits);
 }
 
-void EFragment::generate_test_instances(std::list<EFragment*>& ls)
+std::list<EFragment> EFragment::generate_test_instances()
 {
-  ls.push_back(new EFragment);
-  ls.push_back(new EFragment);
-  ls.back()->op = OP_PREPARE;
-  ls.back()->ino = 1;
-  ls.back()->bits = 5;
+  std::list<EFragment> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().op = OP_PREPARE;
+  ls.back().ino = 1;
+  ls.back().bits = 5;
+  return ls;
 }
 
 void dirfrag_rollback::encode(bufferlist &bl) const
@@ -3243,10 +3279,11 @@ void EExport::dump(Formatter *f) const
   f->close_section(); // bounds dirfrags
 }
 
-void EExport::generate_test_instances(std::list<EExport*>& ls)
+std::list<EExport> EExport::generate_test_instances()
 {
-  EExport *sample = new EExport();
-  ls.push_back(sample);
+  std::list<EExport> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 
@@ -3342,9 +3379,11 @@ void EImportStart::dump(Formatter *f) const
   f->close_section();
 }
 
-void EImportStart::generate_test_instances(std::list<EImportStart*>& ls)
+std::list<EImportStart> EImportStart::generate_test_instances()
 {
-  ls.push_back(new EImportStart);
+  std::list<EImportStart> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 // -----------------------
@@ -3400,11 +3439,13 @@ void EImportFinish::dump(Formatter *f) const
   f->dump_stream("base dirfrag") << base;
   f->dump_string("success", success ? "true" : "false");
 }
-void EImportFinish::generate_test_instances(std::list<EImportFinish*>& ls)
+std::list<EImportFinish> EImportFinish::generate_test_instances()
 {
-  ls.push_back(new EImportFinish);
-  ls.push_back(new EImportFinish);
-  ls.back()->success = true;
+  std::list<EImportFinish> ls;
+  ls.emplace_back();
+  ls.emplace_back();
+  ls.back().success = true;
+  return ls;
 }
 
 
@@ -3430,9 +3471,11 @@ void EResetJournal::dump(Formatter *f) const
   f->dump_stream("timestamp") << stamp;
 }
 
-void EResetJournal::generate_test_instances(std::list<EResetJournal*>& ls)
+std::list<EResetJournal> EResetJournal::generate_test_instances()
 {
-  ls.push_back(new EResetJournal());
+  std::list<EResetJournal> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void EResetJournal::replay(MDSRank *mds)
@@ -3479,9 +3522,11 @@ void ESegment::dump(Formatter *f) const
   f->dump_int("seq", seq);
 }
 
-void ESegment::generate_test_instances(std::list<ESegment*>& ls)
+std::list<ESegment> ESegment::generate_test_instances()
 {
-  ls.push_back(new ESegment);
+  std::list<ESegment> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void ELid::encode(bufferlist &bl, uint64_t features) const
@@ -3508,9 +3553,11 @@ void ELid::dump(Formatter *f) const
   f->dump_int("seq", seq);
 }
 
-void ELid::generate_test_instances(std::list<ELid*>& ls)
+std::list<ELid> ELid::generate_test_instances()
 {
-  ls.push_back(new ELid);
+  std::list<ELid> ls;
+  ls.emplace_back();
+  return ls;
 }
 
 void ENoOp::encode(bufferlist &bl, uint64_t features) const

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -84,14 +84,16 @@ void frag_info_t::decode_json(JSONObj *obj){
   JSONDecoder::decode_json("change_attr", change_attr, obj, true);
 }
 
-void frag_info_t::generate_test_instances(std::list<frag_info_t*>& ls)
+std::list<frag_info_t> frag_info_t::generate_test_instances()
 {
-  ls.push_back(new frag_info_t);
-  ls.push_back(new frag_info_t);
-  ls.back()->version = 1;
-  ls.back()->mtime = utime_t(2, 3);
-  ls.back()->nfiles = 4;
-  ls.back()->nsubdirs = 5;
+  std::list<frag_info_t> ls;
+  ls.push_back(frag_info_t{});
+  ls.push_back(frag_info_t{});
+  ls.back().version = 1;
+  ls.back().mtime = utime_t(2, 3);
+  ls.back().nfiles = 4;
+  ls.back().nsubdirs = 5;
+  return ls;
 }
 
 ostream& operator<<(ostream &out, const frag_info_t &f)
@@ -165,16 +167,18 @@ void nest_info_t::decode_json(JSONObj *obj){
   JSONDecoder::decode_json("rctime", rctime, obj, true);
 }
 
-void nest_info_t::generate_test_instances(std::list<nest_info_t*>& ls)
+std::list<nest_info_t> nest_info_t::generate_test_instances()
 {
-  ls.push_back(new nest_info_t);
-  ls.push_back(new nest_info_t);
-  ls.back()->version = 1;
-  ls.back()->rbytes = 2;
-  ls.back()->rfiles = 3;
-  ls.back()->rsubdirs = 4;
-  ls.back()->rsnaps = 6;
-  ls.back()->rctime = utime_t(7, 8);
+  std::list<nest_info_t> ls;
+  ls.push_back(nest_info_t{});
+  ls.push_back(nest_info_t{});
+  ls.back().version = 1;
+  ls.back().rbytes = 2;
+  ls.back().rfiles = 3;
+  ls.back().rsubdirs = 4;
+  ls.back().rsnaps = 6;
+  ls.back().rctime = utime_t(7, 8);
+  return ls;
 }
 
 ostream& operator<<(ostream &out, const nest_info_t &n)
@@ -209,12 +213,14 @@ void  quota_info_t::decode_json(JSONObj *obj){
   JSONDecoder::decode_json("max_files", max_files, obj, true);
 }
 
-void quota_info_t::generate_test_instances(std::list<quota_info_t *>& ls)
+std::list<quota_info_t> quota_info_t::generate_test_instances()
 {
-  ls.push_back(new quota_info_t);
-  ls.push_back(new quota_info_t);
-  ls.back()->max_bytes = 16;
-  ls.back()->max_files = 16;
+  std::list<quota_info_t> ls;
+  ls.push_back(quota_info_t{});
+  ls.push_back(quota_info_t{});
+  ls.back().max_bytes = 16;
+  ls.back().max_files = 16;
+  return ls;
 }
 
 ostream& operator<<(ostream &out, const quota_info_t &n)
@@ -263,13 +269,15 @@ void client_writeable_range_t::byte_range_t::decode_json(JSONObj *obj){
   JSONDecoder::decode_json("last", last, obj, true);
 }
 
-void client_writeable_range_t::generate_test_instances(std::list<client_writeable_range_t*>& ls)
+std::list<client_writeable_range_t> client_writeable_range_t::generate_test_instances()
 {
-  ls.push_back(new client_writeable_range_t);
-  ls.push_back(new client_writeable_range_t);
-  ls.back()->range.first = 123;
-  ls.back()->range.last = 456;
-  ls.back()->follows = 12;
+  std::list<client_writeable_range_t> ls;
+  ls.push_back(client_writeable_range_t{});
+  ls.push_back(client_writeable_range_t{});
+  ls.back().range.first = 123;
+  ls.back().range.last = 456;
+  ls.back().follows = 12;
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const client_writeable_range_t& r)
@@ -309,13 +317,15 @@ void inline_data_t::dump(Formatter *f) const
   f->dump_unsigned("length", length());
 }
 
-void inline_data_t::generate_test_instances(std::list<inline_data_t*>& ls)
+std::list<inline_data_t> inline_data_t::generate_test_instances()
 {
-  ls.push_back(new inline_data_t);
-  ls.push_back(new inline_data_t);
+  std::list<inline_data_t> ls;
+  ls.push_back(inline_data_t{});
+  ls.push_back(inline_data_t{});
   bufferlist bl;
   bl.append("inline data");
-  ls.back()->set_data(bl);
+  ls.back().set_data(bl);
+  return ls;
 }
 
 
@@ -391,20 +401,20 @@ void fnode_t::decode_json(JSONObj *obj){
   JSONDecoder::decode_json("rstat", rstat, obj, true);
   JSONDecoder::decode_json("accounted_rstat", accounted_rstat, obj, true);
 }
-void fnode_t::generate_test_instances(std::list<fnode_t*>& ls)
+std::list<fnode_t> fnode_t::generate_test_instances()
 {
-  ls.push_back(new fnode_t);
-  ls.push_back(new fnode_t);
-  ls.back()->version = 1;
-  ls.back()->snap_purged_thru = 2;
-  list<frag_info_t*> fls;
-  frag_info_t::generate_test_instances(fls);
-  ls.back()->fragstat = *fls.back();
-  ls.back()->accounted_fragstat = *fls.front();
-  list<nest_info_t*> nls;
-  nest_info_t::generate_test_instances(nls);
-  ls.back()->rstat = *nls.front();
-  ls.back()->accounted_rstat = *nls.back();
+  std::list<fnode_t> ls;
+  ls.push_back(fnode_t{});
+  ls.push_back(fnode_t{});
+  ls.back().version = 1;
+  ls.back().snap_purged_thru = 2;
+  list<frag_info_t> fls = frag_info_t::generate_test_instances();
+  ls.back().fragstat = fls.back();
+  ls.back().accounted_fragstat = fls.front();
+  list<nest_info_t> nls = nest_info_t::generate_test_instances();
+  ls.back().rstat = nls.front();
+  ls.back().accounted_rstat = nls.back();
+  return ls;
 }
 
 
@@ -440,15 +450,16 @@ void old_rstat_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void old_rstat_t::generate_test_instances(std::list<old_rstat_t*>& ls)
+std::list<old_rstat_t> old_rstat_t::generate_test_instances()
 {
-  ls.push_back(new old_rstat_t());
-  ls.push_back(new old_rstat_t());
-  ls.back()->first = 12;
-  list<nest_info_t*> nls;
-  nest_info_t::generate_test_instances(nls);
-  ls.back()->rstat = *nls.back();
-  ls.back()->accounted_rstat = *nls.front();
+  std::list<old_rstat_t> ls;
+  ls.push_back(old_rstat_t());
+  ls.push_back(old_rstat_t());
+  ls.back().first = 12;
+  list<nest_info_t> nls = nest_info_t::generate_test_instances();
+  ls.back().rstat = nls.back();
+  ls.back().accounted_rstat = nls.front();
+  return ls;
 }
 
 void old_rstat_t::print(std::ostream& out) const {
@@ -547,13 +558,15 @@ void feature_bitset_t::dump(Formatter *f) const {
   f->dump_string("feature_bits", css->strv());
 }
 
-void feature_bitset_t::generate_test_instances(std::list<feature_bitset_t*>& ls)
+std::list<feature_bitset_t> feature_bitset_t::generate_test_instances()
 {
-  ls.push_back(new feature_bitset_t());
-  ls.push_back(new feature_bitset_t());
-  ls.back()->_vec.push_back(1);
-  ls.back()->_vec.push_back(2);
-  ls.back()->_vec.push_back(3);
+  std::list<feature_bitset_t> ls;
+  ls.push_back(feature_bitset_t());
+  ls.push_back(feature_bitset_t());
+  ls.back()._vec.push_back(1);
+  ls.back()._vec.push_back(2);
+  ls.back()._vec.push_back(3);
+  return ls;
 }
 
 void feature_bitset_t::print(ostream& out) const
@@ -592,11 +605,13 @@ void metric_spec_t::dump(Formatter *f) const {
   f->dump_object("metric_flags", metric_flags);
 }
 
-void metric_spec_t::generate_test_instances(std::list<metric_spec_t*>& ls)
+std::list<metric_spec_t> metric_spec_t::generate_test_instances()
 {
-  ls.push_back(new metric_spec_t());
-  ls.push_back(new metric_spec_t());
-  ls.back()->metric_flags = 1;
+  std::list<metric_spec_t> ls;
+  ls.push_back(metric_spec_t());
+  ls.push_back(metric_spec_t());
+  ls.back().metric_flags = 1;
+  return ls;
 }
 
 void metric_spec_t::print(ostream& out) const
@@ -636,14 +651,16 @@ void client_metadata_t::dump(Formatter *f) const
     f->dump_string(name.c_str(), val);
 }
 
-void client_metadata_t::generate_test_instances(std::list<client_metadata_t*>& ls)
+std::list<client_metadata_t> client_metadata_t::generate_test_instances()
 {
-  ls.push_back(new client_metadata_t());
-  ls.push_back(new client_metadata_t());
-  ls.back()->kv_map["key1"] = "val1";
-  ls.back()->kv_map["key2"] = "val2";
-  ls.back()->features = 0x12345678;
-  ls.back()->metric_spec.metric_flags = 0x12345678;
+  std::list<client_metadata_t> ls;
+  ls.push_back(client_metadata_t());
+  ls.push_back(client_metadata_t());
+  ls.back().kv_map["key1"] = "val1";
+  ls.back().kv_map["key2"] = "val2";
+  ls.back().features = 0x12345678;
+  ls.back().metric_spec.metric_flags = 0x12345678;
+  return ls;
 }
 
 /*
@@ -722,16 +739,18 @@ void session_info_t::dump(Formatter *f) const
   f->dump_object("client_metadata", client_metadata);
 }
 
-void session_info_t::generate_test_instances(std::list<session_info_t*>& ls)
+std::list<session_info_t> session_info_t::generate_test_instances()
 {
-  ls.push_back(new session_info_t);
-  ls.push_back(new session_info_t);
-  ls.back()->inst = entity_inst_t(entity_name_t::MDS(12), entity_addr_t());
-  ls.back()->completed_requests.insert(make_pair(234, inodeno_t(111222)));
-  ls.back()->completed_requests.insert(make_pair(237, inodeno_t(222333)));
-  ls.back()->prealloc_inos.insert(333, 12);
-  ls.back()->prealloc_inos.insert(377, 112);
+  std::list<session_info_t>ls;
+  ls.push_back(session_info_t{});
+  ls.push_back(session_info_t{});
+  ls.back().inst = entity_inst_t(entity_name_t::MDS(12), entity_addr_t());
+  ls.back().completed_requests.insert(make_pair(234, inodeno_t(111222)));
+  ls.back().completed_requests.insert(make_pair(237, inodeno_t(222333)));
+  ls.back().prealloc_inos.insert(333, 12);
+  ls.back().prealloc_inos.insert(377, 112);
   // we can't add used inos; they're cleared on decode
+  return ls;
 }
 
 /*
@@ -783,15 +802,17 @@ void string_snap_t::dump(Formatter *f) const
   f->dump_unsigned("snapid", snapid);
 }
 
-void string_snap_t::generate_test_instances(std::list<string_snap_t*>& ls)
+std::list<string_snap_t> string_snap_t::generate_test_instances()
 {
-  ls.push_back(new string_snap_t);
-  ls.push_back(new string_snap_t);
-  ls.back()->name = "foo";
-  ls.back()->snapid = 123;
-  ls.push_back(new string_snap_t);
-  ls.back()->name = "bar";
-  ls.back()->snapid = 456;
+  std::list<string_snap_t> ls;
+  ls.push_back(string_snap_t{});
+  ls.push_back(string_snap_t{});
+  ls.back().name = "foo";
+  ls.back().snapid = 123;
+  ls.push_back(string_snap_t{});
+  ls.back().name = "bar";
+  ls.back().snapid = 456;
+  return ls;
 }
 
 
@@ -837,19 +858,21 @@ void MDSCacheObjectInfo::print(std::ostream& out) const {
   }
 }
 
-void MDSCacheObjectInfo::generate_test_instances(std::list<MDSCacheObjectInfo*>& ls)
+std::list<MDSCacheObjectInfo> MDSCacheObjectInfo::generate_test_instances()
 {
-  ls.push_back(new MDSCacheObjectInfo);
-  ls.push_back(new MDSCacheObjectInfo);
-  ls.back()->ino = 1;
-  ls.back()->dirfrag = dirfrag_t(2, 3);
-  ls.back()->dname = "fooname";
-  ls.back()->snapid = CEPH_NOSNAP;
-  ls.push_back(new MDSCacheObjectInfo);
-  ls.back()->ino = 121;
-  ls.back()->dirfrag = dirfrag_t(222, 0);
-  ls.back()->dname = "bar foo";
-  ls.back()->snapid = 21322;
+  std::list<MDSCacheObjectInfo> ls;
+  ls.push_back(MDSCacheObjectInfo{});
+  ls.push_back(MDSCacheObjectInfo{});
+  ls.back().ino = 1;
+  ls.back().dirfrag = dirfrag_t(2, 3);
+  ls.back().dname = "fooname";
+  ls.back().snapid = CEPH_NOSNAP;
+  ls.push_back(MDSCacheObjectInfo{});
+  ls.back().ino = 121;
+  ls.back().dirfrag = dirfrag_t(222, 0);
+  ls.back().dname = "bar foo";
+  ls.back().snapid = 21322;
+  return ls;
 }
 
 /*
@@ -880,13 +903,15 @@ void mds_table_pending_t::dump(Formatter *f) const
   f->dump_unsigned("tid", tid);
 }
 
-void mds_table_pending_t::generate_test_instances(std::list<mds_table_pending_t*>& ls)
+std::list<mds_table_pending_t> mds_table_pending_t::generate_test_instances()
 {
-  ls.push_back(new mds_table_pending_t);
-  ls.push_back(new mds_table_pending_t);
-  ls.back()->reqid = 234;
-  ls.back()->mds = 2;
-  ls.back()->tid = 35434;
+  std::list<mds_table_pending_t> ls;
+  ls.push_back(mds_table_pending_t{});
+  ls.push_back(mds_table_pending_t{});
+  ls.back().reqid = 234;
+  ls.back().mds = 2;
+  ls.back().tid = 35434;
+  return ls;
 }
 
 void metareqid_t::dump(ceph::Formatter* f) const {
@@ -898,9 +923,11 @@ void metareqid_t::print(std::ostream& out) const {
   out << name << ":" << tid;
 }
 
-void metareqid_t::generate_test_instances(std::list<metareqid_t*>& ls) {
-  ls.push_back(new metareqid_t);
-  ls.push_back(new metareqid_t(entity_name_t::CLIENT(123), 456));
+std::list<metareqid_t> metareqid_t::generate_test_instances() {
+  std::list<metareqid_t> ls;
+  ls.push_back(metareqid_t{});
+  ls.push_back(metareqid_t(entity_name_t::CLIENT(123), 456));
+  return ls;
 }
 
 /*
@@ -918,10 +945,12 @@ void dirfrag_t::dump(ceph::Formatter *f) const {
   f->dump_unsigned("frag", frag);
 }
 
-void dirfrag_t::generate_test_instances(std::list<dirfrag_t*>& ls) {
-  ls.push_back(new dirfrag_t);
-  ls.push_back(new dirfrag_t(1, frag_t()));
-  ls.push_back(new dirfrag_t(2, frag_t(3)));
+std::list<dirfrag_t> dirfrag_t::generate_test_instances() {
+  std::list<dirfrag_t> ls;
+  ls.push_back(dirfrag_t{});
+  ls.push_back(dirfrag_t(1, frag_t()));
+  ls.push_back(dirfrag_t(2, frag_t(3)));
+  return ls;
 }
 
 /*
@@ -956,9 +985,11 @@ void inode_load_vec_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void inode_load_vec_t::generate_test_instances(std::list<inode_load_vec_t*>& ls)
+std::list<inode_load_vec_t> inode_load_vec_t::generate_test_instances()
 {
-  ls.push_back(new inode_load_vec_t(DecayRate()));
+  std::list<inode_load_vec_t> ls;
+  ls.push_back(inode_load_vec_t(DecayRate()));
+  return ls;
 }
 
 
@@ -999,9 +1030,11 @@ void dirfrag_load_vec_t::print(std::ostream& out) const {
   out << css->strv();
 }
 
-void dirfrag_load_vec_t::generate_test_instances(std::list<dirfrag_load_vec_t*>& ls)
+std::list<dirfrag_load_vec_t> dirfrag_load_vec_t::generate_test_instances()
 {
-  ls.push_back(new dirfrag_load_vec_t(DecayRate()));
+  std::list<dirfrag_load_vec_t> ls;
+  ls.push_back(dirfrag_load_vec_t(DecayRate()));
+  return ls;
 }
 
 /*
@@ -1052,9 +1085,11 @@ void mds_load_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void mds_load_t::generate_test_instances(std::list<mds_load_t*>& ls)
+std::list<mds_load_t> mds_load_t::generate_test_instances()
 {
-  ls.push_back(new mds_load_t(DecayRate()));
+  std::list<mds_load_t> ls;
+  ls.push_back(mds_load_t(DecayRate()));
+  return ls;
 }
 
 /*
@@ -1101,11 +1136,13 @@ void cap_reconnect_t::dump(Formatter *f) const
   f->dump_string("has file locks", capinfo.flock_len ? "true" : "false");
 }
 
-void cap_reconnect_t::generate_test_instances(std::list<cap_reconnect_t*>& ls)
+std::list<cap_reconnect_t> cap_reconnect_t::generate_test_instances()
 {
-  ls.push_back(new cap_reconnect_t);
-  ls.back()->path = "/test/path";
-  ls.back()->capinfo.cap_id = 1;
+  std::list<cap_reconnect_t> ls;
+  ls.push_back(cap_reconnect_t{});
+  ls.back().path = "/test/path";
+  ls.back().capinfo.cap_id = 1;
+  return ls;
 }
 
 /*
@@ -1140,12 +1177,14 @@ void snaprealm_reconnect_t::dump(Formatter *f) const
   f->dump_int("parent", realm.parent);
 }
 
-void snaprealm_reconnect_t::generate_test_instances(std::list<snaprealm_reconnect_t*>& ls)
+std::list<snaprealm_reconnect_t> snaprealm_reconnect_t::generate_test_instances()
 {
-  ls.push_back(new snaprealm_reconnect_t);
-  ls.back()->realm.ino = 0x10000000001ULL;
-  ls.back()->realm.seq = 2;
-  ls.back()->realm.parent = 1;
+  std::list<snaprealm_reconnect_t> ls;
+  ls.push_back(snaprealm_reconnect_t{});
+  ls.back().realm.ino = 0x10000000001ULL;
+  ls.back().realm.seq = 2;
+  ls.back().realm.parent = 1;
+  return ls;
 }
 
 void EstimatedReplayTime::print(std::ostream& out) {
@@ -1180,13 +1219,15 @@ void BlockDiff::dump(Formatter *f) const {
   f->dump_stream("blocks") << blocks;
 }
 
-void BlockDiff::generate_test_instances(std::list<BlockDiff*>& ls)
+std::list<BlockDiff> BlockDiff::generate_test_instances()
 {
-  ls.push_back(new BlockDiff());
-  ls.push_back(new BlockDiff());
-  ls.back()->rval = 0;
-  ls.back()->scan_idx = 1;
-  ls.back()->blocks.union_insert(0, 200);
+  std::list<BlockDiff> ls;
+  ls.push_back(BlockDiff());
+  ls.push_back(BlockDiff());
+  ls.back().rval = 0;
+  ls.back().scan_idx = 1;
+  ls.back().blocks.union_insert(0, 200);
+  return ls;
 }
 
 void BlockDiff::print(ostream& out) const

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -165,7 +165,7 @@ struct old_inode_t {
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<old_inode_t*>& ls);
+  static std::list<old_inode_t> generate_test_instances();
 };
 
 // These methods may be moved back to mdstypes.cc when we have pmr
@@ -203,16 +203,17 @@ void old_inode_t<Allocator>::dump(ceph::Formatter *f) const
 }
 
 template<template<typename> class Allocator>
-void old_inode_t<Allocator>::generate_test_instances(std::list<old_inode_t<Allocator>*>& ls)
+auto old_inode_t<Allocator>::generate_test_instances() -> std::list<old_inode_t<Allocator>>
 {
-  ls.push_back(new old_inode_t<Allocator>);
-  ls.push_back(new old_inode_t<Allocator>);
-  ls.back()->first = 2;
-  std::list<inode_t<Allocator>*> ils;
-  inode_t<Allocator>::generate_test_instances(ils);
-  ls.back()->inode = *ils.back();
-  ls.back()->xattrs["user.foo"] = ceph::buffer::copy("asdf", 4);
-  ls.back()->xattrs["user.unprintable"] = ceph::buffer::copy("\000\001\002", 3);
+  std::list<old_inode_t<Allocator>> ls;
+  ls.push_back(old_inode_t<Allocator>{});
+  ls.push_back(old_inode_t<Allocator>{});
+  ls.back().first = 2;
+  std::list<inode_t<Allocator>> ils = inode_t<Allocator>::generate_test_instances();
+  ls.back().inode = ils.back();
+  ls.back().xattrs["user.foo"] = ceph::buffer::copy("asdf", 4);
+  ls.back().xattrs["user.unprintable"] = ceph::buffer::copy("\000\001\002", 3);
+  return ls;
 }
 
 template<template<typename> class Allocator>
@@ -236,7 +237,7 @@ struct fnode_t {
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<fnode_t*>& ls);
+  static std::list<fnode_t> generate_test_instances();
 
   version_t version = 0;
   snapid_t snap_purged_thru;   // the max_last_destroy snapid we've been purged thru
@@ -258,7 +259,7 @@ struct old_rstat_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<old_rstat_t*>& ls);
+  static std::list<old_rstat_t> generate_test_instances();
 
   void print(std::ostream& out) const;
 
@@ -328,7 +329,7 @@ public:
   void decode(ceph::buffer::list::const_iterator &p);
   void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;
-  static void generate_test_instances(std::list<feature_bitset_t*>& ls);
+  static std::list<feature_bitset_t> generate_test_instances();
 private:
   void init_array(const std::vector<size_t>& v);
 
@@ -367,7 +368,7 @@ struct metric_spec_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<metric_spec_t*>& ls);
+  static std::list<metric_spec_t> generate_test_instances();
   void print(std::ostream& out) const;
 
   // set of metrics that a client is capable of forwarding
@@ -414,7 +415,7 @@ struct client_metadata_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<client_metadata_t*>& ls);
+  static std::list<client_metadata_t> generate_test_instances();
 
   kv_map_t kv_map;
   feature_bitset_t features;
@@ -440,7 +441,7 @@ struct session_info_t {
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<session_info_t*>& ls);
+  static std::list<session_info_t> generate_test_instances();
 
   entity_inst_t inst;
   std::map<ceph_tid_t,inodeno_t> completed_requests;
@@ -533,7 +534,7 @@ struct string_snap_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<string_snap_t*>& ls);
+  static std::list<string_snap_t> generate_test_instances();
 
   std::string name;
   snapid_t snapid;
@@ -559,7 +560,7 @@ struct mds_table_pending_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<mds_table_pending_t*>& ls);
+  static std::list<mds_table_pending_t> generate_test_instances();
 
   uint64_t reqid = 0;
   __s32 mds = 0;
@@ -599,7 +600,7 @@ struct metareqid_t {
   }
   void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;
-  static void generate_test_instances(std::list<metareqid_t*>& ls);
+  static std::list<metareqid_t> generate_test_instances();
   entity_name_t name;
   uint64_t tid = 0;
 };
@@ -652,7 +653,7 @@ struct cap_reconnect_t {
   void decode_old(ceph::buffer::list::const_iterator& bl);
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<cap_reconnect_t*>& ls);
+  static std::list<cap_reconnect_t> generate_test_instances();
 
   std::string path;
   mutable ceph_mds_cap_reconnect capinfo = {};
@@ -674,7 +675,7 @@ struct snaprealm_reconnect_t {
   void decode_old(ceph::buffer::list::const_iterator& bl);
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<snaprealm_reconnect_t*>& ls);
+  static std::list<snaprealm_reconnect_t> generate_test_instances();
 
   mutable ceph_mds_snaprealm_reconnect realm = {};
 };
@@ -747,7 +748,7 @@ struct dirfrag_t {
     decode(frag, bl);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<dirfrag_t*>& ls);
+  static std::list<dirfrag_t> generate_test_instances();
 
   inodeno_t ino = 0;
   frag_t frag;
@@ -801,7 +802,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<inode_load_vec_t*>& ls);
+  static std::list<inode_load_vec_t> generate_test_instances();
 
 private:
   std::array<DecayCounter, NUM> vec;
@@ -848,7 +849,7 @@ public:
   void dump(ceph::Formatter *f) const;
   void dump(ceph::Formatter *f, const DecayRate& rate) const;
   void print(std::ostream& out) const;
-  static void generate_test_instances(std::list<dirfrag_load_vec_t*>& ls);
+  static std::list<dirfrag_load_vec_t> generate_test_instances();
 
   const DecayCounter &get(int t) const {
     return vec[t];
@@ -921,7 +922,7 @@ struct mds_load_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<mds_load_t*>& ls);
+  static std::list<mds_load_t> generate_test_instances();
 };
 inline void encode(const mds_load_t &c, ceph::buffer::list &bl) {
   c.encode(bl);
@@ -948,7 +949,7 @@ public:
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;
-  static void generate_test_instances(std::list<MDSCacheObjectInfo*>& ls);
+  static std::list<MDSCacheObjectInfo> generate_test_instances();
 
   inodeno_t ino = 0;
   dirfrag_t dirfrag;
@@ -980,7 +981,7 @@ struct BlockDiff {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<BlockDiff*>& ls);
+  static std::list<BlockDiff> generate_test_instances();
   void print(std::ostream& out) const;
 };
 WRITE_CLASS_ENCODER(BlockDiff);

--- a/src/mds/snap.cc
+++ b/src/mds/snap.cc
@@ -64,15 +64,17 @@ void SnapInfo::dump(Formatter *f) const
   f->close_section();
 }
 
-void SnapInfo::generate_test_instances(std::list<SnapInfo*>& ls)
+std::list<SnapInfo> SnapInfo::generate_test_instances()
 {
-  ls.push_back(new SnapInfo);
-  ls.push_back(new SnapInfo);
-  ls.back()->snapid = 1;
-  ls.back()->ino = 2;
-  ls.back()->stamp = utime_t(3, 4);
-  ls.back()->name = "foo";
-  ls.back()->metadata = {{"foo", "bar"}};
+  std::list<SnapInfo> ls;
+  ls.push_back(SnapInfo{});
+  ls.push_back(SnapInfo{});
+  ls.back().snapid = 1;
+  ls.back().ino = 2;
+  ls.back().stamp = utime_t(3, 4);
+  ls.back().name = "foo";
+  ls.back().metadata = {{"foo", "bar"}};
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const SnapInfo &sn)
@@ -121,12 +123,14 @@ void snaplink_t::dump(Formatter *f) const
   f->dump_unsigned("first", first);
 }
 
-void snaplink_t::generate_test_instances(std::list<snaplink_t*>& ls)
+std::list<snaplink_t> snaplink_t::generate_test_instances()
 {
-  ls.push_back(new snaplink_t);
-  ls.push_back(new snaplink_t);
-  ls.back()->ino = 2;
-  ls.back()->first = 123;
+  std::list<snaplink_t> ls;
+  ls.push_back(snaplink_t{});
+  ls.push_back(snaplink_t{});
+  ls.back().ino = 2;
+  ls.back().first = 123;
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const snaplink_t &l)
@@ -219,25 +223,27 @@ void sr_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void sr_t::generate_test_instances(std::list<sr_t*>& ls)
+std::list<sr_t> sr_t::generate_test_instances()
 {
-  ls.push_back(new sr_t);
-  ls.push_back(new sr_t);
-  ls.back()->seq = 1;
-  ls.back()->created = 2;
-  ls.back()->last_created = 3;
-  ls.back()->last_destroyed = 4;
-  ls.back()->current_parent_since = 5;
-  ls.back()->snaps[123].snapid = 7;
-  ls.back()->snaps[123].ino = 8;
-  ls.back()->snaps[123].stamp = utime_t(9, 10);
-  ls.back()->snaps[123].name = "name1";
-  ls.back()->past_parents[12].ino = 12;
-  ls.back()->past_parents[12].first = 3;
+  std::list<sr_t> ls;
+  ls.push_back(sr_t{});
+  ls.push_back(sr_t{});
+  ls.back().seq = 1;
+  ls.back().created = 2;
+  ls.back().last_created = 3;
+  ls.back().last_destroyed = 4;
+  ls.back().current_parent_since = 5;
+  ls.back().snaps[123].snapid = 7;
+  ls.back().snaps[123].ino = 8;
+  ls.back().snaps[123].stamp = utime_t(9, 10);
+  ls.back().snaps[123].name = "name1";
+  ls.back().past_parents[12].ino = 12;
+  ls.back().past_parents[12].first = 3;
 
-  ls.back()->past_parent_snaps.insert(5);
-  ls.back()->past_parent_snaps.insert(6);
-  ls.back()->last_modified = utime_t(9, 10);
-  ls.back()->change_attr++;
+  ls.back().past_parent_snaps.insert(5);
+  ls.back().past_parent_snaps.insert(6);
+  ls.back().last_modified = utime_t(9, 10);
+  ls.back().change_attr++;
+  return ls;
 }
 

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -34,7 +34,7 @@ struct SnapInfo {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SnapInfo*>& ls);
+  static std::list<SnapInfo> generate_test_instances();
 
   std::string_view get_long_name() const;
 
@@ -66,7 +66,7 @@ struct snaplink_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<snaplink_t*>& ls);
+  static std::list<snaplink_t> generate_test_instances();
 
   inodeno_t ino;
   snapid_t first;
@@ -88,7 +88,7 @@ struct sr_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<sr_t*>& ls);
+  static std::list<sr_t> generate_test_instances();
 
   snapid_t seq = 0;                     // basically, a version/seq # for changes to _this_ realm.
   snapid_t created = 0;                 // when this realm was created.

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -324,11 +324,13 @@ public:
     f->dump_unsigned("created_ino", created_ino);
     f->dump_stream("delegated_inos") << delegated_inos;
   }
-  static void generate_test_instances(std::list<openc_response_t*>& ls) {
-    ls.push_back(new openc_response_t);
-    ls.push_back(new openc_response_t);
-    ls.back()->created_ino = 1;
-    ls.back()->delegated_inos.insert(1, 10);
+  static std::list<openc_response_t> generate_test_instances() {
+    std::list<openc_response_t> ls;
+    ls.push_back(openc_response_t{});
+    ls.push_back(openc_response_t{});
+    ls.back().created_ino = 1;
+    ls.back().delegated_inos.insert(1, 10);
+    return ls;
   }
 } __attribute__ ((__may_alias__));
 WRITE_CLASS_ENCODER(openc_response_t)

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -65,11 +65,13 @@ struct SnapPayload {
       f->dump_string(i.first.c_str(), i.second);
     }
   }
-  static void generate_test_instances(std::list<SnapPayload *> &o) {
-    o.push_back(new SnapPayload);
-    o.push_back(new SnapPayload);
-    o.back()->metadata["key1"] = "val1";
-    o.back()->metadata["key2"] = "val2";
+  static std::list<SnapPayload> generate_test_instances() {
+    std::list<SnapPayload> o;
+    o.push_back(SnapPayload{});
+    o.push_back(SnapPayload{});
+    o.back().metadata["key1"] = "val1";
+    o.back().metadata["key2"] = "val2";
+    return o;
   }
 };
 
@@ -120,11 +122,13 @@ public:
       f->dump_unsigned("dname_len", item.dname_len);
     }
 
-    static void generate_test_instances(std::list<Release*>& ls) {
-      ls.push_back(new Release);
-      ls.push_back(new Release);
-      ls.back()->item.dname_len = 4;
-      ls.back()->dname = "test";
+    static std::list<Release> generate_test_instances() {
+      std::list<Release> ls;
+      ls.push_back(Release{});
+      ls.push_back(Release{});
+      ls.back().item.dname_len = 4;
+      ls.back().dname = "test";
+      return ls;
     }
   };
   mutable std::vector<Release> releases; /* XXX HACK! */

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -170,12 +170,14 @@ struct MDSHealthMetric
     f->close_section();
   }
 
-  static void generate_test_instances(std::list<MDSHealthMetric*>& ls) {
-    ls.push_back(new MDSHealthMetric());
-    ls.back()->type = MDS_HEALTH_CACHE_OVERSIZED;
-    ls.push_back(new MDSHealthMetric(MDS_HEALTH_TRIM, HEALTH_WARN, "MDS is behind on trimming"));
-    ls.back()->metadata["mds"] = "a";
-    ls.back()->metadata["num"] = "1";
+  static std::list<MDSHealthMetric> generate_test_instances() {
+    std::list<MDSHealthMetric> ls;
+    ls.push_back(MDSHealthMetric());
+    ls.back().type = MDS_HEALTH_CACHE_OVERSIZED;
+    ls.push_back(MDSHealthMetric(MDS_HEALTH_TRIM, HEALTH_WARN, "MDS is behind on trimming"));
+    ls.back().metadata["mds"] = "a";
+    ls.back().metadata["num"] = "1";
+    return ls;
   }
 
   bool operator==(MDSHealthMetric const &other) const
@@ -220,11 +222,13 @@ struct MDSHealth
     f->close_section();
   }
 
-  static void generate_test_instances(std::list<MDSHealth*>& ls) {
-    ls.push_back(new MDSHealth);
-    ls.push_back(new MDSHealth);
-    ls.back()->metrics.push_back(MDSHealthMetric(MDS_HEALTH_TRIM, HEALTH_WARN,
+  static std::list<MDSHealth> generate_test_instances() {
+    std::list<MDSHealth> ls;
+    ls.push_back(MDSHealth{});
+    ls.push_back(MDSHealth{});
+    ls.back().metrics.push_back(MDSHealthMetric(MDS_HEALTH_TRIM, HEALTH_WARN,
              "MDS is behind on trimming"));
+    return ls;
   }
 
   bool operator==(MDSHealth const &other) const

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -70,9 +70,11 @@ public:
       f->dump_int("nestlock", nestlock);
       f->dump_int("dftlock", dftlock);
     }
-    static void generate_test_instances(std::list<inode_strong*>& ls) {
-      ls.push_back(new inode_strong);
-      ls.push_back(new inode_strong(1, 2, 3, 4, 5));
+    static std::list<inode_strong> generate_test_instances() {
+      std::list<inode_strong> ls;
+      ls.push_back(inode_strong{});
+      ls.push_back(inode_strong(1, 2, 3, 4, 5));
+      return ls;
     }
   };
   WRITE_CLASS_ENCODER(inode_strong)
@@ -92,9 +94,11 @@ public:
       decode(nonce, bl);
       decode(dir_rep, bl);
     }
-    static void generate_test_instances(std::list<dirfrag_strong*>& ls) {
-      ls.push_back(new dirfrag_strong);
-      ls.push_back(new dirfrag_strong(1, 2));
+    static std::list<dirfrag_strong> generate_test_instances() {
+      std::list<dirfrag_strong> ls;
+      ls.push_back(dirfrag_strong{});
+      ls.push_back(dirfrag_strong(1, 2));
+      return ls;
     }
     void dump(ceph::Formatter *f) const {
       f->dump_unsigned("nonce", nonce);
@@ -137,9 +141,11 @@ public:
       decode(lock, bl);
       decode(alternate_name, bl);
     }
-    static void generate_test_instances(std::list<dn_strong*>& ls) {
-      ls.push_back(new dn_strong);
-      ls.push_back(new dn_strong(1, "alternate_name", 2, 3, 4, 5, 6));
+    static std::list<dn_strong> generate_test_instances() {
+      std::list<dn_strong> ls;
+      ls.push_back(dn_strong{});
+      ls.push_back(dn_strong(1, "alternate_name", 2, 3, 4, 5, 6));
+      return ls;
     }
     void dump(ceph::Formatter *f) const {
       f->dump_unsigned("first", first);
@@ -193,9 +199,11 @@ public:
       decode(referent_ino, bl);
       DECODE_FINISH(bl);
     }
-    static void generate_test_instances(std::list<dn_strong_new*>& ls) {
-      ls.push_back(new dn_strong_new);
-      ls.push_back(new dn_strong_new(1, "alternate_name", 2, 3, 4, 5, 6, 7));
+    static std::list<dn_strong_new> generate_test_instances() {
+      std::list<dn_strong_new> ls;
+      ls.push_back(dn_strong_new{});
+      ls.push_back(dn_strong_new(1, "alternate_name", 2, 3, 4, 5, 6, 7));
+      return ls;
     }
     void dump(ceph::Formatter *f) const {
       f->dump_unsigned("first", first);

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -84,16 +84,18 @@ public:
     f->dump_int("priority", priority);
     f->dump_int("unit", unit);
   }
-  static void generate_test_instances(std::list<PerfCounterType*>& ls)
+  static std::list<PerfCounterType> generate_test_instances()
   {
-    ls.push_back(new PerfCounterType);
-    ls.push_back(new PerfCounterType);
-    ls.back()->path = "mycounter";
-    ls.back()->description = "mycounter description";
-    ls.back()->nick = "mycounter nick";
-    ls.back()->type = PERFCOUNTER_COUNTER;
-    ls.back()->priority = PerfCountersBuilder::PRIO_CRITICAL;
-    ls.back()->unit = UNIT_BYTES;
+    std::list<PerfCounterType> ls;
+    ls.push_back(PerfCounterType{});
+    ls.push_back(PerfCounterType{});
+    ls.back().path = "mycounter";
+    ls.back().description = "mycounter description";
+    ls.back().nick = "mycounter nick";
+    ls.back().type = PERFCOUNTER_COUNTER;
+    ls.back().priority = PerfCountersBuilder::PRIO_CRITICAL;
+    ls.back().unit = UNIT_BYTES;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(PerfCounterType)

--- a/src/mgr/DaemonHealthMetric.h
+++ b/src/mgr/DaemonHealthMetric.h
@@ -74,9 +74,11 @@ public:
     f->dump_int("n1", get_n1());
     f->dump_int("n2", get_n2());
   }
-  static void generate_test_instances(std::list<DaemonHealthMetric*>& o) {
-    o.push_back(new DaemonHealthMetric(daemon_metric::SLOW_OPS, 1));
-    o.push_back(new DaemonHealthMetric(daemon_metric::PENDING_CREATING_PGS, 1, 2));
+  static std::list<DaemonHealthMetric> generate_test_instances() {
+    std::list<DaemonHealthMetric> o;
+    o.push_back(DaemonHealthMetric(daemon_metric::SLOW_OPS, 1));
+    o.push_back(DaemonHealthMetric(daemon_metric::PENDING_CREATING_PGS, 1, 2));
+    return o;
   }
   std::string get_type_name() const {
     return daemon_metric_name(get_type());

--- a/src/mgr/MDSPerfMetricTypes.h
+++ b/src/mgr/MDSPerfMetricTypes.h
@@ -397,11 +397,13 @@ struct MDSPerfMetricReport {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<MDSPerfMetricReport *> &o) {
-    o.push_back(new MDSPerfMetricReport);
-    o.push_back(new MDSPerfMetricReport);
-    o.back()->reports.emplace(MDSPerfMetricQuery(), MDSPerfMetrics());
-    o.back()->rank_metrics_delayed.insert(1);
+  static std::list<MDSPerfMetricReport> generate_test_instances() {
+    std::list<MDSPerfMetricReport> o;
+    o.push_back(MDSPerfMetricReport{});
+    o.push_back(MDSPerfMetricReport{});
+    o.back().reports.emplace(MDSPerfMetricQuery(), MDSPerfMetrics());
+    o.back().rank_metrics_delayed.insert(1);
+    return o;
   }
 };
 

--- a/src/mgr/MetricTypes.h
+++ b/src/mgr/MetricTypes.h
@@ -43,8 +43,10 @@ struct OSDMetricPayload {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<OSDMetricPayload*>& ls) {
-    ls.push_back(new OSDMetricPayload());
+  static std::list<OSDMetricPayload> generate_test_instances() {
+    std::list<OSDMetricPayload> ls;
+    ls.push_back(OSDMetricPayload());
+    return ls;
   }
 };
 
@@ -66,8 +68,10 @@ struct MDSMetricPayload {
   void dump(ceph::Formatter *f) const {
     metric_report.dump(f);
   }
-  static void generate_test_instances(std::list<MDSMetricPayload*>& ls) {
-    ls.push_back(new MDSMetricPayload());
+  static std::list<MDSMetricPayload> generate_test_instances() {
+    std::list<MDSMetricPayload> ls;
+    ls.push_back(MDSMetricPayload());
+    return ls;
   }
 };
 
@@ -176,9 +180,11 @@ struct MetricReportMessage {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<MetricReportMessage*>& ls) {
-    ls.push_back(new MetricReportMessage(OSDMetricPayload()));
-    ls.push_back(new MetricReportMessage(MDSMetricPayload()));
+  static std::list<MetricReportMessage> generate_test_instances() {
+    std::list<MetricReportMessage> ls;
+    ls.push_back(MetricReportMessage(OSDMetricPayload()));
+    ls.push_back(MetricReportMessage(MDSMetricPayload()));
+    return ls;
   }
 };
 
@@ -236,8 +242,10 @@ struct MDSConfigPayload {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<MDSConfigPayload*>& ls) {
-    ls.push_back(new MDSConfigPayload);
+  static std::list<MDSConfigPayload> generate_test_instances() {
+    std::list<MDSConfigPayload> ls;
+    ls.push_back(MDSConfigPayload{});
+    return ls;
   }
 };
 

--- a/src/mgr/MgrCap.cc
+++ b/src/mgr/MgrCap.cc
@@ -385,26 +385,28 @@ void MgrCap::dump(ceph::Formatter *f) const {
   f->dump_string("text", text);
 }
 
-void MgrCap::generate_test_instances(std::list<MgrCap*>& ls) {
-  ls.push_back(new MgrCap);
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow *");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow rwx");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow service foo x");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow command bar x");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow service foo r, allow command bar x");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow command bar with k1=v1 x");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow command bar with k1=v1 k2=v2 x");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("allow module bar with k1=v1 k2=v2 x");
-  ls.push_back(new MgrCap);
-  ls.back()->parse("profile rbd pool=rbd");
+std::list<MgrCap> MgrCap::generate_test_instances() {
+  std::list<MgrCap> ls;
+  ls.push_back(MgrCap{});
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow *");
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow rwx");
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow service foo x");
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow command bar x");
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow service foo r, allow command bar x");
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow command bar with k1=v1 x");
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow command bar with k1=v1 k2=v2 x");
+  ls.push_back(MgrCap{});
+  ls.back().parse("allow module bar with k1=v1 k2=v2 x");
+  ls.push_back(MgrCap{});
+  ls.back().parse("profile rbd pool=rbd");
+  return ls;
 }
 
 // grammar

--- a/src/mgr/MgrCap.h
+++ b/src/mgr/MgrCap.h
@@ -195,7 +195,7 @@ struct MgrCap {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<MgrCap*>& ls);
+  static std::list<MgrCap> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(MgrCap)
 

--- a/src/mgr/OSDPerfMetricTypes.h
+++ b/src/mgr/OSDPerfMetricTypes.h
@@ -77,16 +77,18 @@ struct OSDPerfMetricSubKeyDescriptor {
     f->dump_string("regex", regex_str);
   }
 
-  static void generate_test_instances(std::list<OSDPerfMetricSubKeyDescriptor*>& o) {
-    o.push_back(new OSDPerfMetricSubKeyDescriptor());
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::CLIENT_ID, ".*"));
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::CLIENT_ADDRESS, ".*"));
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::POOL_ID, ".*"));
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::NAMESPACE, ".*"));
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::OSD_ID, ".*"));
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::PG_ID, ".*"));
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::OBJECT_NAME, ".*"));
-    o.push_back(new OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::SNAP_ID, ".*"));
+  static std::list<OSDPerfMetricSubKeyDescriptor> generate_test_instances() {
+    std::list<OSDPerfMetricSubKeyDescriptor> o;
+    o.push_back(OSDPerfMetricSubKeyDescriptor());
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::CLIENT_ID, ".*"));
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::CLIENT_ADDRESS, ".*"));
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::POOL_ID, ".*"));
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::NAMESPACE, ".*"));
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::OSD_ID, ".*"));
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::PG_ID, ".*"));
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::OBJECT_NAME, ".*"));
+    o.push_back(OSDPerfMetricSubKeyDescriptor(OSDPerfMetricSubKeyType::SNAP_ID, ".*"));
+    return o;
   }
 };
 WRITE_CLASS_DENC(OSDPerfMetricSubKeyDescriptor)
@@ -206,17 +208,19 @@ struct PerformanceCounterDescriptor {
     f->dump_unsigned("type", static_cast<uint8_t>(type));
   }
 
-  static void generate_test_instances(std::list<PerformanceCounterDescriptor*>& o) {
-    o.push_back(new PerformanceCounterDescriptor());
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::OPS));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::WRITE_OPS));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::READ_OPS));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::BYTES));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::WRITE_BYTES));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::READ_BYTES));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::LATENCY));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::WRITE_LATENCY));
-    o.push_back(new PerformanceCounterDescriptor(PerformanceCounterType::READ_LATENCY));
+  static std::list<PerformanceCounterDescriptor> generate_test_instances() {
+    std::list<PerformanceCounterDescriptor> o;
+    o.push_back(PerformanceCounterDescriptor());
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::OPS));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::WRITE_OPS));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::READ_OPS));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::BYTES));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::WRITE_BYTES));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::READ_BYTES));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::LATENCY));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::WRITE_LATENCY));
+    o.push_back(PerformanceCounterDescriptor(PerformanceCounterType::READ_LATENCY));
+    return o;
   }
 
   void pack_counter(const PerformanceCounter &c, ceph::buffer::list *bl) const;
@@ -347,20 +351,22 @@ struct OSDPerfMetricQuery {
                 performance_counter_descriptors, f);
   }
 
-  static void generate_test_instances(std::list<OSDPerfMetricQuery*> &o) {
-    o.push_back(new OSDPerfMetricQuery());
-    o.push_back(new OSDPerfMetricQuery(OSDPerfMetricKeyDescriptor(),
-                                       PerformanceCounterDescriptors()));
-    o.push_back(new OSDPerfMetricQuery(OSDPerfMetricKeyDescriptor(),
-                                       PerformanceCounterDescriptors{
-                                         PerformanceCounterType::WRITE_OPS,
-                                         PerformanceCounterType::READ_OPS,
-                                         PerformanceCounterType::BYTES,
-                                         PerformanceCounterType::WRITE_BYTES,
-                                         PerformanceCounterType::READ_BYTES,
-                                         PerformanceCounterType::LATENCY,
-                                         PerformanceCounterType::WRITE_LATENCY,
-                                         PerformanceCounterType::READ_LATENCY}));
+  static std::list<OSDPerfMetricQuery> generate_test_instances() {
+    std::list<OSDPerfMetricQuery> o;
+    o.push_back(OSDPerfMetricQuery());
+    o.push_back(OSDPerfMetricQuery(OSDPerfMetricKeyDescriptor(),
+				   PerformanceCounterDescriptors()));
+    o.push_back(OSDPerfMetricQuery(OSDPerfMetricKeyDescriptor(),
+				   PerformanceCounterDescriptors{
+				     PerformanceCounterType::WRITE_OPS,
+				     PerformanceCounterType::READ_OPS,
+				     PerformanceCounterType::BYTES,
+				     PerformanceCounterType::WRITE_BYTES,
+				     PerformanceCounterType::READ_BYTES,
+				     PerformanceCounterType::LATENCY,
+				     PerformanceCounterType::WRITE_LATENCY,
+				     PerformanceCounterType::READ_LATENCY}));
+    return o;
   }
 
   void get_performance_counter_descriptors(
@@ -418,15 +424,17 @@ struct OSDPerfMetricReport {
                 group_packed_performance_counters, f);
   }
 
-  static void generate_test_instances(std::list<OSDPerfMetricReport *> &o) {
-    o.push_back(new OSDPerfMetricReport);
-    o.push_back(new OSDPerfMetricReport);
-    o.back()->performance_counter_descriptors.push_back(
+  static std::list<OSDPerfMetricReport> generate_test_instances() {
+    std::list<OSDPerfMetricReport> o;
+    o.push_back(OSDPerfMetricReport{});
+    o.push_back(OSDPerfMetricReport{});
+    o.back().performance_counter_descriptors.push_back(
         PerformanceCounterDescriptor(PerformanceCounterType::OPS));
-    o.back()->performance_counter_descriptors.push_back(
+    o.back().performance_counter_descriptors.push_back(
         PerformanceCounterDescriptor(PerformanceCounterType::WRITE_OPS));
-    o.back()->performance_counter_descriptors.push_back(
+    o.back().performance_counter_descriptors.push_back(
         PerformanceCounterDescriptor(PerformanceCounterType::READ_OPS));
+    return o;
   }
 };
 WRITE_CLASS_DENC(OSDPerfMetricReport)

--- a/src/mgr/ServiceMap.cc
+++ b/src/mgr/ServiceMap.cc
@@ -58,13 +58,15 @@ void ServiceMap::Daemon::dump(Formatter *f) const
   f->close_section();
 }
 
-void ServiceMap::Daemon::generate_test_instances(std::list<Daemon*>& ls)
+auto ServiceMap::Daemon::generate_test_instances() -> std::list<Daemon>
 {
-  ls.push_back(new Daemon);
-  ls.push_back(new Daemon);
-  ls.back()->gid = 222;
-  ls.back()->metadata["this"] = "that";
-  ls.back()->task_status["task1"] = "running";
+  std::list<Daemon> ls;
+  ls.push_back(Daemon{});
+  ls.push_back(Daemon{});
+  ls.back().gid = 222;
+  ls.back().metadata["this"] = "that";
+  ls.back().task_status["task1"] = "running";
+  return ls;
 }
 
 // Service
@@ -194,12 +196,14 @@ void ServiceMap::Service::dump(Formatter *f) const
   f->close_section();
 }
 
-void ServiceMap::Service::generate_test_instances(std::list<Service*>& ls)
+auto ServiceMap::Service::generate_test_instances() -> std::list<Service>
 {
-  ls.push_back(new Service);
-  ls.push_back(new Service);
-  ls.back()->daemons["one"].gid = 1;
-  ls.back()->daemons["two"].gid = 2;
+  std::list<Service> ls;
+  ls.push_back(Service{});
+  ls.push_back(Service{});
+  ls.back().daemons["one"].gid = 1;
+  ls.back().daemons["two"].gid = 2;
+  return ls;
 }
 
 // ServiceMap
@@ -233,12 +237,14 @@ void ServiceMap::dump(Formatter *f) const
   f->close_section();
 }
 
-void ServiceMap::generate_test_instances(std::list<ServiceMap*>& ls)
+std::list<ServiceMap> ServiceMap::generate_test_instances()
 {
-  ls.push_back(new ServiceMap);
-  ls.push_back(new ServiceMap);
-  ls.back()->epoch = 123;
-  ls.back()->services["rgw"].daemons["one"].gid = 123;
-  ls.back()->services["rgw"].daemons["two"].gid = 344;
-  ls.back()->services["iscsi"].daemons["foo"].gid = 3222;
+  std::list<ServiceMap> ls;
+  ls.push_back(ServiceMap{});
+  ls.push_back(ServiceMap{});
+  ls.back().epoch = 123;
+  ls.back().services["rgw"].daemons["one"].gid = 123;
+  ls.back().services["rgw"].daemons["two"].gid = 344;
+  ls.back().services["iscsi"].daemons["foo"].gid = 3222;
+  return ls;
 }

--- a/src/mgr/ServiceMap.h
+++ b/src/mgr/ServiceMap.h
@@ -28,7 +28,7 @@ struct ServiceMap {
     void encode(ceph::buffer::list& bl, uint64_t features) const;
     void decode(ceph::buffer::list::const_iterator& p);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<Daemon*>& ls);
+    static std::list<Daemon> generate_test_instances();
   };
 
   struct Service {
@@ -38,7 +38,7 @@ struct ServiceMap {
     void encode(ceph::buffer::list& bl, uint64_t features) const;
     void decode(ceph::buffer::list::const_iterator& p);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<Service*>& ls);
+    static std::list<Service> generate_test_instances();
 
     std::string get_summary() const;
     bool has_running_tasks() const;
@@ -54,7 +54,7 @@ struct ServiceMap {
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ServiceMap*>& ls);
+  static std::list<ServiceMap> generate_test_instances();
 
   std::pair<Daemon*,bool> get_daemon(const std::string& service,
 				     const std::string& daemon) {

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -82,15 +82,17 @@ public:
       f->dump_int("auth_type", auth_type);
       f->dump_int("auth_data_len", auth_data.length());
     }
-    static void generate_test_instances(std::list<Incremental*>& ls) {
-      ls.push_back(new Incremental);
-      ls.push_back(new Incremental);
-      ls.back()->inc_type = GLOBAL_ID;
-      ls.back()->max_global_id = 1234;
-      ls.push_back(new Incremental);
-      ls.back()->inc_type = AUTH_DATA;
-      ls.back()->auth_type = 12;
-      ls.back()->auth_data.append("foo");
+    static std::list<Incremental> generate_test_instances() {
+      std::list<Incremental> ls;
+      ls.push_back(Incremental{});
+      ls.push_back(Incremental{});
+      ls.back().inc_type = GLOBAL_ID;
+      ls.back().max_global_id = 1234;
+      ls.push_back(Incremental{});
+      ls.back().inc_type = AUTH_DATA;
+      ls.back().auth_type = 12;
+      ls.back().auth_data.append("foo");
+      return ls;
     }
   };
 

--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -501,15 +501,17 @@ void ConnectionReport::dump(ceph::Formatter *f) const
   f->close_section(); // peer scores
 }
 
-void ConnectionReport::generate_test_instances(std::list<ConnectionReport*>& o)
+std::list<ConnectionReport> ConnectionReport::generate_test_instances()
 {
-  o.push_back(new ConnectionReport);
-  o.push_back(new ConnectionReport);
-  o.back()->rank = 1;
-  o.back()->epoch = 2;
-  o.back()->epoch_version = 3;
-  o.back()->current[0] = true;
-  o.back()->history[0] = .4;
+  std::list<ConnectionReport> o;
+  o.push_back(ConnectionReport{});
+  o.push_back(ConnectionReport{});
+  o.back().rank = 1;
+  o.back().epoch = 2;
+  o.back().epoch_version = 3;
+  o.back().current[0] = true;
+  o.back().history[0] = .4;
+  return o;
 }
 
 void ConnectionTracker::dump(ceph::Formatter *f) const
@@ -528,15 +530,17 @@ void ConnectionTracker::dump(ceph::Formatter *f) const
   f->close_section(); // reports
 }
 
-void ConnectionTracker::generate_test_instances(std::list<ConnectionTracker*>& o)
+std::list<ConnectionTracker> ConnectionTracker::generate_test_instances()
 {
-  o.push_back(new ConnectionTracker);
-  o.push_back(new ConnectionTracker);
-  ConnectionTracker *e = o.back();
-  e->rank = 2;
-  e->epoch = 3;
-  e->version = 4;
-  e->peer_reports[0];
-  e->peer_reports[1];
-  e->my_reports = e->peer_reports[2];
+  std::list<ConnectionTracker> o;
+  o.push_back(ConnectionTracker{});
+  o.push_back(ConnectionTracker{});
+  ConnectionTracker& e = o.back();
+  e.rank = 2;
+  e.epoch = 3;
+  e.version = 4;
+  e.peer_reports[0];
+  e.peer_reports[1];
+  e.my_reports = e.peer_reports[2];
+  return o;
 }

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -47,7 +47,7 @@ struct ConnectionReport {
   friend std::ostream& operator<<(std::ostream&o, const ConnectionReport& c);
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ConnectionReport*>& o);
+  static std::list<ConnectionReport> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ConnectionReport);
 
@@ -220,7 +220,7 @@ class ConnectionTracker {
   friend ConnectionReport *get_connection_reports(ConnectionTracker& ct);
   friend std::map<int,ConnectionReport> *get_peer_reports(ConnectionTracker& ct);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ConnectionTracker*>& o);
+  static std::list<ConnectionTracker> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(ConnectionTracker);

--- a/src/mon/CreatingPGs.h
+++ b/src/mon/CreatingPGs.h
@@ -83,16 +83,18 @@ struct creating_pgs_t {
       f->dump_object("pg_history", history);
       f->dump_object("past_intervals", past_intervals);
     }
-    static void generate_test_instances(std::list<pg_create_info*>& o) {
-      o.push_back(new pg_create_info);
-      o.back()->create_epoch = 10;
-      o.push_back(new pg_create_info);
-      o.back()->create_epoch = 1;
-      o.back()->create_stamp = utime_t(2, 3);
-      o.back()->up = {1, 2, 3};
-      o.back()->up_primary = 1;
-      o.back()->acting = {1, 2, 3};
-      o.back()->acting_primary = 1;
+    static std::list<pg_create_info> generate_test_instances() {
+      std::list<pg_create_info> o;
+      o.push_back(pg_create_info{});
+      o.back().create_epoch = 10;
+      o.push_back(pg_create_info{});
+      o.back().create_epoch = 1;
+      o.back().create_stamp = utime_t(2, 3);
+      o.back().up = {1, 2, 3};
+      o.back().up_primary = 1;
+      o.back().acting = {1, 2, 3};
+      o.back().acting_primary = 1;
+      return o;
     }
 
     pg_create_info() 
@@ -227,18 +229,20 @@ struct creating_pgs_t {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<creating_pgs_t*>& o) {
-    auto c = new creating_pgs_t;
-    c->last_scan_epoch = 17;
-    c->pgs.emplace(pg_t{42, 2}, pg_create_info(31, utime_t{891, 113}));
-    c->pgs.emplace(pg_t{44, 2}, pg_create_info(31, utime_t{891, 113}));
-    c->created_pools = {0, 1};
+  static std::list<creating_pgs_t> generate_test_instances() {
+    std::list<creating_pgs_t> o;
+    auto c = creating_pgs_t{};
+    c.last_scan_epoch = 17;
+    c.pgs.emplace(pg_t{42, 2}, pg_create_info(31, utime_t{891, 113}));
+    c.pgs.emplace(pg_t{44, 2}, pg_create_info(31, utime_t{891, 113}));
+    c.created_pools = {0, 1};
     o.push_back(c);
-    c = new creating_pgs_t;
-    c->last_scan_epoch = 18;
-    c->pgs.emplace(pg_t{42, 3}, pg_create_info(31, utime_t{891, 113}));
-    c->created_pools = {};
+    c = creating_pgs_t{};
+    c.last_scan_epoch = 18;
+    c.pgs.emplace(pg_t{42, 3}, pg_create_info(31, utime_t{891, 113}));
+    c.created_pools = {};
     o.push_back(c);
+    return o;
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(creating_pgs_t::pg_create_info)

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -107,22 +107,24 @@ public:
       }
       f->close_section();
     }
-    static void generate_test_instances(std::list<ModuleOption*>& ls)
+    static std::list<ModuleOption> generate_test_instances()
     {
-      ls.push_back(new ModuleOption);
-      ls.push_back(new ModuleOption);
-      ls.back()->name = "name";
-      ls.back()->type = Option::TYPE_STR;
-      ls.back()->level = Option::LEVEL_ADVANCED;
-      ls.back()->flags = Option::FLAG_RUNTIME;
-      ls.back()->default_value = "default_value";
-      ls.back()->min = "min";
-      ls.back()->max = "max";
-      ls.back()->enum_allowed.insert("enum_allowed");
-      ls.back()->desc = "desc";
-      ls.back()->long_desc = "long_desc";
-      ls.back()->tags.insert("tag");
-      ls.back()->see_also.insert("see_also");
+      std::list<ModuleOption> ls;
+      ls.push_back(ModuleOption{});
+      ls.push_back(ModuleOption{});
+      ls.back().name = "name";
+      ls.back().type = Option::TYPE_STR;
+      ls.back().level = Option::LEVEL_ADVANCED;
+      ls.back().flags = Option::FLAG_RUNTIME;
+      ls.back().default_value = "default_value";
+      ls.back().min = "min";
+      ls.back().max = "max";
+      ls.back().enum_allowed.insert("enum_allowed");
+      ls.back().desc = "desc";
+      ls.back().long_desc = "long_desc";
+      ls.back().tags.insert("tag");
+      ls.back().see_also.insert("see_also");
+      return ls;
     }
   };
 
@@ -175,14 +177,16 @@ public:
       f->close_section();
     }
 
-    static void generate_test_instances(std::list<ModuleInfo*>& ls)
+    static std::list<ModuleInfo> generate_test_instances()
     {
-      ls.push_back(new ModuleInfo);
-      ls.push_back(new ModuleInfo);
-      ls.back()->name = "name";
-      ls.back()->can_run = true;
-      ls.back()->error_string = "error_string";
-      ls.back()->module_options["module_option"] = ModuleOption();
+      std::list<ModuleInfo> ls;
+      ls.push_back(ModuleInfo{});
+      ls.push_back(ModuleInfo{});
+      ls.back().name = "name";
+      ls.back().can_run = true;
+      ls.back().error_string = "error_string";
+      ls.back().module_options["module_option"] = ModuleOption();
+      return ls;
     }
   };
 
@@ -249,11 +253,13 @@ public:
       encode_json("available_modules", available_modules, f);
       f->dump_unsigned("mgr_features", mgr_features);
     }
-    static void generate_test_instances(std::list<StandbyInfo*>& ls)
+    static std::list<StandbyInfo> generate_test_instances()
     {
-      ls.push_back(new StandbyInfo(1, "a", {}, 0));
-      ls.push_back(new StandbyInfo(2, "b", {}, 0));
-      ls.push_back(new StandbyInfo(3, "c", {}, 0));
+      std::list<StandbyInfo> ls;
+      ls.push_back(StandbyInfo(1, "a", {}, 0));
+      ls.push_back(StandbyInfo(2, "b", {}, 0));
+      ls.push_back(StandbyInfo(3, "c", {}, 0));
+      return ls;
     }
 
     bool have_module(const std::string &module_name) const
@@ -633,9 +639,11 @@ public:
     f->close_section(); // active_clients
   }
 
-  static void generate_test_instances(std::list<MgrMap*> &l)
+  static std::list<MgrMap> generate_test_instances()
   {
-    l.push_back(new MgrMap);
+    std::list<MgrMap> l;
+    l.push_back(MgrMap{});
+    return l;
   }
 
   void print_summary(ceph::Formatter *f, std::ostream *ss) const

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -529,23 +529,25 @@ void MonCap::dump(Formatter *f) const
   f->dump_string("text", text);
 }
 
-void MonCap::generate_test_instances(list<MonCap*>& ls)
+list<MonCap> MonCap::generate_test_instances()
 {
-  ls.push_back(new MonCap);
-  ls.push_back(new MonCap);
-  ls.back()->parse("allow *");
-  ls.push_back(new MonCap);
-  ls.back()->parse("allow rwx");
-  ls.push_back(new MonCap);
-  ls.back()->parse("allow service foo x");
-  ls.push_back(new MonCap);
-  ls.back()->parse("allow command bar x");
-  ls.push_back(new MonCap);
-  ls.back()->parse("allow service foo r, allow command bar x");
-  ls.push_back(new MonCap);
-  ls.back()->parse("allow command bar with k1=v1 x");
-  ls.push_back(new MonCap);
-  ls.back()->parse("allow command bar with k1=v1 k2=v2 x");
+  list<MonCap> ls;
+  ls.push_back(MonCap{});
+  ls.push_back(MonCap{});
+  ls.back().parse("allow *");
+  ls.push_back(MonCap{});
+  ls.back().parse("allow rwx");
+  ls.push_back(MonCap{});
+  ls.back().parse("allow service foo x");
+  ls.push_back(MonCap{});
+  ls.back().parse("allow command bar x");
+  ls.push_back(MonCap{});
+  ls.back().parse("allow service foo r, allow command bar x");
+  ls.push_back(MonCap{});
+  ls.back().parse("allow command bar with k1=v1 x");
+  ls.push_back(MonCap{});
+  ls.back().parse("allow command bar with k1=v1 k2=v2 x");
+  return ls;
 }
 
 // grammar

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -185,7 +185,7 @@ struct MonCap {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<MonCap*>& ls);
+  static std::list<MonCap> generate_test_instances();
 
   std::vector<std::string> allowed_fs_names() const {
     std::vector<std::string> ret;

--- a/src/mon/MonCommand.h
+++ b/src/mon/MonCommand.h
@@ -62,14 +62,16 @@ struct MonCommand {
     f->dump_unsigned("flags", flags);
   }
 
-  static void generate_test_instances(std::list<MonCommand*>& ls) {
-    ls.push_back(new MonCommand);
-    ls.push_back(new MonCommand);
-    ls.back()->cmdstring = "foo";
-    ls.back()->helpstring = "bar";
-    ls.back()->module = "baz";
-    ls.back()->req_perms = "quux";
-    ls.back()->flags = FLAG_NOFORWARD;
+  static std::list<MonCommand> generate_test_instances() {
+    std::list<MonCommand> ls;
+    ls.push_back(MonCommand{});
+    ls.push_back(MonCommand{});
+    ls.back().cmdstring = "foo";
+    ls.back().helpstring = "bar";
+    ls.back().module = "baz";
+    ls.back().req_perms = "quux";
+    ls.back().flags = FLAG_NOFORWARD;
+    return ls;
   }
 
   /**

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -120,16 +120,18 @@ void mon_info_t::dump(ceph::Formatter *f) const
   encode_json("crush_location", crush_loc, f);
 }
 
-void mon_info_t::generate_test_instances(list<mon_info_t*>& ls)
+list<mon_info_t> mon_info_t::generate_test_instances()
 {
-  ls.push_back(new mon_info_t);
-  ls.push_back(new mon_info_t);
-  ls.back()->name = "noname";
-  ls.back()->public_addrs.parse("v1:1.2.3.4:567/890");
-  ls.back()->priority = 1;
-  ls.back()->weight = 1.0;
-  ls.back()->crush_loc.emplace("root", "default");
-  ls.back()->crush_loc.emplace("host", "foo");
+  list<mon_info_t> ls;
+  ls.push_back(mon_info_t{});
+  ls.push_back(mon_info_t{});
+  ls.back().name = "noname";
+  ls.back().public_addrs.parse("v1:1.2.3.4:567/890");
+  ls.back().priority = 1;
+  ls.back().weight = 1.0;
+  ls.back().crush_loc.emplace("root", "default");
+  ls.back().crush_loc.emplace("host", "foo");
+  return ls;
 }
 namespace {
   struct rank_cmp {
@@ -323,26 +325,27 @@ void MonMap::decode(ceph::buffer::list::const_iterator& p)
   DECODE_FINISH(p);
 }
 
-void MonMap::generate_test_instances(list<MonMap*>& o)
+list<MonMap> MonMap::generate_test_instances()
 {
-  o.push_back(new MonMap);
-  o.push_back(new MonMap);
-  o.back()->epoch = 1;
-  o.back()->last_changed = utime_t(123, 456);
-  o.back()->created = utime_t(789, 101112);
-  o.back()->add("one", entity_addrvec_t());
+  list<MonMap> o;
+  o.push_back(MonMap{});
+  o.push_back(MonMap{});
+  o.back().epoch = 1;
+  o.back().last_changed = utime_t(123, 456);
+  o.back().created = utime_t(789, 101112);
+  o.back().add("one", entity_addrvec_t());
 
-  MonMap *m = new MonMap;
+  MonMap m;
   {
-    m->epoch = 1;
-    m->last_changed = utime_t(123, 456);
+    m.epoch = 1;
+    m.last_changed = utime_t(123, 456);
 
     entity_addrvec_t empty_addr_one = entity_addrvec_t(entity_addr_t());
     empty_addr_one.v[0].set_nonce(1);
-    m->add("empty_addr_one", empty_addr_one);
+    m.add("empty_addr_one", empty_addr_one);
     entity_addrvec_t empty_addr_two = entity_addrvec_t(entity_addr_t());
     empty_addr_two.v[0].set_nonce(2);
-    m->add("empty_addr_two", empty_addr_two);
+    m.add("empty_addr_two", empty_addr_two);
 
     const char *local_pub_addr_s = "127.0.1.2";
 
@@ -350,11 +353,12 @@ void MonMap::generate_test_instances(list<MonMap*>& o)
     entity_addrvec_t local_pub_addr;
     local_pub_addr.parse(local_pub_addr_s, &end_p);
 
-    m->add(mon_info_t("filled_pub_addr", entity_addrvec_t(local_pub_addr), 1, 1));
+    m.add(mon_info_t("filled_pub_addr", entity_addrvec_t(local_pub_addr), 1, 1));
 
-    m->add("empty_addr_zero", entity_addrvec_t());
+    m.add("empty_addr_zero", entity_addrvec_t());
   }
-  o.push_back(m);
+  o.push_back(std::move(m));
+  return o;
 }
 
 // read from/write to a file

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -89,7 +89,7 @@ struct mon_info_t {
   void decode(ceph::buffer::list::const_iterator& p);
   void print(std::ostream& out) const;
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<mon_info_t*>& ls);
+  static std::list<mon_info_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(mon_info_t)
 
@@ -485,7 +485,7 @@ public:
 
   void check_health(health_check_map_t *checks) const;
 
-  static void generate_test_instances(std::list<MonMap*>& o);
+  static std::list<MonMap> generate_test_instances();
 protected:
   /**
    * build a monmap from a list of entity_addrvec_t's

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -119,9 +119,11 @@ class MonitorDBStore
 	4 + bl.length();
     }
 
-    static void generate_test_instances(std::list<Op*>& ls) {
-      ls.push_back(new Op);
+    static std::list<Op> generate_test_instances() {
+      std::list<Op> ls;
+      ls.push_back(Op{});
       // we get coverage here from the Transaction instances
+      return ls;
     }
   };
 
@@ -205,16 +207,18 @@ class MonitorDBStore
       DECODE_FINISH(bl);
     }
 
-    static void generate_test_instances(std::list<Transaction*>& ls) {
-      ls.push_back(new Transaction);
-      ls.push_back(new Transaction);
+    static std::list<Transaction> generate_test_instances() {
+      std::list<Transaction> ls;
+      ls.push_back(Transaction{});
+      ls.push_back(Transaction{});
       ceph::buffer::list bl;
       bl.append("value");
-      ls.back()->put("prefix", "key", bl);
-      ls.back()->erase("prefix2", "key2");
-      ls.back()->erase_range("prefix3", "key3", "key4");
-      ls.back()->compact_prefix("prefix3");
-      ls.back()->compact_range("prefix4", "from", "to");
+      ls.back().put("prefix", "key", bl);
+      ls.back().erase("prefix2", "key2");
+      ls.back().erase_range("prefix3", "key3", "key4");
+      ls.back().compact_prefix("prefix3");
+      ls.back().compact_range("prefix4", "from", "to");
+      return ls;
     }
 
     void append(TransactionRef other) {

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -194,9 +194,11 @@ void PGMapDigest::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void PGMapDigest::generate_test_instances(list<PGMapDigest*>& ls)
+list<PGMapDigest> PGMapDigest::generate_test_instances()
 {
-  ls.push_back(new PGMapDigest);
+  list<PGMapDigest> ls;
+  ls.push_back(PGMapDigest{});
+  return ls;
 }
 
 inline std::string percentify(const float& a) {
@@ -1113,25 +1115,27 @@ void PGMap::Incremental::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void PGMap::Incremental::generate_test_instances(list<PGMap::Incremental*>& o)
+list<PGMap::Incremental> PGMap::Incremental::generate_test_instances()
 {
-  o.push_back(new Incremental);
-  o.push_back(new Incremental);
-  o.back()->version = 1;
-  o.back()->stamp = utime_t(123,345);
-  o.push_back(new Incremental);
-  o.back()->version = 2;
-  o.back()->pg_stat_updates[pg_t(1,2)] = pg_stat_t();
-  o.back()->osd_stat_updates[5] = osd_stat_t();
-  o.push_back(new Incremental);
-  o.back()->version = 3;
-  o.back()->osdmap_epoch = 1;
-  o.back()->pg_scan = 2;
-  o.back()->pg_stat_updates[pg_t(4,5)] = pg_stat_t();
-  o.back()->osd_stat_updates[6] = osd_stat_t();
-  o.back()->pg_remove.insert(pg_t(1,2));
-  o.back()->osd_stat_rm.insert(5);
-  o.back()->pool_statfs_updates[std::make_pair(1234,4)] = store_statfs_t();
+  list<PGMap::Incremental> o;
+  o.push_back(Incremental{});
+  o.push_back(Incremental{});
+  o.back().version = 1;
+  o.back().stamp = utime_t(123,345);
+  o.push_back(Incremental{});
+  o.back().version = 2;
+  o.back().pg_stat_updates[pg_t(1,2)] = pg_stat_t();
+  o.back().osd_stat_updates[5] = osd_stat_t();
+  o.push_back(Incremental{});
+  o.back().version = 3;
+  o.back().osdmap_epoch = 1;
+  o.back().pg_scan = 2;
+  o.back().pg_stat_updates[pg_t(4,5)] = pg_stat_t();
+  o.back().osd_stat_updates[6] = osd_stat_t();
+  o.back().pg_remove.insert(pg_t(1,2));
+  o.back().osd_stat_rm.insert(5);
+  o.back().pool_statfs_updates[std::make_pair(1234,4)] = store_statfs_t();
+  return o;
 }
 
 // --
@@ -2257,21 +2261,19 @@ void PGMap::clear_delta()
   stamp_delta = utime_t();
 }
 
-void PGMap::generate_test_instances(list<PGMap*>& o)
+list<PGMap> PGMap::generate_test_instances()
 {
-  o.push_back(new PGMap);
-  list<Incremental*> inc;
-  Incremental::generate_test_instances(inc);
-  delete inc.front();
+  list<PGMap> o;
+  o.push_back(PGMap{});
+  list<Incremental> inc = Incremental::generate_test_instances();
   inc.pop_front();
   while (!inc.empty()) {
-    PGMap *pmp = new PGMap();
-    *pmp = *o.back();
+    PGMap pmp = o.back();
     o.push_back(pmp);
-    o.back()->apply_incremental(NULL, *inc.front());
-    delete inc.front();
+    o.back().apply_incremental(nullptr, inc.front());
     inc.pop_front();
   }
+  return o;
 }
 
 void PGMap::get_filtered_pg_stats(uint64_t state, int64_t poolid, int64_t osdid,

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -82,12 +82,14 @@ public:
       f->dump_int("up_not_acting", up_not_acting);
       f->dump_int("primary", primary);
     }
-    static void generate_test_instances(std::list<pg_count*>& o) {
-      o.push_back(new pg_count);
-      o.push_back(new pg_count);
-      o.back()->acting = 1;
-      o.back()->up_not_acting = 2;
-      o.back()->primary = 3;
+    static std::list<pg_count> generate_test_instances() {
+      std::list<pg_count> o;
+      o.push_back(pg_count{});
+      o.push_back(pg_count{});
+      o.back().acting = 1;
+      o.back().up_not_acting = 2;
+      o.back().primary = 3;
+      return o;
     }
   };
   mempool::pgmap::unordered_map<int32_t,pg_count> num_pg_by_osd;
@@ -248,7 +250,7 @@ public:
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<PGMapDigest*>& ls);
+  static std::list<PGMapDigest> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(PGMapDigest::pg_count);
 WRITE_CLASS_ENCODER_FEATURES(PGMapDigest);
@@ -318,7 +320,7 @@ public:
       osd_stat_updates.erase(osd);
     }
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<Incremental*>& o);
+    static std::list<Incremental> generate_test_instances();
 
     Incremental() : version(0), osdmap_epoch(0), pg_scan(0) {}
   };
@@ -524,7 +526,7 @@ public:
     health_check_map_t *checks) const;
   void print_summary(ceph::Formatter *f, std::ostream *out) const;
 
-  static void generate_test_instances(std::list<PGMap*>& o);
+  static std::list<PGMap> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(PGMap)
 

--- a/src/mon/health_check.h
+++ b/src/mon/health_check.h
@@ -58,14 +58,16 @@ struct health_check_t {
     }
   }
 
-  static void generate_test_instances(std::list<health_check_t*>& ls) {
-    ls.push_back(new health_check_t);
-    ls.back()->severity = HEALTH_WARN;
-    ls.push_back(new health_check_t);
-    ls.back()->severity = HEALTH_ERR;
-    ls.back()->summary = "summarization";
-    ls.back()->detail = {"one", "two", "three"};
-    ls.back()->count = 42;
+  static std::list<health_check_t> generate_test_instances() {
+    std::list<health_check_t> ls;
+    ls.push_back(health_check_t{});
+    ls.back().severity = HEALTH_WARN;
+    ls.push_back(health_check_t{});
+    ls.back().severity = HEALTH_ERR;
+    ls.back().summary = "summarization";
+    ls.back().detail = {"one", "two", "three"};
+    ls.back().count = 42;
+    return ls;
   }
 };
 WRITE_CLASS_DENC(health_check_t)
@@ -98,14 +100,16 @@ struct health_mute_t {
     f->dump_int("count", count);
   }
 
-  static void generate_test_instances(std::list<health_mute_t*>& ls) {
-    ls.push_back(new health_mute_t);
-    ls.push_back(new health_mute_t);
-    ls.back()->code = "OSD_DOWN";
-    ls.back()->ttl = utime_t(1, 2);
-    ls.back()->sticky = true;
-    ls.back()->summary = "foo bar";
-    ls.back()->count = 2;
+  static std::list<health_mute_t> generate_test_instances() {
+    std::list<health_mute_t> ls;
+    ls.push_back(health_mute_t{});
+    ls.push_back(health_mute_t{});
+    ls.back().code = "OSD_DOWN";
+    ls.back().ttl = utime_t(1, 2);
+    ls.back().sticky = true;
+    ls.back().summary = "foo bar";
+    ls.back().count = 2;
+    return ls;
   }
 };
 WRITE_CLASS_DENC(health_mute_t)
@@ -125,20 +129,23 @@ struct health_check_map_t {
     }
   }
 
-  static void generate_test_instances(std::list<health_check_map_t*>& ls) {
-    ls.push_back(new health_check_map_t);
-    ls.push_back(new health_check_map_t);
+  static std::list<health_check_map_t> generate_test_instances() {
+    std::list<health_check_map_t> ls;
+
+    ls.push_back(health_check_map_t{});
+    ls.push_back(health_check_map_t{});
     {
-      auto& d = ls.back()->add("FOO", HEALTH_WARN, "foo", 2);
+      auto& d = ls.back().add("FOO", HEALTH_WARN, "foo", 2);
       d.detail.push_back("a");
       d.detail.push_back("b");
     }
     {
-      auto& d = ls.back()->add("BAR", HEALTH_ERR, "bar!", 3);
+      auto& d = ls.back().add("BAR", HEALTH_ERR, "bar!", 3);
       d.detail.push_back("c");
       d.detail.push_back("d");
       d.detail.push_back("e");
     }
+    return ls;
   }
 
   void clear() {

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -118,13 +118,15 @@ struct FeatureMap {
     }
   }
 
-  static void generate_test_instances(std::list<FeatureMap*>& ls) {
-    ls.push_back(new FeatureMap);
-    ls.push_back(new FeatureMap);
-    ls.back()->add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_UID);
-    ls.back()->add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_NOSRCADDR);
-    ls.back()->add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_PGID64);
-    ls.back()->add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_INCSUBOSDMAP);
+  static std::list<FeatureMap> generate_test_instances() {
+    std::list<FeatureMap> ls;
+    ls.push_back(FeatureMap{});
+    ls.push_back(FeatureMap{});
+    ls.back().add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_UID);
+    ls.back().add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_NOSRCADDR);
+    ls.back().add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_PGID64);
+    ls.back().add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_INCSUBOSDMAP);
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(FeatureMap)
@@ -175,14 +177,16 @@ struct MonitorDBStoreStats {
     DECODE_FINISH(p);
   }
 
-  static void generate_test_instances(std::list<MonitorDBStoreStats*>& ls) {
-    ls.push_back(new MonitorDBStoreStats);
-    ls.push_back(new MonitorDBStoreStats);
-    ls.back()->bytes_total = 1024*1024;
-    ls.back()->bytes_sst = 512*1024;
-    ls.back()->bytes_log = 256*1024;
-    ls.back()->bytes_misc = 256*1024;
-    ls.back()->last_update = utime_t();
+  static std::list<MonitorDBStoreStats> generate_test_instances() {
+    std::list<MonitorDBStoreStats> ls;
+    ls.push_back(MonitorDBStoreStats{});
+    ls.push_back(MonitorDBStoreStats{});
+    ls.back().bytes_total = 1024*1024;
+    ls.back().bytes_sst = 512*1024;
+    ls.back().bytes_log = 256*1024;
+    ls.back().bytes_misc = 256*1024;
+    ls.back().last_update = utime_t();
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(MonitorDBStoreStats)
@@ -206,19 +210,21 @@ struct DataStats {
     store_stats.dump(f);
     f->close_section();
   }
-  static void generate_test_instances(std::list<DataStats*>& ls) {
-    ls.push_back(new DataStats);
-    ls.push_back(new DataStats);
-    ls.back()->fs_stats.byte_total = 1024*1024;
-    ls.back()->fs_stats.byte_used = 512*1024;
-    ls.back()->fs_stats.byte_avail = 256*1024;
-    ls.back()->fs_stats.avail_percent = 50;
-    ls.back()->last_update = utime_t();
-    ls.back()->store_stats.bytes_total = 1024*1024;
-    ls.back()->store_stats.bytes_sst = 512*1024;
-    ls.back()->store_stats.bytes_log = 256*1024;
-    ls.back()->store_stats.bytes_misc = 256*1024;
-    ls.back()->store_stats.last_update = utime_t();
+  static std::list<DataStats> generate_test_instances() {
+    std::list<DataStats> ls;
+    ls.push_back(DataStats{});
+    ls.push_back(DataStats{});
+    ls.back().fs_stats.byte_total = 1024*1024;
+    ls.back().fs_stats.byte_used = 512*1024;
+    ls.back().fs_stats.byte_avail = 256*1024;
+    ls.back().fs_stats.avail_percent = 50;
+    ls.back().last_update = utime_t();
+    ls.back().store_stats.bytes_total = 1024*1024;
+    ls.back().store_stats.bytes_sst = 512*1024;
+    ls.back().store_stats.bytes_log = 256*1024;
+    ls.back().store_stats.bytes_misc = 256*1024;
+    ls.back().store_stats.last_update = utime_t();
+    return ls;
   }
 
   void encode(ceph::buffer::list &bl) const {
@@ -287,11 +293,13 @@ struct ScrubResult {
       f->dump_unsigned(p->first.c_str(), p->second);
     f->close_section();
   }
-  static void generate_test_instances(std::list<ScrubResult*>& ls) {
-    ls.push_back(new ScrubResult);
-    ls.push_back(new ScrubResult);
-    ls.back()->prefix_crc["foo"] = 123;
-    ls.back()->prefix_keys["bar"] = 456;
+  static std::list<ScrubResult> generate_test_instances() {
+    std::list<ScrubResult> ls;
+    ls.push_back(ScrubResult{});
+    ls.push_back(ScrubResult{});
+    ls.back().prefix_crc["foo"] = 123;
+    ls.back().prefix_keys["bar"] = 456;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(ScrubResult)
@@ -498,12 +506,14 @@ public:
     DECODE_FINISH(p);
   }
 
-  static void generate_test_instances(std::list<mon_feature_t*>& ls) {
-    ls.push_back(new mon_feature_t);
-    ls.push_back(new mon_feature_t);
-    ls.back()->features = 1;
-    ls.push_back(new mon_feature_t);
-    ls.back()->features = 2;
+  static std::list<mon_feature_t> generate_test_instances() {
+    std::list<mon_feature_t> ls;
+    ls.push_back(mon_feature_t{});
+    ls.push_back(mon_feature_t{});
+    ls.back().features = 1;
+    ls.push_back(mon_feature_t{});
+    ls.back().features = 2;
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(mon_feature_t)
@@ -727,12 +737,14 @@ struct ProgressEvent {
     f->dump_float("progress", progress);
     f->dump_bool("add_to_ceph_s", add_to_ceph_s);
   }
-  static void generate_test_instances(std::list<ProgressEvent*>& o) {
-    o.push_back(new ProgressEvent);
-    o.push_back(new ProgressEvent);
-    o.back()->message = "test message";
-    o.back()->progress = 0.5;
-    o.back()->add_to_ceph_s = true;
+  static std::list<ProgressEvent> generate_test_instances() {
+    std::list<ProgressEvent> o;
+    o.push_back(ProgressEvent{});
+    o.push_back(ProgressEvent{});
+    o.back().message = "test message";
+    o.back().progress = 0.5;
+    o.back().add_to_ceph_s = true;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(ProgressEvent)
@@ -787,20 +799,22 @@ struct PoolAvailability {
     DECODE_FINISH(p);
   }
 
-  static void generate_test_instances(std::list<PoolAvailability*>& o) {
-    o.push_back(new PoolAvailability);
-    o.back()->started_at = utime_t(123, 456);      
-    o.back()->last_uptime = utime_t(123, 456);      
-    o.back()->last_downtime = utime_t(123, 456);   
-    o.push_back(new PoolAvailability);
-    o.back()->pool_name = "foo";    
-    o.back()->started_at = utime_t(123, 456);    
-    o.back()->uptime = 100;    
-    o.back()->last_uptime = utime_t(123, 456);    
-    o.back()->downtime = 15;    
-    o.back()->last_downtime = utime_t(123, 456);    
-    o.back()->num_failures = 2;    
-    o.back()->is_avail = true;    
+  static std::list<PoolAvailability> generate_test_instances() {
+    std::list<PoolAvailability> o;
+    o.push_back(PoolAvailability{});
+    o.back().started_at = utime_t(123, 456);
+    o.back().last_uptime = utime_t(123, 456);
+    o.back().last_downtime = utime_t(123, 456);
+    o.push_back(PoolAvailability{});
+    o.back().pool_name = "foo";
+    o.back().started_at = utime_t(123, 456);
+    o.back().uptime = 100;
+    o.back().last_uptime = utime_t(123, 456);
+    o.back().downtime = 15;
+    o.back().last_downtime = utime_t(123, 456);
+    o.back().num_failures = 2;
+    o.back().is_avail = true;
+    return o;
   }  
 };
 WRITE_CLASS_ENCODER(PoolAvailability)

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -63,39 +63,45 @@ void entity_inst_t::dump(ceph::Formatter *f) const
   f->dump_object("addr", addr);
 }
 
-void entity_name_t::generate_test_instances(std::list<entity_name_t*>& o)
+std::list<entity_name_t> entity_name_t::generate_test_instances()
 {
-  o.push_back(new entity_name_t(entity_name_t::MON()));
-  o.push_back(new entity_name_t(entity_name_t::MON(1)));
-  o.push_back(new entity_name_t(entity_name_t::OSD(1)));
-  o.push_back(new entity_name_t(entity_name_t::CLIENT(1)));
+  std::list<entity_name_t> o;
+  o.push_back(entity_name_t(entity_name_t::MON()));
+  o.push_back(entity_name_t(entity_name_t::MON(1)));
+  o.push_back(entity_name_t(entity_name_t::OSD(1)));
+  o.push_back(entity_name_t(entity_name_t::CLIENT(1)));
+  return o;
 }
 
-void entity_addr_t::generate_test_instances(std::list<entity_addr_t*>& o)
+std::list<entity_addr_t> entity_addr_t::generate_test_instances()
 {
-  o.push_back(new entity_addr_t());
-  entity_addr_t *a = new entity_addr_t();
-  a->set_nonce(1);
+  std::list<entity_addr_t> o;
+  o.push_back(entity_addr_t());
+  entity_addr_t a;
+  a.set_nonce(1);
   o.push_back(a);
-  entity_addr_t *b = new entity_addr_t();
-  b->set_type(entity_addr_t::TYPE_LEGACY);
-  b->set_nonce(5);
-  b->set_family(AF_INET);
-  b->set_in4_quad(0, 127);
-  b->set_in4_quad(1, 0);
-  b->set_in4_quad(2, 1);
-  b->set_in4_quad(3, 2);
-  b->set_port(2);
+  entity_addr_t b;
+  b.set_type(entity_addr_t::TYPE_LEGACY);
+  b.set_nonce(5);
+  b.set_family(AF_INET);
+  b.set_in4_quad(0, 127);
+  b.set_in4_quad(1, 0);
+  b.set_in4_quad(2, 1);
+  b.set_in4_quad(3, 2);
+  b.set_port(2);
   o.push_back(b);
+  return o;
 }
 
-void entity_inst_t::generate_test_instances(std::list<entity_inst_t*>& o)
+std::list<entity_inst_t> entity_inst_t::generate_test_instances()
 {
-  o.push_back(new entity_inst_t());
+  std::list<entity_inst_t> o;
+  o.push_back(entity_inst_t());
   entity_name_t name;
   entity_addr_t addr;
-  entity_inst_t *a = new entity_inst_t(name, addr);
-  o.push_back(a);
+  entity_inst_t a(name, addr);
+  o.push_back(std::move(a));
+  return o;
 }
 
 bool entity_addr_t::parse(const std::string_view s, int default_type)
@@ -399,14 +405,16 @@ void entity_addrvec_t::dump(ceph::Formatter *f) const
   f->close_section();
 }
 
-void entity_addrvec_t::generate_test_instances(std::list<entity_addrvec_t*>& ls)
+std::list<entity_addrvec_t> entity_addrvec_t::generate_test_instances()
 {
-  ls.push_back(new entity_addrvec_t());
-  ls.push_back(new entity_addrvec_t());
-  ls.back()->v.push_back(entity_addr_t());
-  ls.push_back(new entity_addrvec_t());
-  ls.back()->v.push_back(entity_addr_t());
-  ls.back()->v.push_back(entity_addr_t());
+  std::list<entity_addrvec_t> ls;
+  ls.push_back(entity_addrvec_t());
+  ls.push_back(entity_addrvec_t());
+  ls.back().v.push_back(entity_addr_t());
+  ls.push_back(entity_addrvec_t());
+  ls.back().v.push_back(entity_addr_t());
+  ls.back().v.push_back(entity_addr_t());
+  return ls;
 }
 
 std::string entity_addr_t::ip_only_to_str() const 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -110,7 +110,7 @@ public:
     }
   }
 
-  static void generate_test_instances(std::list<entity_name_t*>& o);
+  static std::list<entity_name_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(entity_name_t)
 
@@ -559,7 +559,7 @@ struct entity_addr_t {
   void dump(ceph::Formatter *f) const;
   std::string fmt_print() const; ///< used by the default fmt formatter
 
-  static void generate_test_instances(std::list<entity_addr_t*>& o);
+  static std::list<entity_addr_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(entity_addr_t)
 
@@ -684,7 +684,7 @@ struct entity_addrvec_t {
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<entity_addrvec_t*>& ls);
+  static std::list<entity_addrvec_t> generate_test_instances();
 
   bool legacy_equals(const entity_addrvec_t& o) const {
     if (v == o.v) {
@@ -797,7 +797,7 @@ struct entity_inst_t {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<entity_inst_t*>& o);
+  static std::list<entity_inst_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(entity_inst_t)
 

--- a/src/os/SequencerPosition.h
+++ b/src/os/SequencerPosition.h
@@ -41,10 +41,12 @@ struct SequencerPosition {
     f->dump_unsigned("trans", trans);
     f->dump_unsigned("op", op);
   }
-  static void generate_test_instances(std::list<SequencerPosition*>& o) {
-    o.push_back(new SequencerPosition);
-    o.push_back(new SequencerPosition(1, 2, 3));
-    o.push_back(new SequencerPosition(4, 5, 6));
+  static std::list<SequencerPosition> generate_test_instances() {
+    std::list<SequencerPosition> o;
+    o.push_back(SequencerPosition{});
+    o.push_back(SequencerPosition(1, 2, 3));
+    o.push_back(SequencerPosition(4, 5, 6));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(SequencerPosition)

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -530,46 +530,50 @@ void Transaction::dump(ceph::Formatter *f)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-void Transaction::generate_test_instances(list<Transaction*>& o)
+list<Transaction> Transaction::generate_test_instances()
 {
-  o.push_back(new Transaction);
+  list<Transaction> o;
 
-  Transaction *t = new Transaction;
-  t->nop();
-  o.push_back(t);
+  o.push_back(Transaction{});
+
+  Transaction t;
+  t.nop();
+  o.push_back(std::move(t));
   
-  t = new Transaction;
+  t = Transaction{};
   coll_t c(spg_t(pg_t(1,2), shard_id_t::NO_SHARD));
   coll_t c2(spg_t(pg_t(4,5), shard_id_t::NO_SHARD));
   ghobject_t o1(hobject_t("obj", "", 123, 456, -1, ""));
   ghobject_t o2(hobject_t("obj2", "", 123, 456, -1, ""));
   ghobject_t o3(hobject_t("obj3", "", 123, 456, -1, ""));
-  t->touch(c, o1);
+  t.touch(c, o1);
   bufferlist bl;
   bl.append("some data");
-  t->write(c, o1, 1, bl.length(), bl);
-  t->zero(c, o1, 22, 33);
-  t->truncate(c, o1, 99);
-  t->remove(c, o1);
-  o.push_back(t);
+  t.write(c, o1, 1, bl.length(), bl);
+  t.zero(c, o1, 22, 33);
+  t.truncate(c, o1, 99);
+  t.remove(c, o1);
+  o.push_back(std::move(t));
 
-  t = new Transaction;
-  t->setattr(c, o1, "key", bl);
+  t = Transaction{};
+  t.setattr(c, o1, "key", bl);
   map<string,bufferptr,less<>> m;
   m["a"] = buffer::copy("this", 4);
   m["b"] = buffer::copy("that", 4);
-  t->setattrs(c, o1, m);
-  t->rmattr(c, o1, "b");
-  t->rmattrs(c, o1);
+  t.setattrs(c, o1, m);
+  t.rmattr(c, o1, "b");
+  t.rmattrs(c, o1);
 
-  t->clone(c, o1, o2);
-  t->clone(c, o1, o3);
-  t->clone_range(c, o1, o2, 1, 12, 99);
+  t.clone(c, o1, o2);
+  t.clone(c, o1, o3);
+  t.clone_range(c, o1, o2, 1, 12, 99);
 
-  t->create_collection(c, 12);
-  t->collection_move_rename(c, o2, c2, o3);
-  t->remove_collection(c);
-  o.push_back(t);  
+  t.create_collection(c, 12);
+  t.collection_move_rename(c, o2, c2, o3);
+  t.remove_collection(c);
+  o.push_back(std::move(t));
+
+  return o;
 }
 
 ostream& operator<<(ostream& out, const Transaction& tx) {

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -1386,7 +1386,7 @@ public:
   }
 
   void dump(ceph::Formatter *f);
-  static void generate_test_instances(std::list<Transaction*>& o);
+  static std::list<Transaction> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ceph::os::Transaction)
 WRITE_CLASS_ENCODER(ceph::os::Transaction::TransactionData)

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -25,13 +25,15 @@ void bluefs_extent_t::dump(Formatter *f) const
   f->dump_unsigned("bdev", bdev);
 }
 
-void bluefs_extent_t::generate_test_instances(list<bluefs_extent_t*>& ls)
+list<bluefs_extent_t> bluefs_extent_t::generate_test_instances()
 {
-  ls.push_back(new bluefs_extent_t);
-  ls.push_back(new bluefs_extent_t);
-  ls.back()->offset = 1;
-  ls.back()->length = 2;
-  ls.back()->bdev = 1;
+  list<bluefs_extent_t> ls;
+  ls.push_back(bluefs_extent_t{});
+  ls.push_back(bluefs_extent_t{});
+  ls.back().offset = 1;
+  ls.back().length = 2;
+  ls.back().bdev = 1;
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const bluefs_extent_t& e)
@@ -163,13 +165,15 @@ void bluefs_layout_t::dump(Formatter *f) const
   f->dump_stream("dedicated_wal") << dedicated_wal;
 }
 
-void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
+list<bluefs_layout_t> bluefs_layout_t::generate_test_instances()
 {
-  ls.push_back(new bluefs_layout_t);
-  ls.push_back(new bluefs_layout_t);
-  ls.back()->shared_bdev = 1;
-  ls.back()->dedicated_db = true;
-  ls.back()->dedicated_wal = true;
+  list<bluefs_layout_t> ls;
+  ls.push_back(bluefs_layout_t{});
+  ls.push_back(bluefs_layout_t{});
+  ls.back().shared_bdev = 1;
+  ls.back().dedicated_db = true;
+  ls.back().dedicated_wal = true;
+  return ls;
 }
 
 // bluefs_super_t
@@ -217,12 +221,14 @@ void bluefs_super_t::dump(Formatter *f) const
   f->dump_object("log_fnode", log_fnode);
 }
 
-void bluefs_super_t::generate_test_instances(list<bluefs_super_t*>& ls)
+list<bluefs_super_t> bluefs_super_t::generate_test_instances()
 {
-  ls.push_back(new bluefs_super_t);
-  ls.push_back(new bluefs_super_t);
-  ls.back()->seq = 1;
-  ls.back()->block_size = 4096;
+  list<bluefs_super_t> ls;
+  ls.push_back(bluefs_super_t{});
+  ls.push_back(bluefs_super_t{});
+  ls.back().seq = 1;
+  ls.back().block_size = 4096;
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const bluefs_super_t& s)
@@ -304,16 +310,18 @@ void bluefs_fnode_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void bluefs_fnode_t::generate_test_instances(list<bluefs_fnode_t*>& ls)
+list<bluefs_fnode_t> bluefs_fnode_t::generate_test_instances()
 {
-  ls.push_back(new bluefs_fnode_t);
-  ls.push_back(new bluefs_fnode_t);
-  ls.back()->ino = 123;
-  ls.back()->size = 1048576;
-  ls.back()->mtime = utime_t(123,45);
-  ls.back()->extents.push_back(bluefs_extent_t(0, 1048576, 4096));
-  ls.back()->__unused__ = 1;
-  ls.back()->encoding = 0;
+  list<bluefs_fnode_t> ls;
+  ls.push_back(bluefs_fnode_t{});
+  ls.push_back(bluefs_fnode_t{});
+  ls.back().ino = 123;
+  ls.back().size = 1048576;
+  ls.back().mtime = utime_t(123,45);
+  ls.back().extents.push_back(bluefs_extent_t(0, 1048576, 4096));
+  ls.back().__unused__ = 1;
+  ls.back().encoding = 0;
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
@@ -408,21 +416,22 @@ void bluefs_transaction_t::dump(Formatter *f) const
   f->dump_unsigned("crc", op_bl.crc32c(-1));
 }
 
-void bluefs_transaction_t::generate_test_instances(
-  list<bluefs_transaction_t*>& ls)
+list<bluefs_transaction_t> bluefs_transaction_t::generate_test_instances()
 {
-  ls.push_back(new bluefs_transaction_t);
-  ls.push_back(new bluefs_transaction_t);
-  ls.back()->op_init();
-  ls.back()->op_dir_create("dir");
-  ls.back()->op_dir_create("dir2");
+  list<bluefs_transaction_t> ls;
+  ls.push_back(bluefs_transaction_t{});
+  ls.push_back(bluefs_transaction_t{});
+  ls.back().op_init();
+  ls.back().op_dir_create("dir");
+  ls.back().op_dir_create("dir2");
   bluefs_fnode_t fnode;
   fnode.ino = 2;
-  ls.back()->op_file_update(fnode);
-  ls.back()->op_dir_link("dir", "file1", 2);
-  ls.back()->op_dir_unlink("dir", "file1");
-  ls.back()->op_file_remove(2);
-  ls.back()->op_dir_remove("dir2");
+  ls.back().op_file_update(fnode);
+  ls.back().op_dir_link("dir", "file1", 2);
+  ls.back().op_dir_unlink("dir", "file1");
+  ls.back().op_file_remove(2);
+  ls.back().op_dir_remove("dir2");
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const bluefs_transaction_t& t)

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -30,7 +30,7 @@ public:
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluefs_extent_t*>&);
+  static std::list<bluefs_extent_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluefs_extent_t)
 
@@ -284,8 +284,7 @@ struct bluefs_fnode_t {
   bluefs_fnode_delta_t* make_delta(bluefs_fnode_delta_t* delta);
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluefs_fnode_t*>& ls);
-
+  static std::list<bluefs_fnode_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluefs_fnode_t)
 
@@ -309,7 +308,7 @@ struct bluefs_layout_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluefs_layout_t*>& ls);
+  static std::list<bluefs_layout_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(bluefs_layout_t)
 
@@ -337,7 +336,7 @@ struct bluefs_super_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluefs_super_t*>& ls);
+  static std::list<bluefs_super_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(bluefs_super_t)
 
@@ -440,7 +439,7 @@ struct bluefs_transaction_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluefs_transaction_t*>& ls);
+  static std::list<bluefs_transaction_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(bluefs_transaction_t)
 

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -69,15 +69,16 @@ void bluestore_bdev_label_t::dump(Formatter *f) const
   }
 }
 
-void bluestore_bdev_label_t::generate_test_instances(
-  list<bluestore_bdev_label_t*>& o)
+list<bluestore_bdev_label_t> bluestore_bdev_label_t::generate_test_instances()
 {
-  o.push_back(new bluestore_bdev_label_t);
-  o.push_back(new bluestore_bdev_label_t);
-  o.back()->size = 123;
-  o.back()->btime = utime_t(4, 5);
-  o.back()->description = "fakey";
-  o.back()->meta["foo"] = "bar";
+  list<bluestore_bdev_label_t> o;
+  o.push_back(bluestore_bdev_label_t{});
+  o.push_back(bluestore_bdev_label_t{});
+  o.back().size = 123;
+  o.back().btime = utime_t(4, 5);
+  o.back().description = "fakey";
+  o.back().meta["foo"] = "bar";
+  return o;
 }
 
 ostream& operator<<(ostream& out, const bluestore_bdev_label_t& l)
@@ -97,11 +98,13 @@ void bluestore_cnode_t::dump(Formatter *f) const
   f->dump_unsigned("bits", bits);
 }
 
-void bluestore_cnode_t::generate_test_instances(list<bluestore_cnode_t*>& o)
+std::list<bluestore_cnode_t> bluestore_cnode_t::generate_test_instances()
 {
-  o.push_back(new bluestore_cnode_t());
-  o.push_back(new bluestore_cnode_t(0));
-  o.push_back(new bluestore_cnode_t(123));
+  std::list<bluestore_cnode_t> o;
+  o.push_back(bluestore_cnode_t());
+  o.push_back(bluestore_cnode_t(0));
+  o.push_back(bluestore_cnode_t(123));
+  return o;
 }
 
 ostream& operator<<(ostream& out, const bluestore_cnode_t& l)
@@ -373,16 +376,17 @@ void bluestore_extent_ref_map_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void bluestore_extent_ref_map_t::generate_test_instances(
-  list<bluestore_extent_ref_map_t*>& o)
+list<bluestore_extent_ref_map_t> bluestore_extent_ref_map_t::generate_test_instances()
 {
-  o.push_back(new bluestore_extent_ref_map_t);
-  o.push_back(new bluestore_extent_ref_map_t);
-  o.back()->get(10, 10);
-  o.back()->get(18, 22);
-  o.back()->get(20, 20);
-  o.back()->get(10, 25);
-  o.back()->get(15, 20);
+  list<bluestore_extent_ref_map_t> o;
+  o.push_back(bluestore_extent_ref_map_t{});
+  o.push_back(bluestore_extent_ref_map_t{});
+  o.back().get(10, 10);
+  o.back().get(18, 22);
+  o.back().get(20, 20);
+  o.back().get(10, 25);
+  o.back().get(15, 20);
+  return o;
 }
 
 ostream& operator<<(ostream& out, const bluestore_extent_ref_map_t& m)
@@ -690,18 +694,19 @@ void bluestore_blob_use_tracker_t::dump(Formatter *f) const
   }
 }
 
-void bluestore_blob_use_tracker_t::generate_test_instances(
-  list<bluestore_blob_use_tracker_t*>& o)
+list<bluestore_blob_use_tracker_t> bluestore_blob_use_tracker_t::generate_test_instances()
 {
-  o.push_back(new bluestore_blob_use_tracker_t());
-  o.back()->init(16, 16);
-  o.back()->get(10, 10);
-  o.back()->get(10, 5);
-  o.push_back(new bluestore_blob_use_tracker_t());
-  o.back()->init(60, 16);
-  o.back()->get(18, 22);
-  o.back()->get(20, 20);
-  o.back()->get(15, 20);
+  list<bluestore_blob_use_tracker_t> o;
+  o.push_back(bluestore_blob_use_tracker_t());
+  o.back().init(16, 16);
+  o.back().get(10, 10);
+  o.back().get(10, 5);
+  o.push_back(bluestore_blob_use_tracker_t());
+  o.back().init(60, 16);
+  o.back().get(18, 22);
+  o.back().get(20, 20);
+  o.back().get(15, 20);
+  return o;
 }
 
 ostream& operator<<(ostream& out, const bluestore_blob_use_tracker_t& m)
@@ -741,10 +746,12 @@ ostream& operator<<(ostream& out, const bluestore_pextent_t& o) {
     return out << "!~" << std::hex << o.length << std::dec;
 }
 
-void bluestore_pextent_t::generate_test_instances(list<bluestore_pextent_t*>& ls)
+list<bluestore_pextent_t> bluestore_pextent_t::generate_test_instances()
 {
-  ls.push_back(new bluestore_pextent_t);
-  ls.push_back(new bluestore_pextent_t(1, 2));
+  list<bluestore_pextent_t> ls;
+  ls.push_back(bluestore_pextent_t{});
+  ls.push_back(bluestore_pextent_t(1, 2));
+  return ls;
 }
 
 // bluestore_blob_t
@@ -824,21 +831,23 @@ void bluestore_blob_t::dump(Formatter *f) const
   f->dump_unsigned("unused", unused);
 }
 
-void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
+list<bluestore_blob_t> bluestore_blob_t::generate_test_instances()
 {
-  ls.push_back(new bluestore_blob_t);
-  ls.push_back(new bluestore_blob_t(0));
-  ls.push_back(new bluestore_blob_t);
-  ls.back()->allocated_test(bluestore_pextent_t(111, 222));
-  ls.push_back(new bluestore_blob_t);
-  ls.back()->init_csum(Checksummer::CSUM_XXHASH32, 16, 65536);
-  ls.back()->csum_data = ceph::buffer::claim_malloc(4, strdup("abcd"));
-  ls.back()->add_unused(0, 3);
-  ls.back()->add_unused(8, 8);
-  ls.back()->allocated_test(bluestore_pextent_t(0x40100000, 0x10000));
-  ls.back()->allocated_test(
+  list<bluestore_blob_t> ls;
+  ls.push_back(bluestore_blob_t{});
+  ls.push_back(bluestore_blob_t(0));
+  ls.push_back(bluestore_blob_t{});
+  ls.back().allocated_test(bluestore_pextent_t(111, 222));
+  ls.push_back(bluestore_blob_t{});
+  ls.back().init_csum(Checksummer::CSUM_XXHASH32, 16, 65536);
+  ls.back().csum_data = ceph::buffer::claim_malloc(4, strdup("abcd"));
+  ls.back().add_unused(0, 3);
+  ls.back().add_unused(8, 8);
+  ls.back().allocated_test(bluestore_pextent_t(0x40100000, 0x10000));
+  ls.back().allocated_test(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x1000));
-  ls.back()->allocated_test(bluestore_pextent_t(0x40120000, 0x10000));
+  ls.back().allocated_test(bluestore_pextent_t(0x40120000, 0x10000));
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const bluestore_blob_t& o)
@@ -1358,19 +1367,16 @@ void bluestore_shared_blob_t::dump(Formatter *f) const
   f->dump_object("ref_map", ref_map);
 }
 
-void bluestore_shared_blob_t::generate_test_instances(
-  list<bluestore_shared_blob_t*>& ls)
+list<bluestore_shared_blob_t> bluestore_shared_blob_t::generate_test_instances()
 {
-  std::list<bluestore_extent_ref_map_t*> extent_ref_maps;
-  bluestore_extent_ref_map_t::generate_test_instances(extent_ref_maps);
+  list<bluestore_shared_blob_t> ls;
+  auto extent_ref_maps = bluestore_extent_ref_map_t::generate_test_instances();
   // use 0 for sbid, as this field is not persited, and is always set during
   // instance construction, so including a non-default value in dumps would
   // cause ceph-dencoder verification failures when comparing original and
   // re-encoded value.
-  ls.push_back(new bluestore_shared_blob_t{0, std::move(*extent_ref_maps.front())});
-  for (auto* m : extent_ref_maps) {
-    delete m;
-  }
+  ls.push_back(bluestore_shared_blob_t{0, std::move(extent_ref_maps.front())});
+  return ls;
 }
 
 ostream& operator<<(ostream& out, const bluestore_shared_blob_t& sb)
@@ -1388,13 +1394,14 @@ void bluestore_onode_t::shard_info::dump(Formatter *f) const
   f->dump_unsigned("bytes", bytes);
 }
 
-void bluestore_onode_t::shard_info::generate_test_instances(
-  list<shard_info*>& o)
+auto bluestore_onode_t::shard_info::generate_test_instances() -> list<shard_info>
 {
-  o.push_back(new shard_info);
-  o.push_back(new shard_info);
-  o.back()->offset = 123;
-  o.back()->bytes = 456;
+  list<shard_info> o;
+  o.push_back(shard_info{});
+  o.push_back(shard_info{});
+  o.back().offset = 123;
+  o.back().bytes = 456;
+  return o;
 }
 
 ostream& operator<<(ostream& out, const bluestore_onode_t::shard_info& si)
@@ -1426,54 +1433,56 @@ void bluestore_onode_t::dump(Formatter *f) const
   f->dump_unsigned("alloc_hint_flags", alloc_hint_flags);
 }
 
-void bluestore_onode_t::generate_test_instances(list<bluestore_onode_t*>& o)
+list<bluestore_onode_t> bluestore_onode_t::generate_test_instances()
 {
+  list<bluestore_onode_t> o;
 
-  auto* onode1 = new bluestore_onode_t();
-  onode1->nid = 0xDEADBEEF;
-  onode1->size = 99999;
-  onode1->expected_object_size = 123456;
-  onode1->expected_write_size = 7890;
-  onode1->set_flag(FLAG_OMAP | FLAG_PERPOOL_OMAP | FLAG_PERPG_OMAP);
+  auto onode1 = bluestore_onode_t();
+  onode1.nid = 0xDEADBEEF;
+  onode1.size = 99999;
+  onode1.expected_object_size = 123456;
+  onode1.expected_write_size = 7890;
+  onode1.set_flag(FLAG_OMAP | FLAG_PERPOOL_OMAP | FLAG_PERPG_OMAP);
 
   ceph::buffer::ptr buf1 = ceph::buffer::create(50);
   memset(buf1.c_str(), 0x42, 50);
-  onode1->attrs["chaos_attr1"] = buf1;
+  onode1.attrs["chaos_attr1"] = buf1;
 
-  onode1->extent_map_shards.push_back({.offset = 555, .bytes = 777});
+  onode1.extent_map_shards.push_back({.offset = 555, .bytes = 777});
 
-  o.push_back(onode1);
+  o.push_back(std::move(onode1));
 
-  auto* onode2 = new bluestore_onode_t();
-  onode2->nid = 0xBAADF00D;
-  onode2->size = 54321;
-  onode2->expected_object_size = 654321;
-  onode2->expected_write_size = 4321;
-  onode2->set_flag(FLAG_OMAP | FLAG_PGMETA_OMAP);
+  auto onode2 = bluestore_onode_t();
+  onode2.nid = 0xBAADF00D;
+  onode2.size = 54321;
+  onode2.expected_object_size = 654321;
+  onode2.expected_write_size = 4321;
+  onode2.set_flag(FLAG_OMAP | FLAG_PGMETA_OMAP);
 
   ceph::buffer::ptr buf2 = ceph::buffer::create(30);
   memset(buf2.c_str(), 0xAB, 30);
-  onode2->attrs["glitch_attr"] = buf2;
+  onode2.attrs["glitch_attr"] = buf2;
 
-  onode2->extent_map_shards.push_back({.offset = 333, .bytes = 444});
+  onode2.extent_map_shards.push_back({.offset = 333, .bytes = 444});
 
-  o.push_back(onode2);
+  o.push_back(std::move(onode2));
 
-  auto* onode3 = new bluestore_onode_t();
-  onode3->nid = 0xFEEDFACE;
-  onode3->size = 0;
-  onode3->expected_object_size = 1;
-  onode3->expected_write_size = 1;
-  onode3->set_flag(FLAG_OMAP | FLAG_PERPOOL_OMAP);
+  auto onode3 = bluestore_onode_t();
+  onode3.nid = 0xFEEDFACE;
+  onode3.size = 0;
+  onode3.expected_object_size = 1;
+  onode3.expected_write_size = 1;
+  onode3.set_flag(FLAG_OMAP | FLAG_PERPOOL_OMAP);
 
   ceph::buffer::ptr buf3 = ceph::buffer::create(100);
   memset(buf3.c_str(), 0xFF, 100);
-  onode3->attrs["maxed_out"] = buf3;
+  onode3.attrs["maxed_out"] = buf3;
 
-  onode3->extent_map_shards.push_back({.offset = 999, .bytes = 2048});
+  onode3.extent_map_shards.push_back({.offset = 999, .bytes = 2048});
 
-  o.push_back(onode3);
+  o.push_back(std::move(onode3));
 
+  return o;
 }
 
 // bluestore_deferred_op_t
@@ -1489,14 +1498,16 @@ void bluestore_deferred_op_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void bluestore_deferred_op_t::generate_test_instances(list<bluestore_deferred_op_t*>& o)
+list<bluestore_deferred_op_t> bluestore_deferred_op_t::generate_test_instances()
 {
-  o.push_back(new bluestore_deferred_op_t);
-  o.push_back(new bluestore_deferred_op_t);
-  o.back()->op = OP_WRITE;
-  o.back()->extents.push_back(bluestore_pextent_t(1, 2));
-  o.back()->extents.push_back(bluestore_pextent_t(100, 5));
-  o.back()->data.append("my data");
+  list<bluestore_deferred_op_t> o;
+  o.push_back(bluestore_deferred_op_t{});
+  o.push_back(bluestore_deferred_op_t{});
+  o.back().op = OP_WRITE;
+  o.back().extents.push_back(bluestore_pextent_t(1, 2));
+  o.back().extents.push_back(bluestore_pextent_t(100, 5));
+  o.back().data.append("my data");
+  return o;
 }
 
 void bluestore_deferred_transaction_t::dump(Formatter *f) const
@@ -1518,16 +1529,18 @@ void bluestore_deferred_transaction_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void bluestore_deferred_transaction_t::generate_test_instances(list<bluestore_deferred_transaction_t*>& o)
+list<bluestore_deferred_transaction_t> bluestore_deferred_transaction_t::generate_test_instances()
 {
-  o.push_back(new bluestore_deferred_transaction_t());
-  o.push_back(new bluestore_deferred_transaction_t());
-  o.back()->seq = 123;
-  o.back()->ops.push_back(bluestore_deferred_op_t());
-  o.back()->ops.push_back(bluestore_deferred_op_t());
-  o.back()->ops.back().op = bluestore_deferred_op_t::OP_WRITE;
-  o.back()->ops.back().extents.push_back(bluestore_pextent_t(1,7));
-  o.back()->ops.back().data.append("foodata");
+  list<bluestore_deferred_transaction_t> o;
+  o.push_back(bluestore_deferred_transaction_t());
+  o.push_back(bluestore_deferred_transaction_t());
+  o.back().seq = 123;
+  o.back().ops.push_back(bluestore_deferred_op_t());
+  o.back().ops.push_back(bluestore_deferred_op_t());
+  o.back().ops.back().op = bluestore_deferred_op_t::OP_WRITE;
+  o.back().ops.back().extents.push_back(bluestore_pextent_t(1,7));
+  o.back().ops.back().data.append("foodata");
+  return o;
 }
 
 void bluestore_compression_header_t::dump(Formatter *f) const
@@ -1539,12 +1552,13 @@ void bluestore_compression_header_t::dump(Formatter *f) const
   }
 }
 
-void bluestore_compression_header_t::generate_test_instances(
-  list<bluestore_compression_header_t*>& o)
+list<bluestore_compression_header_t> bluestore_compression_header_t::generate_test_instances()
 {
-  o.push_back(new bluestore_compression_header_t);
-  o.push_back(new bluestore_compression_header_t(1));
-  o.back()->length = 1234;
+  list<bluestore_compression_header_t> o;
+  o.push_back(bluestore_compression_header_t{});
+  o.push_back(bluestore_compression_header_t(1));
+  o.back().length = 1234;
+  return o;
 }
 
 // adds more salt to build a hash func input

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -46,7 +46,7 @@ struct bluestore_bdev_label_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_bdev_label_t*>& o);
+  static std::list<bluestore_bdev_label_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(bluestore_bdev_label_t)
 
@@ -64,7 +64,7 @@ struct bluestore_cnode_t {
     DENC_FINISH(p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_cnode_t*>& o);
+  static std::list<bluestore_cnode_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluestore_cnode_t)
 
@@ -108,7 +108,7 @@ struct bluestore_pextent_t : public bluestore_interval_t<uint64_t, uint32_t>
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_pextent_t*>& ls);
+  static std::list<bluestore_pextent_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluestore_pextent_t)
 
@@ -163,9 +163,11 @@ struct bluestore_extent_ref_map_t {
       f->dump_unsigned("length", length);
       f->dump_unsigned("refs", refs);
     }
-    static void generate_test_instances(std::list<record_t*>& o) {
-      o.push_back(new record_t);
-      o.push_back(new record_t(123, 456));
+    static std::list<record_t> generate_test_instances() {
+      std::list<record_t> o;
+      o.push_back(record_t{});
+      o.push_back(record_t(123, 456));
+      return o;
     }
   };
 
@@ -235,7 +237,7 @@ struct bluestore_extent_ref_map_t {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_extent_ref_map_t*>& o);
+  static std::list<bluestore_extent_ref_map_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluestore_extent_ref_map_t)
 WRITE_CLASS_DENC(bluestore_extent_ref_map_t::record_t)
@@ -477,7 +479,7 @@ struct bluestore_blob_use_tracker_t {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_blob_use_tracker_t*>& o);
+  static std::list<bluestore_blob_use_tracker_t> generate_test_instances();
 private:
   void allocate(uint32_t _num_au);
   void release(uint32_t _num_au, uint32_t* ptr);
@@ -594,7 +596,7 @@ public:
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_blob_t*>& ls);
+  static std::list<bluestore_blob_t> generate_test_instances();
 
   bool has_flag(unsigned f) const {
     return flags & f;
@@ -1106,7 +1108,7 @@ struct bluestore_shared_blob_t {
 
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_shared_blob_t*>& ls);
+  static std::list<bluestore_shared_blob_t> generate_test_instances();
 
   bool empty() const {
     return ref_map.empty();
@@ -1131,7 +1133,7 @@ struct bluestore_onode_t {
       denc_varint(v.bytes, p);
     }
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<shard_info*>& ls);
+    static std::list<shard_info> generate_test_instances();
   };
   std::vector<shard_info> extent_map_shards; ///< extent std::map shards (if any)
 
@@ -1289,7 +1291,7 @@ struct bluestore_onode_t {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_onode_t*>& o);
+  static std::list<bluestore_onode_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluestore_onode_t::shard_info)
 WRITE_CLASS_DENC_FEATURED(bluestore_onode_t)
@@ -1314,7 +1316,7 @@ struct bluestore_deferred_op_t {
     DENC_FINISH(p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_deferred_op_t*>& o);
+  static std::list<bluestore_deferred_op_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluestore_deferred_op_t)
 
@@ -1335,7 +1337,7 @@ struct bluestore_deferred_transaction_t {
     DENC_FINISH(p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_deferred_transaction_t*>& o);
+  static std::list<bluestore_deferred_transaction_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluestore_deferred_transaction_t)
 
@@ -1358,7 +1360,7 @@ struct bluestore_compression_header_t {
     DENC_FINISH(p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<bluestore_compression_header_t*>& o);
+  static std::list<bluestore_compression_header_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(bluestore_compression_header_t)
 

--- a/src/os/kstore/kstore_types.cc
+++ b/src/os/kstore/kstore_types.cc
@@ -42,11 +42,13 @@ void kstore_cnode_t::dump(Formatter *f) const
   f->dump_unsigned("bits", bits);
 }
 
-void kstore_cnode_t::generate_test_instances(list<kstore_cnode_t*>& o)
+list<kstore_cnode_t> kstore_cnode_t::generate_test_instances()
 {
-  o.push_back(new kstore_cnode_t());
-  o.push_back(new kstore_cnode_t(0));
-  o.push_back(new kstore_cnode_t(123));
+  list<kstore_cnode_t> o;
+  o.push_back(kstore_cnode_t());
+  o.push_back(kstore_cnode_t(0));
+  o.push_back(kstore_cnode_t(123));
+  return o;
 }
 
 
@@ -99,8 +101,10 @@ void kstore_onode_t::dump(Formatter *f) const
   f->dump_unsigned("alloc_hint_flags", alloc_hint_flags);
 }
 
-void kstore_onode_t::generate_test_instances(list<kstore_onode_t*>& o)
+list<kstore_onode_t> kstore_onode_t::generate_test_instances()
 {
-  o.push_back(new kstore_onode_t());
+  list<kstore_onode_t> o;
+  o.push_back(kstore_onode_t());
   // FIXME
+  return o;
 }

--- a/src/os/kstore/kstore_types.h
+++ b/src/os/kstore/kstore_types.h
@@ -33,7 +33,7 @@ struct kstore_cnode_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<kstore_cnode_t*>& o);
+  static std::list<kstore_cnode_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(kstore_cnode_t)
 
@@ -61,7 +61,7 @@ struct kstore_onode_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<kstore_onode_t*>& o);
+  static std::list<kstore_onode_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(kstore_onode_t)
 

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -122,23 +122,25 @@ void ECSubWrite::dump(Formatter *f) const
   f->dump_bool("backfill_or_async_recovery", backfill_or_async_recovery);
 }
 
-void ECSubWrite::generate_test_instances(list<ECSubWrite*> &o)
+list<ECSubWrite> ECSubWrite::generate_test_instances()
 {
-  o.push_back(new ECSubWrite());
-  o.back()->tid = 1;
-  o.back()->at_version = eversion_t(2, 100);
-  o.back()->trim_to = eversion_t(1, 40);
-  o.push_back(new ECSubWrite());
-  o.back()->tid = 4;
-  o.back()->reqid = osd_reqid_t(entity_name_t::CLIENT(123), 1, 45678);
-  o.back()->at_version = eversion_t(10, 300);
-  o.back()->trim_to = eversion_t(5, 42);
-  o.push_back(new ECSubWrite());
-  o.back()->tid = 9;
-  o.back()->reqid = osd_reqid_t(entity_name_t::CLIENT(123), 1, 45678);
-  o.back()->at_version = eversion_t(10, 300);
-  o.back()->trim_to = eversion_t(5, 42);
-  o.back()->pg_committed_to = eversion_t(8, 250);
+  list<ECSubWrite> o;
+  o.emplace_back();
+  o.back().tid = 1;
+  o.back().at_version = eversion_t(2, 100);
+  o.back().trim_to = eversion_t(1, 40);
+  o.emplace_back();
+  o.back().tid = 4;
+  o.back().reqid = osd_reqid_t(entity_name_t::CLIENT(123), 1, 45678);
+  o.back().at_version = eversion_t(10, 300);
+  o.back().trim_to = eversion_t(5, 42);
+  o.emplace_back();
+  o.back().tid = 9;
+  o.back().reqid = osd_reqid_t(entity_name_t::CLIENT(123), 1, 45678);
+  o.back().at_version = eversion_t(10, 300);
+  o.back().trim_to = eversion_t(5, 42);
+  o.back().pg_committed_to = eversion_t(8, 250);
+  return o;
 }
 
 void ECSubWriteReply::encode(bufferlist &bl) const
@@ -181,16 +183,18 @@ void ECSubWriteReply::dump(Formatter *f) const
   f->dump_bool("applied", applied);
 }
 
-void ECSubWriteReply::generate_test_instances(list<ECSubWriteReply*>& o)
+list<ECSubWriteReply> ECSubWriteReply::generate_test_instances()
 {
-  o.push_back(new ECSubWriteReply());
-  o.back()->tid = 20;
-  o.back()->last_complete = eversion_t(100, 2000);
-  o.back()->committed = true;
-  o.push_back(new ECSubWriteReply());
-  o.back()->tid = 80;
-  o.back()->last_complete = eversion_t(50, 200);
-  o.back()->applied = true;
+  list<ECSubWriteReply> o;
+  o.push_back(ECSubWriteReply());
+  o.back().tid = 20;
+  o.back().last_complete = eversion_t(100, 2000);
+  o.back().committed = true;
+  o.push_back(ECSubWriteReply());
+  o.back().tid = 80;
+  o.back().last_complete = eversion_t(50, 200);
+  o.back().applied = true;
+  return o;
 }
 
 void ECSubRead::encode(bufferlist &bl, uint64_t features) const
@@ -288,24 +292,26 @@ void ECSubRead::dump(Formatter *f) const
       [](Formatter& f, const hobject_t& oid) { f.dump_stream("oid") << oid; });
 }
 
-void ECSubRead::generate_test_instances(list<ECSubRead*>& o)
+list<ECSubRead> ECSubRead::generate_test_instances()
 {
+  list<ECSubRead> o;
   hobject_t hoid1(sobject_t("asdf", 1));
   hobject_t hoid2(sobject_t("asdf2", CEPH_NOSNAP));
-  o.push_back(new ECSubRead());
-  o.back()->from = pg_shard_t(2, shard_id_t(-1));
-  o.back()->tid = 1;
-  o.back()->to_read[hoid1].push_back(boost::make_tuple(100, 200, 0));
-  o.back()->to_read[hoid1].push_back(boost::make_tuple(400, 600, 0));
-  o.back()->to_read[hoid2].push_back(boost::make_tuple(400, 600, 0));
-  o.back()->attrs_to_read.insert(hoid1);
-  o.push_back(new ECSubRead());
-  o.back()->from = pg_shard_t(2, shard_id_t(-1));
-  o.back()->tid = 300;
-  o.back()->to_read[hoid1].push_back(boost::make_tuple(300, 200, 0));
-  o.back()->to_read[hoid2].push_back(boost::make_tuple(400, 600, 0));
-  o.back()->to_read[hoid2].push_back(boost::make_tuple(2000, 600, 0));
-  o.back()->attrs_to_read.insert(hoid2);
+  o.push_back(ECSubRead());
+  o.back().from = pg_shard_t(2, shard_id_t(-1));
+  o.back().tid = 1;
+  o.back().to_read[hoid1].push_back(boost::make_tuple(100, 200, 0));
+  o.back().to_read[hoid1].push_back(boost::make_tuple(400, 600, 0));
+  o.back().to_read[hoid2].push_back(boost::make_tuple(400, 600, 0));
+  o.back().attrs_to_read.insert(hoid1);
+  o.push_back(ECSubRead());
+  o.back().from = pg_shard_t(2, shard_id_t(-1));
+  o.back().tid = 300;
+  o.back().to_read[hoid1].push_back(boost::make_tuple(300, 200, 0));
+  o.back().to_read[hoid2].push_back(boost::make_tuple(400, 600, 0));
+  o.back().to_read[hoid2].push_back(boost::make_tuple(2000, 600, 0));
+  o.back().attrs_to_read.insert(hoid2);
+  return o;
 }
 
 void ECSubReadReply::encode(bufferlist &bl) const
@@ -444,27 +450,29 @@ void ECSubReadReply::dump(Formatter* f) const
       });
 }
 
-void ECSubReadReply::generate_test_instances(list<ECSubReadReply*>& o)
+list<ECSubReadReply> ECSubReadReply::generate_test_instances()
 {
+  list<ECSubReadReply> o;
   hobject_t hoid1(sobject_t("asdf", 1));
   hobject_t hoid2(sobject_t("asdf2", CEPH_NOSNAP));
   bufferlist bl;
   bl.append_zero(100);
   bufferlist bl2;
   bl2.append_zero(200);
-  o.push_back(new ECSubReadReply());
-  o.back()->from = pg_shard_t(2, shard_id_t(-1));
-  o.back()->tid = 1;
-  o.back()->buffers_read[hoid1].push_back(make_pair(20, bl));
-  o.back()->buffers_read[hoid1].push_back(make_pair(2000, bl2));
-  o.back()->buffers_read[hoid2].push_back(make_pair(0, bl));
-  o.back()->attrs_read[hoid1]["foo"] = bl;
-  o.back()->attrs_read[hoid1]["_"] = bl2;
-  o.push_back(new ECSubReadReply());
-  o.back()->from = pg_shard_t(2, shard_id_t(-1));
-  o.back()->tid = 300;
-  o.back()->buffers_read[hoid2].push_back(make_pair(0, bl2));
-  o.back()->attrs_read[hoid2]["foo"] = bl;
-  o.back()->attrs_read[hoid2]["_"] = bl2;
-  o.back()->errors[hoid1] = -2;
+  o.push_back(ECSubReadReply());
+  o.back().from = pg_shard_t(2, shard_id_t(-1));
+  o.back().tid = 1;
+  o.back().buffers_read[hoid1].push_back(make_pair(20, bl));
+  o.back().buffers_read[hoid1].push_back(make_pair(2000, bl2));
+  o.back().buffers_read[hoid2].push_back(make_pair(0, bl));
+  o.back().attrs_read[hoid1]["foo"] = bl;
+  o.back().attrs_read[hoid1]["_"] = bl2;
+  o.push_back(ECSubReadReply());
+  o.back().from = pg_shard_t(2, shard_id_t(-1));
+  o.back().tid = 300;
+  o.back().buffers_read[hoid2].push_back(make_pair(0, bl2));
+  o.back().attrs_read[hoid2]["foo"] = bl;
+  o.back().attrs_read[hoid2]["_"] = bl2;
+  o.back().errors[hoid1] = -2;
+  return o;
 }

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -87,7 +87,7 @@ struct ECSubWrite {
   void decode(ceph::buffer::list::const_iterator &p_bl,
 	      ceph::buffer::list::const_iterator &d_bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ECSubWrite*>& o);
+  static std::list<ECSubWrite> generate_test_instances();
 private:
   // no outside copying -- slow
   ECSubWrite(ECSubWrite& other);
@@ -106,7 +106,7 @@ struct ECSubWriteReply {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ECSubWriteReply*>& o);
+  static std::list<ECSubWriteReply> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ECSubWriteReply)
 
@@ -119,7 +119,7 @@ struct ECSubRead {
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ECSubRead*>& o);
+  static std::list<ECSubRead> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(ECSubRead)
 
@@ -137,7 +137,7 @@ struct ECSubReadReply {
   void decode(ceph::buffer::list::const_iterator &p_bl,
 	      ceph::buffer::list::const_iterator &d_pl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ECSubReadReply*>& o);
+  static std::list<ECSubReadReply> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ECSubReadReply)
 

--- a/src/osd/ECTypes.h
+++ b/src/osd/ECTypes.h
@@ -47,9 +47,11 @@ struct raw_shard_id_t {
   void dump(ceph::Formatter *f) const {
     f->dump_int("id", id);
   }
-  static void generate_test_instances(std::list<raw_shard_id_t*>& ls) {
-    ls.push_back(new raw_shard_id_t(1));
-    ls.push_back(new raw_shard_id_t(2));
+  static std::list<raw_shard_id_t> generate_test_instances() {
+    std::list<raw_shard_id_t> ls;
+    ls.push_back(raw_shard_id_t(1));
+    ls.push_back(raw_shard_id_t(2));
+    return ls;
   }
   raw_shard_id_t& operator++() { ++id; return *this; }
   friend constexpr std::strong_ordering operator<=>(const raw_shard_id_t &lhs, const raw_shard_id_t &rhs) { return lhs.id <=> rhs.id; }

--- a/src/osd/ECUtilL.cc
+++ b/src/osd/ECUtilL.cc
@@ -240,9 +240,10 @@ END_IGNORE_DEPRECATED
   }
   }
 
-  void ECUtilL::HashInfo::generate_test_instances(list<HashInfo*>& o)
+  auto ECUtilL::HashInfo::generate_test_instances() -> list<HashInfo>
   {
-    o.push_back(new HashInfo(3));
+    list<HashInfo> o;
+    o.push_back(HashInfo(3));
     {
       bufferlist bl;
       bl.append_zero(20);
@@ -250,10 +251,11 @@ END_IGNORE_DEPRECATED
       buffers[0] = bl;
       buffers[1] = bl;
       buffers[2] = bl;
-      o.back()->append(0, buffers);
-      o.back()->append(20, buffers);
+      o.back().append(0, buffers);
+      o.back().append(20, buffers);
     }
-    o.push_back(new HashInfo(4));
+    o.push_back(HashInfo(4));
+    return o;
   }
 
   const string HINFO_KEY = "hinfo_key";

--- a/src/osd/ECUtilL.h
+++ b/src/osd/ECUtilL.h
@@ -229,7 +229,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<HashInfo*>& o);
+  static std::list<HashInfo> generate_test_instances();
   uint32_t get_chunk_hash(int shard) const {
     ceph_assert((unsigned)shard < cumulative_shard_hashes.size());
     return cumulative_shard_hashes[shard];

--- a/src/osd/HitSet.cc
+++ b/src/osd/HitSet.cc
@@ -94,21 +94,23 @@ void HitSet::dump(Formatter *f) const
     impl->dump(f);
 }
 
-void HitSet::generate_test_instances(list<HitSet*>& o)
+list<HitSet> HitSet::generate_test_instances()
 {
-  o.push_back(new HitSet);
-  o.push_back(new HitSet(new BloomHitSet(10, .1, 1)));
-  o.back()->insert(hobject_t());
-  o.back()->insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
-  o.back()->insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
-  o.push_back(new HitSet(new ExplicitHashHitSet));
-  o.back()->insert(hobject_t());
-  o.back()->insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
-  o.back()->insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
-  o.push_back(new HitSet(new ExplicitObjectHitSet));
-  o.back()->insert(hobject_t());
-  o.back()->insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
-  o.back()->insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+  list<HitSet> o;
+  o.push_back(HitSet{});
+  o.push_back(HitSet(new BloomHitSet(10, .1, 1)));
+  o.back().insert(hobject_t());
+  o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
+  o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+  o.push_back(HitSet(new ExplicitHashHitSet));
+  o.back().insert(hobject_t());
+  o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
+  o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+  o.push_back(HitSet(new ExplicitObjectHitSet));
+  o.back().insert(hobject_t());
+  o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
+  o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+  return o;
 }
 
 HitSet::Params::Params(const Params& o) noexcept
@@ -190,23 +192,22 @@ void HitSet::Params::dump(Formatter *f) const
     impl->dump(f);
 }
 
-void HitSet::Params::generate_test_instances(list<HitSet::Params*>& o)
+list<HitSet::Params> HitSet::Params::generate_test_instances()
 {
+  list<HitSet::Params> o;
 #define loop_hitset_params(kind) \
 { \
-  list<kind::Params*> params; \
-  kind::Params::generate_test_instances(params); \
-  for (list<kind::Params*>::iterator i = params.begin(); \
-  i != params.end(); ++i) \
-    o.push_back(new Params(*i)); \
+  for (auto& i : kind::Params::generate_test_instances()) \
+    o.push_back(Params(&i)); \
 }
-  o.push_back(new Params);
-  o.push_back(new Params(new BloomHitSet::Params));
+  o.push_back(Params{});
+  o.push_back(Params(new BloomHitSet::Params));
   loop_hitset_params(BloomHitSet);
-  o.push_back(new Params(new ExplicitHashHitSet::Params));
+  o.push_back(Params(new ExplicitHashHitSet::Params));
   loop_hitset_params(ExplicitHashHitSet);
-  o.push_back(new Params(new ExplicitObjectHitSet::Params));
+  o.push_back(Params(new ExplicitObjectHitSet::Params));
   loop_hitset_params(ExplicitObjectHitSet);
+  return o;
 }
 
 ostream& operator<<(ostream& out, const HitSet::Params& p) {

--- a/src/osd/HitSet.h
+++ b/src/osd/HitSet.h
@@ -110,7 +110,7 @@ public:
     void encode(ceph::buffer::list &bl) const;
     void decode(ceph::buffer::list::const_iterator& bl);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<HitSet::Params*>& o);
+    static std::list<HitSet::Params> generate_test_instances();
 
     friend std::ostream& operator<<(std::ostream& out, const HitSet::Params& p);
   };
@@ -163,7 +163,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<HitSet*>& o);
+  static std::list<HitSet> generate_test_instances();
 
 private:
   void reset_to_type(impl_type_t type);
@@ -190,8 +190,10 @@ public:
     HitSet::Impl *get_new_impl() const override {
       return new ExplicitHashHitSet;
     }
-    static void generate_test_instances(std::list<Params*>& o) {
-      o.push_back(new Params);
+    static std::list<Params> generate_test_instances() {
+      std::list<Params> o;
+      o.push_back(Params{});
+      return o;
     }
   };
 
@@ -236,12 +238,14 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const override;
-  static void generate_test_instances(std::list<ExplicitHashHitSet*>& o) {
-    o.push_back(new ExplicitHashHitSet);
-    o.push_back(new ExplicitHashHitSet);
-    o.back()->insert(hobject_t());
-    o.back()->insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
-    o.back()->insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+  static std::list<ExplicitHashHitSet> generate_test_instances() {
+    std::list<ExplicitHashHitSet> o;
+    o.push_back(ExplicitHashHitSet{});
+    o.push_back(ExplicitHashHitSet{});
+    o.back().insert(hobject_t());
+    o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
+    o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(ExplicitHashHitSet)
@@ -261,8 +265,10 @@ public:
     HitSet::Impl *get_new_impl() const override {
       return new ExplicitObjectHitSet;
     }
-    static void generate_test_instances(std::list<Params*>& o) {
-      o.push_back(new Params);
+    static std::list<Params> generate_test_instances() {
+      std::list<Params> o;
+      o.push_back(Params{});
+      return o;
     }
   };
 
@@ -307,12 +313,14 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const override;
-  static void generate_test_instances(std::list<ExplicitObjectHitSet*>& o) {
-    o.push_back(new ExplicitObjectHitSet);
-    o.push_back(new ExplicitObjectHitSet);
-    o.back()->insert(hobject_t());
-    o.back()->insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
-    o.back()->insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+  static std::list<ExplicitObjectHitSet> generate_test_instances() {
+    std::list<ExplicitObjectHitSet> o;
+    o.push_back(ExplicitObjectHitSet{});
+    o.push_back(ExplicitObjectHitSet{});
+    o.back().insert(hobject_t());
+    o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
+    o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(ExplicitObjectHitSet)
@@ -378,12 +386,14 @@ public:
 	<< get_fpp() << ", target_size: " << target_size
 	<< ", seed: " << seed;
     }
-    static void generate_test_instances(std::list<Params*>& o) {
-      o.push_back(new Params);
-      o.push_back(new Params);
-      (*o.rbegin())->fpp_micro = 123456;
-      (*o.rbegin())->target_size = 300;
-      (*o.rbegin())->seed = 99;
+    static std::list<Params> generate_test_instances() {
+      std::list<Params> o;
+      o.push_back(Params{});
+      o.push_back(Params{});
+      o.back().fpp_micro = 123456;
+      o.back().target_size = 300;
+      o.back().seed = 99;
+      return o;
     }
   };
 
@@ -442,12 +452,14 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(ceph::Formatter *f) const override;
-  static void generate_test_instances(std::list<BloomHitSet*>& o) {
-    o.push_back(new BloomHitSet);
-    o.push_back(new BloomHitSet(10, .1, 1));
-    o.back()->insert(hobject_t());
-    o.back()->insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
-    o.back()->insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+  static std::list<BloomHitSet> generate_test_instances() {
+    std::list<BloomHitSet> o;
+    o.push_back(BloomHitSet{});
+    o.push_back(BloomHitSet(10, .1, 1));
+    o.back().insert(hobject_t());
+    o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
+    o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(BloomHitSet)

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -106,16 +106,18 @@ void osd_info_t::decode(ceph::buffer::list::const_iterator& bl)
   decode(lost_at, bl);
 }
 
-void osd_info_t::generate_test_instances(list<osd_info_t*>& o)
+list<osd_info_t> osd_info_t::generate_test_instances()
 {
-  o.push_back(new osd_info_t);
-  o.push_back(new osd_info_t);
-  o.back()->last_clean_begin = 1;
-  o.back()->last_clean_end = 2;
-  o.back()->up_from = 30;
-  o.back()->up_thru = 40;
-  o.back()->down_at = 5;
-  o.back()->lost_at = 6;
+  list<osd_info_t> o;
+  o.push_back(osd_info_t{});
+  o.push_back(osd_info_t{});
+  o.back().last_clean_begin = 1;
+  o.back().last_clean_end = 2;
+  o.back().up_from = 30;
+  o.back().up_thru = 40;
+  o.back().down_at = 5;
+  o.back().lost_at = 6;
+  return o;
 }
 
 ostream& operator<<(ostream& out, const osd_info_t& info)
@@ -188,14 +190,16 @@ void osd_xinfo_t::decode(ceph::buffer::list::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void osd_xinfo_t::generate_test_instances(list<osd_xinfo_t*>& o)
+list<osd_xinfo_t> osd_xinfo_t::generate_test_instances()
 {
-  o.push_back(new osd_xinfo_t);
-  o.push_back(new osd_xinfo_t);
-  o.back()->down_stamp = utime_t(2, 3);
-  o.back()->laggy_probability = .123;
-  o.back()->laggy_interval = 123456;
-  o.back()->old_weight = 0x7fff;
+  list<osd_xinfo_t> o;
+  o.push_back(osd_xinfo_t{});
+  o.push_back(osd_xinfo_t{});
+  o.back().down_stamp = utime_t(2, 3);
+  o.back().laggy_probability = .123;
+  o.back().laggy_interval = 123456;
+  o.back().old_weight = 0x7fff;
+  return o;
 }
 
 ostream& operator<<(ostream& out, const osd_xinfo_t& xi)
@@ -1387,9 +1391,11 @@ void OSDMap::Incremental::dump(Formatter *f) const
   f->close_section();
 }
 
-void OSDMap::Incremental::generate_test_instances(list<Incremental*>& o)
+auto OSDMap::Incremental::generate_test_instances() -> list<Incremental>
 {
-  o.push_back(new Incremental);
+  list<Incremental> o;
+  o.push_back(Incremental{});
+  return o;
 }
 
 // ----------------------------------
@@ -4259,17 +4265,19 @@ void OSDMap::dump(Formatter *f, CephContext *cct) const
   f->close_section();
 }
 
-void OSDMap::generate_test_instances(list<OSDMap*>& o)
+list<OSDMap> OSDMap::generate_test_instances()
 {
-  o.push_back(new OSDMap);
+  list<OSDMap> o;
+  o.emplace_back();
 
   CephContext *cct = new CephContext(CODE_ENVIRONMENT_UTILITY);
-  o.push_back(new OSDMap);
+  o.emplace_back();
   uuid_d fsid;
-  o.back()->build_simple(cct, 1, fsid, 16);
-  o.back()->created = o.back()->modified = utime_t(1, 2);  // fix timestamp
-  o.back()->blocklist[entity_addr_t()] = utime_t(5, 6);
+  o.back().build_simple(cct, 1, fsid, 16);
+  o.back().created = o.back().modified = utime_t(1, 2);  // fix timestamp
+  o.back().blocklist[entity_addr_t()] = utime_t(5, 6);
   cct->put();
+  return o;
 }
 
 string OSDMap::get_flag_string(unsigned f)

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -84,7 +84,7 @@ struct osd_info_t {
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
-  static void generate_test_instances(std::list<osd_info_t*>& o);
+  static std::list<osd_info_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(osd_info_t)
 
@@ -105,7 +105,7 @@ struct osd_xinfo_t {
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
-  static void generate_test_instances(std::list<osd_xinfo_t*>& o);
+  static std::list<osd_xinfo_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(osd_xinfo_t)
 
@@ -346,11 +346,13 @@ struct PGTempMap {
       f->close_section();
     }
   }
-  static void generate_test_instances(std::list<PGTempMap*>& o) {
-    o.push_back(new PGTempMap);
-    o.push_back(new PGTempMap);
-    o.back()->set(pg_t(1, 2), { 3, 4 });
-    o.back()->set(pg_t(2, 3), { 4, 5 });
+  static std::list<PGTempMap> generate_test_instances() {
+    std::list<PGTempMap> o;
+    o.push_back(PGTempMap{});
+    o.push_back(PGTempMap{});
+    o.back().set(pg_t(1, 2), { 3, 4 });
+    o.back().set(pg_t(2, 3), { 4, 5 });
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(PGTempMap)
@@ -453,7 +455,7 @@ public:
     void decode_classic(ceph::buffer::list::const_iterator &p);
     void decode(ceph::buffer::list::const_iterator &bl);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<Incremental*>& o);
+    static std::list<Incremental> generate_test_instances();
 
     explicit Incremental(epoch_t e=0) :
       encode_features(0),
@@ -1849,7 +1851,7 @@ public:
   void dump_osds(ceph::Formatter *f) const;
   void dump_pool(CephContext *cct, int64_t pid, const pg_pool_t &pdata, ceph::Formatter *f) const;
   void dump_read_balance_score(CephContext *cct, int64_t pid, const pg_pool_t &pdata, ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<OSDMap*>& o);
+  static std::list<OSDMap> generate_test_instances();
   bool check_new_blocklist_entries() const { return new_blocklist_entries; }
 
   void check_health(CephContext *cct, health_check_map_t *checks) const;

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -327,14 +327,15 @@ void SnapMapper::object_snaps::dump(ceph::Formatter *f) const
   f->dump_stream("snaps") << snaps;
 }
 
-void SnapMapper::object_snaps::generate_test_instances(
-  std::list<object_snaps *> &o)
+auto SnapMapper::object_snaps::generate_test_instances() -> std::list<object_snaps>
 {
-  o.push_back(new object_snaps);
-  o.push_back(new object_snaps);
-  o.back()->oid = hobject_t(sobject_t("name", CEPH_NOSNAP));
-  o.back()->snaps.insert(1);
-  o.back()->snaps.insert(2);
+  std::list<object_snaps> o;
+  o.push_back(object_snaps{});
+  o.push_back(object_snaps{});
+  o.back().oid = hobject_t(sobject_t("name", CEPH_NOSNAP));
+  o.back().snaps.insert(1);
+  o.back().snaps.insert(2);
+  return o;
 }
 
 bool SnapMapper::check(const hobject_t &hoid) const

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -136,7 +136,7 @@ public:
     void encode(ceph::buffer::list &bl) const;
     void decode(ceph::buffer::list::const_iterator &bp);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<object_snaps*>& o);
+    static std::list<object_snaps> generate_test_instances();
   };
 
   struct Mapping {
@@ -161,11 +161,13 @@ public:
       f->dump_unsigned("snap", snap);
       f->dump_stream("hoid") << hoid;
     }
-    static void generate_test_instances(std::list<Mapping*>& o) {
-      o.push_back(new Mapping);
-      o.push_back(new Mapping);
-      o.back()->snap = 1;
-      o.back()->hoid = hobject_t(object_t("objname"), "key", 123, 456, 0, "");
+    static std::list<Mapping> generate_test_instances() {
+      std::list<Mapping> o;
+      o.push_back(Mapping{});
+      o.push_back(Mapping{});
+      o.back().snap = 1;
+      o.back().hoid = hobject_t(object_t("objname"), "key", 123, 456, 0, "");
+      return o;
     }
   };
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -239,10 +239,12 @@ void osd_reqid_t::dump(Formatter *f) const
   f->dump_unsigned("tid", tid);
 }
 
-void osd_reqid_t::generate_test_instances(list<osd_reqid_t*>& o)
+list<osd_reqid_t> osd_reqid_t::generate_test_instances()
 {
-  o.push_back(new osd_reqid_t);
-  o.push_back(new osd_reqid_t(entity_name_t::CLIENT(123), 1, 45678));
+  list<osd_reqid_t> o;
+  o.push_back(osd_reqid_t{});
+  o.push_back(osd_reqid_t(entity_name_t::CLIENT(123), 1, 45678));
+  return o;
 }
 
 // -- object_locator_t --
@@ -298,14 +300,16 @@ void object_locator_t::dump(Formatter *f) const
   f->dump_int("hash", hash);
 }
 
-void object_locator_t::generate_test_instances(list<object_locator_t*>& o)
+list<object_locator_t> object_locator_t::generate_test_instances()
 {
-  o.push_back(new object_locator_t);
-  o.push_back(new object_locator_t(123));
-  o.push_back(new object_locator_t(123, 876));
-  o.push_back(new object_locator_t(1, "n2"));
-  o.push_back(new object_locator_t(1234, "", "key"));
-  o.push_back(new object_locator_t(12, "n1", "key2"));
+  list<object_locator_t> o;
+  o.push_back(object_locator_t{});
+  o.push_back(object_locator_t(123));
+  o.push_back(object_locator_t(123, 876));
+  o.push_back(object_locator_t(1, "n2"));
+  o.push_back(object_locator_t(1234, "", "key"));
+  o.push_back(object_locator_t(12, "n1", "key2"));
+  return o;
 }
 
 // -- request_redirect_t --
@@ -340,13 +344,15 @@ void request_redirect_t::dump(Formatter *f) const
   f->close_section(); // locator
 }
 
-void request_redirect_t::generate_test_instances(list<request_redirect_t*>& o)
+list<request_redirect_t> request_redirect_t::generate_test_instances()
 {
+  list<request_redirect_t> o;
   object_locator_t loc(1, "redir_obj");
-  o.push_back(new request_redirect_t());
-  o.push_back(new request_redirect_t(loc, 0));
-  o.push_back(new request_redirect_t(loc, "redir_obj"));
-  o.push_back(new request_redirect_t(loc));
+  o.push_back(request_redirect_t());
+  o.push_back(request_redirect_t(loc, 0));
+  o.push_back(request_redirect_t(loc, "redir_obj"));
+  o.push_back(request_redirect_t(loc));
+  return o;
 }
 
 void objectstore_perf_stat_t::dump(Formatter *f) const
@@ -396,12 +402,14 @@ void objectstore_perf_stat_t::decode(ceph::buffer::list::const_iterator &bl)
   DECODE_FINISH(bl);
 }
 
-void objectstore_perf_stat_t::generate_test_instances(std::list<objectstore_perf_stat_t*>& o)
+std::list<objectstore_perf_stat_t> objectstore_perf_stat_t::generate_test_instances()
 {
-  o.push_back(new objectstore_perf_stat_t());
-  o.push_back(new objectstore_perf_stat_t());
-  o.back()->os_commit_latency_ns = 20000000;
-  o.back()->os_apply_latency_ns = 30000000;
+  std::list<objectstore_perf_stat_t> o;
+  o.push_back(objectstore_perf_stat_t());
+  o.push_back(objectstore_perf_stat_t());
+  o.back().os_commit_latency_ns = 20000000;
+  o.back().os_apply_latency_ns = 30000000;
+  return o;
 }
 
 // -- osd_stat_t --
@@ -684,29 +692,32 @@ void osd_stat_t::decode(ceph::buffer::list::const_iterator &bl)
   DECODE_FINISH(bl);
 }
 
-void osd_stat_t::generate_test_instances(std::list<osd_stat_t*>& o)
+std::list<osd_stat_t> osd_stat_t::generate_test_instances()
 {
-  o.push_back(new osd_stat_t);
+  std::list<osd_stat_t> o;
 
-  o.push_back(new osd_stat_t);
-  list<store_statfs_t*> ll;
-  store_statfs_t::generate_test_instances(ll);
-  o.back()->statfs = *ll.back();
-  o.back()->hb_peers.push_back(7);
-  o.back()->snap_trim_queue_len = 8;
-  o.back()->num_snap_trimming = 99;
-  o.back()->num_shards_repaired = 101;
-  o.back()->os_alerts[0].emplace(
+  o.push_back(osd_stat_t{});
+
+  o.push_back(osd_stat_t{});
+  list<store_statfs_t> ll = store_statfs_t::generate_test_instances();
+  o.back().statfs = ll.back();
+  o.back().hb_peers.push_back(7);
+  o.back().snap_trim_queue_len = 8;
+  o.back().num_snap_trimming = 99;
+  o.back().num_shards_repaired = 101;
+  o.back().os_alerts[0].emplace(
     "some alert", "some alert details");
-  o.back()->os_alerts[1].emplace(
+  o.back().os_alerts[1].emplace(
     "some alert2", "some alert2 details");
   struct Interfaces gen_interfaces = {
 	123456789, { 1000, 900, 800 }, { 990, 890, 790 }, { 1010, 910, 810 }, 1001,
 	 { 1100, 1000, 900 }, { 1090, 990, 890 }, { 1110, 1010, 910 }, 1101 };
-  o.back()->hb_pingtime[20] = gen_interfaces;
+  o.back().hb_pingtime[20] = gen_interfaces;
   gen_interfaces = {
 	987654321, { 100, 200, 300 }, { 90, 190, 290 }, { 110, 210, 310 }, 101 };
-  o.back()->hb_pingtime[30] = gen_interfaces;
+  o.back().hb_pingtime[30] = gen_interfaces;
+
+  return o;
 }
 
 // -- pg_t --
@@ -906,12 +917,14 @@ void pg_t::dump(Formatter *f) const
   f->dump_unsigned("seed", m_seed);
 }
 
-void pg_t::generate_test_instances(list<pg_t*>& o)
+list<pg_t> pg_t::generate_test_instances()
 {
-  o.push_back(new pg_t);
-  o.push_back(new pg_t(1, 2));
-  o.push_back(new pg_t(13123, 3));
-  o.push_back(new pg_t(131223, 4));
+  list<pg_t> o;
+  o.push_back(pg_t{});
+  o.push_back(pg_t(1, 2));
+  o.push_back(pg_t(13123, 3));
+  o.push_back(pg_t(131223, 4));
+  return o;
 }
 
 char *pg_t::calc_name(char *buf, const char *suffix_backwords) const
@@ -1098,14 +1111,16 @@ void coll_t::dump(Formatter *f) const
   f->dump_string("name", to_str());
 }
 
-void coll_t::generate_test_instances(list<coll_t*>& o)
+list<coll_t> coll_t::generate_test_instances()
 {
-  o.push_back(new coll_t());
-  o.push_back(new coll_t(spg_t(pg_t(1, 0), shard_id_t::NO_SHARD)));
-  o.push_back(new coll_t(o.back()->get_temp()));
-  o.push_back(new coll_t(spg_t(pg_t(3, 2), shard_id_t(12))));
-  o.push_back(new coll_t(o.back()->get_temp()));
-  o.push_back(new coll_t());
+  list<coll_t> o;
+  o.push_back(coll_t());
+  o.push_back(coll_t(spg_t(pg_t(1, 0), shard_id_t::NO_SHARD)));
+  o.push_back(coll_t(o.back().get_temp()));
+  o.push_back(coll_t(spg_t(pg_t(3, 2), shard_id_t(12))));
+  o.push_back(coll_t(o.back().get_temp()));
+  o.push_back(coll_t());
+  return o;
 }
 
 // ---
@@ -1323,13 +1338,15 @@ void pool_snap_info_t::decode(ceph::buffer::list::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void pool_snap_info_t::generate_test_instances(list<pool_snap_info_t*>& o)
+list<pool_snap_info_t> pool_snap_info_t::generate_test_instances()
 {
-  o.push_back(new pool_snap_info_t);
-  o.push_back(new pool_snap_info_t);
-  o.back()->snapid = 1;
-  o.back()->stamp = utime_t(1, 2);
-  o.back()->name = "foo";
+  list<pool_snap_info_t> o;
+  o.push_back(pool_snap_info_t{});
+  o.push_back(pool_snap_info_t{});
+  o.back().snapid = 1;
+  o.back().stamp = utime_t(1, 2);
+  o.back().name = "foo";
+  return o;
 }
 
 // -- pool_opts_t --
@@ -1542,9 +1559,11 @@ void pool_opts_t::decode(ceph::buffer::list::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void pool_opts_t::generate_test_instances(std::list<pool_opts_t*>& o)
+std::list<pool_opts_t> pool_opts_t::generate_test_instances()
 {
-  o.push_back(new pool_opts_t);
+  std::list<pool_opts_t> o;
+  o.push_back(pool_opts_t{});
+  return o;
 }
 
 ostream& operator<<(ostream& out, const pool_opts_t& opts)
@@ -2324,10 +2343,12 @@ bool pg_pool_t::stretch_set_can_peer(const set<int>& want, const OSDMap& osdmap,
   return true;
 }
 
-void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
+list<pg_pool_t> pg_pool_t::generate_test_instances()
 {
+  list<pg_pool_t> o;
+
   pg_pool_t a;
-  o.push_back(new pg_pool_t(a));
+  o.push_back(pg_pool_t(a));
 
   a.create_time = utime_t(4,5);
   a.type = TYPE_REPLICATED;
@@ -2350,7 +2371,7 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.auid = 12;
   a.quota_max_bytes = 473;
   a.quota_max_objects = 474;
-  o.push_back(new pg_pool_t(a));
+  o.push_back(pg_pool_t(a));
 
   a.snaps[3].name = "asdf";
   a.snaps[3].snapid = 3;
@@ -2358,7 +2379,7 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.snaps[6].name = "qwer";
   a.snaps[6].snapid = 6;
   a.snaps[6].stamp = utime_t(23423, 4);
-  o.push_back(new pg_pool_t(a));
+  o.push_back(pg_pool_t(a));
 
   a.flags = FLAG_SELFMANAGED_SNAPS;
   a.snaps.clear();
@@ -2392,14 +2413,16 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.fast_read = false;
   a.nonprimary_shards.clear();
   a.application_metadata = {{"rbd", {{"key", "value"}}}};
-  o.push_back(new pg_pool_t(a));
+  o.push_back(pg_pool_t(a));
 
   // test stretch CRUSH buckets
   a.peering_crush_bucket_count = 10;
   a.peering_crush_bucket_barrier = 11;
   a.peering_crush_mandatory_member = 12;
   a.peering_crush_bucket_target = 13;
-  o.push_back(new pg_pool_t(a));
+  o.push_back(pg_pool_t(a));
+
+  return o;
 }
 
 ostream& operator<<(ostream& out, const pg_pool_t& p)
@@ -2649,8 +2672,10 @@ void object_stat_sum_t::decode(ceph::buffer::list::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
+list<object_stat_sum_t> object_stat_sum_t::generate_test_instances()
 {
+  list<object_stat_sum_t> o;
+
   object_stat_sum_t a;
 
   a.num_bytes = 1;
@@ -2689,7 +2714,9 @@ void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
   a.num_omap_bytes = 20000;
   a.num_omap_keys = 200;
   a.num_objects_repaired = 300;
-  o.push_back(new object_stat_sum_t(a));
+  o.push_back(object_stat_sum_t(a));
+
+  return o;
 }
 
 void object_stat_sum_t::add(const object_stat_sum_t& o)
@@ -2853,16 +2880,18 @@ void object_stat_collection_t::decode(ceph::buffer::list::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void object_stat_collection_t::generate_test_instances(list<object_stat_collection_t*>& o)
+list<object_stat_collection_t> object_stat_collection_t::generate_test_instances()
 {
+  list<object_stat_collection_t> o;
+
   object_stat_collection_t a;
-  o.push_back(new object_stat_collection_t(a));
-  list<object_stat_sum_t*> l;
-  object_stat_sum_t::generate_test_instances(l);
-  for (auto p = l.begin(); p != l.end(); ++p) {
-    a.add(**p);
-    o.push_back(new object_stat_collection_t(a));
+  o.push_back(object_stat_collection_t(a));
+  for (auto& p : object_stat_sum_t::generate_test_instances()) {
+    a.add(p);
+    o.push_back(object_stat_collection_t(a));
   }
+
+  return o;
 }
 
 
@@ -3217,10 +3246,12 @@ void pg_stat_t::decode(ceph::buffer::list::const_iterator &bl)
   DECODE_FINISH(bl);
 }
 
-void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
+list<pg_stat_t> pg_stat_t::generate_test_instances()
 {
+  list<pg_stat_t> o;
+
   pg_stat_t a;
-  o.push_back(new pg_stat_t(a));
+  o.push_back(pg_stat_t(a));
 
   a.version = eversion_t(1, 3);
   a.reported_epoch = 1;
@@ -3251,9 +3282,8 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   a.objects_scrubbed = 0;
   a.objects_trimmed = 0;
   a.snaptrim_duration = 0.123;
-  list<object_stat_collection_t*> l;
-  object_stat_collection_t::generate_test_instances(l);
-  a.stats = *l.back();
+  list<object_stat_collection_t> l = object_stat_collection_t::generate_test_instances();
+  a.stats = l.back();
   a.log_size = 99;
   a.ondisk_log_size = 88;
   a.up.push_back(123);
@@ -3265,7 +3295,7 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   sset.insert(pg_shard_t(2));
   a.object_location_counts.insert(make_pair(sset, 5));
   a.acting_primary = 456;
-  o.push_back(new pg_stat_t(a));
+  o.push_back(pg_stat_t(a));
 
   a.up.push_back(124);
   a.up_primary = 124;
@@ -3273,7 +3303,9 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   a.acting_primary = 124;
   a.blocked_by.push_back(155);
   a.blocked_by.push_back(156);
-  o.push_back(new pg_stat_t(a));
+  o.push_back(pg_stat_t(a));
+
+  return o;
 }
 
 bool operator==(const pg_stat_t& l, const pg_stat_t& r)
@@ -3381,10 +3413,11 @@ ostream& operator<<(ostream& out, const store_statfs_t &s)
   return out;
 }
 
-void store_statfs_t::generate_test_instances(list<store_statfs_t*>& o)
+list<store_statfs_t> store_statfs_t::generate_test_instances()
 {
+  list<store_statfs_t> o;
   store_statfs_t a;
-  o.push_back(new store_statfs_t(a));
+  o.push_back(store_statfs_t(a));
   a.total = 234;
   a.available = 123;
   a.internally_reserved = 33;
@@ -3395,7 +3428,8 @@ void store_statfs_t::generate_test_instances(list<store_statfs_t*>& o)
   a.data_compressed_original = 13;
   a.omap_allocated = 14;
   a.internal_metadata = 15;
-  o.push_back(new store_statfs_t(a));
+  o.push_back(store_statfs_t(a));
+  return o;
 }
 
 // -- pool_stat_t --
@@ -3482,23 +3516,24 @@ void pool_stat_t::decode(ceph::buffer::list::const_iterator &bl)
   DECODE_FINISH(bl);
 }
 
-void pool_stat_t::generate_test_instances(list<pool_stat_t*>& o)
+list<pool_stat_t> pool_stat_t::generate_test_instances()
 {
-  pool_stat_t a;
-  o.push_back(new pool_stat_t(a));
+  list<pool_stat_t> o;
 
-  list<object_stat_collection_t*> l;
-  object_stat_collection_t::generate_test_instances(l);
-  list<store_statfs_t*> ll;
-  store_statfs_t::generate_test_instances(ll);
-  a.stats = *l.back();
-  a.store_stats = *ll.back();
+  pool_stat_t a;
+  o.push_back(pool_stat_t(a));
+
+  list<object_stat_collection_t> l = object_stat_collection_t::generate_test_instances();
+  list<store_statfs_t> ll = store_statfs_t::generate_test_instances();
+  a.stats = l.back();
+  a.store_stats = ll.back();
   a.log_size = 123;
   a.ondisk_log_size = 456;
   a.acting = 3;
   a.up = 4;
   a.num_store_stats = 1;
-  o.push_back(new pool_stat_t(a));
+  o.push_back(pool_stat_t(a));
+  return o;
 }
 
 
@@ -3603,27 +3638,29 @@ void pg_history_t::dump(Formatter *f) const
     std::chrono::duration<double>(prior_readable_until_ub).count());
 }
 
-void pg_history_t::generate_test_instances(list<pg_history_t*>& o)
+list<pg_history_t> pg_history_t::generate_test_instances()
 {
-  o.push_back(new pg_history_t);
-  o.push_back(new pg_history_t);
-  o.back()->epoch_created = 1;
-  o.back()->epoch_pool_created = 1;
-  o.back()->last_epoch_started = 2;
-  o.back()->last_interval_started = 2;
-  o.back()->last_epoch_clean = 3;
-  o.back()->last_interval_clean = 2;
-  o.back()->last_epoch_split = 4;
-  o.back()->prior_readable_until_ub = make_timespan(3.1415);
-  o.back()->same_up_since = 5;
-  o.back()->same_interval_since = 6;
-  o.back()->same_primary_since = 7;
-  o.back()->last_scrub = eversion_t(8, 9);
-  o.back()->last_scrub_stamp = utime_t(10, 11);
-  o.back()->last_deep_scrub = eversion_t(12, 13);
-  o.back()->last_deep_scrub_stamp = utime_t(14, 15);
-  o.back()->last_clean_scrub_stamp = utime_t(16, 17);
-  o.back()->last_epoch_marked_full = 18;
+  list<pg_history_t> o;
+  o.push_back(pg_history_t{});
+  o.push_back(pg_history_t{});
+  o.back().epoch_created = 1;
+  o.back().epoch_pool_created = 1;
+  o.back().last_epoch_started = 2;
+  o.back().last_interval_started = 2;
+  o.back().last_epoch_clean = 3;
+  o.back().last_interval_clean = 2;
+  o.back().last_epoch_split = 4;
+  o.back().prior_readable_until_ub = make_timespan(3.1415);
+  o.back().same_up_since = 5;
+  o.back().same_interval_since = 6;
+  o.back().same_primary_since = 7;
+  o.back().last_scrub = eversion_t(8, 9);
+  o.back().last_scrub_stamp = utime_t(10, 11);
+  o.back().last_deep_scrub = eversion_t(12, 13);
+  o.back().last_deep_scrub_stamp = utime_t(14, 15);
+  o.back().last_clean_scrub_stamp = utime_t(16, 17);
+  o.back().last_epoch_marked_full = 18;
+  return o;
 }
 
 
@@ -3736,29 +3773,28 @@ void pg_info_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void pg_info_t::generate_test_instances(list<pg_info_t*>& o)
+list<pg_info_t> pg_info_t::generate_test_instances()
 {
-  o.push_back(new pg_info_t);
-  o.push_back(new pg_info_t);
-  list<pg_history_t*> h;
-  pg_history_t::generate_test_instances(h);
-  o.back()->history = *h.back();
-  o.back()->pgid = spg_t(pg_t(1, 2), shard_id_t::NO_SHARD);
-  o.back()->last_update = eversion_t(3, 4);
-  o.back()->last_complete = eversion_t(5, 6);
-  o.back()->last_user_version = 2;
-  o.back()->log_tail = eversion_t(7, 8);
-  o.back()->last_backfill = hobject_t(object_t("objname"), "key", 123, 456, -1, "");
+  list<pg_info_t> o;
+  o.push_back(pg_info_t{});
+  o.push_back(pg_info_t{});
+  list<pg_history_t> h = pg_history_t::generate_test_instances();
+  o.back().history = h.back();
+  o.back().pgid = spg_t(pg_t(1, 2), shard_id_t::NO_SHARD);
+  o.back().last_update = eversion_t(3, 4);
+  o.back().last_complete = eversion_t(5, 6);
+  o.back().last_user_version = 2;
+  o.back().log_tail = eversion_t(7, 8);
+  o.back().last_backfill = hobject_t(object_t("objname"), "key", 123, 456, -1, "");
   {
-    list<pg_stat_t*> s;
-    pg_stat_t::generate_test_instances(s);
-    o.back()->stats = *s.back();
+    list<pg_stat_t> s = pg_stat_t::generate_test_instances();
+    o.back().stats = s.back();
   }
   {
-    list<pg_hit_set_history_t*> s;
-    pg_hit_set_history_t::generate_test_instances(s);
-    o.back()->hit_set = *s.back();
+    list<pg_hit_set_history_t> s = pg_hit_set_history_t::generate_test_instances();
+    o.back().hit_set = s.back();
   }
+  return o;
 }
 
 // -- pg_notify_t --
@@ -3806,15 +3842,19 @@ void pg_notify_t::dump(Formatter *f) const
   f->dump_object("past_intervals", past_intervals);
 }
 
-void pg_notify_t::generate_test_instances(list<pg_notify_t*>& o)
+list<pg_notify_t> pg_notify_t::generate_test_instances()
 {
-  o.push_back(new pg_notify_t);
-  o.push_back(new pg_notify_t(shard_id_t(3), shard_id_t::NO_SHARD, 1, 1,
+  list<pg_notify_t> o;
+
+  o.push_back(pg_notify_t{});
+  o.push_back(pg_notify_t(shard_id_t(3), shard_id_t::NO_SHARD, 1, 1,
 	    pg_info_t(spg_t(pg_t(0,10), shard_id_t(-1))), PastIntervals(),
             PG_FEATURE_CLASSIC_ALL));
-  o.push_back(new pg_notify_t(shard_id_t(0), shard_id_t(2), 3, 10,
+  o.push_back(pg_notify_t(shard_id_t(0), shard_id_t(2), 3, 10,
 	    pg_info_t(spg_t(pg_t(10,10), shard_id_t(2))), PastIntervals(),
             PG_FEATURE_CLASSIC_ALL));
+
+  return o;
 }
 
 ostream &operator<<(ostream &lhs, const pg_notify_t &notify)
@@ -3897,16 +3937,18 @@ std::string PastIntervals::pg_interval_t::fmt_print() const
       acting, primary, maybe_went_rw ? " maybe_went_rw" : "");
 }
 
-void PastIntervals::pg_interval_t::generate_test_instances(list<pg_interval_t*>& o)
+auto PastIntervals::pg_interval_t::generate_test_instances() -> list<pg_interval_t>
 {
-  o.push_back(new pg_interval_t);
-  o.push_back(new pg_interval_t);
-  o.back()->up.push_back(1);
-  o.back()->acting.push_back(2);
-  o.back()->acting.push_back(3);
-  o.back()->first = 4;
-  o.back()->last = 5;
-  o.back()->maybe_went_rw = true;
+  list<pg_interval_t> o;
+  o.push_back(pg_interval_t{});
+  o.push_back(pg_interval_t{});
+  o.back().up.push_back(1);
+  o.back().acting.push_back(2);
+  o.back().acting.push_back(3);
+  o.back().first = 4;
+  o.back().last = 5;
+  o.back().maybe_went_rw = true;
+  return o;
 }
 
 /**
@@ -3961,8 +4003,9 @@ struct compact_interval_t {
   std::string fmt_print() const {
     return fmt::format("([{},{}] acting={})", first, last, acting);
   }
-  static void generate_test_instances(list<compact_interval_t*> & o) {
+  static list<compact_interval_t> generate_test_instances() {
     /* Not going to be used, we'll generate pi_compact_rep directly */
+    return {};
   }
 };
 ostream &operator<<(ostream &o, const compact_interval_t &rhs)
@@ -4081,11 +4124,12 @@ public:
     f->close_section();
     f->close_section();
   }
-  static void generate_test_instances(list<pi_compact_rep*> &o) {
+  static list<pi_compact_rep> generate_test_instances() {
+    list<pi_compact_rep> o;
     using ival = PastIntervals::pg_interval_t;
     using ivallst = std::list<ival>;
     o.push_back(
-      new pi_compact_rep(
+      pi_compact_rep(
 	true, ivallst
 	{ ival{{0, 1, 2}, {0, 1, 2}, 10, 20,  true, 0, 0}
 	, ival{{   1, 2}, {   1, 2}, 21, 30,  true, 1, 1}
@@ -4093,7 +4137,7 @@ public:
 	, ival{{0,    2}, {0,    2}, 36, 50,  true, 0, 0}
 	}));
     o.push_back(
-      new pi_compact_rep(
+      pi_compact_rep(
 	false, ivallst
 	{ ival{{0, 1, 2}, {0, 1, 2}, 10, 20,  true, 0, 0}
 	, ival{{   1, 2}, {   1, 2}, 21, 30,  true, 1, 1}
@@ -4101,13 +4145,14 @@ public:
 	, ival{{0,    2}, {0,    2}, 36, 50,  true, 0, 0}
 	}));
     o.push_back(
-      new pi_compact_rep(
+      pi_compact_rep(
 	true, ivallst
 	{ ival{{2, 1, 0}, {2, 1, 0}, 10, 20,  true, 1, 1}
 	, ival{{   0, 2}, {   0, 2}, 21, 30,  true, 0, 0}
 	, ival{{   0, 2}, {2,    0}, 31, 35,  true, 2, 2}
 	, ival{{   0, 2}, {   0, 2}, 36, 50,  true, 0, 0}
 	}));
+    return o;
   }
   void iterate_mayberw_back_to(
     epoch_t les,
@@ -4185,17 +4230,16 @@ void PastIntervals::decode(ceph::buffer::list::const_iterator &bl)
   DECODE_FINISH(bl);
 }
 
-void PastIntervals::generate_test_instances(list<PastIntervals*> &o)
+list<PastIntervals> PastIntervals::generate_test_instances()
 {
+  list<PastIntervals> o;
   {
-    list<pi_compact_rep *> compact;
-    pi_compact_rep::generate_test_instances(compact);
-    for (auto &&i: compact) {
+    for (auto &&i: pi_compact_rep::generate_test_instances()) {
       // takes ownership of contents
-      o.push_back(new PastIntervals(i));
+      o.push_back(PastIntervals(i.clone().release()));
     }
   }
-  return;
+  return o;
 }
 
 bool PastIntervals::is_new_interval(
@@ -4548,18 +4592,19 @@ void pg_query_t::dump(Formatter *f) const
   history.dump(f);
   f->close_section();
 }
-void pg_query_t::generate_test_instances(list<pg_query_t*>& o)
+list<pg_query_t> pg_query_t::generate_test_instances()
 {
-  o.push_back(new pg_query_t());
-  list<pg_history_t*> h;
-  pg_history_t::generate_test_instances(h);
-  o.push_back(new pg_query_t(pg_query_t::INFO, shard_id_t(1), shard_id_t(2), *h.back(), 4));
-  o.push_back(new pg_query_t(pg_query_t::MISSING, shard_id_t(2), shard_id_t(3), *h.back(), 4));
-  o.push_back(new pg_query_t(pg_query_t::LOG, shard_id_t(0), shard_id_t(0),
-			     eversion_t(4, 5), *h.back(), 4));
-  o.push_back(new pg_query_t(pg_query_t::FULLLOG,
-			     shard_id_t::NO_SHARD, shard_id_t::NO_SHARD,
-			     *h.back(), 5));
+  list<pg_query_t> o;
+  o.push_back(pg_query_t());
+  list<pg_history_t> h = pg_history_t::generate_test_instances();
+  o.push_back(pg_query_t(pg_query_t::INFO, shard_id_t(1), shard_id_t(2), h.back(), 4));
+  o.push_back(pg_query_t(pg_query_t::MISSING, shard_id_t(2), shard_id_t(3), h.back(), 4));
+  o.push_back(pg_query_t(pg_query_t::LOG, shard_id_t(0), shard_id_t(0),
+			 eversion_t(4, 5), h.back(), 4));
+  o.push_back(pg_query_t(pg_query_t::FULLLOG,
+			 shard_id_t::NO_SHARD, shard_id_t::NO_SHARD,
+			 h.back(), 5));
+  return o;
 }
 
 // -- pg_lease_t --
@@ -4589,13 +4634,15 @@ void pg_lease_t::dump(Formatter *f) const
   f->dump_stream("interval") << interval;
 }
 
-void pg_lease_t::generate_test_instances(std::list<pg_lease_t*>& o)
+std::list<pg_lease_t> pg_lease_t::generate_test_instances()
 {
-  o.push_back(new pg_lease_t());
-  o.push_back(new pg_lease_t());
-  o.back()->readable_until = make_timespan(1.5);
-  o.back()->readable_until_ub = make_timespan(3.4);
-  o.back()->interval = make_timespan(1.0);
+  std::list<pg_lease_t> o;
+  o.push_back(pg_lease_t());
+  o.push_back(pg_lease_t());
+  o.back().readable_until = make_timespan(1.5);
+  o.back().readable_until_ub = make_timespan(3.4);
+  o.back().interval = make_timespan(1.0);
+  return o;
 }
 
 // -- pg_lease_ack_t --
@@ -4619,11 +4666,13 @@ void pg_lease_ack_t::dump(Formatter *f) const
   f->dump_stream("readable_until_ub") << readable_until_ub;
 }
 
-void pg_lease_ack_t::generate_test_instances(std::list<pg_lease_ack_t*>& o)
+std::list<pg_lease_ack_t> pg_lease_ack_t::generate_test_instances()
 {
-  o.push_back(new pg_lease_ack_t());
-  o.push_back(new pg_lease_ack_t());
-  o.back()->readable_until_ub = make_timespan(3.4);
+  std::list<pg_lease_ack_t> o;
+  o.push_back(pg_lease_ack_t());
+  o.push_back(pg_lease_ack_t());
+  o.back().readable_until_ub = make_timespan(3.4);
+  return o;
 }
 
 
@@ -4775,25 +4824,27 @@ void ObjectModDesc::dump(Formatter *f) const
   f->close_section();
 }
 
-void ObjectModDesc::generate_test_instances(list<ObjectModDesc*>& o)
+list<ObjectModDesc> ObjectModDesc::generate_test_instances()
 {
+  list<ObjectModDesc> o;
   map<string, std::optional<ceph::buffer::list> > attrs;
   attrs[OI_ATTR];
   attrs[SS_ATTR];
   attrs["asdf"];
-  o.push_back(new ObjectModDesc());
-  o.back()->append(100);
-  o.back()->setattrs(attrs);
-  o.push_back(new ObjectModDesc());
-  o.back()->rmobject(1001);
-  o.push_back(new ObjectModDesc());
-  o.back()->create();
-  o.back()->setattrs(attrs);
-  o.push_back(new ObjectModDesc());
-  o.back()->create();
-  o.back()->setattrs(attrs);
-  o.back()->mark_unrollbackable();
-  o.back()->append(1000);
+  o.push_back(ObjectModDesc());
+  o.back().append(100);
+  o.back().setattrs(attrs);
+  o.push_back(ObjectModDesc());
+  o.back().rmobject(1001);
+  o.push_back(ObjectModDesc());
+  o.back().create();
+  o.back().setattrs(attrs);
+  o.push_back(ObjectModDesc());
+  o.back().create();
+  o.back().setattrs(attrs);
+  o.back().mark_unrollbackable();
+  o.back().append(1000);
+  return o;
 }
 
 void ObjectModDesc::encode(ceph::buffer::list &_bl) const
@@ -4925,13 +4976,15 @@ void ObjectCleanRegions::dump(Formatter *f) const
   f->close_section();
 }
 
-void ObjectCleanRegions::generate_test_instances(list<ObjectCleanRegions*>& o)
+list<ObjectCleanRegions> ObjectCleanRegions::generate_test_instances()
 {
-  o.push_back(new ObjectCleanRegions());
-  o.push_back(new ObjectCleanRegions());
-  o.back()->mark_data_region_dirty(4096, 40960);
-  o.back()->mark_omap_dirty();
-  o.back()->mark_object_new();
+  list<ObjectCleanRegions> o;
+  o.push_back(ObjectCleanRegions());
+  o.push_back(ObjectCleanRegions());
+  o.back().mark_data_region_dirty(4096, 40960);
+  o.back().mark_omap_dirty();
+  o.back().mark_object_new();
+  return o;
 }
 
 std::string ObjectCleanRegions::fmt_print() const
@@ -5150,16 +5203,18 @@ void pg_log_entry_t::dump(Formatter *f) const
   }
 }
 
-void pg_log_entry_t::generate_test_instances(list<pg_log_entry_t*>& o)
+list<pg_log_entry_t> pg_log_entry_t::generate_test_instances()
 {
-  o.push_back(new pg_log_entry_t());
+  list<pg_log_entry_t> o;
+  o.push_back(pg_log_entry_t());
   hobject_t oid(object_t("objname"), "key", 123, 456, 0, "");
-  o.push_back(new pg_log_entry_t(MODIFY, oid, eversion_t(1,2), eversion_t(3,4),
-				 1, osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
-				 utime_t(8,9), 0));
-  o.push_back(new pg_log_entry_t(ERROR, oid, eversion_t(1,2), eversion_t(3,4),
-				 1, osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
-				 utime_t(8,9), -ENOENT));
+  o.push_back(pg_log_entry_t(MODIFY, oid, eversion_t(1,2), eversion_t(3,4),
+			     1, osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			     utime_t(8,9), 0));
+  o.push_back(pg_log_entry_t(ERROR, oid, eversion_t(1,2), eversion_t(3,4),
+			     1, osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			     utime_t(8,9), -ENOENT));
+  return o;
 }
 
 ostream& operator<<(ostream& out, const pg_log_entry_t& e)
@@ -5244,17 +5299,19 @@ void pg_log_dup_t::dump(Formatter *f) const
   }
 }
 
-void pg_log_dup_t::generate_test_instances(list<pg_log_dup_t*>& o)
+list<pg_log_dup_t> pg_log_dup_t::generate_test_instances()
 {
-  o.push_back(new pg_log_dup_t());
-  o.push_back(new pg_log_dup_t(eversion_t(1,2),
-			       1,
-			       osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
-			       0));
-  o.push_back(new pg_log_dup_t(eversion_t(1,2),
-			       2,
-			       osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
-			       -ENOENT));
+  list<pg_log_dup_t> o;
+  o.push_back(pg_log_dup_t());
+  o.push_back(pg_log_dup_t(eversion_t(1,2),
+			   1,
+			   osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			   0));
+  o.push_back(pg_log_dup_t(eversion_t(1,2),
+			   2,
+			   osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			   -ENOENT));
+  return o;
 }
 
 
@@ -5370,18 +5427,19 @@ void pg_log_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void pg_log_t::generate_test_instances(list<pg_log_t*>& o)
+list<pg_log_t> pg_log_t::generate_test_instances()
 {
-  o.push_back(new pg_log_t);
+  list<pg_log_t> o;
+  o.push_back(pg_log_t{});
 
   // this is nonsensical:
-  o.push_back(new pg_log_t);
-  o.back()->head = eversion_t(1,2);
-  o.back()->tail = eversion_t(3,4);
-  list<pg_log_entry_t*> e;
-  pg_log_entry_t::generate_test_instances(e);
-  for (auto p = e.begin(); p != e.end(); ++p)
-    o.back()->log.push_back(**p);
+  o.push_back(pg_log_t{});
+  o.back().head = eversion_t(1,2);
+  o.back().tail = eversion_t(3,4);
+  for (auto& p : pg_log_entry_t::generate_test_instances()) {
+    o.back().log.push_back(p);
+  }
+  return o;
 }
 
 static void _handle_dups(CephContext* cct, pg_log_t &target, const pg_log_t &other, unsigned maxdups)
@@ -5518,20 +5576,22 @@ void object_copy_cursor_t::dump(Formatter *f) const
   f->dump_unsigned("omap_complete", (int)omap_complete);
 }
 
-void object_copy_cursor_t::generate_test_instances(list<object_copy_cursor_t*>& o)
+list<object_copy_cursor_t> object_copy_cursor_t::generate_test_instances()
 {
-  o.push_back(new object_copy_cursor_t);
-  o.push_back(new object_copy_cursor_t);
-  o.back()->attr_complete = true;
-  o.back()->data_offset = 123;
-  o.push_back(new object_copy_cursor_t);
-  o.back()->attr_complete = true;
-  o.back()->data_complete = true;
-  o.back()->omap_offset = "foo";
-  o.push_back(new object_copy_cursor_t);
-  o.back()->attr_complete = true;
-  o.back()->data_complete = true;
-  o.back()->omap_complete = true;
+  list<object_copy_cursor_t> o;
+  o.push_back(object_copy_cursor_t{});
+  o.push_back(object_copy_cursor_t{});
+  o.back().attr_complete = true;
+  o.back().data_offset = 123;
+  o.push_back(object_copy_cursor_t{});
+  o.back().attr_complete = true;
+  o.back().data_complete = true;
+  o.back().omap_offset = "foo";
+  o.push_back(object_copy_cursor_t{});
+  o.back().attr_complete = true;
+  o.back().data_complete = true;
+  o.back().omap_complete = true;
+  return o;
 }
 
 // -- object_copy_data_t --
@@ -5625,37 +5685,40 @@ void object_copy_data_t::decode(ceph::buffer::list::const_iterator& bl)
   DECODE_FINISH(bl);
 }
 
-void object_copy_data_t::generate_test_instances(list<object_copy_data_t*>& o)
+list<object_copy_data_t> object_copy_data_t::generate_test_instances()
 {
-  o.push_back(new object_copy_data_t());
+  list<object_copy_data_t> o;
 
-  list<object_copy_cursor_t*> cursors;
-  object_copy_cursor_t::generate_test_instances(cursors);
+  o.push_back(object_copy_data_t());
+
+  list<object_copy_cursor_t> cursors = object_copy_cursor_t::generate_test_instances();
   auto ci = cursors.begin();
-  o.back()->cursor = **(ci++);
+  o.back().cursor = *(ci++);
 
-  o.push_back(new object_copy_data_t());
-  o.back()->cursor = **(ci++);
+  o.push_back(object_copy_data_t());
+  o.back().cursor = *(ci++);
 
-  o.push_back(new object_copy_data_t());
-  o.back()->size = 1234;
-  o.back()->mtime.set_from_double(1234);
+  o.push_back(object_copy_data_t());
+  o.back().size = 1234;
+  o.back().mtime.set_from_double(1234);
   ceph::buffer::ptr bp("there", 5);
   ceph::buffer::list bl;
   bl.push_back(bp);
-  o.back()->attrs["hello"] = bl;
+  o.back().attrs["hello"] = bl;
   ceph::buffer::ptr bp2("not", 3);
   ceph::buffer::list bl2;
   bl2.push_back(bp2);
   map<string,ceph::buffer::list> omap;
   omap["why"] = bl2;
   using ceph::encode;
-  encode(omap, o.back()->omap_data);
+  encode(omap, o.back().omap_data);
   ceph::buffer::ptr databp("iamsomedatatocontain", 20);
-  o.back()->data.push_back(databp);
-  o.back()->omap_header.append("this is an omap header");
-  o.back()->snaps.push_back(123);
-  o.back()->reqids.push_back(make_pair(osd_reqid_t(), version_t()));
+  o.back().data.push_back(databp);
+  o.back().omap_header.append("this is an omap header");
+  o.back().snaps.push_back(123);
+  o.back().reqids.push_back(make_pair(osd_reqid_t(), version_t()));
+
+  return o;
 }
 
 void object_copy_data_t::dump(Formatter *f) const
@@ -5722,10 +5785,12 @@ void pg_create_t::dump(Formatter *f) const
   f->dump_int("split_bits", split_bits);
 }
 
-void pg_create_t::generate_test_instances(list<pg_create_t*>& o)
+list<pg_create_t> pg_create_t::generate_test_instances()
 {
-  o.push_back(new pg_create_t);
-  o.push_back(new pg_create_t(1, pg_t(3, 4), 2));
+  list<pg_create_t> o;
+  o.push_back(pg_create_t{});
+  o.push_back(pg_create_t(1, pg_t(3, 4), 2));
+  return o;
 }
 
 
@@ -5763,12 +5828,14 @@ void pg_hit_set_info_t::dump(Formatter *f) const
   f->dump_stream("using_gmt") << using_gmt;
 }
 
-void pg_hit_set_info_t::generate_test_instances(list<pg_hit_set_info_t*>& ls)
+list<pg_hit_set_info_t> pg_hit_set_info_t::generate_test_instances()
 {
-  ls.push_back(new pg_hit_set_info_t);
-  ls.push_back(new pg_hit_set_info_t);
-  ls.back()->begin = utime_t(1, 2);
-  ls.back()->end = utime_t(3, 4);
+  list<pg_hit_set_info_t> ls;
+  ls.push_back(pg_hit_set_info_t{});
+  ls.push_back(pg_hit_set_info_t{});
+  ls.back().begin = utime_t(1, 2);
+  ls.back().end = utime_t(3, 4);
+  return ls;
 }
 
 
@@ -5818,12 +5885,14 @@ void pg_hit_set_history_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void pg_hit_set_history_t::generate_test_instances(list<pg_hit_set_history_t*>& ls)
+list<pg_hit_set_history_t> pg_hit_set_history_t::generate_test_instances()
 {
-  ls.push_back(new pg_hit_set_history_t);
-  ls.push_back(new pg_hit_set_history_t);
-  ls.back()->current_last_update = eversion_t(1, 2);
-  ls.back()->history.push_back(pg_hit_set_info_t());
+  list<pg_hit_set_history_t> ls;
+  ls.push_back(pg_hit_set_history_t{});
+  ls.push_back(pg_hit_set_history_t{});
+  ls.back().current_last_update = eversion_t(1, 2);
+  ls.back().history.push_back(pg_hit_set_info_t());
+  return ls;
 }
 
 // -- GuardedMap --
@@ -5932,10 +6001,11 @@ void OSDSuperblock::dump(Formatter *f) const
   f->dump_stream("maps") << get_maps();
 }
 
-void OSDSuperblock::generate_test_instances(list<OSDSuperblock*>& o)
+list<OSDSuperblock> OSDSuperblock::generate_test_instances()
 {
+  list<OSDSuperblock> o;
   OSDSuperblock z;
-  o.push_back(new OSDSuperblock(z));
+  o.push_back(OSDSuperblock(z));
   z.cluster_fsid.parse("01010101-0101-0101-0101-010101010101");
   z.osd_fsid.parse("02020202-0202-0202-0202-020202020202");
   z.whoami = 3;
@@ -5943,8 +6013,9 @@ void OSDSuperblock::generate_test_instances(list<OSDSuperblock*>& o)
   z.insert_osdmap_epochs(5, 9);
   z.mounted = 8;
   z.clean_thru = 7;
-  o.push_back(new OSDSuperblock(z));
-  o.push_back(new OSDSuperblock(z));
+  o.push_back(OSDSuperblock(z));
+  o.push_back(OSDSuperblock(z));
+  return o;
 }
 
 // -- SnapSet --
@@ -6011,17 +6082,19 @@ void SnapSet::dump(Formatter *f) const
   f->close_section();
 }
 
-void SnapSet::generate_test_instances(list<SnapSet*>& o)
+list<SnapSet> SnapSet::generate_test_instances()
 {
-  o.push_back(new SnapSet);
-  o.push_back(new SnapSet);
-  o.back()->seq = 123;
-  o.push_back(new SnapSet);
-  o.back()->seq = 123;
-  o.back()->clones.push_back(12);
-  o.back()->clone_size[12] = 12345;
-  o.back()->clone_overlap[12];
-  o.back()->clone_snaps[12] = {12, 10, 8};
+  list<SnapSet> o;
+  o.push_back(SnapSet{});
+  o.push_back(SnapSet{});
+  o.back().seq = 123;
+  o.push_back(SnapSet{});
+  o.back().seq = 123;
+  o.back().clones.push_back(12);
+  o.back().clone_size[12] = 12345;
+  o.back().clone_overlap[12];
+  o.back().clone_snaps[12] = {12, 10, 8};
+  return o;
 }
 
 ostream& operator<<(ostream& out, const SnapSet& cs)
@@ -6118,12 +6191,13 @@ std::string watch_info_t::fmt_print() const
 }
 
 
-void watch_info_t::generate_test_instances(list<watch_info_t*>& o)
+list<watch_info_t> watch_info_t::generate_test_instances()
 {
-  o.push_back(new watch_info_t);
-  o.push_back(new watch_info_t);
-  o.back()->cookie = 123;
-  o.back()->timeout_seconds = 99;
+  list<watch_info_t> o;
+  o.push_back(watch_info_t{});
+  o.push_back(watch_info_t{});
+  o.back().cookie = 123;
+  o.back().timeout_seconds = 99;
   entity_addr_t ea;
   ea.set_type(entity_addr_t::TYPE_LEGACY);
   ea.set_nonce(1);
@@ -6133,7 +6207,8 @@ void watch_info_t::generate_test_instances(list<watch_info_t*>& o)
   ea.set_in4_quad(2, 1);
   ea.set_in4_quad(3, 2);
   ea.set_port(2);
-  o.back()->addr = ea;
+  o.back().addr = ea;
+  return o;
 }
 
 // -- chunk_info_t --
@@ -6170,13 +6245,15 @@ void chunk_info_t::dump(Formatter *f) const
   f->dump_unsigned("flags", flags);
 }
 
-void chunk_info_t::generate_test_instances(std::list<chunk_info_t*>& o)
+std::list<chunk_info_t> chunk_info_t::generate_test_instances()
 {
-  o.push_back(new chunk_info_t);
-  o.push_back(new chunk_info_t);
-  o.back()->length = 123;
-  o.back()->oid = hobject_t(object_t("foo"), "", 123, 456, -1, "");
-  o.back()->flags = cflag_t::FLAG_DIRTY;
+  std::list<chunk_info_t> o;
+  o.push_back(chunk_info_t{});
+  o.push_back(chunk_info_t{});
+  o.back().length = 123;
+  o.back().oid = hobject_t(object_t("foo"), "", 123, 456, -1, "");
+  o.back().flags = cflag_t::FLAG_DIRTY;
+  return o;
 }
 
 bool chunk_info_t::operator==(const chunk_info_t& cit) const
@@ -6433,10 +6510,12 @@ void object_manifest_t::dump(Formatter *f) const
   }
 }
 
-void object_manifest_t::generate_test_instances(list<object_manifest_t*>& o)
+list<object_manifest_t> object_manifest_t::generate_test_instances()
 {
-  o.push_back(new object_manifest_t());
-  o.back()->type = TYPE_REDIRECT;
+  list<object_manifest_t> o;
+  o.push_back(object_manifest_t());
+  o.back().type = TYPE_REDIRECT;
+  return o;
 }
 
 ostream& operator<<(ostream& out, const object_manifest_t& om)
@@ -6654,11 +6733,13 @@ void object_info_t::dump(Formatter *f) const
   f->close_section();
 }
 
-void object_info_t::generate_test_instances(list<object_info_t*>& o)
+list<object_info_t> object_info_t::generate_test_instances()
 {
-  o.push_back(new object_info_t());
+  list<object_info_t> o;
+  o.push_back(object_info_t());
   
   // fixme
+  return o;
 }
 
 
@@ -6713,20 +6794,22 @@ ostream &operator<<(ostream &out, const ObjectRecoveryProgress &prog)
   return out << prog.fmt_print();
 }
 
-void ObjectRecoveryProgress::generate_test_instances(
-  list<ObjectRecoveryProgress*>& o)
+list<ObjectRecoveryProgress> ObjectRecoveryProgress::generate_test_instances()
 {
-  o.push_back(new ObjectRecoveryProgress);
-  o.back()->first = false;
-  o.back()->data_complete = true;
-  o.back()->omap_complete = true;
-  o.back()->data_recovered_to = 100;
+  list<ObjectRecoveryProgress> o;
+  o.push_back(ObjectRecoveryProgress{});
+  o.back().first = false;
+  o.back().data_complete = true;
+  o.back().omap_complete = true;
+  o.back().data_recovered_to = 100;
 
-  o.push_back(new ObjectRecoveryProgress);
-  o.back()->first = true;
-  o.back()->data_complete = false;
-  o.back()->omap_complete = false;
-  o.back()->data_recovered_to = 0;
+  o.push_back(ObjectRecoveryProgress{});
+  o.back().first = true;
+  o.back().data_complete = false;
+  o.back().omap_complete = false;
+  o.back().data_recovered_to = 0;
+
+  return o;
 }
 
 ostream &ObjectRecoveryProgress::print(ostream &out) const
@@ -6796,14 +6879,15 @@ void ObjectRecoveryInfo::decode(ceph::buffer::list::const_iterator &bl,
   }
 }
 
-void ObjectRecoveryInfo::generate_test_instances(
-  list<ObjectRecoveryInfo*>& o)
+list<ObjectRecoveryInfo> ObjectRecoveryInfo::generate_test_instances()
 {
-  o.push_back(new ObjectRecoveryInfo);
-  o.back()->soid = hobject_t(sobject_t("key", CEPH_NOSNAP));
-  o.back()->version = eversion_t(0,0);
-  o.back()->size = 100;
-  o.back()->object_exist = false;
+  list<ObjectRecoveryInfo> o;
+  o.push_back(ObjectRecoveryInfo{});
+  o.back().soid = hobject_t(sobject_t("key", CEPH_NOSNAP));
+  o.back().version = eversion_t(0,0);
+  o.back().size = 100;
+  o.back().object_exist = false;
+  return o;
 }
 
 
@@ -6841,13 +6925,15 @@ std::string ObjectRecoveryInfo::fmt_print() const
 }
 
 // -- PushReplyOp --
-void PushReplyOp::generate_test_instances(list<PushReplyOp*> &o)
+list<PushReplyOp> PushReplyOp::generate_test_instances()
 {
-  o.push_back(new PushReplyOp);
-  o.push_back(new PushReplyOp);
-  o.back()->soid = hobject_t(sobject_t("asdf", 2));
-  o.push_back(new PushReplyOp);
-  o.back()->soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
+  list<PushReplyOp> o;
+  o.push_back(PushReplyOp{});
+  o.push_back(PushReplyOp{});
+  o.back().soid = hobject_t(sobject_t("asdf", 2));
+  o.push_back(PushReplyOp{});
+  o.back().soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
+  return o;
 }
 
 void PushReplyOp::encode(ceph::buffer::list &bl) const
@@ -6914,15 +7000,17 @@ uint64_t PushReplyOp::cost(CephContext *cct) const
 }
 
 // -- PullOp --
-void PullOp::generate_test_instances(list<PullOp*> &o)
+list<PullOp> PullOp::generate_test_instances()
 {
-  o.push_back(new PullOp);
-  o.push_back(new PullOp);
-  o.back()->soid = hobject_t(sobject_t("asdf", 2));
-  o.back()->recovery_info.version = eversion_t(3, 10);
-  o.push_back(new PullOp);
-  o.back()->soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
-  o.back()->recovery_info.version = eversion_t(0, 0);
+  list<PullOp> o;
+  o.push_back(PullOp{});
+  o.push_back(PullOp{});
+  o.back().soid = hobject_t(sobject_t("asdf", 2));
+  o.back().recovery_info.version = eversion_t(3, 10);
+  o.push_back(PullOp{});
+  o.back().soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
+  o.back().recovery_info.version = eversion_t(0, 0);
+  return o;
 }
 
 void PullOp::encode(ceph::buffer::list &bl, uint64_t features) const
@@ -6991,15 +7079,17 @@ uint64_t PullOp::cost(CephContext *cct) const
 }
 
 // -- PushOp --
-void PushOp::generate_test_instances(list<PushOp*> &o)
+list<PushOp> PushOp::generate_test_instances()
 {
-  o.push_back(new PushOp);
-  o.push_back(new PushOp);
-  o.back()->soid = hobject_t(sobject_t("asdf", 2));
-  o.back()->version = eversion_t(3, 10);
-  o.push_back(new PushOp);
-  o.back()->soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
-  o.back()->version = eversion_t(0, 0);
+  list<PushOp> o;
+  o.push_back(PushOp{});
+  o.push_back(PushOp{});
+  o.back().soid = hobject_t(sobject_t("asdf", 2));
+  o.back().version = eversion_t(3, 10);
+  o.push_back(PushOp{});
+  o.back().soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
+  o.back().version = eversion_t(0, 0);
+  return o;
 }
 
 void PushOp::encode(ceph::buffer::list &bl, uint64_t features) const
@@ -7166,17 +7256,18 @@ void ScrubMap::dump(Formatter *f) const
   f->close_section();
 }
 
-void ScrubMap::generate_test_instances(list<ScrubMap*>& o)
+list<ScrubMap> ScrubMap::generate_test_instances()
 {
-  o.push_back(new ScrubMap);
-  o.push_back(new ScrubMap);
-  o.back()->valid_through = eversion_t(1, 2);
-  o.back()->incr_since = eversion_t(3, 4);
-  list<object*> obj;
-  object::generate_test_instances(obj);
-  o.back()->objects[hobject_t(object_t("foo"), "fookey", 123, 456, 0, "")] = *obj.back();
+  list<ScrubMap> o;
+  o.push_back(ScrubMap{});
+  o.push_back(ScrubMap{});
+  o.back().valid_through = eversion_t(1, 2);
+  o.back().incr_since = eversion_t(3, 4);
+  list<object> obj = object::generate_test_instances();
+  o.back().objects[hobject_t(object_t("foo"), "fookey", 123, 456, 0, "")] = obj.back();
   obj.pop_back();
-  o.back()->objects[hobject_t(object_t("bar"), string(), 123, 456, 0, "")] = *obj.back();
+  o.back().objects[hobject_t(object_t("bar"), string(), 123, 456, 0, "")] = obj.back();
+  return o;
 }
 
 // -- ScrubMap::object --
@@ -7268,23 +7359,26 @@ void ScrubMap::object::dump(Formatter *f) const
   f->close_section();
 }
 
-void ScrubMap::object::generate_test_instances(list<object*>& o)
+auto ScrubMap::object::generate_test_instances() -> list<object>
 {
-  o.push_back(new object);
-  o.push_back(new object);
-  o.back()->negative = true;
-  o.push_back(new object);
-  o.back()->size = 123;
+  list<object> o;
+
+  o.push_back(object{});
+  o.push_back(object{});
+  o.back().negative = true;
+  o.push_back(object{});
+  o.back().size = 123;
   {
     bufferlist foobl;
     foobl.push_back(ceph::buffer::copy("foo", 3));
-    o.back()->attrs["foo"] = std::move(foobl);
+    o.back().attrs["foo"] = std::move(foobl);
   }
   {
     bufferlist barbl;
     barbl.push_back(ceph::buffer::copy("barval", 6));
-    o.back()->attrs["bar"] = std::move(barbl);
+    o.back().attrs["bar"] = std::move(barbl);
   }
+  return o;
 }
 
 // -- OSDOp --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -177,7 +177,7 @@ struct osd_reqid_t {
     DENC_FINISH(p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<osd_reqid_t*>& o);
+  static std::list<osd_reqid_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(osd_reqid_t)
 
@@ -202,10 +202,12 @@ struct pg_shard_t {
       f->dump_unsigned("shard", static_cast<unsigned>(shard));
     }
   }
-  static void generate_test_instances(std::list<pg_shard_t*>& o) {
-    o.push_back(new pg_shard_t);
-    o.push_back(new pg_shard_t(1));
-    o.push_back(new pg_shard_t(1, shard_id_t(2)));
+  static std::list<pg_shard_t> generate_test_instances() {
+    std::list<pg_shard_t> o;
+    o.push_back(pg_shard_t{});
+    o.push_back(pg_shard_t(1));
+    o.push_back(pg_shard_t(1, shard_id_t(2)));
+    return o;
   }
   auto operator<=>(const pg_shard_t&) const = default;
 };
@@ -307,7 +309,7 @@ struct object_locator_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<object_locator_t*>& o);
+  static std::list<object_locator_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(object_locator_t)
 
@@ -357,7 +359,7 @@ public:
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<request_redirect_t*>& o);
+  static std::list<request_redirect_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(request_redirect_t)
 
@@ -505,7 +507,7 @@ struct pg_t {
     *this = opg;
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_t*>& o);
+  static std::list<pg_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_t)
 
@@ -615,9 +617,11 @@ struct spg_t {
     f->dump_stream("pgid") << pgid;
     f->dump_unsigned("shard", static_cast<unsigned>(shard));
   }
-  static void generate_test_instances(std::list<spg_t*>& o) {
-    o.push_back(new spg_t);
-    o.push_back(new spg_t(pg_t(1, 2), shard_id_t(3)));
+  static std::list<spg_t> generate_test_instances() {
+    std::list<spg_t> o;
+    o.push_back(spg_t{});
+    o.push_back(spg_t(pg_t(1, 2), shard_id_t(3)));
+    return o;
   }
   ghobject_t make_temp_ghobject(const std::string& name) const {
     return ghobject_t(
@@ -802,7 +806,7 @@ public:
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<coll_t*>& o);
+  static std::list<coll_t> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(coll_t)
@@ -950,9 +954,11 @@ public:
     f->dump_unsigned("version", version);
     f->dump_unsigned("epoch", epoch);
   }
-  static void generate_test_instances(std::list<eversion_t*>& o) {
-    o.push_back(new eversion_t);
-    o.push_back(new eversion_t(1, 2));
+  static std::list<eversion_t> generate_test_instances() {
+    std::list<eversion_t> o;
+    o.push_back(eversion_t{});
+    o.push_back(eversion_t(1, 2));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(eversion_t)
@@ -1008,7 +1014,7 @@ struct objectstore_perf_stat_t {
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
-  static void generate_test_instances(std::list<objectstore_perf_stat_t*>& o);
+  static std::list<objectstore_perf_stat_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(objectstore_perf_stat_t)
 
@@ -1068,7 +1074,7 @@ struct pool_snap_info_t {
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
-  static void generate_test_instances(std::list<pool_snap_info_t*>& o);
+  static std::list<pool_snap_info_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(pool_snap_info_t)
 
@@ -1190,7 +1196,7 @@ public:
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
-  static void generate_test_instances(std::list<pool_opts_t*>& o);
+  static std::list<pool_opts_t> generate_test_instances();
 
 private:
   typedef std::map<key_t, value_t> opts_t;
@@ -1244,15 +1250,17 @@ struct pg_merge_meta_t {
     f->dump_stream("source_version") << source_version;
     f->dump_stream("target_version") << target_version;
   }
-  static void generate_test_instances(std::list<pg_merge_meta_t*>& o) {
-    o.push_back(new pg_merge_meta_t);
-    o.push_back(new pg_merge_meta_t);
-    o.back()->source_pgid = pg_t(1,2);
-    o.back()->ready_epoch = 1;
-    o.back()->last_epoch_started = 2;
-    o.back()->last_epoch_clean = 3;
-    o.back()->source_version = eversion_t(4,5);
-    o.back()->target_version = eversion_t(6,7);
+  static std::list<pg_merge_meta_t> generate_test_instances() {
+    std::list<pg_merge_meta_t> o;
+    o.push_back(pg_merge_meta_t{});
+    o.push_back(pg_merge_meta_t{});
+    o.back().source_pgid = pg_t(1,2);
+    o.back().ready_epoch = 1;
+    o.back().last_epoch_started = 2;
+    o.back().last_epoch_clean = 3;
+    o.back().source_version = eversion_t(4,5);
+    o.back().target_version = eversion_t(6,7);
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(pg_merge_meta_t)
@@ -1948,7 +1956,7 @@ public:
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
 
-  static void generate_test_instances(std::list<pg_pool_t*>& o);
+  static std::list<pg_pool_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(pg_pool_t)
 
@@ -2186,7 +2194,7 @@ struct object_stat_sum_t {
   }
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
-  static void generate_test_instances(std::list<object_stat_sum_t*>& o);
+  static std::list<object_stat_sum_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(object_stat_sum_t)
 
@@ -2210,7 +2218,7 @@ struct object_stat_collection_t {
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
-  static void generate_test_instances(std::list<object_stat_collection_t*>& o);
+  static std::list<object_stat_collection_t> generate_test_instances();
 
   bool is_zero() const {
     return sum.is_zero();
@@ -2437,7 +2445,7 @@ struct pg_stat_t {
   std::string dump_scrub_schedule() const;
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
-  static void generate_test_instances(std::list<pg_stat_t*>& o);
+  static std::list<pg_stat_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_stat_t)
 
@@ -2567,7 +2575,7 @@ struct store_statfs_t
     denc(v.internal_metadata, p);
     DENC_FINISH(p);
   }
-  static void generate_test_instances(std::list<store_statfs_t*>& o);
+  static std::list<store_statfs_t> generate_test_instances();
 };
 WRITE_CLASS_DENC(store_statfs_t)
 
@@ -2655,7 +2663,7 @@ struct osd_stat_t {
   void dump_ping_time(ceph::Formatter *f) const;
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
-  static void generate_test_instances(std::list<osd_stat_t*>& o);
+  static std::list<osd_stat_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(osd_stat_t)
 
@@ -2798,7 +2806,7 @@ struct pool_stat_t {
   void dump(ceph::Formatter *f) const;
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
-  static void generate_test_instances(std::list<pool_stat_t*>& o);
+  static std::list<pool_stat_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(pool_stat_t)
 
@@ -2831,7 +2839,7 @@ struct pg_hit_set_info_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_hit_set_info_t*>& o);
+  static std::list<pg_hit_set_info_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_hit_set_info_t)
 
@@ -2855,7 +2863,7 @@ struct pg_hit_set_history_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_hit_set_history_t*>& o);
+  static std::list<pg_hit_set_history_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_hit_set_history_t)
 
@@ -3005,7 +3013,7 @@ struct pg_history_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_history_t*>& o);
+  static std::list<pg_history_t> generate_test_instances();
 
   ceph::signedspan refresh_prior_readable_until_ub(
     ceph::signedspan now,  ///< now, relative to osd startup_time
@@ -3119,7 +3127,7 @@ struct pg_info_t {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_info_t*>& o);
+  static std::list<pg_info_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_info_t)
 
@@ -3331,19 +3339,21 @@ struct pg_fast_info_t {
     f->dump_unsigned("num_objects_dirty", stats.stats.sum.num_objects_dirty);
     f->close_section();
   }
-  static void generate_test_instances(std::list<pg_fast_info_t*>& o) {
-    o.push_back(new pg_fast_info_t);
-    o.push_back(new pg_fast_info_t);
-    o.back()->last_update = eversion_t(1, 2);
-    o.back()->last_complete = eversion_t(3, 4);
-    o.back()->last_user_version = version_t(5);
-    o.back()->stats.version = eversion_t(7, 8);
-    o.back()->stats.reported_seq = 9;
-    o.back()->stats.last_fresh = utime_t(10, 0);
-    o.back()->stats.last_active = utime_t(11, 0);
-    o.back()->stats.last_peered = utime_t(12, 0);
-    o.back()->stats.last_clean = utime_t(13, 0);
-    o.back()->stats.last_unstale = utime_t(14, 0);
+  static std::list<pg_fast_info_t> generate_test_instances() {
+    std::list<pg_fast_info_t> o;
+    o.push_back(pg_fast_info_t{});
+    o.push_back(pg_fast_info_t{});
+    o.back().last_update = eversion_t(1, 2);
+    o.back().last_complete = eversion_t(3, 4);
+    o.back().last_user_version = version_t(5);
+    o.back().stats.version = eversion_t(7, 8);
+    o.back().stats.reported_seq = 9;
+    o.back().stats.last_fresh = utime_t(10, 0);
+    o.back().stats.last_active = utime_t(11, 0);
+    o.back().stats.last_peered = utime_t(12, 0);
+    o.back().stats.last_clean = utime_t(13, 0);
+    o.back().stats.last_unstale = utime_t(14, 0);
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(pg_fast_info_t)
@@ -3390,7 +3400,7 @@ public:
     void decode(ceph::buffer::list::const_iterator& bl);
     void dump(ceph::Formatter *f) const;
     std::string fmt_print() const;
-    static void generate_test_instances(std::list<pg_interval_t*>& o);
+    static std::list<pg_interval_t> generate_test_instances();
   };
 
   PastIntervals();
@@ -3463,7 +3473,7 @@ public:
 
   std::string fmt_print() const;
 
-  static void generate_test_instances(std::list<PastIntervals *> & o);
+  static std::list<PastIntervals> generate_test_instances();
 
   /**
    * Determines whether there is an interval change
@@ -3895,7 +3905,7 @@ struct pg_notify_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &p);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_notify_t*> &o);
+  static std::list<pg_notify_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_notify_t)
 std::ostream &operator<<(std::ostream &lhs, const pg_notify_t &notify);
@@ -3960,7 +3970,7 @@ struct pg_query_t {
   void decode(ceph::buffer::list::const_iterator &bl);
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_query_t*>& o);
+  static std::list<pg_query_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(pg_query_t)
 
@@ -3999,7 +4009,7 @@ struct pg_lease_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_lease_t*>& o);
+  static std::list<pg_lease_t> generate_test_instances();
 
   friend std::ostream& operator<<(std::ostream& out, const pg_lease_t& l) {
     return out << "pg_lease(ru " << l.readable_until
@@ -4026,7 +4036,7 @@ struct pg_lease_ack_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_lease_ack_t*>& o);
+  static std::list<pg_lease_ack_t> generate_test_instances();
 
   friend std::ostream& operator<<(std::ostream& out, const pg_lease_ack_t& l) {
     return out << "pg_lease_ack(ruub " << l.readable_until_ub << ")";
@@ -4232,7 +4242,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ObjectModDesc*>& o);
+  static std::list<ObjectModDesc> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ObjectModDesc)
 
@@ -4278,7 +4288,7 @@ public:
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
   std::string fmt_print() const;
-  static void generate_test_instances(std::list<ObjectCleanRegions*>& o);
+  static std::list<ObjectCleanRegions> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ObjectCleanRegions)
 std::ostream& operator<<(std::ostream& out, const ObjectCleanRegions& ocr);
@@ -4405,12 +4415,14 @@ struct pg_log_op_return_item_t {
     f->dump_int("rval", rval);
     f->dump_unsigned("bl_length", bl.length());
   }
-  static void generate_test_instances(std::list<pg_log_op_return_item_t*>& o) {
-    o.push_back(new pg_log_op_return_item_t);
-    o.back()->rval = 0;
-    o.push_back(new pg_log_op_return_item_t);
-    o.back()->rval = 1;
-    o.back()->bl.append("asdf");
+  static std::list<pg_log_op_return_item_t> generate_test_instances() {
+    std::list<pg_log_op_return_item_t> o;
+    o.push_back(pg_log_op_return_item_t{});
+    o.back().rval = 0;
+    o.push_back(pg_log_op_return_item_t{});
+    o.back().rval = 1;
+    o.back().bl.append("asdf");
+    return o;
   }
   friend bool operator==(const pg_log_op_return_item_t& lhs,
 			 const pg_log_op_return_item_t& rhs) {
@@ -4591,7 +4603,7 @@ struct pg_log_entry_t {
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
   std::string fmt_print() const;
-  static void generate_test_instances(std::list<pg_log_entry_t*>& o);
+  static std::list<pg_log_entry_t> generate_test_instances();
 
 };
 WRITE_CLASS_ENCODER(pg_log_entry_t)
@@ -4625,7 +4637,7 @@ struct pg_log_dup_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_log_dup_t*>& o);
+  static std::list<pg_log_dup_t> generate_test_instances();
 
   bool operator==(const pg_log_dup_t &rhs) const {
     return reqid == rhs.reqid &&
@@ -4854,7 +4866,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl, int64_t pool = -1);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_log_t*>& o);
+  static std::list<pg_log_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_log_t)
 
@@ -4955,17 +4967,19 @@ struct pg_missing_item {
     f->dump_stream("flags") << flag_str();
     f->dump_stream("clean_regions") << clean_regions;
   }
-  static void generate_test_instances(std::list<pg_missing_item*>& o) {
-    o.push_back(new pg_missing_item);
-    o.push_back(new pg_missing_item);
-    o.back()->need = eversion_t(1, 2);
-    o.back()->have = eversion_t(1, 1);
-    o.push_back(new pg_missing_item);
-    o.back()->need = eversion_t(3, 5);
-    o.back()->have = eversion_t(3, 4);
-    o.back()->clean_regions.mark_data_region_dirty(4096, 8192);
-    o.back()->clean_regions.mark_omap_dirty();
-    o.back()->flags = FLAG_DELETE;
+  static std::list<pg_missing_item> generate_test_instances() {
+    std::list<pg_missing_item> o;
+    o.push_back(pg_missing_item{});
+    o.push_back(pg_missing_item{});
+    o.back().need = eversion_t(1, 2);
+    o.back().have = eversion_t(1, 1);
+    o.push_back(pg_missing_item{});
+    o.back().need = eversion_t(3, 5);
+    o.back().have = eversion_t(3, 4);
+    o.back().clean_regions.mark_data_region_dirty(4096, 8192);
+    o.back().clean_regions.mark_omap_dirty();
+    o.back().flags = FLAG_DELETE;
+    return o;
   }
   bool operator==(const pg_missing_item &rhs) const {
     return need == rhs.need && have == rhs.have && flags == rhs.flags;
@@ -5319,19 +5333,21 @@ public:
       }
     }
   }
-  static void generate_test_instances(std::list<pg_missing_set*>& o) {
-    o.push_back(new pg_missing_set);
-    o.back()->may_include_deletes = true;
-    o.push_back(new pg_missing_set);
-    o.back()->add(
+  static std::list<pg_missing_set> generate_test_instances() {
+    std::list<pg_missing_set> o;
+    o.push_back(pg_missing_set{});
+    o.back().may_include_deletes = true;
+    o.push_back(pg_missing_set{});
+    o.back().add(
       hobject_t(object_t("foo"), "foo", 123, 456, 0, ""),
       eversion_t(5, 6), eversion_t(5, 1), false);
-    o.back()->may_include_deletes = true;
-    o.push_back(new pg_missing_set);
-    o.back()->add(
+    o.back().may_include_deletes = true;
+    o.push_back(pg_missing_set{});
+    o.back().add(
       hobject_t(object_t("foo"), "foo", 123, 456, 0, ""),
       eversion_t(5, 6), eversion_t(5, 1), true);
-    o.back()->may_include_deletes = true;
+    o.back().may_include_deletes = true;
+    return o;
   }
   template <typename F>
   void get_changed(F &&f) const {
@@ -5462,26 +5478,28 @@ struct pg_nls_response_template {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<pg_nls_response_template<T>*>& o) {
-    o.push_back(new pg_nls_response_template<T>);
-    o.push_back(new pg_nls_response_template<T>);
-    o.back()->handle = hobject_t(object_t("hi"), "key", 1, 2, -1, "");
-    o.back()->entries.push_back(librados::ListObjectImpl("", "one", ""));
-    o.back()->entries.push_back(librados::ListObjectImpl("", "two", "twokey"));
-    o.back()->entries.push_back(librados::ListObjectImpl("", "three", ""));
-    o.push_back(new pg_nls_response_template<T>);
-    o.back()->handle = hobject_t(object_t("hi"), "key", 3, 4, -1, "");
-    o.back()->entries.push_back(librados::ListObjectImpl("n1", "n1one", ""));
-    o.back()->entries.push_back(librados::ListObjectImpl("n1", "n1two", "n1twokey"));
-    o.back()->entries.push_back(librados::ListObjectImpl("n1", "n1three", ""));
-    o.push_back(new pg_nls_response_template<T>);
-    o.back()->handle = hobject_t(object_t("hi"), "key", 5, 6, -1, "");
-    o.back()->entries.push_back(librados::ListObjectImpl("", "one", ""));
-    o.back()->entries.push_back(librados::ListObjectImpl("", "two", "twokey"));
-    o.back()->entries.push_back(librados::ListObjectImpl("", "three", ""));
-    o.back()->entries.push_back(librados::ListObjectImpl("n1", "n1one", ""));
-    o.back()->entries.push_back(librados::ListObjectImpl("n1", "n1two", "n1twokey"));
-    o.back()->entries.push_back(librados::ListObjectImpl("n1", "n1three", ""));
+  static std::list<pg_nls_response_template> generate_test_instances() {
+    std::list<pg_nls_response_template<T>> o;
+    o.push_back(pg_nls_response_template<T>{});
+    o.push_back(pg_nls_response_template<T>{});
+    o.back().handle = hobject_t(object_t("hi"), "key", 1, 2, -1, "");
+    o.back().entries.push_back(librados::ListObjectImpl("", "one", ""));
+    o.back().entries.push_back(librados::ListObjectImpl("", "two", "twokey"));
+    o.back().entries.push_back(librados::ListObjectImpl("", "three", ""));
+    o.push_back(pg_nls_response_template<T>{});
+    o.back().handle = hobject_t(object_t("hi"), "key", 3, 4, -1, "");
+    o.back().entries.push_back(librados::ListObjectImpl("n1", "n1one", ""));
+    o.back().entries.push_back(librados::ListObjectImpl("n1", "n1two", "n1twokey"));
+    o.back().entries.push_back(librados::ListObjectImpl("n1", "n1three", ""));
+    o.push_back(pg_nls_response_template<T>{});
+    o.back().handle = hobject_t(object_t("hi"), "key", 5, 6, -1, "");
+    o.back().entries.push_back(librados::ListObjectImpl("", "one", ""));
+    o.back().entries.push_back(librados::ListObjectImpl("", "two", "twokey"));
+    o.back().entries.push_back(librados::ListObjectImpl("", "three", ""));
+    o.back().entries.push_back(librados::ListObjectImpl("n1", "n1one", ""));
+    o.back().entries.push_back(librados::ListObjectImpl("n1", "n1two", "n1twokey"));
+    o.back().entries.push_back(librados::ListObjectImpl("n1", "n1three", ""));
+    return o;
   }
 };
 
@@ -5520,12 +5538,14 @@ struct pg_ls_response_t {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<pg_ls_response_t*>& o) {
-    o.push_back(new pg_ls_response_t);
-    o.push_back(new pg_ls_response_t);
-    o.back()->handle = hobject_t(object_t("hi"), "key", 1, 2, -1, "");
-    o.back()->entries.push_back(std::make_pair(object_t("one"), std::string()));
-    o.back()->entries.push_back(std::make_pair(object_t("two"), std::string("twokey")));
+  static std::list<pg_ls_response_t> generate_test_instances() {
+    std::list<pg_ls_response_t> o;
+    o.push_back(pg_ls_response_t{});
+    o.push_back(pg_ls_response_t{});
+    o.back().handle = hobject_t(object_t("hi"), "key", 1, 2, -1, "");
+    o.back().entries.push_back(std::make_pair(object_t("one"), std::string()));
+    o.back().entries.push_back(std::make_pair(object_t("two"), std::string("twokey")));
+    return o;
   }
 };
 
@@ -5555,7 +5575,7 @@ struct object_copy_cursor_t {
     return attr_complete && data_complete && omap_complete;
   }
 
-  static void generate_test_instances(std::list<object_copy_cursor_t*>& o);
+  static std::list<object_copy_cursor_t> generate_test_instances();
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
@@ -5612,7 +5632,7 @@ public:
     truncate_seq(0),
     truncate_size(0) {}
 
-  static void generate_test_instances(std::list<object_copy_data_t*>& o);
+  static std::list<object_copy_data_t> generate_test_instances();
   void encode(ceph::buffer::list& bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
@@ -5635,7 +5655,7 @@ struct pg_create_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<pg_create_t*>& o);
+  static std::list<pg_create_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(pg_create_t)
 
@@ -5835,7 +5855,7 @@ public:
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<OSDSuperblock*>& o);
+  static std::list<OSDSuperblock> generate_test_instances();
 
   // Allow default operators to avoid crimson related errors
   OSDSuperblock(OSDSuperblock&&) noexcept = default;
@@ -5892,7 +5912,7 @@ struct SnapSet {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<SnapSet*>& o);
+  static std::list<SnapSet> generate_test_instances();
 
   SnapContext get_ssc_as_of(snapid_t as_of) const {
     SnapContext out;
@@ -5936,7 +5956,7 @@ struct watch_info_t {
   void decode(ceph::buffer::list::const_iterator& bl);
   void dump(ceph::Formatter *f) const;
   std::string fmt_print() const;
-  static void generate_test_instances(std::list<watch_info_t*>& o);
+  static std::list<watch_info_t> generate_test_instances();
 };
 WRITE_CLASS_ENCODER_FEATURES(watch_info_t)
 
@@ -6074,7 +6094,7 @@ struct chunk_info_t {
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<chunk_info_t*>& ls);
+  static std::list<chunk_info_t> generate_test_instances();
   friend std::ostream& operator<<(std::ostream& out, const chunk_info_t& ci);
   bool operator==(const chunk_info_t& cit) const;
   bool operator!=(const chunk_info_t& cit) const {
@@ -6173,7 +6193,7 @@ struct object_manifest_t {
     object_ref_delta_t &delta    ///< [out] set of refs to drop
   ) const;
 
-  static void generate_test_instances(std::list<object_manifest_t*>& o);
+  static std::list<object_manifest_t> generate_test_instances();
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   void dump(ceph::Formatter *f) const;
@@ -6359,7 +6379,7 @@ struct object_info_t {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<object_info_t*>& o);
+  static std::list<object_info_t> generate_test_instances();
 
   explicit object_info_t()
     : user_version(0), size(0), flags((flag_t)0),
@@ -6406,7 +6426,7 @@ struct ObjectRecoveryInfo {
 
   ObjectRecoveryInfo() : size(0), object_exist(true) { }
 
-  static void generate_test_instances(std::list<ObjectRecoveryInfo*>& o);
+  static std::list<ObjectRecoveryInfo> generate_test_instances();
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl, int64_t pool = -1);
   std::string fmt_print() const;
@@ -6437,7 +6457,7 @@ struct ObjectRecoveryProgress {
     return info.size - data_recovered_to;
   }
 
-  static void generate_test_instances(std::list<ObjectRecoveryProgress*>& o);
+  static std::list<ObjectRecoveryProgress> generate_test_instances();
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   std::ostream &print(std::ostream &out) const;
@@ -6450,7 +6470,7 @@ std::ostream& operator<<(std::ostream& out, const ObjectRecoveryProgress &prog);
 struct PushReplyOp {
   hobject_t soid;
 
-  static void generate_test_instances(std::list<PushReplyOp*>& o);
+  static std::list<PushReplyOp> generate_test_instances();
   void encode(ceph::buffer::list &bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   std::ostream &print(std::ostream &out) const;
@@ -6467,7 +6487,7 @@ struct PullOp {
   ObjectRecoveryInfo recovery_info;
   ObjectRecoveryProgress recovery_progress;
 
-  static void generate_test_instances(std::list<PullOp*>& o);
+  static std::list<PullOp> generate_test_instances();
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   std::ostream &print(std::ostream &out) const;
@@ -6491,7 +6511,7 @@ struct PushOp {
   ObjectRecoveryProgress before_progress;
   ObjectRecoveryProgress after_progress;
 
-  static void generate_test_instances(std::list<PushOp*>& o);
+  static std::list<PushOp> generate_test_instances();
   void encode(ceph::buffer::list &bl, uint64_t features) const;
   void decode(ceph::buffer::list::const_iterator &bl);
   std::ostream &print(std::ostream &out) const;
@@ -6536,7 +6556,7 @@ struct ScrubMap {
     void encode(ceph::buffer::list& bl) const;
     void decode(ceph::buffer::list::const_iterator& bl);
     void dump(ceph::Formatter *f) const;
-    static void generate_test_instances(std::list<object*>& o);
+    static std::list<object> generate_test_instances();
   };
   WRITE_CLASS_ENCODER(object)
 
@@ -6565,7 +6585,7 @@ struct ScrubMap {
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl, int64_t pool=-1);
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<ScrubMap*>& o);
+  static std::list<ScrubMap> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ScrubMap::object)
 WRITE_CLASS_ENCODER(ScrubMap)
@@ -6666,7 +6686,8 @@ struct watch_item_t {
     addr.dump(f);
     f->close_section();
   }
-  static void generate_test_instances(std::list<watch_item_t*>& o) {
+  static std::list<watch_item_t> generate_test_instances() {
+    std::list<watch_item_t> o;
     entity_addr_t ea;
     ea.set_type(entity_addr_t::TYPE_LEGACY);
     ea.set_nonce(1000);
@@ -6676,11 +6697,12 @@ struct watch_item_t {
     ea.set_in4_quad(2, 0);
     ea.set_in4_quad(3, 1);
     ea.set_port(1024);
-    o.push_back(new watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 1), 10, 30, ea));
+    o.push_back(watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 1), 10, 30, ea));
     ea.set_nonce(1001);
     ea.set_in4_quad(3, 2);
     ea.set_port(1025);
-    o.push_back(new watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 2), 20, 60, ea));
+    o.push_back(watch_item_t(entity_name_t(entity_name_t::TYPE_CLIENT, 2), 20, 60, ea));
+    return o;
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(watch_item_t)
@@ -6716,16 +6738,16 @@ struct obj_list_watch_response_t {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<obj_list_watch_response_t*>& o) {
+  static std::list<obj_list_watch_response_t> generate_test_instances() {
+    std::list<obj_list_watch_response_t> o;
     entity_addr_t ea;
-    o.push_back(new obj_list_watch_response_t);
-    o.push_back(new obj_list_watch_response_t);
-    std::list<watch_item_t*> test_watchers;
-    watch_item_t::generate_test_instances(test_watchers);
+    o.push_back(obj_list_watch_response_t{});
+    o.push_back(obj_list_watch_response_t{});
+    std::list<watch_item_t> test_watchers = watch_item_t::generate_test_instances();
     for (auto &e : test_watchers) {
-      o.back()->entries.push_back(*e);
-      delete e;
+      o.back().entries.push_back(e);
     }
+    return o;
   }
 };
 WRITE_CLASS_ENCODER_FEATURES(obj_list_watch_response_t)
@@ -6777,17 +6799,19 @@ struct clone_info {
     f->close_section();
     f->dump_unsigned("size", size);
   }
-  static void generate_test_instances(std::list<clone_info*>& o) {
-    o.push_back(new clone_info);
-    o.push_back(new clone_info);
-    o.back()->cloneid = 1;
-    o.back()->snaps.push_back(1);
-    o.back()->overlap.push_back(std::pair<uint64_t,uint64_t>(0,4096));
-    o.back()->overlap.push_back(std::pair<uint64_t,uint64_t>(8192,4096));
-    o.back()->size = 16384;
-    o.push_back(new clone_info);
-    o.back()->cloneid = CEPH_NOSNAP;
-    o.back()->size = 32768;
+  static std::list<clone_info> generate_test_instances() {
+    std::list<clone_info> o;
+    o.push_back(clone_info{});
+    o.push_back(clone_info{});
+    o.back().cloneid = 1;
+    o.back().snaps.push_back(1);
+    o.back().overlap.push_back(std::pair<uint64_t,uint64_t>(0,4096));
+    o.back().overlap.push_back(std::pair<uint64_t,uint64_t>(8192,4096));
+    o.back().size = 16384;
+    o.push_back(clone_info{});
+    o.back().cloneid = CEPH_NOSNAP;
+    o.back().size = 32768;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(clone_info)
@@ -6825,22 +6849,24 @@ struct obj_list_snap_response_t {
     f->dump_unsigned("seq", seq);
     f->close_section();
   }
-  static void generate_test_instances(std::list<obj_list_snap_response_t*>& o) {
-    o.push_back(new obj_list_snap_response_t);
-    o.push_back(new obj_list_snap_response_t);
+  static std::list<obj_list_snap_response_t> generate_test_instances() {
+    std::list<obj_list_snap_response_t> o;
+    o.push_back(obj_list_snap_response_t{});
+    o.push_back(obj_list_snap_response_t{});
     clone_info cl;
     cl.cloneid = 1;
     cl.snaps.push_back(1);
     cl.overlap.push_back(std::pair<uint64_t,uint64_t>(0,4096));
     cl.overlap.push_back(std::pair<uint64_t,uint64_t>(8192,4096));
     cl.size = 16384;
-    o.back()->clones.push_back(cl);
+    o.back().clones.push_back(cl);
     cl.cloneid = CEPH_NOSNAP;
     cl.snaps.clear();
     cl.overlap.clear();
     cl.size = 32768;
-    o.back()->clones.push_back(cl);
-    o.back()->seq = 123;
+    o.back().clones.push_back(cl);
+    o.back().seq = 123;
+    return o;
   }
 };
 
@@ -6947,8 +6973,10 @@ struct pool_pg_num_history_t {
     }
     f->close_section();
   }
-  static void generate_test_instances(std::list<pool_pg_num_history_t*>& ls) {
-    ls.push_back(new pool_pg_num_history_t);
+  static std::list<pool_pg_num_history_t> generate_test_instances() {
+    std::list<pool_pg_num_history_t> ls;
+    ls.push_back(pool_pg_num_history_t{});
+    return ls;
   }
   friend std::ostream& operator<<(std::ostream& out, const pool_pg_num_history_t& h) {
     return out << "pg_num_history(e" << h.epoch

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -195,19 +195,23 @@ public:
          << std::dec;
     }
 
-    static void generate_test_instances(std::list<Header*> &ls)
+    static std::list<Header> generate_test_instances()
     {
-      ls.push_back(new Header());
+      std::list<Header> ls;
 
-      ls.push_back(new Header());
-      ls.back()->trimmed_pos = 1;
-      ls.back()->expire_pos = 2;
-      ls.back()->unused_field = 3;
-      ls.back()->write_pos = 4;
-      ls.back()->magic = "magique";
+      ls.push_back(Header());
 
-      ls.push_back(new Header());
-      ls.back()->stream_format = JOURNAL_FORMAT_RESILIENT;
+      ls.push_back(Header());
+      ls.back().trimmed_pos = 1;
+      ls.back().expire_pos = 2;
+      ls.back().unused_field = 3;
+      ls.back().write_pos = 4;
+      ls.back().magic = "magique";
+
+      ls.push_back(Header());
+      ls.back().stream_format = JOURNAL_FORMAT_RESILIENT;
+
+      return ls;
     }
   };
   WRITE_CLASS_ENCODER(Header)

--- a/src/rbd_replay/ActionTypes.cc
+++ b/src/rbd_replay/ActionTypes.cc
@@ -105,9 +105,11 @@ void Dependency::dump(Formatter *f) const {
   f->dump_unsigned("time_delta", time_delta);
 }
 
-void Dependency::generate_test_instances(std::list<Dependency *> &o) {
-  o.push_back(new Dependency());
-  o.push_back(new Dependency(1, 123456789));
+std::list<Dependency> Dependency::generate_test_instances() {
+  std::list<Dependency> o;
+  o.push_back(Dependency());
+  o.push_back(Dependency(1, 123456789));
+  return o;
 }
 
 void ActionBase::encode(bufferlist &bl) const {
@@ -335,47 +337,51 @@ void ActionEntry::dump(Formatter *f) const {
   std::visit(DumpVisitor(f), action);
 }
 
-void ActionEntry::generate_test_instances(std::list<ActionEntry *> &o) {
+std::list<ActionEntry>  ActionEntry::generate_test_instances() {
+  std::list<ActionEntry> o;
+
   Dependencies dependencies;
   dependencies.push_back(Dependency(3, 123456789));
   dependencies.push_back(Dependency(4, 234567890));
 
-  o.push_back(new ActionEntry(StartThreadAction()));
-  o.push_back(new ActionEntry(StartThreadAction(1, 123456789, dependencies)));
-  o.push_back(new ActionEntry(StopThreadAction()));
-  o.push_back(new ActionEntry(StopThreadAction(1, 123456789, dependencies)));
+  o.push_back(ActionEntry(StartThreadAction()));
+  o.push_back(ActionEntry(StartThreadAction(1, 123456789, dependencies)));
+  o.push_back(ActionEntry(StopThreadAction()));
+  o.push_back(ActionEntry(StopThreadAction(1, 123456789, dependencies)));
 
-  o.push_back(new ActionEntry(ReadAction()));
-  o.push_back(new ActionEntry(ReadAction(1, 123456789, dependencies, 3, 4, 5)));
-  o.push_back(new ActionEntry(WriteAction()));
-  o.push_back(new ActionEntry(WriteAction(1, 123456789, dependencies, 3, 4,
-                                          5)));
-  o.push_back(new ActionEntry(DiscardAction()));
-  o.push_back(new ActionEntry(DiscardAction(1, 123456789, dependencies, 3, 4,
+  o.push_back(ActionEntry(ReadAction()));
+  o.push_back(ActionEntry(ReadAction(1, 123456789, dependencies, 3, 4, 5)));
+  o.push_back(ActionEntry(WriteAction()));
+  o.push_back(ActionEntry(WriteAction(1, 123456789, dependencies, 3, 4,
+                                      5)));
+  o.push_back(ActionEntry(DiscardAction()));
+  o.push_back(ActionEntry(DiscardAction(1, 123456789, dependencies, 3, 4,
                                             5)));
-  o.push_back(new ActionEntry(AioReadAction()));
-  o.push_back(new ActionEntry(AioReadAction(1, 123456789, dependencies, 3, 4,
-                                            5)));
-  o.push_back(new ActionEntry(AioWriteAction()));
-  o.push_back(new ActionEntry(AioWriteAction(1, 123456789, dependencies, 3, 4,
-                                             5)));
-  o.push_back(new ActionEntry(AioDiscardAction()));
-  o.push_back(new ActionEntry(AioDiscardAction(1, 123456789, dependencies, 3, 4,
-                                               5)));
+  o.push_back(ActionEntry(AioReadAction()));
+  o.push_back(ActionEntry(AioReadAction(1, 123456789, dependencies, 3, 4,
+                                        5)));
+  o.push_back(ActionEntry(AioWriteAction()));
+  o.push_back(ActionEntry(AioWriteAction(1, 123456789, dependencies, 3, 4,
+                                         5)));
+  o.push_back(ActionEntry(AioDiscardAction()));
+  o.push_back(ActionEntry(AioDiscardAction(1, 123456789, dependencies, 3, 4,
+                                           5)));
 
-  o.push_back(new ActionEntry(OpenImageAction()));
-  o.push_back(new ActionEntry(OpenImageAction(1, 123456789, dependencies, 3,
-                                              "image_name", "snap_name",
-                                              true)));
-  o.push_back(new ActionEntry(CloseImageAction()));
-  o.push_back(new ActionEntry(CloseImageAction(1, 123456789, dependencies, 3)));
+  o.push_back(ActionEntry(OpenImageAction()));
+  o.push_back(ActionEntry(OpenImageAction(1, 123456789, dependencies, 3,
+                                          "image_name", "snap_name",
+                                          true)));
+  o.push_back(ActionEntry(CloseImageAction()));
+  o.push_back(ActionEntry(CloseImageAction(1, 123456789, dependencies, 3)));
 
-  o.push_back(new ActionEntry(AioOpenImageAction()));
-  o.push_back(new ActionEntry(AioOpenImageAction(1, 123456789, dependencies, 3,
-                                              "image_name", "snap_name",
-                                              true)));
-  o.push_back(new ActionEntry(AioCloseImageAction()));
-  o.push_back(new ActionEntry(AioCloseImageAction(1, 123456789, dependencies, 3)));
+  o.push_back(ActionEntry(AioOpenImageAction()));
+  o.push_back(ActionEntry(AioOpenImageAction(1, 123456789, dependencies, 3,
+					     "image_name", "snap_name",
+					     true)));
+  o.push_back(ActionEntry(AioCloseImageAction()));
+  o.push_back(ActionEntry(AioCloseImageAction(1, 123456789, dependencies, 3)));
+
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &out,

--- a/src/rbd_replay/ActionTypes.h
+++ b/src/rbd_replay/ActionTypes.h
@@ -54,7 +54,7 @@ struct Dependency {
   void decode(__u8 version, bufferlist::const_iterator &it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<Dependency *> &o);
+  static std::list<Dependency> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(Dependency);
@@ -322,7 +322,7 @@ public:
   void decode_unversioned(bufferlist::const_iterator &it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<ActionEntry *> &o);
+  static std::list<ActionEntry> generate_test_instances();
 
 private:
   void decode_versioned(__u8 version, bufferlist::const_iterator &it);

--- a/src/rgw/driver/rados/groups.cc
+++ b/src/rgw/driver/rados/groups.cc
@@ -124,12 +124,14 @@ void resource_metadata::dump(ceph::Formatter* f) const
   encode_json("group_id", group_id, f);
 }
 
-void resource_metadata::generate_test_instances(std::list<resource_metadata*>& o)
+std::list<resource_metadata> resource_metadata::generate_test_instances()
 {
-  o.push_back(new resource_metadata);
-  auto m = new resource_metadata;
-  m->group_id = "id";
-  o.push_back(m);
+  std::list<resource_metadata> o;
+  o.push_back(resource_metadata{});
+  resource_metadata m;
+  m.group_id = "id";
+  o.push_back(std::move(m));
+  return o;
 }
 
 } // namespace rgwrados::groups

--- a/src/rgw/driver/rados/groups.h
+++ b/src/rgw/driver/rados/groups.h
@@ -72,7 +72,7 @@ struct resource_metadata {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<resource_metadata*>& o);
+  static std::list<resource_metadata> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(resource_metadata);
 

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3658,15 +3658,18 @@ auto create_archive_bucket_instance_metadata_handler(rgw::sal::Driver* driver,
                                                                    svc_datalog);
 }
 
-void RGWBucketEntryPoint::generate_test_instances(list<RGWBucketEntryPoint*>& o)
+list<RGWBucketEntryPoint> RGWBucketEntryPoint::generate_test_instances()
 {
-  RGWBucketEntryPoint *bp = new RGWBucketEntryPoint();
-  init_bucket(&bp->bucket, "tenant", "bucket", "pool", ".index.pool", "marker", "10");
-  bp->owner = "owner";
-  bp->creation_time = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
+  list<RGWBucketEntryPoint> o;
+  RGWBucketEntryPoint bp;
+  init_bucket(&bp.bucket, "tenant", "bucket", "pool", ".index.pool", "marker", "10");
+  bp.owner = "owner";
+  bp.creation_time = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
 
-  o.push_back(bp);
-  o.push_back(new RGWBucketEntryPoint);
+  o.push_back(std::move(bp));
+  o.push_back(RGWBucketEntryPoint{});
+
+  return o;
 }
 
 void RGWBucketEntryPoint::dump(Formatter *f) const

--- a/src/rgw/driver/rados/rgw_d3n_datacache.h
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.h
@@ -36,7 +36,6 @@ struct D3nChunkDataInfo : public LRUObject {
 	}
 
 	void dump(Formatter *f) const;
-	static void generate_test_instances(std::list<D3nChunkDataInfo*>& o);
 };
 
 struct D3nCacheAioWriteRequest {

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -6669,28 +6669,34 @@ int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
                                                   status));
 }
 
-void rgw_data_sync_info::generate_test_instances(list<rgw_data_sync_info*>& o)
+list<rgw_data_sync_info> rgw_data_sync_info::generate_test_instances()
 {
-  auto info = new rgw_data_sync_info;
-  info->state = rgw_data_sync_info::StateBuildingFullSyncMaps;
-  info->num_shards = 8;
-  o.push_back(info);
-  o.push_back(new rgw_data_sync_info);
+  list<rgw_data_sync_info> o;
+  rgw_data_sync_info info;
+  info.state = rgw_data_sync_info::StateBuildingFullSyncMaps;
+  info.num_shards = 8;
+  o.push_back(std::move(info));
+  o.push_back(rgw_data_sync_info{});
+  return o;
 }
 
-void rgw_data_sync_marker::generate_test_instances(list<rgw_data_sync_marker*>& o)
+list<rgw_data_sync_marker> rgw_data_sync_marker::generate_test_instances()
 {
-  auto marker = new rgw_data_sync_marker;
-  marker->state = rgw_data_sync_marker::IncrementalSync;
-  marker->marker = "01234";
-  marker->pos = 5;
-  o.push_back(marker);
-  o.push_back(new rgw_data_sync_marker);
+  list<rgw_data_sync_marker> o;
+  rgw_data_sync_marker marker;
+  marker.state = rgw_data_sync_marker::IncrementalSync;
+  marker.marker = "01234";
+  marker.pos = 5;
+  o.push_back(std::move(marker));
+  o.push_back(rgw_data_sync_marker{});
+  return o;
 }
 
-void rgw_data_sync_status::generate_test_instances(list<rgw_data_sync_status*>& o)
+list<rgw_data_sync_status> rgw_data_sync_status::generate_test_instances()
 {
-  o.push_back(new rgw_data_sync_status);
+  list<rgw_data_sync_status> o;
+  o.push_back(rgw_data_sync_status{});
+  return o;
 }
 
 void rgw_bucket_shard_full_sync_marker::dump(Formatter *f) const

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -125,7 +125,7 @@ struct rgw_data_sync_info {
     JSONDecoder::decode_json("num_shards", num_shards, obj);
     JSONDecoder::decode_json("instance_id", instance_id, obj);
   }
-  static void generate_test_instances(std::list<rgw_data_sync_info*>& o);
+  static std::list<rgw_data_sync_info> generate_test_instances();
 
   rgw_data_sync_info() : state((int)StateInit), num_shards(0) {}
 };
@@ -203,7 +203,7 @@ struct rgw_data_sync_marker {
     JSONDecoder::decode_json("timestamp", t, obj);
     timestamp = t.to_real_time();
   }
-  static void generate_test_instances(std::list<rgw_data_sync_marker*>& o);
+  static std::list<rgw_data_sync_marker> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_data_sync_marker)
 
@@ -235,7 +235,7 @@ struct rgw_data_sync_status {
     JSONDecoder::decode_json("info", sync_info, obj);
     JSONDecoder::decode_json("markers", sync_markers, obj);
   }
-  static void generate_test_instances(std::list<rgw_data_sync_status*>& o);
+  static std::list<rgw_data_sync_status> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_data_sync_status)
 

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -91,13 +91,15 @@ void rgw_data_change::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("gen", gen, obj);
 }
 
-void rgw_data_change::generate_test_instances(std::list<rgw_data_change *>& l) {
-  l.push_back(new rgw_data_change{});
-  l.push_back(new rgw_data_change);
-  l.back()->entity_type = ENTITY_TYPE_BUCKET;
-  l.back()->key = "bucket_name";
-  l.back()->timestamp = ceph::real_clock::zero();
-  l.back()->gen = 0;
+std::list<rgw_data_change> rgw_data_change::generate_test_instances() {
+  std::list<rgw_data_change> l;
+  l.push_back(rgw_data_change{});
+  l.push_back(rgw_data_change{});
+  l.back().entity_type = ENTITY_TYPE_BUCKET;
+  l.back().key = "bucket_name";
+  l.back().timestamp = ceph::real_clock::zero();
+  l.back().gen = 0;
+  return l;
 }
 
 void rgw_data_change_log_entry::dump(Formatter *f) const

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -102,7 +102,7 @@ struct rgw_data_change {
 
   void dump(ceph::Formatter* f) const;
   void decode_json(JSONObj* obj);
-  static void generate_test_instances(std::list<rgw_data_change *>& l);
+  static std::list<rgw_data_change> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_data_change)
 inline std::ostream& operator <<(std::ostream& m,

--- a/src/rgw/driver/rados/rgw_obj_manifest.cc
+++ b/src/rgw/driver/rados/rgw_obj_manifest.cc
@@ -271,23 +271,29 @@ int RGWObjManifest::generator::create_begin(CephContext *cct, RGWObjManifest *_m
   return 0;
 }
 
-void RGWObjManifestPart::generate_test_instances(std::list<RGWObjManifestPart*>& o)
+std::list<RGWObjManifestPart> RGWObjManifestPart::generate_test_instances()
 {
-  o.push_back(new RGWObjManifestPart);
+  std::list<RGWObjManifestPart> o;
 
-  RGWObjManifestPart *p = new RGWObjManifestPart;
+  o.push_back(RGWObjManifestPart{});
+
+  RGWObjManifestPart p;
   rgw_bucket b;
   init_bucket(&b, "tenant", "bucket", ".pool", ".index_pool", "marker_", "12");
 
-  p->loc = rgw_obj(b, "object");
-  p->loc_ofs = 512 * 1024;
-  p->size = 128 * 1024;
-  o.push_back(p);
+  p.loc = rgw_obj(b, "object");
+  p.loc_ofs = 512 * 1024;
+  p.size = 128 * 1024;
+  o.push_back(std::move(p));
+
+  return o;
 }
 
-void RGWObjManifest::generate_test_instances(std::list<RGWObjManifest*>& o)
+std::list<RGWObjManifest> RGWObjManifest::generate_test_instances()
 {
-  RGWObjManifest *m = new RGWObjManifest;
+  std::list<RGWObjManifest> o;
+
+  RGWObjManifest m;
   map<uint64_t, RGWObjManifestPart> objs;
   uint64_t total_size = 0;
   for (int i = 0; i<10; i++) {
@@ -300,9 +306,10 @@ void RGWObjManifest::generate_test_instances(std::list<RGWObjManifest*>& o)
     total_size += p.size;
     objs[total_size] = p;
   }
-  m->set_explicit(total_size, objs);
-  o.push_back(m);
-  o.push_back(new RGWObjManifest);
+  m.set_explicit(total_size, objs);
+  o.push_back(std::move(m));
+  o.push_back(RGWObjManifest{});
+  return o;
 }
 
 void RGWObjManifestPart::dump(Formatter *f) const
@@ -367,16 +374,18 @@ void RGWObjManifestRule::dump(Formatter *f) const
   encode_json("override_prefix", override_prefix, f);
 }
 
-void RGWObjManifestRule::generate_test_instances(std::list<RGWObjManifestRule*>& o)
+std::list<RGWObjManifestRule> RGWObjManifestRule::generate_test_instances()
 {
-  RGWObjManifestRule *r = new RGWObjManifestRule;
-  r->start_part_num = 0;
-  r->start_ofs = 0;
-  r->part_size = 512 * 1024;
-  r->stripe_max_size = 512 * 1024 * 1024;
-  r->override_prefix = "override_prefix";
-  o.push_back(r);
-  o.push_back(new RGWObjManifestRule);
+  std::list<RGWObjManifestRule> o;
+  RGWObjManifestRule r;
+  r.start_part_num = 0;
+  r.start_ofs = 0;
+  r.part_size = 512 * 1024;
+  r.stripe_max_size = 512 * 1024 * 1024;
+  r.override_prefix = "override_prefix";
+  o.push_back(std::move(r));
+  o.push_back(RGWObjManifestRule{});
+  return o;
 }
 
 void rgw_obj_select::dump(Formatter *f) const
@@ -394,18 +403,18 @@ void RGWObjTier::dump(Formatter *f) const
   encode_json("is_multipart_upload", is_multipart_upload, f);
 }
 
-void RGWObjTier::generate_test_instances(std::list<RGWObjTier*>& o)
+std::list<RGWObjTier> RGWObjTier::generate_test_instances()
 {
-  RGWObjTier *t = new RGWObjTier;
-  t->name = "name";
-  std::list<RGWZoneGroupPlacementTier *> tiers;
-  RGWZoneGroupPlacementTier::generate_test_instances(tiers);
-  for (auto iter = tiers.begin(); iter != tiers.end(); ++iter) {
-    t->tier_placement = *(*iter);
+  std::list<RGWObjTier> o;
+  RGWObjTier t;
+  t.name = "name";
+  for (auto& tier : RGWZoneGroupPlacementTier::generate_test_instances()) {
+    t.tier_placement = tier;
   }
-  t->is_multipart_upload = true;
-  o.push_back(t);
-  o.push_back(new RGWObjTier);
+  t.is_multipart_upload = true;
+  o.push_back(std::move(t));
+  o.push_back(RGWObjTier{});
+  return o;
 }
 
 // returns true on success, false on failure

--- a/src/rgw/driver/rados/rgw_obj_manifest.h
+++ b/src/rgw/driver/rados/rgw_obj_manifest.h
@@ -111,7 +111,7 @@ struct RGWObjManifestPart {
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWObjManifestPart*>& o);
+  static std::list<RGWObjManifestPart> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWObjManifestPart)
 
@@ -163,7 +163,7 @@ struct RGWObjManifestRule {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWObjManifestRule*>& o);
+  static std::list<RGWObjManifestRule> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWObjManifestRule)
 
@@ -190,7 +190,7 @@ struct RGWObjTier {
       DECODE_FINISH(bl);
     }
     void dump(Formatter *f) const;
-    static void generate_test_instances(std::list<RGWObjTier*>& o);
+    static std::list<RGWObjTier> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWObjTier)
 
@@ -374,7 +374,7 @@ public:
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWObjManifest*>& o);
+  static std::list<RGWObjManifest> generate_test_instances();
 
   int append(const DoutPrefixProvider *dpp, RGWObjManifest& m, const RGWZoneGroup& zonegroup,
              const RGWZoneParams& zone_params);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11574,15 +11574,17 @@ int RGWRados::delete_obj_aio(const DoutPrefixProvider *dpp, const rgw_obj& obj,
   return ret;
 } // delete_obj_aio
 
-void objexp_hint_entry::generate_test_instances(list<objexp_hint_entry*>& o)
+list<objexp_hint_entry> objexp_hint_entry::generate_test_instances()
 {
-  auto it = new objexp_hint_entry;
-  it->tenant = "tenant1";
-  it->bucket_name = "bucket1";
-  it->bucket_id = "1234";
-  it->obj_key = rgw_obj_key("obj");
-  o.push_back(it);
-  o.push_back(new objexp_hint_entry);
+  list<objexp_hint_entry> o;
+  objexp_hint_entry it;
+  it.tenant = "tenant1";
+  it.bucket_name = "bucket1";
+  it.bucket_id = "1234";
+  it.obj_key = rgw_obj_key("obj");
+  o.push_back(std::move(it));
+  o.push_back(objexp_hint_entry{});
+  return o;
 }
 
 void objexp_hint_entry::dump(Formatter *f) const
@@ -11597,12 +11599,14 @@ void objexp_hint_entry::dump(Formatter *f) const
   f->close_section();
 }
 
-void RGWOLHInfo::generate_test_instances(list<RGWOLHInfo*> &o)
+list<RGWOLHInfo> RGWOLHInfo::generate_test_instances()
 {
-  RGWOLHInfo *olh = new RGWOLHInfo;
-  olh->removed = false;
+  list<RGWOLHInfo> o;
+  RGWOLHInfo olh;
+  olh.removed = false;
   o.push_back(olh);
-  o.push_back(new RGWOLHInfo);
+  o.push_back(RGWOLHInfo{});
+  return o;
 }
 
 void RGWOLHInfo::dump(Formatter *f) const
@@ -11617,9 +11621,11 @@ void RGWOLHPendingInfo::dump(Formatter *f) const
   encode_json("time", ut, f);
 }
 
-void RGWOLHPendingInfo::generate_test_instances(list<RGWOLHPendingInfo*>& o)
+list<RGWOLHPendingInfo> RGWOLHPendingInfo::generate_test_instances()
 {
-  auto it = new RGWOLHPendingInfo;
-  it->time = ceph::real_clock::zero();
-  o.push_back(it);
+  list<RGWOLHPendingInfo> o;
+  RGWOLHPendingInfo it;
+  it.time = ceph::real_clock::zero();
+  o.push_back(std::move(it));
+  return o;
 }

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -112,7 +112,7 @@ struct RGWOLHInfo {
      decode(removed, bl);
      DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<RGWOLHInfo*>& o);
+  static std::list<RGWOLHInfo> generate_test_instances();
   void dump(Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(RGWOLHInfo)
@@ -135,7 +135,7 @@ struct RGWOLHPendingInfo {
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWOLHPendingInfo*>& o);
+  static std::list<RGWOLHPendingInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWOLHPendingInfo)
 
@@ -298,7 +298,7 @@ struct objexp_hint_entry {
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<objexp_hint_entry*>& o);
+  static std::list<objexp_hint_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(objexp_hint_entry)
 

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -60,10 +60,12 @@ struct RGWUID
   void dump(Formatter *f) const {
     f->dump_string("user_id", id);
   }
-  static void generate_test_instances(std::list<RGWUID*>& o) {
-    o.push_back(new RGWUID);
-    o.push_back(new RGWUID);
-    o.back()->id = "test:tester";
+  static std::list<RGWUID> generate_test_instances() {
+    std::list<RGWUID> o;
+    o.push_back(RGWUID{});
+    o.push_back(RGWUID{});
+    o.back().id = "test:tester";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(RGWUID)

--- a/src/rgw/driver/rados/roles.cc
+++ b/src/rgw/driver/rados/roles.cc
@@ -163,12 +163,14 @@ void resource_metadata::dump(ceph::Formatter* f) const
   encode_json("role_id", role_id, f);
 }
 
-void resource_metadata::generate_test_instances(std::list<resource_metadata*>& o)
+std::list<resource_metadata> resource_metadata::generate_test_instances()
 {
-  o.push_back(new resource_metadata);
-  auto m = new resource_metadata;
-  m->role_id = "id";
-  o.push_back(m);
+  std::list<resource_metadata> o;
+  o.push_back(resource_metadata{});
+  resource_metadata m;
+  m.role_id = "id";
+  o.push_back(std::move(m));
+  return o;
 }
 
 } // namespace rgwrados::roles

--- a/src/rgw/driver/rados/roles.h
+++ b/src/rgw/driver/rados/roles.h
@@ -80,7 +80,7 @@ struct resource_metadata {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<resource_metadata*>& o);
+  static std::list<resource_metadata> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(resource_metadata);
 

--- a/src/rgw/driver/rados/users.cc
+++ b/src/rgw/driver/rados/users.cc
@@ -163,12 +163,14 @@ void resource_metadata::dump(ceph::Formatter* f) const
   encode_json("user_id", user_id, f);
 }
 
-void resource_metadata::generate_test_instances(std::list<resource_metadata*>& o)
+std::list<resource_metadata> resource_metadata::generate_test_instances()
 {
-  o.push_back(new resource_metadata);
-  auto m = new resource_metadata;
-  m->user_id = "uid";
-  o.push_back(m);
+  std::list<resource_metadata> o;
+  o.push_back(resource_metadata{});
+  resource_metadata m;;
+  m.user_id = "uid";
+  o.push_back(std::move(m));
+  return o;
 }
 
 } // namespace rgwrados::users

--- a/src/rgw/driver/rados/users.h
+++ b/src/rgw/driver/rados/users.h
@@ -80,7 +80,7 @@ struct resource_metadata {
   }
 
   void dump(ceph::Formatter* f) const;
-  static void generate_test_instances(std::list<resource_metadata*>& o);
+  static std::list<resource_metadata> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(resource_metadata);
 

--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -254,12 +254,14 @@ bool ACLOwner::empty() const
       ), id);
 }
 
-void ACLPermission::generate_test_instances(list<ACLPermission*>& o)
+list<ACLPermission> ACLPermission::generate_test_instances()
 {
-  ACLPermission *p = new ACLPermission;
-  p->set_permissions(RGW_PERM_WRITE_ACP);
-  o.push_back(p);
-  o.push_back(new ACLPermission);
+  list<ACLPermission> o;
+  ACLPermission p;
+  p.set_permissions(RGW_PERM_WRITE_ACP);
+  o.push_back(std::move(p));
+  o.push_back(ACLPermission{});
+  return o;
 }
 
 void ACLPermission::dump(Formatter *f) const
@@ -301,69 +303,70 @@ void ACLGrant::dump(Formatter *f) const
   encode_json("permission", permission, f);
 }
 
-void ACLGrant::generate_test_instances(list<ACLGrant*>& o)
+list<ACLGrant> ACLGrant::generate_test_instances()
 {
-  ACLGrant *g1 = new ACLGrant;
-  g1->set_canon(rgw_user{"rgw"}, "Mr. RGW", RGW_PERM_READ);
-  o.push_back(g1);
+  list<ACLGrant> o;
+  ACLGrant g1;
+  g1.set_canon(rgw_user{"rgw"}, "Mr. RGW", RGW_PERM_READ);
+  o.push_back(std::move(g1));
 
-  ACLGrant *g2 = new ACLGrant;
-  g1->set_group(ACL_GROUP_AUTHENTICATED_USERS, RGW_PERM_WRITE);
-  o.push_back(g2);
+  ACLGrant g2;
+  g1.set_group(ACL_GROUP_AUTHENTICATED_USERS, RGW_PERM_WRITE);
+  o.push_back(std::move(g2));
 
-  o.push_back(new ACLGrant);
+  o.push_back(ACLGrant{});
+  return o;
 }
 
-void ACLGranteeType::generate_test_instances(list<ACLGranteeType*>& o)
+list<ACLGranteeType> ACLGranteeType::generate_test_instances()
 {
-  o.push_back(new ACLGranteeType(ACL_TYPE_CANON_USER));
-  o.push_back(new ACLGranteeType);
+  list<ACLGranteeType> o;
+  o.push_back(ACLGranteeType(ACL_TYPE_CANON_USER));
+  o.push_back(ACLGranteeType{});
+  return o;
 }
 
-void RGWAccessControlList::generate_test_instances(list<RGWAccessControlList*>& o)
+list<RGWAccessControlList> RGWAccessControlList::generate_test_instances()
 {
-  RGWAccessControlList *acl = new RGWAccessControlList;
-
-  list<ACLGrant *> grants;
-  ACLGrant::generate_test_instances(grants);
-  for (ACLGrant* grant : grants) {
-    acl->add_grant(*grant);
-    delete grant;
+  list<RGWAccessControlList> o;
+  RGWAccessControlList acl;
+  list<ACLGrant> grants = ACLGrant::generate_test_instances();
+  for (ACLGrant& grant : grants) {
+    acl.add_grant(grant);
   }
-  o.push_back(acl);
-  o.push_back(new RGWAccessControlList);
+  o.push_back(std::move(acl));
+  o.push_back(RGWAccessControlList{});
+  return o;
 }
 
-void ACLOwner::generate_test_instances(list<ACLOwner*>& o)
+list<ACLOwner> ACLOwner::generate_test_instances()
 {
-  ACLOwner *owner = new ACLOwner;
-  owner->id = "rgw";
-  owner->display_name = "Mr. RGW";
-  o.push_back(owner);
-  o.push_back(new ACLOwner);
+  list<ACLOwner> o;
+  ACLOwner owner;
+  owner.id = "rgw";
+  owner.display_name = "Mr. RGW";
+  o.push_back(std::move(owner));
+  o.push_back(ACLOwner{});
+  return o;
 }
 
-void RGWAccessControlPolicy::generate_test_instances(list<RGWAccessControlPolicy*>& o)
+list<RGWAccessControlPolicy> RGWAccessControlPolicy::generate_test_instances()
 {
-  list<RGWAccessControlList *> acl_list;
-  list<RGWAccessControlList *>::iterator iter;
-  for (iter = acl_list.begin(); iter != acl_list.end(); ++iter) {
-    RGWAccessControlList::generate_test_instances(acl_list);
-    iter = acl_list.begin();
+  list<RGWAccessControlPolicy> o;
+  list<RGWAccessControlList> acl_list = RGWAccessControlList::generate_test_instances();
+  for (auto& acl : acl_list) {
+    RGWAccessControlPolicy p;
+    p.acl = acl;
 
-    RGWAccessControlPolicy *p = new RGWAccessControlPolicy;
-    RGWAccessControlList *l = *iter;
-    p->acl = *l;
+    p.owner.id = rgw_user{"rgw"};
+    p.owner.display_name = "radosgw";
 
-    p->owner.id = rgw_user{"rgw"};
-    p->owner.display_name = "radosgw";
-
-    o.push_back(p);
-
-    delete l;
+    o.push_back(std::move(p));
   }
 
-  o.push_back(new RGWAccessControlPolicy);
+  o.push_back(RGWAccessControlPolicy{});
+
+  return o;
 }
 
 void RGWAccessControlList::dump(Formatter *f) const

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -176,7 +176,7 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<ACLGrant*>& o);
+  static std::list<ACLGrant> generate_test_instances();
 
   static ACLGroupTypeEnum uri_to_group(std::string_view uri);
 
@@ -328,7 +328,7 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWAccessControlList*>& o);
+  static std::list<RGWAccessControlList> generate_test_instances();
 
   bool empty() const { return grant_map.empty(); }
 
@@ -374,7 +374,7 @@ struct ACLOwner {
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<ACLOwner*>& o);
+  static std::list<ACLOwner> generate_test_instances();
 
   bool empty() const;
 
@@ -414,7 +414,7 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWAccessControlPolicy*>& o);
+  static std::list<RGWAccessControlPolicy> generate_test_instances();
   void decode_owner(bufferlist::const_iterator& bl) { // sometimes we only need that, should be faster
     DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl);
     decode(owner, bl);

--- a/src/rgw/rgw_acl_types.h
+++ b/src/rgw/rgw_acl_types.h
@@ -78,7 +78,7 @@ struct RGWAccessKey {
   void dump(Formatter *f) const;
   void dump_plain(Formatter *f) const;
   void dump(Formatter *f, const std::string& user, bool swift) const;
-  static void generate_test_instances(std::list<RGWAccessKey*>& o);
+  static std::list<RGWAccessKey> generate_test_instances();
 
   void decode_json(JSONObj *obj);
   void decode_json(JSONObj *obj, bool swift);
@@ -105,7 +105,7 @@ struct RGWSubUser {
   }
   void dump(Formatter *f) const;
   void dump(Formatter *f, const std::string& user) const;
-  static void generate_test_instances(std::list<RGWSubUser*>& o);
+  static std::list<RGWSubUser> generate_test_instances();
 
   void decode_json(JSONObj *obj);
 };
@@ -137,7 +137,7 @@ public:
   bool is_valid_cap_type(const std::string& tp);
   void dump(Formatter *f) const;
   void dump(Formatter *f, const char *name) const;
-  static void generate_test_instances(std::list<RGWUserCaps*>& o);
+  static std::list<RGWUserCaps> generate_test_instances();
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(RGWUserCaps)
@@ -179,7 +179,7 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<ACLPermission*>& o);
+  static std::list<ACLPermission> generate_test_instances();
 
   friend bool operator==(const ACLPermission& lhs, const ACLPermission& rhs);
   friend bool operator!=(const ACLPermission& lhs, const ACLPermission& rhs);
@@ -210,7 +210,7 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<ACLGranteeType*>& o);
+  static std::list<ACLGranteeType> generate_test_instances();
 
   friend bool operator==(const ACLGranteeType& lhs, const ACLGranteeType& rhs);
   friend bool operator!=(const ACLGranteeType& lhs, const ACLGranteeType& rhs);

--- a/src/rgw/rgw_basic_types.cc
+++ b/src/rgw/rgw_basic_types.cc
@@ -78,12 +78,14 @@ std::string rgw_bucket::get_key(char tenant_delim, char id_delim, size_t reserve
   return key;
 }
 
-void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
+list<rgw_bucket> rgw_bucket::generate_test_instances()
 {
-  rgw_bucket *b = new rgw_bucket;
-  init_bucket(b, "tenant", "name", "pool", ".index_pool", "marker", "123");
-  o.push_back(b);
-  o.push_back(new rgw_bucket);
+  list<rgw_bucket> o;
+  rgw_bucket b;
+  init_bucket(&b, "tenant", "name", "pool", ".index_pool", "marker", "123");
+  o.push_back(std::move(b));
+  o.push_back(rgw_bucket{});
+  return o;
 }
 
 std::string rgw_bucket_shard::get_key(char tenant_delim, char id_delim,
@@ -120,12 +122,14 @@ void decode_json_obj(rgw_zone_id& zid, JSONObj *obj)
   decode_json_obj(zid.id, obj);
 }
 
-void rgw_user::generate_test_instances(list<rgw_user*>& o)
+list<rgw_user> rgw_user::generate_test_instances()
 {
-  rgw_user *u = new rgw_user("tenant", "user");
+  list<rgw_user> o;
+  rgw_user u("tenant", "user");
 
   o.push_back(u);
-  o.push_back(new rgw_user);
+  o.push_back(rgw_user{});
+  return o;
 }
 
 void rgw_data_placement_target::dump(Formatter *f) const

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -81,9 +81,11 @@ struct rgw_zone_id {
     f->dump_string("id", id);
   }
 
-  static void generate_test_instances(std::list<rgw_zone_id*>& o) {
-    o.push_back(new rgw_zone_id);
-    o.push_back(new rgw_zone_id("id"));
+  static std::list<rgw_zone_id> generate_test_instances() {
+    std::list<rgw_zone_id> o;
+    o.push_back(rgw_zone_id{});
+    o.push_back(rgw_zone_id("id"));
+    return o;
   }
 
   void clear() {
@@ -318,6 +320,6 @@ struct RGWUploadPartInfo {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWUploadPartInfo*>& o);
+  static std::list<RGWUploadPartInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWUploadPartInfo)

--- a/src/rgw/rgw_bucket_encryption.h
+++ b/src/rgw/rgw_bucket_encryption.h
@@ -137,6 +137,6 @@ public:
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWBucketEncryptionConfig*>& o);
+  static std::list<RGWBucketEncryptionConfig> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWBucketEncryptionConfig)

--- a/src/rgw/rgw_bucket_types.h
+++ b/src/rgw/rgw_bucket_types.h
@@ -161,7 +161,7 @@ struct rgw_bucket {
 
   void dump(ceph::Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_bucket*>& o);
+  static std::list<rgw_bucket> generate_test_instances();
 
   rgw_bucket& operator=(const rgw_bucket&) = default;
 

--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -357,12 +357,14 @@ ObjectCache::~ObjectCache()
   }
 }
 
-void ObjectMetaInfo::generate_test_instances(list<ObjectMetaInfo*>& o)
+list<ObjectMetaInfo> ObjectMetaInfo::generate_test_instances()
 {
-  ObjectMetaInfo *m = new ObjectMetaInfo;
-  m->size = 1024 * 1024;
-  o.push_back(m);
-  o.push_back(new ObjectMetaInfo);
+  list<ObjectMetaInfo> o;
+  ObjectMetaInfo m;
+  m.size = 1024 * 1024;
+  o.push_back(std::move(m));
+  o.push_back(ObjectMetaInfo{});
+  return o;
 }
 
 void ObjectMetaInfo::dump(Formatter *f) const
@@ -371,25 +373,27 @@ void ObjectMetaInfo::dump(Formatter *f) const
   encode_json("mtime", utime_t(mtime), f);
 }
 
-void ObjectCacheInfo::generate_test_instances(list<ObjectCacheInfo*>& o)
+list<ObjectCacheInfo> ObjectCacheInfo::generate_test_instances()
 {
   using ceph::encode;
-  ObjectCacheInfo *i = new ObjectCacheInfo;
-  i->status = 0;
-  i->flags = CACHE_FLAG_MODIFY_XATTRS;
+  list<ObjectCacheInfo> o;
+  ObjectCacheInfo i;
+  i.status = 0;
+  i.flags = CACHE_FLAG_MODIFY_XATTRS;
   string s = "this is a string";
   string s2 = "this is a another string";
   bufferlist data, data2;
   encode(s, data);
   encode(s2, data2);
-  i->data = data;
-  i->xattrs["x1"] = data;
-  i->xattrs["x2"] = data2;
-  i->rm_xattrs["r2"] = data2;
-  i->rm_xattrs["r3"] = data;
-  i->meta.size = 512 * 1024;
-  o.push_back(i);
-  o.push_back(new ObjectCacheInfo);
+  i.data = data;
+  i.xattrs["x1"] = data;
+  i.xattrs["x2"] = data2;
+  i.rm_xattrs["r2"] = data2;
+  i.rm_xattrs["r3"] = data;
+  i.meta.size = 512 * 1024;
+  o.push_back(std::move(i));
+  o.push_back(ObjectCacheInfo{});
+  return o;
 }
 
 void ObjectCacheInfo::dump(Formatter *f) const
@@ -403,9 +407,11 @@ void ObjectCacheInfo::dump(Formatter *f) const
 
 }
 
-void RGWCacheNotifyInfo::generate_test_instances(list<RGWCacheNotifyInfo*>& o)
+list<RGWCacheNotifyInfo> RGWCacheNotifyInfo::generate_test_instances()
 {
-  o.push_back(new RGWCacheNotifyInfo);
+  list<RGWCacheNotifyInfo> o;
+  o.push_back(RGWCacheNotifyInfo{});
+  return o;
 }
 
 void RGWCacheNotifyInfo::dump(Formatter *f) const

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -45,7 +45,7 @@ struct ObjectMetaInfo {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<ObjectMetaInfo*>& o);
+  static std::list<ObjectMetaInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ObjectMetaInfo)
 
@@ -90,7 +90,7 @@ struct ObjectCacheInfo {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<ObjectCacheInfo*>& o);
+  static std::list<ObjectCacheInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ObjectCacheInfo)
 
@@ -122,7 +122,7 @@ struct RGWCacheNotifyInfo {
     DECODE_FINISH(ibl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWCacheNotifyInfo*>& o);
+  static std::list<RGWCacheNotifyInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWCacheNotifyInfo)
 inline std::ostream& operator <<(std::ostream& m, const RGWCacheNotifyInfo& cni) {

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2069,13 +2069,15 @@ void RGWUserCaps::dump(Formatter *f) const
   dump(f, "caps");
 }
 
-void RGWUserCaps::generate_test_instances(list<RGWUserCaps*>& o)
+list<RGWUserCaps> RGWUserCaps::generate_test_instances()
 {
-  o.push_back(new RGWUserCaps);
-  RGWUserCaps *caps = new RGWUserCaps;
-  caps->add_cap("read");
-  caps->add_cap("write");
-  o.push_back(caps);
+  list<RGWUserCaps> o;
+  o.push_back(RGWUserCaps{});
+  RGWUserCaps caps;
+  caps.add_cap("read");
+  caps.add_cap("write");
+  o.push_back(std::move(caps));
+  return o;
 }
 
 void RGWUserCaps::dump(Formatter *f, const char *name) const
@@ -2207,14 +2209,16 @@ void rgw_raw_obj::decode_from_rgw_obj(bufferlist::const_iterator& bl)
   pool = old_obj.get_explicit_data_pool();
 }
 
-void rgw_raw_obj::generate_test_instances(std::list<rgw_raw_obj*>& o)
+std::list<rgw_raw_obj> rgw_raw_obj::generate_test_instances()
 {
-  rgw_raw_obj *r = new rgw_raw_obj;
-  r->oid = "foo";
-  r->loc = "bar";
-  r->pool.name = "baz";
-  r->pool.ns = "ns";
-  o.push_back(r);
+  std::list<rgw_raw_obj> o;
+  rgw_raw_obj r;
+  r.oid = "foo";
+  r.loc = "bar";
+  r.pool.name = "baz";
+  r.pool.ns = "ns";
+  o.push_back(std::move(r));
+  return o;
 }
 
 static struct rgw_name_to_flag op_type_mapping[] = { {"*",  RGW_OP_TYPE_ALL},
@@ -2512,15 +2516,17 @@ void encode_json(const char *name, const RGWUserCaps& val, Formatter *f)
   val.dump(f, name);
 }
 
-void RGWBucketEnt::generate_test_instances(list<RGWBucketEnt*>& o)
+list<RGWBucketEnt> RGWBucketEnt::generate_test_instances()
 {
-  RGWBucketEnt *e = new RGWBucketEnt;
-  init_bucket(&e->bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
-  e->size = 1024;
-  e->size_rounded = 4096;
-  e->count = 1;
-  o.push_back(e);
-  o.push_back(new RGWBucketEnt);
+  list<RGWBucketEnt> o;
+  RGWBucketEnt e;
+  init_bucket(&e.bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
+  e.size = 1024;
+  e.size_rounded = 4096;
+  e.count = 1;
+  o.push_back(std::move(e));
+  o.push_back(RGWBucketEnt{});
+  return o;
 }
 
 void RGWBucketEnt::dump(Formatter *f) const
@@ -2534,13 +2540,14 @@ void RGWBucketEnt::dump(Formatter *f) const
   encode_json("placement_rule", placement_rule.to_str(), f);
 }
 
-void rgw_obj::generate_test_instances(list<rgw_obj*>& o)
+list<rgw_obj> rgw_obj::generate_test_instances()
 {
+  list<rgw_obj> o;
   rgw_bucket b;
   init_bucket(&b, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
-  rgw_obj *obj = new rgw_obj(b, "object");
-  o.push_back(obj);
-  o.push_back(new rgw_obj);
+  o.push_back(rgw_obj(b, "object"));
+  o.push_back(rgw_obj{});
+  return o;
 }
 
 void rgw_bucket_placement::dump(Formatter *f) const
@@ -2549,8 +2556,9 @@ void rgw_bucket_placement::dump(Formatter *f) const
   encode_json("placement_rule", placement_rule, f);
 }
 
-void RGWBucketInfo::generate_test_instances(list<RGWBucketInfo*>& o)
+list<RGWBucketInfo> RGWBucketInfo::generate_test_instances()
 {
+  list<RGWBucketInfo> o;
   // Since things without a log will have one synthesized on decode,
   // ensure the things we attempt to encode will have one added so we
   // round-trip properly.
@@ -2565,15 +2573,16 @@ void RGWBucketInfo::generate_test_instances(list<RGWBucketInfo*>& o)
   };
 
 
-  RGWBucketInfo *i = new RGWBucketInfo;
-  init_bucket(&i->bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
-  i->owner = "owner";
-  i->flags = BUCKET_SUSPENDED;
-  gen_layout(i->layout);
-  o.push_back(i);
-  i = new RGWBucketInfo;
-  gen_layout(i->layout);
-  o.push_back(i);
+  RGWBucketInfo i;
+  init_bucket(&i.bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
+  i.owner = "owner";
+  i.flags = BUCKET_SUSPENDED;
+  gen_layout(i.layout);
+  o.push_back(std::move(i));
+  i = RGWBucketInfo{};
+  gen_layout(i.layout);
+  o.push_back(std::move(i));
+  return o;
 }
 
 void RGWBucketInfo::dump(Formatter *f) const
@@ -2648,17 +2657,18 @@ void RGWBucketInfo::decode_json(JSONObj *obj) {
   }
 }
 
-void RGWUserInfo::generate_test_instances(list<RGWUserInfo*>& o)
+list<RGWUserInfo> RGWUserInfo::generate_test_instances()
 {
-  RGWUserInfo *i = new RGWUserInfo;
-  i->user_id = "user_id";
-  i->display_name =  "display_name";
-  i->user_email = "user@email";
-  i->account_id = "RGW12345678901234567";
-  i->path = "/";
-  i->create_date = ceph::real_time{std::chrono::hours(1)};
-  i->tags.emplace("key", "value");
-  i->group_ids.insert("group");
+  list<RGWUserInfo> o;
+  RGWUserInfo i;
+  i.user_id = "user_id";
+  i.display_name =  "display_name";
+  i.user_email = "user@email";
+  i.account_id = "RGW12345678901234567";
+  i.path = "/";
+  i.create_date = ceph::real_time{std::chrono::hours(1)};
+  i.tags.emplace("key", "value");
+  i.group_ids.insert("group");
   RGWAccessKey k1, k2;
   k1.id = "id1";
   k1.key = "key1";
@@ -2667,12 +2677,13 @@ void RGWUserInfo::generate_test_instances(list<RGWUserInfo*>& o)
   RGWSubUser u;
   u.name = "id2";
   u.perm_mask = 0x1;
-  i->access_keys[k1.id] = k1;
-  i->swift_keys[k2.id] = k2;
-  i->subusers[u.name] = u;
-  o.push_back(i);
+  i.access_keys[k1.id] = k1;
+  i.swift_keys[k2.id] = k2;
+  i.subusers[u.name] = u;
+  o.push_back(std::move(i));
 
-  o.push_back(new RGWUserInfo);
+  o.push_back(RGWUserInfo{});
+  return o;
 }
 
 static void user_info_dump_subuser(const char *name, const RGWSubUser& subuser, Formatter *f, void *parent)
@@ -2957,13 +2968,15 @@ void RGWUserInfo::decode_json(JSONObj *obj)
 }
 
 
-void RGWSubUser::generate_test_instances(list<RGWSubUser*>& o)
+list<RGWSubUser> RGWSubUser::generate_test_instances()
 {
-  RGWSubUser *u = new RGWSubUser;
-  u->name = "name";
-  u->perm_mask = 0xf;
-  o.push_back(u);
-  o.push_back(new RGWSubUser);
+  list<RGWSubUser> o;
+  RGWSubUser u;
+  u.name = "name";
+  u.perm_mask = 0xf;
+  o.push_back(std::move(u));
+  o.push_back(RGWSubUser{});
+  return o;
 }
 
 void RGWSubUser::dump(Formatter *f) const
@@ -3010,14 +3023,16 @@ void RGWSubUser::decode_json(JSONObj *obj)
   perm_mask = str_to_perm(perm_str);
 }
 
-void RGWAccessKey::generate_test_instances(list<RGWAccessKey*>& o)
+list<RGWAccessKey> RGWAccessKey::generate_test_instances()
 {
-  RGWAccessKey *k = new RGWAccessKey;
-  k->id = "id";
-  k->key = "key";
-  k->subuser = "subuser";
-  o.push_back(k);
-  o.push_back(new RGWAccessKey);
+  list<RGWAccessKey> o;
+  RGWAccessKey k;
+  k.id = "id";
+  k.key = "key";
+  k.subuser = "subuser";
+  o.push_back(std::move(k));
+  o.push_back(RGWAccessKey{});
+  return o;
 }
 
 void RGWAccessKey::dump(Formatter *f) const
@@ -3117,20 +3132,22 @@ void RGWAccountInfo::decode_json(JSONObj* obj)
   JSONDecoder::decode_json("max_access_keys", max_access_keys, obj);
 }
 
-void RGWAccountInfo::generate_test_instances(std::list<RGWAccountInfo*>& o)
+std::list<RGWAccountInfo> RGWAccountInfo::generate_test_instances()
 {
-  o.push_back(new RGWAccountInfo);
-  auto p = new RGWAccountInfo;
-  p->id = "account1";
-  p->tenant = "tenant1";
-  p->name = "name1";
-  p->email = "email@example.com";
-  p->max_users = 10;
-  p->max_roles = 10;
-  p->max_groups = 10;
-  p->max_buckets = 10;
-  p->max_access_keys = 10;
-  o.push_back(p);
+  std::list<RGWAccountInfo> o;
+  o.push_back(RGWAccountInfo{});
+  auto p = RGWAccountInfo{};
+  p.id = "account1";
+  p.tenant = "tenant1";
+  p.name = "name1";
+  p.email = "email@example.com";
+  p.max_users = 10;
+  p.max_roles = 10;
+  p.max_groups = 10;
+  p.max_buckets = 10;
+  p.max_access_keys = 10;
+  o.push_back(std::move(p));
+  return o;
 }
 
 void RGWGroupInfo::dump(Formatter * const f) const
@@ -3151,16 +3168,18 @@ void RGWGroupInfo::decode_json(JSONObj* obj)
   JSONDecoder::decode_json("account_id", account_id, obj);
 }
 
-void RGWGroupInfo::generate_test_instances(std::list<RGWGroupInfo*>& o)
+std::list<RGWGroupInfo> RGWGroupInfo::generate_test_instances()
 {
-  o.push_back(new RGWGroupInfo);
-  auto p = new RGWGroupInfo;
-  p->id = "id";
-  p->tenant = "tenant";
-  p->name = "name";
-  p->path = "/path/";
-  p->account_id = "account";
-  o.push_back(p);
+  std::list<RGWGroupInfo> o;
+  o.push_back(RGWGroupInfo{});
+  auto p = RGWGroupInfo{};
+  p.id = "id";
+  p.tenant = "tenant";
+  p.name = "name";
+  p.path = "/path/";
+  p.account_id = "account";
+  o.push_back(std::move(p));
+  return o;
 }
 
 void RGWStorageStats::dump(Formatter *f) const

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -799,7 +799,7 @@ struct RGWUserInfo
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWUserInfo*>& o);
+  static std::list<RGWUserInfo> generate_test_instances();
 
   void decode_json(JSONObj *obj);
 };
@@ -865,7 +865,7 @@ struct RGWAccountInfo {
 
   void dump(Formatter* f) const;
   void decode_json(JSONObj* obj);
-  static void generate_test_instances(std::list<RGWAccountInfo*>& o);
+  static std::list<RGWAccountInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWAccountInfo)
 
@@ -899,7 +899,7 @@ struct RGWGroupInfo {
 
   void dump(Formatter* f) const;
   void decode_json(JSONObj* obj);
-  static void generate_test_instances(std::list<RGWGroupInfo*>& o);
+  static std::list<RGWGroupInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWGroupInfo)
 
@@ -1109,7 +1109,7 @@ struct RGWBucketInfo {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWBucketInfo*>& o);
+  static std::list<RGWBucketInfo> generate_test_instances();
 
   void decode_json(JSONObj *obj);
 
@@ -1206,7 +1206,7 @@ struct RGWBucketEntryPoint
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWBucketEntryPoint*>& o);
+  static std::list<RGWBucketEntryPoint> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWBucketEntryPoint)
 
@@ -1534,7 +1534,7 @@ struct RGWBucketEnt {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWBucketEnt*>& o);
+  static std::list<RGWBucketEnt> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWBucketEnt)
 
@@ -1600,11 +1600,13 @@ struct multipart_upload_info
     dest_placement.dump(f);
   }
 
-  static void generate_test_instances(std::list<multipart_upload_info*>& o) {
-    o.push_back(new multipart_upload_info);
-    o.push_back(new multipart_upload_info);
-    o.back()->dest_placement.name = "dest_placement";
-    o.back()->dest_placement.storage_class = "dest_storage_class";
+  static std::list<multipart_upload_info> generate_test_instances() {
+    std::list<multipart_upload_info> o;
+    o.push_back(multipart_upload_info{});
+    o.push_back(multipart_upload_info{});
+    o.back().dest_placement.name = "dest_placement";
+    o.back().dest_placement.storage_class = "dest_storage_class";
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(multipart_upload_info)

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -234,14 +234,16 @@ void RGWCompressionInfo::dump(Formatter *f) const
   ::encode_json("blocks", blocks, f);
 }
 
-void RGWCompressionInfo::generate_test_instances(list<RGWCompressionInfo*>& o)
+list<RGWCompressionInfo> RGWCompressionInfo::generate_test_instances()
 {
-  RGWCompressionInfo *i = new RGWCompressionInfo;
-  i->compression_type = "type";
-  i->orig_size = 1024;
-  i->blocks.push_back(compression_block());
-  i->blocks.back().old_ofs = 0;
-  i->blocks.back().new_ofs = 0;
-  i->blocks.back().len = 1024;
-  o.push_back(i);
+  list<RGWCompressionInfo> o;
+  RGWCompressionInfo i;
+  i.compression_type = "type";
+  i.orig_size = 1024;
+  i.blocks.push_back(compression_block());
+  i.blocks.back().old_ofs = 0;
+  i.blocks.back().new_ofs = 0;
+  i.blocks.back().len = 1024;
+  o.push_back(std::move(i));
+  return o;
 }

--- a/src/rgw/rgw_compression_types.h
+++ b/src/rgw/rgw_compression_types.h
@@ -71,7 +71,7 @@ struct RGWCompressionInfo {
      DECODE_FINISH(bl);
   } 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWCompressionInfo*>& o);
+  static std::list<RGWCompressionInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWCompressionInfo)
 

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -65,18 +65,20 @@ void RGWCORSRule::erase_origin_if_present(string& origin, bool *rule_empty) {
   }
 }
 
-void RGWCORSRule::generate_test_instances(list<RGWCORSRule*>& o)
+list<RGWCORSRule> RGWCORSRule::generate_test_instances()
 {
-  o.push_back(new RGWCORSRule);
-  o.push_back(new RGWCORSRule);
-  o.back()->id = "test";
-  o.back()->max_age = 100;
-  o.back()->allowed_methods = RGW_CORS_GET | RGW_CORS_PUT;
-  o.back()->allowed_origins.insert("http://origin1");
-  o.back()->allowed_origins.insert("http://origin2");
-  o.back()->allowed_hdrs.insert("accept-encoding");
-  o.back()->allowed_hdrs.insert("accept-language");
-  o.back()->exposable_hdrs.push_back("x-rgw-something");
+  list<RGWCORSRule> o;
+  o.push_back(RGWCORSRule{});
+  o.push_back(RGWCORSRule{});
+  o.back().id = "test";
+  o.back().max_age = 100;
+  o.back().allowed_methods = RGW_CORS_GET | RGW_CORS_PUT;
+  o.back().allowed_origins.insert("http://origin1");
+  o.back().allowed_origins.insert("http://origin2");
+  o.back().allowed_hdrs.insert("accept-encoding");
+  o.back().allowed_hdrs.insert("accept-language");
+  o.back().exposable_hdrs.push_back("x-rgw-something");
+  return o;
 }
 
 /*

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -80,7 +80,7 @@ public:
     decode(exposable_hdrs, bl);
     DECODE_FINISH(bl);
   }
-  static void generate_test_instances(std::list<RGWCORSRule*>& o);
+  static std::list<RGWCORSRule> generate_test_instances();
   bool has_wildcard_origin();
   bool is_origin_present(const char *o);
   void format_exp_headers(std::string& s);

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -19,23 +19,29 @@ using namespace std;
 
 static string shadow_ns = RGW_OBJ_NS_SHADOW;
 
-void obj_version::generate_test_instances(list<obj_version*>& o)
+list<obj_version> obj_version::generate_test_instances()
 {
-  obj_version *v = new obj_version;
-  v->ver = 5;
-  v->tag = "tag";
+  list<obj_version> o;
 
-  o.push_back(v);
-  o.push_back(new obj_version);
+  obj_version v;
+  v.ver = 5;
+  v.tag = "tag";
+
+  o.push_back(std::move(v));
+  o.push_back(obj_version{});
+  return o;
 }
 
-void RGWBucketEncryptionConfig::generate_test_instances(std::list<RGWBucketEncryptionConfig*>& o)
+std::list<RGWBucketEncryptionConfig> RGWBucketEncryptionConfig::generate_test_instances()
 {
-  auto *bc = new RGWBucketEncryptionConfig("aws:kms", "some:key", true);
-  o.push_back(bc);
+  std::list<RGWBucketEncryptionConfig> o;
 
-  bc = new RGWBucketEncryptionConfig("AES256");
-  o.push_back(bc);
+  auto bc = RGWBucketEncryptionConfig("aws:kms", "some:key", true);
+  o.push_back(std::move(bc));
 
-  o.push_back(new RGWBucketEncryptionConfig);
+  bc = RGWBucketEncryptionConfig("AES256");
+  o.push_back(std::move(bc));
+
+  o.push_back(RGWBucketEncryptionConfig{});
+  return o;
 }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2673,10 +2673,11 @@ RGWLC::LCWorker::~LCWorker()
   delete workpool;
 } /* ~LCWorker */
 
-void RGWLifecycleConfiguration::generate_test_instances(
-  list<RGWLifecycleConfiguration*>& o)
+list<RGWLifecycleConfiguration> RGWLifecycleConfiguration::generate_test_instances()
 {
-  o.push_back(new RGWLifecycleConfiguration);
+  list<RGWLifecycleConfiguration> o;
+  o.push_back(RGWLifecycleConfiguration{});
+  return o;
 }
 
 template<typename F>

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -68,7 +68,7 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  //  static void generate_test_instances(list<ACLOwner*>& o);
+  //  static list<ACLOwner> generate_test_instances();
   void set_days(const std::string& _days) { days = _days; }
   std::string get_days_str() const {
     return days;
@@ -542,7 +542,7 @@ public:
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWLifecycleConfiguration*>& o);
+  static std::list<RGWLifecycleConfiguration> generate_test_instances();
 
   void add_rule(const LCRule& rule);
 

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -679,30 +679,32 @@ int rgw_log_op(RGWREST* const rest, req_state *s, const RGWOp* op, OpsLogSink *o
   return 0;
 }
 
-void rgw_log_entry::generate_test_instances(list<rgw_log_entry*>& o)
+list<rgw_log_entry> rgw_log_entry::generate_test_instances()
 {
-  rgw_log_entry *e = new rgw_log_entry;
-  e->object_owner = parse_owner("object_owner");
-  e->bucket_owner = parse_owner("bucket_owner");
-  e->bucket = "bucket";
-  e->remote_addr = "1.2.3.4";
-  e->user = "user";
-  e->obj = rgw_obj_key("obj");
-  e->uri = "http://uri/bucket/obj";
-  e->http_status = "200";
-  e->error_code = "error_code";
-  e->bytes_sent = 1024;
-  e->bytes_received = 512;
-  e->obj_size = 2048;
-  e->user_agent = "user_agent";
-  e->referrer = "referrer";
-  e->bucket_id = "10";
-  e->trans_id = "trans_id";
-  e->identity_type = TYPE_RGW;
-  e->account_id = "account_id";
-  e->role_id = "role_id";
-  o.push_back(e);
-  o.push_back(new rgw_log_entry);
+  list<rgw_log_entry> o;
+  rgw_log_entry e;
+  e.object_owner = parse_owner("object_owner");
+  e.bucket_owner = parse_owner("bucket_owner");
+  e.bucket = "bucket";
+  e.remote_addr = "1.2.3.4";
+  e.user = "user";
+  e.obj = rgw_obj_key("obj");
+  e.uri = "http://uri/bucket/obj";
+  e.http_status = "200";
+  e.error_code = "error_code";
+  e.bytes_sent = 1024;
+  e.bytes_received = 512;
+  e.obj_size = 2048;
+  e.user_agent = "user_agent";
+  e.referrer = "referrer";
+  e.bucket_id = "10";
+  e.trans_id = "trans_id";
+  e.identity_type = TYPE_RGW;
+  e.account_id = "account_id";
+  e.role_id = "role_id";
+  o.push_back(std::move(e));
+  o.push_back(rgw_log_entry{});
+  return o;
 }
 
 void rgw_log_entry::dump(Formatter *f) const

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -221,7 +221,7 @@ struct rgw_log_entry {
     DECODE_FINISH(p);
   }
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_log_entry*>& o);
+  static std::list<rgw_log_entry> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_log_entry)
 

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -164,7 +164,7 @@ struct RGWMetadataLogData {
   void decode(bufferlist::const_iterator& bl);
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWMetadataLogData *>& l);
+  static std::list<RGWMetadataLogData> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWMetadataLogData)
 

--- a/src/rgw/rgw_meta_sync_status.h
+++ b/src/rgw/rgw_meta_sync_status.h
@@ -41,7 +41,7 @@ struct rgw_meta_sync_info {
 
   void decode_json(JSONObj *obj);
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_meta_sync_info*>& ls);
+  static std::list<rgw_meta_sync_info> generate_test_instances();
 
   rgw_meta_sync_info() : state((int)StateInit), num_shards(0) {}
 };
@@ -90,7 +90,7 @@ struct rgw_meta_sync_marker {
 
   void decode_json(JSONObj *obj);
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_meta_sync_marker*>& ls);
+  static std::list<rgw_meta_sync_marker> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_meta_sync_marker)
 
@@ -116,6 +116,6 @@ struct rgw_meta_sync_status {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_meta_sync_status*>& ls);
+  static std::list<rgw_meta_sync_status> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_meta_sync_status)

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -97,14 +97,16 @@ void RGWMetadataLogData::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("status", status, obj);
 }
 
-void RGWMetadataLogData::generate_test_instances(std::list<RGWMetadataLogData *>& l) {
-  l.push_back(new RGWMetadataLogData{});
-  l.push_back(new RGWMetadataLogData);
-  l.back()->read_version = obj_version();
-  l.back()->read_version.tag = "read_tag";
-  l.back()->write_version = obj_version();
-  l.back()->write_version.tag = "write_tag";
-  l.back()->status = MDLOG_STATUS_WRITE;
+std::list<RGWMetadataLogData> RGWMetadataLogData::generate_test_instances() {
+  std::list<RGWMetadataLogData> l;
+  l.push_back(RGWMetadataLogData{});
+  l.push_back(RGWMetadataLogData{});
+  l.back().read_version = obj_version();
+  l.back().read_version.tag = "read_tag";
+  l.back().write_version = obj_version();
+  l.back().write_version.tag = "write_tag";
+  l.back().status = MDLOG_STATUS_WRITE;
+  return l;
 }
 
 class RGWMetadataTopHandler : public RGWMetadataHandler {

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -81,14 +81,16 @@ bool is_v2_upload_id(const string& upload_id)
          (strncmp(uid, MULTIPART_UPLOAD_ID_PREFIX_LEGACY, sizeof(MULTIPART_UPLOAD_ID_PREFIX_LEGACY) - 1) == 0);
 }
 
-void RGWUploadPartInfo::generate_test_instances(list<RGWUploadPartInfo*>& o)
+list<RGWUploadPartInfo> RGWUploadPartInfo::generate_test_instances()
 {
-  RGWUploadPartInfo *i = new RGWUploadPartInfo;
-  i->num = 1;
-  i->size = 10 * 1024 * 1024;
-  i->etag = "etag";
-  o.push_back(i);
-  o.push_back(new RGWUploadPartInfo);
+  list<RGWUploadPartInfo> o;
+  RGWUploadPartInfo i;
+  i.num = 1;
+  i.size = 10 * 1024 * 1024;
+  i.etag = "etag";
+  o.push_back(std::move(i));
+  o.push_back(RGWUploadPartInfo{});
+  return o;
 }
 
 void RGWUploadPartInfo::dump(Formatter *f) const

--- a/src/rgw/rgw_obj_types.h
+++ b/src/rgw/rgw_obj_types.h
@@ -88,11 +88,13 @@ struct rgw_obj_index_key { // cls_rgw_obj_key now aliases this type
     f->dump_string("instance", instance);
   }
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<rgw_obj_index_key*>& ls) {
-    ls.push_back(new rgw_obj_index_key);
-    ls.push_back(new rgw_obj_index_key);
-    ls.back()->name = "name";
-    ls.back()->instance = "instance";
+  static std::list<rgw_obj_index_key> generate_test_instances() {
+    std::list<rgw_obj_index_key> ls;
+    ls.push_back(rgw_obj_index_key{});
+    ls.push_back(rgw_obj_index_key{});
+    ls.back().name = "name";
+    ls.back().instance = "instance";
+    return ls;
   }
 
   size_t estimate_encoded_size() const {
@@ -475,7 +477,7 @@ struct rgw_raw_obj {
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_raw_obj*>& o);
+  static std::list<rgw_raw_obj> generate_test_instances();
   void decode_json(JSONObj *obj);
 
   inline std::string to_str() const {
@@ -596,7 +598,7 @@ struct rgw_obj {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_obj*>& o);
+  static std::list<rgw_obj> generate_test_instances();
 
   bool operator==(const rgw_obj& o) const {
     return (key == o.key) &&

--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -49,9 +49,10 @@ void ObjectLockRule::dump(Formatter *f) const {
   f->close_section();
 }
 
-void ObjectLockRule::generate_test_instances(std::list<ObjectLockRule*>& o) {
-  ObjectLockRule *obj = new ObjectLockRule;
-  o.push_back(obj);
+std::list<ObjectLockRule> ObjectLockRule::generate_test_instances() {
+  std::list<ObjectLockRule> o;
+  o.push_back(ObjectLockRule{});
+  return o;
 }
 
 void RGWObjectLock::decode_xml(XMLObj *obj) {
@@ -94,15 +95,17 @@ ceph::real_time RGWObjectLock::get_lock_until_date(const ceph::real_time& mtime)
   return mtime + std::chrono::years(get_years());
 }
 
-void RGWObjectLock::generate_test_instances(list<RGWObjectLock*>& o) {
-  RGWObjectLock *obj = new RGWObjectLock;
-  obj->enabled = true;
-  obj->rule_exist = true;
-  o.push_back(obj);
-  obj = new RGWObjectLock;
-  obj->enabled = false;
-  obj->rule_exist = false;
-  o.push_back(obj);
+list<RGWObjectLock> RGWObjectLock::generate_test_instances() {
+  list<RGWObjectLock> o;
+  RGWObjectLock obj;
+  obj.enabled = true;
+  obj.rule_exist = true;
+  o.push_back(std::move(obj));
+  obj = RGWObjectLock{};
+  obj.enabled = false;
+  obj.rule_exist = false;
+  o.push_back(std::move(obj));
+  return o;
 }
 
 void RGWObjectRetention::decode_xml(XMLObj *obj) {

--- a/src/rgw/rgw_object_lock.h
+++ b/src/rgw/rgw_object_lock.h
@@ -83,7 +83,7 @@ public:
   void decode_xml(XMLObj *obj);
   void dump_xml(Formatter *f) const;
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<ObjectLockRule*>& o);
+  static std::list<ObjectLockRule> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(ObjectLockRule)
 
@@ -144,7 +144,7 @@ public:
   void dump_xml(Formatter *f) const;
   ceph::real_time get_lock_until_date(const ceph::real_time& mtime) const;
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWObjectLock*>& o);
+  static std::list<RGWObjectLock> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWObjectLock)
 

--- a/src/rgw/rgw_oidc_provider.cc
+++ b/src/rgw/rgw_oidc_provider.cc
@@ -27,15 +27,17 @@ void RGWOIDCProviderInfo::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("thumbprints", thumbprints, obj);
 }
 
-void RGWOIDCProviderInfo::generate_test_instances(std::list<RGWOIDCProviderInfo*>& l)
+std::list<RGWOIDCProviderInfo> RGWOIDCProviderInfo::generate_test_instances()
 {
-  auto p = new RGWOIDCProviderInfo;
-  p->id = "id";
-  p->provider_url = "server.example.com";
-  p->arn = "arn:aws:iam::acct:oidc-provider/server.example.com";
-  p->creation_date = "someday";
-  p->client_ids = {"a", "b"};
-  p->thumbprints = {"c", "d"};
-  l.push_back(p);
-  l.push_back(new RGWOIDCProviderInfo);
+  std::list<RGWOIDCProviderInfo> l;
+  RGWOIDCProviderInfo p;
+  p.id = "id";
+  p.provider_url = "server.example.com";
+  p.arn = "arn:aws:iam::acct:oidc-provider/server.example.com";
+  p.creation_date = "someday";
+  p.client_ids = {"a", "b"};
+  p.thumbprints = {"c", "d"};
+  l.push_back(std::move(p));
+  l.push_back(RGWOIDCProviderInfo{});
+  return l;
 }

--- a/src/rgw/rgw_oidc_provider.h
+++ b/src/rgw/rgw_oidc_provider.h
@@ -45,6 +45,6 @@ struct RGWOIDCProviderInfo
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWOIDCProviderInfo*>& l);
+  static std::list<RGWOIDCProviderInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWOIDCProviderInfo)

--- a/src/rgw/rgw_period.cc
+++ b/src/rgw/rgw_period.cc
@@ -98,11 +98,12 @@ int RGWPeriod::update_sync_status(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-void RGWPeriod::generate_test_instances(list<RGWPeriod*> &o)
+std::list<RGWPeriod> RGWPeriod::generate_test_instances()
 {
-  RGWPeriod *z = new RGWPeriod;
-  o.push_back(z);
-  o.push_back(new RGWPeriod);
+  std::list<RGWPeriod> o;
+  o.emplace_back();
+  o.emplace_back();
+  return o;
 }
 
 const string& RGWPeriod::get_info_oid_prefix() const

--- a/src/rgw/rgw_placement_types.h
+++ b/src/rgw/rgw_placement_types.h
@@ -94,9 +94,11 @@ struct rgw_placement_rule {
     f->dump_string("storage_class", get_storage_class());
   }
 
-  static void generate_test_instances(std::list<rgw_placement_rule*>& o) {
-    o.push_back(new rgw_placement_rule);
-    o.push_back(new rgw_placement_rule("name", "storage_class"));
+  static std::list<rgw_placement_rule> generate_test_instances() {
+    std::list<rgw_placement_rule> o;
+    o.push_back(rgw_placement_rule{});
+    o.push_back(rgw_placement_rule("name", "storage_class"));
+    return o;
   }
 
   std::string to_str() const {

--- a/src/rgw/rgw_pool_types.h
+++ b/src/rgw/rgw_pool_types.h
@@ -95,9 +95,11 @@ struct rgw_pool {
     f->dump_string("ns", ns);
   }
 
-  static void generate_test_instances(std::list<rgw_pool*>& o) {
-    o.push_back(new rgw_pool);
-    o.push_back(new rgw_pool("pool", "ns"));
+  static std::list<rgw_pool> generate_test_instances() {
+    std::list<rgw_pool> o;
+    o.push_back(rgw_pool{});
+    o.push_back(rgw_pool("pool", "ns"));
+    return o;
   }
 
   rgw_pool& operator=(const rgw_pool&) = default;

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1039,14 +1039,16 @@ void RGWQuotaInfo::dump(Formatter *f) const
   f->dump_int("max_objects", max_objects);
 }
 
-void RGWQuotaInfo::generate_test_instances(std::list<RGWQuotaInfo*>& o)
+std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
 {
-  o.push_back(new RGWQuotaInfo);
-  o.push_back(new RGWQuotaInfo);
-  o.back()->enabled = true;
-  o.back()->check_on_raw = true;
-  o.back()->max_size = 1024;
-  o.back()->max_objects = 1;
+  std::list<RGWQuotaInfo> o;
+  o.push_back(RGWQuotaInfo{});
+  o.push_back(RGWQuotaInfo{});
+  o.back().enabled = true;
+  o.back().check_on_raw = true;
+  o.back().max_size = 1024;
+  o.back().max_objects = 1;
+  return o;
 }
 
 void RGWQuotaInfo::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_quota_types.h
+++ b/src/rgw/rgw_quota_types.h
@@ -73,7 +73,7 @@ struct RGWQuotaInfo {
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWQuotaInfo*>& o);
+  static std::list<RGWQuotaInfo> generate_test_instances();
   void decode_json(JSONObj *obj);
 
 };

--- a/src/rgw/rgw_realm.cc
+++ b/src/rgw/rgw_realm.cc
@@ -83,11 +83,12 @@ int RGWRealm::find_zone(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-void RGWRealm::generate_test_instances(list<RGWRealm*> &o)
+list<RGWRealm> RGWRealm::generate_test_instances()
 {
-  RGWRealm *z = new RGWRealm;
-  o.push_back(z);
-  o.push_back(new RGWRealm);
+  list<RGWRealm> o;
+  o.push_back(RGWRealm{});
+  o.push_back(RGWRealm{});
+  return o;
 }
 
 void RGWRealm::dump(Formatter *f) const

--- a/src/rgw/rgw_sync_policy.cc
+++ b/src/rgw/rgw_sync_policy.cc
@@ -789,10 +789,11 @@ void rgw_sync_policy_info::dump(Formatter *f) const
   }
 }
 
-void rgw_sync_policy_info::generate_test_instances(list<rgw_sync_policy_info*>& o)
+list<rgw_sync_policy_info> rgw_sync_policy_info::generate_test_instances()
 {
-  rgw_sync_policy_info *info = new rgw_sync_policy_info;
-  o.push_back(info);
+  list<rgw_sync_policy_info> o;
+  o.push_back(rgw_sync_policy_info{});
+  return o;
 }
 
 void rgw_sync_policy_info::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_sync_policy.h
+++ b/src/rgw/rgw_sync_policy.h
@@ -675,7 +675,7 @@ struct rgw_sync_policy_info {
   }
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_sync_policy_info*>& o);
+  static std::list<rgw_sync_policy_info> generate_test_instances();
   void decode_json(JSONObj *obj);
 
   bool empty() const {

--- a/src/rgw/rgw_tag.cc
+++ b/src/rgw/rgw_tag.cc
@@ -65,12 +65,14 @@ void RGWObjTags::dump(Formatter *f) const
   f->close_section();
 }
 
-void RGWObjTags::generate_test_instances(std::list<RGWObjTags*>& o)
+std::list<RGWObjTags> RGWObjTags::generate_test_instances()
 {
-  RGWObjTags *r = new RGWObjTags;
-  r->add_tag("key1","val1");
-  r->add_tag("key2","val2");
-  o.push_back(r);
-  o.push_back(new RGWObjTags);
+  std::list<RGWObjTags> o;
+  RGWObjTags r;
+  r.add_tag("key1","val1");
+  r.add_tag("key2","val2");
+  o.push_back(std::move(r));
+  o.push_back(RGWObjTags{});
+  return o;
 }
 

--- a/src/rgw/rgw_tag.h
+++ b/src/rgw/rgw_tag.h
@@ -36,7 +36,7 @@ protected:
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(std::list<RGWObjTags*>& o);
+  static std::list<RGWObjTags> generate_test_instances();
   void add_tag(const std::string& key, const std::string& val="");
   void emplace_tag(std::string&& key, std::string&& val);
   int check_and_add_tag(const std::string& key, const std::string& val="");

--- a/src/rgw/rgw_user_types.h
+++ b/src/rgw/rgw_user_types.h
@@ -132,7 +132,7 @@ struct rgw_user {
   friend auto operator<=>(const rgw_user&, const rgw_user&) = default;
 
   void dump(ceph::Formatter *f) const;
-  static void generate_test_instances(std::list<rgw_user*>& o);
+  static std::list<rgw_user> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(rgw_user)
 

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -68,11 +68,12 @@ static void decode_placement_targets(map<string, RGWZoneGroupPlacementTarget>& t
   targets[t.name] = t;
 }
 
-void RGWZone::generate_test_instances(list<RGWZone*> &o)
+list<RGWZone> RGWZone::generate_test_instances()
 {
-  RGWZone *z = new RGWZone;
-  o.push_back(z);
-  o.push_back(new RGWZone);
+  list<RGWZone> o;
+  o.push_back(RGWZone{});
+  o.push_back(RGWZone{});
+  return o;
 }
 
 void RGWZone::dump(Formatter *f) const
@@ -507,15 +508,17 @@ void RGWZonePlacementInfo::dump(Formatter *f) const
    * rather not clutter the output */
 }
 
-void RGWZonePlacementInfo::generate_test_instances(list<RGWZonePlacementInfo*>& o)
+list<RGWZonePlacementInfo> RGWZonePlacementInfo::generate_test_instances()
 {
-  o.push_back(new RGWZonePlacementInfo);
-  o.push_back(new RGWZonePlacementInfo);
-  o.back()->index_pool = rgw_pool("rgw.buckets.index");
+  list<RGWZonePlacementInfo> o;
+  o.push_back(RGWZonePlacementInfo{});
+  o.push_back(RGWZonePlacementInfo{});
+  o.back().index_pool = rgw_pool("rgw.buckets.index");
   
-  o.back()->data_extra_pool = rgw_pool("rgw.buckets.non-ec");
-  o.back()->index_type = rgw::BucketIndexType::Normal;
-  o.back()->inline_data = false;
+  o.back().data_extra_pool = rgw_pool("rgw.buckets.non-ec");
+  o.back().index_type = rgw::BucketIndexType::Normal;
+  o.back().inline_data = false;
+  return o;
 }
 
 void RGWZonePlacementInfo::decode_json(JSONObj *obj)
@@ -579,9 +582,11 @@ void RGWZoneStorageClasses::dump(Formatter *f) const
   }
 }
 
-void RGWZoneStorageClasses::generate_test_instances(list<RGWZoneStorageClasses*>& o)
+list<RGWZoneStorageClasses> RGWZoneStorageClasses::generate_test_instances()
 {
-  o.push_back(new RGWZoneStorageClasses);
+  list<RGWZoneStorageClasses> o;
+  o.push_back(RGWZoneStorageClasses{});
+  return o;
 }
 
 void RGWZoneStorageClasses::decode_json(JSONObj *obj)
@@ -664,12 +669,14 @@ void RGWZoneStorageClass::dump(Formatter *f) const
   }
 }
 
-void RGWZoneStorageClass::generate_test_instances(list<RGWZoneStorageClass*>& o)
+list<RGWZoneStorageClass> RGWZoneStorageClass::generate_test_instances()
 {
-  o.push_back(new RGWZoneStorageClass);
-  o.push_back(new RGWZoneStorageClass);
-  o.back()->data_pool = rgw_pool("pool1");
-  o.back()->compression_type = "zlib";
+  list<RGWZoneStorageClass> o;
+  o.push_back(RGWZoneStorageClass{});
+  o.push_back(RGWZoneStorageClass{});
+  o.back().data_pool = rgw_pool("pool1");
+  o.back().compression_type = "zlib";
+  return o;
 }
 
 void RGWZoneStorageClass::decode_json(JSONObj *obj)
@@ -2080,49 +2087,59 @@ int RGWZoneGroupTierS3Glacier::clear_params(const JSONFormattable& config)
   return 0;
 }
 
-void rgw_meta_sync_info::generate_test_instances(list<rgw_meta_sync_info*>& o)
+std::list<rgw_meta_sync_info> rgw_meta_sync_info::generate_test_instances()
 {
-  auto info = new rgw_meta_sync_info;
-  info->state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
-  info->period = "periodid";
-  info->realm_epoch = 5;
-  o.push_back(info);
-  o.push_back(new rgw_meta_sync_info);
+  std::list<rgw_meta_sync_info> o;
+  rgw_meta_sync_info info;
+  info.state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
+  info.period = "periodid";
+  info.realm_epoch = 5;
+  o.push_back(std::move(info));
+  o.emplace_back();
+  return o;
 }
 
-void rgw_meta_sync_marker::generate_test_instances(list<rgw_meta_sync_marker*>& o)
+std::list<rgw_meta_sync_marker> rgw_meta_sync_marker::generate_test_instances()
 {
-  auto marker = new rgw_meta_sync_marker;
-  marker->state = rgw_meta_sync_marker::IncrementalSync;
-  marker->marker = "01234";
-  marker->realm_epoch = 5;
-  o.push_back(marker);
-  o.push_back(new rgw_meta_sync_marker);
+  std::list<rgw_meta_sync_marker> o;
+  rgw_meta_sync_marker marker;
+  marker.state = rgw_meta_sync_marker::IncrementalSync;
+  marker.marker = "01234";
+  marker.realm_epoch = 5;
+  o.push_back(std::move(marker));
+  o.emplace_back();
+  return o;
 }
 
-void rgw_meta_sync_status::generate_test_instances(list<rgw_meta_sync_status*>& o)
+std::list<rgw_meta_sync_status> rgw_meta_sync_status::generate_test_instances()
 {
-  o.push_back(new rgw_meta_sync_status);
+  std::list<rgw_meta_sync_status> o;
+  o.emplace_back();
+  return o;
 }
 
-void RGWZoneParams::generate_test_instances(list<RGWZoneParams*> &o)
+std::list<RGWZoneParams> RGWZoneParams::generate_test_instances()
 {
-  o.push_back(new RGWZoneParams);
-  o.push_back(new RGWZoneParams);
+  std::list<RGWZoneParams> o;
+  o.emplace_back();
+  o.emplace_back();
+  return o;
 }
 
-void RGWPeriodLatestEpochInfo::generate_test_instances(list<RGWPeriodLatestEpochInfo*> &o)
+std::list<RGWPeriodLatestEpochInfo> RGWPeriodLatestEpochInfo::generate_test_instances()
 {
-  RGWPeriodLatestEpochInfo *z = new RGWPeriodLatestEpochInfo;
-  o.push_back(z);
-  o.push_back(new RGWPeriodLatestEpochInfo);
+  std::list<RGWPeriodLatestEpochInfo> o;
+  o.emplace_back();
+  o.emplace_back();
+  return o;
 }
 
-void RGWZoneGroup::generate_test_instances(list<RGWZoneGroup*>& o)
+std::list<RGWZoneGroup> RGWZoneGroup::generate_test_instances()
 {
-  RGWZoneGroup *r = new RGWZoneGroup;
-  o.push_back(r);
-  o.push_back(new RGWZoneGroup);
+  std::list<RGWZoneGroup> o;
+  o.emplace_back();
+  o.emplace_back();
+  return o;
 }
 
 void RGWPeriodLatestEpochInfo::dump(Formatter *f) const {
@@ -2141,10 +2158,12 @@ void RGWNameToId::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("obj_id", obj_id, obj);
 }
 
-void RGWNameToId::generate_test_instances(list<RGWNameToId*>& o) {
-  RGWNameToId *n = new RGWNameToId;
-  n->obj_id = "id";
-  o.push_back(n);
-  o.push_back(new RGWNameToId);
+std::list<RGWNameToId> RGWNameToId::generate_test_instances() {
+  std::list<RGWNameToId> o;
+  RGWNameToId n;
+  n.obj_id = "id";
+  o.push_back(std::move(n));
+  o.emplace_back();
+  return o;
 }
 

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -203,7 +203,7 @@ struct RGWZoneParams {
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZoneParams*>& o);
+  static std::list<RGWZoneParams> generate_test_instances();
 
   bool get_placement(const std::string& placement_id, RGWZonePlacementInfo *placement) const {
     auto iter = placement_pools.find(placement_id);
@@ -375,7 +375,7 @@ struct RGWZoneGroup {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZoneGroup*>& o);
+  static std::list<RGWZoneGroup> generate_test_instances();
 
   bool supports(std::string_view feature) const {
     return enabled_features.contains(feature);
@@ -513,7 +513,7 @@ public:
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWRealm*>& o);
+  static std::list<RGWRealm> generate_test_instances();
 
   const std::string& get_current_period() const {
     return current_period;
@@ -553,7 +553,7 @@ struct RGWPeriodLatestEpochInfo {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWPeriodLatestEpochInfo*>& o);
+  static std::list<RGWPeriodLatestEpochInfo> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWPeriodLatestEpochInfo)
 
@@ -707,7 +707,7 @@ public:
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWPeriod*>& o);
+  static std::list<RGWPeriod> generate_test_instances();
 
   static std::string get_staging_id(const std::string& realm_id) {
     return realm_id + ":staging";

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -79,7 +79,7 @@ struct RGWNameToId {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWNameToId*>& o);
+  static std::list<RGWNameToId> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWNameToId)
 
@@ -123,7 +123,7 @@ struct RGWZoneStorageClass {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZoneStorageClass*>& o);
+  static std::list<RGWZoneStorageClass> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWZoneStorageClass)
 
@@ -211,7 +211,7 @@ public:
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZoneStorageClasses*>& o);
+  static std::list<RGWZoneStorageClasses> generate_test_instances();
 };
 WRITE_CLASS_ENCODER(RGWZoneStorageClasses)
 
@@ -308,7 +308,7 @@ struct RGWZonePlacementInfo {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZonePlacementInfo*>& o);
+  static std::list<RGWZonePlacementInfo> generate_test_instances();
 
 };
 WRITE_CLASS_ENCODER(RGWZonePlacementInfo)
@@ -399,7 +399,7 @@ struct RGWZone {
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZone*>& o);
+  static std::list<RGWZone> generate_test_instances();
 
   bool is_read_only() const { return read_only; }
 
@@ -570,10 +570,12 @@ struct RGWZoneGroupTierS3Glacier {
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZoneGroupTierS3Glacier*>& o) {
-    o.push_back(new RGWZoneGroupTierS3Glacier);
-    o.back()->glacier_restore_days = 2;
-    o.back()->glacier_restore_tier_type = GlacierRestoreTierType::Expedited;
+  static std::list<RGWZoneGroupTierS3Glacier> generate_test_instances() {
+    std::list<RGWZoneGroupTierS3Glacier> o;
+    o.push_back(RGWZoneGroupTierS3Glacier{});
+    o.back().glacier_restore_days = 2;
+    o.back().glacier_restore_tier_type = GlacierRestoreTierType::Expedited;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(RGWZoneGroupTierS3Glacier)
@@ -667,15 +669,17 @@ struct RGWZoneGroupPlacementTier {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZoneGroupPlacementTier*>& o) {
-    o.push_back(new RGWZoneGroupPlacementTier);
-    o.push_back(new RGWZoneGroupPlacementTier);
-    o.back()->tier_type = RGWTierType::CLOUD_S3;
-    o.back()->storage_class = RGW_STORAGE_CLASS_STANDARD;
-    o.back()->allow_read_through = false;
-    o.back()->restore_storage_class = RGW_STORAGE_CLASS_STANDARD;
-    o.back()->s3_glacier.glacier_restore_days = 2;
-    o.back()->s3_glacier.glacier_restore_tier_type = GlacierRestoreTierType::Expedited;
+  static std::list<RGWZoneGroupPlacementTier> generate_test_instances() {
+    std::list<RGWZoneGroupPlacementTier> o;
+    o.push_back(RGWZoneGroupPlacementTier{});
+    o.push_back(RGWZoneGroupPlacementTier{});
+    o.back().tier_type = RGWTierType::CLOUD_S3;
+    o.back().storage_class = RGW_STORAGE_CLASS_STANDARD;
+    o.back().allow_read_through = false;
+    o.back().restore_storage_class = RGW_STORAGE_CLASS_STANDARD;
+    o.back().s3_glacier.glacier_restore_days = 2;
+    o.back().s3_glacier.glacier_restore_tier_type = GlacierRestoreTierType::Expedited;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTier)
@@ -724,16 +728,18 @@ struct RGWZoneGroupPlacementTarget {
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<RGWZoneGroupPlacementTarget*>& o) {
-    o.push_back(new RGWZoneGroupPlacementTarget);
-    o.back()->storage_classes.insert(RGW_STORAGE_CLASS_STANDARD);
-    o.push_back(new RGWZoneGroupPlacementTarget);
-    o.back()->name = "target";
-    o.back()->tags.insert("tag1");
-    o.back()->tags.insert("tag2");
-    o.back()->storage_classes.insert("STANDARD_IA");
-    o.back()->tier_targets[RGWTierType::CLOUD_S3].tier_type = RGWTierType::CLOUD_S3;
-    o.back()->tier_targets[RGWTierType::CLOUD_S3].storage_class = RGW_STORAGE_CLASS_STANDARD;
+  static std::list<RGWZoneGroupPlacementTarget> generate_test_instances() {
+    std::list<RGWZoneGroupPlacementTarget> o;
+    o.push_back(RGWZoneGroupPlacementTarget{});
+    o.back().storage_classes.insert(RGW_STORAGE_CLASS_STANDARD);
+    o.push_back(RGWZoneGroupPlacementTarget{});
+    o.back().name = "target";
+    o.back().tags.insert("tag1");
+    o.back().tags.insert("tag2");
+    o.back().storage_classes.insert("STANDARD_IA");
+    o.back().tier_targets[RGWTierType::CLOUD_S3].tier_type = RGWTierType::CLOUD_S3;
+    o.back().tier_targets[RGWTierType::CLOUD_S3].storage_class = RGW_STORAGE_CLASS_STANDARD;
+    return o;
   }
 };
 WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTarget)

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -102,34 +102,29 @@ TEST(pg_pool_t, encodeDecode)
                           CEPH_FEATUREMASK_SERVER_MIMIC |
                           CEPH_FEATUREMASK_SERVER_NAUTILUS;
   {
-    pg_pool_t p;
-    std::list<pg_pool_t*> pools;
-
-    p.generate_test_instances(pools);
+    std::list<pg_pool_t> pools = pg_pool_t::generate_test_instances();
     for(auto p1 : pools){
       bufferlist bl;
-      p1->encode(bl, features);
+      p1.encode(bl, features);
       bl.hexdump(std::cout);
       auto pbl = bl.cbegin();
       pg_pool_t p2;
       p2.decode(pbl);
-      compare_pg_pool_t(*p1, p2);
+      compare_pg_pool_t(p1, p2);
     }
   }
 
   {
     // test reef
-    pg_pool_t p;
-    std::list<pg_pool_t*> pools;
-    p.generate_test_instances(pools);
+    std::list<pg_pool_t> pools = pg_pool_t::generate_test_instances();
     for(auto p1 : pools){
       bufferlist bl;
-      p1->encode(bl, features|CEPH_FEATUREMASK_SERVER_REEF);
+      p1.encode(bl, features|CEPH_FEATUREMASK_SERVER_REEF);
       bl.hexdump(std::cout);
       auto pbl = bl.cbegin();
       pg_pool_t p2;
       p2.decode(pbl);
-      compare_pg_pool_t(*p1, p2);
+      compare_pg_pool_t(p1, p2);
     }
   }
 }

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -101,7 +101,6 @@ struct old_rgw_bucket {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
-  static void generate_test_instances(std::list<old_rgw_bucket*>& o);
 
   bool operator<(const old_rgw_bucket& b) const {
     return name.compare(b.name) < 0;

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -48,7 +48,6 @@ struct OldObjManifestPart {
   }
 
   void dump(Formatter *f) const;
-  static void generate_test_instances(list<OldObjManifestPart*>& o);
 };
 WRITE_CLASS_ENCODER(OldObjManifestPart)
 

--- a/src/tools/ceph-dencoder/ceph_time.h
+++ b/src/tools/ceph-dencoder/ceph_time.h
@@ -28,9 +28,11 @@ class time_point_wrapper {
     auto epoch_time = Clock::to_time_t(t);
     f->dump_string("time", std::ctime(&epoch_time));
   }
-  static void generate_test_instances(std::list<time_point_wrapper*>& ls) {
+  static std::list<time_point_wrapper> generate_test_instances() {
+    std::list<time_point_wrapper> ls;
     constexpr time_t t{455500800}; // Ghostbusters release date
-    ls.push_back(new time_point_wrapper(Clock::from_time_t(t)));
+    ls.push_back(time_point_wrapper(Clock::from_time_t(t)));
+    return ls;
   }
 };
 
@@ -58,9 +60,11 @@ class timespan_wrapper {
   void dump(Formatter* f) {
     f->dump_int("timespan", d.count());
   }
-  static void generate_test_instances(std::list<timespan_wrapper*>& ls) {
+  static std::list<timespan_wrapper> generate_test_instances() {
+    std::list<timespan_wrapper> ls;
     constexpr std::chrono::seconds d{7377}; // marathon world record (2:02:57)
-    ls.push_back(new timespan_wrapper(d));
+    ls.push_back(timespan_wrapper(d));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(timespan_wrapper)

--- a/src/tools/ceph-dencoder/denc_registry.h
+++ b/src/tools/ceph-dencoder/denc_registry.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -41,25 +42,33 @@ struct Dencoder {
 
 template<class T>
 class DencoderBase : public Dencoder {
+  using deleter_type = std::function<void(T*)>;
+  using ptr_type = std::unique_ptr<T, deleter_type>;
 protected:
-  T* m_object;
-  std::list<T*> m_list;
+  enum class do_delete {
+    no,
+    yes,
+  };
+  static ptr_type make_ptr(T* ptr, do_delete del) {
+    auto deleter = (del == do_delete::yes ?
+		    deleter_type{std::default_delete<T>{}} :
+		    deleter_type{[](T*) {}});
+    return ptr_type{ptr, deleter};
+  }
+  ptr_type m_object = make_ptr(nullptr, do_delete::yes);
+  std::list<T> m_list;
   bool stray_okay;
   bool nondeterministic;
-
 public:
-  template<typename... Args>
-  DencoderBase(bool stray_okay, bool nondeterministic, Args&&... args)
-    : m_object(new T(std::forward<Args>(args)...)),
-      stray_okay(stray_okay),
+  DencoderBase(bool stray_okay, bool nondeterministic)
+    : stray_okay(stray_okay),
       nondeterministic(nondeterministic) {}
-  ~DencoderBase() override {
-    delete m_object;
-  }
+  ~DencoderBase() override {}
 
   std::string decode(bufferlist bl, uint64_t seek) override {
     auto p = bl.cbegin();
     p.seek(seek);
+    m_object = make_ptr(new T, do_delete::yes);
     try {
       using ceph::decode;
       decode(*m_object, p);
@@ -78,10 +87,11 @@ public:
   void encode(bufferlist& out, uint64_t features) override = 0;
 
   void dump(ceph::Formatter *f) override {
+    assert(m_object);
     m_object->dump(f);
   }
   void generate() override {
-    T::generate_test_instances(m_list);
+    m_list = T::generate_test_instances();
   }
   int num_generated() override {
     return m_list.size();
@@ -92,7 +102,7 @@ public:
       i = m_list.size();
     if ((i == 0) || (i > m_list.size()))
       return "invalid id for generated object";
-    m_object = *(std::next(m_list.begin(), i-1));
+    m_object = make_ptr(std::addressof(*std::next(m_list.begin(), i-1)), do_delete::no);
     return {};
   }
 
@@ -112,6 +122,7 @@ public:
     : DencoderBase<T>(stray_ok, nondeterministic) {}
   void encode(bufferlist& out, uint64_t features) override {
     out.clear();
+    assert(this->m_object);
     using ceph::encode;
     encode(*this->m_object, out);
   }
@@ -119,19 +130,21 @@ public:
 
 template<class T>
 class DencoderImplNoFeature : public DencoderImplNoFeatureNoCopy<T> {
+  using do_delete = typename DencoderBase<T>::do_delete;
+
 public:
   DencoderImplNoFeature(bool stray_ok, bool nondeterministic)
     : DencoderImplNoFeatureNoCopy<T>(stray_ok, nondeterministic) {}
   void copy() override {
+    assert(this->m_object);
     T *n = new T;
     *n = *this->m_object;
-    delete this->m_object;
-    this->m_object = n;
+    this->m_object = this->make_ptr(n, do_delete::yes);
   }
   void copy_ctor() override {
+    assert(this->m_object);
     T *n = new T(*this->m_object);
-    delete this->m_object;
-    this->m_object = n;
+    this->m_object = this->make_ptr(n, do_delete::yes);
   }
 };
 
@@ -141,6 +154,7 @@ public:
   DencoderImplFeaturefulNoCopy(bool stray_ok, bool nondeterministic)
     : DencoderBase<T>(stray_ok, nondeterministic) {}
   void encode(bufferlist& out, uint64_t features) override {
+    assert(this->m_object);
     out.clear();
     using ceph::encode;
     encode(*(this->m_object), out, features);
@@ -149,19 +163,21 @@ public:
 
 template<class T>
 class DencoderImplFeatureful : public DencoderImplFeaturefulNoCopy<T> {
+  using do_delete = typename DencoderBase<T>::do_delete;
+
 public:
   DencoderImplFeatureful(bool stray_ok, bool nondeterministic)
     : DencoderImplFeaturefulNoCopy<T>(stray_ok, nondeterministic) {}
   void copy() override {
-    T *n = new T;
+    assert(this->m_object);
+    T* n = new T;
     *n = *this->m_object;
-    delete this->m_object;
-    this->m_object = n;
+    this->m_object = this->make_ptr(n, do_delete::yes);
   }
   void copy_ctor() override {
+    assert(this->m_object);
     T *n = new T(*this->m_object);
-    delete this->m_object;
-    this->m_object = n;
+    this->m_object = this->make_ptr(n, do_delete::yes);
   }
 };
 
@@ -208,7 +224,7 @@ public:
     m_object->dump(f);
   }
   void generate() override {
-    //T::generate_test_instances(m_list);
+    //m_list = T::generate_test_instances();
   }
   int num_generated() override {
     return m_list.size();

--- a/src/tools/ceph-dencoder/nvmeof_types.h
+++ b/src/tools/ceph-dencoder/nvmeof_types.h
@@ -40,7 +40,8 @@ class NVMeofGwMapDencoder {
     f->dump_stream("NVMeofGwMap") << m;
   }
 
-  static void generate_test_instances(std::list<NVMeofGwMapDencoder*>& ls) {
+  static std::list<NVMeofGwMapDencoder> generate_test_instances() {
+    std::list<NVMeofGwMapDencoder> ls;
     std::string pool = "pool1";
     std::string group = "grp1";
     auto group_key = std::make_pair(pool, group);
@@ -57,8 +58,8 @@ class NVMeofGwMapDencoder {
 
     m.created_gws[group_key]["GW2"].nonce_map[2] = new_nonces;
 
-    ls.push_back(new NVMeofGwMapDencoder(m));
-
+    ls.push_back(NVMeofGwMapDencoder(m));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(NVMeofGwMapDencoder)
@@ -84,7 +85,8 @@ class MNVMeofGwMapDencoder {
     f->dump_stream("MNVMeofGwMap") << m;
   }
 
-  static void generate_test_instances(std::list<MNVMeofGwMapDencoder*>& ls) {
+  static std::list<MNVMeofGwMapDencoder> generate_test_instances() {
+    std::list<MNVMeofGwMapDencoder> ls;
     std::map<NvmeGroupKey, NvmeGwMonClientStates> map;
     std::string pool = "pool1";
     std::string group = "grp1";
@@ -114,8 +116,9 @@ class MNVMeofGwMapDencoder {
     pending_map.start_timer(gw_id, group_key, group, 30);
 
     m = MNVMeofGwMap(pending_map);
-    ls.push_back(new MNVMeofGwMapDencoder(m));
+    ls.push_back(MNVMeofGwMapDencoder(m));
 
+    return ls
   }
 };
 WRITE_CLASS_ENCODER(MNVMeofGwMapDencoder)
@@ -141,7 +144,8 @@ class MNVMeofGwBeaconDencoder {
     f->dump_stream("MNVMeofGwBeacon") << m;
   }
 
-  static void generate_test_instances(std::list<MNVMeofGwBeaconDencoder*>& ls) {
+  static std::list<MNVMeofGwBeaconDencoder> generate_test_instances() {
+    std::list<MNVMeofGwBeaconDencoder> ls;
     std::string gw_id = "GW";
     std::string gw_pool = "pool";
     std::string gw_group = "group";
@@ -162,8 +166,9 @@ class MNVMeofGwBeaconDencoder {
       osd_epoch,
       gwmap_epoch);
 
-    ls.push_back(new MNVMeofGwBeaconDencoder(m));
+    ls.push_back(MNVMeofGwBeaconDencoder(m));
 
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(MNVMeofGwBeaconDencoder)

--- a/src/tools/ceph-dencoder/sstring.h
+++ b/src/tools/ceph-dencoder/sstring.h
@@ -25,14 +25,16 @@ class sstring_wrapper {
     f->dump_string("s1", s1.c_str());
     f->dump_string("s2", reinterpret_cast<const char*>(s2.c_str()));
   }
-  static void generate_test_instances(std::list<sstring_wrapper*>& ls) {
-    ls.push_back(new sstring_wrapper());
+  static std::list<sstring_wrapper> generate_test_instances() {
+    std::list<sstring_wrapper> ls;
+    ls.push_back(sstring_wrapper());
     // initialize sstrings that fit in internal storage
     constexpr auto cstr6 = "abcdef";
-    ls.push_back(new sstring_wrapper(sstring16{cstr6}, sstring24{cstr6}));
+    ls.push_back(sstring_wrapper(sstring16{cstr6}, sstring24{cstr6}));
     // initialize sstrings that overflow into external storage
     constexpr auto cstr26 = "abcdefghijklmnopqrstuvwxyz";
-    ls.push_back(new sstring_wrapper(sstring16{cstr26}, sstring24{cstr26}));
+    ls.push_back(sstring_wrapper(sstring16{cstr26}, sstring24{cstr26}));
+    return ls;
   }
 };
 WRITE_CLASS_DENC(sstring_wrapper)

--- a/src/tools/ceph-dencoder/str.h
+++ b/src/tools/ceph-dencoder/str.h
@@ -26,11 +26,13 @@ class string_wrapper {
     f->dump_string("s", s);
   }
 
-  static void generate_test_instances(std::list<string_wrapper*>& ls) {
-    ls.push_back(new string_wrapper());
+  static std::list<string_wrapper> generate_test_instances() {
+    std::list<string_wrapper> ls;
+    ls.push_back(string_wrapper());
     // initialize strings that fit in internal storage
     std::string s1 = "abcdef";
-    ls.push_back(new string_wrapper(s1));
+    ls.push_back(string_wrapper(s1));
+    return ls;
   }
 };
 WRITE_CLASS_ENCODER(string_wrapper)

--- a/src/tools/rbd_mirror/image_map/Types.cc
+++ b/src/tools/rbd_mirror/image_map/Types.cc
@@ -105,8 +105,10 @@ void PolicyData::dump(Formatter *f) const {
   std::visit(DumpVisitor(f, "policy_meta_type"), policy_meta);
 }
 
-void PolicyData::generate_test_instances(std::list<PolicyData *> &o) {
-  o.push_back(new PolicyData(PolicyMetaNone()));
+std::list<PolicyData> PolicyData::generate_test_instances() {
+  std::list<PolicyData> o;
+  o.push_back(PolicyData(PolicyMetaNone()));
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &os, const ActionType& action_type) {

--- a/src/tools/rbd_mirror/image_map/Types.h
+++ b/src/tools/rbd_mirror/image_map/Types.h
@@ -116,7 +116,7 @@ struct PolicyData {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<PolicyData *> &o);
+  static std::list<PolicyData> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(PolicyData);

--- a/src/tools/rbd_mirror/instance_watcher/Types.cc
+++ b/src/tools/rbd_mirror/instance_watcher/Types.cc
@@ -179,21 +179,23 @@ void NotifyMessage::dump(Formatter *f) const {
   std::visit(DumpPayloadVisitor(f), payload);
 }
 
-void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
-  o.push_back(new NotifyMessage(ImageAcquirePayload()));
-  o.push_back(new NotifyMessage(ImageAcquirePayload(1, "gid")));
+std::list<NotifyMessage> NotifyMessage::generate_test_instances() {
+  std::list<NotifyMessage> o;
+  o.push_back(NotifyMessage(ImageAcquirePayload()));
+  o.push_back(NotifyMessage(ImageAcquirePayload(1, "gid")));
 
-  o.push_back(new NotifyMessage(ImageReleasePayload()));
-  o.push_back(new NotifyMessage(ImageReleasePayload(1, "gid")));
+  o.push_back(NotifyMessage(ImageReleasePayload()));
+  o.push_back(NotifyMessage(ImageReleasePayload(1, "gid")));
 
-  o.push_back(new NotifyMessage(PeerImageRemovedPayload()));
-  o.push_back(new NotifyMessage(PeerImageRemovedPayload(1, "gid", "uuid")));
+  o.push_back(NotifyMessage(PeerImageRemovedPayload()));
+  o.push_back(NotifyMessage(PeerImageRemovedPayload(1, "gid", "uuid")));
 
-  o.push_back(new NotifyMessage(SyncRequestPayload()));
-  o.push_back(new NotifyMessage(SyncRequestPayload(1, "sync_id")));
+  o.push_back(NotifyMessage(SyncRequestPayload()));
+  o.push_back(NotifyMessage(SyncRequestPayload(1, "sync_id")));
 
-  o.push_back(new NotifyMessage(SyncStartPayload()));
-  o.push_back(new NotifyMessage(SyncStartPayload(1, "sync_id")));
+  o.push_back(NotifyMessage(SyncStartPayload()));
+  o.push_back(NotifyMessage(SyncStartPayload(1, "sync_id")));
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &out, const NotifyOp &op) {

--- a/src/tools/rbd_mirror/instance_watcher/Types.h
+++ b/src/tools/rbd_mirror/instance_watcher/Types.h
@@ -160,7 +160,7 @@ struct NotifyMessage {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<NotifyMessage *> &o);
+  static std::list<NotifyMessage> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(NotifyMessage);

--- a/src/tools/rbd_mirror/leader_watcher/Types.cc
+++ b/src/tools/rbd_mirror/leader_watcher/Types.cc
@@ -132,10 +132,12 @@ void NotifyMessage::dump(Formatter *f) const {
   std::visit(DumpPayloadVisitor(f), payload);
 }
 
-void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
-  o.push_back(new NotifyMessage(HeartbeatPayload()));
-  o.push_back(new NotifyMessage(LockAcquiredPayload()));
-  o.push_back(new NotifyMessage(LockReleasedPayload()));
+std::list<NotifyMessage> NotifyMessage::generate_test_instances() {
+  std::list<NotifyMessage> o;
+  o.push_back(NotifyMessage(HeartbeatPayload()));
+  o.push_back(NotifyMessage(LockAcquiredPayload()));
+  o.push_back(NotifyMessage(LockReleasedPayload()));
+  return o;
 }
 
 std::ostream &operator<<(std::ostream &out, const NotifyOp &op) {

--- a/src/tools/rbd_mirror/leader_watcher/Types.h
+++ b/src/tools/rbd_mirror/leader_watcher/Types.h
@@ -100,7 +100,7 @@ struct NotifyMessage {
   void decode(bufferlist::const_iterator& it);
   void dump(Formatter *f) const;
 
-  static void generate_test_instances(std::list<NotifyMessage *> &o);
+  static std::list<NotifyMessage> generate_test_instances();
 };
 
 WRITE_CLASS_ENCODER(NotifyMessage);


### PR DESCRIPTION
## Problem:

The current `generate_test_instance()` function returns `std::list<T*>`, which creates memory management issues:

- Inconsistent lifecycle management of test instances
- Callers don't always properly clean up allocated memory
- Results in ASan memory leak reports in unit tests and ceph-dencoder

## Solution:

Change `generate_test_instance()` to return `std::list<T>` instead of `std::list<T*>`:

## Core Changes:

- Modified all classes with `generate_test_instance()` to return `std::list<T>`
- Use `emplace_back()` without parameters** to avoid copy/move constructors for classes that don't define them
- Updated ceph-dencoder to handle the new return type

## ceph-dencoder Adaptations:

Since `m_list` now holds `T` objects instead of `T*`, and we can't assume `T` is copyable/moveable:

- Keep `m_object` as a pointer for flexibility
- Handle two scenarios:
  1. `m_object` points to an element in `m_list`
  2. `m_object` points to a decoded instance (requires manual cleanup)
- Introduce `is_owned` flag to track when manual cleanup is needed

## Additional Cleanup:

- Simplify DencoderBase constructor from template to plain function (extra parameters were never used in derived classes)

With this change, object lifecycles are now managed by value semantics instead of raw pointers, eliminating memory leaks.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
