### PR TITLE
squid: doc/radosgw: Promptify CLI commands and fix formatting in layout.rst

### DIFF
--- a/doc/radosgw/layout.rst
+++ b/doc/radosgw/layout.rst
@@ -25,9 +25,14 @@ Metadata
 ^^^^^^^^
 
 RGW stores multiple types of metadata.  The list of types can be shown
-with the below command. The types as of 2025 April are shown below::
+with the below command. The types as of 2025 April are shown below:
 
-    $ bin/radosgw-admin metadata list
+.. prompt:: bash #
+
+   radosgw-admin metadata list
+
+::
+
     [
         "account",
         "bucket",
@@ -39,16 +44,17 @@ with the below command. The types as of 2025 April are shown below::
         "user"
     ]
 
-Use commands of the following forms to inspect metadata entries: ::
+Use commands of the following forms to inspect metadata entries:
 
-    $ radosgw-admin metadata list
-    $ radosgw-admin metadata list bucket
-    $ radosgw-admin metadata list bucket.instance
-    $ radosgw-admin metadata list user
+.. prompt:: bash #
 
-    $ radosgw-admin metadata get bucket:<bucket>
-    $ radosgw-admin metadata get bucket.instance:<bucket>:<bucket_id>
-    $ radosgw-admin metadata get user:<user>   # get or set
+   radosgw-admin metadata list
+   radosgw-admin metadata list bucket
+   radosgw-admin metadata list bucket.instance
+   radosgw-admin metadata list user
+   radosgw-admin metadata get bucket:<bucket>
+   radosgw-admin metadata get bucket.instance:<bucket>:<bucket_id>
+   radosgw-admin metadata get user:<user>   # get or set
     
 Variables are used in above command examples; when issuing commands you must
 substitute your specific values:
@@ -115,11 +121,18 @@ different users\` buckets will be created in different RADOS pools by default,
 thus providing the necessary scaling. The layout and naming of these pools
 is controlled by a 'policy' setting.[3]
 
-An RGW object may consist of several RADOS objects, the first of which
-is the head that contains the metadata, such as manifest, ACLs, content type,
-ETag, and user-defined metadata. The metadata is stored in xattrs.
-The head may also contain up to :confval:`rgw_max_chunk_size` of object data, for efficiency
-and atomicity. The manifest describes how each object is laid out in RADOS
+An RGW object may consist of several RADOS objects, the first of which is the
+head that contains the metadata, such as manifest, ACLs, content type, ETag,
+and user-defined metadata. The metadata is stored in xattrs.  The ``HEAD``
+object may also inline up to :confval:`rgw_max_chunk_size` of object data, for
+efficiency and atomicity.  This enables a convenenient tiering strategy:  index
+pools are necessarily replicated (cannot be EC) and should be placed on fast
+SSD OSDs.  With a mix of small/hot RGW objects and larger, warm/cold RGW
+objects like video files, the larger objects will automatically be placed in
+the ``buckets.data`` pool, which may be EC and/or slower storage like HDDs or
+QLC SSDs.
+
+The manifest describes how each RGW object is laid out across RADOS
 objects.
 
 Bucket and Object Listing
@@ -185,8 +198,8 @@ Known pools:
       prodtx/test%25star
       testcont
 
-  namespace: users.uid
-    Contains _both_ per-user information (RGWUserInfo) in "<user>" objects
+  namespace: ``users.uid``
+    Contains *both* per-user information (RGWUserInfo) in "<user>" objects
     and per-user lists of buckets in omaps of "<user>.buckets" objects.
     The "<user>" may contain the tenant if non-empty, for example::
 
@@ -215,7 +228,7 @@ Known pools:
   default.7593.4__shadow_.488urDFerTYXavx4yAd-Op8mxehnvTI_1
   <marker>_<key>
 
-An example of a marker would be "default.16004.1" or "default.7593.4".
-The current format is "<zone>.<instance_id>.<bucket_id>". But once
+An example of a marker would be ``default.16004.1`` or ``default.7593.4``.
+The current format is ``<zone>.<instance_id>.<bucket_id>``. But once
 generated, a marker is not parsed again, so its format may change
 freely in the future.


### PR DESCRIPTION
Move two example CLI command blocks to use a bash prompt block with the correct privileged prompt instead of hardcoded unprivileged prompt.

Don't use the directory "bin/" in command "bin/radosgw-admin" especially when the next commands also don't use it.

Fix 2 instances of double-backtick missing the second backtick that caused the rendered doc to be jumbled.

Do not use _emphasis_ that renders as underscores, instead use RST syntax for italic for the word.


(cherry picked from commit 6783245e98be4bd83be754fa39353d268e25b896)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
