### PR TITLE
pybind/cephfs, mgr/volumes: introduce non-recurisve rmtree(), refactor purge() to use it and add MDS optimizations

### DIFF
--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -1,6 +1,4 @@
 #!/bin/sh -ex
 
-# Running as root because the filesystem root directory will be
-# owned by uid 0, and that's where we're writing.
-sudo python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
+python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
 exit 0

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7689,7 +7689,10 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, InodeRef *end
   return rc;
 }
 
-int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options)
+int Client::path_walk(InodeRef dirinode, const filepath& origpath,
+		      walk_dentry_result* result, const UserPerm& perms,
+		      const PathWalk_ExtraOptions& extra_options,
+		      std::string trimmed_path)
 {
   int rc = 0;
   filepath path = origpath;
@@ -7713,7 +7716,11 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
   int symlinks = 0;
   unsigned i = 0;
 
-  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << path << dendl;
+  if (trimmed_path == "") {
+    std::string trimmed_path = path.get_trimmed_path();
+  }
+
+  ldout(cct, 10) << __func__ << ": cur=" << *diri << " path=" << trimmed_path << dendl;
 
   if (path.depth() == 0) {
     /* diri/dname can also be used as a filepath; or target */
@@ -7727,7 +7734,7 @@ int Client::path_walk(InodeRef dirinode, const filepath& origpath, walk_dentry_r
     int caps = 0;
     dname = path[i];
     ldout(cct, 10) << " " << i << " " << *diri << " " << dname << dendl;
-    ldout(cct, 20) << "  (path is " << path << ")" << dendl;
+    ldout(cct, 20) << "  (path is " << trimmed_path << ")" << dendl;
     InodeRef next;
     if (!diri.get()->is_dir()) {
       ldout(cct, 20) << diri.get() << " is not a dir inode, name " << dname.c_str() << dendl;
@@ -15420,11 +15427,12 @@ int Client::ll_unlink(Inode *in, const char *name, const UserPerm& perm)
 
 int Client::_rmdir(Inode *dir, const char *name, const UserPerm& perms, bool check_perms)
 {
-  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << name << " uid "
+  std::string trimmed_path = filepath(name).get_trimmed_path();
+  ldout(cct, 8) << "_rmdir(" << dir->ino << " " << trimmed_path << " uid "
 		<< perms.uid() << " gid " << perms.gid() << ")" << dendl;
 
   walk_dentry_result wdr;
-  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}); rc < 0) {
+  if (int rc = path_walk(dir, filepath(name), &wdr, perms, {.followsym = false}, trimmed_path); rc < 0) {
     return rc;
   }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1073,7 +1073,7 @@ protected:
     bool is_rename = false;
     bool require_target = true;
   };
-  int path_walk(InodeRef dirinode, const filepath& fp, struct walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options);
+  int path_walk(InodeRef dirinode, const filepath& fp, struct walk_dentry_result* result, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options, std::string trimmed_path=std::string());
   int path_walk(InodeRef dirinode, const filepath& fp, InodeRef *end, const UserPerm& perms, const PathWalk_ExtraOptions& extra_options);
 
   // fake inode number for 32-bits ino_t

--- a/src/common/strescape.h
+++ b/src/common/strescape.h
@@ -34,4 +34,21 @@ inline std::string binstrprint(std::string_view sv, size_t maxlen=0)
   return s;
 }
 
+inline std::string get_trimmed_path_str(const std::string& path)
+{
+  // index of '/' before 10th component (count from end of the path).
+  size_t n = 0;
+
+  for (int i = 1; i <= 10; ++i) {
+    n = path.rfind("/", n - 1);
+    if (n == std::string::npos) {
+      // path doesn't contain 10 components, return path as it is.
+      return path;
+      break;
+    }
+  }
+
+  return std::string("..." + path.substr(n, -1));
+}
+
 #endif

--- a/src/include/filepath.cc
+++ b/src/include/filepath.cc
@@ -17,6 +17,21 @@
 
 #include <ostream>
 
+/* Trim given path to final 10 components and return it by prefixing it with
+ * "..."  to indicate that the path has been trimmed. */
+std::string filepath::get_trimmed_path() const
+{
+  std::size_t n = 0;
+  for (int i = 1; i <= 10; ++i) {
+    n = path.rfind("/", n - 1);
+    if (n == std::string::npos) {
+      return std::string(path);
+    }
+  }
+
+  return std::string("..." + path.substr(n, -1));
+}
+
 void filepath::rebuild_path() {
   path.clear();
   for (unsigned i=0; i<bits.size(); i++) {

--- a/src/include/filepath.cc
+++ b/src/include/filepath.cc
@@ -41,6 +41,14 @@ void filepath::parse_bits() const {
   }
 }
 
+void filepath::set_trimmed() {
+  if (trimmed)
+    return;
+  // indicates that the path has been shortened.
+  path += "...";
+  trimmed = true;
+}
+
 void filepath::set_path(std::string_view s) {
   if (!s.empty() && s[0] == '/') {
     path = s.substr(1);

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -38,6 +38,9 @@ namespace ceph { class Formatter; }
 class filepath {
   inodeno_t ino = 0;   // base inode.  ino=0 implies pure relative path.
   std::string path;     // relative path.
+  // tells get_path() whether it should prefix path with "..." to indicate that
+  // it was shortened.
+  bool trimmed = false;
 
   /** bits - path segments
    * this is ['a', 'b', 'c'] for both the aboslute and relative case.
@@ -82,6 +85,7 @@ class filepath {
   // accessors
   inodeno_t get_ino() const { return ino; }
   const std::string& get_path() const { return path; }
+  void set_trimmed();
   const char *c_str() const { return path.c_str(); }
 
   int length() const { return path.length(); }

--- a/src/include/filepath.h
+++ b/src/include/filepath.h
@@ -86,6 +86,7 @@ class filepath {
   inodeno_t get_ino() const { return ino; }
   const std::string& get_path() const { return path; }
   void set_trimmed();
+  std::string get_trimmed_path() const;
   const char *c_str() const { return path.c_str(); }
 
   int length() const { return path.length(); }

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -312,6 +312,24 @@ void CDentry::make_path_string(string& s, bool projected,
   s.append(name.data(), name.length());
 }
 
+/* path_comp_count = path component count. default value is 10 which implies
+ * generate entire path.
+ *
+ * XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ */
+void CDentry::make_trimmed_path_string(string& s, bool projected,
+				       int path_comp_count) const
+{
+  make_path_string(s, projected, path_comp_count);
+}
+
 /* path_comp_count = path component count. default value is -1 which implies
  * generate entire path.
  */

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -300,10 +300,11 @@ void CDentry::clear_auth()
   }
 }
 
-void CDentry::make_path_string(string& s, bool projected) const
+void CDentry::make_path_string(string& s, bool projected,
+			       int path_comp_count) const
 {
   if (dir) {
-    dir->inode->make_path_string(s, projected);
+    dir->inode->make_path_string(s, projected, NULL, path_comp_count);
   } else {
     s = "???";
   }

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -85,7 +85,7 @@ const LockType CDentry::versionlock_type(CEPH_LOCK_DVERSION);
 ostream& operator<<(ostream& out, const CDentry& dn)
 {
   filepath path;
-  dn.make_path(path);
+  dn.make_trimmed_path(path);
   
   out << "[dentry " << path;
   
@@ -312,13 +312,44 @@ void CDentry::make_path_string(string& s, bool projected,
   s.append(name.data(), name.length());
 }
 
-void CDentry::make_path(filepath& fp, bool projected) const
+/* path_comp_count = path component count. default value is -1 which implies
+ * generate entire path.
+ */
+void CDentry::make_path(filepath& fp, bool projected,
+		        int path_comp_count) const
 {
-  ceph_assert(dir);
-  dir->inode->make_path(fp, projected);
-  fp.push_dentry(get_name());
+  fp.set_trimmed();
+
+  if (path_comp_count == -1) {
+    ceph_assert(dir);
+    dir->inode->make_path(fp, projected, path_comp_count);
+    fp.push_dentry(get_name());
+  } else if (path_comp_count >= 1) {
+    --path_comp_count;
+
+    ceph_assert(dir);
+    dir->inode->make_path(fp, projected, path_comp_count);
+    fp.push_dentry(get_name());
+  }
 }
 
+/* path_comp_count = path component count. default value is 10 which implies
+ * generate entire path.
+ *
+ * XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ */
+void CDentry::make_trimmed_path(filepath& fp, bool projected,
+				int path_comp_count) const
+{
+  make_path(fp, projected, path_comp_count);
+}
 /*
  * we only add ourselves to remote_parents when the linkage is
  * active (no longer projected).  if the passed dnl is projected,

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -252,7 +252,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
-  void make_path_string(std::string& s, bool projected=false) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false) const;
 
   // -- version --

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -254,7 +254,10 @@ public:
   // misc
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& fp, bool projected=false) const;
+  void make_path(filepath& fp, bool projected=false,
+		 int path_comp_count=-1) const;
+  void make_trimmed_path(filepath& fp, bool projected=false,
+			 int path_comp_count=10) const;
 
   // -- version --
   version_t get_version() const { return version; }

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -252,6 +252,8 @@ public:
   const CDentry& operator= (const CDentry& right);
 
   // misc
+  void make_trimmed_path_string(std::string& s, bool projected,
+				int path_comp_count=10) const;
   void make_path_string(std::string& s, bool projected=false,
 		        int path_comp_count=-1) const;
   void make_path(filepath& fp, bool projected=false,

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -91,7 +91,7 @@ public:
 
 ostream& operator<<(ostream& out, const CDir& dir)
 {
-  out << "[dir " << dir.dirfrag() << " " << dir.get_path() << "/"
+  out << "[dir " << dir.dirfrag() << " " << dir.get_trimmed_path() << "/"
       << " [" << dir.first << ",head]";
   if (dir.is_auth()) {
     out << " auth";
@@ -2094,8 +2094,8 @@ CDentry *CDir::_load_dentry(
                 << " mode " << ref_in->get_inode()->mode
                 << " mtime " << ref_in->get_inode()->mtime << dendl;
         string dirpath, inopath;
-        this->inode->make_path_string(dirpath);
-        ref_in->make_path_string(inopath);
+        this->inode->make_trimmed_path_string(dirpath);
+        ref_in->make_trimmed_path_string(inopath);
         mdcache->mds->clog->error() << "loaded dup referent inode " << inode_data.inode->ino
           << " [" << first << "," << last << "] v" << inode_data.inode->version
           << " at " << dirpath << "/" << dname
@@ -2245,7 +2245,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
     dout(0) << "_fetched missing object for " << *this << dendl;
 
     clog->error() << "dir " << dirfrag() << " object missing on disk; some "
-                     "files may be lost (" << get_path() << ")";
+                     "files may be lost (" << get_trimmed_path() << ")";
 
     go_bad(complete);
     return;
@@ -2260,14 +2260,14 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
       derr << "Corrupt fnode in dirfrag " << dirfrag()
 	   << ": " << err.what() << dendl;
       clog->warn() << "Corrupt fnode header in " << dirfrag() << ": "
-		   << err.what() << " (" << get_path() << ")";
+		   << err.what() << " (" << get_trimmed_path() << ")";
       go_bad(complete);
       return;
     }
     if (!p.end()) {
       clog->warn() << "header buffer of dir " << dirfrag() << " has "
 		  << hdrbl.length() - p.get_off() << " extra bytes ("
-                  << get_path() << ")";
+                  << get_trimmed_path() << ")";
       go_bad(complete);
       return;
     }
@@ -2385,7 +2385,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
     } catch (const buffer::error &err) {
       mdcache->mds->clog->warn() << "Corrupt dentry '" << key.name << "' in "
                                   "dir frag " << dirfrag() << ": "
-                               << err.what() << "(" << get_path() << ")";
+                               << err.what() << "(" << get_trimmed_path() << ")";
 
       // Remember that this dentry is damaged.  Subsequent operations
       // that try to act directly on it will get their EIOs, but this
@@ -4057,7 +4057,22 @@ bool CDir::scrub_local()
   return good;
 }
 
-std::string CDir::get_path() const
+/* XXX: Return string containing only final 10 components of the path. This
+ * shortened path is to be used usually for only logging. This prevents the
+ * unnecessary generation of full version of a very long path (imagine a path
+ * with 2000 components) from inode because not only repeatedly printing long
+ * path in logs is unnecessary and unreadable but more importantly because it
+ * is an expensive process (since it's done for more or less individual log
+ * entries).
+ */
+std::string CDir::get_trimmed_path() const
+{
+  std::string path;
+  get_inode()->make_trimmed_path_string(path, true);
+  return path;
+}
+
+std::string CDir::get_path(bool trim_path) const
 {
   std::string path;
   get_inode()->make_path_string(path, true);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -786,7 +786,8 @@ private:
   void steal_dentry(CDentry *dn);  // from another dir.  used by merge/split.
   void finish_old_fragment(std::vector<MDSContext*>& waiters, bool replay);
   void init_fragment_pins();
-  std::string get_path() const;
+  std::string get_trimmed_path() const;
+  std::string get_path(bool trim_path=false) const;
 
   // -- authority --
   /*

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1153,12 +1153,12 @@ void CInode::make_trimmed_path_string(string& s, bool projected,
   make_path_string(s, projected, use_parent, path_comp_count);
 }
 
-void CInode::make_path(filepath& fp, bool projected) const
+void CInode::make_path(filepath& fp, bool projected, int path_comp_count) const
 {
   const CDentry *use_parent = projected ? get_projected_parent_dn() : parent;
   if (use_parent) {
     ceph_assert(!is_base());
-    use_parent->make_path(fp, projected);
+    use_parent->make_path(fp, projected, path_comp_count);
   } else {
     fp = filepath(ino());
   }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -177,7 +177,7 @@ int num_cinode_locks = sizeof(cinode_lock_info) / sizeof(cinode_lock_info[0]);
 ostream& operator<<(ostream& out, const CInode& in)
 {
   string path;
-  in.make_path_string(path, true);
+  in.make_trimmed_path_string(path);
 
   out << "[inode " << in.ino();
   out << " [" 
@@ -1095,15 +1095,29 @@ bool CInode::is_projected_ancestor_of(const CInode *other) const
  * use_parent is NULL and projected is true, the primary parent's projected
  * inode is used all the way up the path chain. Otherwise the primary parent
  * stable inode is used.
+ *
+ * path_comp_count = path components count. default value is -1, which implies
+ * generate full path.
  */
-void CInode::make_path_string(string& s, bool projected, const CDentry *use_parent) const
+void CInode::make_path_string(string& s, bool projected,
+			      const CDentry *use_parent,
+			      int path_comp_count) const
 {
   if (!use_parent) {
     use_parent = projected ? get_projected_parent_dn() : parent;
   }
 
   if (use_parent) {
-    use_parent->make_path_string(s, projected);
+    if (path_comp_count == -1) {
+      use_parent->make_path_string(s, projected, path_comp_count);
+    } else if (path_comp_count >= 1) {
+      --path_comp_count;
+      use_parent->make_path_string(s, projected, path_comp_count);
+    } else if (path_comp_count == 0) {
+      // this indicates that path has been shortened.
+      s = "...";
+      return;
+    }
   } else if (is_root()) {
     s = "";
   } else if (is_mdsdir()) {
@@ -1118,6 +1132,25 @@ void CInode::make_path_string(string& s, bool projected, const CDentry *use_pare
     snprintf(n, sizeof(n), "#%" PRIx64, eino);
     s += n;
   }
+}
+
+/* XXX Generating more than 10 components of a path for printing in logs will
+ * consume too much time when the path is too long (imagine a path with 2000
+ * components) since the path would've to be generated indidividually for each
+ * log entry.
+ *
+ * Besides consuming too much time, such long paths in logs are not only not
+ * useful but also it makes reading logs harder. Therefore, shorten the path
+ * when used for logging.
+ *
+ * path_comp_count = path components count. default value is 10, which implies
+ * generate full path.
+ */
+void CInode::make_trimmed_path_string(string& s, bool projected,
+				      const CDentry* use_parent,
+				      int path_comp_count) const
+{
+  make_path_string(s, projected, use_parent, path_comp_count);
 }
 
 void CInode::make_path(filepath& fp, bool projected) const
@@ -2695,7 +2728,7 @@ void CInode::finish_scatter_gather_update(int type, MutationRef& mut)
 
       if (pi->dirstat.nfiles < 0 || pi->dirstat.nsubdirs < 0) {
         std::string path;
-        make_path_string(path);
+	make_trimmed_path_string(path);
 	clog->error() << "Inconsistent statistics detected: fragstat on inode "
                       << ino() << " (" << path << "), inode has " << pi->dirstat;
 	ceph_assert(!"bad/negative fragstat" == g_conf()->mds_verify_scatter);
@@ -5000,7 +5033,7 @@ next:
 
       if (!results->backtrace.passed && in->scrub_infop->header->get_repair()) {
         std::string path;
-        in->make_path_string(path);
+	in->make_trimmed_path_string(path);
         in->mdcache->mds->clog->warn() << "bad backtrace on inode " << in->ino()
                                        << "(" << path << "), rewriting it";
         in->mark_dirty_parent(in->mdcache->mds->mdlog->get_current_segment(),

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -745,7 +745,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void make_path_string(std::string& s, bool projected=false,
 		        const CDentry *use_parent=NULL,
 		        int path_comp_count=-1) const;
-  void make_path(filepath& s, bool projected=false) const;
   void make_trimmed_path_string(std::string& s, bool projected=false,
 				const CDentry *use_parent=NULL,
 				int path_comp_count=10) const;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -742,8 +742,15 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool is_ancestor_of(const CInode *other, std::unordered_map<CInode const*,bool>* visited=nullptr) const;
   bool is_projected_ancestor_of(const CInode *other) const;
 
-  void make_path_string(std::string& s, bool projected=false, const CDentry *use_parent=NULL) const;
+  void make_path_string(std::string& s, bool projected=false,
+		        const CDentry *use_parent=NULL,
+		        int path_comp_count=-1) const;
   void make_path(filepath& s, bool projected=false) const;
+  void make_trimmed_path_string(std::string& s, bool projected=false,
+				const CDentry *use_parent=NULL,
+				int path_comp_count=10) const;
+  void make_path(filepath& s, bool projected=false,
+		 int path_comp_count=-1) const;
   void name_stray_dentry(std::string& dname);
   
   // -- dirtyness --

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -237,7 +237,7 @@ bool MDSAuthCaps::is_capable(string_view fs_name,
 			     const entity_addr_t& addr,
 			     string_view trimmed_inode_path) const
 {
-  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name
+  ldout(g_ceph_context, 10) << __func__ << " fs_name " << fs_name
 		 << " inode(path /" << trimmed_inode_path
 		 << " owner " << inode_uid << ":" << inode_gid
 		 << " mode 0" << std::oct << inode_mode << std::dec

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -234,9 +234,11 @@ bool MDSAuthCaps::is_capable(string_view fs_name,
 			     const vector<uint64_t> *caller_gid_list,
 			     unsigned mask,
 			     uid_t new_uid, gid_t new_gid,
-			     const entity_addr_t& addr) const
+			     const entity_addr_t& addr,
+			     string_view trimmed_inode_path) const
 {
-  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name << " inode(path /" << inode_path
+  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name
+		 << " inode(path /" << trimmed_inode_path
 		 << " owner " << inode_uid << ":" << inode_gid
 		 << " mode 0" << std::oct << inode_mode << std::dec
 		 << ") by caller " << caller_uid << ":" << caller_gid

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -272,7 +272,7 @@ public:
 		  uid_t inode_uid, gid_t inode_gid, unsigned inode_mode,
 		  uid_t uid, gid_t gid, const std::vector<uint64_t> *caller_gid_list,
 		  unsigned mask, uid_t new_uid, gid_t new_gid,
-		  const entity_addr_t& addr) const;
+		  const entity_addr_t& addr, std::string_view trimmed_inode_path) const;
   bool path_capable(std::string_view inode_path) const;
 
   bool fs_name_capable(std::string_view fs_name, unsigned mask) const {

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -508,8 +508,6 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *done)
       ++it; /* trim (in the future) may remove dentry */
 
       if (dn->scrub(next_seq)) {
-        std::string path;
-        dir->get_inode()->make_path_string(path, true);
         clog->warn() << "Scrub error on dentry " << *dn
                      << " see " << g_conf()->name
                      << " log and `damage ls` output for details";

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -9227,7 +9227,7 @@ void Server::_rmdir_rollback_finish(const MDRequestRef& mdr, metareqid_t reqid, 
  */
 bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
 {
-  dout(10) << "dir_is_nonempty_unlocked " << *in << dendl;
+  dout(10) << __func__ << " " << *in << dendl;
   ceph_assert(in->is_auth());
 
   if (in->filelock.is_cached())
@@ -9240,7 +9240,7 @@ bool Server::_dir_is_nonempty_unlocked(const MDRequestRef& mdr, CInode *in)
     // is the frag obviously non-empty?
     if (dir->is_auth()) {
       if (dir->get_projected_fnode()->fragstat.size()) {
-	dout(10) << "dir_is_nonempty_unlocked dirstat has " 
+	dout(10) << __func__ << " dirstat has "
 		 << dir->get_projected_fnode()->fragstat.size() << " items " << *dir << dendl;
 	return true;
       }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -63,6 +63,7 @@
 
 #include "include/stringify.h"
 #include "include/filepath.h"
+#include "common/strescape.h"
 #include "common/ceph_json.h"
 #include "common/debug.h"
 #include "common/Timer.h"
@@ -10190,7 +10191,10 @@ void Server::_rename_prepare(const MDRequestRef& mdr,
       {
         std::string t;
         destdn->make_path_string(t, true);
-        dout(20) << " stray_prior_path = " << t << dendl;
+
+	/* Log only 10 final components fo the path to since logging entire
+	 * path is not useful and also reduces readability. */
+        dout(20) << " stray_prior_path = " << get_trimmed_path_str(t) << dendl;
         tpi->stray_prior_path = std::move(t);
       }
       tpi->nlink--;
@@ -10205,8 +10209,11 @@ void Server::_rename_prepare(const MDRequestRef& mdr,
       {
         std::string t;
         destdn->make_path_string(t, true);
-        dout(20) << __func__ << " referent stray_prior_path = " << t << dendl;
-        trpi->stray_prior_path = std::move(t);
+
+	/* Log only 10 final components fo the path to since logging entire
+	 * path is not useful and also reduces readability. */
+	dout(20) << __func__ << " referent stray_prior_path = " << get_trimmed_path_str(t) << dendl;
+	trpi->stray_prior_path = std::move(t);
       }
     }
   }

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -28,6 +28,7 @@
 #include "common/errno.h"
 #include "common/DecayCounter.h"
 #include "common/perf_counters.h"
+#include "common/strescape.h" // for get_trimmed_path()
 #include "include/ceph_assert.h"
 #include "include/stringify.h"
 
@@ -1122,11 +1123,14 @@ int Session::check_access(std::string_view fs_name, CInode *in, unsigned mask,
     }
   }
 
+  string trimmed_path = "";
   if (!path.empty()) {
     dout(20) << __func__ << " stray_prior_path " << path << dendl;
   } else {
     in->make_path_string(path, true);
-    dout(20) << __func__ << " path " << path << dendl;
+    /* Log only 10 final components fo the path to since logging entire
+     * path is not useful and also reduces readability. */
+    dout(20) << __func__ << " path " << get_trimmed_path_str(path) << dendl;
   }
   if (path.length())
     path = path.substr(1);    // drop leading /
@@ -1142,8 +1146,7 @@ int Session::check_access(std::string_view fs_name, CInode *in, unsigned mask,
 
   if (!auth_caps.is_capable(fs_name, path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
-			    new_uid, new_gid,
-			    info.inst.addr)) {
+			    new_uid, new_gid, info.inst.addr, trimmed_path)) {
     return -EACCES;
   }
   return 0;

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -19,11 +19,17 @@ ELSE:
     from c_cephfs cimport *
     from rados cimport Rados
 
-from collections import namedtuple
+from collections import namedtuple, deque
 from datetime import datetime
 import os
 import time
+import stat
 from typing import Any, Dict, Optional
+from logging import getLogger
+
+
+log = getLogger(__name__)
+
 
 AT_SYMLINK_NOFOLLOW = 0x0100
 AT_STATX_SYNC_TYPE  = 0x6000
@@ -198,6 +204,17 @@ class DiskQuotaExceeded(OSError):
     pass
 class PermissionDenied(OSError):
     pass
+
+class OpCanceled(OSError):
+    def __init__(self, op_name):
+        '''
+        op_name should be the name of (FS) operation that has been cancelled.
+        '''
+        self.errno = 125 # ECANCELED
+        self.strerror = f'CephFS op {op_name} was cancelled by the user'
+
+        super(OpCanceled, self).__init__(self.errno, self.strerror)
+
 
 cdef errno_to_exception =  {
     EPERM      : PermissionError,
@@ -2836,3 +2853,283 @@ cdef class LibCephFS(object):
 
         finally:
            free(buf)
+
+    def rmtree(self, trash_path, should_cancel, suppress_errors=False):
+        '''
+        Delete entire file hierarchy present under trash_path when trash_path is
+        a dir. Do this deletion using depth-first (to prevent excessive memory
+        consumption) and non-recursive (to prevent hitting Python's max recursion
+        limit error) approach.
+
+        If trash_path is a path to regfile, symlink or something else, delete
+        them and return.
+        '''
+        # st_b = stat buffer
+        st_b = self.stat(trash_path, AT_SYMLINK_NOFOLLOW)
+        if stat.S_ISDIR(st_b.st_mode):
+            NonRecursiveRmtree(self, trash_path, should_cancel,
+                               suppress_errors).rmtree()
+        else:
+            try:
+                self.unlink(trash_path)
+                return
+            except Exception as e:
+                log.info('Following exception occurred while unlinking '
+                         f'file at path {trash_path}: {e}')
+                raise
+
+
+class NonRecursiveRmtree:
+    '''
+    Contains code to delete entire file tree under a directory with a
+    depth-first, non-recursive approach along with some helper code.
+
+    Primary focus of this class is to traverse the file hierarchy by operating
+    on the stack while using class RmTreeDir for running opendir(), rmdir() and
+    unlink() (in a safe way) and recording failures.
+    '''
+
+    def __init__(self, fs, trash_path, should_cancel, suppress_errors=False):
+        self.fs = fs
+        self.trash_path = trash_path
+
+        self.should_cancel = should_cancel
+        self.suppress_errors = suppress_errors
+
+        # Stack needed for traversing the file heirarchy under trash_path in
+        # depth-first, non-recursive fashion. Each stack member is an instance
+        # of class RmtreeDir.
+        self.stack = deque([])
+
+        # Current directory, dir entries of which are being currently removed.
+        # It should always be the directory at the top of stack, it should
+        # always be an instance of class RmtreeDir.
+        self.curr_dir = None
+
+    def add_dir_to_stack(self, de_name):
+        '''
+        Add new dir to stack and start traversing it. If it fails, add this
+        new dir to current dir's ignorelist since most likely we don't have
+        permissions for it.
+        '''
+        # ensure we are dealing with the dir at the top of the stack.
+        assert self.curr_dir is self.stack[-1]
+
+        de_path = os.path.join(self.curr_dir.path, de_name)
+        try:
+            self.stack.append(RmtreeDir(self.fs, de_path))
+            return True
+        except Error as e:
+            if self.suppress_errors:
+                # add to ignore list, traversal should continue for current dir.
+                log.info(f'dir "{de_name}" couldn\'t be opened and therefore '
+                          'it can\'t be remvoved. perhaps permissions for it '
+                          'are not granted.')
+                self.curr_dir.add_to_de_ignore_list(de_name)
+
+                return False
+            else:
+                raise
+
+    def notify_parent_dir(self):
+        '''
+        Add current dir's name to parent dir's "de_ignore_list". This is
+        necessary since parent dir can't be deleted when current dir can't be
+        deleted.
+        '''
+        # ensure we are dealing with the dir at the top of the stack.
+        assert self.curr_dir is self.stack[-1]
+
+        if len(self.stack) < 2:
+            return
+        parent_dir = self.stack[-2]
+        parent_dir.add_to_de_ignore_list(self.curr_dir.name)
+
+    def rmtree(self):
+        '''
+        This is where depth-first, non-recursive traversal is done.
+        '''
+        try:
+            self.stack.append(RmtreeDir(self.fs, self.trash_path))
+        except Exception as e:
+            log.error('opening root dir of the file tree failed with exception '
+                      f'"{e}", exiting.')
+            if self.suppress_errors:
+                return
+            else:
+                raise
+
+        while self.stack:
+            if self.should_cancel():
+                raise OpCanceled('rmtree')
+
+            self.curr_dir = self.stack[-1]
+
+            # de = directory entry
+            de = self.curr_dir.read_dir()
+            while de:
+                if self.should_cancel():
+                    raise OpCanceled('rmtree')
+
+                if de.is_dir():
+                    try:
+                        self.curr_dir.try_rmdir(de.d_name, self.suppress_errors)
+                    except ObjectNotEmpty:
+                        if self.add_dir_to_stack(de.d_name):
+                            # since adding new dir to stack was successful, stop
+                            # traversing the current dir and start traversing
+                            # the new dir that has been freshly added to the
+                            # stack.
+                            break
+                else:
+                    self.curr_dir.try_unlink(de.d_name, self.suppress_errors)
+
+                de = self.curr_dir.read_dir()
+
+            if self.curr_dir.has_any_fs_op_failed() or self.curr_dir.is_empty:
+                if self.curr_dir.has_any_fs_op_failed():
+                    self.notify_parent_dir()
+
+                if self.curr_dir.is_empty:
+                    try:
+                        self.fs.rmdir(self.curr_dir.path)
+                    except ObjectNotEmpty:
+                        log.info(f'removing "{self.curr_dir.name}" failed with '
+                                  'with ObjectNotEmpty even though dir empty '
+                                  'implying it contains a snapshot in its snap'
+                                  'dir')
+                        self.notify_parent_dir()
+
+                self.stack.pop()
+
+
+class RmtreeDir:
+    '''
+    Holds the path, name and handle of the directory being traversed for
+    rmtree() along with some helper code.
+
+    Primary focus of this class is to run rmtree() and unlink() in a safe way
+    and record failures to prevent hitting them again in future. It serves as
+    helper for class NonRecursiveRmtree.
+    '''
+
+    def __init__(self, fs, path):
+        self.fs = fs
+
+        self.path = path
+        if isinstance(self.path, str):
+            self.path = self.path.encode('utf-8')
+        self.name = os.path.basename(self.path)
+        # XXX: exception (if) raised here should be handled by caller based on
+        # the context.
+        self.handle = self.fs.opendir(self.path)
+
+        # Is this directory empty? It will be set by self.read_dir().
+        self.is_empty = None
+
+        # List of dir entries to be ignored instead of calling rmdir()
+        # or unlink() for them.
+        self.de_ignore_list = []
+
+        # Indicates whether an error occured during call to readdir().
+        self.has_readdir_failed = False
+
+        # If a dir entry has been removed and readdir() returns None,
+        # rewinddir() should be called since POSIX doesn't guarantee
+        # anything regarding behaviour of readdir() when readdir() and
+        # unlink()/rmdir() calls are interleaved. Whenever calls to
+        # unlink()/rmdir() are made, reading dir might've to be
+        # restarted.
+        self.de_has_been_removed = False
+
+    def __str__(self):
+        return self.path
+
+    def add_to_de_ignore_list(self, de_name):
+        self.de_ignore_list.append(de_name)
+
+    def set_readdir_error(self):
+        self.has_readdir_failed = True
+
+    def should_skip_d_name(self, de_name):
+        return de_name in self.de_ignore_list
+
+    def has_any_fs_op_failed(self):
+        return self.has_readdir_failed or len(self.de_ignore_list) > 0
+
+    def read_dir(self):
+        '''
+        Read this dir, return a dentry besides . and .. and ignorelist-ed
+        dentries.
+
+        If a dentry was removed and return value of readdir() is None, rewind
+        the dir and staring read the dir again.
+        '''
+        # Assuming True for now, if it's not empty it will be set to
+        # False by the following loop.
+        self.is_empty = True
+
+        try:
+            de = self.fs.readdir(self.handle)
+            while de:
+                if de.d_name in (b'.', b'..'):
+                    pass
+                elif de.d_name in self.de_ignore_list:
+                    self.is_empty = False
+                else:
+                    self.is_empty = False
+                    return de
+
+                de = self.fs.readdir(self.handle)
+                if self.de_has_been_removed:
+                    log.debug('rewinding and restarting reading current dir '
+                              f'"{self.name}", since a dentry has been '
+                              'removed.')
+                    self.handle.rewinddir()
+                    # reset de_has_been_removed flag
+                    self.de_has_been_removed = False
+
+                    de = self.fs.readdir(self.handle)
+        except Error as e:
+            log.error(f'Exception occured: "{e}"')
+            self.set_readdir_error()
+
+    def try_rmdir(self, de_name, suppress_errors=False):
+        '''
+        Remove given directory. If that fails because its not empty, raise the
+        exception, the caller should handle it.
+
+        In case of a failure for some other reason, add it to the ignorelist
+        and tell caller whether to continue or break loop based through the
+        return value.
+        '''
+        de_path = os.path.join(self.path, de_name)
+        try:
+            self.fs.rmdir(de_path)
+            self.de_has_been_removed = True
+        except ObjectNotEmpty:
+            # XXX: push this dir to stack, done in the caller method
+            raise
+        except Error as e:
+            log.error('Following exception occured while calling rmdir() for '
+                      f'dir "{self.name}": "{e}"')
+            self.add_to_de_ignore_list(de_name)
+
+            if not suppress_errors:
+                raise
+
+    def try_unlink(self, de_name, suppress_errors=False):
+        '''
+        Unlink given file and add it to the ignore list if that fails.
+        '''
+        de_path = os.path.join(self.path, de_name)
+        try:
+            self.fs.unlink(de_path)
+            self.de_has_been_removed = True
+        except Error as e:
+            log.error('Following exception occured while calling unlink() for '
+                      f'file "{de_name}": "{e}"')
+            self.add_to_de_ignore_list(de_name)
+
+            if not suppress_errors:
+                raise

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -184,7 +184,7 @@ TEST(MDSAuthCaps, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable(fsname, "foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo/bar"));
 }
 
 TEST(MDSAuthCaps, AllowUid) {
@@ -193,11 +193,11 @@ TEST(MDSAuthCaps, AllowUid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowUidGid) {
@@ -206,24 +206,24 @@ TEST(MDSAuthCaps, AllowUidGid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // user
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // group
   vector<uint64_t> glist10;
@@ -235,59 +235,59 @@ TEST(MDSAuthCaps, AllowUidGid) {
   glist11.push_back(11);
   vector<uint64_t> glist12;
   glist12.push_back(12);
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > group
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
 
   // group > other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 
   // user > other
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPath) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * path=/sandbox", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, AllowPathChars) {
   MDSAuthCaps unquo_cap;
   ASSERT_TRUE(unquo_cap.parse("allow * path=/sandbox-._foo", NULL));
   ASSERT_FALSE(unquo_cap.allow_all());
-  ASSERT_TRUE(unquo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(unquo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 
@@ -295,21 +295,21 @@ TEST(MDSAuthCaps, AllowPathCharsQuoted) {
   MDSAuthCaps quo_cap;
   ASSERT_TRUE(quo_cap.parse("allow * path=\"/sandbox-._foo\"", NULL));
   ASSERT_FALSE(quo_cap.allow_all());
-  ASSERT_TRUE(quo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(quo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, RootSquash) {
   MDSAuthCaps rs_cap;
   ASSERT_TRUE(rs_cap.parse("allow rw root_squash, allow rw path=/sandbox", NULL));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_FALSE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr, "foo"));
 }
 
 TEST(MDSAuthCaps, OutputParsed) {
@@ -371,7 +371,7 @@ TEST(MDSAuthCaps, network) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
 
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a));
-  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b));
-  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a, "foo"));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b, "foo"));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c, "foo"));
 }

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -12,13 +12,26 @@ import stat
 import uuid
 import json
 from datetime import datetime
+from subprocess import getoutput as get_cmd_output
+
 
 cephfs = None
+
 
 def setup_module():
     global cephfs
     cephfs = libcephfs.LibCephFS(conffile='')
+
+    username = get_cmd_output('id -un')
+    uid = get_cmd_output(f'id -u {username}')
+    gid = get_cmd_output(f'id -g {username}')
+    cephfs.conf_set('client_mount_uid', uid)
+    cephfs.conf_set('client_mount_gid', gid)
     cephfs.mount()
+
+    cephfs.conf_set('client_permissions' , 'false')
+    cephfs.chown('/', int(uid), int(gid))
+    cephfs.conf_set('client_permissions' , 'true')
 
 def teardown_module():
     global cephfs
@@ -569,142 +582,6 @@ def test_fchmod(testdir):
     cephfs.close(fd)
     cephfs.unlink(b'/file-fchmod')
 
-def test_chown(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-    cephfs.close(fd)
-
-    uid = 1012
-    gid = 1012
-    cephfs.chown('file1', uid, gid)
-    st = cephfs.stat(b'/file1')
-    assert_equal(st.st_uid, uid)
-    assert_equal(st.st_gid, gid)
-
-def test_chown_change_uid_but_not_gid(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-    cephfs.close(fd)
-
-    st1 = cephfs.stat(b'/file1')
-
-    uid = 1012
-    cephfs.chown('file1', uid, -1)
-    st2 = cephfs.stat(b'/file1')
-    assert_equal(st2.st_uid, uid)
-
-    # ensure that gid is unchaged.
-    assert_equal(st1.st_gid, st2.st_gid)
-
-def test_chown_change_gid_but_not_uid(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-    cephfs.close(fd)
-
-    st1 = cephfs.stat(b'/file1')
-
-    gid = 1012
-    cephfs.chown('file1', -1, gid)
-    st2 = cephfs.stat(b'/file1')
-    assert_equal(st2.st_gid, gid)
-
-    # ensure that uid is unchaged.
-    assert_equal(st1.st_uid, st2.st_uid)
-
-def test_lchown(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-    cephfs.close(fd)
-    cephfs.symlink('file1', 'slink1')
-
-    uid = 1012
-    gid = 1012
-    cephfs.lchown('slink1', uid, gid)
-    st = cephfs.lstat(b'/slink1')
-    assert_equal(st.st_uid, uid)
-    assert_equal(st.st_gid, gid)
-
-def test_lchown_change_uid_but_not_gid(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-    cephfs.close(fd)
-    cephfs.symlink('file1', 'slink1')
-
-    st1 = cephfs.lstat(b'slink1')
-
-    uid = 1012
-    cephfs.lchown('slink1', uid, -1)
-    st2 = cephfs.lstat(b'/slink1')
-    assert_equal(st2.st_uid, uid)
-
-    # ensure that gid is unchaged.
-    assert_equal(st1.st_gid, st2.st_gid)
-
-def test_lchown_change_gid_but_not_uid(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-    cephfs.close(fd)
-    cephfs.symlink('file1', 'slink1')
-
-    st1 = cephfs.lstat(b'slink1')
-
-    gid = 1012
-    cephfs.lchown('slink1', -1, gid)
-    st2 = cephfs.lstat(b'/slink1')
-    assert_equal(st2.st_gid, gid)
-
-    # ensure that uid is unchaged.
-    assert_equal(st1.st_uid, st2.st_uid)
-
-def test_fchown(testdir):
-    fd = cephfs.open(b'/file-fchown', 'w', 0o655)
-    uid = os.getuid()
-    gid = os.getgid()
-    assert_raises(TypeError, cephfs.fchown, b'/file-fchown', uid, gid)
-    assert_raises(TypeError, cephfs.fchown, fd, "uid", "gid")
-    cephfs.fchown(fd, uid, gid)
-    st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
-    assert_equal(st["uid"], uid)
-    assert_equal(st["gid"], gid)
-    cephfs.fchown(fd, 9999, 9999)
-    st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
-    assert_equal(st["uid"], 9999)
-    assert_equal(st["gid"], 9999)
-    cephfs.close(fd)
-    cephfs.unlink(b'/file-fchown')
-
-def test_fchown_change_uid_but_not_gid(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-
-    st1 = cephfs.stat(b'/file1')
-
-    uid = 1012
-    cephfs.fchown(fd, uid, -1)
-    st2 = cephfs.stat(b'/file1')
-    assert_equal(st2.st_uid, uid)
-
-    # ensure that uid is unchanged.
-    assert_equal(st1.st_gid, st2.st_gid)
-
-    cephfs.close(fd)
-
-def test_fchown_change_gid_but_not_uid(testdir):
-    fd = cephfs.open('file1', 'w', 0o755)
-    cephfs.write(fd, b'abcd', 0)
-
-    st1 = cephfs.stat(b'/file1')
-
-    gid = 1012
-    cephfs.chown('file1', -1, gid)
-    st2 = cephfs.stat(b'/file1')
-    assert_equal(st2.st_gid, gid)
-
-    # ensure that gid is unchanged.
-    assert_equal(st1.st_uid, st2.st_uid)
-
-    cephfs.close(fd)
-
 def test_truncate(testdir):
     fd = cephfs.open(b'/file-truncate', 'w', 0o755)
     cephfs.write(fd, b"1111", 0)
@@ -839,80 +716,6 @@ def test_preadv_pwritev():
     assert_equal([b"asdf", b"zxcvb"], list(buf))
     cephfs.close(fd)
     cephfs.unlink(b'file-1')
-
-def test_setattrx(testdir):
-    fd = cephfs.open(b'file-setattrx', 'w', 0o655)
-    cephfs.write(fd, b"1111", 0)
-    cephfs.close(fd)
-    st = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE, 0)
-    mode = st["mode"] | stat.S_IXUSR
-    assert_raises(TypeError, cephfs.setattrx, b'file-setattrx', "dict", 0, 0)
-
-    time.sleep(1)
-    statx_dict = dict()
-    statx_dict["mode"] = mode
-    statx_dict["uid"] = 9999
-    statx_dict["gid"] = 9999
-    dt = datetime.now()
-    statx_dict["mtime"] = dt
-    statx_dict["atime"] = dt
-    statx_dict["ctime"] = dt
-    statx_dict["size"] = 10
-    statx_dict["btime"] = dt
-    cephfs.setattrx(b'file-setattrx', statx_dict, libcephfs.CEPH_SETATTR_MODE | libcephfs.CEPH_SETATTR_UID |
-                                                  libcephfs.CEPH_SETATTR_GID | libcephfs.CEPH_SETATTR_MTIME |
-                                                  libcephfs.CEPH_SETATTR_ATIME | libcephfs.CEPH_SETATTR_CTIME |
-                                                  libcephfs.CEPH_SETATTR_SIZE | libcephfs.CEPH_SETATTR_BTIME, 0)
-    st1 = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE | libcephfs.CEPH_STATX_UID |
-                                         libcephfs.CEPH_STATX_GID | libcephfs.CEPH_STATX_MTIME |
-                                         libcephfs.CEPH_STATX_ATIME | libcephfs.CEPH_STATX_CTIME |
-                                         libcephfs.CEPH_STATX_SIZE | libcephfs.CEPH_STATX_BTIME, 0)
-    assert_equal(mode, st1["mode"])
-    assert_equal(9999, st1["uid"])
-    assert_equal(9999, st1["gid"])
-    assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
-    assert_equal(10, st1["size"])
-    cephfs.unlink(b'file-setattrx')
-
-def test_fsetattrx(testdir):
-    fd = cephfs.open(b'file-fsetattrx', 'w', 0o655)
-    cephfs.write(fd, b"1111", 0)
-    st = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE, 0)
-    mode = st["mode"] | stat.S_IXUSR
-    assert_raises(TypeError, cephfs.fsetattrx, fd, "dict", 0, 0)
-
-    time.sleep(1)
-    statx_dict = dict()
-    statx_dict["mode"] = mode
-    statx_dict["uid"] = 9999
-    statx_dict["gid"] = 9999
-    dt = datetime.now()
-    statx_dict["mtime"] = dt
-    statx_dict["atime"] = dt
-    statx_dict["ctime"] = dt
-    statx_dict["size"] = 10
-    statx_dict["btime"] = dt
-    cephfs.fsetattrx(fd, statx_dict, libcephfs.CEPH_SETATTR_MODE | libcephfs.CEPH_SETATTR_UID |
-                                                  libcephfs.CEPH_SETATTR_GID | libcephfs.CEPH_SETATTR_MTIME |
-                                                  libcephfs.CEPH_SETATTR_ATIME | libcephfs.CEPH_SETATTR_CTIME |
-                                                  libcephfs.CEPH_SETATTR_SIZE | libcephfs.CEPH_SETATTR_BTIME)
-    st1 = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE | libcephfs.CEPH_STATX_UID |
-                                         libcephfs.CEPH_STATX_GID | libcephfs.CEPH_STATX_MTIME |
-                                         libcephfs.CEPH_STATX_ATIME | libcephfs.CEPH_STATX_CTIME |
-                                         libcephfs.CEPH_STATX_SIZE | libcephfs.CEPH_STATX_BTIME, 0)
-    assert_equal(mode, st1["mode"])
-    assert_equal(9999, st1["uid"])
-    assert_equal(9999, st1["gid"])
-    assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
-    assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
-    assert_equal(10, st1["size"])
-    cephfs.close(fd)
-    cephfs.unlink(b'file-fsetattrx')
 
 def test_get_layout(testdir):
     fd = cephfs.open(b'file-get-layout', 'w', 0o755)
@@ -1059,6 +862,260 @@ def test_multi_target_command():
     if isinstance(mds_status, list): # if multi target command result
         for mds_sessions in session_map:
             assert(list(mds_sessions.keys())[0].startswith('mds.'))
+
+
+class TestWithRootUser:
+
+    def setup_method(self):
+        cephfs.unmount()
+        cephfs.conf_set('client_mount_uid', '0')
+        cephfs.conf_set('client_mount_gid', '0')
+        cephfs.mount()
+
+        cephfs.conf_set('client_permissions' , 'false')
+        cephfs.chown('/', 0, 0)
+        cephfs.conf_set('client_permissions' , 'true')
+
+    def teardown_method(self):
+        cephfs.unmount()
+
+        username = get_cmd_output('id -un')
+        uid = get_cmd_output(f'id -u {username}')
+        gid = get_cmd_output(f'id -g {username}')
+
+        cephfs.conf_set('client_mount_uid', uid)
+        cephfs.conf_set('client_mount_gid', gid)
+        cephfs.mount()
+
+        cephfs.conf_set('client_permissions' , 'false')
+        cephfs.chown('/', int(uid), int(gid))
+        cephfs.conf_set('client_permissions' , 'true')
+
+    def test_chown(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        uid = 1012
+        gid = 1012
+        cephfs.chown('file1', uid, gid)
+        st = cephfs.stat(b'/file1')
+        assert_equal(st.st_uid, uid)
+        assert_equal(st.st_gid, gid)
+
+    def test_chown_change_uid_but_not_gid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        st1 = cephfs.stat(b'/file1')
+
+        uid = 1012
+        cephfs.chown('file1', uid, -1)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_uid, uid)
+
+        # ensure that gid is unchaged.
+        assert_equal(st1.st_gid, st2.st_gid)
+
+    def test_chown_change_gid_but_not_uid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        st1 = cephfs.stat(b'/file1')
+
+        gid = 1012
+        cephfs.chown('file1', -1, gid)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_gid, gid)
+
+        # ensure that uid is unchaged.
+        assert_equal(st1.st_uid, st2.st_uid)
+
+    def test_lchown(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file1', 'slink1')
+
+        uid = 1012
+        gid = 1012
+        cephfs.lchown('slink1', uid, gid)
+        st = cephfs.lstat(b'/slink1')
+        assert_equal(st.st_uid, uid)
+        assert_equal(st.st_gid, gid)
+
+    def test_lchown_change_uid_but_not_gid(testdir):
+        fd = cephfs.open('file2', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file2', 'slink2')
+
+        st1 = cephfs.lstat(b'slink2')
+
+        uid = 1012
+        cephfs.lchown('slink2', uid, -1)
+        st2 = cephfs.lstat(b'/slink2')
+        assert_equal(st2.st_uid, uid)
+
+        # ensure that gid is unchaged.
+        assert_equal(st1.st_gid, st2.st_gid)
+
+    def test_lchown_change_gid_but_not_uid(testdir):
+        fd = cephfs.open('file3', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file3', 'slink3')
+
+        st1 = cephfs.lstat(b'slink3')
+
+        gid = 1012
+        cephfs.lchown('slink3', -1, gid)
+        st2 = cephfs.lstat(b'/slink3')
+        assert_equal(st2.st_gid, gid)
+
+        # ensure that uid is unchaged.
+        assert_equal(st1.st_uid, st2.st_uid)
+
+    def test_fchown(testdir):
+        fd = cephfs.open(b'/file-fchown', 'w', 0o655)
+        uid = os.getuid()
+        gid = os.getgid()
+        assert_raises(TypeError, cephfs.fchown, b'/file-fchown', uid, gid)
+        assert_raises(TypeError, cephfs.fchown, fd, "uid", "gid")
+        cephfs.fchown(fd, uid, gid)
+        st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
+        assert_equal(st["uid"], uid)
+        assert_equal(st["gid"], gid)
+        cephfs.fchown(fd, 9999, 9999)
+        st = cephfs.statx(b'/file-fchown', libcephfs.CEPH_STATX_UID | libcephfs.CEPH_STATX_GID, 0)
+        assert_equal(st["uid"], 9999)
+        assert_equal(st["gid"], 9999)
+        cephfs.close(fd)
+        cephfs.unlink(b'/file-fchown')
+
+    def test_fchown_change_uid_but_not_gid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+
+        st1 = cephfs.stat(b'/file1')
+
+        uid = 1012
+        cephfs.fchown(fd, uid, -1)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_uid, uid)
+
+        # ensure that uid is unchanged.
+        assert_equal(st1.st_gid, st2.st_gid)
+
+        cephfs.close(fd)
+
+    def test_fchown_change_gid_but_not_uid(testdir):
+        fd = cephfs.open('file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+
+        st1 = cephfs.stat(b'/file1')
+
+        gid = 1012
+        cephfs.chown('file1', -1, gid)
+        st2 = cephfs.stat(b'/file1')
+        assert_equal(st2.st_gid, gid)
+
+        # ensure that gid is unchanged.
+        assert_equal(st1.st_uid, st2.st_uid)
+
+        cephfs.close(fd)
+
+    def test_setattrx(testdir):
+        fd = cephfs.open(b'file-setattrx', 'w', 0o655)
+        cephfs.write(fd, b"1111", 0)
+        cephfs.close(fd)
+        st = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE, 0)
+        mode = st["mode"] | stat.S_IXUSR
+        assert_raises(TypeError, cephfs.setattrx, b'file-setattrx', "dict", 0, 0)
+
+        time.sleep(1)
+        statx_dict = dict()
+        statx_dict["mode"] = mode
+        statx_dict["uid"] = 9999
+        statx_dict["gid"] = 9999
+        dt = datetime.now()
+        statx_dict["mtime"] = dt
+        statx_dict["atime"] = dt
+        statx_dict["ctime"] = dt
+        statx_dict["size"] = 10
+        statx_dict["btime"] = dt
+        cephfs.setattrx(b'file-setattrx', statx_dict, libcephfs.CEPH_SETATTR_MODE |
+                                                      libcephfs.CEPH_SETATTR_UID |
+                                                      libcephfs.CEPH_SETATTR_GID |
+                                                      libcephfs.CEPH_SETATTR_MTIME |
+                                                      libcephfs.CEPH_SETATTR_ATIME |
+                                                      libcephfs.CEPH_SETATTR_CTIME |
+                                                      libcephfs.CEPH_SETATTR_SIZE |
+                                                      libcephfs.CEPH_SETATTR_BTIME, 0)
+        st1 = cephfs.statx(b'file-setattrx', libcephfs.CEPH_STATX_MODE |
+                                             libcephfs.CEPH_STATX_UID |
+                                             libcephfs.CEPH_STATX_GID |
+                                             libcephfs.CEPH_STATX_MTIME |
+                                             libcephfs.CEPH_STATX_ATIME |
+                                             libcephfs.CEPH_STATX_CTIME |
+                                             libcephfs.CEPH_STATX_SIZE |
+                                             libcephfs.CEPH_STATX_BTIME, 0)
+        assert_equal(mode, st1["mode"])
+        assert_equal(9999, st1["uid"])
+        assert_equal(9999, st1["gid"])
+        assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
+        assert_equal(10, st1["size"])
+        cephfs.unlink(b'file-setattrx')
+
+    def test_fsetattrx(testdir):
+        fd = cephfs.open(b'file-fsetattrx', 'w', 0o655)
+        cephfs.write(fd, b"1111", 0)
+        st = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE, 0)
+        mode = st["mode"] | stat.S_IXUSR
+        assert_raises(TypeError, cephfs.fsetattrx, fd, "dict", 0, 0)
+
+        time.sleep(1)
+        statx_dict = dict()
+        statx_dict["mode"] = mode
+        statx_dict["uid"] = 9999
+        statx_dict["gid"] = 9999
+        dt = datetime.now()
+        statx_dict["mtime"] = dt
+        statx_dict["atime"] = dt
+        statx_dict["ctime"] = dt
+        statx_dict["size"] = 10
+        statx_dict["btime"] = dt
+        cephfs.fsetattrx(fd, statx_dict, libcephfs.CEPH_SETATTR_MODE |
+                                         libcephfs.CEPH_SETATTR_UID |
+                                         libcephfs.CEPH_SETATTR_GID |
+                                         libcephfs.CEPH_SETATTR_MTIME |
+                                         libcephfs.CEPH_SETATTR_ATIME |
+                                         libcephfs.CEPH_SETATTR_CTIME |
+                                         libcephfs.CEPH_SETATTR_SIZE |
+                                         libcephfs.CEPH_SETATTR_BTIME)
+        st1 = cephfs.statx(b'file-fsetattrx', libcephfs.CEPH_STATX_MODE |
+                                              libcephfs.CEPH_STATX_UID |
+                                              libcephfs.CEPH_STATX_GID |
+                                              libcephfs.CEPH_STATX_MTIME |
+                                              libcephfs.CEPH_STATX_ATIME |
+                                              libcephfs.CEPH_STATX_CTIME |
+                                              libcephfs.CEPH_STATX_SIZE |
+                                              libcephfs.CEPH_STATX_BTIME, 0)
+        assert_equal(mode, st1["mode"])
+        assert_equal(9999, st1["uid"])
+        assert_equal(9999, st1["gid"])
+        assert_equal(int(dt.timestamp()), int(st1["mtime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["atime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["ctime"].timestamp()))
+        assert_equal(int(dt.timestamp()), int(st1["btime"].timestamp()))
+        assert_equal(10, st1["size"])
+        cephfs.close(fd)
+        cephfs.unlink(b'file-fsetattrx')
 
 
 class TestRmtree:

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -1059,3 +1059,511 @@ def test_multi_target_command():
     if isinstance(mds_status, list): # if multi target command result
         for mds_sessions in session_map:
             assert(list(mds_sessions.keys())[0].startswith('mds.'))
+
+
+class TestRmtree:
+    '''
+    Test rmtree() method of CephFS python bindings.
+    '''
+
+    def test_rmtree_on_regfile(self, testdir):
+        should_cancel = lambda: False
+
+        fd = cephfs.open(f'/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('/file1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'file1')
+
+    def test_rmtree_on_regfile_no_perms(self, testdir):
+        should_cancel = lambda: False
+
+        fd = cephfs.open(f'/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+
+        cephfs.chmod('/file1', 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('/file1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'file1')
+
+    def test_rmtree_on_symlink(self, testdir):
+        should_cancel = lambda: False
+
+        fd = cephfs.open(f'/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file1', '/slink1')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('/slink1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'slink1')
+        cephfs.stat('file1')
+
+    def test_rmtree_on_symlink_no_perms(self, testdir):
+        should_cancel = lambda: False
+
+        fd = cephfs.open(f'/file1', 'w', 0o755)
+        cephfs.write(fd, b'abcd', 0)
+        cephfs.close(fd)
+        cephfs.symlink('file1', '/slink1')
+
+        cephfs.chmod('/file1', 0o000)
+        cephfs.chmod('/slink1', 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('/slink1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'slink1')
+        cephfs.stat('file1')
+
+    def test_rmtree_when_tree_contains_only_regfiles(self, testdir):
+        '''
+        Test rmtree() successfully deletes the entire file hierarchy that contains
+        only regular files.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_when_tree_contains_dirs_and_regfiles(self, testdir):
+        '''
+        Test that rmtree() successfully deletes the entire file hierarchy that
+        contains only directories and regular files.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir2', 0o755)
+        for i in range(1, 6):
+            cephfs.mkdir(f'/dir2/dir2{i}', 0o755)
+            for j in range(1, 6):
+                fd = cephfs.open(f'/dir2/dir2{i}/file{j}', 'w', 0o755)
+                cephfs.write(fd, b'abcd', 0)
+                cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir2', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir2')
+
+    def test_rmtree_when_tree_contains_dirs_regfiles_and_symlinks(self, testdir):
+        '''
+        Test that rmtree() successfully deletes entire file hierarchy that
+        contains directories, regular files as well as symbolic links.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir3', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir3/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+            file_name = f'/dir3/file{i}'.encode('utf-8')
+            slink_name = f'slink{i}'.encode('utf-8')
+            cephfs.symlink(file_name, slink_name)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir3', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir3')
+
+    def test_rmtree_when_symlink_points_to_parent_dir(self, testdir):
+        '''
+        Test that rmtree() successfully deletes entire file hierarchy that
+        contains directories, regular files as well as symbolic links.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir3', 0o755)
+        cephfs.mkdir('dir3/dir4', 0o755)
+        cephfs.symlink('../dir4', 'dir3/dir4/slink1')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir3', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir3')
+
+    def test_rmtree_when_tree_contains_only_empty_dirs(self, testdir):
+        '''
+        Test that rmtree() successfully deletes entire file hierarchy that contains
+        only empty directories.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir4', 0o755)
+        for i in range(1, 6):
+            cephfs.mkdir(f'/dir4/dir4{i}', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir4', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir4')
+
+    def test_rmtree_when_root_is_empty_dir(self, testdir):
+        '''
+        Test that rmtree() successfully deletes entire file hierarchy when it is
+        only an empty directory.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir5', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir5', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir5')
+
+    def test_rmtree_no_perm_on_nonroot_dir_suppress_errors(self, testdir):
+        '''
+        Test that rmtree() successfully deletes the entire file hierarchy except the
+        branch where permission for one of the (non-root) directories is not
+        granted.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+
+        cephfs.mkdir('dir1/dir2', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir2/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.mkdir('dir1/dir3', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir3/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.mkdir('dir1/dir4', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir4/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # actual test
+        cephfs.chmod('/dir1/dir3', 0o000)
+        # Errors are expected from call to this method. Set suppress_errors to
+        # True to confirm that this argument works.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=True)
+        # ensure /dir1/dir3 wasn't deleted
+        cephfs.stat('dir1/dir3')
+        cephfs.chmod('/dir1/dir3', 0o755)
+        for i in range(1, 6):
+            cephfs.stat(f'dir1/dir3/file{i}')
+
+        # cleanup
+        cephfs.rmtree('dir1', should_cancel)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_no_perm_on_nonroot_dir_dont_suppress_errors(self, testdir):
+        '''
+        Test that rmtree() successfully deletes the entire file hierarchy except the
+        branch where permission for one of the (non-root) directories is not
+        granted.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+
+        cephfs.mkdir('dir1/dir2', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir2/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.mkdir('dir1/dir3', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir3/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.mkdir('dir1/dir4', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir4/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # actual test
+        cephfs.chmod('/dir1/dir3', 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        assert_raises(libcephfs.PermissionDenied, cephfs.rmtree, 'dir1',
+                      should_cancel, suppress_errors=False)
+        # ensure /dir1/dir3 wasn't deleted
+        cephfs.stat('dir1/dir3')
+
+        # cleanup
+        cephfs.chmod('/dir1/dir3', 0o755)
+        cephfs.rmtree('dir1', should_cancel)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_no_perm_on_root_suppress_errors(self, testdir):
+        '''
+        Test rmtree() exits when permission is not granted for the root of the file
+        hierarchy.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.chmod('/dir1', 0o000)
+        # Errors are expected from call to this method. Set suppress_errors to
+        # True to confirm that this argument works.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=True)
+        # ensure /dir1 wasn't deleted
+        cephfs.stat('dir1')
+
+        # cleanup
+        cephfs.chmod('/dir1', 0o755)
+        cephfs.rmtree('dir1', should_cancel)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_no_perm_on_root_dont_suppress_errors(self, testdir):
+        '''
+        Test rmtree() exits when permission is not granted for the root of the file
+        hierarchy.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        cephfs.chmod('/dir1', 0o000)
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        assert_raises(libcephfs.PermissionDenied, cephfs.rmtree, 'dir1',
+                      should_cancel, suppress_errors=False)
+        # ensure /dir1 wasn't deleted
+        cephfs.stat('dir1')
+
+        # cleanup
+        cephfs.chmod('/dir1', 0o755)
+        cephfs.rmtree('dir1', should_cancel)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_on_tree_with_snaps(self, testdir):
+        '''
+        Test that rmtree() successfully deletes the entire file hierarchy except
+        the branch where one of the directories contains one or many snapshots.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.mkdir('dir1/dir2', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/dir2/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+        cephfs.mksnap('/dir1/dir2', 'snap1', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        # ensure dir1 wasn't deleted
+        cephfs.stat('dir1')
+
+        # cleanup
+        cephfs.rmsnap('/dir1/dir2', 'snap1')
+        cephfs.rmtree('dir1', should_cancel)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_on_tree_with_snaps_on_root(self, testdir):
+        '''
+        Test that rmtree() successfully deletes the entire file hierarchy except
+        the branch where one of the directories contains one or many snapshots.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        for i in range(1, 6):
+            fd = cephfs.open(f'/dir1/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+        cephfs.mksnap('/dir1', 'snap1', 0o755)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        # ensure dir1 wasn't deleted
+        cephfs.stat('dir1')
+
+        # cleanup
+        cephfs.rmsnap('/dir1', 'snap1')
+        cephfs.rmtree('dir1', should_cancel)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def get_file_count(self, dir_path):
+        '''
+        Return the number of files present in the given directory.
+        '''
+        i = 0
+        with cephfs.opendir(dir_path) as dir_handle:
+            de = cephfs.readdir(dir_handle)
+            while de:
+                if de.d_name not in (b'.', b'..'):
+                    i += 1
+                de = cephfs.readdir(dir_handle)
+        return i
+
+    def test_rmtree_aborts_when_should_cancel_is_true(self, testdir):
+        '''
+        Test that rmtree() stops deleting the file hierarchy when the return
+        value of "should_cancel" becomes True.
+        '''
+        from threading import Event, Thread
+        cancel_flag = Event()
+        def should_cancel():
+            time.sleep(0.1)
+            return cancel_flag.is_set()
+
+        # NOTE: this method is just a wrapper to provide an appropriate location
+        # to catch the exception OpCanceled. If left uncaught the test passes
+        # but pytest fails citing this exception.
+        def rmtree(path, should_cancel, suppress_error=False):
+            assert_raises(libcephfs.OpCanceled, cephfs.rmtree, path,
+                          should_cancel, suppress_error)
+
+        cephfs.mkdir('dir6', 0o755)
+        for i in range(1, 101):
+            fd = cephfs.open(f'/dir6/file{i}', 'w', 0o755)
+            cephfs.write(fd, b'abcd', 0)
+            cephfs.close(fd)
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        Thread(target=rmtree, args=('dir6', should_cancel, False)).start()
+        time.sleep(1)
+
+        # this will change return value of should_cancel and therefore halt
+        # execution of rmtree()
+        cancel_flag.set()
+        # ensure dir6 wasn't deleted
+        cephfs.stat('dir6')
+        # ensure that deletion had begun but hadn't finished and was halted
+        file_count = self.get_file_count('dir6')
+        assert file_count > 0 and file_count < 100
+
+        # ensure that deletion has made no progress since it was halted
+        time.sleep(2)
+        file_count = self.get_file_count('dir6')
+        assert file_count > 0 and file_count < 100
+
+        # cleanup
+        cancel_flag.clear()
+        cephfs.rmtree('dir6', should_cancel)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_on_a_very_broad_tree(self, testdir):
+        '''
+        Test that rmtree() successfully deletes a file hierarchy with 200
+        subdirectories on the same level.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.chdir('dir1')
+        for i in range(1, 201):
+            dirname = f'dir{i}'
+            cephfs.mkdir(dirname, 0o755)
+        cephfs.chdir('/')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_on_a_very_very_broad_tree(self, testdir):
+        '''
+        Test that rmtree() successfully deletes a file hierarchy with 2000
+        subdirectories on the same level.
+        '''
+        should_cancel = lambda: False
+
+        cephfs.mkdir('dir1', 0o755)
+        cephfs.chdir('dir1')
+        for i in range(1, 2001):
+            dirname = f'dir{i}'
+            cephfs.mkdir(dirname, 0o755)
+        cephfs.chdir('/')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_on_a_very_deep_tree(self, testdir):
+        '''
+        Test that rmtree() successfully deletes a file hierarchy with 2000
+        levels.
+        '''
+        should_cancel = lambda: False
+
+        for i in range(1, 201):
+            dirname = f'dir{i}'
+            cephfs.mkdir(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')
+
+    def test_rmtree_on_a_very_very_deep_tree(self, testdir):
+        '''
+        Test that rmtree() successfully deletes a file hierarchy with 2000
+        levels.
+        '''
+        should_cancel = lambda: False
+
+        for i in range(1, 2001):
+            dirname = f'dir{i}'
+            cephfs.mkdir(dirname, 0o755)
+            cephfs.chdir(dirname)
+        cephfs.chdir('/')
+
+        # Errors are not expected from the call to this method. Therefore, set
+        # suppress_errors to False so that tests abort as soon as any errors
+        # occur.
+        cephfs.rmtree('dir1', should_cancel, suppress_errors=False)
+        assert_raises(libcephfs.ObjectNotFound, cephfs.stat, 'dir1')


### PR DESCRIPTION
Method purge() in trash.py calls rmtree() which is recursive method. To
avoid Python's recurision limit, switch to non-recursive approach.

Fixes: https://tracker.ceph.com/issues/71648

Also fixes https://tracker.ceph.com/issues/72779 and https://tracker.ceph.com/issues/72993.






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>