### PR TITLE
doc: Fix sphinx warnings and one error

### DIFF
--- a/doc/cephadm/services/snmp-gateway.rst
+++ b/doc/cephadm/services/snmp-gateway.rst
@@ -2,10 +2,10 @@
 SNMP Gateway Service
 ====================
 
-SNMP_ is still a widely used protocol, to monitor distributed systems and devices across a variety of hardware
-and software platforms. Ceph's SNMP integration focuses on forwarding alerts from its Prometheus Alertmanager
+`SNMP`_ is a widely used protocol for monitoring distributed systems and devices.
+Ceph's SNMP integration focuses on forwarding alerts from its Prometheus Alertmanager
 cluster to a gateway daemon. The gateway daemon transforms the alert into an SNMP Notification and sends
-it on to a designated SNMP management platform. The gateway daemon is from the ``snmp_notifier``_ project,
+it on to a designated SNMP management platform. The gateway daemon is from the `snmp_notifier`_ project,
 which provides SNMP V2c and V3 support (authentication and encryption).
 
 Ceph's SNMP gateway service deploys one instance of the gateway by default. You may increase this
@@ -159,13 +159,13 @@ with a credentials file of the following form:
 AlertManager Integration
 ========================
 When an SNMP gateway service is deployed or updated, the Prometheus Alertmanager configuration is automatically updated to forward any
-alert that has an OID_ label to the SNMP gateway daemon for processing.
+alert that has an `OID`_ label to the SNMP gateway daemon for processing.
 
 .. _OID: https://en.wikipedia.org/wiki/Object_identifier
 
 Implementing the MIB
 ======================
 To make sense of SNMP notifications and traps, you'll need to apply the MIB to your SNMP management platform. The MIB (``CEPH-MIB.txt``) can
-downloaded from the main Ceph GitHub repository_
+downloaded from the main Ceph GitHub `repository`_
 
 .. _repository: https://github.com/ceph/ceph/tree/master/monitoring/snmp

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -387,6 +387,7 @@ status. Commands of this kind take the form ``filesystem-name@filesystem-id peer
 .. prompt:: bash $
 
    ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror peer status cephfs@360 a2dc7784-e7a1-4723-b103-03ee8d8768f8
+
 ::
 
   {
@@ -432,6 +433,7 @@ status:
 
    ceph fs snapshot mirror add cephfs /f0
    ceph --admin-daemon /var/run/ceph/cephfs-mirror.asok fs mirror peer status cephfs@360 a2dc7784-e7a1-4723-b103-03ee8d8768f8
+
 ::
 
   {
@@ -470,6 +472,7 @@ mapped to use, run a command of the following form:
 .. prompt:: bash $
 
    ceph fs snapshot mirror dirmap cephfs /d0/d1/d2
+
 ::
 
   {
@@ -489,6 +492,7 @@ If no mirror daemons are running, the same command shows the following:
 .. prompt:: bash $
 
    ceph fs snapshot mirror dirmap cephfs /d0/d1/d2
+
 ::
 
   {

--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -65,7 +65,7 @@ and other parameters that help the project develop a better understanding of
 the way Ceph is used.
 
 Data is sent secured to
-`https://telemetry.ceph.com<https://telemetry.ceph.com>`_.
+`https://telemetry.ceph.com <https://telemetry.ceph.com>`_.
 
 Individual channels can be enabled or disabled by running the following
 commands:


### PR DESCRIPTION
`doc/cephadm/services/snmp-gateway.rst`:  
Don't use double backticks for links. Makes it a link instead of rendering syntax verbatim.  
Also for consistency add single backticks for links instead of a plain trailing underscore.

- Before: https://docs.ceph.com/en/latest/cephadm/services/snmp-gateway/
- Rendered PR: https://ceph--63920.org.readthedocs.build/en/63920/cephadm/services/snmp-gateway/

```console
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/63919/doc/cephadm/services/snmp-gateway.rst:5: WARNING: Inline literal start-string without end-string.
```

`doc/dev/cephfs-mirroring.rst`:  
Add missing empty line before preformatted blocks. No change in rendered docs.

- Before: https://docs.ceph.com/en/latest/dev/cephfs-mirroring/
- Rendered PR: https://ceph--63920.org.readthedocs.build/en/63920/dev/cephfs-mirroring/

```console
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/63919/doc/dev/cephfs-mirroring.rst:390: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/63919/doc/dev/cephfs-mirroring.rst:435: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/63919/doc/dev/cephfs-mirroring.rst:473: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/63919/doc/dev/cephfs-mirroring.rst:492: WARNING: Explicit markup ends without a blank line; unexpected unindent.
```

`doc/mgr/telemetry.rst`:  
Fix external link syntax. Makes it a working link instead of rendering syntax and pointing to non-existing link.

- Before: https://docs.ceph.com/en/latest/mgr/telemetry/
- Rendered PR: https://ceph--63920.org.readthedocs.build/en/63920/mgr/telemetry/

```console
/home/docs/checkouts/readthedocs.org/user_builds/ceph/checkouts/63919/doc/mgr/telemetry.rst:67: ERROR: Unknown target name: "https://telemetry.ceph.com<https://telemetry.ceph.com>".
```




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
