### PR TITLE
doc/dev: Fix typos and formatting in cephfs-mirroring.rst

### DIFF
--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -17,7 +17,7 @@ Key Idea
 --------
 
 For a given snapshot pair in a directory, `cephfs-mirror` daemon will rely on
-`CephFS Snapdiff Feature` to identify changes in a directory tree. The diffs
+`CephFS Snapdiff Feature`_ to identify changes in a directory tree. The diffs
 are applied to directory in the remote file system thereby only synchronizing
 files that have changed between two snapshots.
 
@@ -93,7 +93,7 @@ Using snapshot names to infer the point-of-continuation would result in the
 "new" snapshot (incarnation) never getting picked up for synchronization.
 
 Snapshots on the secondary file system stores the snap-id of the snapshot it
-was synchronized from. This metadata is stored in `SnapInfo` structure on the
+was synchronized from. This metadata is stored in ``SnapInfo`` structure on the
 MDS.
 
 Interfaces
@@ -112,7 +112,7 @@ mirroring. The module is implemented as a Ceph Manager plugin. The mirroring
 module does not manage the spawning of (and terminating of) the mirror
 daemons. `systemctl(1)` is the preferred way to start and stop mirror daemons.
 In the future, mirror daemons will be deployed and managed by `cephadm`
-(Tracker: http://tracker.ceph.com/issues/47261).
+(tracker: http://tracker.ceph.com/issues/47261).
 
 The manager module is responsible for assigning directories to mirror daemons
 for synchronization. Multiple mirror daemons can be spawned to achieve
@@ -177,7 +177,7 @@ To remove a peer, run a command of the following form:
 
    ceph fs snapshot mirror peer_remove <fs_name> <peer_uuid>
 
-.. note:: See the `Mirror Daemon Status` section on how to figure out Peer
+.. note:: See the `Mirror Daemon Status`_ section on how to figure out Peer
    UUID.
 
 To list the file system mirror peers, run a command of the following form:
@@ -186,7 +186,7 @@ To list the file system mirror peers, run a command of the following form:
 
    ceph fs snapshot mirror peer_list <fs_name>
 
-To configure a directory for mirroring, run a command of the following form: 
+To configure a directory for mirroring, run a command of the following form:
 
 .. prompt:: bash $
 
@@ -232,7 +232,7 @@ directories are not allowed to be added for mirroring:
    Error EINVAL: /d0/d1/d2/d3 is a subtree of tracked path /d0/d1/d2
 
 Commands for checking directory mapping (to mirror daemons) and directory
-distribution are detailed in the `Mirror Daemon Status` section.
+distribution are detailed in the `Mirror Daemon Status`_ section.
 
 Bootstrap Peers
 ---------------
@@ -280,7 +280,7 @@ Mirror Daemon Status
 Mirror daemons are asynchronously notified about changes in
 file-system-mirroring status and peer updates.
 
-The CephFS mirroring module provides the ``mirror daemon status`` interface for 
+The CephFS mirroring module provides the ``mirror daemon status`` interface for
 checking the status of the mirror daemon. Run the following command to check
 the status of the mirror daemon:
 
@@ -348,7 +348,7 @@ command:
 Commands that have the ``fs mirror status`` prefix provide mirror status for
 mirror-enabled file systems. Note that ``cephfs@360`` has the format
 ``filesystem-name@filesystem-id``. This format is required because mirror
-daemons are asynchronously notified of file-system mirror status (A file
+daemons are asynchronously notified of file-system mirror status (a file
 system can be deleted and recreated with the same name).
 
 Currently (May 2025), the command provides minimal information regarding mirror
@@ -410,11 +410,11 @@ mirror daemons are deployed), when a directory is reassigned to another mirror
 daemon.
 
 
-A directory can be in one of the following states::
+A directory can be in one of the following states:
 
-  - `idle`: The directory is currently not being synchronized
-  - `syncing`: The directory is currently being synchronized
-  - `failed`: The directory has hit upper limit of consecutive failures
+- `idle`: The directory is currently not being synchronized
+- `syncing`: The directory is currently being synchronized
+- `failed`: The directory has hit upper limit of consecutive failures
 
 When a directory hits a configured number of consecutive synchronization
 failures, the mirror daemon marks it as ``failed``. Synchronization for these
@@ -458,7 +458,7 @@ status:
 This allows a user to add a non-existent directory for synchronization. The
 mirror daemon marks the directory as failed and retries (less frequently).
 When the directory comes into existence, the mirror daemons notice the
-successful snapshot synchronization and unmark the failed state. 
+successful snapshot synchronization and unmark the failed state.
 
 When mirroring is disabled, the ``fs mirror status`` command for the file
 system will not show up in command help.
@@ -505,7 +505,7 @@ Re-adding Peers
 When re-adding (reassigning) a peer to a file system in another cluster, ensure
 that all mirror daemons have stopped synchronizing with the peer. This can be
 checked via the  ``fs mirror status`` admin socket command (the ``Peer UUID``
-should not show up in the command output). We recommend purging 
+should not show up in the command output). We recommend purging
 synchronized directories from the peer before re-adding them to another file
 system (especially those directories which might exist in the new primary file
 system). This is not required if you re-add a peer to the same primary file
@@ -515,6 +515,6 @@ Feature Status
 --------------
 
 The ``cephfs-mirror`` daemon is built by default. It follows the
-``WITH_CEPHFS`` CMake rule).
+``WITH_CEPHFS`` CMake rule.
 
 .. _CephFS Snapdiff Feature: https://croit.io/blog/cephfs-snapdiff-feature


### PR DESCRIPTION
Linkify several phrases that were just italic, but seem to be intended to be links.
Basically just add an underscore at the end as they were already otherwise OK.

Use inline preformatted for struct name.

Don't capitalize after opening paren.

Remove whitespace at end of several lines.

Don't use preformatted block for what should be an unordered list.

Remove stray closing paren.

**See comment for discussion whether this file should exist at all**

- Before: https://docs.ceph.com/en/latest/dev/cephfs-mirroring/
- Rendered PR: https://ceph--63923.org.readthedocs.build/en/63923/dev/cephfs-mirroring/



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
