### PR TITLE
tentacle: qa/rgw: bump maven version in hadoop task to resolve 404 Not Found

### DIFF
--- a/qa/tasks/s3a_hadoop.py
+++ b/qa/tasks/s3a_hadoop.py
@@ -15,7 +15,7 @@ def task(ctx, config):
       -tasks:
          ceph-ansible:
          s3a-hadoop:
-           maven-version: '3.6.3' (default)
+           maven-version: '3.9.10' (default)
            hadoop-version: '2.9.2'
            bucket-name: 's3atest' (default)
            access-key: 'anykey' (uses a default value)
@@ -41,7 +41,7 @@ def task(ctx, config):
 
     # get versions
     maven_major = config.get('maven-major', 'maven-3')
-    maven_version = config.get('maven-version', '3.9.9')
+    maven_version = config.get('maven-version', '3.9.10')
     hadoop_ver = config.get('hadoop-version', '2.9.2')
     bucket_name = config.get('bucket-name', 's3atest')
     access_key = config.get('access-key', 'EGAQRD2ULOIFKFSKCT4F')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71672

---

backport of https://github.com/ceph/ceph/pull/63793
parent tracker: https://tracker.ceph.com/issues/71584

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh