### PR TITLE
reef: osd/scrub: allow longer waits for replicas to respond

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -600,7 +600,7 @@ options:
   desc: Duration before issuing a cluster-log warning
   long_desc: Waiting too long for a replica to respond (after at least half of the
     replicas have responded).
-  default: 2200
+  default: 22000
   min: 500
   see_also:
   - osd_scrub_reservation_timeout
@@ -613,7 +613,7 @@ options:
   desc: Duration before aborting the scrub session
   long_desc: Waiting too long for some replicas to respond to
     scrub reservation requests.
-  default: 5000
+  default: 50000
   min: 2000
   see_also:
   - osd_scrub_slow_reservation_response

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -151,7 +151,7 @@ sc::result ReservingReplicas::react(const ReservationTimeout&)
   scrbr->get_clog()->warn()
     << "osd." << scrbr->get_whoami()
     << " PgScrubber: " << scrbr->get_spgid()
-    << " timeout on reserving replicsa (since " << entered_at
+    << " timeout on reserving replicas (since " << entered_at
     << ")";
 
   scrbr->on_replica_reservation_timeout();


### PR DESCRIPTION
Increase the two timeouts associated with replica responses to scrub requests.

This change addresses cases where a cluster event—such as an OSD in the active set going down—triggers re-peering. In such scenarios, scrub requests may time out before a new replica interval is established. While this does not cause data loss or crashes, it does result in log warnings and test failures.

Fixes: https://tracker.ceph.com/issues/68698

