### PR TITLE
cephfs-mirror: cephfs-mirror should be able to do operations concurrently for large directory(updated)

### DIFF
--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -103,3 +103,25 @@ options:
   - cephfs-mirror
   min: 0
   max: 11
+- name: cephfs_mirror_file_sync_thread
+  type: uint
+  level: advanced
+  desc: number of threads running for file transfers per peer
+  long_desc: number of threads running for file transfers per peer.
+    Each thread is responsible for transfering file.
+  default: 3
+  services:
+  - cephfs-mirror
+  min: 1
+  with_legacy: true
+- name: cephfs_mirror_dir_scanning_thread
+  type: uint
+  level: advanced
+  desc: number of threads running for concurrently scanning directory
+  long_desc: number of threads running associated for each sync.
+    Each thread is responsible for several libcephfs operations.
+  default: 3
+  services:
+  - cephfs-mirror
+  min: 1
+  with_legacy: true

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -108,7 +108,7 @@ private:
 // helper to open a directory relative to a file descriptor
 int opendirat(MountRef mnt, int dirfd, const std::string &relpath, int flags,
               ceph_dir_result **dirp) {
-  int r = ceph_openat(mnt, dirfd, relpath.c_str(), flags, 0);
+  int r = ceph_openat(mnt, dirfd, relpath.c_str(), flags | O_DIRECTORY, 0);
   if (r < 0) {
     return r;
   }
@@ -177,7 +177,9 @@ PeerReplayer::PeerReplayer(CephContext *cct, FSMirror *fs_mirror,
     m_local_mount(mount),
     m_service_daemon(service_daemon),
     m_asok_hook(new PeerReplayerAdminSocketHook(cct, filesystem, peer, this)),
-    m_lock(ceph::make_mutex("cephfs::mirror::PeerReplayer::" + stringify(peer.uuid))) {
+    m_lock(ceph::make_mutex("cephfs::mirror::PeerReplayer::" + stringify(peer.uuid))),
+    file_sync_pool(g_ceph_context->_conf->cephfs_mirror_file_sync_thread, m_peer) {
+  g_conf().add_observer(this);
   // reset sync stats sent via service daemon
   m_service_daemon->add_or_update_peer_attribute(m_filesystem.fscid, m_peer,
                                                  SERVICE_DAEMON_FAILED_DIR_COUNT_KEY, (uint64_t)0);
@@ -226,10 +228,30 @@ PeerReplayer::~PeerReplayer() {
   }
 }
 
+void PeerReplayer::handle_conf_change(const ConfigProxy &conf,
+                                      const std::set<std::string> &changed) {
+  if (changed.count("cephfs_mirror_file_sync_thread")) {
+    file_sync_pool.update_state();
+  }
+  if (changed.count("cephfs_mirror_dir_scanning_thread")) {
+    std::unique_lock locker(m_lock);
+    for (auto& [dir, registry]: m_registered) {
+      if (registry->sync_pool) {
+        registry->sync_pool->update_state();
+      }
+    }
+  }
+}
+
+std::vector<std::string> PeerReplayer::get_tracked_keys() const noexcept {
+  return {"cephfs_mirror_file_sync_thread"s,
+          "cephfs_mirror_dir_scanning_thread"s};
+}
+
 int PeerReplayer::init() {
   dout(20) << ": initial dir list=[" << m_directories << "]" << dendl;
   for (auto &dir_root : m_directories) {
-    m_snap_sync_stats.emplace(dir_root, SnapSyncStat());
+    m_snap_sync_stats.emplace(dir_root, new SnapSyncStat());
   }
 
   auto &remote_client = m_peer.remote.client_name;
@@ -286,6 +308,10 @@ int PeerReplayer::init() {
   }
 
   std::scoped_lock locker(m_lock);
+  dout(0) << ": Activating file sync thread pool having, "
+          << g_ceph_context->_conf->cephfs_mirror_file_sync_thread
+          << "number of threads" << dendl;
+  file_sync_pool.activate();
   auto nr_replayers = g_ceph_context->_conf.get_val<uint64_t>(
     "cephfs_mirror_max_concurrent_directory_syncs");
   dout(20) << ": spawning " << nr_replayers << " snapshot replayer(s)" << dendl;
@@ -304,10 +330,19 @@ int PeerReplayer::init() {
 void PeerReplayer::shutdown() {
   dout(20) << dendl;
 
+  file_sync_pool.deactivate();
+  dout(0) << ": File sync thread pool deactivated" << dendl;
+
   {
     std::scoped_lock locker(m_lock);
     ceph_assert(!m_stopping);
     m_stopping = true;
+    for (auto &[dir_root, registry] : m_registered) {
+      if (registry->sync_pool) {
+        registry->sync_pool->deactivate();
+      }
+    }
+    dout(0) << ": Directory scanning thread pools deactivated" << dendl;
     m_cond.notify_all();
   }
 
@@ -326,7 +361,7 @@ void PeerReplayer::add_directory(string_view dir_root) {
 
   std::scoped_lock locker(m_lock);
   m_directories.emplace_back(dir_root);
-  m_snap_sync_stats.emplace(dir_root, SnapSyncStat());
+  m_snap_sync_stats.emplace(dir_root, new SnapSyncStat());
   m_cond.notify_all();
 }
 
@@ -344,7 +379,7 @@ void PeerReplayer::remove_directory(string_view dir_root) {
   if (it1 == m_registered.end()) {
     m_snap_sync_stats.erase(_dir_root);
   } else {
-    it1->second.canceled = true;
+    it1->second->canceled.store(true);
   }
   m_cond.notify_all();
 }
@@ -359,8 +394,8 @@ boost::optional<std::string> PeerReplayer::pick_directory() {
   boost::optional<std::string> candidate;
   for (auto &dir_root : m_directories) {
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    if (sync_stat.failed) {
-      std::chrono::duration<double> d = now - *sync_stat.last_failed;
+    if (sync_stat->failed) {
+      std::chrono::duration<double> d = now - *sync_stat->last_failed;
       if (d.count() < retry_timo) {
         continue;
       }
@@ -380,15 +415,15 @@ int PeerReplayer::register_directory(const std::string &dir_root,
   dout(20) << ": dir_root=" << dir_root << dendl;
   ceph_assert(m_registered.find(dir_root) == m_registered.end());
 
-  DirRegistry registry;
-  int r = try_lock_directory(dir_root, replayer, &registry);
+  DirRegistry* registry = new DirRegistry();
+  int r = try_lock_directory(dir_root, replayer, registry);
   if (r < 0) {
     return r;
   }
 
   dout(5) << ": dir_root=" << dir_root << " registered with replayer="
           << replayer << dendl;
-  m_registered.emplace(dir_root, std::move(registry));
+  m_registered.emplace(dir_root, registry);
   return 0;
 }
 
@@ -459,18 +494,18 @@ int PeerReplayer::try_lock_directory(const std::string &dir_root,
   return 0;
 }
 
-void PeerReplayer::unlock_directory(const std::string &dir_root, const DirRegistry &registry) {
+void PeerReplayer::unlock_directory(const std::string &dir_root, DirRegistry* registry) {
   dout(20) << ": dir_root=" << dir_root << dendl;
 
-  int r = ceph_flock(m_remote_mount, registry.fd, LOCK_UN,
-                     (uint64_t)registry.replayer->get_thread_id());
+  int r = ceph_flock(m_remote_mount, registry->fd, LOCK_UN,
+                     (uint64_t)registry->replayer->get_thread_id());
   if (r < 0) {
     derr << ": failed to unlock remote dir_root=" << dir_root << ": " << cpp_strerror(r)
          << dendl;
     return;
   }
 
-  r = ceph_close(m_remote_mount, registry.fd);
+  r = ceph_close(m_remote_mount, registry->fd);
   if (r < 0) {
     derr << ": failed to close remote dir_root=" << dir_root << ": " << cpp_strerror(r)
          << dendl;
@@ -528,7 +563,7 @@ int PeerReplayer::build_snap_map(const std::string &dir_root,
       if (!info.nr_snap_metadata) {
         std::string failed_reason = "snapshot '" + snap  + "' has invalid metadata";
         derr << ": " << failed_reason << dendl;
-        m_snap_sync_stats.at(dir_root).last_failed_reason = failed_reason;
+        m_snap_sync_stats.at(dir_root)->last_failed_reason = failed_reason;
         rv = -EINVAL;
       } else {
         auto metadata = decode_snap_metadata(info.snap_metadata, info.nr_snap_metadata);
@@ -611,69 +646,108 @@ int PeerReplayer::propagate_snap_renames(
   return 0;
 }
 
-int PeerReplayer::remote_mkdir(const std::string &epath, const struct ceph_statx &stx,
-                               const FHandles &fh) {
-  dout(10) << ": remote epath=" << epath << dendl;
+int PeerReplayer::sync_attributes(std::shared_ptr<SyncEntry> &cur_entry,
+                                  const FHandles &fh) {
+  int r = 0;
+  if ((cur_entry->change_mask & CEPH_STATX_UID) ||
+      (cur_entry->change_mask & CEPH_STATX_GID)) {
+    r = ceph_chownat(m_remote_mount, fh.r_fd_dir_root, cur_entry->epath.c_str(),
+                     cur_entry->stx.stx_uid, cur_entry->stx.stx_gid,
+                     AT_SYMLINK_NOFOLLOW);
+    if (r < 0) {
+      derr << ": failed to chown remote directory=" << cur_entry->epath << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
 
-  int r = ceph_mkdirat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), stx.stx_mode & ~S_IFDIR);
+  if ((cur_entry->change_mask & CEPH_STATX_MODE)) {
+    r = ceph_chmodat(m_remote_mount, fh.r_fd_dir_root, cur_entry->epath.c_str(),
+                     cur_entry->stx.stx_mode & ~S_IFMT, AT_SYMLINK_NOFOLLOW);
+    if (r < 0) {
+      derr << ": failed to chmod remote directory=" << cur_entry->epath << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  if (!cur_entry->is_directory() &&
+      (cur_entry->change_mask & CEPH_STATX_MTIME)) {
+    struct timespec times[] = {
+        {cur_entry->stx.stx_atime.tv_sec, cur_entry->stx.stx_atime.tv_nsec},
+        {cur_entry->stx.stx_mtime.tv_sec, cur_entry->stx.stx_mtime.tv_nsec}};
+    r = ceph_utimensat(m_remote_mount, fh.r_fd_dir_root,
+                       cur_entry->epath.c_str(), times, AT_SYMLINK_NOFOLLOW);
+    if (r < 0) {
+      derr << ": failed to change [am]time on remote directory="
+           << cur_entry->epath << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+  return 0;
+}
+
+int PeerReplayer::_remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
+                                const FHandles &fh, SnapSyncStat *sync_stat) {
+  int r =
+      ceph_mkdirat(m_remote_mount, fh.r_fd_dir_root, cur_entry->epath.c_str(),
+                   cur_entry->stx.stx_mode & ~S_IFDIR);
   if (r < 0 && r != -EEXIST) {
-    derr << ": failed to create remote directory=" << epath << ": " << cpp_strerror(r)
-         << dendl;
-    return r;
-  }
-
-  r = ceph_chownat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), stx.stx_uid, stx.stx_gid,
-                   AT_SYMLINK_NOFOLLOW);
-  if (r < 0) {
-    derr << ": failed to chown remote directory=" << epath << ": " << cpp_strerror(r)
-         << dendl;
-    return r;
-  }
-
-  r = ceph_chmodat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), stx.stx_mode & ~S_IFMT,
-                   AT_SYMLINK_NOFOLLOW);
-  if (r < 0) {
-    derr << ": failed to chmod remote directory=" << epath << ": " << cpp_strerror(r)
-         << dendl;
-    return r;
-  }
-
-  struct timespec times[] = {{stx.stx_atime.tv_sec, stx.stx_atime.tv_nsec},
-                             {stx.stx_mtime.tv_sec, stx.stx_mtime.tv_nsec}};
-  r = ceph_utimensat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), times, AT_SYMLINK_NOFOLLOW);
-  if (r < 0) {
-    derr << ": failed to change [am]time on remote directory=" << epath << ": "
+    derr << ": failed to create remote directory=" << cur_entry->epath << ": "
          << cpp_strerror(r) << dendl;
     return r;
   }
-
+  sync_stat->current_stat.inc_dir_created_count();
   return 0;
+}
+
+int PeerReplayer::remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry,
+                               const FHandles &fh, SnapSyncStat *sync_stat) {
+  dout(10) << ": remote epath=" << cur_entry->epath << dendl;
+  int r = 0;
+  /*
+    We know that if it is not create fresh and purge remote
+    then remote already has the dir entry, we just need to
+    sync_attributes, thus saving a ceph_mkdirat call.
+  */
+  if (cur_entry->create_fresh() || cur_entry->purge_remote()) {
+    r = _remote_mkdir(cur_entry, fh, sync_stat);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  r = sync_attributes(cur_entry, fh);
+  return r;
 }
 
 #define NR_IOVECS 8 // # iovecs
 #define IOVEC_SIZE (8 * 1024 * 1024) // buffer size for each iovec
-int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string &epath,
-                                 const struct ceph_statx &stx, const FHandles &fh,
-                                 uint64_t num_blocks, struct cblock *b) {
-  dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << ", num_blocks="
-           << num_blocks << dendl;
+int PeerReplayer::copy_to_remote(std::shared_ptr<SyncEntry> &cur_entry,
+                                 DirRegistry *registry, const FHandles &fh,
+                                 uint64_t num_blocks, struct cblock *b, bool trunc) {
+  dout(10) << ": dir_root=" << registry->dir_root
+           << ", epath=" << cur_entry->epath << ", num_blocks=" << num_blocks
+           << dendl;
   int l_fd;
   int r_fd;
   void *ptr;
   struct iovec iov[NR_IOVECS];
 
-  int r = ceph_openat(m_local_mount, fh.c_fd, epath.c_str(), O_RDONLY | O_NOFOLLOW, 0);
+  int r = ceph_openat(m_local_mount, fh.c_fd, cur_entry->epath.c_str(),
+                      O_RDONLY | O_NOFOLLOW, 0);
   if (r < 0) {
-    derr << ": failed to open local file path=" << epath << ": "
+    derr << ": failed to open local file path=" << cur_entry->epath << ": "
          << cpp_strerror(r) << dendl;
     return r;
   }
 
   l_fd = r;
-  r = ceph_openat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(),
-                  O_CREAT | O_WRONLY | O_NOFOLLOW, stx.stx_mode);
+  r = ceph_openat(m_remote_mount, fh.r_fd_dir_root, cur_entry->epath.c_str(),
+                  O_CREAT | O_WRONLY | O_NOFOLLOW | (trunc ? O_TRUNC : 0),
+                  cur_entry->stx.stx_mode);
   if (r < 0) {
-    derr << ": failed to create remote file path=" << epath << ": "
+    derr << ": failed to create remote file path=" << cur_entry->epath << ": "
          << cpp_strerror(r) << dendl;
     goto close_local_fd;
   }
@@ -690,14 +764,15 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
     auto offset = b->offset;
     auto len = b->len;
 
-    dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << ", block: ["
-             << offset << "~" << len << "]" << dendl;
+    dout(10) << ": dir_root=" << registry->dir_root
+             << ", epath=" << cur_entry->epath << ", block: [" << offset << "~"
+             << len << "]" << dendl;
 
     auto end_offset = offset + len;
     dout(20) << ": start offset=" << offset << ", end offset=" << end_offset
              << dendl;
     while (offset < end_offset) {
-      if (should_backoff(dir_root, &r)) {
+      if (should_backoff(registry, &r)) {
         dout(0) << ": backing off r=" << r << dendl;
         break;
       }
@@ -726,7 +801,7 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
 
       r = ceph_preadv(m_local_mount, l_fd, iov, num_buffers, offset);
       if (r < 0) {
-        derr << ": failed to read local file path=" << epath << ": "
+        derr << ": failed to read local file path=" << cur_entry->epath << ": "
              << cpp_strerror(r) << dendl;
         break;
       }
@@ -745,12 +820,13 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
       dout(10) << ": writing to offset: " << offset << dendl;
       r = ceph_pwritev(m_remote_mount, r_fd, iov, iovs, offset);
       if (r < 0) {
-        derr << ": failed to write remote file path=" << epath << ": "
-             << cpp_strerror(r) << dendl;
+        derr << ": failed to write remote file path=" << cur_entry->epath
+             << ": " << cpp_strerror(r) << dendl;
         break;
       }
 
       offset += r;
+      len -= r;
     }
 
     --num_blocks;
@@ -758,17 +834,17 @@ int PeerReplayer::copy_to_remote(const std::string &dir_root,  const std::string
   }
 
   if (num_blocks == 0 && r >= 0) { // handle blocklist case
-    dout(20) << ": truncating epath=" << epath << " to " << stx.stx_size << " bytes"
-             << dendl;
-    r = ceph_ftruncate(m_remote_mount, r_fd, stx.stx_size);
+    dout(20) << ": truncating epath=" << cur_entry->epath << " to "
+             << cur_entry->stx.stx_size << " bytes" << dendl;
+    r = ceph_ftruncate(m_remote_mount, r_fd, cur_entry->stx.stx_size);
     if (r < 0) {
-      derr << ": failed to truncate remote file path=" << epath << ": "
-           << cpp_strerror(r) << dendl;
+      derr << ": failed to truncate remote file path=" << cur_entry->epath
+           << ": " << cpp_strerror(r) << dendl;
       goto freeptr;
     }
     r = ceph_fsync(m_remote_mount, r_fd, 0);
     if (r < 0) {
-      derr << ": failed to sync data for file path=" << epath << ": "
+      derr << ": failed to sync data for file path=" << cur_entry->epath << ": "
            << cpp_strerror(r) << dendl;
     }
   }
@@ -778,117 +854,145 @@ freeptr:
 
 close_remote_fd:
   if (ceph_close(m_remote_mount, r_fd) < 0) {
-    derr << ": failed to close remote fd path=" << epath << ": " << cpp_strerror(r)
-         << dendl;
+    derr << ": failed to close remote fd path=" << cur_entry->epath << ": "
+         << cpp_strerror(r) << dendl;
     return -EINVAL;
   }
 
 close_local_fd:
   if (ceph_close(m_local_mount, l_fd) < 0) {
-    derr << ": failed to close local fd path=" << epath << ": " << cpp_strerror(r)
-         << dendl;
+    derr << ": failed to close local fd path=" << cur_entry->epath << ": "
+         << cpp_strerror(r) << dendl;
     return -EINVAL;
   }
-
   return r == 0 ? 0 : r;
 }
 
-int PeerReplayer::remote_file_op(SyncMechanism *syncm, const std::string &dir_root,
-                                 const std::string &epath, const struct ceph_statx &stx,
-                                 bool sync_check, const FHandles &fh, bool need_data_sync, bool need_attr_sync) {
-  dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << ", need_data_sync=" << need_data_sync
-           << ", need_attr_sync=" << need_attr_sync << dendl;
+int PeerReplayer::remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
+                                 DirRegistry *registry, SnapSyncStat *sync_stat,
+                                 const FHandles &fh) {
+  bool need_data_sync = cur_entry->create_fresh() ||
+                        cur_entry->purge_remote() ||
+                        ((cur_entry->change_mask & CEPH_STATX_SIZE) > 0) ||
+                        (((cur_entry->change_mask & CEPH_STATX_MTIME) > 0));
+
+  dout(10) << ": dir_root=" << registry->dir_root
+           << ", epath=" << cur_entry->epath
+           << ", need_data_sync=" << need_data_sync
+           << ", stat_change_mask=" << cur_entry->change_mask << dendl;
 
   int r;
   if (need_data_sync) {
-    if (S_ISREG(stx.stx_mode)) {
-      r = syncm->get_changed_blocks(epath, stx, sync_check,
-                                    [this, &dir_root, &epath, &stx, &fh](uint64_t num_blocks, struct cblock *b) {
-                                      int ret = copy_to_remote(dir_root, epath, stx, fh, num_blocks, b);
-                                      if (ret < 0) {
-                                        derr << ": failed to copy path=" << epath << ": " << ret << dendl;
-                                      }
-                                      return ret;
-                                    });
-      if (r < 0) {
-        return r;
-      }
-      if (m_perf_counters) {
-        m_perf_counters->inc(l_cephfs_mirror_peer_replayer_sync_bytes, stx.stx_size);
-      }
-      inc_sync_bytes(dir_root, stx.stx_size);
-    } else if (S_ISLNK(stx.stx_mode)) {
+    if (S_ISREG(cur_entry->stx.stx_mode)) {
+      sync_stat->current_stat.inc_file_in_flight_count();
+      FileSyncMechanism *syncm = new FileSyncMechanism(
+          m_local_mount, std::move(cur_entry), registry, sync_stat, fh, this);
+      file_sync_pool.sync_file_data(syncm);
+      return 0;
+    } else if (S_ISLNK(cur_entry->stx.stx_mode)) {
       // free the remote link before relinking
-      r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), 0);
+      r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root,
+                        cur_entry->epath.c_str(), 0);
       if (r < 0 && r != -ENOENT) {
-        derr << ": failed to remove remote symlink=" << epath << dendl;
+        derr << ": failed to remove remote symlink=" << cur_entry->epath << dendl;
         return r;
       }
-      char *target = (char *)alloca(stx.stx_size+1);
-      r = ceph_readlinkat(m_local_mount, fh.c_fd, epath.c_str(), target, stx.stx_size);
+      char *target = (char *)alloca(cur_entry->stx.stx_size + 1);
+      r = ceph_readlinkat(m_local_mount, fh.c_fd, cur_entry->epath.c_str(),
+                          target, cur_entry->stx.stx_size);
       if (r < 0) {
-        derr << ": failed to readlink local path=" << epath << ": " << cpp_strerror(r)
-             << dendl;
+        derr << ": failed to readlink local path=" << cur_entry->epath << ": "
+             << cpp_strerror(r) << dendl;
         return r;
       }
 
-      target[stx.stx_size] = '\0';
-      r = ceph_symlinkat(m_remote_mount, target, fh.r_fd_dir_root, epath.c_str());
+      target[cur_entry->stx.stx_size] = '\0';
+      r = ceph_symlinkat(m_remote_mount, target, fh.r_fd_dir_root,
+                         cur_entry->epath.c_str());
       if (r < 0 && r != EEXIST) {
-        derr << ": failed to symlink remote path=" << epath << " to target=" << target
-             << ": " << cpp_strerror(r) << dendl;
+        derr << ": failed to symlink remote path=" << cur_entry->epath
+             << " to target=" << target << ": " << cpp_strerror(r) << dendl;
         return r;
       }
+      cur_entry->change_mask =
+          (CEPH_STATX_MODE | CEPH_STATX_SIZE | CEPH_STATX_UID | CEPH_STATX_GID |
+           CEPH_STATX_MTIME);
     } else {
-      dout(5) << ": skipping entry=" << epath << ": unsupported mode=" << stx.stx_mode
-              << dendl;
+      dout(5) << ": skipping entry=" << cur_entry->epath
+              << ": unsupported mode=" << cur_entry->stx.stx_mode << dendl;
       return 0;
     }
   }
-
-  if (need_attr_sync) {
-    r = ceph_chownat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), stx.stx_uid, stx.stx_gid,
-                     AT_SYMLINK_NOFOLLOW);
-    if (r < 0) {
-      derr << ": failed to chown remote directory=" << epath << ": " << cpp_strerror(r)
-           << dendl;
-      return r;
-    }
-
-    r = ceph_chmodat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), stx.stx_mode & ~S_IFMT,
-                     AT_SYMLINK_NOFOLLOW);
-    if (r < 0) {
-      derr << ": failed to chmod remote directory=" << epath << ": " << cpp_strerror(r)
-           << dendl;
-      return r;
-    }
-
-    struct timespec times[] = {{stx.stx_atime.tv_sec, stx.stx_atime.tv_nsec},
-                               {stx.stx_mtime.tv_sec, stx.stx_mtime.tv_nsec}};
-    r = ceph_utimensat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), times, AT_SYMLINK_NOFOLLOW);
-    if (r < 0) {
-      derr << ": failed to change [am]time on remote directory=" << epath << ": "
-           << cpp_strerror(r) << dendl;
-      return r;
-    }
+  unsigned int all_change =
+      (CEPH_STATX_MODE | CEPH_STATX_SIZE | CEPH_STATX_UID | CEPH_STATX_GID |
+       CEPH_STATX_MTIME);
+  r = sync_attributes(cur_entry, fh);
+  if (r < 0) {
+    return r;
+  }
+  if (cur_entry->change_mask & all_change) {
+    sync_stat->current_stat.inc_files_synced(false, cur_entry->stx.stx_size);
   }
 
   return 0;
 }
 
-int PeerReplayer::cleanup_remote_dir(const std::string &dir_root,
-                                     const std::string &epath, const FHandles &fh) {
-  dout(20) << ": dir_root=" << dir_root << ", epath=" << epath
+int PeerReplayer::cleanup_remote_entry(const std::string &epath,
+                                       DirRegistry *registry,
+                                       const FHandles &fh,
+                                       SnapSyncStat *sync_stat, int not_dir) {
+  dout(20) << ": dir_root=" << registry->dir_root << ", epath=" << epath
            << dendl;
+  int r = 0;
+  /*
+    not_dir is a hint whether in the base state it's directory or not.
+    This hint works always.
+  */
+  if (not_dir == 1) {
+    r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), 0);
+    if (r < 0 && r != -ENOENT && r != -EISDIR) {
+      derr << ": failed to remove remote entry=" << epath << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+    if (r == -ENOENT) {
+      dout(10) << ": entry already removed=" << epath << dendl;
+      return r;
+    }
+    if (r == 0) {
+      sync_stat->current_stat.inc_file_del_count();
+      return r;
+    }
+  }
 
+  r = 0;
   struct ceph_statx tstx;
-  int r = ceph_statxat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), &tstx,
-                       CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                       CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                       AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  r = ceph_statxat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), &tstx,
+                   CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                       CEPH_STATX_SIZE | CEPH_STATX_MTIME,
+                   AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  if (r == -ENOENT) {
+    dout(10) << ": entry already removed=" << epath << dendl;
+    return r;
+  }
   if (r < 0) {
-    derr << ": failed to stat remote directory=" << epath << ": "
+    derr << ": failed to remove remote entry=" << epath << ": "
          << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  /*
+    if the hint didn't work(it should work always but for the sanity check), 
+    that means we thought it as a directory in base state, our goal is to 
+    just clean it up. No matter it's file or directory.
+  */
+  if (!S_ISDIR(tstx.stx_mode)) {
+    r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, epath.c_str(), 0);
+    if (r < 0) {
+      derr << ": failed to remove remote entry=" << epath << ": "
+           << cpp_strerror(r) << dendl;
+    }
+    sync_stat->current_stat.inc_file_del_count();
     return r;
   }
 
@@ -897,14 +1001,14 @@ int PeerReplayer::cleanup_remote_dir(const std::string &dir_root,
                 &tdirp);
   if (r < 0) {
     derr << ": failed to open remote directory=" << epath << ": "
-         << cpp_strerror(r) << dendl;
+        << cpp_strerror(r) << dendl;
     return r;
   }
 
   std::stack<SyncEntry> rm_stack;
   rm_stack.emplace(SyncEntry(epath, tdirp, tstx));
   while (!rm_stack.empty()) {
-    if (should_backoff(dir_root, &r)) {
+    if (should_backoff(registry, &r)) {
       dout(0) << ": backing off r=" << r << dendl;
       break;
     }
@@ -918,7 +1022,8 @@ int PeerReplayer::cleanup_remote_dir(const std::string &dir_root,
       struct dirent de;
       while (true) {
         r = ceph_readdirplus_r(m_remote_mount, entry.dirp, &de, &stx,
-                               CEPH_STATX_MODE, AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
+                              CEPH_STATX_MODE,
+                              AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
         if (r < 0) {
           derr << ": failed to read remote directory=" << entry.epath << dendl;
           break;
@@ -935,15 +1040,17 @@ int PeerReplayer::cleanup_remote_dir(const std::string &dir_root,
       }
 
       if (r == 0) {
-        r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, entry.epath.c_str(), AT_REMOVEDIR);
+        r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, entry.epath.c_str(),
+                          AT_REMOVEDIR);
         if (r < 0) {
           derr << ": failed to remove remote directory=" << entry.epath << ": "
-               << cpp_strerror(r) << dendl;
+              << cpp_strerror(r) << dendl;
           break;
         }
+        sync_stat->current_stat.inc_dir_deleted_count();
 
         dout(10) << ": done for remote directory=" << entry.epath << dendl;
-        if (ceph_closedir(m_remote_mount, entry.dirp) < 0) {
+        if (entry.dirp && ceph_closedir(m_remote_mount, entry.dirp) < 0) {
           derr << ": failed to close remote directory=" << entry.epath << dendl;
         }
         rm_stack.pop();
@@ -956,11 +1063,11 @@ int PeerReplayer::cleanup_remote_dir(const std::string &dir_root,
       auto epath = entry_path(entry.epath, e_name);
       if (S_ISDIR(stx.stx_mode)) {
         ceph_dir_result *dirp;
-        r = opendirat(m_remote_mount, fh.r_fd_dir_root, epath, AT_SYMLINK_NOFOLLOW,
-                      &dirp);
+        r = opendirat(m_remote_mount, fh.r_fd_dir_root, epath,
+                      AT_SYMLINK_NOFOLLOW, &dirp);
         if (r < 0) {
           derr << ": failed to open remote directory=" << epath << ": "
-               << cpp_strerror(r) << dendl;
+              << cpp_strerror(r) << dendl;
           break;
         }
         rm_stack.emplace(SyncEntry(epath, dirp, stx));
@@ -968,13 +1075,15 @@ int PeerReplayer::cleanup_remote_dir(const std::string &dir_root,
         rm_stack.emplace(SyncEntry(epath, stx));
       }
     } else {
-      r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, entry.epath.c_str(), 0);
+      r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, entry.epath.c_str(),
+                        0);
       if (r < 0) {
         derr << ": failed to remove remote directory=" << entry.epath << ": "
-             << cpp_strerror(r) << dendl;
+            << cpp_strerror(r) << dendl;
         break;
       }
       dout(10) << ": done for remote file=" << entry.epath << dendl;
+      sync_stat->current_stat.inc_file_del_count();
       rm_stack.pop();
     }
   }
@@ -983,7 +1092,7 @@ int PeerReplayer::cleanup_remote_dir(const std::string &dir_root,
     auto &entry = rm_stack.top();
     if (entry.is_directory()) {
       dout(20) << ": closing remote directory=" << entry.epath << dendl;
-      if (ceph_closedir(m_remote_mount, entry.dirp) < 0) {
+      if (entry.dirp && ceph_closedir(m_remote_mount, entry.dirp) < 0) {
         derr << ": failed to close remote directory=" << entry.epath << dendl;
       }
     }
@@ -1038,10 +1147,13 @@ int PeerReplayer::should_sync_entry(const std::string &epath, const struct ceph_
   return 0;
 }
 
-int PeerReplayer::propagate_deleted_entries(const std::string &dir_root,
-                                            const std::string &epath, const FHandles &fh) {
-  dout(10) << ": dir_root=" << dir_root << ", epath=" << epath << dendl;
-
+int PeerReplayer::propagate_deleted_entries(
+    const std::string &epath, DirRegistry *registry, SnapSyncStat *sync_stat,
+    const FHandles &fh,
+    std::unordered_map<std::string, unsigned int> &change_mask_map,
+    int &change_mask_map_size) {
+  dout(10) << ": dir_root=" << registry->dir_root << ", epath=" << epath
+           << dendl;
   ceph_dir_result *dirp;
   int r = opendirat(fh.p_mnt, fh.p_fd, epath, AT_SYMLINK_NOFOLLOW, &dirp);
   if (r < 0) {
@@ -1056,23 +1168,29 @@ int PeerReplayer::propagate_deleted_entries(const std::string &dir_root,
       return 0;
     }
     if (r == -ENOENT) {
-      dout(5) << ": epath=" << epath << " missing in previous-snap/remote dir-root"
-              << dendl;
+      dout(5) << ": epath=" << epath
+              << " missing in previous-snap/remote dir-root" << dendl;
     }
     return r;
   }
-
-  struct dirent *dire = (struct dirent *)alloca(512 * sizeof(struct dirent));
+  struct ceph_statx pstx;
+  struct dirent de;
   while (true) {
-    if (should_backoff(dir_root, &r)) {
+    if (should_backoff(registry, &r)) {
       dout(0) << ": backing off r=" << r << dendl;
       break;
     }
+    unsigned int extra_flags = (change_mask_map_size < max_change_mask_map_size)
+                                   ? (CEPH_STATX_UID | CEPH_STATX_GID |
+                                      CEPH_STATX_SIZE | CEPH_STATX_MTIME)
+                                   : 0;
+    r = ceph_readdirplus_r(fh.p_mnt, dirp, &de, &pstx,
+                           CEPH_STATX_MODE | extra_flags,
+                           AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
 
-    int len = ceph_getdents(fh.p_mnt, dirp, (char *)dire, 512);
-    if (len < 0) {
-      derr << ": failed to read directory entries: " << cpp_strerror(len) << dendl;
-      r = len;
+    if (r < 0) {
+      derr << ": failed to read directory entries: " << cpp_strerror(r)
+           << dendl;
       // flip errno to signal that we got an err (possible the
       // snapshot getting deleted in midst).
       if (r == -ENOENT) {
@@ -1080,77 +1198,65 @@ int PeerReplayer::propagate_deleted_entries(const std::string &dir_root,
       }
       break;
     }
-    if (len == 0) {
+    if (r == 0) {
       dout(10) << ": reached EOD" << dendl;
       break;
     }
-    int nr = len / sizeof(struct dirent);
-    for (int i = 0; i < nr; ++i) {
-      if (should_backoff(dir_root, &r)) {
-        dout(0) << ": backing off r=" << r << dendl;
-        break;
-      }
-      std::string d_name = std::string(dire[i].d_name);
-      if (d_name == "." || d_name == "..") {
-        continue;
-      }
+    std::string d_name = std::string(de.d_name);
+    if (d_name == "." || d_name == "..") {
+      continue;
+    }
+    auto dpath = entry_path(epath, d_name);
 
-      struct ceph_statx pstx;
-      auto dpath = entry_path(epath, d_name);
-      r = ceph_statxat(fh.p_mnt, fh.p_fd, dpath.c_str(), &pstx,
-                       CEPH_STATX_MODE, AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-      if (r < 0) {
-        derr << ": failed to stat (prev) directory=" << dpath << ": "
-             << cpp_strerror(r) << dendl;
-        // flip errno to signal that we got an err (possible the
-        // snapshot getting deleted in midst).
-        if (r == -ENOENT) {
-          r = -EINVAL;
-        }
-        return r;
-      }
+    struct ceph_statx cstx;
+    r = ceph_statxat(m_local_mount, fh.c_fd, dpath.c_str(), &cstx,
+                     CEPH_STATX_MODE | extra_flags,
+                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+    if (r < 0 && r != -ENOENT) {
+      derr << ": failed to stat local (cur) directory=" << dpath << ": "
+           << cpp_strerror(r) << dendl;
+      break;
+    }
 
-      struct ceph_statx cstx;
-      r = ceph_statxat(m_local_mount, fh.c_fd, dpath.c_str(), &cstx,
-                       CEPH_STATX_MODE, AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-      if (r < 0 && r != -ENOENT) {
-        derr << ": failed to stat local (cur) directory=" << dpath << ": "
-             << cpp_strerror(r) << dendl;
-        return r;
-      }
-
-      bool purge_remote = true;
-      if (r == 0) {
-        // directory entry present in both snapshots -- check inode
-        // type
-        if ((pstx.stx_mode & S_IFMT) == (cstx.stx_mode & S_IFMT)) {
-          dout(5) << ": mode matches for entry=" << d_name << dendl;
-          purge_remote = false;
-        } else {
-          dout(5) << ": mode mismatch for entry=" << d_name << dendl;
-        }
+    bool purge_remote = true;
+    bool entry_present = false;
+    if (r == 0) {
+      // directory entry present in both snapshots -- check inode
+      // type
+      entry_present = true;
+      if ((pstx.stx_mode & S_IFMT) == (cstx.stx_mode & S_IFMT)) {
+        dout(5) << ": mode matches for entry=" << d_name << dendl;
+        purge_remote = false;
       } else {
-        dout(5) << ": entry=" << d_name << " missing in current snapshot" << dendl;
+        dout(5) << ": mode mismatch for entry=" << d_name << dendl;
       }
+    } else {
+      dout(5) << ": entry=" << d_name << " missing in current snapshot"
+              << dendl;
+    }
 
-      if (purge_remote) {
-        dout(5) << ": purging remote entry=" << dpath << dendl;
-        if (S_ISDIR(pstx.stx_mode)) {
-          r = cleanup_remote_dir(dir_root, dpath, fh);
-        } else {
-          r = ceph_unlinkat(m_remote_mount, fh.r_fd_dir_root, dpath.c_str(), 0);
-        }
-
-        if (r < 0 && r != -ENOENT) {
-          derr << ": failed to cleanup remote entry=" << d_name << ": "
-               << cpp_strerror(r) << dendl;
-          return r;
-        }
-      }
+    if (purge_remote && !entry_present) {
+      dout(5) << ": purging remote entry=" << dpath << dendl;
+      SyncMechanism *syncm = new DeleteMechanism(
+          m_local_mount, std::move(std::make_shared<SyncEntry>(dpath)),
+          registry, sync_stat, fh, this, !S_ISDIR(pstx.stx_mode));
+      registry->sync_pool->sync_anyway(syncm);
+    } else if (extra_flags) {
+      unsigned int change_mask = 0;
+      build_change_mask(pstx, cstx, false, purge_remote, change_mask);
+      /*
+        saving some of change_mask, such that we can avoid doing
+        stat in previous snapshot/remote if it is found in the chage_mask map.
+        This map is strategically maintained such that we can best use of
+        max_change_mask_map_size threshold.
+      */
+      change_mask_map[d_name] = change_mask;
+      ++change_mask_map_size;
     }
   }
-
-  ceph_closedir(fh.p_mnt, dirp);
+  if (dirp) {
+    ceph_closedir(fh.p_mnt, dirp);
+  }
   return r;
 }
 
@@ -1194,7 +1300,7 @@ int PeerReplayer::open_dir(MountRef mnt, const std::string &dir_path,
 int PeerReplayer::pre_sync_check_and_open_handles(
     const std::string &dir_root,
     const Snapshot &current, boost::optional<Snapshot> prev,
-    FHandles *fh) {
+    FHandles *snapdiff_fh, FHandles* remotediff_fh) {
   dout(20) << ": dir_root=" << dir_root << ", current=" << current << dendl;
   if (prev) {
     dout(20) << ": prev=" << prev << dendl;
@@ -1205,48 +1311,43 @@ int PeerReplayer::pre_sync_check_and_open_handles(
   if (fd < 0) {
     return fd;
   }
+  snapdiff_fh->c_fd = snapdiff_fh->p_fd = remotediff_fh->c_fd =
+      remotediff_fh->p_fd = -1;
 
   // current snapshot file descriptor
-  fh->c_fd = fd;
+  snapdiff_fh->m_current = current;
+  snapdiff_fh->m_prev = prev;
+  snapdiff_fh->c_fd = fd;
+  remotediff_fh->c_fd = fd;
 
-  MountRef mnt;
   if (prev) {
-    mnt = m_local_mount;
     auto prev_snap_path = snapshot_path(m_cct, dir_root, (*prev).first);
-    fd = open_dir(mnt, prev_snap_path, (*prev).second);
-  } else {
-    mnt = m_remote_mount;
-    fd = open_dir(mnt, dir_root, boost::none);
+    snapdiff_fh->p_fd = open_dir(m_local_mount, prev_snap_path, (*prev).second);
+    snapdiff_fh->p_mnt = m_local_mount;
   }
+  remotediff_fh->p_fd = open_dir(m_remote_mount, dir_root, boost::none);
+  remotediff_fh->p_mnt = m_remote_mount;
 
-  if (fd < 0) {
-    if (!prev || fd != -ENOENT) {
-      ceph_close(m_local_mount, fh->c_fd);
-      return fd;
+  if (remotediff_fh->p_fd < 0) {
+    ceph_close(m_local_mount, remotediff_fh->c_fd);
+    if (snapdiff_fh->p_fd >= 0) {
+      ceph_close(m_local_mount, snapdiff_fh->p_fd);
     }
-
-    // ENOENT of previous snap
-    dout(5) << ": previous snapshot=" << *prev << " missing" << dendl;
-    mnt = m_remote_mount;
-    fd = open_dir(mnt, dir_root, boost::none);
-    if (fd < 0) {
-      ceph_close(m_local_mount, fh->c_fd);
-      return fd;
-    }
+    return remotediff_fh->p_fd;
   }
-
-  // "previous" snapshot or dir_root file descriptor
-  fh->p_fd = fd;
-  fh->p_mnt = mnt;
 
   {
     std::scoped_lock locker(m_lock);
     auto it = m_registered.find(dir_root);
     ceph_assert(it != m_registered.end());
-    fh->r_fd_dir_root = it->second.fd;
+    snapdiff_fh->r_fd_dir_root = it->second->fd;
+    remotediff_fh->r_fd_dir_root = it->second->fd;
   }
 
-  dout(5) << ": using " << ((fh->p_mnt == m_local_mount) ? "local (previous) snapshot" : "remote dir_root")
+  dout(0) << ": using "
+          << ((snapdiff_fh->p_fd >= 0)
+                  ? ("local (previous) snapshot " + (*prev).first)
+                  : "remote dir_root")
           << " for incremental transfer" << dendl;
   return 0;
 }
@@ -1272,289 +1373,477 @@ int PeerReplayer::sync_perms(const std::string& path) {
   return 0;
 }
 
-PeerReplayer::SyncMechanism::SyncMechanism(MountRef local, MountRef remote, FHandles *fh,
-                                           const Peer &peer, const Snapshot &current,
-                                           boost::optional<Snapshot> prev)
-    : m_local(local),
-      m_remote(remote),
-      m_fh(fh),
-      m_peer(peer),
-      m_current(current),
-      m_prev(prev) {
-  }
+PeerReplayer::FileSyncPool::FileSyncPool(int num_threads, const Peer &m_peer)
+    : num_threads(num_threads), qlimit(max(10 * num_threads, 5000)),
+      stop_thread(num_threads, true), pool_stats(this), sync_count(0),
+      active(false), m_peer(m_peer) {}
 
-PeerReplayer::SyncMechanism::~SyncMechanism() {
+void PeerReplayer::FileSyncPool::activate() {
+  {
+    std::scoped_lock lock(mtx);
+    active = true;
+    for (int i = 0; i < num_threads; ++i) {
+      stop_thread[i] = false;
+    }
+  }
+  for (int i = 0; i < num_threads; ++i) {
+    workers.emplace_back(
+        std::make_unique<std::thread>(&FileSyncPool::run, this, i));
+  }
 }
 
-int PeerReplayer::SyncMechanism::get_changed_blocks(const std::string &epath,
-                                                    const struct ceph_statx &stx, bool sync_check,
-                                                    const std::function<int (uint64_t, struct cblock *)> &callback) {
-  dout(20) << ": epath=" << epath << dendl;
+void PeerReplayer::FileSyncPool::deactivate() {
+  {
+    std::scoped_lock lock(mtx);
+    active = false;
+    for (int i = 0; i < workers.size(); ++i) {
+      stop_thread[i] = true;
+    }
+  }
+  pick_cv.notify_all();
+  give_cv.notify_all();
+  for (auto &worker : workers) {
+    if (worker->joinable()) {
+      worker->join();
+    }
+  }
+  drain_queue();
+}
+
+void PeerReplayer::FileSyncPool::drain_queue() {
+  std::scoped_lock lock(mtx);
+  for (int i = 0; i < sync_queue.size(); ++i) {
+    while (!sync_queue[i].empty()) {
+      auto &task = sync_queue[i].front();
+      task->complete(-1);
+      sync_queue[i].pop();
+    }
+  }
+}
+
+void PeerReplayer::FileSyncPool::run(int thread_idx) {
+  while (true) {
+    FileSyncMechanism *task;
+    int sync_idx = 0;
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      pick_cv.wait(lock, [this, thread_idx] {
+        return (stop_thread[thread_idx] || !sync_ring.empty());
+      });
+      if (stop_thread[thread_idx]) {
+        return;
+      }
+      task = sync_ring.front();
+      sync_idx = task->get_file_sync_queue_idx();
+      ceph_assert(sync_idx < sync_queue.size() &&
+                  !sync_queue[sync_idx].empty());
+      sync_queue[sync_idx].pop();
+      sync_ring.pop();
+      if (!sync_queue[sync_idx].empty()) {
+        sync_ring.emplace(sync_queue[sync_idx].front());
+      }
+      pool_stats.remove_file(task->get_file_size());
+    }
+    give_cv.notify_one();
+    task->complete(0);
+  }
+}
+
+void PeerReplayer::FileSyncPool::sync_file_data(FileSyncMechanism *task) {
+  int sync_idx = task->get_file_sync_queue_idx();
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    give_cv.wait(lock, [this, sync_idx] {
+      return (!active || sync_queue[sync_idx].size() < qlimit);
+    });
+    if (!active) {
+      return;
+    }
+    if (sync_queue[sync_idx].empty()) {
+      sync_ring.emplace(task);
+    }
+    sync_queue[sync_idx].emplace(task);
+    pool_stats.add_file(task->get_file_size());
+    task->sync_in_flight();
+  }
+  pick_cv.notify_one();
+}
+
+int PeerReplayer::FileSyncPool::sync_start() {
+  std::scoped_lock lock(mtx);
+  int sync_idx = 0;
+  if (!unassigned_sync_ids.empty()) {
+    sync_idx = unassigned_sync_ids.back();
+    sync_queue[sync_idx] = std::queue<FileSyncMechanism *>();
+    unassigned_sync_ids.pop_back();
+  } else {
+    sync_idx = sync_count++;
+    sync_queue.emplace_back(std::queue<FileSyncMechanism *>());
+  }
+  return sync_idx;
+}
+
+void PeerReplayer::FileSyncPool::sync_finish(int sync_idx) {
+  std::scoped_lock lock(mtx);
+  ceph_assert(sync_idx >= 0 && sync_idx < sync_queue.size());
+  while (!sync_queue[sync_idx].empty()) {
+    auto &task = sync_queue[sync_idx].front();
+    task->complete(-1);
+    sync_queue[sync_idx].pop();
+  }
+  unassigned_sync_ids.push_back(sync_idx);
+}
+
+void PeerReplayer::FileSyncPool::update_state() {
+  int thread_count = g_ceph_context->_conf->cephfs_mirror_file_sync_thread;
+  std::unique_lock<std::mutex> lock(mtx);
+  if (!active) {
+    return;
+  }
+  if (thread_count == workers.size()) {
+    return;
+  }
+
+  if (thread_count < workers.size()) {
+    for (int i = thread_count; i < workers.size(); ++i) {
+      stop_thread[i] = true;
+    }
+    lock.unlock();
+    pick_cv.notify_all();
+    for (int i = thread_count; i < workers.size(); ++i) {
+      if (workers[i]->joinable()) {
+        workers[i]->join();
+        dout(0) << ": shutdown of thread having thread idx=" << i
+                << ", from file sync thread pool" << dendl;
+      }
+    }
+    lock.lock();
+    while (workers.size() > thread_count) {
+      workers.pop_back();
+      stop_thread.pop_back();
+    }
+  } else {
+    for (int i = workers.size(); i < thread_count; ++i) {
+      stop_thread.emplace_back(false);
+      workers.emplace_back(
+          std::make_unique<std::thread>(&FileSyncPool::run, this, i));
+      dout(0) << ": creating thread having thread idx=" << i
+              << ", in file sync thread pool" << dendl;
+    }
+  }
+  num_threads = thread_count;
+
+  dout(0) << ": updating number of threads in file sync threadpool to "
+          << thread_count << dendl;
+}
+
+void PeerReplayer::DirSyncPool::activate() {
+  {
+    std::scoped_lock lock(mtx);
+    active = true;
+    qlimit = 1 << 15;
+  }
+  for (int i = 0; i < num_threads; ++i) {
+    thread_status.emplace_back(new ThreadStatus());
+    thread_status[i]->stop_called = false;
+    workers.emplace_back(std::make_unique<std::thread>(&DirSyncPool::run, this,
+                                                       thread_status[i]));
+    thread_status[i]->active = true;
+  }
+}
+
+void PeerReplayer::DirSyncPool::drain_queue() {
+  std::scoped_lock lock(mtx);
+  while (!sync_queue.empty()) {
+    auto &task = sync_queue.front();
+    task->complete(-1);
+    sync_queue.pop();
+    queued--;
+  }
+}
+
+void PeerReplayer::DirSyncPool::deactivate() {
+  std::unique_lock<std::mutex> lock(mtx);
+  active = false;
+  for (int i = 0; i < thread_status.size(); ++i) {
+    thread_status[i]->stop_called = true;
+  }
+  lock.unlock();
+  pick_cv.notify_all();
+  for (auto &worker : workers) {
+    if (worker->joinable()) {
+      worker->join();
+    }
+  }
+  lock.lock();
+  workers.clear();
+  for (int i = 0; i < thread_status.size(); ++i) {
+    if (thread_status[i]) {
+      delete thread_status[i];
+      thread_status[i] = nullptr;
+    }
+  }
+  thread_status.clear();
+  lock.unlock();
+  drain_queue();
+}
+
+void PeerReplayer::DirSyncPool::run(ThreadStatus *status) {
+  while (true) {
+    SyncMechanism *task;
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      pick_cv.wait(lock, [this, status] {
+        return (status->stop_called || !sync_queue.empty());
+      });
+      if (status->stop_called) {
+        status->active = false;
+        break;
+      }
+      task = sync_queue.front();
+      sync_queue.pop();
+      queued--;
+    }
+    task->complete(0);
+  }
+}
+
+bool PeerReplayer::DirSyncPool::_try_sync(SyncMechanism *task) {
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    if (sync_queue.size() >= qlimit) {
+      return false;
+    }
+    task->sync_in_flight();
+    sync_queue.emplace(task);
+    queued++;
+  }
+  pick_cv.notify_one();
+  return true;
+}
+
+bool PeerReplayer::DirSyncPool::try_sync(SyncMechanism *task) {
+  bool success = false;
+  if (sync_queue.size() < qlimit) {
+    success = _try_sync(task);
+  }
+  return success;
+}
+
+void PeerReplayer::DirSyncPool::sync_anyway(SyncMechanism *task) {
+  if (!try_sync(task)) {
+    sync_direct(task);
+  }
+}
+
+void PeerReplayer::DirSyncPool::sync_direct(SyncMechanism *task) {
+  task->sync_in_flight();
+  task->complete(1);
+}
+
+void PeerReplayer::DirSyncPool::update_state() {
+  std::unique_lock<std::mutex> lock(mtx);
+  int thread_count = g_ceph_context->_conf->cephfs_mirror_dir_scanning_thread;
+  if (!active) {
+    return;
+  }
+  if (thread_count == num_threads) {
+    return;
+  }
+
+  if (thread_count < num_threads) {
+    for (int i = thread_count; i < num_threads; ++i) {
+      thread_status[i]->stop_called = true;
+      dout(0) << ": Lazy shutdown of thread no " << i
+              << " from directory scanning threadpool for " << epath << dendl;
+    }
+    num_threads = thread_count;
+    lock.unlock();
+    pick_cv.notify_all();
+  } else {
+    int i;
+    for (i = num_threads; i < workers.size() && num_threads < thread_count;
+         ++i) {
+      if (thread_status[i]->active) {
+        swap(workers[i], workers[num_threads]);
+        swap(thread_status[i], thread_status[num_threads]);
+        thread_status[num_threads++]->stop_called = false;
+        dout(0) << ": Reactivating thread no " << i
+                << " of directory scanning threadpool for " << epath << dendl;
+      }
+    }
+    for (int i = (int)workers.size() - 1; i >= num_threads; --i) {
+      if (num_threads == thread_count && thread_status[i]->active) {
+        break;
+      }
+    }
+    lock.unlock();
+    pick_cv.notify_all();
+    if (i < num_threads) {
+      for (i = (int)workers.size() - 1; i >= num_threads; --i) {
+        if (workers[i]->joinable()) {
+          workers[i]->join();
+          dout(0) << ": Force shutdown of already lazy shut thread having "
+                     "thread no "
+                  << i << " from directory scanning threadpool for " << epath
+                  << dendl;
+        }
+        workers.pop_back();
+        if (thread_status[i]) {
+          delete thread_status[i];
+          thread_status[i] = nullptr;
+        }
+        thread_status.pop_back();
+      }
+    }
+
+    for (i = num_threads; i < thread_count; ++i) {
+      thread_status.emplace_back(new ThreadStatus());
+      thread_status[i]->stop_called = false;
+      workers.emplace_back(std::make_unique<std::thread>(
+          &DirSyncPool::run, this, thread_status[i]));
+      thread_status[i]->active = true;
+      dout(0) << ": Creating thread no " << i
+              << " in directory scanning threadpool for " << epath << dendl;
+    }
+    num_threads = thread_count;
+  }
+  dout(0) << ": updating number of threads in directory scanner threadpool for "
+             "directory="
+          << epath << " to" << thread_count << dendl;
+}
+
+int PeerReplayer::SyncMechanism::populate_current_stat(const FHandles& fh) {
+  int r = 0;
+  if (!cur_entry->stat_known) { // stat populated
+    r = ceph_statxat(m_local, fh.c_fd, cur_entry->epath.c_str(),
+                     &cur_entry->stx,
+                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                         CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+    if (r < 0) {
+      derr << ": failed to stat cur entry= " << cur_entry->epath << ": "
+           << cpp_strerror(r) << dendl;
+      derr << ": failed to stat cur entry= " << cur_entry->epath << ", "
+           << cur_entry->sync_is_snapdiff() << dendl;
+      return r;
+    }
+    cur_entry->set_stat_known();
+  }
+  return r;
+}
+
+int PeerReplayer::SyncMechanism::populate_change_mask(
+    const FHandles &fh) {
+  int r = 0;
+  bool purge_remote = cur_entry->purge_remote();
+  bool create_fresh = cur_entry->create_fresh();
+  struct ceph_statx pstx;
+  if (cur_entry->change_mask_populated()) {
+    return 0;
+  }
+  if (!create_fresh && !purge_remote) {
+    int pstat_r =
+        ceph_statxat(fh.p_mnt, fh.p_fd, cur_entry->epath.c_str(), &pstx,
+                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                         CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+    if (pstat_r < 0 && pstat_r != -ENOENT && pstat_r != -ENOTDIR) {
+      r = pstat_r;
+      derr << ": failed to stat prev entry= " << cur_entry->epath << ": "
+           << cpp_strerror(r) << dendl;
+      return r;
+    }
+    purge_remote = pstat_r == 0 && ((cur_entry->stx.stx_mode & S_IFMT) !=
+                                    (pstx.stx_mode & S_IFMT));
+    create_fresh = (pstat_r < 0);
+  }
+  replayer->build_change_mask(pstx, cur_entry->stx, create_fresh, purge_remote,
+                              cur_entry->change_mask);
+  return 0;
+}
+
+
+void PeerReplayer::DeleteMechanism::finish(int r) {
+  if (r < 0) {
+    goto notify_finish;
+  }
+  r = replayer->cleanup_remote_entry(cur_entry->epath, registry, fh, sync_stat,
+                                     not_dir);
+  if (r < 0 && r != -ENOENT) {
+    derr << ": failed to cleanup remote entry=" << cur_entry->epath << ": "
+         << cpp_strerror(r) << dendl;
+    registry->set_failed(r);
+  }
+notify_finish:
+  registry->dec_sync_indicator();
+}
+
+void PeerReplayer::FileSyncMechanism::finish(int r) {
+  if (r < 0) {
+    goto notify_finish;
+  }
+  r = sync_file();
+  if (r < 0) {
+    registry->set_failed(r);
+  }
+notify_finish:
+  sync_stat->current_stat.dec_file_in_flight_count();
+  registry->dec_sync_indicator();
+}
+
+int PeerReplayer::FileSyncMechanism::_sync_file() {
+  dout(20) << ": epath=" << cur_entry->epath << dendl;
 
   struct cblock b;
   // extent covers the whole file
   b.offset = 0;
-  b.len = stx.stx_size;
+  b.len = cur_entry->stx.stx_size;
 
   struct ceph_file_blockdiff_changedblocks block;
   block.num_blocks = 1;
   block.b = &b;
-
-  return callback(block.num_blocks, block.b);
-}
-
-PeerReplayer::SnapDiffSync::SnapDiffSync(std::string_view dir_root, MountRef local, MountRef remote,
-                                         FHandles *fh, const Peer &peer, const Snapshot &current,
-                                         boost::optional<Snapshot> prev)
-  : SyncMechanism(local, remote, fh, peer, current, prev),
-    m_dir_root(dir_root) {
-}
-
-PeerReplayer::SnapDiffSync::~SnapDiffSync() {
-}
-
-int PeerReplayer::SnapDiffSync::init_sync() {
-  struct ceph_statx tstx;
-  int r = ceph_fstatx(m_local, m_fh->c_fd, &tstx,
-                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                      CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                      AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  int r = replayer->copy_to_remote(cur_entry, registry, fh, block.num_blocks,
+                                   block.b, true);
   if (r < 0) {
-    derr << ": failed to stat snap=" << m_current.first << ": " << cpp_strerror(r)
-         << dendl;
+    derr << ": failed to copy path=" << cur_entry->epath << ": "
+         << cpp_strerror(r) << dendl;
     return r;
   }
-
-  dout(20) << ": open_snapdiff for dir_root=" << m_dir_root << ", path=., prev="
-           << (*m_prev).first << ", current=" << m_current.first << dendl;
-
-  ceph_snapdiff_info info;
-  r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), ".",
-                         stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
-  if (r != 0) {
-    derr << ": failed to open snapdiff for " << m_dir_root << ": r=" << r << dendl;
-    return r;
-  }
-
-  m_sync_stack.emplace(SyncEntry(".", info, tstx));
-  return 0;
+  r = replayer->sync_attributes(cur_entry, fh);
+  sync_stat->current_stat.inc_files_synced(true, cur_entry->stx.stx_size);
+  return r;
 }
 
-int PeerReplayer::SnapDiffSync::init_directory(const std::string &epath,
-                                               const struct ceph_statx &stx, bool pic, SyncEntry *se) {
-  dout(20) << ": epath=" << epath << dendl;
-
-  int r;
-  if (pic) {
-    dout(20) << ": non snapdiff dir_root=" << m_dir_root << ", path=" << epath << dendl;
-
-    ceph_dir_result *dirp;
-    r = opendirat(m_local, m_fh->c_fd, epath, AT_SYMLINK_NOFOLLOW, &dirp);
-    if (r < 0) {
-      derr << ": failed to open local directory=" << epath << ": " << r << dendl;
-      return r;
-    }
-
-    *se = SyncEntry(epath, dirp, stx);
-  } else {
-    dout(20) << ": open_snapdiff for dir_root=" << m_dir_root << ", path=" << epath
-             << ", prev=" << (*m_prev).first << ", current=" << m_current.first << dendl;
-
-    ceph_snapdiff_info info;
-    r = ceph_open_snapdiff(m_local, m_dir_root.c_str(), epath.c_str(),
-                           stringify((*m_prev).first).c_str(), stringify(m_current.first).c_str(), &info);
-    if (r != 0) {
-      derr << ": failed to open snapdiff for " << m_dir_root << ", r=" << r << dendl;
-      return r;
-    }
-
-    *se = SyncEntry(epath, info, stx);
-  }
-
-  return 0;
-}
-
-int PeerReplayer::SnapDiffSync::next_entry(SyncEntry &entry, std::string *e_name,
-                                           snapid_t *snapid) {
-  int r;
-  if (!entry.sync_is_snapdiff()) {
-    dout(20) << ": not snapdiff" << dendl;
-    struct dirent de;
-    r = ceph_readdirplus_r(m_local, entry.dirp, &de, NULL, 0,
-                           AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
-    if (r < 0) {
-      derr << ": failed to read directory=" << entry.epath << ", r=" << r << dendl;
-      return r;
-    }
-
-    if (r == 0) {
-      return 0;
-    }
-
-    *e_name = de.d_name;
-    *snapid = m_current.second;
-  } else {
-    dout(20) << ": is snapdiff" << dendl;
-    ceph_snapdiff_entry_t sd_entry;
-    r = ceph_readdir_snapdiff(&(entry.info), &sd_entry);
-    if (r < 0) {
-      derr << ": failed to read directory=" << entry.epath << ", r=" << r << dendl;
-      return r;
-    }
-
-    if (r == 0) {
-      return 0;
-    }
-
-    *e_name = sd_entry.dir_entry.d_name;
-    *snapid = sd_entry.snapid;
-  }
-
-  return 1;
-}
-
-void PeerReplayer::SnapDiffSync::fini_directory(SyncEntry &entry) {
-  if (!entry.sync_is_snapdiff()) {
-    if (ceph_closedir(m_local, entry.dirp) < 0) {
-      derr << ": failed to close local directory=" << entry.epath << dendl;
-    }
-  } else {
-    if (ceph_close_snapdiff(&(entry.info)) < 0) {
-      derr << ": failed to close snapdiff for " << entry.epath << dendl;
-    }
-  }
-}
-
-int PeerReplayer::SnapDiffSync::get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
-                                          const std::function<int (const std::string&)> &dirsync_func,
-                                          const std::function<int (const std::string &)> &purge_func) {
-  dout(20) << ": sync stack size=" << m_sync_stack.size() << dendl;
-
-  while (!m_sync_stack.empty()) {
-    auto &entry = m_sync_stack.top();
-    dout(20) << ": top of stack path=" << entry.epath << dendl;
-    ceph_assert(entry.is_directory());
-
-    int r;
-    snapid_t snapid;
-    std::string e_name;
-    while (true) {
-      e_name.clear();
-      r = next_entry(entry, &e_name, &snapid);
-      if (r < 0 || r == 0) {
-        break;
-      }
-
-      dout(20) << ": entry=" << e_name << ", snapid=" << snapid << dendl;
-      if (e_name != "." && e_name != "..") {
-        break;
-      }
-    }
-
-    if (r == 0) {
-      dout(10) << ": done for directory=" << entry.epath << dendl;
-      fini_directory(entry);
-      m_sync_stack.pop();
-      continue;
-    }
-
-    if (r < 0) {
-      return r;
-    }
-
-    auto _epath = entry_path(entry.epath, e_name);
-    dout(20) << ": epath=" << _epath << dendl;
-    if (snapid == (*m_prev).second) {
-      dout(20) << ": epath=" << _epath << " is deleted in current snapshot " << dendl;
-      // do not depend on d_type reported in struct dirent as the
-      // delete and create could have been processed and a restart
-      // of an interrupted sync would use the incorrect unlink API.
-      // N.B.: snapdiff returns the deleted entry before the newly
-      // created one.
-      struct ceph_statx pstx;
-      r = ceph_statxat(m_remote, m_fh->r_fd_dir_root, _epath.c_str(), &pstx,
-                       CEPH_STATX_MODE, AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-      if (r < 0 && r != -ENOENT) {
-        derr << ": failed to stat remote entry=" << _epath << ", r=" << r << dendl;
-        return r;
-      }
-      if (r == 0) {
-        if (!S_ISDIR(pstx.stx_mode)) {
-          r = ceph_unlinkat(m_remote, m_fh->r_fd_dir_root, _epath.c_str(), 0);
-        } else {
-          r = purge_func(_epath);
-        }
-
-        if (r < 0) {
-          derr << ": failed to propagate missing dirs r=" << r << dendl;
-          return r;
-        }
-      }
-
-      m_deleted[entry.epath].emplace(e_name);
-      continue;
-    }
-
-    struct ceph_statx estx;
-    r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &estx,
-                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                     CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-    if (r < 0) {
-      derr << ": failed to stat epath=" << epath << ", r=" << r << dendl;
-      return r;
-    }
-
-    bool pic = entry.is_purged_or_itype_changed() || m_deleted[entry.epath].contains(e_name);
-    if (S_ISDIR(estx.stx_mode)) {
-      SyncEntry se;
-      r = init_directory(_epath, estx, pic, &se);
-      if (r < 0) {
-        return r;
-      }
-
-      if (pic) {
-        dout(10) << ": purge or itype change (including parent) found for entry="
-                 << se.epath << dendl;
-        se.set_purged_or_itype_changed();
-      }
-
-      m_sync_stack.emplace(se);
-    }
-
-    *epath = _epath;
-    *stx = estx;
-    *sync_check = !pic;
-
-    dout(10) << ": sync_check=" << *sync_check << " for epath=" << *epath << dendl;
-    return 0;
-  }
-
-  *epath = "";
-  return 0;
-}
-
-int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
-                                                   const struct ceph_statx &stx, bool sync_check,
-                                                   const std::function<int (uint64_t, struct cblock *)> &callback) {
-  dout(20) << ": dir_root=" << m_dir_root << ", epath=" << epath
-           << ", sync_check=" << sync_check << dendl;
-
-  if (!sync_check) {
-    return SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+int PeerReplayer::FileSyncMechanism::sync_file() {
+  dout(20) << ": dir_root=" << registry->dir_root
+           << ", epath=" << cur_entry->epath
+           << ", is_snapdiff=" << cur_entry->sync_is_snapdiff() << dendl;
+  int r = 0;
+  if (!cur_entry->sync_is_snapdiff() || cur_entry->create_fresh() ||
+      cur_entry->purge_remote()) {
+    return _sync_file();
   }
 
   ceph_file_blockdiff_info info;
-  int r = ceph_file_blockdiff_init(m_local, m_dir_root.c_str(), epath.c_str(),
-                                   (*m_prev).first.c_str(), m_current.first.c_str(), &info);
-  if (r != 0 && r != -ENOENT) {
-    derr << ": failed to init file blockdiff: r=" << r << dendl;
+  r = ceph_file_blockdiff_init(
+      m_local, registry->dir_root.c_str(), cur_entry->epath.c_str(),
+      (*fh.m_prev).first.c_str(), fh.m_current.first.c_str(), &info);
+  if (r != 0) {
+    dout(5) << ": failed to init file blockdiff: r=" << r << dendl;
     return r;
   }
 
   if (r < 0) {
-    dout(20) << ": new file epath=" << epath << dendl;
-    return SyncMechanism::get_changed_blocks(epath, stx, sync_check, callback);
+    if (r == -ENOENT) {
+      dout(20) << ": new file epath=" << cur_entry->epath << dendl;
+    }
+    /*
+      Even if block diff failed with an error which is not ENOENT,
+      which should not be the case. But still we should just try 
+      the brute copy once.
+    */
+    return _sync_file();
   }
 
   r = 1;
@@ -1568,7 +1857,8 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
 
     int rr = r;
     if (blocks.num_blocks) {
-      r = callback(blocks.num_blocks, blocks.b);
+      r = replayer->copy_to_remote(cur_entry, registry, fh, blocks.num_blocks,
+                                   blocks.b);
       ceph_free_file_blockdiff_buffer(&blocks);
       if (r < 0) {
         derr << ": blockdiff callback returned error: r=" << r << dendl;
@@ -1583,18 +1873,290 @@ int PeerReplayer::SnapDiffSync::get_changed_blocks(const std::string &epath,
   }
 
   ceph_file_blockdiff_finish(&info);
+  if (r >= 0) {
+    r = replayer->sync_attributes(cur_entry, fh);
+  }
+  sync_stat->current_stat.inc_files_synced(true, cur_entry->stx.stx_size);
   return r;
 }
 
-void PeerReplayer::SnapDiffSync::finish_sync() {
+void PeerReplayer::build_change_mask(const struct ceph_statx &pstx,
+                                     const struct ceph_statx &cstx,
+                                     bool create_fresh, bool purge_remote,
+                                     unsigned int &change_mask) {
+  change_mask |= SyncEntry::CHANGE_MASK_POPULATED;
+  if (!S_ISDIR(pstx.stx_mode)) {
+    change_mask |= SyncEntry::WASNT_DIR_IN_PREV_SNAPSHOT;
+  }
+  if (create_fresh || purge_remote) {
+    change_mask |= (CEPH_STATX_MODE | CEPH_STATX_SIZE | CEPH_STATX_UID |
+                    CEPH_STATX_GID | CEPH_STATX_MTIME);
+    if (create_fresh) {
+      change_mask |= SyncEntry::CREATE_FRESH;
+    }
+    if (purge_remote) {
+      change_mask |= SyncEntry::PURGE_REMOTE;
+    }
+    return;
+  }
+
+  if ((cstx.stx_mode & ~S_IFMT) != (pstx.stx_mode & ~S_IFMT)) {
+    change_mask = change_mask | CEPH_STATX_MODE;
+  }
+  if (cstx.stx_size != pstx.stx_size) {
+    change_mask = change_mask | CEPH_STATX_SIZE;
+  }
+  if (cstx.stx_uid != pstx.stx_uid) {
+    change_mask = change_mask | CEPH_STATX_UID;
+  }
+  if (cstx.stx_gid != pstx.stx_gid) {
+    change_mask = change_mask | CEPH_STATX_GID;
+  }
+  if (cstx.stx_mtime != pstx.stx_mtime) {
+    change_mask = change_mask | CEPH_STATX_MTIME;
+  }
+}
+
+void PeerReplayer::DirSyncMechanism::finish(int r) {
+  if (r < 0) {
+    goto notify_finish;
+  }
+  r = sync_tree();
+  if (r < 0) {
+    registry->set_failed(r);
+  }
+notify_finish:
+  registry->dec_sync_indicator();
+}
+
+int PeerReplayer::DirSyncMechanism::sync_tree() {
+
+  int r = 0;
+  while (cur_entry && !replayer->should_backoff(registry, &r)) {
+    if (cur_entry->needs_remote_sync()) {
+      // **--> sync remote
+      r = sync_current_entry();
+      if (r < 0) {
+        break;
+      }
+    }
+    r = go_next();
+    if (r < 0) {
+      break;
+    }
+  }
+  finish_sync();
+  return r;
+}
+
+bool PeerReplayer::DirSyncMechanism::try_spawning(SyncMechanism *syncm) {
+  if (registry->sync_pool->try_sync(syncm)) {
+    cur_entry = nullptr;
+    return true;
+  }
+  cur_entry = syncm->move_cur_entry();
+  delete syncm;
+  return false;
+}
+
+int PeerReplayer::DirSnapDiffSync::go_next() {
+  bool failed_prev =
+      (sync_stat->nr_failures > 0 || sync_stat->synced_snap_count == 0);
+  int r = 0;
+  while (!m_sync_stack.empty()) {
+    std::shared_ptr<SyncEntry> &entry = m_sync_stack.top();
+    dout(20) << ": top of stack path=" << entry->epath << dendl;
+    std::string e_name;
+    ceph_snapdiff_entry_t sd_entry;
+    while (true) {
+      if (replayer->should_backoff(registry, &r)) {
+        dout(0) << ": backing off r=" << r << dendl;
+        return r;
+      }
+      r = ceph_readdir_snapdiff(&entry->info, &sd_entry);
+      if (r < 0) {
+        derr << ": failed to read directory=" << entry->epath << dendl;
+        return r;
+      }
+      if (r == 0) {
+        break;
+      }
+      std::string d_name = sd_entry.dir_entry.d_name;
+      if (d_name == "." || d_name == "..") {
+        continue;
+      }
+      e_name = d_name;
+      break;
+    }
+
+    std::string epath = entry_path(entry->epath, e_name);
+    if (entry->deleted_sibling_exist &&
+        entry->deleted_sibling.snapid == (*fh.m_prev).second) {
+      std::string deleted_sibling_d_name =
+          entry->deleted_sibling.dir_entry.d_name;
+      if (r == 0 || sd_entry.snapid == (*fh.m_prev).second ||
+          e_name != deleted_sibling_d_name) {
+        // prev sibling is a deleted entry, we need to delete it now.
+        std::shared_ptr<SyncEntry> deleted_entry = std::make_shared<SyncEntry>(
+            entry_path(entry->epath, deleted_sibling_d_name));
+        SyncMechanism *syncm = new DeleteMechanism(
+            m_local, std::move(deleted_entry), registry, sync_stat, fh,
+            replayer, (DT_DIR != entry->deleted_sibling.dir_entry.d_type));
+        registry->sync_pool->sync_anyway(syncm);
+        entry->deleted_sibling_exist = false;
+      }
+    }
+
+    if (r == 0) {
+      dout(10) << ": done for directory=" << entry->epath << dendl;
+      if (!(m_sync_stack.size() == 1 && entry->epath == ".")) {
+        if (ceph_close_snapdiff(&entry->info) < 0) {
+          derr << ": failed to close directory=" << entry->epath << dendl;
+        }
+      }
+      m_sync_stack.pop();
+      continue;
+    }
+
+    if (sd_entry.snapid == (*fh.m_prev).second) {
+      entry->deleted_sibling = sd_entry;
+      entry->deleted_sibling_exist = true;
+      continue;
+    }
+
+    struct ceph_statx cstx;
+    cur_entry =
+        std::make_shared<SyncEntry>(epath, ceph_snapdiff_info(), cstx, 0);
+    if (entry->deleted_sibling_exist &&
+        entry->deleted_sibling.snapid == (*fh.m_prev).second &&
+        sd_entry.snapid == fh.m_current.second &&
+        std::string(entry->deleted_sibling.dir_entry.d_name) == e_name) {
+      // this is an entry where previous need to be purged
+      cur_entry->change_mask |= SyncEntry::PURGE_REMOTE;
+      entry->deleted_sibling_exist = false;
+    }
+
+    SyncMechanism *syncm = new DirSnapDiffSync(
+        m_local, std::move(cur_entry), registry, sync_stat, fh, replayer);
+    if (try_spawning(syncm)) {
+      continue;
+    }
+    r = 0;
+    break;
+  }
+  return r;
+}
+
+int PeerReplayer::DirSnapDiffSync::sync_current_entry() {
+  int r = 0;
+  bool failed_prev =
+      (sync_stat->nr_failures > 0 || sync_stat->synced_snap_count == 0);
+  /*
+  Our goal here, when this is a fresh syncing we will go for DirSnapDiffSync.
+  When we already know that previous sync failed, then our goal is to, for the
+  unchanged part(same as previous snapshot) we will scan through DirSnapDiffSync
+  for other parts we will scan through DirBruteDiffSync comparing with the remote
+  state(more specifically keeping remote as diff base). With this strategy we
+  will get rid of transferring already transferred file for a failed scenario.
+  Also, we are traversing the unchanged part(between previous and current snapshot)
+  of the tree using snapdiff.
+
+  Scenario when previous sync failed:
+  1. For file, we completely skipped file blockdiff strategy and based on 
+    remote we synced the file. Which will eventually save us from already 
+    synced file.
+  2. For directory, we used local previous snapshot as diff base for
+    change mask building to find out whether is a newly created entry
+    (or previous snapshot has same entry with different type). Some cases are 
+    give below,
+    * If directory doesn't exist in prev snapshot, it might be possible
+      that remote state has some patial subtree under that directory. So
+      we let DirBruteDiffSync class to handle by using remote diff base
+      by sending registry->remotediff_fh.
+    * Same case for when entry type is different in previous snapshot
+    * If both is not the case, then we went for snapdiff optimized strategy.
+
+  Scenario when previous sync didn't fail:
+    For every new entry or entry need to be purged in remote before creating
+    We let DirBruteDiffSync class handle this matter as we know snapdiff
+    has no impact here. And as remote state is not corrupted, we let DirBruteDiffSync
+    class to use local previous snapshot as diff base.
+  */
+
+  r = populate_current_stat(fh);
+  if (r < 0) {
+    return r;
+  }
+
+  bool remote_fh = failed_prev && (!cur_entry->is_directory());
+  if (remote_fh) {
+    // because I am rebuilding change mask for remote state as diff base
+    cur_entry->reset_change_mask();
+  }
+
+  r = populate_change_mask(remote_fh ? registry->remotediff_fh : fh);
+  if (r < 0) {
+    return r;
+  }
+
+  if ((failed_prev && !cur_entry->is_directory()) ||
+      cur_entry->create_fresh() || cur_entry->purge_remote()) {
+    if (failed_prev && cur_entry->is_directory()) {
+      /*
+      we need to reset it when it's a directory, because DirBruteDiffSync
+      will rebuild the change mask keeping remote state as diff base as
+      the remote state is inconsistent because of failed sync attempt.
+      For file we don't need to reset as we already built the change mask
+      keeping remote state as diff base(using remote_fh flag), So 
+      DirBruteDiffSync will automatically skip it.
+      */
+      cur_entry->reset_change_mask();
+    }
+    cur_entry->set_is_snapdiff(false);
+
+    SyncMechanism *syncm = new DirBruteDiffSync(
+        m_local, std::move(cur_entry), registry, sync_stat,
+        failed_prev ? registry->remotediff_fh : fh, replayer);
+    registry->sync_pool->sync_direct(syncm);
+    return 0;
+  }
+
+  if (S_ISDIR(cur_entry->stx.stx_mode)) { // is a directory
+    r = replayer->remote_mkdir(cur_entry, fh, sync_stat);
+    if (r < 0) {
+      return r;
+    }
+    sync_stat->current_stat.inc_dir_scanned_count();
+  } else {
+    r = replayer->remote_file_op(cur_entry, registry, sync_stat, fh);
+    cur_entry = nullptr;
+    return r;
+  }
+  r = ceph_open_snapdiff(fh.p_mnt, registry->dir_root.c_str(),
+                         cur_entry->epath.c_str(), (*fh.m_prev).first.c_str(),
+                         fh.m_current.first.c_str(), &cur_entry->info);
+  if (r != 0) {
+    derr << ": failed to open snapdiff, entry=" << cur_entry->epath
+         << ", r=" << r << dendl;
+    return r;
+  }
+  cur_entry->set_remote_synced();
+  m_sync_stack.emplace(std::move(cur_entry));
+  cur_entry = nullptr;
+  return 0;
+}
+
+void PeerReplayer::DirSnapDiffSync::finish_sync() {
   dout(20) << dendl;
 
   while (!m_sync_stack.empty()) {
     auto &entry = m_sync_stack.top();
-    if (entry.is_directory()) {
-      dout(20) << ": closing local directory=" << entry.epath << dendl;
-      if (ceph_close_snapdiff(&(entry.info)) < 0) {
-        derr << ": failed to close snapdiff directory=" << entry.epath << dendl;
+    if (entry->is_directory() &&
+        !(m_sync_stack.size() == 1 && entry->epath == ".")) {
+      dout(20) << ": closing local directory=" << entry->epath << dendl;
+      if (ceph_close_snapdiff(&(entry->info)) < 0) {
+        derr << ": failed to close snapdiff directory=" << entry->epath
+             << dendl;
       }
     }
 
@@ -1602,145 +2164,162 @@ void PeerReplayer::SnapDiffSync::finish_sync() {
   }
 }
 
-PeerReplayer::RemoteSync::RemoteSync(MountRef local, MountRef remote, FHandles *fh,
-                                       const Peer &peer, const Snapshot &current,
-                                       boost::optional<Snapshot> prev)
-  : SyncMechanism(local, remote, fh, peer, current, prev) {
-}
-
-PeerReplayer::RemoteSync::~RemoteSync() {
-}
-
-int PeerReplayer::RemoteSync::init_sync() {
-  struct ceph_statx tstx;
-  int r = ceph_fstatx(m_local, m_fh->c_fd, &tstx,
-                      CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                      CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                      AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-  if (r < 0) {
-    derr << ": failed to stat snap=" << m_current.first << ": " << cpp_strerror(r)
-         << dendl;
-    return r;
-  }
-
-  ceph_dir_result *tdirp;
-  r = ceph_fdopendir(m_local, m_fh->c_fd, &tdirp);
-  if (r < 0) {
-    derr << ": failed to open local snap=" << m_current.first << ": " << cpp_strerror(r)
-         << dendl;
-    return r;
-  }
-
-  m_sync_stack.emplace(SyncEntry(".", tdirp, tstx));
-  return 0;
-}
-
-int PeerReplayer::RemoteSync::get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
-                                        const std::function<int (const std::string&)> &dirsync_func,
-                                        const std::function<int (const std::string &)> &purge_func) {
-  dout(20) << ": sync stack size=" << m_sync_stack.size() << dendl;
-
+int PeerReplayer::DirBruteDiffSync::go_next() {
+  int r = 0;
   while (!m_sync_stack.empty()) {
-    auto &entry = m_sync_stack.top();
-    dout(20) << ": top of stack path=" << entry.epath << dendl;
-
-    if (!entry.is_directory()) {
-      *epath = entry.epath;
-      *stx = entry.stx;
-      m_sync_stack.pop();
-      return 0;
-    }
-
-    // entry is a directory -- propagate deletes for missing entries
-    // (and changed inode types) to the remote filesystem.
-    if (!entry.needs_remote_sync()) {
-      int r = dirsync_func(entry.epath);
-      if (r < 0 && r != -ENOENT) {
-        derr << ": failed to propagate missing dirs: " << cpp_strerror(r) << dendl;
+    std::shared_ptr<SyncEntry> &entry = m_sync_stack.top();
+    dout(20) << ": top of stack path=" << entry->epath << dendl;
+    std::string e_name;
+    struct dirent de;
+    struct ceph_statx stx;
+    while (true) {
+      if (replayer->should_backoff(registry, &r)) {
+        dout(0) << ": backing off r=" << r << dendl;
         return r;
       }
-      entry.set_remote_synced();
-    }
-
-    int r;
-    std::string e_name;
-    while (true) {
-      struct dirent de;
-      r = ceph_readdirplus_r(m_local, entry.dirp, &de, NULL,
+      r = ceph_readdirplus_r(m_local, entry->dirp, &de, &stx,
                              CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                             CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
+                                 CEPH_STATX_SIZE | CEPH_STATX_ATIME |
+                                 CEPH_STATX_MTIME,
                              AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW, NULL);
       if (r < 0) {
-        derr << ": failed to local read directory=" << entry.epath << dendl;
-        break;
+        derr << ": failed to local read directory=" << entry->epath << dendl;
+        return r;
       }
       if (r == 0) {
         break;
       }
-
       auto d_name = std::string(de.d_name);
       if (d_name != "." && d_name != "..") {
         e_name = d_name;
         break;
       }
     }
-
     if (r == 0) {
-      dout(10) << ": done for directory=" << entry.epath << dendl;
-      if (ceph_closedir(m_local, entry.dirp) < 0) {
-        derr << ": failed to close local directory=" << entry.epath << dendl;
+      dout(10) << ": done for directory=" << entry->epath << dendl;
+      if (!(m_sync_stack.size() == 1 && entry->epath == ".")) {
+        if (entry->dirp && ceph_closedir(m_local, entry->dirp) < 0) {
+          derr << ": failed to close local directory=" << entry->epath << dendl;
+        }
       }
       m_sync_stack.pop();
+      change_mask_map_size -= (int)m_change_mask_map_stack.top().size();
+      m_change_mask_map_stack.pop();
       continue;
     }
+    std::shared_ptr<SyncEntry> &par_entry = m_sync_stack.top();
+    auto& par_change_mask_map = m_change_mask_map_stack.top();
+    uint64_t change_mask = 0;
+    bool create_fresh = par_entry->create_fresh() || par_entry->purge_remote();
 
+    if (!create_fresh) {
+      auto it = par_change_mask_map.find(e_name);
+      /*
+        found in the map so, we don't need to do extra stat in prev
+        snapshot or remote.
+      */
+      if (it != par_change_mask_map.end()) {
+        change_mask = it->second;
+        // we already take the change mask and deleting it from memory, to insert
+        // more entry
+        par_change_mask_map.erase(it);
+        change_mask_map_size--;
+      }
+    } else {
+      change_mask |= SyncEntry::CREATE_FRESH;
+    }
+    cur_entry = std::make_shared<SyncEntry>(
+        entry_path(par_entry->epath, e_name), nullptr, stx, change_mask);
+    
+
+    // this will help us to avoid doing stat again in current snapshot
+    // in populate_current_stat function.
+    cur_entry->set_stat_known();
+    SyncMechanism *syncm = new DirBruteDiffSync(
+        m_local, std::move(cur_entry), registry, sync_stat, fh, replayer);
+    if (try_spawning(syncm)) {
+      continue;
+    }
+    r = 0;
+    break;
+  }
+  return r;
+}
+
+int PeerReplayer::DirBruteDiffSync::sync_current_entry() {
+  int r = 0, rem_r = 0;
+  r = populate_current_stat(fh);
+  if (r < 0) {
+    return r;
+  }
+  r = populate_change_mask(fh);
+  if (r < 0) {
+    return r;
+  }
+  if (cur_entry->purge_remote()) {
+    rem_r = replayer->cleanup_remote_entry(
+        cur_entry->epath, registry, fh, sync_stat,
+        cur_entry->wasnt_dir_in_prev_snapshot());
+    if (rem_r < 0 && rem_r != -ENOENT) {
+      derr << ": failed to cleanup remote entry=" << cur_entry->epath << ": "
+           << cpp_strerror(rem_r) << dendl;
+      r = rem_r;
+      return r;
+    }
+  }
+  if (S_ISDIR(cur_entry->stx.stx_mode)) {
+    r = replayer->remote_mkdir(cur_entry, fh, sync_stat);
     if (r < 0) {
       return r;
     }
+    sync_stat->current_stat.inc_dir_scanned_count();
+  } else {
+    r = replayer->remote_file_op(cur_entry, registry, sync_stat, fh);
+    cur_entry = nullptr;
+    return r;
+  }
+  r = opendirat(m_local, fh.c_fd, cur_entry->epath, AT_SYMLINK_NOFOLLOW,
+                &cur_entry->dirp);
+  if (r < 0) {
+    derr << ": failed to open local directory=" << cur_entry->epath << ": "
+         << cpp_strerror(r) << dendl;
+    return r;
+  }
+  std::unordered_map<std::string, unsigned int> change_mask_map;
 
-    struct ceph_statx cstx;
-    auto _epath = entry_path(entry.epath, e_name);
-    r = ceph_statxat(m_local, m_fh->c_fd, _epath.c_str(), &cstx,
-                     CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
-                     CEPH_STATX_SIZE | CEPH_STATX_ATIME | CEPH_STATX_MTIME,
-                     AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
-    if (r < 0) {
-      derr << ": failed to stat epath=" << _epath << ": " << cpp_strerror(r)
+  /*
+    when cur_entry is fresh or entry in previous snapshot need to
+    be purged, then we don't need unnecessary propagate_deleted_entries
+    Saving some api calls.
+  */
+
+  if (!cur_entry->create_fresh() && !cur_entry->purge_remote()) {
+    r = replayer->propagate_deleted_entries(cur_entry->epath, registry,
+                                            sync_stat, fh, change_mask_map,
+                                            change_mask_map_size);
+    if (r < 0 && r != -ENOENT) {
+      derr << ": failed to propagate missing dirs: " << cpp_strerror(r)
            << dendl;
       return r;
     }
-
-    if (S_ISDIR(cstx.stx_mode)) {
-      ceph_dir_result *dirp;
-      r = opendirat(m_local, m_fh->c_fd, _epath, AT_SYMLINK_NOFOLLOW, &dirp);
-      if (r < 0) {
-        derr << ": failed to open local directory=" << _epath << ": "
-             << cpp_strerror(r) << dendl;
-        break;
-      }
-
-      m_sync_stack.emplace(SyncEntry(_epath, dirp, cstx));
-    }
-
-    *epath = _epath;
-    *stx = cstx;
-
-    return 0;
   }
 
-  *epath = "";
+  cur_entry->set_remote_synced();
+  m_sync_stack.emplace(std::move(cur_entry));
+  m_change_mask_map_stack.emplace(std::move(change_mask_map));
   return 0;
 }
 
-void PeerReplayer::RemoteSync::finish_sync() {
+void PeerReplayer::DirBruteDiffSync::finish_sync() {
   dout(20) << dendl;
 
   while (!m_sync_stack.empty()) {
     auto &entry = m_sync_stack.top();
-    if (entry.is_directory()) {
-      dout(20) << ": closing local directory=" << entry.epath << dendl;
-      if (ceph_closedir(m_local, entry.dirp) < 0) {
-        derr << ": failed to close local directory=" << entry.epath << dendl;
+    if (entry && entry->is_directory() &&
+        !(m_sync_stack.size() == 1 && entry->epath == ".")) {
+      dout(20) << ": closing local directory=" << entry->epath << dendl;
+      if (ceph_closedir(m_local, entry->dirp) < 0) {
+        derr << ": failed to close local directory=" << entry->epath << dendl;
       }
     }
 
@@ -1750,107 +2329,116 @@ void PeerReplayer::RemoteSync::finish_sync() {
 
 int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &current,
                                  boost::optional<Snapshot> prev) {
+  dout(0) << ": sync start-->" << dir_root << dendl;
   dout(20) << ": dir_root=" << dir_root << ", current=" << current << dendl;
-  FHandles fh;
-  int r = pre_sync_check_and_open_handles(dir_root, current, prev, &fh);
+  std::unique_lock<ceph::mutex> lock(m_lock);
+  DirRegistry *registry = m_registered.at(dir_root);
+  SnapSyncStat* sync_stat = m_snap_sync_stats.at(dir_root);
+  lock.unlock();
+  int r = pre_sync_check_and_open_handles(dir_root, current, prev,
+                                          &registry->snapdiff_fh,
+                                          &registry->remotediff_fh);
   if (r < 0) {
     dout(5) << ": cannot proceed with sync: " << cpp_strerror(r) << dendl;
     return r;
   }
+  registry->dir_root = dir_root, registry->failed = registry->canceled = false;
+  registry->failed_reason = 0;
+  FHandles *fh;
+  if (registry->snapdiff_fh.p_fd >= 0) {
+    fh = &registry->snapdiff_fh;
+  } else {
+    fh = &registry->remotediff_fh;
+  }
+
+  auto close_p_fd = [&registry]() {
+    if (registry->snapdiff_fh.p_fd >= 0) {
+      ceph_close(registry->snapdiff_fh.p_mnt, registry->snapdiff_fh.p_fd);
+    }
+    if (registry->remotediff_fh.p_fd >= 0) {
+      ceph_close(registry->remotediff_fh.p_mnt, registry->remotediff_fh.p_fd);
+    }
+  };
 
   // record that we are going to "dirty" the data under this
   // directory root
   auto snap_id_str{stringify(current.second)};
-  r = ceph_fsetxattr(m_remote_mount, fh.r_fd_dir_root, "ceph.mirror.dirty_snap_id",
+  r = ceph_fsetxattr(m_remote_mount, fh->r_fd_dir_root, "ceph.mirror.dirty_snap_id",
                      snap_id_str.c_str(), snap_id_str.size(), 0);
   if (r < 0) {
     derr << ": error setting \"ceph.mirror.dirty_snap_id\" on dir_root=" << dir_root
          << ": " << cpp_strerror(r) << dendl;
-    ceph_close(m_local_mount, fh.c_fd);
-    ceph_close(fh.p_mnt, fh.p_fd);
+    ceph_close(m_local_mount, fh->c_fd);
+    close_p_fd();
+    return r;
+  }
+
+  struct ceph_statx stx;
+  r = ceph_fstatx(m_local_mount, fh->c_fd, &stx,
+                  CEPH_STATX_MODE | CEPH_STATX_UID | CEPH_STATX_GID |
+                      CEPH_STATX_SIZE | CEPH_STATX_MTIME,
+                  AT_STATX_DONT_SYNC | AT_SYMLINK_NOFOLLOW);
+  if (r < 0) {
+    derr << ": failed to stat snap=" << current.first << ": " << cpp_strerror(r)
+         << dendl;
+    ceph_close(m_local_mount, fh->c_fd);
+    close_p_fd();
     return r;
   }
 
   SyncMechanism *syncm;
-  if (fh.p_mnt == m_local_mount) {
-    syncm = new SnapDiffSync(dir_root, m_local_mount, m_remote_mount, &fh,
-                             m_peer, current, prev);
+  std::shared_ptr <SyncEntry> root_entry;
+
+  lock.lock();
+  dout(0) << ": Number of dir scanning threads="
+          << g_ceph_context->_conf->cephfs_mirror_dir_scanning_thread << dendl;
+  registry->sync_start(file_sync_pool.sync_start());
+  sync_stat->current_stat.start_timer();
+  registry->sync_pool = std::make_unique<DirSyncPool>(
+      g_ceph_context->_conf->cephfs_mirror_dir_scanning_thread, dir_root,
+      m_peer);
+  registry->sync_pool->activate();
+  lock.unlock();
+
+  if (registry->snapdiff_fh.p_fd >= 0) {
+    std::shared_ptr<SyncEntry> cur_entry =
+        std::make_shared<SyncEntry>(".", ceph_snapdiff_info(), stx, 0);
+    cur_entry->set_stat_known();
+    root_entry = cur_entry;
+    syncm = new DirSnapDiffSync(m_local_mount, std::move(cur_entry), registry,
+                                sync_stat, registry->snapdiff_fh, this);
   } else {
-    syncm = new RemoteSync(m_local_mount, m_remote_mount, &fh,
-                           m_peer, current, boost::none);
+    std::shared_ptr<SyncEntry> cur_entry =
+        std::make_shared<SyncEntry>(".", nullptr, stx, 0);
+    cur_entry->set_stat_known();
+    root_entry = cur_entry;
+    syncm = new DirBruteDiffSync(m_local_mount, std::move(cur_entry), registry,
+                                 sync_stat, registry->remotediff_fh, this);
+  }
+  registry->sync_pool->sync_anyway(syncm);
+  registry->wait_for_sync_finish();
+  if (!prev || registry->snapdiff_fh.p_fd < 0) {
+    if (root_entry->dirp &&
+        ceph_closedir(m_local_mount, root_entry->dirp) < 0) {
+      derr << ": failed to close local directory=." << dendl;
+    }
+  } else if (ceph_close_snapdiff(&root_entry->info) < 0) {
+    derr << ": failed to close local directory=." << dendl;
   }
 
-  r = syncm->init_sync();
-  if (r < 0) {
-    derr << ": failed to initialize sync mechanism" << dendl;
-    ceph_close(m_local_mount, fh.c_fd);
-    ceph_close(fh.p_mnt, fh.p_fd);
-    delete syncm;
-    return r;
+  should_backoff(registry, &r);
+  if (registry->failed) {
+    r = registry->failed_reason;
   }
 
-  // starting from this point we shouldn't care about manual closing of fh.c_fd,
-  // it will be closed automatically when bound tdirp is closed.
-  while (true) {
-    if (should_backoff(dir_root, &r)) {
-      dout(0) << ": backing off r=" << r << dendl;
-      break;
-    }
+  lock.lock();
+  registry->sync_pool->deactivate();
+  registry->sync_pool = nullptr;
+  sync_stat->reset_stats();
+  lock.unlock();
 
-    bool sync_check = true;
-    std::string epath;
-    struct ceph_statx stx;
-    r = syncm->get_entry(&epath, &stx, &sync_check,
-                         [this, &dir_root, &fh](const std::string &epath) {
-                           return propagate_deleted_entries(dir_root, epath, fh);
-                         },
-                         [this, &dir_root, &fh](const std::string &epath) {
-                           return cleanup_remote_dir(dir_root, epath, fh);
-                         });
-    dout(20) << ": r=" << r << dendl;
-    if (r < 0) {
-      break;
-    }
-
-    dout(20) << ": epath=" << epath << dendl;
-    if (epath == "") {
-      dout(10) << ": tree traversal done for dir_root=" << dir_root << dendl;
-      break;
-    }
-
-    if (S_ISDIR(stx.stx_mode)) {
-      r = remote_mkdir(epath, stx, fh);
-      if (r < 0) {
-        break;
-      }
-    } else {
-      bool need_data_sync = true;
-      bool need_attr_sync = true;
-      if (sync_check) {
-        r = should_sync_entry(epath, stx, fh,
-                              &need_data_sync, &need_attr_sync);
-        if (r < 0) {
-          break;
-        }
-      }
-
-      dout(5) << ": entry=" << epath << ", data_sync=" << need_data_sync
-              << ", attr_sync=" << need_attr_sync << dendl;
-      if (need_data_sync || need_attr_sync) {
-        r = remote_file_op(syncm, dir_root, epath, stx, sync_check, fh, need_data_sync, need_attr_sync);
-        if (r < 0) {
-          break;
-        }
-      }
-      dout(10) << ": done for epath=" << epath << dendl;
-    }
-  }
-
-  syncm->finish_sync();
-  delete syncm;
-
-  dout(20) << " cur:" << fh.c_fd
-           << " prev:" << fh.p_fd
+  dout(20) << " cur:" << fh->c_fd
+           << " prev:" << fh->p_fd
            << " ret = " << r
            << dendl;
 
@@ -1859,7 +2447,9 @@ int PeerReplayer::do_synchronize(const std::string &dir_root, const Snapshot &cu
 
   // c_fd has been used in ceph_fdopendir call so
   // there is no need to close this fd manually.
-  ceph_close(fh.p_mnt, fh.p_fd);
+  ceph_close(m_local_mount, fh->c_fd);
+  close_p_fd();
+  dout(0) << ": sync done-->" << dir_root << ", " << current.first << dendl;
 
   return r;
 }
@@ -2020,7 +2610,7 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
       t.set_from_double(duration);
       m_perf_counters->tinc(l_cephfs_mirror_peer_replayer_avg_sync_time, t);
       m_perf_counters->tset(l_cephfs_mirror_peer_replayer_last_synced_duration, t);
-      m_perf_counters->set(l_cephfs_mirror_peer_replayer_last_synced_bytes, m_snap_sync_stats.at(dir_root).sync_bytes);
+      m_perf_counters->set(l_cephfs_mirror_peer_replayer_last_synced_bytes, m_snap_sync_stats.at(dir_root)->sync_bytes);
     }
 
     set_last_synced_stat(dir_root, it->first, it->second, duration);
@@ -2112,38 +2702,47 @@ void PeerReplayer::peer_status(Formatter *f) {
   f->open_object_section("stats");
   for (auto &[dir_root, sync_stat] : m_snap_sync_stats) {
     f->open_object_section(dir_root);
-    if (sync_stat.failed) {
+    if (sync_stat->failed) {
       f->dump_string("state", "failed");
-      if (sync_stat.last_failed_reason) {
-	f->dump_string("failure_reason", *sync_stat.last_failed_reason);
+      if (sync_stat->last_failed_reason) {
+	f->dump_string("failure_reason", *sync_stat->last_failed_reason);
       }
-    } else if (!sync_stat.current_syncing_snap) {
+    } else if (!sync_stat->current_syncing_snap) {
       f->dump_string("state", "idle");
     } else {
       f->dump_string("state", "syncing");
       f->open_object_section("current_syncing_snap");
-      f->dump_unsigned("id", (*sync_stat.current_syncing_snap).first);
-      f->dump_string("name", (*sync_stat.current_syncing_snap).second);
+      f->dump_unsigned("id", (*sync_stat->current_syncing_snap).first);
+      f->dump_string("name", (*sync_stat->current_syncing_snap).second);
+      sync_stat->current_stat.dump(f);
+      auto &dir_sync_pool = m_registered.at(dir_root)->sync_pool;
+      if (dir_sync_pool) {
+        dir_sync_pool->dump_stats(f);
+      }
       f->close_section();
     }
-    if (sync_stat.last_synced_snap) {
+    if (sync_stat->last_synced_snap) {
       f->open_object_section("last_synced_snap");
-      f->dump_unsigned("id", (*sync_stat.last_synced_snap).first);
-      f->dump_string("name", (*sync_stat.last_synced_snap).second);
-      if (sync_stat.last_sync_duration) {
-        f->dump_float("sync_duration", *sync_stat.last_sync_duration);
-        f->dump_stream("sync_time_stamp") << sync_stat.last_synced;
+      f->dump_unsigned("id", (*sync_stat->last_synced_snap).first);
+      f->dump_string("name", (*sync_stat->last_synced_snap).second);
+      if (sync_stat->last_sync_duration) {
+        f->dump_float("sync_duration", *sync_stat->last_sync_duration);
+        f->dump_stream("sync_time_stamp") << sync_stat->last_synced;
       }
-      if (sync_stat.last_sync_bytes) {
-	f->dump_unsigned("sync_bytes", *sync_stat.last_sync_bytes);
+      if (sync_stat->last_sync_bytes) {
+        f->dump_unsigned("sync_bytes", *sync_stat->last_sync_bytes);
       }
+      sync_stat->last_stat.dump(f);
       f->close_section();
     }
-    f->dump_unsigned("snaps_synced", sync_stat.synced_snap_count);
-    f->dump_unsigned("snaps_deleted", sync_stat.deleted_snap_count);
-    f->dump_unsigned("snaps_renamed", sync_stat.renamed_snap_count);
+    f->dump_unsigned("snaps_synced", sync_stat->synced_snap_count);
+    f->dump_unsigned("snaps_deleted", sync_stat->deleted_snap_count);
+    f->dump_unsigned("snaps_renamed", sync_stat->renamed_snap_count);
     f->close_section(); // dir_root
   }
+  f->open_object_section("file_sync_pool");
+  file_sync_pool.dump_stats(f);
+  f->close_section();
   f->close_section(); // stats
 }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -9,6 +9,7 @@
 #include "mds/FSMap.h"
 #include "ServiceDaemon.h"
 #include "Types.h"
+#include "common/Cond.h"
 
 #include <stack>
 #include <boost/optional.hpp>
@@ -19,13 +20,16 @@ namespace mirror {
 class FSMirror;
 class PeerReplayerAdminSocketHook;
 
-class PeerReplayer {
+class PeerReplayer : public md_config_obs_t {
 public:
   PeerReplayer(CephContext *cct, FSMirror *fs_mirror,
                RadosRef local_cluster, const Filesystem &filesystem,
                const Peer &peer, const std::set<std::string, std::less<>> &directories,
                MountRef mount, ServiceDaemon *service_daemon);
   ~PeerReplayer();
+  std::vector<std::string> get_tracked_keys() const noexcept override;
+  void handle_conf_change(const ConfigProxy &conf,
+                          const std::set<std::string> &changed) override;
 
   // initialize replayer for a peer
   int init();
@@ -59,7 +63,7 @@ private:
     // open file descriptor on the snap directory for snapshot
     // currently being synchronized. Always use this fd with
     // @m_local_mount.
-    int c_fd;
+    int c_fd = -1;
 
     // open file descriptor on the "previous" snapshot or on
     // dir_root on remote filesystem (based on if the snapshot
@@ -67,12 +71,14 @@ private:
     // fd with p_mnt which either points to @m_local_mount (
     // for local incremental comparison) or @m_remote_mount (
     // for remote incremental comparison).
-    int p_fd;
+    int p_fd = -1;
     MountRef p_mnt;
 
     // open file descriptor on dir_root on remote filesystem.
     // Always use this fd with @m_remote_mount.
-    int r_fd_dir_root;
+    int r_fd_dir_root = -1;
+    Snapshot m_current;
+    boost::optional<Snapshot> m_prev;
   };
 
   bool is_stopping() {
@@ -95,27 +101,73 @@ private:
     PeerReplayer *m_peer_replayer;
   };
 
+  class DirSyncPool;
   struct DirRegistry {
     int fd;
-    bool canceled = false;
+    std::atomic<bool> canceled = false;
+    std::atomic<bool> failed = false;
     SnapshotReplayerThread *replayer;
+    std::string dir_root;
+    FHandles snapdiff_fh, remotediff_fh;
+    std::atomic<int> failed_reason = 0;
+    int file_sync_queue_idx = -1;
+    std::unique_ptr<C_SaferCond> sync_finish_cond;
+    std::atomic <int> sync_indicator = 0;
+    std::unique_ptr <DirSyncPool> sync_pool = nullptr;
+    void set_failed(int r) {
+      ceph_assert(r < 0);
+      if (failed) {
+        return;
+      }
+      failed.store(true);
+      failed_reason.store(r);
+    }
+    void sync_start(int _file_sync_queue_idx) {
+      sync_indicator = 0;
+      file_sync_queue_idx = _file_sync_queue_idx;
+      sync_finish_cond = std::make_unique<C_SaferCond>();
+    }
+    void wait_for_sync_finish() {
+      sync_finish_cond->wait();
+    }
+    int get_file_sync_queue_idx() {
+      return file_sync_queue_idx;
+    }
+    void inc_sync_indicator() {
+      ++sync_indicator;
+    }
+    void dec_sync_indicator() {
+      --sync_indicator;
+      if (sync_indicator <= 0) {
+        sync_finish_cond->complete(0);
+      }
+    }
   };
 
   struct SyncEntry {
+    static const unsigned int PURGE_REMOTE = (1 << 20);
+    static const unsigned int CREATE_FRESH = (1 << 21);
+    static const unsigned int WASNT_DIR_IN_PREV_SNAPSHOT = (1 << 22);
+    static const unsigned int CHANGE_MASK_POPULATED = (1 << 23);
     std::string epath;
-    ceph_dir_result *dirp; // valid for directories
+    ceph_dir_result *dirp = nullptr; // valid for directories
     ceph_snapdiff_info info;
     struct ceph_statx stx;
     // set by incremental sync _after_ ensuring missing entries
     // in the currently synced snapshot have been propagated to
     // the remote filesystem.
     bool remote_synced = false;
-    // includes parent dentry purge
-    bool purged_or_itype_changed = false;
+
+    unsigned int change_mask = 0;
     bool is_snapdiff = false;
+    ceph_snapdiff_entry_t deleted_sibling;
+    bool deleted_sibling_exist = false;
+    bool stat_known = false;
 
     SyncEntry() {
     }
+
+    SyncEntry(std::string_view path) : epath(path) {}
 
     SyncEntry(std::string_view path,
               const struct ceph_statx &stx)
@@ -129,12 +181,12 @@ private:
         dirp(dirp),
         stx(stx) {
     }
-    SyncEntry(std::string_view path,
-              const ceph_snapdiff_info &info,
-              const struct ceph_statx &stx)
-      : epath(path),
-        info(info),
-        stx(stx) {
+    SyncEntry(std::string_view path, ceph_dir_result *dirp,
+              const struct ceph_statx &stx, unsigned int change_mask)
+        : epath(path), dirp(dirp), stx(stx), change_mask(change_mask) {}
+    SyncEntry(std::string_view path, const ceph_snapdiff_info &info,
+              const struct ceph_statx &stx, unsigned int change_mask)
+        : epath(path), info(info), stx(stx), change_mask(change_mask) {
       is_snapdiff = true;
     }
 
@@ -143,96 +195,254 @@ private:
     }
 
     bool needs_remote_sync() const {
-      return remote_synced;
+      return !remote_synced;
     }
     void set_remote_synced() {
       remote_synced = true;
     }
 
-    bool is_purged_or_itype_changed() const {
-      return purged_or_itype_changed;
-    }
-    void set_purged_or_itype_changed() {
-      purged_or_itype_changed = true;
+    void set_is_snapdiff(bool f) { 
+      is_snapdiff = f; 
     }
 
     bool sync_is_snapdiff() const {
       return is_snapdiff;
     }
+
+    void set_stat_known() {
+      stat_known = true;
+    }
+
+    void reset_change_mask() {
+      change_mask = 0;
+    }
+
+    bool change_mask_populated() {
+      return (change_mask & CHANGE_MASK_POPULATED);
+    }
+
+    bool purge_remote() {
+      return (change_mask & PURGE_REMOTE);
+    }
+    bool create_fresh() {
+      return (change_mask & CREATE_FRESH);
+    }
+    bool wasnt_dir_in_prev_snapshot() {
+      return (change_mask & WASNT_DIR_IN_PREV_SNAPSHOT);
+    }
+  };
+  class FileSyncMechanism;
+  class FileSyncPool {
+  public:
+    struct PoolStats {
+      uint64_t total_bytes_queued = 0;
+      int file_queued = 0;
+      FileSyncPool *pool;
+      void add_file(uint64_t file_size) {
+        file_queued++;
+        total_bytes_queued += file_size;
+      }
+      void remove_file(uint64_t file_size) {
+        file_queued--;
+        total_bytes_queued -= file_size;
+      }
+      PoolStats() {}
+      PoolStats(FileSyncPool *pool) : pool(pool) {}
+      void dump(Formatter *f) {
+        f->dump_int("queued_file_count", file_queued);
+        f->dump_unsigned("bytes_queued_for_transfer", total_bytes_queued);
+      }
+    };
+
+    FileSyncPool(int num_thread, const Peer& m_peer);
+    void activate();
+    void deactivate();
+    void sync_file_data(FileSyncMechanism *task);
+    // bool do_task_async(C_MirrorContext *task);
+    void dump_stats(Formatter *f) {
+      std::scoped_lock lock(mtx);
+      pool_stats.dump(f);
+    }
+    int sync_start();
+    void sync_finish(int idx);
+    void update_state();
+    friend class PoolStats;
+
+  private:
+    void run(int idx);
+    void drain_queue();
+    int num_threads;
+    std::queue<FileSyncMechanism *> sync_ring;
+    std::vector<std::queue<FileSyncMechanism *>> sync_queue;
+    std::condition_variable pick_cv;
+    std::condition_variable give_cv;
+    std::mutex mtx;
+    int qlimit;
+    std::vector<std::unique_ptr<std::thread>> workers;
+    std::vector<bool> stop_thread;
+    PoolStats pool_stats;
+    std::vector<int> unassigned_sync_ids;
+    int sync_count = 0;
+    bool active;
+    const Peer& m_peer; // for dout
+  };
+  FileSyncPool file_sync_pool;
+
+  class SyncMechanism;
+  class DirSyncPool {
+  public:
+    DirSyncPool(int num_threads, const std::string epath, const Peer &m_peer)
+        : num_threads(num_threads), active(false), queued(0), qlimit(0),
+          epath(epath), m_peer(m_peer) {}
+    void activate();
+    void deactivate();
+    bool try_sync(SyncMechanism *task);
+    void sync_anyway(SyncMechanism *task);
+    void sync_direct(SyncMechanism *task);
+    void update_state();
+    void dump_stats(Formatter *f) {
+      std::scoped_lock lock(mtx);
+      f->dump_unsigned("dir_sync_queue_size", sync_queue.size());
+    }
+    friend class PeerReplayer;
+
+  private:
+    struct ThreadStatus {
+      bool stop_called = true;
+      bool active = false;
+      ThreadStatus() {}
+      ThreadStatus(bool stop_called, bool active)
+          : stop_called(stop_called), active(active) {}
+    };
+    void run(ThreadStatus *status);
+    void drain_queue();
+    bool _try_sync(SyncMechanism *task);
+    int num_threads;
+    std::queue<SyncMechanism *> sync_queue;
+    std::vector<std::unique_ptr<std::thread>> workers;
+    std::vector<ThreadStatus *> thread_status;
+    bool active;
+    std::condition_variable pick_cv;
+    std::mutex mtx;
+    int queued = 0;
+    int qlimit;
+    std::string epath;
+    const Peer &m_peer; // just for using dout
   };
 
-  class SyncMechanism {
+  struct SnapSyncStat;
+
+  class SyncMechanism : public Context {
   public:
-    SyncMechanism(MountRef local, MountRef remote, FHandles *fh,
-                  const Peer &peer, /* keep dout happy */
-                  const Snapshot &current, boost::optional<Snapshot> prev);
-    virtual ~SyncMechanism() = 0;
+    SyncMechanism(MountRef m_local, std::shared_ptr<SyncEntry> &&cur_entry,
+                  DirRegistry *registry, SnapSyncStat *sync_stat,
+                  const FHandles &fh, PeerReplayer *replayer)
+        : m_local(m_local), m_peer(replayer->m_peer),
+          cur_entry(std::move(cur_entry)), registry(registry),
+          sync_stat(sync_stat), fh(fh), replayer(replayer) {}
 
-    virtual int init_sync() = 0;
-
-    virtual int get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
-                          const std::function<int (const std::string&)> &dirsync_func,
-                          const std::function<int (const std::string&)> &purge_func) = 0;
-
-    virtual int get_changed_blocks(const std::string &epath,
-                                   const struct ceph_statx &stx, bool sync_check,
-                                   const std::function<int (uint64_t, struct cblock *)> &callback);
-
-    virtual void finish_sync() = 0;
+    void sync_in_flight() { registry->inc_sync_indicator(); }
+    std::shared_ptr<SyncEntry> &&move_cur_entry() {
+      return std::move(cur_entry);
+    }
 
   protected:
     MountRef m_local;
-    MountRef m_remote;
-    FHandles *m_fh;
-    Peer m_peer;
-    Snapshot m_current;
-    boost::optional<Snapshot> m_prev;
-    std::stack<PeerReplayer::SyncEntry> m_sync_stack;
+    Peer &m_peer;
+    std::shared_ptr<SyncEntry> cur_entry;
+    DirRegistry *registry;
+    SnapSyncStat *sync_stat;
+    const FHandles &fh;
+    PeerReplayer *replayer;
+    int populate_change_mask(const FHandles &fh);
+    int populate_current_stat(const FHandles& fh);
   };
 
-  class RemoteSync : public SyncMechanism {
+  class DeleteMechanism : public SyncMechanism {
   public:
-    RemoteSync(MountRef local, MountRef remote, FHandles *fh,
-               const Peer &peer, /* keep dout happy */
-               const Snapshot &current, boost::optional<Snapshot> prev);
-    ~RemoteSync();
-
-    int init_sync() override;
-
-    int get_entry(std::string *epath, struct ceph_statx *stx, bool *sync_check,
-                  const std::function<int (const std::string&)> &dirsync_func,
-                  const std::function<int (const std::string&)> &purge_func);
-
-    void finish_sync();
-  };
-
-  class SnapDiffSync : public SyncMechanism {
-  public:
-    SnapDiffSync(std::string_view dir_root, MountRef local, MountRef remote,
-                 FHandles *fh, const Peer &peer, const Snapshot &current,
-                 boost::optional<Snapshot> prev);
-    ~SnapDiffSync();
-
-    int init_sync() override;
-
-    int get_entry(std::string *epeth, struct ceph_statx *stx, bool *sync_check,
-                  const std::function<int (const std::string&)> &dirsync_func,
-                  const std::function<int (const std::string&)> &purge_func);
-
-    int get_changed_blocks(const std::string &epath,
-                           const struct ceph_statx &stx, bool sync_check,
-                           const std::function<int (uint64_t, struct cblock *)> &callback);
-
-    void finish_sync();
+    DeleteMechanism(MountRef m_local, std::shared_ptr<SyncEntry> &&cur_entry,
+                    DirRegistry *registry, SnapSyncStat *sync_stat,
+                    const FHandles &fh, PeerReplayer *replayer,
+                    int not_dir = -1)
+        : SyncMechanism(m_local, std::move(cur_entry), registry, sync_stat, fh,
+                        replayer),
+          not_dir(not_dir) {}
 
   private:
-    int init_directory(const std::string &epath,
-                       const struct ceph_statx &stx, bool pic, SyncEntry *se);
-    int next_entry(SyncEntry &entry, std::string *e_name, snapid_t *snapid);
-    void fini_directory(SyncEntry &entry);
+    void finish(int r) override;
+    int not_dir = -1;
+  };
 
-    std::string m_dir_root;
-    std::map<std::string, std::set<std::string>> m_deleted;
+  class FileSyncMechanism : public SyncMechanism {
+  public:
+    FileSyncMechanism(MountRef m_local, std::shared_ptr<SyncEntry> &&cur_entry,
+                      DirRegistry *registry, SnapSyncStat *sync_stat,
+                      const FHandles &fh, PeerReplayer *replayer)
+        : SyncMechanism(m_local, std::move(cur_entry), registry, sync_stat, fh,
+                        replayer) {}
+
+    uint64_t get_file_size() { return cur_entry->stx.stx_size; }
+    int get_file_sync_queue_idx() {
+      return registry->get_file_sync_queue_idx();
+    }
+
+  private:
+    void finish(int r) override;
+    int sync_file();
+    int _sync_file();
+  };
+
+  class DirSyncMechanism : public SyncMechanism {
+  public:
+    DirSyncMechanism(MountRef m_local, std::shared_ptr<SyncEntry> &&cur_entry,
+                     DirRegistry *registry, SnapSyncStat *sync_stat,
+                     const FHandles &fh, PeerReplayer *replayer)
+        : SyncMechanism(m_local, std::move(cur_entry), registry, sync_stat, fh,
+                        replayer) {}
+
+  protected:
+    void finish(int r) override;
+    int sync_tree();
+    bool try_spawning(SyncMechanism* syncm);
+    std::stack<std::shared_ptr<SyncEntry>> m_sync_stack;
+
+  private:
+    virtual void finish_sync() = 0;
+    virtual int go_next() = 0;
+    virtual int sync_current_entry() = 0;
+  };
+
+  static const int max_change_mask_map_size = 1e5;
+  class DirBruteDiffSync : public DirSyncMechanism {
+  public:
+    DirBruteDiffSync(MountRef m_local, std::shared_ptr<SyncEntry> &&cur_entry,
+                     DirRegistry *registry, SnapSyncStat *sync_stat,
+                     const FHandles &fh, PeerReplayer *replayer)
+        : DirSyncMechanism(m_local, std::move(cur_entry), registry, sync_stat,
+                           fh, replayer) {}
+
+  private:
+    std::stack<std::unordered_map<std::string, unsigned int>>
+        m_change_mask_map_stack;
+    int change_mask_map_size = 0;
+    void finish_sync() override;
+    int go_next() override;
+    int sync_current_entry() override;
+  };
+
+  class DirSnapDiffSync : public DirSyncMechanism {
+  public:
+    DirSnapDiffSync(MountRef m_local, std::shared_ptr<SyncEntry> &&cur_entry,
+                    DirRegistry *registry, SnapSyncStat *sync_stat,
+                    const FHandles &fh, PeerReplayer *replayer)
+        : DirSyncMechanism(m_local, std::move(cur_entry), registry, sync_stat,
+                           fh, replayer) {}
+
+  private:
+    void finish_sync() override;
+    int go_next() override;
+    int sync_current_entry() override;
+    bool should_delete_current_entry(int not_dir = -1);
   };
 
   // stats sent to service daemon
@@ -255,15 +465,94 @@ private:
     boost::optional<double> last_sync_duration;
     boost::optional<uint64_t> last_sync_bytes; //last sync bytes for display in status
     uint64_t sync_bytes = 0; //sync bytes counter, independently for each directory sync.
+    struct SyncStat {
+      std::atomic<uint64_t> files_in_flight{0};
+      std::atomic<uint64_t> files_synced{0};
+      std::atomic<uint64_t> files_deleted{0};
+      std::atomic<uint64_t> file_bytes_synced{0};
+      std::atomic<uint64_t> dir_created{0};
+      std::atomic<uint64_t> dir_deleted{0};
+      std::atomic<uint64_t> dir_scanned{0};
+      boost::optional<monotime> start_time;
+      SyncStat() : start_time(boost::none) {}
+      SyncStat(const SyncStat &other)
+          : files_in_flight(other.files_in_flight.load()),
+            files_synced(other.files_synced.load()),
+            files_deleted(other.files_deleted.load()),
+            file_bytes_synced(other.file_bytes_synced.load()),
+            dir_created(other.dir_created.load()),
+            dir_deleted(other.dir_deleted.load()),
+            dir_scanned(other.dir_scanned.load()) {}
+      SyncStat &operator=(const SyncStat &other) {
+        if (this != &other) { // Self-assignment check
+          files_in_flight.store(other.files_in_flight.load());
+          files_synced.store(other.files_synced.load());
+          files_deleted.store(other.files_deleted.load());
+          file_bytes_synced.store(other.file_bytes_synced.load());
+          dir_created.store(other.dir_created.load());
+          dir_deleted.store(other.dir_deleted.load());
+          dir_scanned.store(other.dir_scanned.load());
+        }
+        return *this;
+      }
+      inline void inc_file_del_count() { files_deleted++; }
+      inline void inc_files_synced(bool data_synced, uint64_t file_size) {
+        files_synced++;
+        if (data_synced) {
+          file_bytes_synced += file_size;
+        }
+      }
+      inline void inc_file_in_flight_count() { files_in_flight++; }
+      inline void dec_file_in_flight_count() { files_in_flight--; }
+      inline void inc_dir_created_count() { dir_created++; }
+      inline void inc_dir_deleted_count() { dir_deleted++; }
+      inline void inc_dir_scanned_count() { dir_scanned++; }
+      inline void start_timer() { start_time = clock::now(); }
+      void dump(Formatter *f) {
+        f->dump_unsigned("files_in_flight", files_in_flight.load());
+        f->dump_unsigned("files_synced", files_synced.load());
+        f->dump_unsigned("files_deleted", files_deleted.load());
+        f->dump_unsigned("files_bytes_synced", file_bytes_synced.load());
+        f->dump_unsigned("dir_created", dir_created);
+        f->dump_unsigned("dir_scanned", dir_scanned);
+        f->dump_unsigned("dir_deleted", dir_deleted);
+        if (start_time) {
+          std::chrono::duration<double> duration = clock::now() - *start_time;
+          double time_elapsed = duration.count();
+          f->dump_float("time_elapsed", time_elapsed);
+          double rate = 0;
+          std::string transfer_rate = "";
+          if (time_elapsed > 0) {
+            rate = file_bytes_synced / time_elapsed;
+            if (rate >= (double)1e9) {
+              transfer_rate = std::to_string(rate / (double)1e9) + " GB/s";
+            } else if (rate >= (double)1e6) {
+              transfer_rate = std::to_string(rate / (double)1e6) + " MB/s";
+            } else if (rate >= (double)1e3) {
+              transfer_rate = std::to_string(rate / (double)1e3) + " KB/s";
+            } else {
+              transfer_rate = std::to_string(rate) + " B/s";
+            }
+            f->dump_string("transfer-rate", transfer_rate);
+          }
+        }
+      }
+    };
+    SyncStat last_stat, current_stat;
+    void reset_stats() {
+      last_stat = current_stat;
+      last_stat.start_time = boost::none;
+      current_stat = SyncStat();
+    }
   };
 
   void _inc_failed_count(const std::string &dir_root) {
     auto max_failures = g_ceph_context->_conf.get_val<uint64_t>(
     "cephfs_mirror_max_consecutive_failures_per_directory");
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.last_failed = clock::now();
-    if (++sync_stat.nr_failures >= max_failures && !sync_stat.failed) {
-      sync_stat.failed = true;
+    sync_stat->last_failed = clock::now();
+    if (++sync_stat->nr_failures >= max_failures && !sync_stat->failed) {
+      sync_stat->failed = true;
       ++m_service_daemon_stats.failed_dir_count;
       m_service_daemon->add_or_update_peer_attribute(m_filesystem.fscid, m_peer,
                                                      SERVICE_DAEMON_FAILED_DIR_COUNT_KEY,
@@ -272,82 +561,80 @@ private:
   }
   void _reset_failed_count(const std::string &dir_root) {
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    if (sync_stat.failed) {
+    if (sync_stat->failed) {
       ++m_service_daemon_stats.recovered_dir_count;
       m_service_daemon->add_or_update_peer_attribute(m_filesystem.fscid, m_peer,
                                                      SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY,
                                                      m_service_daemon_stats.recovered_dir_count);
     }
-    sync_stat.nr_failures = 0;
-    sync_stat.failed = false;
-    sync_stat.last_failed = boost::none;
-    sync_stat.last_failed_reason = boost::none;
+    sync_stat->nr_failures = 0;
+    sync_stat->failed = false;
+    sync_stat->last_failed = boost::none;
+    sync_stat->last_failed_reason = boost::none;
   }
 
   void _set_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name) {
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.last_synced_snap = std::make_pair(snap_id, snap_name);
-    sync_stat.current_syncing_snap = boost::none;
+    sync_stat->last_synced_snap = std::make_pair(snap_id, snap_name);
+    sync_stat->current_syncing_snap = boost::none;
   }
   void set_last_synced_snap(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name) {
     std::scoped_lock locker(m_lock);
     _set_last_synced_snap(dir_root, snap_id, snap_name);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.sync_bytes = 0;
+    sync_stat->sync_bytes = 0;
   }
   void set_current_syncing_snap(const std::string &dir_root, uint64_t snap_id,
                                 const std::string &snap_name) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.current_syncing_snap = std::make_pair(snap_id, snap_name);
+    sync_stat->current_syncing_snap = std::make_pair(snap_id, snap_name);
   }
   void clear_current_syncing_snap(const std::string &dir_root) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.current_syncing_snap = boost::none;
+    sync_stat->current_syncing_snap = boost::none;
   }
   void inc_deleted_snap(const std::string &dir_root) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    ++sync_stat.deleted_snap_count;
+    ++sync_stat->deleted_snap_count;
   }
   void inc_renamed_snap(const std::string &dir_root) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    ++sync_stat.renamed_snap_count;
+    ++sync_stat->renamed_snap_count;
   }
   void set_last_synced_stat(const std::string &dir_root, uint64_t snap_id,
                             const std::string &snap_name, double duration) {
     std::scoped_lock locker(m_lock);
     _set_last_synced_snap(dir_root, snap_id, snap_name);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.last_synced = clock::now();
-    sync_stat.last_sync_duration = duration;
-    sync_stat.last_sync_bytes = sync_stat.sync_bytes;
-    ++sync_stat.synced_snap_count;
+    sync_stat->last_synced = clock::now();
+    sync_stat->last_sync_duration = duration;
+    sync_stat->last_sync_bytes = sync_stat->sync_bytes;
+    ++sync_stat->synced_snap_count;
   }
   void inc_sync_bytes(const std::string &dir_root, const uint64_t& b) {
     std::scoped_lock locker(m_lock);
     auto &sync_stat = m_snap_sync_stats.at(dir_root);
-    sync_stat.sync_bytes += b;
+    sync_stat->sync_bytes += b;
   }
-  bool should_backoff(const std::string &dir_root, int *retval) {
+  bool should_backoff(DirRegistry* registry, int *retval) {
     if (m_fs_mirror->is_blocklisted()) {
       *retval = -EBLOCKLISTED;
       return true;
     }
 
-    std::scoped_lock locker(m_lock);
     if (is_stopping()) {
       // ceph defines EBLOCKLISTED to ESHUTDOWN (108). so use
       // EINPROGRESS to identify shutdown.
       *retval = -EINPROGRESS;
       return true;
     }
-    auto &dr = m_registered.at(dir_root);
-    if (dr.canceled) {
+    if (registry->failed || registry->canceled) {
       *retval = -ECANCELED;
       return true;
     }
@@ -364,9 +651,9 @@ private:
   Filesystem m_filesystem;
   Peer m_peer;
   // probably need to be encapsulated when supporting cancelations
-  std::map<std::string, DirRegistry> m_registered;
+  std::map<std::string, DirRegistry*> m_registered;
   std::vector<std::string> m_directories;
-  std::map<std::string, SnapSyncStat> m_snap_sync_stats;
+  std::map<std::string, SnapSyncStat *> m_snap_sync_stats;
   MountRef m_local_mount;
   ServiceDaemon *m_service_daemon;
   PeerReplayerAdminSocketHook *m_asok_hook = nullptr;
@@ -389,7 +676,7 @@ private:
   void unregister_directory(const std::string &dir_root);
   int try_lock_directory(const std::string &dir_root, SnapshotReplayerThread *replayer,
                          DirRegistry *registry);
-  void unlock_directory(const std::string &dir_root, const DirRegistry &registry);
+  void unlock_directory(const std::string &dir_root, DirRegistry* registry);
   int sync_snaps(const std::string &dir_root, std::unique_lock<ceph::mutex> &locker);
 
 
@@ -399,17 +686,24 @@ private:
   int propagate_snap_deletes(const std::string &dir_root, const std::set<std::string> &snaps);
   int propagate_snap_renames(const std::string &dir_root,
                              const std::set<std::pair<std::string,std::string>> &snaps);
-  int propagate_deleted_entries(const std::string &dir_root, const std::string &epath,
-                                const FHandles &fh);
-  int cleanup_remote_dir(const std::string &dir_root, const std::string &epath,
-                         const FHandles &fh);
+  int propagate_deleted_entries(
+      const std::string &epath, DirRegistry *registry, SnapSyncStat *sync_stat,
+      const FHandles &fh,
+      std::unordered_map<std::string, unsigned int> &change_mask_map,
+      int &change_mask_map_size);
+  int cleanup_remote_entry(const std::string &epath, DirRegistry *registry,
+                           const FHandles &fh, SnapSyncStat *sync_stat,
+                           int not_dir = -1);
 
   int should_sync_entry(const std::string &epath, const struct ceph_statx &cstx,
                         const FHandles &fh, bool *need_data_sync, bool *need_attr_sync);
 
   int open_dir(MountRef mnt, const std::string &dir_path, boost::optional<uint64_t> snap_id);
-  int pre_sync_check_and_open_handles(const std::string &dir_root, const Snapshot &current,
-                                      boost::optional<Snapshot> prev, FHandles *fh);
+  int pre_sync_check_and_open_handles(const std::string &dir_root,
+                                      const Snapshot &current,
+                                      boost::optional<Snapshot> prev,
+                                      FHandles *snapdiff_fh,
+                                      FHandles *remotediff_fh);
 
   int do_synchronize(const std::string &dir_root, const Snapshot &current,
                      boost::optional<Snapshot> prev);
@@ -421,13 +715,22 @@ private:
                   boost::optional<Snapshot> prev);
   int do_sync_snaps(const std::string &dir_root);
 
-  int remote_mkdir(const std::string &epath, const struct ceph_statx &stx, const FHandles &fh);
-  int remote_file_op(SyncMechanism *syncm, const std::string &dir_root,
-                     const std::string &epath, const struct ceph_statx &stx,
-                     bool sync_check, const FHandles &fh, bool need_data_sync, bool need_attr_sync);
-  int copy_to_remote(const std::string &dir_root, const std::string &epath, const struct ceph_statx &stx,
-                     const FHandles &fh, uint64_t num_blocks, struct cblock *b);
+  int sync_attributes(std::shared_ptr<SyncEntry> &cur_entry, const FHandles &fh);
+
+  int remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry, const FHandles &fh,
+                   SnapSyncStat *sync_stat);
+  int _remote_mkdir(std::shared_ptr<SyncEntry> &cur_entry, const FHandles &fh,
+                    SnapSyncStat *sync_stat);
+  int remote_file_op(std::shared_ptr<SyncEntry> &cur_entry,
+                     DirRegistry *registry, SnapSyncStat *sync_stat,
+                     const FHandles &fh);
+  int copy_to_remote(std::shared_ptr<SyncEntry> &cur_entry,
+                     DirRegistry *registry, const FHandles &fh,
+                     uint64_t num_blocks, struct cblock *b, bool trunc = false);
   int sync_perms(const std::string& path);
+  void build_change_mask(const struct ceph_statx &pstx,
+                         const struct ceph_statx &cstx, bool create_fresh,
+                         bool purge_remote, unsigned int &change_mask);
 };
 
 } // namespace mirror


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/69190
Signed-off-by: Md Mahamudur Rahaman Sajib [mahamudur.sajib@croit.io](mailto:mahamudur.sajib@croit.io)

# Concurrent Full Mirroring Design

## Overview
The goal of this design is to improve the efficiency of directory mirroring at scale.  
In the previous approach, concurrency was present but provided little benefit when:
- A single large directory was being mirrored, or
- The number of active directories being synced was small.

To solve this, the mirroring process is restructured around **two dedicated task thread pools**.

---

## Thread Pools

### 1. FileSyncPool
- Responsible for **file transfers**.  
- Files are leaf nodes of the directory tree → no dependencies.  
- Each file transfer request is pushed into this pool’s queue and executed asynchronously.  
- This achieves maximum concurrency for file transfers with no complexity.

### 2. DirScanPool
- Responsible for **directory scanning and creation**, directory I/O, file metadata I/O.  
- Directory creation has dependencies:  

                (1)
               /   \
            (2)     (3)
           /   \     /  \
       (4)    (5)(6)   (7)

In this tree, directory **(2)** must exist before **(4)** and **(5)** can be created.  

- To respect ordering, tasks are defined as:  
> **“Create a directory and push tasks for its sub-directories into the pool.”**

- Example:  
- Task 1 creates directory (1) and enqueues tasks for (2) and (3).  
- One thread take task 2 creates directory (2) and enqueues tasks for (4) and (5).  
- Another thread take task 3 creates directory (2) and enqueues tasks for (6) and (7).  
- This results in a **concurrent breadth-first traversal** of the tree.

---

## Queue Size Constraint
- In production, we manage **hundreds of millions of directories** (up to ~800M).  
- Storing every directory as a task in the queue is infeasible.  
- The queue size is therefore **capped** (e.g., `1e5` tasks).

---

## Avoiding Deadlocks
A naïve wait–notify model can deadlock. Example:
- Queue size = 1, worker count = 1.  
- While processing Task 1, the worker cannot enqueue Task 3 because the queue is full.  
- Task 1 never finishes → deadlock.

**Solution:**  
- If the queue is full, instead of enqueuing sub-directory tasks, the worker **processes them inline** with DFS.  
- While DFS, always looking for chance to push subdirectory task into the queue to distribute I/O load between threads evenly
- This ensures continuous progress and avoids deadlocks.

---

## Benefits
- **Uniform Workload Distribution**: Keeps all threads busy scanning directories.  
- **Continuous Throughput**: Ensures FileSyncPool is constantly fed with file-transfer tasks.  
- **Scalability**: Handles massive directory trees without blowing up memory.  
- **Robustness**: Prevents deadlocks under high load.  

---

## Summary
This design achieves **true concurrent mirroring** by separating file transfers and directory operations into dedicated pools, applying dependency-aware task definitions, limiting queue size, and adopting an inline execution fallback when the queue is full.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
