### PR TITLE
osd: Remove all references to hinfo from optimized EC

### DIFF
--- a/src/erasure-code/consistency/ECEncoder.cc
+++ b/src/erasure-code/consistency/ECEncoder.cc
@@ -106,7 +106,7 @@ std::optional<ceph::bufferlist> ECEncoder<stripe_info_o_t>::do_encode(ceph::buff
 
   sinfo.ro_range_to_shard_extent_map(0, inbl.length(), inbl, encoded_data);
   encoded_data.insert_parity_buffers();
-  int r = encoded_data.encode(ec_impl, nullptr, encoded_data.get_ro_end());
+  int r = encoded_data.encode(ec_impl);
   if (r < 0) {
     std::cerr << "Failed to encode: " << cpp_strerror(r) << std::endl;
     return {};

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -217,7 +217,6 @@ class ECBackend : public ECCommon {
     ceph::ErasureCodeInterfaceRef ec_impl;
     const ECUtil::stripe_info_t &sinfo;
     ReadPipeline &read_pipeline;
-    UnstableHashInfoRegistry &unstable_hashinfo_registry;
     // TODO: lay an interface down here
     ECListener *parent;
     ECBackend *ecbackend;
@@ -244,7 +243,6 @@ class ECBackend : public ECCommon {
                     ceph::ErasureCodeInterfaceRef ec_impl,
                     const ECUtil::stripe_info_t &sinfo,
                     ReadPipeline &read_pipeline,
-                    UnstableHashInfoRegistry &unstable_hashinfo_registry,
                     ECListener *parent,
                     ECBackend *ecbackend);
 
@@ -278,7 +276,6 @@ class ECBackend : public ECCommon {
       // must be filled if state == WRITING
       std::optional<ECUtil::shard_extent_map_t> returned_data;
       std::map<std::string, ceph::buffer::list, std::less<>> xattrs;
-      ECUtil::HashInfoRef hinfo;
       ObjectContextRef obc;
       std::set<pg_shard_t> waiting_on_pushes;
 
@@ -352,12 +349,10 @@ class ECBackend : public ECCommon {
                       ceph::ErasureCodeInterfaceRef ec_impl,
                       const ECUtil::stripe_info_t &sinfo,
                       ReadPipeline &read_pipeline,
-                      UnstableHashInfoRegistry &unstable_hashinfo_registry,
                       PGBackend::Listener *parent,
                       ECBackend *ecbackend)
       : RecoveryBackend(cct, coll, std::move(ec_impl), sinfo, read_pipeline,
-                        unstable_hashinfo_registry, parent->get_eclistener(),
-                        ecbackend),
+                        parent->get_eclistener(), ecbackend),
         parent(parent) {}
 
     void commit_txn_send_replies(
@@ -481,16 +476,11 @@ class ECBackend : public ECCommon {
 
   const ECUtil::stripe_info_t sinfo;
 
-  ECCommon::UnstableHashInfoRegistry unstable_hashinfo_registry;
-
-
   std::tuple<
     int,
     std::map<std::string, ceph::bufferlist, std::less<>>,
     size_t
   > get_attrs_n_size_from_disk(const hobject_t &hoid);
-
-  ECUtil::HashInfoRef get_hinfo_from_disk(hobject_t oid);
 
   std::optional<object_info_t> get_object_info_from_obc(
       ObjectContextRef &obc_map

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -32,8 +32,6 @@ struct ECTransaction {
     bool invalidates_cache = false; // Yes, both are possible
     std::map<hobject_t,extent_set> to_read;
     std::map<hobject_t,extent_set> will_write;
-
-    std::map<hobject_t,ECUtil::HashInfoRef> hash_infos;
   };
 };
 
@@ -635,30 +633,6 @@ struct ECCommon {
         ec_backend(ec_backend),
         extent_cache(*this, ec_extent_cache_lru, sinfo, cct),
         ec_pdw_write_mode(cct->_conf.get_val<uint64_t>("ec_pdw_write_mode")) {}
-  };
-
-  class UnstableHashInfoRegistry {
-    CephContext *cct;
-    ceph::ErasureCodeInterfaceRef ec_impl;
-    /// If modified, ensure that the ref is held until the update is applied
-    SharedPtrRegistry<hobject_t, ECUtil::HashInfo> registry;
-
-   public:
-    UnstableHashInfoRegistry(
-        CephContext *cct,
-        ceph::ErasureCodeInterfaceRef ec_impl)
-      : cct(cct),
-        ec_impl(std::move(ec_impl)) {}
-
-    ECUtil::HashInfoRef maybe_put_hash_info(
-        const hobject_t &hoid,
-        ECUtil::HashInfo &&hinfo);
-
-    ECUtil::HashInfoRef get_hash_info(
-        const hobject_t &hoid,
-        bool create,
-        const std::map<std::string, ceph::buffer::list, std::less<>> &attrs,
-        uint64_t size);
   };
 };
 

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -26,8 +26,6 @@ class WritePlanObj {
   const hobject_t hoid;
   std::optional<ECUtil::shard_extent_set_t> to_read;
   ECUtil::shard_extent_set_t will_write;
-  const ECUtil::HashInfoRef hinfo;
-  const ECUtil::HashInfoRef shinfo;
   const uint64_t orig_size;
   const uint64_t projected_size;
   bool invalidates_cache;
@@ -43,16 +41,12 @@ class WritePlanObj {
       uint64_t orig_size,
       const std::optional<object_info_t> &oi,
       const std::optional<object_info_t> &soi,
-      const ECUtil::HashInfoRef &&hinfo,
-      const ECUtil::HashInfoRef &&shinfo,
-      const unsigned pdw_write_mode);
+      unsigned pdw_write_mode);
 
   void print(std::ostream &os) const {
     os << "{hoid: " << hoid
        << " to_read: " << to_read
        << " will_write: " << will_write
-       << " hinfo: " << hinfo
-       << " shinfo: " << shinfo
        << " orig_size: " << orig_size
        << " projected_size: " << projected_size
        << " invalidates_cache: " << invalidates_cache
@@ -113,7 +107,6 @@ class Generate {
   void appends_and_clone_ranges();
   void written_and_present_shards();
   void attr_updates();
-  void handle_deletes();
 
  public:
   Generate(PGTransaction &t,

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -13,6 +13,7 @@
 #include "include/utime_fmt.h"
 #include "messages/MOSDRepScrubMap.h"
 #include "osd/ECUtil.h"
+#include "osd/ECUtilL.h"
 #include "osd/OSD.h"
 #include "osd/PG.h"
 #include "osd/PrimaryLogPG.h"
@@ -664,7 +665,7 @@ shard_as_auth_t ScrubBackend::possible_auth_shard(const hobject_t& obj,
   }
 
   if (m_pg.get_is_hinfo_required()) {
-    auto k = smap_obj.attrs.find(ECUtil::get_hinfo_key());
+    auto k = smap_obj.attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
     if (dup_error_cond(err,
                        false,
                        (k == smap_obj.attrs.end()),
@@ -673,7 +674,7 @@ shard_as_auth_t ScrubBackend::possible_auth_shard(const hobject_t& obj,
                        "candidate had a missing hinfo key"sv,
                        errstream)) {
       const bufferlist& hk_bl = k->second;
-      ECUtil::HashInfo hi;
+      ECLegacy::ECUtilL::HashInfo hi;
       try {
         auto bliter = hk_bl.cbegin();
         decode(hi, bliter);
@@ -1310,11 +1311,11 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
     if (!shard_result.has_hinfo_missing() &&
         !shard_result.has_hinfo_corrupted()) {
 
-      auto can_hi = candidate.attrs.find(ECUtil::get_hinfo_key());
+      auto can_hi = candidate.attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
       ceph_assert(can_hi != candidate.attrs.end());
       const bufferlist& can_bl = can_hi->second;
 
-      auto auth_hi = auth.attrs.find(ECUtil::get_hinfo_key());
+      auto auth_hi = auth.attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
       ceph_assert(auth_hi != auth.attrs.end());
       const bufferlist& auth_bl = auth_hi->second;
 

--- a/src/test/osd/TestECBackend.cc
+++ b/src/test/osd/TestECBackend.cc
@@ -1262,7 +1262,7 @@ TEST(ECCommon, encode)
     bl.append_zero(i>=k?4096:2048);
     semap.insert_in_shard(i, 12*1024, bl);
   }
-  semap.encode(ec_impl, nullptr, 0);
+  semap.encode(ec_impl);
 }
 
 TEST(ECCommon, decode)

--- a/src/test/osd/test_ec_transaction.cc
+++ b/src/test/osd/test_ec_transaction.cc
@@ -57,8 +57,6 @@ TEST(ectransaction, two_writes_separated_append)
     0,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -95,8 +93,6 @@ TEST(ectransaction, two_writes_separated_misaligned_overwrite)
     oi.size,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -135,8 +131,6 @@ TEST(ectransaction, partial_write)
     0,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -177,8 +171,6 @@ TEST(ectransaction, overlapping_write_non_aligned)
     8,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -220,8 +212,6 @@ TEST(ectransaction, test_appending_write_non_aligned)
     8,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -263,8 +253,6 @@ TEST(ectransaction, append_with_large_hole)
     4096,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -306,8 +294,6 @@ TEST(ectransaction, test_append_not_page_aligned_with_large_hole)
     EC_ALIGN_SIZE,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -351,8 +337,6 @@ TEST(ectransaction, test_overwrite_with_missing)
     42*(EC_ALIGN_SIZE / 4),
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -392,8 +376,6 @@ TEST(ectransaction, truncate_to_bigger_without_write)
     4096,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -423,8 +405,6 @@ TEST(ectransaction, truncate_to_smalelr_without_write) {
     16*EC_ALIGN_SIZE,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -470,8 +450,6 @@ TEST(ectransaction, delete_and_write_misaligned) {
     16*EC_ALIGN_SIZE,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -5,7 +5,7 @@ set(rados_srcs
   rados/PoolDump.cc
   ${PROJECT_SOURCE_DIR}/src/common/util.cc
   ${PROJECT_SOURCE_DIR}/src/common/obj_bencher.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/ECUtil.cc)
+  ${PROJECT_SOURCE_DIR}/src/osd/ECUtilL.cc)
 if(WIN32)
   list(APPEND rados_srcs ../common/win32/code_page.rc)
 endif()

--- a/src/tools/ceph-dencoder/osd_types.h
+++ b/src/tools/ceph-dencoder/osd_types.h
@@ -72,9 +72,9 @@ TYPE(eversion_t)
 //TYPE(compact_interval_t) declared in .cc
 //TYPE(pg_missing_t::item)
 
-#include "osd/ECUtil.h"
+#include "osd/ECUtilL.h"
 // TYPE(stripe_info_t) non-standard encoding/decoding functions
-TYPE(ECUtil::HashInfo)
+TYPE(ECLegacy::ECUtilL::HashInfo)
 
 #include "osd/ECMsgTypes.h"
 TYPE_NOCOPY(ECSubWrite)

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -38,7 +38,7 @@
 #include "osd/PGLog.h"
 #include "osd/OSD.h"
 #include "osd/PG.h"
-#include "osd/ECUtil.h"
+#include "osd/ECUtilL.h"
 
 #include "json_spirit/json_spirit_value.h"
 #include "json_spirit/json_spirit_reader.h"
@@ -2899,9 +2899,9 @@ int print_obj_info(ObjectStore *store, coll_t coll, ghobject_t &ghobj, Formatter
     }
   }
   bufferlist hattr;
-  gr = store->getattr(ch, ghobj, ECUtil::get_hinfo_key(), hattr);
+  gr = store->getattr(ch, ghobj, ECLegacy::ECUtilL::get_hinfo_key(), hattr);
   if (gr == 0) {
-    ECUtil::HashInfo hinfo;
+    ECLegacy::ECUtilL::HashInfo hinfo;
     auto hp = hattr.cbegin();
     try {
       decode(hinfo, hp);

--- a/src/tools/erasure-code/ceph-erasure-code-tool.cc
+++ b/src/tools/erasure-code/ceph-erasure-code-tool.cc
@@ -216,7 +216,7 @@ int do_encode(const std::vector<const char*> &args) {
 
   sinfo->ro_range_to_shard_extent_map(0, input_data.length(), input_data, encoded_data);
   encoded_data.insert_parity_buffers();
-  r = encoded_data.encode(ec_impl, nullptr, encoded_data.get_ro_end());
+  r = encoded_data.encode(ec_impl);
   if (r < 0) {
     std::cerr << "failed to encode: " << cpp_strerror(r) << std::endl;
     return 1;

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -60,7 +60,7 @@
 #include "PoolDump.h"
 #include "RadosImport.h"
 
-#include "osd/ECUtil.h"
+#include "osd/ECUtilL.h" // For hinfo in legacy EC
 #include "objclass/objclass.h"
 #include "cls/refcount/cls_refcount_ops.h"
 
@@ -1643,10 +1643,10 @@ static void dump_shard(const shard_info_t& shard,
        || inc.union_shards.has_hinfo_corrupted()
        || inc.has_hinfo_inconsistency()) &&
        !shard.has_hinfo_missing()) {
-    map<std::string, ceph::bufferlist>::iterator k = (const_cast<shard_info_t&>(shard)).attrs.find(ECUtil::get_hinfo_key());
+    map<std::string, ceph::bufferlist>::iterator k = (const_cast<shard_info_t&>(shard)).attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
     ceph_assert(k != shard.attrs.end()); // Can't be missing
     if (!shard.has_hinfo_corrupted()) {
-      ECUtil::HashInfo hi;
+      ECLegacy::ECUtilL::HashInfo hi;
       bufferlist bl;
       auto bliter = k->second.cbegin();
       decode(hi, bliter);  // Can't be corrupted


### PR DESCRIPTION
depends on #63873 (Please only look at final commit)

Tracker: https://tracker.ceph.com/issues/71813

Legacy EC used hinfo attribute to store two things:

1.  Shard size
2. CRCs of the shards

However:

-  Optimized EC stores different object sizes on each shard
-  Optimized EC scrub calculates the correct sizes of shards and checks them, so shard size checks are not needed in hinfo.
-  Bluestore checks the CRC.
-  Seastore checks the CRC:

Seastore supports CRC checks for both meta and data internally.
Upon overwriting an object, Seastore will update CRC and will verify it on full object reads.

  As such, the hinfo object is redundant. As such we remove it in  optimized EC:

1. Remove all references/upgrades to hinfo.
2 Delete hinfo attribute if found on recovery/backfill.
3 Redirect all scrub references for hinfo to legacy EC.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
