### PR TITLE
mgr/dashboard: Allow host with labels in listener form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-form/nvmeof-listeners-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-form/nvmeof-listeners-form.component.html
@@ -12,7 +12,7 @@
           <label class="cd-col-form-label"
                  for="host">
             <span class="required"
-                  i18n>Host Name</span>
+                  i18n>Hostname</span>
           </label>
           <div class="cd-col-form-input">
             <select id="host"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-form/nvmeof-listeners-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-form/nvmeof-listeners-form.component.ts
@@ -1,8 +1,9 @@
+import _ from 'lodash';
 import { Component, OnInit } from '@angular/core';
 import { UntypedFormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { ListenerRequest, NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { GatewayGroup, ListenerRequest, NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -15,7 +16,7 @@ import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { HostService } from '~/app/shared/api/host.service';
 import { map } from 'rxjs/operators';
 import { forkJoin } from 'rxjs';
-import { CephServiceSpec } from '~/app/shared/models/service.interface';
+import { Host } from '~/app/shared/models/host.interface';
 
 @Component({
   selector: 'cd-nvmeof-listeners-form',
@@ -51,26 +52,42 @@ export class NvmeofListenersFormComponent implements OnInit {
     this.pageURL = 'block/nvmeof/subsystems';
   }
 
+  filterHostsByLabel(allHosts: Host[], gwNodesLabel: string | string[]) {
+    return allHosts.filter((host: Host) => {
+      const hostLabels: string[] = host?.labels;
+      if (typeof gwNodesLabel === 'string') {
+        return hostLabels.includes(gwNodesLabel);
+      }
+      return hostLabels?.length === gwNodesLabel?.length && _.isEqual(hostLabels, gwNodesLabel);
+    });
+  }
+
+  filterHostsByHostname(allHosts: Host[], gwNodes: string[]) {
+    return allHosts.filter((host: Host) => gwNodes.includes(host.hostname));
+  }
+
+  getGwGroupPlacement(gwGroups: GatewayGroup[][]) {
+    return (
+      gwGroups?.[0]?.find((gwGroup: GatewayGroup) => gwGroup?.spec?.group === this.group)
+        ?.placement || { hosts: [], label: [] }
+    );
+  }
+
   setHosts() {
     forkJoin({
       gwGroups: this.nvmeofService.listGatewayGroups(),
-      hosts: this.hostService.getAllHosts()
+      allHosts: this.hostService.getAllHosts()
     })
       .pipe(
-        map(({ gwGroups, hosts }) => {
-          // Find the gateway hosts in current group
-          const selectedGwGroup: CephServiceSpec = gwGroups?.[0]?.find(
-            (gwGroup: CephServiceSpec) => gwGroup?.spec?.group === this.group
-          );
-          const gatewayHosts: string[] = selectedGwGroup?.placement?.hosts;
-          // Return the gateway hosts in current group with their metadata
-          return gatewayHosts
-            ? hosts.filter((host: any) => gatewayHosts.includes(host.hostname))
-            : [];
+        map(({ gwGroups, allHosts }) => {
+          const { hosts, label } = this.getGwGroupPlacement(gwGroups);
+          if (hosts?.length) return this.filterHostsByHostname(allHosts, hosts);
+          else if (label?.length) return this.filterHostsByLabel(allHosts, label);
+          return [];
         })
       )
-      .subscribe((nvmeofHosts: any[]) => {
-        this.hosts = nvmeofHosts.map((h) => ({ hostname: h.hostname, addr: h.addr }));
+      .subscribe((nvmeofGwNodes: Host[]) => {
+        this.hosts = nvmeofGwNodes.map((h) => ({ hostname: h.hostname, addr: h.addr }));
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
@@ -21,6 +21,7 @@ import { Permission } from '~/app/shared/models/permissions';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { PoolService } from '~/app/shared/api/pool.service';
 import { Pool } from '../../pool/pool';
+import { Host } from '~/app/shared/models/host.interface';
 
 @Component({
   selector: 'cd-cephfs-form',
@@ -176,7 +177,7 @@ export class CephfsVolumeFormComponent extends CdForm implements OnInit {
         labels: this.hostService.getLabels()
       }).pipe(
         map(({ hosts, labels }) => ({
-          hosts: hosts.map((host: any) => ({ content: host['hostname'] })),
+          hosts: hosts.map((host: Host) => ({ content: host['hostname'] })),
           labels: labels.map((label: string) => ({ content: label }))
         }))
       );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -34,6 +34,7 @@ import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { FinishedTask } from '~/app/shared/models/finished-task';
+import { Host } from '~/app/shared/models/host.interface';
 import { CephServiceSpec } from '~/app/shared/models/service.interface';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -636,9 +637,9 @@ export class ServiceFormComponent extends CdForm implements OnInit {
 
       this.serviceTypes = _.difference(resp, this.hiddenServices).sort();
     });
-    this.hostService.getAllHosts().subscribe((resp: object[]) => {
+    this.hostService.getAllHosts().subscribe((resp: Host[]) => {
       const options: SelectOption[] = [];
-      _.forEach(resp, (host: object) => {
+      _.forEach(resp, (host: Host) => {
         if (_.get(host, 'sources.orchestrator', false)) {
           const option = new SelectOption(false, _.get(host, 'hostname'), '');
           options.push(option);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/smb/smb-cluster-form/smb-cluster-form.component.ts
@@ -37,6 +37,7 @@ import { CephServicePlacement } from '~/app/shared/models/service.interface';
 import { UpperFirstPipe } from '~/app/shared/pipes/upper-first.pipe';
 import { CLUSTER_PATH } from '../smb-cluster-list/smb-cluster-list.component';
 import { USERSGROUPS_PATH } from '../smb-usersgroups-list/smb-usersgroups-list.component';
+import { Host } from '~/app/shared/models/host.interface';
 
 @Component({
   selector: 'cd-smb-cluster-form',
@@ -95,7 +96,7 @@ export class SmbClusterFormComponent extends CdForm implements OnInit {
       labels: this.hostService.getLabels()
     }).pipe(
       map(({ hosts, labels }) => ({
-        hosts: hosts.map((host: any) => ({ content: host['hostname'] })),
+        hosts: hosts.map((host: Host) => ({ content: host['hostname'] })),
         labels: labels.map((label: string) => ({ content: label }))
       }))
     );
@@ -169,7 +170,7 @@ export class SmbClusterFormComponent extends CdForm implements OnInit {
         labels: this.hostService.getLabels()
       }).pipe(
         map(({ hosts, labels }) => ({
-          hosts: hosts.map((host: any) => ({ content: host['hostname'] })),
+          hosts: hosts.map((host: Host) => ({ content: host['hostname'] })),
           labels: labels.map((label: string) => ({ content: label }))
         }))
       );

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
@@ -13,6 +13,7 @@ import { Daemon } from '../models/daemon.interface';
 import { CdDevice } from '../models/devices';
 import { SmartDataResponseV1 } from '../models/smart';
 import { DeviceService } from '../services/device.service';
+import { Host } from '../models/host.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -163,7 +164,7 @@ export class HostService extends ApiClient {
     );
   }
 
-  getAllHosts(): Observable<object[]> {
-    return this.http.get<object[]>(`${this.baseUIURL}/list`);
+  getAllHosts(): Observable<Host[]> {
+    return this.http.get<Host[]>(`${this.baseUIURL}/list`);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -8,6 +8,8 @@ import { CephServiceSpec } from '../models/service.interface';
 
 export const MAX_NAMESPACE = 1024;
 
+export type GatewayGroup = CephServiceSpec;
+
 export type GroupsComboboxItem = {
   content: string;
   serviceName?: string;
@@ -72,7 +74,7 @@ export class NvmeofService {
 
   // Gateway groups
   listGatewayGroups() {
-    return this.http.get(`${API_PATH}/gateway/group`);
+    return this.http.get<GatewayGroup[][]>(`${API_PATH}/gateway/group`);
   }
 
   // Gateways

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/host.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/host.interface.ts
@@ -1,0 +1,13 @@
+export interface Host {
+  ceph_version: string;
+  services: Array<{ type: string; id: string }>;
+  sources: {
+    ceph: boolean;
+    orchestrator: boolean;
+  };
+  hostname: string;
+  addr: string;
+  labels: string[];
+  status: any;
+  service_instances: Array<{ type: string; count: number }>;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -68,5 +68,5 @@ export interface CephServicePlacement {
   count?: number;
   placement?: string;
   hosts?: string[];
-  label?: string;
+  label?: string | string[];
 }


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/71686

* Currently, listeners cannot be added with the Ceph Dashboard if the gateway nodes are selected by label instead of hosts.

* Refactored the code to incorporate nodes with labels
* Also added missing typings and removed 'any'


https://github.com/user-attachments/assets/ed5897f7-46eb-44c0-95ea-6c15458a59ce




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
