### PR TITLE
cmake/rgw: apply -DCLS_CLIENT_HIDE_IOCTX to rgw_common too

### DIFF
--- a/src/cls/otp/cls_otp_client.cc
+++ b/src/cls/otp/cls_otp_client.cc
@@ -160,23 +160,18 @@ namespace rados {
         return get(op, ioctx, oid, nullptr, true, result);
       }
 
-      int OTP::get_current_time(librados::IoCtx& ioctx, const string& oid,
-                                ceph::real_time *result) {
+      void get_current_time(librados::ObjectReadOperation& rop,
+                            bufferlist& out, int& op_ret)
+      {
         cls_otp_get_current_time_op op;
         bufferlist in;
-        bufferlist out;
-        int op_ret;
         encode(op, in);
-        ObjectReadOperation rop;
         rop.exec("otp", "get_current_time", in, &out, &op_ret);
-        int r = ioctx.operate(oid, &rop, nullptr);
-        if (r < 0) {
-          return r;
-        }
-        if (op_ret < 0) {
-          return op_ret;
-        }
+      }
 
+      int get_current_time_decode(const bufferlist& out,
+                                  ceph::real_time& result)
+      {
         cls_otp_get_current_time_reply ret;
         auto iter = out.cbegin();
         try {
@@ -185,7 +180,7 @@ namespace rados {
 	  return -EBADMSG;
         }
 
-        *result = ret.time;
+        result = ret.time;
 
         return 0;
       }

--- a/src/cls/otp/cls_otp_client.cc
+++ b/src/cls/otp/cls_otp_client.cc
@@ -58,34 +58,31 @@ namespace rados {
         rados_op->exec("otp", "otp_remove", in);
       }
 
-      int OTP::check(CephContext *cct, librados::IoCtx& ioctx, const string& oid,
-                     const string& id, const string& val, otp_check_t *result) {
+      void check(librados::ObjectWriteOperation& wop,
+                 std::string id, std::string val, std::string token)
+      {
         cls_otp_check_otp_op op;
-        op.id = id;
-        op.val = val;
-#define TOKEN_LEN 16
-        op.token = gen_rand_alphanumeric(cct, TOKEN_LEN);
-        
+        op.id = std::move(id);
+        op.val = std::move(val);
+        op.token = std::move(token);
+
         bufferlist in;
-        bufferlist out;
         encode(op, in);
-        librados::ObjectWriteOperation wop;
         wop.exec("otp", "otp_check", in);
-        int r = ioctx.operate(oid, &wop);
-        if (r < 0) {
-          return r;
-        }
+      }
 
-        cls_otp_get_result_op op2;
-        op2.token = op.token;
-        bufferlist in2;
-        bufferlist out2;
-        encode(op2, in2);
-        r = ioctx.exec(oid, "otp", "otp_get_result", in, out);
-        if (r < 0) {
-          return r;
-        }
-
+      void check_result(librados::ObjectReadOperation& rop, std::string token,
+                        bufferlist& out, int& op_ret)
+      {
+        cls_otp_get_result_op op;
+        op.token = std::move(token);
+        bufferlist in;
+        encode(op, in);
+        rop.exec("otp", "otp_get_result", in, &out, &op_ret);
+      }
+      int check_result_decode(const bufferlist& out,
+                              otp_check_t& result)
+      {
         auto iter = out.cbegin();
         cls_otp_get_result_reply ret;
         try {
@@ -94,7 +91,7 @@ namespace rados {
 	  return -EBADMSG;
         }
 
-        *result = ret.result;
+        result = ret.result;
 
         return 0;
       }

--- a/src/cls/otp/cls_otp_client.h
+++ b/src/cls/otp/cls_otp_client.h
@@ -28,10 +28,18 @@ namespace rados {
         static int get(librados::ObjectReadOperation *op,
                        librados::IoCtx& ioctx, const std::string& oid,
                        const std::list<std::string> *ids, bool get_all, std::list<otp_info_t> *result);
-        static int check(CephContext *cct, librados::IoCtx& ioctx, const std::string& oid,
-                         const std::string& id, const std::string& val, otp_check_t *result);
 #endif
       };
+
+      // perform a check
+      void check(librados::ObjectWriteOperation& op, std::string id,
+                 std::string val, std::string token);
+      // read the result of a check
+      void check_result(librados::ObjectReadOperation& op, std::string token,
+                        bufferlist& bl, int& rval);
+      // decode the check result
+      int check_result_decode(const bufferlist& bl,
+                              otp_check_t& result);
 
       void get_current_time(librados::ObjectReadOperation& op,
                             bufferlist& bl, int& rval);

--- a/src/cls/otp/cls_otp_client.h
+++ b/src/cls/otp/cls_otp_client.h
@@ -30,10 +30,13 @@ namespace rados {
                        const std::list<std::string> *ids, bool get_all, std::list<otp_info_t> *result);
         static int check(CephContext *cct, librados::IoCtx& ioctx, const std::string& oid,
                          const std::string& id, const std::string& val, otp_check_t *result);
-        static int get_current_time(librados::IoCtx& ioctx, const std::string& oid,
-                                    ceph::real_time *result);
 #endif
       };
+
+      void get_current_time(librados::ObjectReadOperation& op,
+                            bufferlist& bl, int& rval);
+      int get_current_time_decode(const bufferlist& bl,
+                                  ceph::real_time& result);
 
       class TOTPConfig {
         otp_info_t config;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -832,18 +832,22 @@ void cls_rgw_reshard_add(librados::ObjectWriteOperation& op,
   op.exec(RGW_CLASS, RGW_RESHARD_ADD, in);
 }
 
-int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& marker, uint32_t max,
-                         list<cls_rgw_reshard_entry>& entries, bool* is_truncated)
+void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
+                          std::string marker, uint32_t max,
+                          bufferlist& out)
 {
-  bufferlist in, out;
+  bufferlist in;
   cls_rgw_reshard_list_op call;
-  call.marker = marker;
+  call.marker = std::move(marker);
   call.max = max;
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_RESHARD_LIST, in, out);
-  if (r < 0)
-    return r;
+  op.exec(RGW_CLASS, RGW_RESHARD_LIST, in, &out, nullptr);
+}
 
+int cls_rgw_reshard_list_decode(const bufferlist& out,
+                                std::list<cls_rgw_reshard_entry>& entries,
+                                bool* is_truncated)
+{
   cls_rgw_reshard_list_ret op_ret;
   auto iter = out.cbegin();
   try {
@@ -858,16 +862,21 @@ int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& mar
   return 0;
 }
 
-int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_reshard_entry& entry)
+void cls_rgw_reshard_get(librados::ObjectReadOperation& op,
+                         std::string tenant, std::string bucket_name,
+                         bufferlist& out)
 {
-  bufferlist in, out;
+  bufferlist in;
   cls_rgw_reshard_get_op call;
-  call.entry = entry;
+  call.entry.tenant = std::move(tenant);
+  call.entry.bucket_name = std::move(bucket_name);
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_RESHARD_GET, in, out);
-  if (r < 0)
-    return r;
+  op.exec(RGW_CLASS, RGW_RESHARD_GET, in, &out, nullptr);
+}
 
+int cls_rgw_reshard_get_decode(const bufferlist& out,
+                               cls_rgw_reshard_entry& entry)
+{
   cls_rgw_reshard_get_ret op_ret;
   auto iter = out.cbegin();
   try {
@@ -876,7 +885,7 @@ int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_resh
     return -EIO;
   }
 
-  entry = op_ret.entry;
+  entry = std::move(op_ret.entry);
 
   return 0;
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -278,13 +278,17 @@ void cls_rgw_reshard_add(librados::ObjectWriteOperation& op,
 			 const cls_rgw_reshard_entry& entry,
 			 const bool create_only);
 void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry);
-// these overloads which call io_ctx.operate() should not be called in the rgw.
-// rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
-#ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const std::string& oid, std::string& marker, uint32_t max,
-                         std::list<cls_rgw_reshard_entry>& entries, bool* is_truncated);
-int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_reshard_entry& entry);
-#endif
+void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
+                          std::string marker, uint32_t max,
+                          bufferlist& bl);
+int cls_rgw_reshard_list_decode(const bufferlist& bl,
+                                std::list<cls_rgw_reshard_entry>& entries,
+                                bool* is_truncated);
+void cls_rgw_reshard_get(librados::ObjectReadOperation& op,
+                         std::string tenant, std::string bucket_name,
+                         bufferlist& bl);
+int cls_rgw_reshard_get_decode(const bufferlist& bl,
+                               cls_rgw_reshard_entry& entry);
 
 // If writes to the bucket index should be blocked during resharding, fail with
 // the given error code. RGWRados::guard_reshard() calls this in a loop to retry

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -232,13 +232,13 @@ void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, ceph::buff
 void cls_rgw_suggest_changes(librados::ObjectWriteOperation& o, ceph::buffer::list& updates);
 
 /* usage logging */
-// these overloads which call io_ctx.operate() should not be called in the rgw.
-// rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
-#ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, const std::string& oid, const std::string& user, const std::string& bucket,
-                           uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries, std::string& read_iter,
-			   std::map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated);
-#endif
+void cls_rgw_usage_log_read(librados::ObjectReadOperation& op,
+                            const std::string& user, const std::string& bucket,
+                            uint64_t start_epoch, uint64_t end_epoch,
+                            uint32_t max_entries, const std::string& read_iter,
+                            bufferlist& bl, int& rval);
+int cls_rgw_usage_log_read_decode(const bufferlist& bl, std::string& read_iter,
+                                  std::map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated);
 
 void cls_rgw_usage_log_trim(librados::ObjectWriteOperation& op, const std::string& user, const std::string& bucket, uint64_t start_epoch, uint64_t end_epoch);
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -334,6 +334,8 @@ target_compile_definitions(rgw_common PUBLIC
   $<$<CONFIG:Debug>:XXH_NO_INLINE_HINTS=1>
   $<$<CONFIG:RelWithDebInfo>:XXH_NO_INLINE_HINTS=1>)
 
+target_compile_definitions(rgw_common PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
+
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
   # used by rgw_kafka.cc
   target_link_libraries(rgw_common
@@ -436,8 +438,6 @@ set_source_files_properties(rgw_iam_policy.cc PROPERTIES
 add_library(rgw_a STATIC
     ${rgw_a_srcs})
 
-target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
-
 target_include_directories(rgw_a
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
@@ -492,7 +492,6 @@ if(WITH_RADOSGW_ARROW_FLIGHT)
   # target_include_directories(radosgw PUBLIC Arrow::Arrow)
 endif(WITH_RADOSGW_ARROW_FLIGHT)
 
-target_compile_definitions(radosgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(radosgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
   PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"
@@ -587,7 +586,6 @@ set(librgw_srcs
   librgw.cc)
 add_library(rgw SHARED ${librgw_srcs})
 
-target_compile_definitions(rgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(rgw
   PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src"
   PRIVATE "${CMAKE_SOURCE_DIR}/src/libkmip"

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1975,14 +1975,16 @@ void get_stale_instances(rgw::sal::Driver* driver, const std::string& bucket_nam
   // with these
   {
     RGWBucketReshardLock reshard_lock(static_cast<rgw::sal::RadosStore*>(driver), cur_bucket->get_info(), true);
-    r = reshard_lock.lock(dpp);
+    r = reshard_lock.lock(dpp, y);
     if (r < 0) {
       // most likely bucket is under reshard, return the sureshot stale instances
       ldpp_dout(dpp, 5) << __func__
                              << "failed to take reshard lock; reshard underway likey" << dendl;
       return;
     }
-    auto sg = make_scope_guard([&reshard_lock](){ reshard_lock.unlock();} );
+    auto sg = make_scope_guard([&reshard_lock, dpp, y] {
+          std::ignore = reshard_lock.unlock(dpp, y);
+        });
     // this should be fast enough that we may not need to renew locks and check
     // exit status?, should we read the values of the instances again?
     stale_instances.insert(std::end(stale_instances),

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -235,7 +235,9 @@ int RGWAsyncLockSystemObj::_send_request(const DoutPrefixProvider *dpp)
   l.set_cookie(cookie);
   l.set_may_renew(true);
 
-  return l.lock_exclusive(&ref.ioctx, ref.obj.oid);
+  librados::ObjectWriteOperation op;
+  l.lock_exclusive(&op);
+  return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), null_yield);
 }
 
 RGWAsyncLockSystemObj::RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
@@ -261,7 +263,9 @@ int RGWAsyncUnlockSystemObj::_send_request(const DoutPrefixProvider *dpp)
 
   l.set_cookie(cookie);
 
-  return l.unlock(&ref.ioctx, ref.obj.oid);
+  librados::ObjectWriteOperation op;
+  l.unlock(&op);
+  return rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), null_yield);
 }
 
 RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -505,24 +505,6 @@ namespace rgw::dedup {
 
   static constexpr uint64_t cost = 1; // 1 throttle unit per request
   static constexpr uint64_t id = 0; // ids unused
-  //---------------------------------------------------------------------------
-  [[maybe_unused]]static void show_ref_tags(const DoutPrefixProvider* dpp, std::string &oid, rgw_rados_ref &obj)
-  {
-    unsigned idx = 0;
-    std::list<std::string> refs;
-    std::string wildcard_tag;
-    int ret = cls_refcount_read(obj.ioctx, oid, &refs, true);
-    if (ret < 0) {
-      ldpp_dout(dpp, 0) << __func__ << "::ERR: manifest::failed cls_refcount_read()"
-                        << " idx=" << idx << dendl;
-      return;
-    }
-
-    for (list<string>::iterator iter = refs.begin(); iter != refs.end(); ++iter) {
-      ldpp_dout(dpp, 20) << __func__ << "::manifest::" << oid << "::" << idx
-                         << "::TAG=" << *iter << dendl;
-    }
-  }
 
   //---------------------------------------------------------------------------
   int Background::free_tail_objs_by_manifest(const string   &ref_tag,

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -259,6 +259,14 @@ static int gc_list(const DoutPrefixProvider* dpp, optional_yield y, librados::Io
   return cls_rgw_gc_list_decode(bl, entries, truncated, next_marker);
 }
 
+static int version_read(const DoutPrefixProvider* dpp, optional_yield y,
+                        librados::IoCtx& io_ctx, std::string& oid, obj_version* objv)
+{
+  librados::ObjectReadOperation op;
+  cls_version_read(op, objv);
+  return rgw_rados_operate(dpp, io_ctx, oid, std::move(op), nullptr, y);
+}
+
 int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue)
 {
   result.clear();
@@ -276,7 +284,8 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
         return ret;
       }
       obj_version objv;
-      cls_version_read(store->gc_pool_ctx, obj_names[*index], &objv);
+      std::ignore = version_read(this, null_yield, store->gc_pool_ctx,
+                                 obj_names[*index], &objv);
       if (ret == -ENOENT || entries.size() == 0) {
         if (objv.ver == 0) {
           continue;
@@ -609,7 +618,8 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
       ", entries.size=" << entries.size() << ", truncated=" << truncated <<
       ", next_marker='" << next_marker << "'" << dendl;
       obj_version objv;
-      cls_version_read(store->gc_pool_ctx, obj_names[index], &objv);
+      std::ignore = version_read(this, y, store->gc_pool_ctx,
+                                 obj_names[index], &objv);
       if ((objv.ver == 1) && entries.size() == 0) {
         std::list<cls_rgw_gc_obj_info> non_expired_entries;
         ret = gc_list(this, y, store->gc_pool_ctx, obj_names[index], marker, 1, false, non_expired_entries, &truncated, next_marker);

--- a/src/rgw/driver/rados/rgw_metadata.cc
+++ b/src/rgw/driver/rados/rgw_metadata.cc
@@ -182,20 +182,6 @@ int RGWMetadataLog::trim(const DoutPrefixProvider *dpp, int shard_id, const real
   return svc.cls->timelog.trim(dpp, oid, from_time, end_time, start_marker,
                                end_marker, nullptr, y);
 }
-  
-int RGWMetadataLog::lock_exclusive(const DoutPrefixProvider *dpp, int shard_id, timespan duration, string& zone_id, string& owner_id) {
-  string oid;
-  get_shard_oid(shard_id, oid);
-
-  return svc.cls->lock.lock_exclusive(dpp, svc.zone->get_zone_params().log_pool, oid, duration, zone_id, owner_id);
-}
-
-int RGWMetadataLog::unlock(const DoutPrefixProvider *dpp, int shard_id, string& zone_id, string& owner_id) {
-  string oid;
-  get_shard_oid(shard_id, oid);
-
-  return svc.cls->lock.unlock(dpp, svc.zone->get_zone_params().log_pool, oid, zone_id, owner_id);
-}
 
 void RGWMetadataLog::mark_modified(int shard_id)
 {

--- a/src/rgw/driver/rados/rgw_object_expirer_core.cc
+++ b/src/rgw/driver/rados/rgw_object_expirer_core.cc
@@ -284,6 +284,24 @@ void RGWObjectExpirer::trim_chunk(const DoutPrefixProvider *dpp,
   return;
 }
 
+static int lock_shard(const DoutPrefixProvider* dpp, optional_yield y,
+                      librados::IoCtx& ioctx, const std::string& oid,
+                      rados::cls::lock::Lock& lock)
+{
+  librados::ObjectWriteOperation op;
+  lock.lock_exclusive(&op);
+  return rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
+}
+
+static int unlock_shard(const DoutPrefixProvider* dpp, optional_yield y,
+                        librados::IoCtx& ioctx, const std::string& oid,
+                        rados::cls::lock::Lock& lock)
+{
+  librados::ObjectWriteOperation op;
+  lock.unlock(&op);
+  return rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
+}
+
 bool RGWObjectExpirer::process_single_shard(const DoutPrefixProvider *dpp, 
                                             const string& shard,
                                             const utime_t& last_run,
@@ -301,12 +319,13 @@ bool RGWObjectExpirer::process_single_shard(const DoutPrefixProvider *dpp,
   utime_t end = ceph_clock_now();
   end += max_secs;
 
+  librados::IoCtx& ioctx = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->objexp_pool_ctx;
   rados::cls::lock::Lock l(objexp_lock_name);
 
   utime_t time(max_secs, 0);
   l.set_duration(time);
 
-  int ret = l.lock_exclusive(&static_cast<rgw::sal::RadosStore*>(driver)->getRados()->objexp_pool_ctx, shard);
+  int ret = lock_shard(dpp, y, ioctx, shard, l);
   if (ret == -EBUSY) { /* already locked by another processor */
     ldpp_dout(dpp, 5) << __func__ << "(): failed to acquire lock on " << shard << dendl;
     return false;
@@ -342,7 +361,7 @@ bool RGWObjectExpirer::process_single_shard(const DoutPrefixProvider *dpp,
     marker = out_marker;
   } while (truncated);
 
-  l.unlock(&static_cast<rgw::sal::RadosStore*>(driver)->getRados()->objexp_pool_ctx, shard);
+  std::ignore = unlock_shard(dpp, y, ioctx, shard, l);
   return done;
 }
 

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1610,7 +1610,8 @@ public:
 
 
   int cls_obj_usage_log_add(const DoutPrefixProvider *dpp, const std::string& oid, rgw_usage_log_info& info, optional_yield y);
-  int cls_obj_usage_log_read(const DoutPrefixProvider *dpp, const std::string& oid, const std::string& user, const std::string& bucket, uint64_t start_epoch,
+  int cls_obj_usage_log_read(const DoutPrefixProvider *dpp, optional_yield y,
+                             const std::string& oid, const std::string& user, const std::string& bucket, uint64_t start_epoch,
                              uint64_t end_epoch, uint32_t max_entries, std::string& read_iter,
 			     std::map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated);
   int cls_obj_usage_log_trim(const DoutPrefixProvider *dpp, const std::string& oid, const std::string& user, const std::string& bucket, uint64_t start_epoch,

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1277,7 +1277,7 @@ int RGWBucketReshard::execute(int num_shards,
   auto unlock = make_scope_guard([this] { reshard_lock.unlock(); });
 
   if (reshard_log) {
-    ret = reshard_log->update(dpp, bucket_info, initiator, y);
+    ret = reshard_log->update(dpp, y, bucket_info.bucket, initiator);
     if (ret < 0) {
       return ret;
     }
@@ -1396,21 +1396,19 @@ int RGWReshard::add(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry,
   return 0;
 }
 
-int RGWReshard::update(const DoutPrefixProvider *dpp,
-		       const RGWBucketInfo& bucket_info,
-		       const cls_rgw_reshard_initiator initiator,
-		       optional_yield y)
+int RGWReshard::update(const DoutPrefixProvider* dpp,
+		       optional_yield y,
+		       const rgw_bucket& bucket,
+		       cls_rgw_reshard_initiator initiator)
 {
   cls_rgw_reshard_entry entry;
-  entry.bucket_name = bucket_info.bucket.name;
-  entry.bucket_id = bucket_info.bucket.bucket_id;
-  entry.tenant = bucket_info.bucket.tenant;
-  entry.initiator = initiator;
 
-  int ret = get(dpp, entry);
+  int ret = get(dpp, y, bucket, entry);
   if (ret < 0) {
     return ret;
   }
+
+  entry.initiator = initiator;
 
   ret = add(dpp, entry, y);
   if (ret < 0) {
@@ -1422,37 +1420,54 @@ int RGWReshard::update(const DoutPrefixProvider *dpp,
 }
 
 
-int RGWReshard::list(const DoutPrefixProvider *dpp, int logshard_num, string& marker, uint32_t max, std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated)
+int RGWReshard::list(const DoutPrefixProvider *dpp, optional_yield y,
+                     int logshard_num, string& marker, uint32_t max,
+                     std::list<cls_rgw_reshard_entry>& entries,
+                     bool *is_truncated)
 {
   string logshard_oid;
 
   get_logshard_oid(logshard_num, &logshard_oid);
 
-  int ret = cls_rgw_reshard_list(store->getRados()->reshard_pool_ctx, logshard_oid, marker, max, entries, is_truncated);
+  bufferlist bl;
+  librados::ObjectReadOperation op;
+  cls_rgw_reshard_list(op, marker, max, bl);
 
+  int ret = rgw_rados_operate(dpp, store->getRados()->reshard_pool_ctx,
+                              logshard_oid, std::move(op), nullptr, y);
   if (ret == -ENOENT) {
     // these shard objects aren't created until we actually write something to
     // them, so treat ENOENT as a successful empty listing
     *is_truncated = false;
-    ret = 0;
-  } else if (ret == -EACCES) {
+    return 0;
+  }
+  if (ret == -EACCES) {
     ldpp_dout(dpp, -1) << "ERROR: access denied to pool " << store->svc()->zone->get_zone_params().reshard_pool
                       << ". Fix the pool access permissions of your client" << dendl;
-  } else if (ret < 0) {
+    return ret;
+  }
+  if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed to list reshard log entries, oid="
         << logshard_oid << " marker=" << marker << " " << cpp_strerror(ret) << dendl;
+    return ret;
   }
 
-  return ret;
+  return cls_rgw_reshard_list_decode(bl, entries, is_truncated);
 }
 
-int RGWReshard::get(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry)
+int RGWReshard::get(const DoutPrefixProvider *dpp, optional_yield y,
+                    const rgw_bucket& bucket, cls_rgw_reshard_entry& entry)
 {
   string logshard_oid;
 
   get_bucket_logshard_oid(entry.tenant, entry.bucket_name, &logshard_oid);
 
-  int ret = cls_rgw_reshard_get(store->getRados()->reshard_pool_ctx, logshard_oid, entry);
+  bufferlist bl;
+  librados::ObjectReadOperation op;
+  cls_rgw_reshard_get(op, bucket.tenant, bucket.name, bl);
+
+  int ret = rgw_rados_operate(dpp, store->getRados()->reshard_pool_ctx,
+                              logshard_oid, std::move(op), nullptr, y);
   if (ret < 0) {
     if (ret != -ENOENT) {
       ldpp_dout(dpp, -1) << "ERROR: failed to get entry from reshard log, oid=" << logshard_oid << " tenant=" << entry.tenant <<
@@ -1461,7 +1476,7 @@ int RGWReshard::get(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry)
     return ret;
   }
 
-  return 0;
+  return cls_rgw_reshard_get_decode(bl, entry);
 }
 
 int RGWReshard::remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entry& entry, optional_yield y)
@@ -1729,7 +1744,7 @@ int RGWReshard::process_single_logshard(int logshard_num, const DoutPrefixProvid
   
   do {
     std::list<cls_rgw_reshard_entry> entries;
-    ret = list(dpp, logshard_num, marker, max_op_entries, entries, &is_truncated);
+    ret = list(dpp, y, logshard_num, marker, max_op_entries, entries, &is_truncated);
     if (ret < 0) {
       ldpp_dout(dpp, 10) << "cannot list all reshards in logshard oid=" <<
 	logshard_oid << dendl;

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -60,9 +60,10 @@ public:
     RGWBucketReshardLock(_store, bucket_info.bucket.get_key(':'), _ephemeral)
   {}
 
-  int lock(const DoutPrefixProvider *dpp);
-  void unlock();
-  int renew(const Clock::time_point&);
+  int lock(const DoutPrefixProvider *dpp, optional_yield y);
+  int unlock(const DoutPrefixProvider *dpp, optional_yield y);
+  int renew(const DoutPrefixProvider *dpp, optional_yield y,
+            const Clock::time_point& now);
 
   bool should_renew(const Clock::time_point& now) const {
     return now >= renew_thresh;
@@ -120,7 +121,7 @@ public:
   int get_status(const DoutPrefixProvider *dpp, optional_yield y,
                  std::list<cls_rgw_bucket_instance_entry> *status);
   int cancel(const DoutPrefixProvider* dpp, optional_yield y);
-  int renew_lock_if_needed(const DoutPrefixProvider *dpp);
+  int renew_lock_if_needed(const DoutPrefixProvider *dpp, optional_yield y);
 
   static int clear_resharding(rgw::sal::RadosStore* store,
 			      RGWBucketInfo& bucket_info,

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -235,10 +235,14 @@ protected:
 public:
   RGWReshard(rgw::sal::RadosStore* _store, bool _verbose = false, std::ostream *_out = nullptr, Formatter *_formatter = nullptr);
   int add(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry, optional_yield y);
-  int update(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const cls_rgw_reshard_initiator initiator, optional_yield y);
-  int get(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry);
+  int update(const DoutPrefixProvider *dpp, optional_yield y,
+             const rgw_bucket& bucket, cls_rgw_reshard_initiator initiator);
+  int get(const DoutPrefixProvider *dpp, optional_yield y,
+          const rgw_bucket& bucket, cls_rgw_reshard_entry& entry);
   int remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entry& entry, optional_yield y);
-  int list(const DoutPrefixProvider *dpp, int logshard_num, std::string& marker, uint32_t max, std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
+  int list(const DoutPrefixProvider *dpp, optional_yield y,
+           int logshard_num, std::string& marker, uint32_t max,
+           std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
 
   /* reshard thread */
   int process_entry(const cls_rgw_reshard_entry& entry, int max_entries,

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -236,92 +236,6 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
   op_ret = meta_log.trim(this, shard_id, {}, {}, {}, marker, y);
 }
 
-void RGWOp_MDLog_Lock::execute(optional_yield y) {
-  string period, shard_id_str, duration_str, locker_id, zone_id;
-  unsigned shard_id;
-
-  op_ret = 0;
-
-  period       = s->info.args.get("period");
-  shard_id_str = s->info.args.get("id");
-  duration_str = s->info.args.get("length");
-  locker_id    = s->info.args.get("locker-id");
-  zone_id      = s->info.args.get("zone-id");
-
-  if (period.empty()) {
-    ldpp_dout(this, 5) << "Missing period id trying to use current" << dendl;
-    period = driver->get_zone()->get_current_period_id();
-  }
-
-  if (period.empty() ||
-      shard_id_str.empty() ||
-      (duration_str.empty()) ||
-      locker_id.empty() ||
-      zone_id.empty()) {
-    ldpp_dout(this, 5) << "Error invalid parameter list" << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
-
-  string err;
-  shard_id = (unsigned)strict_strtol(shard_id_str.c_str(), 10, &err);
-  if (!err.empty()) {
-    ldpp_dout(this, 5) << "Error parsing shard_id param " << shard_id_str << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
-
-  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone, static_cast<rgw::sal::RadosStore*>(driver)->svc()->cls, period};
-  unsigned dur;
-  dur = (unsigned)strict_strtol(duration_str.c_str(), 10, &err);
-  if (!err.empty() || dur <= 0) {
-    ldpp_dout(this, 5) << "invalid length param " << duration_str << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
-  op_ret = meta_log.lock_exclusive(s, shard_id, make_timespan(dur), zone_id,
-				     locker_id);
-  if (op_ret == -EBUSY)
-    op_ret = -ERR_LOCKED;
-}
-
-void RGWOp_MDLog_Unlock::execute(optional_yield y) {
-  string period, shard_id_str, locker_id, zone_id;
-  unsigned shard_id;
-
-  op_ret = 0;
-
-  period       = s->info.args.get("period");
-  shard_id_str = s->info.args.get("id");
-  locker_id    = s->info.args.get("locker-id");
-  zone_id      = s->info.args.get("zone-id");
-
-  if (period.empty()) {
-    ldpp_dout(this, 5) << "Missing period id trying to use current" << dendl;
-    period = driver->get_zone()->get_current_period_id();
-  }
-
-  if (period.empty() ||
-      shard_id_str.empty() ||
-      locker_id.empty() ||
-      zone_id.empty()) {
-    ldpp_dout(this, 5) << "Error invalid parameter list" << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
-
-  string err;
-  shard_id = (unsigned)strict_strtol(shard_id_str.c_str(), 10, &err);
-  if (!err.empty()) {
-    ldpp_dout(this, 5) << "Error parsing shard_id param " << shard_id_str << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
-
-  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone, static_cast<rgw::sal::RadosStore*>(driver)->svc()->cls, period};
-  op_ret = meta_log.unlock(s, shard_id, zone_id, locker_id);
-}
-
 void RGWOp_MDLog_Notify::execute(optional_yield y) {
 #define LARGE_ENOUGH_BUF (128 * 1024)
 
@@ -1273,11 +1187,7 @@ RGWOp *RGWHandler_Log::op_post() {
   }
 
   if (type.compare("metadata") == 0) {
-    if (s->info.args.exists("lock"))
-      return new RGWOp_MDLog_Lock;
-    else if (s->info.args.exists("unlock"))
-      return new RGWOp_MDLog_Unlock;
-    else if (s->info.args.exists("notify"))
+    if (s->info.args.exists("notify"))
       return new RGWOp_MDLog_Notify;
   } else if (type.compare("data") == 0) {
     if (s->info.args.exists("notify")) {

--- a/src/rgw/driver/rados/rgw_rest_log.h
+++ b/src/rgw/driver/rados/rgw_rest_log.h
@@ -147,34 +147,6 @@ public:
   }
 };
 
-class RGWOp_MDLog_Lock : public RGWRESTOp {
-public:
-  RGWOp_MDLog_Lock() {}
-  ~RGWOp_MDLog_Lock() override {}
-
-  int check_caps(const RGWUserCaps& caps) override {
-    return caps.check_cap("mdlog", RGW_CAP_WRITE);
-  }
-  void execute(optional_yield y) override;
-  const char* name() const override {
-    return "lock_mdlog_object";
-  }
-};
-
-class RGWOp_MDLog_Unlock : public RGWRESTOp {
-public:
-  RGWOp_MDLog_Unlock() {}
-  ~RGWOp_MDLog_Unlock() override {}
-
-  int check_caps(const RGWUserCaps& caps) override {
-    return caps.check_cap("mdlog", RGW_CAP_WRITE);
-  }
-  void execute(optional_yield y) override;
-  const char* name() const override {
-    return "unlock_mdlog_object";
-  }
-};
-
 class RGWOp_MDLog_Notify : public RGWRESTOp {
 public:
   RGWOp_MDLog_Notify() {}

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -4706,8 +4706,10 @@ RadosRestoreSerializer::RadosRestoreSerializer(RadosStore* store, const std::str
 
 int RadosRestoreSerializer::try_lock(const DoutPrefixProvider *dpp, utime_t dur, optional_yield y)
 {
+  librados::ObjectWriteOperation op;
   lock.set_duration(dur);
-  return lock.lock_exclusive((librados::IoCtx*)(&ioctx), oid);
+  lock.lock_exclusive(&op);
+  return rgw_rados_operate(dpp, ioctx, oid, std::move(op), y);
 }
 
 int RadosRestoreSerializer::unlock(const DoutPrefixProvider *dpp, optional_yield y)

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8807,7 +8807,8 @@ next:
       std::string marker;
       do {
 	std::list<cls_rgw_reshard_entry> entries;
-        ret = reshard.list(dpp(), i, marker, max_entries - count, entries, &is_truncated);
+        ret = reshard.list(dpp(), null_yield, i, marker, max_entries - count,
+                           entries, &is_truncated);
         if (ret < 0) {
           cerr << "Error listing resharding buckets: " << cpp_strerror(-ret) << std::endl;
           return ret;

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -138,8 +138,6 @@ public:
   int trim(const DoutPrefixProvider *dpp, int shard_id, const real_time& from_time, const real_time& end_time, const std::string& start_marker, const std::string& end_marker, optional_yield y);
   int get_info(const DoutPrefixProvider *dpp, int shard_id, RGWMetadataLogInfo *info, optional_yield y);
   int get_info_async(const DoutPrefixProvider *dpp, int shard_id, RGWMetadataLogInfoCompletion *completion);
-  int lock_exclusive(const DoutPrefixProvider *dpp, int shard_id, timespan duration, std::string&zone_id, std::string& owner_id);
-  int unlock(const DoutPrefixProvider *dpp, int shard_id, std::string& zone_id, std::string& owner_id);
 
   int update_shards(std::list<int>& shards);
 

--- a/src/rgw/services/svc_cls.cc
+++ b/src/rgw/services/svc_cls.cc
@@ -177,12 +177,20 @@ int RGWSI_Cls::MFA::otp_get_current_time(const DoutPrefixProvider *dpp, const rg
     return r;
   }
 
-  r = rados::cls::otp::OTP::get_current_time(ref.ioctx, ref.obj.oid, result);
+  librados::ObjectReadOperation op;
+  bufferlist bl;
+  int rval = 0;
+  rados::cls::otp::get_current_time(op, bl, rval);
+
+  r = rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, std::move(op), nullptr, y);
   if (r < 0) {
     return r;
   }
+  if (rval < 0) {
+    return rval;
+  }
 
-  return 0;
+  return rados::cls::otp::get_current_time_decode(bl, *result);
 }
 
 int RGWSI_Cls::MFA::set_mfa(const DoutPrefixProvider *dpp, const string& oid, const list<rados::cls::otp::otp_info_t>& entries,

--- a/src/rgw/services/svc_cls.h
+++ b/src/rgw/services/svc_cls.h
@@ -126,26 +126,7 @@ public:
              optional_yield y);
   } timelog;
 
-  class Lock : public ClsSubService {
-    int init_obj(const std::string& oid, rgw_rados_ref& obj);
-    public:
-    Lock(CephContext *cct): ClsSubService(cct) {}
-    int lock_exclusive(const DoutPrefixProvider *dpp,
-                       const rgw_pool& pool,
-                       const std::string& oid,
-                       timespan& duration,
-                       std::string& zone_id,
-                       std::string& owner_id,
-                       std::optional<std::string> lock_name = std::nullopt);
-    int unlock(const DoutPrefixProvider *dpp,
-               const rgw_pool& pool,
-               const std::string& oid,
-               std::string& zone_id,
-               std::string& owner_id,
-               std::optional<std::string> lock_name = std::nullopt);
-  } lock;
-
-  RGWSI_Cls(CephContext *cct): RGWServiceInstance(cct), mfa(cct), timelog(cct), lock(cct) {}
+  RGWSI_Cls(CephContext *cct): RGWServiceInstance(cct), mfa(cct), timelog(cct) {}
 
   void init(RGWSI_Zone *_zone_svc, librados::Rados* rados_) {
     rados = rados_;
@@ -153,7 +134,6 @@ public:
 
     mfa.init(this);
     timelog.init(this);
-    lock.init(this);
   }
 
   int do_start(optional_yield, const DoutPrefixProvider *dpp) override;

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -1025,6 +1025,28 @@ auto gen_usage_log_info(std::string payer, std::string bucket, int total_usage_e
   return info;
 }
 
+static int usage_log_read(librados::IoCtx& io_ctx, const std::string& oid,
+                          const std::string& user, const std::string& bucket,
+                          uint64_t start_epoch, uint64_t end_epoch,
+                          uint32_t max_entries, std::string& read_iter,
+                          std::map<rgw_user_bucket, rgw_usage_log_entry>& usage,
+                          bool* truncated)
+{
+  librados::ObjectReadOperation op;
+  bufferlist bl;
+  int rval = 0;
+  cls_rgw_usage_log_read(op, user, bucket, start_epoch, end_epoch,
+                         max_entries, read_iter, bl, rval);
+  int ret = io_ctx.operate(oid, &op, nullptr);
+  if (ret < 0) {
+    return ret;
+  }
+  if (rval < 0) {
+    return rval;
+  }
+  return cls_rgw_usage_log_read_decode(bl, read_iter, usage, truncated);
+}
+
 // Copied from cls_rgw.cc in order to populate usage logs with old keys
 static void usage_record_name_by_time(uint64_t epoch, const std::string& user, const std::string& bucket, std::string& key)
 {
@@ -1100,19 +1122,19 @@ TEST_F(cls_rgw, usage_key_transition)
   string read_iter;
   map <rgw_user_bucket, rgw_usage_log_entry> usage, usage2, usage3;
   bool truncated;
-  int ret = cls_rgw_usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage, &truncated);
+  int ret = usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage, &truncated);
   ASSERT_EQ(ret, 0);
   ASSERT_TRUE(truncated);
   ASSERT_TRUE(!read_iter.empty() && read_iter.at(0) == '0'); // Old key;
   ASSERT_EQ(usage.size(), total_usage_entries);
 
-  ret = cls_rgw_usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage2, &truncated);
+  ret = usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage2, &truncated);
   ASSERT_EQ(ret, 0);
   ASSERT_TRUE(truncated); // Still have more left
   ASSERT_TRUE(!read_iter.empty() && read_iter.at(0) == '~'); // New key;
   ASSERT_EQ(usage2.size(), total_usage_entries);
 
-  ret = cls_rgw_usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage3, &truncated);
+  ret = usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage3, &truncated);
   ASSERT_EQ(ret, 0);
   ASSERT_FALSE(truncated); // Nothing left
   ASSERT_TRUE(read_iter.empty()); // Done
@@ -1122,7 +1144,7 @@ TEST_F(cls_rgw, usage_key_transition)
   ASSERT_EQ(ret, 0);
 
   usage.clear();
-  ret = cls_rgw_usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage, &truncated);
+  ret = usage_log_read(ioctx, oid, user, payer, start_epoch, end_epoch, max_entries, read_iter, usage, &truncated);
   ASSERT_EQ(ret, 0);
   ASSERT_FALSE(truncated); // Nothing left
   ASSERT_EQ(usage.size(), 0); // Got nothing
@@ -1153,8 +1175,8 @@ TEST_F(cls_rgw, usage_basic)
   map <rgw_user_bucket, rgw_usage_log_entry> usage, usage2;
   bool truncated;
 
-  int ret = cls_rgw_usage_log_read(ioctx, oid, user, "", start_epoch, end_epoch,
-				   max_entries, read_iter, usage, &truncated);
+  int ret = usage_log_read(ioctx, oid, user, "", start_epoch, end_epoch,
+                           max_entries, read_iter, usage, &truncated);
   // read the entries, and see that we have all the added entries
   ASSERT_EQ(0, ret);
   ASSERT_FALSE(truncated);
@@ -1163,8 +1185,8 @@ TEST_F(cls_rgw, usage_basic)
   // delete and read to assert that we've deleted all the values
   ASSERT_EQ(0, cls_rgw_usage_log_trim(ioctx, oid, "", "", start_epoch, end_epoch));
 
-  ret = cls_rgw_usage_log_read(ioctx, oid, user, "", start_epoch, end_epoch,
-			       max_entries, read_iter, usage2, &truncated);
+  ret = usage_log_read(ioctx, oid, user, "", start_epoch, end_epoch,
+                       max_entries, read_iter, usage2, &truncated);
   ASSERT_EQ(0, ret);
   ASSERT_EQ(0u, usage2.size());
 
@@ -1178,16 +1200,16 @@ TEST_F(cls_rgw, usage_basic)
   info = gen_usage_log_info(payer, bucket2, 100);
   cls_rgw_usage_log_add(op, info);
   ASSERT_EQ(0, ioctx.operate(oid, &op));
-  ret = cls_rgw_usage_log_read(ioctx, oid, "", bucket1, start_epoch, end_epoch,
-                              max_entries, read_iter, usage2, &truncated);
+  ret = usage_log_read(ioctx, oid, "", bucket1, start_epoch, end_epoch,
+                       max_entries, read_iter, usage2, &truncated);
   ASSERT_EQ(0, ret);
   ASSERT_EQ(100u, usage2.size());
 
   // delete and read to assert that bucket option is valid for usage trim
   ASSERT_EQ(0, cls_rgw_usage_log_trim(ioctx, oid, "", bucket1, start_epoch, end_epoch));
 
-  ret = cls_rgw_usage_log_read(ioctx, oid, "", bucket1, start_epoch, end_epoch,
-                               max_entries, read_iter, usage2, &truncated);
+  ret = usage_log_read(ioctx, oid, "", bucket1, start_epoch, end_epoch,
+                       max_entries, read_iter, usage2, &truncated);
   ASSERT_EQ(0, ret);
   ASSERT_EQ(0u, usage2.size());
   ASSERT_EQ(0, cls_rgw_usage_log_trim(ioctx, oid, "", bucket2, start_epoch, end_epoch));
@@ -1226,8 +1248,8 @@ TEST_F(cls_rgw, usage_clear)
   bool truncated;
   uint64_t start_epoch{0}, end_epoch{(uint64_t) -1};
   string read_iter;
-  ret = cls_rgw_usage_log_read(ioctx, oid, user, "", start_epoch, end_epoch,
-			       max_entries, read_iter, usage, &truncated);
+  ret = usage_log_read(ioctx, oid, user, "", start_epoch, end_epoch,
+                       max_entries, read_iter, usage, &truncated);
   ASSERT_EQ(0, ret);
   ASSERT_EQ(0u, usage.size());
 }


### PR DESCRIPTION
this CLS_CLIENT_HIDE_IOCTX define from https://github.com/ceph/ceph/pull/28569 wasn't applying to the rgw_common target, so several blocking cls calls there went unnoticed

add/use ObjectOperation overloads for those and submit them with rgw_rados_operate()

finally, move the CLS_CLIENT_HIDE_IOCTX define to the rgw_common target so it applies to all rgw targets


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
