### PR TITLE
cmake: use find_program(REQUIRED) to fail early on missing programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,10 +76,8 @@ if(WITH_CCACHE)
   if(CMAKE_C_COMPILER_LAUNCHER OR CMAKE_CXX_COMPILER_LAUNCHER)
     message(WARNING "Compiler launcher already set. stop configuring ccache")
   else()
-    find_program(CCACHE_EXECUTABLE ccache)
-    if(NOT CCACHE_EXECUTABLE)
-      message(FATAL_ERROR "Can't find ccache. Is it installed?")
-    endif()
+    find_program(CCACHE_EXECUTABLE ccache
+      REQUIRED)
     message(STATUS "Building with ccache: ${CCACHE_EXECUTABLE}, CCACHE_DIR=$ENV{CCACHE_DIR}")
     set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
     set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
@@ -88,10 +86,8 @@ endif(WITH_CCACHE)
 
 option(WITH_SCCACHE "Build with sccache.")
 if(WITH_SCCACHE)
-  find_program(SCCACHE_EXECUTABLE sccache)
-  if(NOT SCCACHE_EXECUTABLE)
-    message(FATAL_ERROR "Can't find sccache. Is it installed?")
-  endif()
+  find_program(SCCACHE_EXECUTABLE sccache
+    REQUIRED)
   if(NOT NINJA_MAX_COMPILE_JOBS)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
       execute_process(
@@ -123,10 +119,8 @@ endif(WITH_SCCACHE)
 option(WITH_MANPAGE "Build man pages." ON)
 if(WITH_MANPAGE)
   find_program(SPHINX_BUILD
-    NAMES sphinx-build sphinx-build-3)
-  if(NOT SPHINX_BUILD)
-    message(FATAL_ERROR "Can't find sphinx-build.")
-  endif(NOT SPHINX_BUILD)
+    NAMES sphinx-build sphinx-build-3
+    REQUIRED)
 endif(WITH_MANPAGE)
 
 include_directories(
@@ -670,10 +664,8 @@ option(WITH_LTTNG "LTTng tracing is enabled" ON)
 if(${WITH_LTTNG})
   find_package(LTTngUST REQUIRED)
   find_program(LTTNG_GEN_TP
-    lttng-gen-tp)
-  if(NOT LTTNG_GEN_TP)
-    message(FATAL_ERROR "Can't find lttng-gen-tp.")
-  endif()
+    lttng-gen-tp
+    REQUIRED)
 endif(${WITH_LTTNG})
 
 option(WITH_OSD_INSTRUMENT_FUNCTIONS OFF)
@@ -808,10 +800,8 @@ include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})
 option(WITH_MGR_DASHBOARD_FRONTEND "Build the mgr/dashboard frontend using `npm`" ON)
 option(WITH_SYSTEM_NPM "Assume that dashboard build tools already installed through packages" OFF)
 if(WITH_SYSTEM_NPM)
-  find_program(NPM_EXECUTABLE npm)
-  if(NOT NPM_EXECUTABLE)
-    message(FATAL_ERROR "Can't find npm.")
-  endif()
+  find_program(NPM_EXECUTABLE npm
+    REQUIRED)
 endif()
 set(DASHBOARD_FRONTEND_LANGS "ALL" CACHE STRING
   "List of comma separated ceph-dashboard frontend languages to build. \

--- a/cmake/modules/FindMake.cmake
+++ b/cmake/modules/FindMake.cmake
@@ -3,10 +3,9 @@ function(find_make make_exe make_cmd)
   #          executable
   # make_cmd the name of the variable whose value will be the command to
   #          used in the generated build script executed by the cmake generator
-  find_program(MAKE_EXECUTABLE NAMES gmake make)
-  if(NOT MAKE_EXECUTABLE)
-    message(FATAL_ERROR "Can't find make")
-  endif()
+  find_program(MAKE_EXECUTABLE
+    NAMES gmake make
+    REQUIRED)
   set(${make_exe} "${MAKE_EXECUTABLE}" PARENT_SCOPE)
   if(CMAKE_MAKE_PROGRAM MATCHES "make")
     # try to inherit command line arguments passed by parent "make" job

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,10 +290,8 @@ endif()
 
 option(ENABLE_COVERAGE "Coverage is enabled" OFF)
 if(${ENABLE_COVERAGE})
-  find_program(HAVE_GCOV gcov)
-  if(NOT HAVE_GCOV)
-    message(FATAL_ERROR "Coverage Enabled but gcov Not Found")
-  endif()
+  find_program(HAVE_GCOV gcov
+    REQUIRED)
   add_compile_options(
     --coverage
     -O0)
@@ -1000,7 +998,8 @@ if(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT)
 
   set(_REFLECTION grpc++_reflection)
   if(CMAKE_CROSSCOMPILING)
-    find_program(_PROTOBUF_PROTOC protoc)
+    find_program(_PROTOBUF_PROTOC protoc
+      REQUIRED)
   else()
     set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
   endif()
@@ -1011,7 +1010,8 @@ if(WITH_NVMEOF_GATEWAY_MONITOR_CLIENT)
   message(STATUS "Using gRPC ${gRPC_VERSION}")
   set(_GRPC_GRPCPP gRPC::grpc++)
   if(CMAKE_CROSSCOMPILING)
-    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+    find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin
+      REQUIRED)
   else()
     set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
   endif()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -1,7 +1,5 @@
-find_program(GPERF gperf)
-if(NOT GPERF)
-  message(FATAL_ERROR "Can't find gperf")
-endif()
+find_program(GPERF gperf
+  REQUIRED)
 
 if(WITH_RADOSGW_BACKTRACE_LOGGING)
   add_definitions(-D_BACKTRACE_LOGGING)


### PR DESCRIPTION
Since upgrading minimum CMake version to 3.22.1 (commit 469d82a1f387f342797636fdfff84f570b22f928), we can now use find_program(REQUIRED) which was introduced in CMake 3.18.

This change replaces manual FATAL_ERROR checks with the REQUIRED option and adds it to programs that are actually needed during the build. This ensures the build fails early during configuration rather than later during compilation when missing programs are invoked.

Changes:
- Replace find_program() + message(FATAL_ERROR) patterns with REQUIRED
- Add REQUIRED to programs that are used during build but previously had no error checking

Reference: https://cmake.org/cmake/help/latest/command/find_program.html





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
