### PR TITLE
squid: test/common: unittest_fault_injector omits unit-main target

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -384,9 +384,8 @@ add_executable(unittest_option test_option.cc)
 target_link_libraries(unittest_option ceph-common GTest::Main)
 add_ceph_unittest(unittest_option)
 
-add_executable(unittest_fault_injector test_fault_injector.cc
-  $<TARGET_OBJECTS:unit-main>)
-target_link_libraries(unittest_fault_injector global)
+add_executable(unittest_fault_injector test_fault_injector.cc)
+target_link_libraries(unittest_fault_injector global GTest::Main)
 add_ceph_unittest(unittest_fault_injector)
 
 add_executable(unittest_blocked_completion test_blocked_completion.cc)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71691

---

backport of https://github.com/ceph/ceph/pull/63822
parent tracker: https://tracker.ceph.com/issues/71600

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh