### PR TITLE
tentacle: rgw/multisite: change HTTP error handling from EIO to ERR_INTERNAL_ERROR

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -286,7 +286,7 @@ public:
         }
 
         if (op_ret < 0) {
-          if (op_ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+          if (op_ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
             ldpp_dout(dpp, 20) << "failed to fetch remote datalog shard info. retry. shard_id=" << shard_id << dendl;
             continue;
           } else {
@@ -389,7 +389,7 @@ public:
         }
 
         if (op_ret < 0) {
-          if (op_ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+          if (op_ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
             ldpp_dout(dpp, 20) << "failed to read remote datalog shard. retry. shard_id=" << shard_id << dendl;
             continue;
           } else {

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4252,7 +4252,7 @@ int RGWRados::stat_remote_obj(const DoutPrefixProvider *dpp,
     ret = conn->complete_request(dpp, in_stream_req, nullptr, &set_mtime, psize,
                                  nullptr, pheaders, y);
     if (ret < 0) {
-      if (ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+      if (ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(dpp, 20) << __func__  << "(): failed to fetch object from remote. retries=" << tries << dendl;
         continue;
       }
@@ -4519,7 +4519,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
     ret = conn->complete_request(rctx.dpp, in_stream_req, &etag, &set_mtime,
                                  &accounted_size, nullptr, nullptr, rctx.y);
     if (ret < 0) {
-      if (ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+      if (ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(rctx.dpp, 20) << __func__ << "(): failed to fetch " << fetched_obj
                                 << " from remote. retries=" << tries << dendl;
         continue;
@@ -4798,7 +4798,7 @@ int RGWRados::copy_obj_to_remote_dest(const DoutPrefixProvider *dpp,
 
     ret = rest_master_conn->complete_request(dpp, out_stream_req, etag, mtime, y);
     if (ret < 0) {
-      if (ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+      if (ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(dpp, 20) << __func__  << "(): failed to put_obj_async_init. retries=" << tries << dendl;
         continue;
       }

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -510,7 +510,7 @@ public:
         }
 
         if (op_ret < 0) {
-          if (op_ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+          if (op_ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
             ldpp_dout(dpp, 20) << "failed to read remote metadata log shard info. retry. shard_id=" << shard_id << dendl;
             continue;
           } else {
@@ -1094,7 +1094,7 @@ public:
         }
 
         if (op_ret < 0) {
-          if (op_ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+          if (op_ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
             ldpp_dout(dpp, 20) << "failed to read remote metadata. retry. section=" << section << " key=" << key << dendl;
             continue;
           } else {
@@ -2440,7 +2440,7 @@ int RGWCloneMetaLogCoroutine::operate(const DoutPrefixProvider *dpp)
           return state_receive_rest_response();
         }
 
-        if (op_ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
+        if (op_ret == -ERR_INTERNAL_ERROR && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
           ldout(cct, 20) << __func__ << ": request IO error. retries=" << tries << dendl;
           continue;
         } else if (op_ret < 0) {
@@ -2547,7 +2547,7 @@ int RGWCloneMetaLogCoroutine::state_send_rest_request(const DoutPrefixProvider *
 int RGWCloneMetaLogCoroutine::state_receive_rest_response()
 {
   op_ret = http_op->wait(sync_env->dpp, &data, null_yield);
-  if (op_ret < 0 && op_ret != -EIO) {
+  if (op_ret < 0 && op_ret != -ERR_INTERNAL_ERROR) {
     error_stream << "http operation failed: " << http_op->to_str() << " status=" << http_op->get_http_status() << std::endl;
     ldpp_dout(sync_env->dpp, 5) << "failed to wait for op, ret=" << op_ret << dendl;
     http_op->put();
@@ -2557,7 +2557,7 @@ int RGWCloneMetaLogCoroutine::state_receive_rest_response()
   http_op->put();
   http_op = NULL;
 
-  if (op_ret == -EIO) {
+  if (op_ret == -ERR_INTERNAL_ERROR) {
     return 0;
   }
 

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -1088,7 +1088,7 @@ int RGWSimpleCoroutine::operate(const DoutPrefixProvider *dpp)
       yield return state_send_request(dpp);
       yield return state_request_complete();
 
-      if (op_ret == -EIO && tries < max_eio_retries - 1) {
+      if (op_ret == -ERR_INTERNAL_ERROR && tries < max_eio_retries - 1) {
         ldout(cct, 20) << "request IO error. retries=" << tries << dendl;
         continue;
       } else if (op_ret < 0) {
@@ -1129,7 +1129,7 @@ int RGWSimpleCoroutine::state_send_request(const DoutPrefixProvider *dpp)
 int RGWSimpleCoroutine::state_request_complete()
 {
   op_ret = request_complete();
-  if (op_ret < 0 && op_ret != -EIO) {
+  if (op_ret < 0 && op_ret != -ERR_INTERNAL_ERROR) {
     call_cleanup();
     return set_state(RGWCoroutine_Error, op_ret);
   }

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -357,7 +357,7 @@ public:
   int wait(const DoutPrefixProvider* dpp, bufferlist *pbl, optional_yield y) {
     int ret = req.wait(dpp, y);
     if (ret < 0) {
-      if (ret == -EIO) {
+      if (ret == -ERR_INTERNAL_ERROR) {
         conn->set_url_unconnectable(req.get_url_orig());
       }
       return ret;
@@ -413,7 +413,7 @@ int RGWRESTReadResource::wait(const DoutPrefixProvider* dpp, T *dest,
 {
   int ret = req.wait(dpp, y);
   if (ret < 0) {
-    if (ret == -EIO) {
+    if (ret == -ERR_INTERNAL_ERROR) {
       conn->set_url_unconnectable(req.get_url_orig());
     }
     return ret;
@@ -488,7 +488,7 @@ public:
     int ret = req.wait(dpp, y);
     *pbl = bl;
 
-    if (ret == -EIO) {
+    if (ret == -ERR_INTERNAL_ERROR) {
       conn->set_url_unconnectable(req.get_url_orig());
     }
 
@@ -509,7 +509,7 @@ int RGWRESTSendResource::wait(const DoutPrefixProvider* dpp, T *dest,
                               optional_yield y, E *err_result)
 {
   int ret = req.wait(dpp, y);
-  if (ret == -EIO) {
+  if (ret == -ERR_INTERNAL_ERROR) {
     conn->set_url_unconnectable(req.get_url_orig());
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71699

---

backport of https://github.com/ceph/ceph/pull/63303
parent tracker: https://tracker.ceph.com/issues/71337

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh