### PR TITLE
deb: use glob match to support systemd unit dir changes

### DIFF
--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -1,5 +1,5 @@
 etc/init.d/ceph
-lib/systemd/system/ceph-crash.service
+{usr/,}lib/systemd/system/ceph-crash.service
 usr/bin/ceph-crash
 usr/bin/ceph-debugpack
 usr/bin/ceph-run

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -4,8 +4,8 @@ etc/bash_completion.d/ceph
 etc/bash_completion.d/rados
 etc/bash_completion.d/radosgw-admin
 etc/bash_completion.d/rbd
-lib/systemd/system/ceph.target
-lib/systemd/system/rbdmap.service
+{usr/,}lib/systemd/system/ceph.target
+{usr/,}lib/systemd/system/rbdmap.service
 usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf

--- a/debian/ceph-exporter.install
+++ b/debian/ceph-exporter.install
@@ -1,2 +1,2 @@
-lib/systemd/system/ceph-exporter*
+{usr/,}lib/systemd/system/ceph-exporter*
 usr/bin/ceph-exporter

--- a/debian/ceph-fuse.install
+++ b/debian/ceph-fuse.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-fuse*
+{usr/,}lib/systemd/system/ceph-fuse*
 usr/bin/ceph-fuse
 usr/sbin/mount.fuse.ceph sbin
 usr/share/man/man8/ceph-fuse.8

--- a/debian/ceph-immutable-object-cache.install
+++ b/debian/ceph-immutable-object-cache.install
@@ -1,3 +1,3 @@
-lib/systemd/system/ceph-immutable-object-cache*
+{usr/,}lib/systemd/system/ceph-immutable-object-cache*
 usr/bin/ceph-immutable-object-cache
 usr/share/man/man8/ceph-immutable-object-cache.8

--- a/debian/ceph-mds.install
+++ b/debian/ceph-mds.install
@@ -1,3 +1,3 @@
-lib/systemd/system/ceph-mds*
+{usr/,}lib/systemd/system/ceph-mds*
 usr/bin/ceph-mds
 usr/share/man/man8/ceph-mds.8

--- a/debian/ceph-mgr.install
+++ b/debian/ceph-mgr.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-mgr*
+{usr/,}lib/systemd/system/ceph-mgr*
 usr/bin/ceph-mgr
 usr/share/ceph/mgr/mgr_module.*
 usr/share/ceph/mgr/mgr_util.*

--- a/debian/ceph-mon.install
+++ b/debian/ceph-mon.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-mon*
+{usr/,}lib/systemd/system/ceph-mon*
 usr/bin/ceph-mon
 usr/bin/ceph-monstore-tool
 usr/share/man/man8/ceph-mon.8

--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -1,6 +1,6 @@
 #! /usr/bin/dh-exec
 
-lib/systemd/system/ceph-osd*
+{usr/,}lib/systemd/system/ceph-osd*
 usr/bin/ceph-bluestore-tool
 usr/bin/ceph-clsinfo
 usr/bin/ceph-erasure-code-tool

--- a/debian/ceph-volume.install
+++ b/debian/ceph-volume.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-volume@.service
+{usr/,}lib/systemd/system/ceph-volume@.service
 usr/lib/python*/dist-packages/ceph_volume/*
 usr/lib/python*/dist-packages/ceph_volume-*
 usr/sbin/ceph-volume

--- a/debian/cephfs-mirror.install
+++ b/debian/cephfs-mirror.install
@@ -1,3 +1,3 @@
-lib/systemd/system/cephfs-mirror*
+{usr/,}lib/systemd/system/cephfs-mirror*
 usr/bin/cephfs-mirror
 usr/share/man/man8/cephfs-mirror.8

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-radosgw*
+{usr/,}lib/systemd/system/ceph-radosgw*
 usr/bin/ceph-diff-sorted
 usr/bin/radosgw
 usr/bin/radosgw-es

--- a/debian/rbd-mirror.install
+++ b/debian/rbd-mirror.install
@@ -1,3 +1,3 @@
-lib/systemd/system/ceph-rbd-mirror*
+{usr/,}lib/systemd/system/ceph-rbd-mirror*
 usr/bin/rbd-mirror
 usr/share/man/man8/rbd-mirror.8


### PR DESCRIPTION
Ubuntu changed the systemd unit directory location between releases:
- Jammy (22.04): /lib/systemd/system
- Noble (24.04): /usr/lib/systemd/system

To maintain compatibility across both versions, update .install files to use brace expansion pattern {usr/,}lib/systemd/system/<service>.

This pattern works because dh_install uses bsd_glob() with GLOB_CSH flags, which expands braces and matches files in both locations depending on where CMakeLists.txt actually installed them.

Fixes installation issues when building packages on Noble while maintaining backward compatibility with Jammy builds.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
