### PR TITLE
mgr/telemetry: add add basic_mgr_modules_list collection

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -231,6 +231,7 @@ To list all collections, run the following command:
   NAME                            STATUS                                               DESC
   basic_base                      NOT REPORTING: NOT OPTED-IN                          Basic information about the cluster (capacity, number and type of daemons, version, etc.)
   basic_mds_metadata              NOT REPORTING: NOT OPTED-IN                          MDS metadata
+  basic_mgr_modules_list          NOT REPORTING: NOT OPTED-IN                          The always_on_modules, force_disabled_modules and enabled_modules of mgr                     
   basic_pool_flags                NOT REPORTING: NOT OPTED-IN                          Per-pool flags
   basic_pool_options_bluestore    NOT REPORTING: NOT OPTED-IN                          Per-pool bluestore config options
   basic_pool_usage                NOT REPORTING: NOT OPTED-IN                          Default pool application and usage statistics

--- a/qa/workunits/test_telemetry_reef_x.sh
+++ b/qa/workunits/test_telemetry_reef_x.sh
@@ -20,7 +20,7 @@ REPORTED_COLLECTIONS=$(ceph telemetry collection ls)
 NUM_REPORTED_COLLECTIONS=$(echo "$REPORTED_COLLECTIONS" | awk '/^NAME/ {flag=1; next} flag' | wc -l)
 KNOWN_COLLECTIONS=("basic_base" "basic_mds_metadata" "basic_pool_flags" "basic_pool_options_bluestore"
 	           "basic_pool_usage" "basic_rook_v01" "basic_usage_by_class" "crash_base" "device_base"
-		   "ident_base" "perf_memory_metrics" "perf_perf" "basic_stretch_cluster")
+		   "ident_base" "perf_memory_metrics" "perf_perf" "basic_stretch_cluster" "basic_mgr_modules_list")
 
 if ! [[ $NUM_REPORTED_COLLECTIONS == "${#KNOWN_COLLECTIONS[@]}" ]];
 then

--- a/qa/workunits/test_telemetry_squid_x.sh
+++ b/qa/workunits/test_telemetry_squid_x.sh
@@ -20,7 +20,7 @@ REPORTED_COLLECTIONS=$(ceph telemetry collection ls)
 NUM_REPORTED_COLLECTIONS=$(echo "$REPORTED_COLLECTIONS" | awk '/^NAME/ {flag=1; next} flag' | wc -l)
 KNOWN_COLLECTIONS=("basic_base" "basic_mds_metadata" "basic_pool_flags" "basic_pool_options_bluestore"
 	           "basic_pool_usage" "basic_rook_v01" "basic_usage_by_class" "crash_base" "device_base"
-		   "ident_base" "perf_memory_metrics" "perf_perf" "basic_stretch_cluster")
+		   "ident_base" "perf_memory_metrics" "perf_perf" "basic_stretch_cluster" "basic_mgr_modules_list")
 
 if ! [[ $NUM_REPORTED_COLLECTIONS == "${#KNOWN_COLLECTIONS[@]}" ]];
 then

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -73,6 +73,7 @@ class Collection(str, enum.Enum):
     basic_pool_options_bluestore = 'basic_pool_options_bluestore'
     basic_pool_flags = 'basic_pool_flags'
     basic_stretch_cluster = 'basic_stretch_cluster'
+    basic_mgr_modules_list = 'basic_mgr_modules_list'
 
 MODULE_COLLECTION : List[Dict] = [
     {
@@ -150,6 +151,12 @@ MODULE_COLLECTION : List[Dict] = [
     {
         "name": Collection.basic_stretch_cluster,
         "description": "Stretch mode information for stretch clusters",
+        "channel": "basic",
+        "nag": False
+    },
+    {
+        "name": Collection.basic_mgr_modules_list,
+        "description": "The always_on_modules, force_disabled_modules and enabled_modules of mgr",
         "channel": "basic",
         "nag": False
     },
@@ -1031,6 +1038,7 @@ class Module(MgrModule):
         if 'basic' in channels:
             mon_map = self.get('mon_map')
             osd_map = self.get('osd_map')
+            mgr_map = self.get('mgr_map')
             service_map = self.get('service_map')
             fs_map = self.get('fs_map')
             df = self.get('df')
@@ -1350,6 +1358,17 @@ class Module(MgrModule):
                     'recovering_stretch_mode': stretch_mode.get("recovering_stretch_mode", {}),
                     'stretch_mode_bucket': stretch_mode.get("stretch_mode_bucket", {}),
                 }
+            
+            # MGR Modules
+            if self.is_enabled_collection(Collection.basic_mgr_modules_list):
+                always_on_modules_all_releases = mgr_map.get("always_on_modules", {})
+                always_on_modules = always_on_modules_all_releases.get(self.release_name, {})
+                force_disabled_modules = mgr_map.get("force_disabled_modules", {})
+                enabled_modules = mgr_map.get("modules", {})
+
+                report['always_on_modules'] = always_on_modules
+                report['force_disabled_modules'] = force_disabled_modules
+                report['enabled_modules'] = enabled_modules
 
         if 'crash' in channels:
             report['crashes'] = self.gather_crashinfo()


### PR DESCRIPTION
Closes: https://tracker.ceph.com/issues/71483

Add the information about the `always_on_modules`, `enabled_modules` and `forced_enabled_modules` of a mgr. This is added via the `basic_mgr_modules_list` collection to the basic channel.

This collection will help in answering the question "How many users have X modules enabled" more easily.

The newly added `basic_mgr_modules_list`  collection in the basic channel looks like:
```json

{
    "always_on_modules": [
        "balancer",
        "crash",
        "devicehealth",
        "orchestrator",
        "pg_autoscaler",
        "progress",
        "rbd_support",
        "status",
        "telemetry",
        "volumes"
    ],
    "enabled_modules": [
        "iostat",
        "nfs"
    ],
    "force_disabled_modules": {}
}
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
