### PR TITLE
tentacle: build: Fix opentelemetry-cpp build failure on Noble

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,7 +65,7 @@
 	url = https://github.com/JuliaStrings/utf8proc
 [submodule "src/jaegertracing/opentelemetry-cpp"]
 	path = src/jaegertracing/opentelemetry-cpp
-	url = https://github.com/open-telemetry/opentelemetry-cpp.git
+	url = https://github.com/ceph/opentelemetry-cpp.git
 [submodule "src/qatlib"]
 	path = src/qatlib
 	url = https://github.com/intel/qatlib.git


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71673

---

backport of https://github.com/ceph/ceph/pull/62616
parent tracker: https://tracker.ceph.com/issues/62804

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh