### PR TITLE
tentacle: deb: use glob match to support systemd unit dir changes

### DIFF
--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -1,5 +1,5 @@
 etc/init.d/ceph
-lib/systemd/system/ceph-crash.service
+{usr/,}lib/systemd/system/ceph-crash.service
 usr/bin/ceph-crash
 usr/bin/ceph-debugpack
 usr/bin/ceph-run

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -4,8 +4,8 @@ etc/bash_completion.d/ceph
 etc/bash_completion.d/rados
 etc/bash_completion.d/radosgw-admin
 etc/bash_completion.d/rbd
-lib/systemd/system/ceph.target
-lib/systemd/system/rbdmap.service
+{usr/,}lib/systemd/system/ceph.target
+{usr/,}lib/systemd/system/rbdmap.service
 usr/bin/ceph
 usr/bin/ceph-authtool
 usr/bin/ceph-conf

--- a/debian/ceph-exporter.install
+++ b/debian/ceph-exporter.install
@@ -1,2 +1,2 @@
-lib/systemd/system/ceph-exporter*
+{usr/,}lib/systemd/system/ceph-exporter*
 usr/bin/ceph-exporter

--- a/debian/ceph-fuse.install
+++ b/debian/ceph-fuse.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-fuse*
+{usr/,}lib/systemd/system/ceph-fuse*
 usr/bin/ceph-fuse
 usr/sbin/mount.fuse.ceph sbin
 usr/share/man/man8/ceph-fuse.8

--- a/debian/ceph-immutable-object-cache.install
+++ b/debian/ceph-immutable-object-cache.install
@@ -1,3 +1,3 @@
-lib/systemd/system/ceph-immutable-object-cache*
+{usr/,}lib/systemd/system/ceph-immutable-object-cache*
 usr/bin/ceph-immutable-object-cache
 usr/share/man/man8/ceph-immutable-object-cache.8

--- a/debian/ceph-mds.install
+++ b/debian/ceph-mds.install
@@ -1,3 +1,3 @@
-lib/systemd/system/ceph-mds*
+{usr/,}lib/systemd/system/ceph-mds*
 usr/bin/ceph-mds
 usr/share/man/man8/ceph-mds.8

--- a/debian/ceph-mgr.install
+++ b/debian/ceph-mgr.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-mgr*
+{usr/,}lib/systemd/system/ceph-mgr*
 usr/bin/ceph-mgr
 usr/share/ceph/mgr/mgr_module.*
 usr/share/ceph/mgr/mgr_util.*

--- a/debian/ceph-mon.install
+++ b/debian/ceph-mon.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-mon*
+{usr/,}lib/systemd/system/ceph-mon*
 usr/bin/ceph-mon
 usr/bin/ceph-monstore-tool
 usr/share/man/man8/ceph-mon.8

--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -1,6 +1,6 @@
 #! /usr/bin/dh-exec
 
-lib/systemd/system/ceph-osd*
+{usr/,}lib/systemd/system/ceph-osd*
 usr/bin/ceph-bluestore-tool
 usr/bin/ceph-clsinfo
 usr/bin/ceph-erasure-code-tool

--- a/debian/ceph-volume.install
+++ b/debian/ceph-volume.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-volume@.service
+{usr/,}lib/systemd/system/ceph-volume@.service
 usr/lib/python*/dist-packages/ceph_volume/*
 usr/lib/python*/dist-packages/ceph_volume-*
 usr/sbin/ceph-volume

--- a/debian/cephfs-mirror.install
+++ b/debian/cephfs-mirror.install
@@ -1,3 +1,3 @@
-lib/systemd/system/cephfs-mirror*
+{usr/,}lib/systemd/system/cephfs-mirror*
 usr/bin/cephfs-mirror
 usr/share/man/man8/cephfs-mirror.8

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -1,4 +1,4 @@
-lib/systemd/system/ceph-radosgw*
+{usr/,}lib/systemd/system/ceph-radosgw*
 usr/bin/ceph-diff-sorted
 usr/bin/radosgw
 usr/bin/radosgw-es

--- a/debian/rbd-mirror.install
+++ b/debian/rbd-mirror.install
@@ -1,3 +1,3 @@
-lib/systemd/system/ceph-rbd-mirror*
+{usr/,}lib/systemd/system/ceph-rbd-mirror*
 usr/bin/rbd-mirror
 usr/share/man/man8/rbd-mirror.8


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71715

---

backport of https://github.com/ceph/ceph/pull/64001
parent tracker: https://tracker.ceph.com/issues/71713

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh