### PR TITLE
rgw/notifications: add support for sharded persistent bucket notifications

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -762,3 +762,11 @@ Relevant tracker: https://tracker.ceph.com/issues/64777
 when decoding, resulting in Linux codes on the wire, and host codes on the receiver.
 All CEPHFS_E* defines have been removed across Ceph (including the Python binding).
 Relevant tracker: https://tracker.ceph.com/issues/64611
+
+* RGW: Persistent bucket notifications will use queues with multiple shards instead of one queue. Number of shards
+can be configured using the `rgw` option `rgw_bucket_persistent_notif_num_shards`. Note that pre-existing topics will continue to function as is, i.e, they are mapped to only one RADOS object.   
+  
+  For more details, see: 
+  https://docs.ceph.com/en/latest/radosgw/notifications/
+
+Relevant tracker: https://tracker.ceph.com/issues/71677

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -85,6 +85,18 @@ which tells the client that it may retry later.
 .. tip:: To minimize the latency added by asynchronous notification, we
    recommended placing the "log" pool on fast media.
 
+Persistent bucket notifications are managed by the following central configuration options:
+
+.. confval:: rgw_bucket_persistent_notif_num_shards
+
+.. note:: When a topic is created during a Ceph upgrade, per-key reordering of notifications may
+   happen on any bucket mapped to that topic.
+   
+.. note:: Persistent topics that were created on a radosgw that does not support sharding, will be treated as a single shard topics
+
+.. tip:: It is also recommended that you avoid modifying or deleting topics created during 
+   upgrades, as this might result in orphan RADOS objects that will not be deleted when the topic is deleted.
+
 
 Topic Management via CLI
 ------------------------

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4511,3 +4511,12 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_bucket_persistent_notif_num_shards
+  type: uint
+  level: advanced
+  desc: Number of shards for a persistent topic.
+  long_desc: Number of shards of persistent topics. The notifications will be sharded by a combination of 
+    the bucket and key name. Changing the number effect only new topics and does not change exiting ones.
+  default: 11
+  services: 
+    - rgw

--- a/src/rgw/driver/rados/rgw_notify.h
+++ b/src/rgw/driver/rados/rgw_notify.h
@@ -47,17 +47,19 @@ struct reservation_t {
   struct topic_t {
     topic_t(const std::string& _configurationId, const rgw_pubsub_topic& _cfg,
             cls_2pc_reservation::id_t _res_id,
-            rgw::notify::EventType _event_type)
+            rgw::notify::EventType _event_type, uint64_t shard_id)
         : configurationId(_configurationId),
           cfg(_cfg),
           res_id(_res_id),
-          event_type(_event_type) {}
+          event_type(_event_type),
+          shard_id(shard_id){}
 
     const std::string configurationId;
     const rgw_pubsub_topic cfg;
     // res_id is reset after topic is committed/aborted
     cls_2pc_reservation::id_t res_id;
     rgw::notify::EventType event_type;
+    uint64_t shard_id; 
   };
 
   const DoutPrefixProvider* const dpp;
@@ -132,7 +134,7 @@ int publish_commit(rgw::sal::Object* obj,
 int publish_abort(reservation_t& reservation);
 
 int get_persistent_queue_stats(const DoutPrefixProvider *dpp, librados::IoCtx &rados_ioctx,
-                               const std::string &queue_name, rgw_topic_stats &stats, optional_yield y);
+                               ShardNamesView shards, rgw_topic_stats &stats, optional_yield y);
 
 }
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -11914,9 +11914,9 @@ next:
     rgw::notify::rgw_topic_stats stats;
     ret = rgw::notify::get_persistent_queue_stats(
         dpp(), ioctx,
-        topic.dest.persistent_queue, stats, null_yield);
+        topic.dest.get_shard_names(), stats, null_yield);
     if (ret < 0) {
-      cerr << "ERROR: could not get persistent queue: " << cpp_strerror(-ret) << std::endl;
+      cerr << "ERROR: could not get persistent queues: " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }
     encode_json("", stats, formatter.get());
@@ -11948,37 +11948,41 @@ next:
     std::string end_marker;
     librados::ObjectReadOperation rop;
     std::vector<cls_queue_entry> queue_entries;
-    bool truncated = true;
+    bool truncated;
     formatter->open_array_section("eventEntries");
-    while (truncated) {
-      bufferlist bl;
-      int rc;
-      cls_2pc_queue_list_entries(rop, marker, max_entries, &bl, &rc);
-      ioctx.operate(topic.dest.persistent_queue, &rop, nullptr);
-      if (rc < 0 ) {
-        cerr << "ERROR: could not list entries from queue. error: " << cpp_strerror(-ret) << std::endl;
-        return -rc;
-      }
-      rc = cls_2pc_queue_list_entries_result(bl, queue_entries, &truncated, end_marker);
-      if (rc < 0) {
-        cerr << "ERROR: failed to parse list entries from queue (skipping). error: " << cpp_strerror(-ret) << std::endl;
-        return -rc;
-      }
 
-      std::for_each(queue_entries.cbegin(), 
-        queue_entries.cend(), 
-        [&formatter](const auto& queue_entry) {
-          rgw::notify::event_entry_t event_entry;
-          bufferlist::const_iterator iter{&queue_entry.data};
-          try {
-            event_entry.decode(iter);
-            encode_json("", event_entry, formatter.get());
-          } catch (const buffer::error& e) {
-            cerr << "ERROR: failed to decode queue entry. error: " << e.what() << std::endl;
-          }
-        });
-      formatter->flush(cout);
-      marker = end_marker;
+    for (const auto& shard_name: topic.dest.get_shard_names()){
+      truncated = true; 
+      marker.clear();
+      while (truncated) {
+        bufferlist bl;
+        int rc;
+        cls_2pc_queue_list_entries(rop, marker, max_entries, &bl, &rc);
+        ioctx.operate(shard_name, &rop, nullptr);
+        if (rc < 0 ) {
+          cerr << "ERROR: could not list entries from queue. error: " << cpp_strerror(-ret) << std::endl;
+          return -rc;
+        }
+        rc = cls_2pc_queue_list_entries_result(bl, queue_entries, &truncated, end_marker);
+        if (rc < 0) {
+          cerr << "ERROR: failed to parse list entries from queue (skipping). error: " << cpp_strerror(-ret) << std::endl;
+          return -rc;
+        }
+        std::for_each(queue_entries.cbegin(), 
+          queue_entries.cend(), 
+          [&formatter](const auto& queue_entry) {
+            rgw::notify::event_entry_t event_entry;
+            bufferlist::const_iterator iter{&queue_entry.data};
+            try {
+              event_entry.decode(iter);
+              encode_json("", event_entry, formatter.get());
+            } catch (const buffer::error& e) {
+              cerr << "ERROR: failed to decode queue entry. error: " << e.what() << std::endl;
+            }
+          });
+        formatter->flush(cout);
+        marker = end_marker;
+      }
     }
     formatter->close_section();
     formatter->flush(cout);

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -21,6 +21,7 @@
 #define dout_subsys ceph_subsys_rgw
 
 static constexpr std::string_view topic_tenant_delim = ":";
+static constexpr std::string_view topic_shard_delim = "."; 
 
 // format and parse topic metadata keys as tenant:name
 std::string get_topic_metadata_key(std::string_view tenant,
@@ -44,6 +45,7 @@ void parse_topic_metadata_key(const std::string& key,
                               std::string& name)
 {
   // expected format: tenant_name:topic_name*
+  // expected format: tenant_name:topic_name.<shard_id>
   auto pos = key.find(topic_tenant_delim);
   if (pos != std::string::npos) {
     tenant = key.substr(0, pos);
@@ -52,6 +54,11 @@ void parse_topic_metadata_key(const std::string& key,
     tenant.clear();
     name = key;
   }
+  //remove shard id if present
+  pos = name.find_last_of(topic_shard_delim);
+  if(pos != std::string::npos){
+    name = name.substr(0, pos);
+  } 
 }
 
 void set_event_id(std::string& id, const std::string& hash, const utime_t& ts) {
@@ -352,6 +359,13 @@ void rgw_pubsub_dest::decode_json(JSONObj* f) {
   JSONDecoder::decode_json("retry_sleep_duration", sleep_dur, f);
   retry_sleep_duration = sleep_dur == DEFAULT_CONFIG ? DEFAULT_GLOBAL_VALUE
                                                      : std::stoul(sleep_dur);
+
+}
+
+ShardNamesView rgw_pubsub_dest::get_shard_names() const {
+  const std::string base_name = persistent_queue; 
+  auto get_shard_name = [base_name](uint64_t i){return i != 0 ? fmt::format("{}.{}", base_name, i) : base_name;};
+  return std::ranges::views::iota(0ul, num_shards) | std::ranges::views::transform(std::function<std::string(uint64_t)>(get_shard_name));
 }
 
 RGWPubSub::RGWPubSub(rgw::sal::Driver* _driver,
@@ -897,12 +911,16 @@ int RGWPubSub::remove_topic_v2(const DoutPrefixProvider* dpp,
   const rgw_pubsub_dest& dest = topic.dest;
   if (!dest.push_endpoint.empty() && dest.persistent &&
       !dest.persistent_queue.empty()) {
-    ret = driver->remove_persistent_topic(dpp, y, dest.persistent_queue);
-    if (ret < 0 && ret != -ENOENT) {
-      ldpp_dout(dpp, 1) << "ERROR: failed to remove queue for "
-          "persistent topic: " << cpp_strerror(ret) << dendl;
-      return ret;
+
+    for(const auto& q: dest.get_shard_names()) {
+      ret = driver->remove_persistent_topic(dpp, y, q);
+      if (ret < 0 && ret != -ENOENT) {
+        ldpp_dout(dpp, 1) << "ERROR: failed to remove shards for "
+            "persistent topic: " << cpp_strerror(ret) << dendl;
+        return ret;
+      }
     }
+    ldpp_dout(dpp, 20) << "Successfully removed " << dest.num_shards << " shards for topic: " + name << dendl;
   }
 
   ret = driver->remove_topic_v2(name, tenant, objv_tracker, y, dpp);
@@ -943,12 +961,15 @@ int RGWPubSub::remove_topic(const DoutPrefixProvider *dpp, const std::string& na
   }
   if (!t->second.dest.push_endpoint.empty() && t->second.dest.persistent &&
       !t->second.dest.persistent_queue.empty()) {
-    ret = driver->remove_persistent_topic(dpp, y, t->second.dest.persistent_queue);
-    if (ret < 0 && ret != -ENOENT) {
-      ldpp_dout(dpp, 1) << "ERROR: failed to remove queue for "
-          "persistent topic: " << cpp_strerror(ret) << dendl;
-      return ret;
-    }
+      for(const auto& q: t->second.dest.get_shard_names()) {
+        ret = driver->remove_persistent_topic(dpp, y, q);
+        if (ret < 0 && ret != -ENOENT) {
+          ldpp_dout(dpp, 1) << "ERROR: failed to remove shards for "
+              "persistent topic: " << cpp_strerror(ret) << dendl;
+          return ret;
+        }
+      }
+      ldpp_dout(dpp, 20) << "Successfully removed " << t->second.dest.num_shards << " shards for topic: " + name << dendl;
   }
   topics.topics.erase(t);
 

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -10,6 +10,7 @@
 #include "rgw_notify_event_type.h"
 #include <boost/container/flat_map.hpp>
 #include "rgw_s3_filter.h"
+#include <ranges>
 
 class XMLObj;
 
@@ -252,6 +253,8 @@ WRITE_CLASS_ENCODER(rgw_pubsub_s3_event)
 // setting a unique ID for an event based on object hash and timestamp
 void set_event_id(std::string& id, const std::string& hash, const utime_t& ts);
 
+using ShardNamesView = std::ranges::transform_view<std::ranges::iota_view<uint64_t, uint64_t>, std::function<std::string(uint64_t)>>; 
+
 struct rgw_pubsub_dest {
   std::string push_endpoint;
   std::string push_endpoint_args;
@@ -263,9 +266,12 @@ struct rgw_pubsub_dest {
   uint32_t time_to_live;
   uint32_t max_retries;
   uint32_t retry_sleep_duration;
+  // naming convention of sharded queues in the 'notif' pool -> persistent_queue, persistent_queue.1, persistent_queue.(num_shards -1)...
+  uint64_t num_shards; //defaults to a single shard for now, for backward compatibility
+
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(7, 1, bl);
+    ENCODE_START(8, 1, bl);
     encode("", bl);
     encode("", bl);
     encode(push_endpoint, bl);
@@ -277,26 +283,30 @@ struct rgw_pubsub_dest {
     encode(max_retries, bl);
     encode(retry_sleep_duration, bl);
     encode(persistent_queue, bl);
+    encode(num_shards, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(7, bl);
+    DECODE_START(8, bl);
     std::string dummy;
     decode(dummy, bl);
     decode(dummy, bl);
     decode(push_endpoint, bl);
     if (struct_v >= 2) {
-        decode(push_endpoint_args, bl);
+      decode(push_endpoint_args, bl);
     }
     if (struct_v >= 3) {
-        decode(arn_topic, bl);
+      decode(arn_topic, bl);
     }
     if (struct_v >= 4) {
-        decode(stored_secret, bl);
+      decode(stored_secret, bl);
     }
     if (struct_v >= 5) {
-        decode(persistent, bl);
+      decode(persistent, bl);
+    }
+    else {
+      num_shards = persistent ? 1 : 0; //defaults to a single shard for backward compatibility
     }
     if (struct_v >= 6) {
       decode(time_to_live, bl);
@@ -305,11 +315,16 @@ struct rgw_pubsub_dest {
     }
     if (struct_v >= 7) {
       decode(persistent_queue, bl);
-    } else if (persistent) {
+    } 
+    else if (persistent) {
       // persistent topics created before v7 did not support tenant namespacing.
       // continue to use 'arn_topic' alone as the queue's rados object name
       persistent_queue = arn_topic;
     }
+    if (struct_v >= 8) { 
+      decode(num_shards, bl);
+    }
+
     DECODE_FINISH(bl);
   }
 
@@ -317,6 +332,9 @@ struct rgw_pubsub_dest {
   void dump_xml(Formatter *f) const;
   std::string to_json_str() const;
   void decode_json(JSONObj* obj);
+
+  // get the names of the shards in the persistent queue
+  ShardNamesView get_shard_names() const; 
 };
 WRITE_CLASS_ENCODER(rgw_pubsub_dest)
 

--- a/src/test/rgw/bucket_notification/api.py
+++ b/src/test/rgw/bucket_notification/api.py
@@ -242,6 +242,12 @@ def admin(args, cluster='noname', **kwargs):
     cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', cluster] + args
     return bash(cmd, **kwargs)
 
+def ceph_admin(args, cluster='noname', **kwargs):
+    """ ceph command """
+    cmd = [test_path + 'test-rgw-call.sh', 'call_ceph', cluster] + args
+    print(' '.join(cmd))
+    return bash(cmd, **kwargs)
+
 def delete_all_topics(conn, tenant, cluster):
     """ delete all topics """
     if tenant == '':
@@ -263,3 +269,7 @@ def delete_all_topics(conn, tenant, cluster):
             for topic in topics_json:
                 admin(['topic', 'rm', '--tenant', tenant, '--topic', topic['name']], cluster)
 
+def set_rgw_config_option(client, option, value, cluster='noname'):
+    """ change a config option """
+    print(f'Setting {option} to {value} for {client} in cluster {cluster}')
+    return ceph_admin(['config', 'set', client, option, str(value)], cluster)

--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -92,6 +92,11 @@ function rgw {
   echo "$mrgw $name $port $ssl_port $rgw_flags $@"
 }
 
+function ceph {
+  [ $# -lt 1 ] && echo "ceph() needs atleast 1 param" && exit 1
+  echo "$mrun $1 ceph"
+}
+
 function init_first_zone {
   [ $# -ne 7 ] && echo "init_first_zone() needs 7 params" && exit 1
 
@@ -173,6 +178,13 @@ function call_rgw_rados {
   x $(rgw_rados $cid) "$@"
 }
 
+function call_ceph {
+  cid=$1
+  shift 1
+  echo $@
+  x $(ceph $cid) "$@"
+}
+
 function get_mstart_parameters {
   [ $# -ne 1 ] && echo "get_mstart_parameters() needs 1 param" && exit 1
   # bash arrays start from zero
@@ -204,4 +216,3 @@ function get_mstart_parameters {
 
   echo "$parameters $VSTART_PARAMETERS"
 }
-


### PR DESCRIPTION
This PR contains changes to add support for sharded persistent bucket notifications. 

Fixes: https://tracker.ceph.com/issues/71677
Signed-off-by: Adarsh Ashokan [dev.9401adarsh@gmail.com](mailto:dev.9401adarsh@gmail.com)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
