### PR TITLE
tentacle: qa: reduce nvmeof thrasher fio to 32 devices from 200 

### DIFF
--- a/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
@@ -1,15 +1,14 @@
-# runs on default nvmeof image (i.e. DEFAULT_NVMEOF_IMAGE)
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: default # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 3
       namespaces_count: 20
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_mtls.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_mtls.yaml
@@ -1,14 +1,14 @@
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: quay.io/ceph/nvmeof:latest # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 3
       namespaces_count: 20
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
       create_mtls_secrets: true
 
 - cephadm.wait_for_service:

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_namespaces.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_namespaces.yaml
@@ -1,14 +1,14 @@
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: quay.io/ceph/nvmeof:latest # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 3
       namespaces_count: 20
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
@@ -1,14 +1,14 @@
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: quay.io/ceph/nvmeof:latest # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 3
       namespaces_count: 20
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0

--- a/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_scalability.yaml
@@ -38,5 +38,5 @@ tasks:
         - nvmeof/scalability_test.sh nvmeof.b,nvmeof.c,nvmeof.d
         - nvmeof/scalability_test.sh nvmeof.b,nvmeof.c
     env:
-      SCALING_DELAYS: '300'
+      SCALING_DELAYS: '400'
       RUNTIME: '1200'

--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/10-subsys-90-namespace-no_huge_pages.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/10-subsys-90-namespace-no_huge_pages.yaml
@@ -1,14 +1,14 @@
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: quay.io/ceph/nvmeof:latest # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 10 
       namespaces_count: 90 # each subsystem
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0

--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/120-subsys-8-namespace.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/120-subsys-8-namespace.yaml
@@ -1,14 +1,14 @@
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: quay.io/ceph/nvmeof:latest # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 120
       namespaces_count: 8 # each subsystem
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0

--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/16-subsys-4-namespace.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/16-subsys-4-namespace.yaml
@@ -1,14 +1,14 @@
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: quay.io/ceph/nvmeof:latest # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 16
       namespaces_count: 4 # each subsystem
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0

--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/2-subsys-8-namespace.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/2-subsys-8-namespace.yaml
@@ -1,14 +1,14 @@
 tasks:
 - nvmeof:
     installer: host.a
-    gw_image: quay.io/ceph/nvmeof:latest # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
+    gw_image: quay.io/ceph/nvmeof:devel # "default" is the image cephadm defaults to; change to test specific nvmeof images, example "latest"
     rbd:
       pool_name: mypool
       image_name_prefix: myimage
     gateway_config:
       subsystems_count: 2
       namespaces_count: 8 # each subsystem
-      cli_image: quay.io/ceph/nvmeof-cli:latest
+      cli_image: quay.io/ceph/nvmeof-cli:devel
 
 - cephadm.wait_for_service:
     service: nvmeof.mypool.mygroup0

--- a/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
+++ b/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
@@ -19,6 +19,8 @@ overrides:
       - is unavailable
       - is in error state
       - failed cephadm daemon
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_DAEMON_PLACE_FAIL
 
 tasks:
 - nvmeof.thrash:

--- a/qa/suites/nvmeof/thrash/thrashers/nvmeof_thrash.yaml
+++ b/qa/suites/nvmeof/thrash/thrashers/nvmeof_thrash.yaml
@@ -14,6 +14,8 @@ overrides:
       - is unavailable
       - is in error state
       - failed cephadm daemon
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_DAEMON_PLACE_FAIL
 
 tasks:
 - nvmeof.thrash:

--- a/qa/suites/nvmeof/thrash/workloads/fio.yaml
+++ b/qa/suites/nvmeof/thrash/workloads/fio.yaml
@@ -4,7 +4,7 @@ tasks:
     timeout: 60m
     clients:
       client.0:
-        - nvmeof/fio_test.sh --random_devices 200
+        - nvmeof/fio_test.sh --random_devices 32
     env:
       RBD_POOL: mypool
       NVMEOF_GROUP: mygroup0

--- a/qa/tasks/nvmeof.py
+++ b/qa/tasks/nvmeof.py
@@ -369,8 +369,8 @@ class NvmeofThrasher(Thrasher, Greenlet):
                 for d in self.daemons:
                     random_gateway_host = d.remote
                     d.remote.sh(d.status_cmd, check_status=False)
-                random_gateway_host.run(args=['ceph', 'orch', 'ls', '--refresh'])
-                random_gateway_host.run(args=['ceph', 'orch', 'ps', '--daemon-type', 'nvmeof', '--refresh'])
+                random_gateway_host.run(args=['ceph', 'orch', 'ls'])
+                random_gateway_host.run(args=['ceph', 'orch', 'ps', '--daemon-type', 'nvmeof'])
                 random_gateway_host.run(args=['ceph', 'health', 'detail'])
                 random_gateway_host.run(args=['ceph', '-s'])
                 random_gateway_host.run(args=['ceph', 'nvme-gw', 'show', 'mypool', 'mygroup0'])

--- a/qa/tasks/nvmeof.py
+++ b/qa/tasks/nvmeof.py
@@ -331,7 +331,7 @@ class NvmeofThrasher(Thrasher, Greenlet):
 
     def _get_devices(self, remote):
         GET_DEVICE_CMD = "sudo nvme list --output-format=json | " \
-            "jq -r '.Devices[].Subsystems[] | select(.Controllers | all(.ModelNumber == \"Ceph bdev Controller\")) | .Namespaces | sort_by(.NSID) | .[] | .NameSpace'"
+            "jq -r '.Devices | sort_by(.NameSpace) | .[] | select(.ModelNumber == \"Ceph bdev Controller\") | .DevicePath'"
         devices = remote.sh(GET_DEVICE_CMD).split()
         return devices
     

--- a/qa/workunits/nvmeof/basic_tests.sh
+++ b/qa/workunits/nvmeof/basic_tests.sh
@@ -39,7 +39,7 @@ connect_all() {
     sudo nvme connect-all --traddr=$NVMEOF_DEFAULT_GATEWAY_IP_ADDRESS --transport=tcp -l 3600
     sleep 5
     expected_devices_count=$1
-    actual_devices=$(sudo nvme list --output-format=json | jq -r ".Devices[].Subsystems[] | select(.Controllers | all(.ModelNumber == \"$SPDK_CONTROLLER\")) | .Namespaces[].NameSpace" | wc -l)
+    actual_devices=$(sudo nvme list --output-format=json | grep -o "$SPDK_CONTROLLER" | wc -l)
     if [ "$actual_devices" -ne "$expected_devices_count" ]; then
         sudo nvme list --output-format=json
         return 1

--- a/qa/workunits/nvmeof/basic_tests.sh
+++ b/qa/workunits/nvmeof/basic_tests.sh
@@ -63,6 +63,9 @@ test_run() {
         echo "[nvmeof] $1 test passed!"
     else
         echo "[nvmeof] $1 test failed!"
+        sudo nvme list-subsys
+        sudo nvme list
+        sudo dmesg -T > $TESTDIR/archive/dmesg.log
         exit 1
     fi
 }

--- a/qa/workunits/nvmeof/fio_test.sh
+++ b/qa/workunits/nvmeof/fio_test.sh
@@ -34,7 +34,7 @@ done
 
 fio_file=$(mktemp -t nvmeof-fio-XXXX)
 all_drives_list=$(sudo nvme list --output-format=json | 
-    jq -r '.Devices[].Subsystems[] | select(.Controllers | all(.ModelNumber == "Ceph bdev Controller")) | .Namespaces | sort_by(.NSID) | .[] | .NameSpace')
+    jq -r '.Devices | sort_by(.NameSpace) | .[] | select(.ModelNumber == "Ceph bdev Controller") | .DevicePath')
 
 # When the script is passed --start_ns and --end_ns (example: `nvmeof_fio_test.sh --start_ns 1 --end_ns 3`), 
 # then fio runs on namespaces only in the defined range (which is 1 to 3 here). 
@@ -50,8 +50,6 @@ fi
 
 
 RUNTIME=${RUNTIME:-600}
-filename=$(echo "$selected_drives" | sed -z 's/\n/:\/dev\//g' | sed 's/:\/dev\/$//')
-filename="/dev/$filename"
 
 cat >> $fio_file <<EOF
 [global]
@@ -73,7 +71,7 @@ EOF
 
 for i in $selected_drives; do
   echo "[job-$i]" >> "$fio_file"
-  echo "filename=/dev/$i" >> "$fio_file"
+  echo "filename=$i" >> "$fio_file"
   echo "" >> "$fio_file"  # Adds a blank line
 done
 

--- a/qa/workunits/nvmeof/mtls_test.sh
+++ b/qa/workunits/nvmeof/mtls_test.sh
@@ -23,7 +23,7 @@ wait_for_service() {
     MAX_RETRIES=30
     for ((RETRY_COUNT=1; RETRY_COUNT<=MAX_RETRIES; RETRY_COUNT++)); do
 
-        if ceph orch ls --refresh | grep -q "nvmeof"; then
+        if ceph orch ls | grep -q "nvmeof"; then
             echo "Found nvmeof in the output!"
             break
         fi
@@ -34,7 +34,7 @@ wait_for_service() {
         sleep 5
     done
     ceph orch ps
-    ceph orch ls --refresh
+    ceph orch ls
 }
 
 # deploy mtls

--- a/qa/workunits/nvmeof/scalability_test.sh
+++ b/qa/workunits/nvmeof/scalability_test.sh
@@ -46,7 +46,7 @@ status_checks() {
 
         diff=$((num_namespaces - expected_avg_ns))
         if [[ $diff -lt -1 || $diff -gt 1 ]]; then
-            echo "Gateway $gw_id has num-namespaces ($num_namespaces), expected around $expected_ns. Indicates a problem in ns load-balancing."
+            echo "Gateway $gw_id has num-namespaces ($num_namespaces), expected around $expected_ns_count. Indicates a problem in ns load-balancing."
             exit 1
         fi
     done


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71724

---

backport of https://github.com/ceph/ceph/pull/63291
parent tracker: https://tracker.ceph.com/issues/70927

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh