### PR TITLE
tentacle: fix: the RGW crash caused by special characters

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1765,13 +1765,14 @@ std::string url_decode(const std::string_view& src_str, bool in_query)
       const char c1 = hex_to_num(*src++);
       const char c2 = hex_to_num(*src);
       if (c1 < 0 || c2 < 0) {
-        return std::string();
+        src--;
+        src--; //going back to the %
+        dest_str.push_back(*src); //add % to the target destination string
       } else {
         dest_str.push_back(c1 << 4 | c2);
       }
     }
   }
-
   return dest_str;
 }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1765,14 +1765,13 @@ std::string url_decode(const std::string_view& src_str, bool in_query)
       const char c1 = hex_to_num(*src++);
       const char c2 = hex_to_num(*src);
       if (c1 < 0 || c2 < 0) {
-        src--;
-        src--; //going back to the %
-        dest_str.push_back(*src); //add % to the target destination string
+        return std::string();
       } else {
         dest_str.push_back(c1 << 4 | c2);
       }
     }
   }
+  
   return dest_str;
 }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1771,7 +1771,7 @@ std::string url_decode(const std::string_view& src_str, bool in_query)
       }
     }
   }
-  
+ 
   return dest_str;
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3993,16 +3993,14 @@ int RGWPutObj::init_processing(optional_yield y) {
     copy_source_bucket_name = copy_source_bucket_name.substr(0, pos);
 #define VERSION_ID_STR "?versionId="
     pos = copy_source_object_name.find(VERSION_ID_STR);
-    if (pos == std::string::npos) {
-      copy_source_object_name = url_decode(copy_source_object_name);
-    } else {
+    if (pos != std::string::npos) {
       copy_source_version_id =
         copy_source_object_name.substr(pos + sizeof(VERSION_ID_STR) - 1);
       copy_source_object_name =
-        url_decode(copy_source_object_name.substr(0, pos));
+        copy_source_object_name.substr(0, pos);
     }
     if (copy_source_object_name.empty()) {
-      //means url_decode returned empty string so the url is formatted badly
+      //means copy_source_object_name is empty string so the url is formatted badly
       ret = -EINVAL;
       ldpp_dout(this, 5) << "x-amz-copy-source bad format" << dendl;
       return ret;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4001,6 +4001,12 @@ int RGWPutObj::init_processing(optional_yield y) {
       copy_source_object_name =
         url_decode(copy_source_object_name.substr(0, pos));
     }
+    if (copy_source_object_name.empty()) {
+      //means url_decode returned empty string so the url is formatted badly
+      ret = -EINVAL;
+      ldpp_dout(this, 5) << "x-amz-copy-source bad format" << dendl;
+      return ret;
+    }
     pos = copy_source_bucket_name.find(":");
     if (pos == std::string::npos) {
       // if tenant is not specified in x-amz-copy-source, use tenant of the requester


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71752

---

backport of https://github.com/ceph/ceph/pull/63521
parent tracker: https://tracker.ceph.com/issues/71458

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh