### PR TITLE
Support clusters larger than 65.5 PiB

### DIFF
--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -151,6 +151,24 @@ ceph osd crush rm osd.$o5
 ceph osd rm osd.$o4
 ceph osd rm osd.$o5
 
+# test reweight-by-scaling-factor
+ceph config set global osd_crush_scaling_factor 0.1
+o6=`ceph osd create`
+o7=`ceph osd create`
+ceph osd crush add $o6 123 root=default host=foobaz
+ceph osd crush add $o7 123 root=default host=foobaz
+ceph osd tree | grep osd.$o6 | grep 123
+ceph osd tree | grep osd.$o7 | grep 123
+ceph osd crush test-reweight-by-scaling-factor --skip-metadata-lookup -o newcrush
+crushdiff compare -c newcrush | grep '(0.00%) bytes to move'
+ceph osd crush reweight-by-scaling-factor --skip-metadata-lookup
+ceph osd tree | grep osd.$o6 | grep '12\.3'
+ceph osd tree | grep osd.$o7 | grep '12\.3'
+ceph osd crush rm osd.$o6
+ceph osd crush rm osd.$o7
+ceph osd rm osd.$o6
+ceph osd rm osd.$o7
+
 # weight sets
 # make sure we require luminous before testing weight-sets
 ceph osd set-require-min-compat-client luminous

--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -152,7 +152,7 @@ ceph osd rm osd.$o4
 ceph osd rm osd.$o5
 
 # test reweight-by-scaling-factor
-ceph config set global osd_crush_scaling_factor 0.1
+ceph osd set set-crush-scaling-factor 0.1
 o6=`ceph osd create`
 o7=`ceph osd create`
 ceph osd crush add $o6 123 root=default host=foobaz
@@ -161,7 +161,7 @@ ceph osd tree | grep osd.$o6 | grep 123
 ceph osd tree | grep osd.$o7 | grep 123
 ceph osd crush test-reweight-by-scaling-factor --skip-metadata-lookup -o newcrush
 crushdiff compare -c newcrush | grep '(0.00%) bytes to move'
-ceph osd crush reweight-by-scaling-factor --skip-metadata-lookup
+ceph osd crush reweight-by-scaling-factor --skip-metadata-lookup --yes-i-really-mean-it
 ceph osd tree | grep osd.$o6 | grep '12\.3'
 ceph osd tree | grep osd.$o7 | grep '12\.3'
 ceph osd crush rm osd.$o6

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6992,3 +6992,21 @@ options:
   flags:
   - no_mon_update
   - startup
+- name: osd_crush_scaling_factor
+  type: float
+  level: advanced
+  desc: Scale device sizes by this factor when calculating CRUSH weights.
+    This value is applied when new OSDs are added to the cluster,
+    or when running 'ceph osd crush reweight-by-scaling-factor'.
+    E.g. When set to 1.0, CRUSH weights will be the same as the device size in TiB and
+    the maximum cluster size is ~65.5PiB.
+    If set to 0.1, CRUSH weights will be 1/10th of the device size in TiB and
+    the maximum cluster size is ~655PiB.
+  default: 1.0
+  min: 0.001
+  max: 1.0
+  services:
+  - mon
+  - osd
+  flags:
+  - runtime

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -7125,3 +7125,21 @@ options:
   flags:
   - no_mon_update
   - startup
+- name: osd_crush_scaling_factor
+  type: float
+  level: advanced
+  desc: Scale device sizes by this factor when calculating CRUSH weights.
+    This value is applied when new OSDs are added to the cluster,
+    or when running 'ceph osd crush reweight-by-scaling-factor'.
+    E.g. When set to 1.0, CRUSH weights will be the same as the device size in TiB and
+    the maximum cluster size is ~65.5PiB.
+    If set to 0.1, CRUSH weights will be 1/10th of the device size in TiB and
+    the maximum cluster size is ~655PiB.
+  default: 1.0
+  min: 0.001
+  max: 1.0
+  services:
+  - mon
+  - osd
+  flags:
+  - runtime

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1442,3 +1442,13 @@ options:
   - mon
   flags:
   - runtime
+- name: mon_warn_on_large_crush_bucket
+  type: bool
+  level: advanced
+  desc: Raise a LARGE_CRUSH_BUCKET health check warning if any CRUSH bucket
+    nears the maximum weight of 65535.
+  default: true
+  services:
+  - mon
+  flags:
+  - runtime

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1544,3 +1544,13 @@ options:
   - mon
   flags:
   - runtime
+- name: mon_warn_on_large_crush_bucket
+  type: bool
+  level: advanced
+  desc: Raise a LARGE_CRUSH_BUCKET health check warning if any CRUSH bucket
+    nears the maximum weight of 65535.
+  default: true
+  services:
+  - mon
+  flags:
+  - runtime

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -733,7 +733,7 @@ seastar::future<> OSD::_add_me_to_crush()
          auto total = st.total;
 	 return seastar::make_ready_future<double>(
            std::max(.00001,
-		    local_conf().get_val<double>("osd_crush_scaling_factor") *
+		    osdmap->get_osd_crush_scaling_factor() *
                     double(total) / double(1ull << 40))); // TiB
        });
     }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -733,7 +733,8 @@ seastar::future<> OSD::_add_me_to_crush()
          auto total = st.total;
 	 return seastar::make_ready_future<double>(
            std::max(.00001,
-		    double(total) / double(1ull << 40))); // TB
+		    local_conf().get_val<double>("osd_crush_scaling_factor") *
+                    double(total) / double(1ull << 40))); // TiB
        });
     }
   };

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -764,7 +764,7 @@ seastar::future<> OSD::_add_me_to_crush()
     auto st = co_await store.stat();
     auto total = st.total;
     weight = std::max(.00001,
-                      local_conf().get_val<double>("osd_crush_scaling_factor") *
+                      osdmap->get_osd_crush_scaling_factor() *
                       double(total) / double(1ull << 40)); // TB
   }
   crimson::crush::CrushLocation loc;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -764,6 +764,7 @@ seastar::future<> OSD::_add_me_to_crush()
     auto st = co_await store.stat();
     auto total = st.total;
     weight = std::max(.00001,
+                      local_conf().get_val<double>("osd_crush_scaling_factor") *
                       double(total) / double(1ull << 40)); // TB
   }
   crimson::crush::CrushLocation loc;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -756,6 +756,10 @@ COMMAND("osd crush reweight-by-scaling-factor "
         "name=yes_i_really_mean_it,type=CephBool,req=false",
 	"reweight all items in the crush map by a scaling factor",
 	"osd", "rw")
+COMMAND("osd crush test-reweight-by-scaling-factor "
+        "name=skip_metadata_lookup,type=CephBool,req=false",
+	"test reweighting all items in the crush map by a scaling factor (dry run)",
+	"osd", "r")
 COMMAND("osd crush tunables "
 	"name=profile,type=CephChoices,strings=legacy|argonaut|bobtail|firefly|hammer|jewel|optimal|default",
 	"set crush tunables values to <profile>", "osd", "rw")
@@ -860,6 +864,10 @@ COMMAND("osd set-backfillfull-ratio "
 COMMAND("osd set-nearfull-ratio "
 	"name=ratio,type=CephFloat,range=0.0|1.0",
 	"set usage ratio at which OSDs are marked near-full",
+	"osd", "rw")
+COMMAND("osd set-crush-scaling-factor "
+	"name=factor,type=CephFloat,range=0.0|1.0",
+	"set CRUSH scaling factor for OSD capacity calculations",
 	"osd", "rw")
 COMMAND("osd get-require-min-compat-client",
         "get the minimum client version we will maintain compatibility with",

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -751,6 +751,11 @@ COMMAND("osd crush reweight-subtree "
 	"name=weight,type=CephFloat,range=0.0",
 	"change all leaf items beneath <name> to <weight> in crush map",
 	"osd", "rw")
+COMMAND("osd crush reweight-by-scaling-factor "
+        "name=skip_metadata_lookup,type=CephBool,req=false "
+        "name=yes_i_really_mean_it,type=CephBool,req=false",
+	"reweight all items in the crush map by a scaling factor",
+	"osd", "rw")
 COMMAND("osd crush tunables "
 	"name=profile,type=CephChoices,strings=legacy|argonaut|bobtail|firefly|hammer|jewel|optimal|default",
 	"set crush tunables values to <profile>", "osd", "rw")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -757,6 +757,10 @@ COMMAND("osd crush reweight-by-scaling-factor "
         "name=yes_i_really_mean_it,type=CephBool,req=false",
 	"reweight all items in the crush map by a scaling factor",
 	"osd", "rw")
+COMMAND("osd crush test-reweight-by-scaling-factor "
+        "name=skip_metadata_lookup,type=CephBool,req=false",
+	"test reweighting all items in the crush map by a scaling factor (dry run)",
+	"osd", "r")
 COMMAND("osd crush tunables "
 	"name=profile,type=CephChoices,strings=legacy|argonaut|bobtail|firefly|hammer|jewel|optimal|default",
 	"set crush tunables values to <profile>", "osd", "rw")
@@ -861,6 +865,10 @@ COMMAND("osd set-backfillfull-ratio "
 COMMAND("osd set-nearfull-ratio "
 	"name=ratio,type=CephFloat,range=0.0|1.0",
 	"set usage ratio at which OSDs are marked near-full",
+	"osd", "rw")
+COMMAND("osd set-crush-scaling-factor "
+	"name=factor,type=CephFloat,range=0.0|1.0",
+	"set CRUSH scaling factor for OSD capacity calculations",
 	"osd", "rw")
 COMMAND("osd get-require-min-compat-client",
         "get the minimum client version we will maintain compatibility with",

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -752,6 +752,11 @@ COMMAND("osd crush reweight-subtree "
 	"name=weight,type=CephFloat,range=0.0",
 	"change all leaf items beneath <name> to <weight> in crush map",
 	"osd", "rw")
+COMMAND("osd crush reweight-by-scaling-factor "
+        "name=skip_metadata_lookup,type=CephBool,req=false "
+        "name=yes_i_really_mean_it,type=CephBool,req=false",
+	"reweight all items in the crush map by a scaling factor",
+	"osd", "rw")
 COMMAND("osd crush tunables "
 	"name=profile,type=CephChoices,strings=legacy|argonaut|bobtail|firefly|hammer|jewel|optimal|default",
 	"set crush tunables values to <profile>", "osd", "rw")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11413,6 +11413,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
   } else if (prefix == "osd crush reweight-by-scaling-factor" ||
              prefix == "osd crush test-reweight-by-scaling-factor") {
 
+    ostringstream output_ss;
+
     bool really = false;
     cmd_getval(cmdmap, "yes_i_really_mean_it", really);
 
@@ -11421,93 +11423,98 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     bool dry_run = prefix == "osd crush test-reweight-by-scaling-factor";
 
-    if (skip_metadata_lookup)
-      ss << "reweighting all OSDs using scaling factor "
-         << g_conf().get_val<double>("osd_crush_scaling_factor") << ":";
-    else
-      ss << "reweighting all OSDs using scaling factor "
-         << g_conf().get_val<double>("osd_crush_scaling_factor")
-         << " based on device size metadata:";
-
-    if (dry_run)
-      ss << "This is a dry run, no changes will be made. "
-         << "Use 'test-reweight-by-scaling-factor -o newcrush' "
-         << "then 'crushdiff compare -c newcrush' "
-         << "to check if this will cause data movement.";
-
+    if (skip_metadata_lookup) {
+      output_ss << "reweighting all OSDs using scaling factor "
+                << osdmap.get_osd_crush_scaling_factor() << ":\n";
+    } else {
+      output_ss << "reweighting all OSDs using scaling factor "
+                << osdmap.get_osd_crush_scaling_factor()
+                << " based on device size metadata:\n";
+    }
+    if (dry_run){
+      output_ss << "This is a dry run, no changes will be made. "
+                << "Use 'test-reweight-by-scaling-factor -o newcrush' "
+                << "then 'crushdiff compare -c newcrush' "
+                << "to check if this will cause data movement.\n";
+    }
     CrushWrapper newcrush = _get_pending_crush();
 
     for (int id = 0; id < newcrush.get_max_devices(); ++id) {
-        if (!newcrush.get_item_weight(id)) {
-          // weight is 0, skip
-          continue;
-        }
-        double new_weight = g_conf().get_val<double>("osd_crush_scaling_factor") *
-                                   newcrush.get_item_weightf(id);
+      if (!newcrush.get_item_weight(id)) {
+        // weight is 0, skip
+        continue;
+      }
+      double new_weight =
+          osdmap.get_osd_crush_scaling_factor() * newcrush.get_item_weightf(id);
 
-        if (!skip_metadata_lookup) {
-          map<string,string> meta;
-          err = load_metadata(id, meta, nullptr);
-          if (err < 0) {
-            ss << "failed to load metadata for osd." << id
-               << ": " << cpp_strerror(err);
-            goto reply_no_propose;
-          }
-
-          // osd statfs.total is bluestore_bdev_size + bluefs_db_size
-          uint64_t total_size = 0;
-          auto p1 = meta.find("bluestore_bdev_size");
-          if (p1 == meta.end()) {
-            ss << "osd." << id << " does not have bluestore_bdev_size metadata";
-            goto reply_no_propose;
-          }
-          total_size = std::stoull(p1->second);
-          auto p2 = meta.find("bluefs_db_size");
-          if (p2 == meta.end()) {
-            ss << "osd." << id << " does not have bluefs_db_size metadata";
-            goto reply_no_propose;
-          }
-          total_size += std::stoull(p2->second);
-
-          // use the same calculation as OSD::update_crush_location
-          new_weight = std::max(0.00001,
-                                g_conf().get_val<double>("osd_crush_scaling_factor") *
-                                double(total_size) /
-                                double(1ull << 40));
-        }
-
-        ss << "reweighting osd." << id << " to " << new_weight;
-
-        err = newcrush.adjust_item_weightf(cct, id, new_weight,
-                                           g_conf()->osd_crush_update_weight_set);
-        if (err < 0)
+      if (!skip_metadata_lookup) {
+        map<string, string> meta;
+        err = load_metadata(id, meta, nullptr);
+        if (err < 0) {
+          ss << "failed to load metadata for osd." << id << ": "
+             << cpp_strerror(err);
           goto reply_no_propose;
+        }
+
+        // TODO: support other store than bluestore
+        // osd statfs.total is bluestore_bdev_size + bluefs_db_size
+        uint64_t total_size = 0;
+        auto p1 = meta.find("bluestore_bdev_size");
+        if (p1 == meta.end()) {
+          ss << "osd." << id << " does not have bluestore_bdev_size metadata";
+          goto reply_no_propose;
+        }
+        total_size = std::stoull(p1->second);
+        auto p2 = meta.find("bluefs_db_size");
+        if (p2 == meta.end()) {
+          ss << "osd." << id << " does not have bluefs_db_size metadata";
+          goto reply_no_propose;
+        }
+        total_size += std::stoull(p2->second);
+
+        // use the same calculation as OSD::update_crush_location
+        new_weight =
+            std::max(0.00001, osdmap.get_osd_crush_scaling_factor() *
+                                  double(total_size) / double(1ull << 40));
+      }
+
+      output_ss << "reweighting osd." << id << " to " << new_weight << "\n";
+
+      err = newcrush.adjust_item_weightf(cct, id, new_weight,
+                                         g_conf()->osd_crush_update_weight_set);
+      if (err < 0) {
+        goto reply_no_propose;
+      }
     }
 
     if (dry_run) {
       // return the new crush map without committing
       newcrush.encode(rdata, mon.get_quorum_con_features());
-      ss << "test reweighted all crush weights by scaling factor "
-         << g_conf().get_val<double>("osd_crush_scaling_factor");
-      return true;
+      output_ss << "\ntest reweighted all crush weights by scaling factor "
+                << osdmap.get_osd_crush_scaling_factor();
+      rs = output_ss.str();
+      goto reply_no_propose;
     }
 
-    if (!really) {
+    if (!dry_run && !really) {
+      rdata.append(output_ss.str());
+
       ss << "WARNING: this will reweight all crush weights by scaling factor "
-        << g_conf().get_val<double>("osd_crush_scaling_factor")
-        << " and may cause data movement."
-        "If you are certain that is what you want, "
-        "pass the flag --yes-i-really-mean-it.";
-      return -EPERM;
+         << osdmap.get_osd_crush_scaling_factor()
+         << " and may cause data movement. "
+            "If you are certain that is what you want, "
+            "pass the flag --yes-i-really-mean-it.\n";
+      err = -EPERM;
+      goto reply_no_propose;
     }
 
     pending_inc.crush.clear();
     newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
-    ss << "reweighted all crush weights by scaling factor "
-       << g_conf().get_val<double>("osd_crush_scaling_factor");
-    getline(ss, rs);
-    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
-						  get_last_committed() + 1));
+    output_ss << "reweighted all crush weights by scaling factor "
+              << osdmap.get_osd_crush_scaling_factor();
+    rs = output_ss.str();
+    wait_for_commit(
+        op, new Monitor::C_Command(mon, op, 0, rs, get_last_committed() + 1));
     return true;
   } else if (prefix == "osd crush reweight-subtree") {
     // osd crush reweight <name> <weight>
@@ -12010,6 +12017,25 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       pending_inc.new_backfillfull_ratio = n;
     else if (prefix == "osd set-nearfull-ratio")
       pending_inc.new_nearfull_ratio = n;
+    ss << prefix << " " << n;
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+					      get_last_committed() + 1));
+    return true;
+  } else if (prefix == "osd set-crush-scaling-factor") {
+    double n;
+    if (!cmd_getval(cmdmap, "factor", n)){
+      ss << "unable to parse 'factor' value '"
+         << cmd_vartype_stringify(cmdmap.at("factor")) << "'";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    if (n < 0.001 || n > 1.0) {
+      ss << "scaling factor must be between 0.001 and 1.0";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    pending_inc.new_osd_crush_scaling_factor = n;
     ss << prefix << " " << n;
     getline(ss, rs);
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11410,6 +11410,105 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 						  get_last_committed() + 1));
     return true;
+  } else if (prefix == "osd crush reweight-by-scaling-factor" ||
+             prefix == "osd crush test-reweight-by-scaling-factor") {
+
+    bool really = false;
+    cmd_getval(cmdmap, "yes_i_really_mean_it", really);
+
+    bool skip_metadata_lookup = false;
+    cmd_getval(cmdmap, "skip_metadata_lookup", skip_metadata_lookup);
+
+    bool dry_run = prefix == "osd crush test-reweight-by-scaling-factor";
+
+    if (skip_metadata_lookup)
+      ss << "reweighting all OSDs using scaling factor "
+         << g_conf().get_val<double>("osd_crush_scaling_factor") << ":";
+    else
+      ss << "reweighting all OSDs using scaling factor "
+         << g_conf().get_val<double>("osd_crush_scaling_factor")
+         << " based on device size metadata:";
+
+    if (dry_run)
+      ss << "This is a dry run, no changes will be made. "
+         << "Use 'test-reweight-by-scaling-factor -o newcrush' "
+         << "then 'crushdiff compare -c newcrush' "
+         << "to check if this will cause data movement.";
+
+    CrushWrapper newcrush = _get_pending_crush();
+
+    for (int id = 0; id < newcrush.get_max_devices(); ++id) {
+        if (!newcrush.get_item_weight(id)) {
+          // weight is 0, skip
+          continue;
+        }
+        double new_weight = g_conf().get_val<double>("osd_crush_scaling_factor") *
+                                   newcrush.get_item_weightf(id);
+
+        if (!skip_metadata_lookup) {
+          map<string,string> meta;
+          err = load_metadata(id, meta, nullptr);
+          if (err < 0) {
+            ss << "failed to load metadata for osd." << id
+               << ": " << cpp_strerror(err);
+            goto reply_no_propose;
+          }
+
+          // osd statfs.total is bluestore_bdev_size + bluefs_db_size
+          uint64_t total_size = 0;
+          auto p1 = meta.find("bluestore_bdev_size");
+          if (p1 == meta.end()) {
+            ss << "osd." << id << " does not have bluestore_bdev_size metadata";
+            goto reply_no_propose;
+          }
+          total_size = std::stoull(p1->second);
+          auto p2 = meta.find("bluefs_db_size");
+          if (p2 == meta.end()) {
+            ss << "osd." << id << " does not have bluefs_db_size metadata";
+            goto reply_no_propose;
+          }
+          total_size += std::stoull(p2->second);
+
+          // use the same calculation as OSD::update_crush_location
+          new_weight = std::max(0.00001,
+                                g_conf().get_val<double>("osd_crush_scaling_factor") *
+                                double(total_size) /
+                                double(1ull << 40));
+        }
+
+        ss << "reweighting osd." << id << " to " << new_weight;
+
+        err = newcrush.adjust_item_weightf(cct, id, new_weight,
+                                           g_conf()->osd_crush_update_weight_set);
+        if (err < 0)
+          goto reply_no_propose;
+    }
+
+    if (dry_run) {
+      // return the new crush map without committing
+      newcrush.encode(rdata, mon.get_quorum_con_features());
+      ss << "test reweighted all crush weights by scaling factor "
+         << g_conf().get_val<double>("osd_crush_scaling_factor");
+      return true;
+    }
+
+    if (!really) {
+      ss << "WARNING: this will reweight all crush weights by scaling factor "
+        << g_conf().get_val<double>("osd_crush_scaling_factor")
+        << " and may cause data movement."
+        "If you are certain that is what you want, "
+        "pass the flag --yes-i-really-mean-it.";
+      return -EPERM;
+    }
+
+    pending_inc.crush.clear();
+    newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
+    ss << "reweighted all crush weights by scaling factor "
+       << g_conf().get_val<double>("osd_crush_scaling_factor");
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+						  get_last_committed() + 1));
+    return true;
   } else if (prefix == "osd crush reweight-subtree") {
     // osd crush reweight <name> <weight>
     CrushWrapper newcrush = _get_pending_crush();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11753,6 +11753,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
   } else if (prefix == "osd crush reweight-by-scaling-factor" ||
              prefix == "osd crush test-reweight-by-scaling-factor") {
 
+    ostringstream output_ss;
+
     bool really = false;
     cmd_getval(cmdmap, "yes_i_really_mean_it", really);
 
@@ -11761,93 +11763,98 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     bool dry_run = prefix == "osd crush test-reweight-by-scaling-factor";
 
-    if (skip_metadata_lookup)
-      ss << "reweighting all OSDs using scaling factor "
-         << g_conf().get_val<double>("osd_crush_scaling_factor") << ":";
-    else
-      ss << "reweighting all OSDs using scaling factor "
-         << g_conf().get_val<double>("osd_crush_scaling_factor")
-         << " based on device size metadata:";
-
-    if (dry_run)
-      ss << "This is a dry run, no changes will be made. "
-         << "Use 'test-reweight-by-scaling-factor -o newcrush' "
-         << "then 'crushdiff compare -c newcrush' "
-         << "to check if this will cause data movement.";
-
+    if (skip_metadata_lookup) {
+      output_ss << "reweighting all OSDs using scaling factor "
+                << osdmap.get_osd_crush_scaling_factor() << ":\n";
+    } else {
+      output_ss << "reweighting all OSDs using scaling factor "
+                << osdmap.get_osd_crush_scaling_factor()
+                << " based on device size metadata:\n";
+    }
+    if (dry_run){
+      output_ss << "This is a dry run, no changes will be made. "
+                << "Use 'test-reweight-by-scaling-factor -o newcrush' "
+                << "then 'crushdiff compare -c newcrush' "
+                << "to check if this will cause data movement.\n";
+    }
     CrushWrapper newcrush = _get_pending_crush();
 
     for (int id = 0; id < newcrush.get_max_devices(); ++id) {
-        if (!newcrush.get_item_weight(id)) {
-          // weight is 0, skip
-          continue;
-        }
-        double new_weight = g_conf().get_val<double>("osd_crush_scaling_factor") *
-                                   newcrush.get_item_weightf(id);
+      if (!newcrush.get_item_weight(id)) {
+        // weight is 0, skip
+        continue;
+      }
+      double new_weight =
+          osdmap.get_osd_crush_scaling_factor() * newcrush.get_item_weightf(id);
 
-        if (!skip_metadata_lookup) {
-          map<string,string> meta;
-          err = load_metadata(id, meta, nullptr);
-          if (err < 0) {
-            ss << "failed to load metadata for osd." << id
-               << ": " << cpp_strerror(err);
-            goto reply_no_propose;
-          }
-
-          // osd statfs.total is bluestore_bdev_size + bluefs_db_size
-          uint64_t total_size = 0;
-          auto p1 = meta.find("bluestore_bdev_size");
-          if (p1 == meta.end()) {
-            ss << "osd." << id << " does not have bluestore_bdev_size metadata";
-            goto reply_no_propose;
-          }
-          total_size = std::stoull(p1->second);
-          auto p2 = meta.find("bluefs_db_size");
-          if (p2 == meta.end()) {
-            ss << "osd." << id << " does not have bluefs_db_size metadata";
-            goto reply_no_propose;
-          }
-          total_size += std::stoull(p2->second);
-
-          // use the same calculation as OSD::update_crush_location
-          new_weight = std::max(0.00001,
-                                g_conf().get_val<double>("osd_crush_scaling_factor") *
-                                double(total_size) /
-                                double(1ull << 40));
-        }
-
-        ss << "reweighting osd." << id << " to " << new_weight;
-
-        err = newcrush.adjust_item_weightf(cct, id, new_weight,
-                                           g_conf()->osd_crush_update_weight_set);
-        if (err < 0)
+      if (!skip_metadata_lookup) {
+        map<string, string> meta;
+        err = load_metadata(id, meta, nullptr);
+        if (err < 0) {
+          ss << "failed to load metadata for osd." << id << ": "
+             << cpp_strerror(err);
           goto reply_no_propose;
+        }
+
+        // TODO: support other store than bluestore
+        // osd statfs.total is bluestore_bdev_size + bluefs_db_size
+        uint64_t total_size = 0;
+        auto p1 = meta.find("bluestore_bdev_size");
+        if (p1 == meta.end()) {
+          ss << "osd." << id << " does not have bluestore_bdev_size metadata";
+          goto reply_no_propose;
+        }
+        total_size = std::stoull(p1->second);
+        auto p2 = meta.find("bluefs_db_size");
+        if (p2 == meta.end()) {
+          ss << "osd." << id << " does not have bluefs_db_size metadata";
+          goto reply_no_propose;
+        }
+        total_size += std::stoull(p2->second);
+
+        // use the same calculation as OSD::update_crush_location
+        new_weight =
+            std::max(0.00001, osdmap.get_osd_crush_scaling_factor() *
+                                  double(total_size) / double(1ull << 40));
+      }
+
+      output_ss << "reweighting osd." << id << " to " << new_weight << "\n";
+
+      err = newcrush.adjust_item_weightf(cct, id, new_weight,
+                                         g_conf()->osd_crush_update_weight_set);
+      if (err < 0) {
+        goto reply_no_propose;
+      }
     }
 
     if (dry_run) {
       // return the new crush map without committing
       newcrush.encode(rdata, mon.get_quorum_con_features());
-      ss << "test reweighted all crush weights by scaling factor "
-         << g_conf().get_val<double>("osd_crush_scaling_factor");
-      return true;
+      output_ss << "\ntest reweighted all crush weights by scaling factor "
+                << osdmap.get_osd_crush_scaling_factor();
+      rs = output_ss.str();
+      goto reply_no_propose;
     }
 
-    if (!really) {
+    if (!dry_run && !really) {
+      rdata.append(output_ss.str());
+
       ss << "WARNING: this will reweight all crush weights by scaling factor "
-        << g_conf().get_val<double>("osd_crush_scaling_factor")
-        << " and may cause data movement."
-        "If you are certain that is what you want, "
-        "pass the flag --yes-i-really-mean-it.";
-      return -EPERM;
+         << osdmap.get_osd_crush_scaling_factor()
+         << " and may cause data movement. "
+            "If you are certain that is what you want, "
+            "pass the flag --yes-i-really-mean-it.\n";
+      err = -EPERM;
+      goto reply_no_propose;
     }
 
     pending_inc.crush.clear();
     newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
-    ss << "reweighted all crush weights by scaling factor "
-       << g_conf().get_val<double>("osd_crush_scaling_factor");
-    getline(ss, rs);
-    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
-						  get_last_committed() + 1));
+    output_ss << "reweighted all crush weights by scaling factor "
+              << osdmap.get_osd_crush_scaling_factor();
+    rs = output_ss.str();
+    wait_for_commit(
+        op, new Monitor::C_Command(mon, op, 0, rs, get_last_committed() + 1));
     return true;
   } else if (prefix == "osd crush reweight-subtree") {
     // osd crush reweight <name> <weight>
@@ -12388,6 +12395,25 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       pending_inc.new_backfillfull_ratio = n;
     else if (prefix == "osd set-nearfull-ratio")
       pending_inc.new_nearfull_ratio = n;
+    ss << prefix << " " << n;
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+					      get_last_committed() + 1));
+    return true;
+  } else if (prefix == "osd set-crush-scaling-factor") {
+    double n;
+    if (!cmd_getval(cmdmap, "factor", n)){
+      ss << "unable to parse 'factor' value '"
+         << cmd_vartype_stringify(cmdmap.at("factor")) << "'";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    if (n < 0.001 || n > 1.0) {
+      ss << "scaling factor must be between 0.001 and 1.0";
+      err = -EINVAL;
+      goto reply_no_propose;
+    }
+    pending_inc.new_osd_crush_scaling_factor = n;
     ss << prefix << " " << n;
     getline(ss, rs);
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11750,6 +11750,105 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 						  get_last_committed() + 1));
     return true;
+  } else if (prefix == "osd crush reweight-by-scaling-factor" ||
+             prefix == "osd crush test-reweight-by-scaling-factor") {
+
+    bool really = false;
+    cmd_getval(cmdmap, "yes_i_really_mean_it", really);
+
+    bool skip_metadata_lookup = false;
+    cmd_getval(cmdmap, "skip_metadata_lookup", skip_metadata_lookup);
+
+    bool dry_run = prefix == "osd crush test-reweight-by-scaling-factor";
+
+    if (skip_metadata_lookup)
+      ss << "reweighting all OSDs using scaling factor "
+         << g_conf().get_val<double>("osd_crush_scaling_factor") << ":";
+    else
+      ss << "reweighting all OSDs using scaling factor "
+         << g_conf().get_val<double>("osd_crush_scaling_factor")
+         << " based on device size metadata:";
+
+    if (dry_run)
+      ss << "This is a dry run, no changes will be made. "
+         << "Use 'test-reweight-by-scaling-factor -o newcrush' "
+         << "then 'crushdiff compare -c newcrush' "
+         << "to check if this will cause data movement.";
+
+    CrushWrapper newcrush = _get_pending_crush();
+
+    for (int id = 0; id < newcrush.get_max_devices(); ++id) {
+        if (!newcrush.get_item_weight(id)) {
+          // weight is 0, skip
+          continue;
+        }
+        double new_weight = g_conf().get_val<double>("osd_crush_scaling_factor") *
+                                   newcrush.get_item_weightf(id);
+
+        if (!skip_metadata_lookup) {
+          map<string,string> meta;
+          err = load_metadata(id, meta, nullptr);
+          if (err < 0) {
+            ss << "failed to load metadata for osd." << id
+               << ": " << cpp_strerror(err);
+            goto reply_no_propose;
+          }
+
+          // osd statfs.total is bluestore_bdev_size + bluefs_db_size
+          uint64_t total_size = 0;
+          auto p1 = meta.find("bluestore_bdev_size");
+          if (p1 == meta.end()) {
+            ss << "osd." << id << " does not have bluestore_bdev_size metadata";
+            goto reply_no_propose;
+          }
+          total_size = std::stoull(p1->second);
+          auto p2 = meta.find("bluefs_db_size");
+          if (p2 == meta.end()) {
+            ss << "osd." << id << " does not have bluefs_db_size metadata";
+            goto reply_no_propose;
+          }
+          total_size += std::stoull(p2->second);
+
+          // use the same calculation as OSD::update_crush_location
+          new_weight = std::max(0.00001,
+                                g_conf().get_val<double>("osd_crush_scaling_factor") *
+                                double(total_size) /
+                                double(1ull << 40));
+        }
+
+        ss << "reweighting osd." << id << " to " << new_weight;
+
+        err = newcrush.adjust_item_weightf(cct, id, new_weight,
+                                           g_conf()->osd_crush_update_weight_set);
+        if (err < 0)
+          goto reply_no_propose;
+    }
+
+    if (dry_run) {
+      // return the new crush map without committing
+      newcrush.encode(rdata, mon.get_quorum_con_features());
+      ss << "test reweighted all crush weights by scaling factor "
+         << g_conf().get_val<double>("osd_crush_scaling_factor");
+      return true;
+    }
+
+    if (!really) {
+      ss << "WARNING: this will reweight all crush weights by scaling factor "
+        << g_conf().get_val<double>("osd_crush_scaling_factor")
+        << " and may cause data movement."
+        "If you are certain that is what you want, "
+        "pass the flag --yes-i-really-mean-it.";
+      return -EPERM;
+    }
+
+    pending_inc.crush.clear();
+    newcrush.encode(pending_inc.crush, mon.get_quorum_con_features());
+    ss << "reweighted all crush weights by scaling factor "
+       << g_conf().get_val<double>("osd_crush_scaling_factor");
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+						  get_last_committed() + 1));
+    return true;
   } else if (prefix == "osd crush reweight-subtree") {
     // osd crush reweight <name> <weight>
     CrushWrapper newcrush = _get_pending_crush();

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3498,6 +3498,21 @@ void PGMap::get_health_checks(
       d.detail.swap(detail);
     }
   }
+
+  // LARGE_CRUSH_BUCKET
+  if (g_conf().get_val<bool>("mon_warn_on_large_crush_bucket")) {
+    for (int b = 0; b < osdmap.crush->get_max_buckets(); ++b) {
+      int bid = -1 - b;
+      if (osdmap.crush->bucket_exists(bid) &&
+          osdmap.crush->get_bucket_weightf(bid) > 60000.0) {
+        ostringstream ss;
+        ss << "CRUSH bucket " << osdmap.crush->get_item_name(bid)
+           << " is nearing the maximum weight of 65535";
+        auto& d = checks->add("LARGE_CRUSH_BUCKET", HEALTH_WARN, ss.str(), 1);
+        d.detail.push_back("use a smaller osd_crush_scaling_factor before adding more OSDs");
+      }
+    }
+  }
 }
 
 void PGMap::print_summary(ceph::Formatter *f, ostream *out) const

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3524,6 +3524,21 @@ void PGMap::get_health_checks(
       d.detail.swap(detail);
     }
   }
+
+  // LARGE_CRUSH_BUCKET
+  if (g_conf().get_val<bool>("mon_warn_on_large_crush_bucket")) {
+    for (int b = 0; b < osdmap.crush->get_max_buckets(); ++b) {
+      int bid = -1 - b;
+      if (osdmap.crush->bucket_exists(bid) &&
+          osdmap.crush->get_bucket_weightf(bid) > 60000.0) {
+        ostringstream ss;
+        ss << "CRUSH bucket " << osdmap.crush->get_item_name(bid)
+           << " is nearing the maximum weight of 65535";
+        auto& d = checks->add("LARGE_CRUSH_BUCKET", HEALTH_WARN, ss.str(), 1);
+        d.detail.push_back("use a smaller osd_crush_scaling_factor before adding more OSDs");
+      }
+    }
+  }
 }
 
 void PGMap::print_summary(ceph::Formatter *f, ostream *out) const

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4894,7 +4894,7 @@ int OSD::check_crush_weight()
   }
 
   double expected_weight = std::max(.00001,
-                g_conf().get_val<double>("osd_crush_scaling_factor") *
+		osdmap->get_osd_crush_scaling_factor() *
                 double(st.total) /
                 double(1ull << 40 /* TiB */));
 
@@ -4914,6 +4914,8 @@ int OSD::check_crush_weight()
 
 int OSD::update_crush_location()
 {
+  OSDMapRef osdmap = get_osdmap();
+
   if (!cct->_conf->osd_crush_update_on_start) {
     dout(10) << __func__ << " osd_crush_update_on_start = false" << dendl;
     return 0;
@@ -4932,7 +4934,7 @@ int OSD::update_crush_location()
     }
     snprintf(weight, sizeof(weight), "%.4lf",
 	     std::max(.00001,
-                      g_conf().get_val<double>("osd_crush_scaling_factor") *
+		      osdmap->get_osd_crush_scaling_factor() *
 		      double(st.total) /
 		      double(1ull << 40 /* TiB */)));
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4890,8 +4890,9 @@ int OSD::update_crush_location()
     }
     snprintf(weight, sizeof(weight), "%.4lf",
 	     std::max(.00001,
+                      g_conf().get_val<double>("osd_crush_scaling_factor") *
 		      double(st.total) /
-		      double(1ull << 40 /* TB */)));
+		      double(1ull << 40 /* TiB */)));
   }
 
   dout(10) << __func__ << " crush location is " << cct->crush_location << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4071,6 +4071,8 @@ int OSD::init()
   maybe_override_options_for_qos();
   maybe_override_max_osd_capacity_for_qos();
 
+  check_crush_weight();
+
   return 0;
 
 out:
@@ -4883,6 +4885,46 @@ int OSD::mon_cmd_maybe_osd_create(string &&cmd)
       return r;
     }
     break;
+  }
+
+  return 0;
+}
+
+int OSD::check_crush_weight()
+{
+  OSDMapRef osdmap = get_osdmap();
+
+  if (!osdmap->crush->item_exists(whoami)) {
+    dout(1) << "osd." << whoami << " is not in CRUSH map" << dendl;
+    return 0;
+  }
+
+  // 1. Current weight from the CRUSH map
+  double crush_weight = osdmap->crush->get_item_weightf(whoami);
+
+  // 2. Correct weight based on total size (TiB) and scaling factor
+  struct store_statfs_t st;
+  osd_alert_list_t alerts;
+  int r = store->statfs(&st, &alerts);
+  if (r < 0) {
+    derr << "statfs: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  double expected_weight = std::max(.00001,
+                g_conf().get_val<double>("osd_crush_scaling_factor") *
+                double(st.total) /
+                double(1ull << 40 /* TiB */));
+
+  // 3. Compare with limited precision (to avoid float noise)
+  if (std::abs(crush_weight - expected_weight) > 0.0001) {
+    dout(1) << "osd." << whoami << " CRUSH weight mismatch: "
+            << "CRUSH = " << crush_weight
+            << ", expected = " << expected_weight << dendl;
+  } else {
+    dout(2) << "osd." << whoami << " CRUSH weight matches: "
+             << "CRUSH = " << crush_weight
+             << ", expected = " << expected_weight << dendl;
   }
 
   return 0;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4908,8 +4908,9 @@ int OSD::update_crush_location()
     }
     snprintf(weight, sizeof(weight), "%.4lf",
 	     std::max(.00001,
+                      g_conf().get_val<double>("osd_crush_scaling_factor") *
 		      double(st.total) /
-		      double(1ull << 40 /* TB */)));
+		      double(1ull << 40 /* TiB */)));
   }
 
   dout(10) << __func__ << " crush location is " << cct->crush_location << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4912,7 +4912,7 @@ int OSD::check_crush_weight()
   }
 
   double expected_weight = std::max(.00001,
-                g_conf().get_val<double>("osd_crush_scaling_factor") *
+		osdmap->get_osd_crush_scaling_factor() *
                 double(st.total) /
                 double(1ull << 40 /* TiB */));
 
@@ -4932,6 +4932,8 @@ int OSD::check_crush_weight()
 
 int OSD::update_crush_location()
 {
+  OSDMapRef osdmap = get_osdmap();
+
   if (!cct->_conf->osd_crush_update_on_start) {
     dout(10) << __func__ << " osd_crush_update_on_start = false" << dendl;
     return 0;
@@ -4950,7 +4952,7 @@ int OSD::update_crush_location()
     }
     snprintf(weight, sizeof(weight), "%.4lf",
 	     std::max(.00001,
-                      g_conf().get_val<double>("osd_crush_scaling_factor") *
+		      osdmap->get_osd_crush_scaling_factor() *
 		      double(st.total) /
 		      double(1ull << 40 /* TiB */)));
   }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2192,6 +2192,7 @@ private:
   int mon_cmd_maybe_osd_create(std::string &&cmd);
   int update_crush_device_class();
   int update_crush_location();
+  int check_crush_weight();
 
   static int write_meta(CephContext *cct,
 			ObjectStore *store,

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2206,6 +2206,7 @@ private:
   int mon_cmd_maybe_osd_create(std::string &&cmd);
   int update_crush_device_class();
   int update_crush_location();
+  int check_crush_weight();
 
   static int write_meta(CephContext *cct,
 			ObjectStore *store,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -666,7 +666,7 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
   }
 
   {
-    uint8_t target_v = 9; // if bumping this, be aware of allow_crimson 12
+    uint8_t target_v = 9; // if bumping this, be aware of osd_crush_scaling_factor 13
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 2;
     } else if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
@@ -737,6 +737,9 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
     }
     if (target_v >= 12) {
       encode(mutate_allow_crimson, bl);
+    }
+    if (target_v >= 13) {
+      encode(new_osd_crush_scaling_factor, bl);
     }
     ENCODE_FINISH(bl); // osd-only data
   }
@@ -951,7 +954,7 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(12, bl); // extended, osd-only data
+    DECODE_START(13, bl); // extended, osd-only data
     decode(new_hb_back_up, bl);
     decode(new_up_thru, bl);
     decode(new_last_clean_interval, bl);
@@ -1023,6 +1026,11 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
     if (struct_v >= 12) {
       decode(mutate_allow_crimson, bl);
     }
+    if (struct_v >= 13) {
+      decode(new_osd_crush_scaling_factor, bl);
+    } else {
+      new_osd_crush_scaling_factor = -1.0;
+    }
     DECODE_FINISH(bl); // osd-only data
   }
 
@@ -1072,6 +1080,7 @@ void OSDMap::Incremental::dump(Formatter *f) const
   f->dump_int("new_require_min_compat_client", to_integer<int>(new_require_min_compat_client));
   f->dump_int("new_require_osd_release", to_integer<int>(new_require_osd_release));
   f->dump_unsigned("mutate_allow_crimson", static_cast<unsigned>(mutate_allow_crimson));
+  f->dump_float("new_osd_crush_scaling_factor", new_osd_crush_scaling_factor);
 
   if (fullmap.length()) {
     f->open_object_section("full_map");
@@ -2701,6 +2710,10 @@ int OSDMap::apply_incremental(const Incremental &inc)
     break;
   }
 
+  if (inc.new_osd_crush_scaling_factor >= 0) {
+    osd_crush_scaling_factor = inc.new_osd_crush_scaling_factor;
+  }
+
   calc_num_osds();
   _calc_up_osd_features();
   return 0;
@@ -3517,7 +3530,7 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
   {
     // NOTE: any new encoding dependencies must be reflected by
     // SIGNIFICANT_FEATURES
-    uint8_t target_v = 9; // when bumping this, be aware of allow_crimson
+    uint8_t target_v = 9; // when bumping this, be aware of osd_crush_scaling_factor 13
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 1;
     } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
@@ -3533,6 +3546,9 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     }
     if (allow_crimson) {
       target_v = std::max((uint8_t)12, target_v);
+    }
+    if (osd_crush_scaling_factor != 1.0) {
+      target_v = std::max((uint8_t)13, target_v);
     }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data
     if (target_v < 7) {
@@ -3594,6 +3610,9 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     }
     if (target_v >= 12) {
       ::encode(allow_crimson, bl);
+    }
+    if (target_v >= 13) {
+      encode(osd_crush_scaling_factor, bl);
     }
     ENCODE_FINISH(bl); // osd-only data
   }
@@ -3860,7 +3879,7 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(12, bl); // extended, osd-only data
+    DECODE_START(13, bl); // extended, osd-only data
     decode(osd_addrs->hb_back_addrs, bl);
     decode(osd_info, bl);
     decode(blocklist, bl);
@@ -3948,6 +3967,11 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
     }
     if (struct_v >= 12) {
       decode(allow_crimson, bl);
+    }
+    if (struct_v >= 13) {
+      decode(osd_crush_scaling_factor, bl);
+    } else {
+      osd_crush_scaling_factor = 1.0;
     }
     DECODE_FINISH(bl); // osd-only data
   }
@@ -4521,6 +4545,7 @@ void OSDMap::print(CephContext *cct, ostream& out) const
   if (allow_crimson) {
     out << "allow_crimson=true\n";
   }
+  out << "osd_crush_scaling_factor " << osd_crush_scaling_factor << "\n";
   out << "\n";
 
   print_pools(cct, out);

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -438,6 +438,8 @@ public:
     float new_backfillfull_ratio = -1;
     float new_full_ratio = -1;
 
+    float new_osd_crush_scaling_factor = -1.0;
+
     ceph_release_t new_require_min_compat_client{0xff};
 
     utime_t new_last_up_change, new_last_in_change;
@@ -651,6 +653,7 @@ private:
   bool new_blocklist_entries;
 
   float full_ratio = 0, backfillfull_ratio = 0, nearfull_ratio = 0;
+  float osd_crush_scaling_factor = 1.0;
 
   /// min compat client we want to support
   ceph_release_t require_min_compat_client{ceph_release_t::unknown};
@@ -776,6 +779,11 @@ public:
   float get_nearfull_ratio() const {
     return nearfull_ratio;
   }
+
+  float get_osd_crush_scaling_factor() const {
+    return osd_crush_scaling_factor;
+  }
+
   void get_full_pools(CephContext *cct,
                       std::set<int64_t> *full,
                       std::set<int64_t> *backfillfull,

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -438,6 +438,8 @@ public:
     float new_backfillfull_ratio = -1;
     float new_full_ratio = -1;
 
+    float new_osd_crush_scaling_factor = -1.0;
+
     ceph_release_t new_require_min_compat_client{0xff};
 
     utime_t new_last_up_change, new_last_in_change;
@@ -652,6 +654,7 @@ private:
   bool new_blocklist_entries;
 
   float full_ratio = 0, backfillfull_ratio = 0, nearfull_ratio = 0;
+  float osd_crush_scaling_factor = 1.0;
 
   /// min compat client we want to support
   ceph_release_t require_min_compat_client{ceph_release_t::unknown};
@@ -777,6 +780,11 @@ public:
   float get_nearfull_ratio() const {
     return nearfull_ratio;
   }
+
+  float get_osd_crush_scaling_factor() const {
+    return osd_crush_scaling_factor;
+  }
+
   void get_full_pools(CephContext *cct,
                       std::set<int64_t> *full,
                       std::set<int64_t> *backfillfull,


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/71763

This PR introduces a configurable `osd_crush_scaling_factor` to adjust how device sizes are translated into CRUSH weights.

CRUSH represents weights using a 16.16 fixed-point format, where `0x10000` corresponds to a weight of `1.0`. Bucket weights use the same representation, which means the maximum weight of a CRUSH bucket is capped to 65535.0:

```
crush/crush.h:#define CRUSH_MAX_BUCKET_WEIGHT (65535u * 0x10000u)
```

As a result, we only support clusters up to ~65.5 PiB.

This has been hit in real life, mainfesting like:

```
# ceph osd crush create-or-move osd.4524 14.98940 root=default host=myhostname
Error ERANGE: (34) Numerical result out of range
```

By setting `osd_crush_scaling_factor` to a value like `0.1`, weights are proportionally reduced, allowing CRUSH buckets to aggregate hundreds of PiB of capacity without exceeding the 16-bit weight ceiling.

This PR includes:

* The new `osd_crush_scaling_factor` option
* Automatic weight scaling during OSD creation and startup
* A new command: `ceph osd crush reweight-by-scaling-factor`
* A `LARGE_CRUSH_BUCKET` health warning
* QA tests validating the reweighting logic

Alternative approaches considered:

* Change the fixed-point scale, e.g., redefine `1.0` as `0x1000` or `0x100`. This would raise the max bucket capacity to 1 EiB or 16 EiB respectively, but required deeper CRUSH changes than the scaling factor approach.
* Introduce 64-bit CRUSH weights: a clean solution for the future, but likely more invasive across the codebase.

This patch provides a simple, backward-compatible way to unlock larger CRUSH buckets with minimal disruption.