### PR TITLE
Increase max device size from 100TiB to 1PiB

### DIFF
--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -26,7 +26,7 @@
 #define CRUSH_MAX_DEPTH 10  /* max crush hierarchy depth */
 #define CRUSH_MAX_RULES (1<<8)  /* max crush rule id */
 
-#define CRUSH_MAX_DEVICE_WEIGHT (100u * 0x10000u)
+#define CRUSH_MAX_DEVICE_WEIGHT (1000u * 0x10000u)
 #define CRUSH_MAX_BUCKET_WEIGHT (65535u * 0x10000u)
 
 #define CRUSH_ITEM_UNDEF  0x7ffffffe  /* undefined result (internal use only) */

--- a/src/test/cli/crushtool/adjust-item-weight.t
+++ b/src/test/cli/crushtool/adjust-item-weight.t
@@ -15,3 +15,11 @@
   $ crushtool -i two --update-item 0 3.0 device0 --loc host host0 --loc cluster cluster0 -o three > /dev/null
   $ crushtool -d three -o final
   $ diff final "$TESTDIR/simple.template.adj.three"
+
+#
+# update the weight of device0 in host=host0 to something above 100.0, which was a hardcoded max at some point in the past.
+#
+
+  $ crushtool -i three --update-item 0 123.0 device0 --loc host host0 --loc cluster cluster0 -o four > /dev/null
+  $ crushtool -d four -o final
+  $ diff final "$TESTDIR/simple.template.adj.four"

--- a/src/test/cli/crushtool/simple.template.adj.four
+++ b/src/test/cli/crushtool/simple.template.adj.four
@@ -1,0 +1,58 @@
+# begin crush map
+
+# devices
+device 0 device0
+
+# types
+type 0 device
+type 1 host
+type 2 cluster
+
+# buckets
+host host0 {
+	id -2		# do not change unnecessarily
+	# weight 123.00000
+	alg straw
+	hash 0	# rjenkins1
+	item device0 weight 123.00000
+}
+host fake {
+	id -3		# do not change unnecessarily
+	# weight 2.00000
+	alg straw
+	hash 0	# rjenkins1
+	item device0 weight 2.00000
+}
+cluster cluster0 {
+	id -1		# do not change unnecessarily
+	# weight 125.00000
+	alg straw
+	hash 0	# rjenkins1
+	item host0 weight 123.00000
+	item fake weight 2.00000
+}
+
+# rules
+rule data {
+	id 0
+	type replicated
+	step take cluster0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+rule metadata {
+	id 1
+	type replicated
+	step take cluster0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+rule rbd {
+	id 2
+	type replicated
+	step take cluster0
+	step chooseleaf firstn 0 type host
+	step emit
+}
+
+# end crush map


### PR DESCRIPTION
120 TiB devices are now on the market.

Fixes: https://tracker.ceph.com/issues/71764