### PR TITLE
squid: doc/radosgw: Cosmetic improvements in dynamicresharding.rst

### DIFF
--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -23,7 +23,7 @@ are blocked (but reads are not) briefly during resharding process.
 
 By default dynamic bucket index resharding can only increase the
 number of bucket index shards to 1999, although this upper-bound is a
-configuration parameter (see Configuration below). When
+configuration parameter (see `Configuration`_ below). When
 possible, the process chooses a prime number of shards in order to
 spread the number of entries across the bucket index
 shards more evenly.
@@ -37,9 +37,9 @@ resharding tasks, one at a time and in order.
 Multisite
 =========
 
-With Ceph releases Prior to Reef, the Ceph Object Gateway (RGW) does not support
+With Ceph releases prior to Reef, the Ceph Object Gateway (RGW) does not support
 dynamic resharding in a
-multisite environment. For information on dynamic resharding, see
+multisite deployment. For information on dynamic resharding, see
 :ref:`Resharding <feature_resharding>` in the RGW multisite documentation.
 
 Configuration
@@ -52,98 +52,106 @@ Configuration
 .. confval:: rgw_reshard_thread_interval
 .. confval:: rgw_reshard_num_logs
 
-Admin commands
+Admin Commands
 ==============
 
-Add a bucket to the resharding queue
+Add a Bucket to the Resharding Queue
 ------------------------------------
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin reshard add --bucket <bucket_name> --num-shards <new number of shards>
+   radosgw-admin reshard add --bucket <bucket_name> --num-shards <new number of shards>
 
-List resharding queue
+List Resharding Queue
 ---------------------
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin reshard list
+   radosgw-admin reshard list
 
-Process tasks on the resharding queue
+Process Tasks on the Resharding Queue
 -------------------------------------
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin reshard process
+   radosgw-admin reshard process
 
-Bucket resharding status
+Bucket Resharding Status
 ------------------------
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin reshard status --bucket <bucket_name>
+   radosgw-admin reshard status --bucket <bucket_name>
 
-The output is a JSON array of 3 objects (reshard_status, new_bucket_instance_id, num_shards) per shard.
+The output is a JSON array of 3 properties (``reshard_status``, ``new_bucket_instance_id``, ``num_shards``) per shard.
 
 For example, the output at each dynamic resharding stage is shown below:
 
-``1. Before resharding occurred:``
-::
+#. Before resharding occurred:
 
-  [
-    {
-        "reshard_status": "not-resharding",
-        "new_bucket_instance_id": "",
-        "num_shards": -1
-    }
-  ]
+   ::
 
-``2. During resharding:``
-::
+     [
+         {
+             "reshard_status": "not-resharding",
+             "new_bucket_instance_id": "",
+             "num_shards": -1
+         }
+     ]
 
-  [
-    {
-        "reshard_status": "in-progress",
-        "new_bucket_instance_id": "1179f470-2ebf-4630-8ec3-c9922da887fd.8652.1",
-        "num_shards": 2
-    },
-    {
-        "reshard_status": "in-progress",
-        "new_bucket_instance_id": "1179f470-2ebf-4630-8ec3-c9922da887fd.8652.1",
-        "num_shards": 2
-    }
-  ]
+#. During resharding:
 
-``3. After resharding completed:``
-::
+   ::
 
-  [
-    {
-        "reshard_status": "not-resharding",
-        "new_bucket_instance_id": "",
-        "num_shards": -1
-    },
-    {
-        "reshard_status": "not-resharding",
-        "new_bucket_instance_id": "",
-        "num_shards": -1
-    }
-  ]
+     [
+         {
+             "reshard_status": "in-progress",
+             "new_bucket_instance_id": "1179f470-2ebf-4630-8ec3-c9922da887fd.8652.1",
+             "num_shards": 2
+         },
+         {
+             "reshard_status": "in-progress",
+             "new_bucket_instance_id": "1179f470-2ebf-4630-8ec3-c9922da887fd.8652.1",
+             "num_shards": 2
+         }
+     ]
+
+#. After resharding completed:
+
+   ::
+
+     [
+         {
+             "reshard_status": "not-resharding",
+             "new_bucket_instance_id": "",
+             "num_shards": -1
+         },
+         {
+             "reshard_status": "not-resharding",
+             "new_bucket_instance_id": "",
+             "num_shards": -1
+         }
+     ]
 
 
-Cancel pending bucket resharding
+Cancel Pending Bucket Resharding
 --------------------------------
 
-Note: Bucket resharding operations cannot be cancelled while executing. ::
+.. note::
 
-   # radosgw-admin reshard cancel --bucket <bucket_name>
+  Bucket resharding tasks cannot be canceled once they transition to
+  the ``in-progress`` state from the initial ``not-resharding`` state.
 
-Manual immediate bucket resharding
+.. prompt:: bash #
+
+   radosgw-admin reshard cancel --bucket <bucket_name>
+
+Manual Immediate Bucket Resharding
 ----------------------------------
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin bucket reshard --bucket <bucket_name> --num-shards <new number of shards>
+   radosgw-admin bucket reshard --bucket <bucket_name> --num-shards <new number of shards>
 
 When choosing a number of shards, the administrator must anticipate each
 bucket's peak number of objects. Ideally one should aim for no
@@ -156,32 +164,47 @@ since the former is prime. A variety of web sites have lists of prime
 numbers; search for "list of prime numbers" with your favorite
 search engine to locate some web sites.
 
+Setting a Bucket's Minimum Number of Shards
+-------------------------------------------
+
+.. prompt:: bash #
+
+   radosgw-admin bucket set-min-shards --bucket <bucket_name> --num-shards <min number of shards>
+
+Since dynamic resharding can now reduce the number of shards,
+administrators may want to prevent the number of shards from becoming
+too low, for example if the expect the number of objects to increase
+in the future. This command allows administrators to set a per-bucket
+minimum. This does not, however, prevent administrators from manually
+resharding to a lower number of shards.
+
 Troubleshooting
 ===============
 
 Clusters prior to Luminous 12.2.11 and Mimic 13.2.5 left behind stale bucket
 instance entries, which were not automatically cleaned up. This issue also affected
-LifeCycle policies, which were no longer applied to resharded buckets. Both of
-these issues could be worked around by running ``radosgw-admin`` commands.
+lifecycle policies, which were no longer applied to resharded buckets. Both of
+these issues can be remediated by running ``radosgw-admin`` commands.
 
-Stale instance management
+Stale Instance Management
 -------------------------
 
-List the stale instances in a cluster that are ready to be cleaned up.
+List the stale instances in a cluster that may be cleaned up:
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin reshard stale-instances list
+   radosgw-admin reshard stale-instances list
 
-Clean up the stale instances in a cluster. Note: cleanup of these
-instances should only be done on a single-site cluster.
+Clean up the stale instances in a cluster:
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin reshard stale-instances delete
+   radosgw-admin reshard stale-instances delete
+
+.. note:: Cleanup of stale instances should not be done in a multisite deployment.
 
 
-Lifecycle fixes
+Lifecycle Fixes
 ---------------
 
 For clusters with resharded instances, it is highly likely that the old
@@ -193,15 +216,15 @@ resharding must be fixed manually.
 
 The command to do so is:
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin lc reshard fix --bucket {bucketname}
+   radosgw-admin lc reshard fix --bucket {bucketname}
 
 
 If the ``--bucket`` argument is not provided, this
 command will try to fix lifecycle policies for all the buckets in the cluster.
 
-Object Expirer fixes
+Object Expirer Fixes
 --------------------
 
 Objects subject to Swift object expiration on older clusters may have
@@ -213,17 +236,16 @@ objects, ``radosgw-admin`` provides two subcommands.
 
 Listing:
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin objects expire-stale list --bucket {bucketname}
+   radosgw-admin objects expire-stale list --bucket {bucketname}
 
 Displays a list of object names and expiration times in JSON format.
 
 Deleting:
 
-::
+.. prompt:: bash #
 
-   # radosgw-admin objects expire-stale rm --bucket {bucketname}
-
+   radosgw-admin objects expire-stale rm --bucket {bucketname}
 
 Initiates deletion of such objects, displaying a list of object names, expiration times, and deletion status in JSON format.


### PR DESCRIPTION
Make reference to config section a hyperlink.

Capitalization consistency: use title case in section titles, fix two invalid capitalizations in text.

Promptify CLI example commands.

A JSON key-value pair is a "property" and not an "object".

Use an ordered list instead of inline code with hardcoded list numbers.

Use the American "canceled" (majority of occurrences in doc/) instead of "cancelled".

Use admonitions instead of spelling out "Note:".
Clarify language on sharding cleanup for multisite.

Format JSON keys as inline code.

Indent example JSON output from radosgw-admin correctly (same as real output) with 4 spaces.

Use colon instead of full stop at the end of text that describes the following example command. Move admonition to after such example command.


(cherry picked from commit cbb9ab7716ae98ab80e485a6a4e3149e49be88aa)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

updater	## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

