### PR TITLE
crimson/os/seastore: introduce 2Q cache replacement algorithm

### DIFF
--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -10,7 +10,7 @@ overrides:
       osd:
         crimson osd obc lru size: 10
         debug ms: 20
-        seastore cache lru size: 64M
+        seastore cachepin size pershard: 64M
         seastore max concurrent transactions: 8
   workunit:
     env:

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -152,6 +152,27 @@ options:
   level: advanced
   desc: Size in bytes of extents to keep in cache (per reactor).
   default: 2_G
+- name: seastore_cachepin_type
+  type: str
+  level: dev
+  desc: The cache replacement algorithm used by extent pinboard in seastore. (LRU/2Q)
+  default: LRU
+  enum_values:
+  - LRU
+  - 2Q
+- name: seastore_cachepin_2q_in_ratio
+  type: float
+  level: advanced
+  desc: Ratio of A1_in queue size to cache size(seastore_cachepin_size_pershard) in 2Q cache algorithm.
+        Note that the size of Am(primary) queue in 2Q is cache_size * (1 - in_ratio).
+  default: 0.5
+- name: seastore_cachepin_2q_out_ratio
+  type: float
+  level: advanced
+  desc: Ratio of A1_out queue size to cache size(seastore_cachepin_size_pershard) in 2Q cache algorithm.
+        Note this size ratio does not reflect actual memory usage, as it represents the size of evicted
+        pages from A1_in queue.
+  default: 0.5
 - name: seastore_obj_data_write_amplification
   type: float
   level: advanced

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -147,7 +147,7 @@ options:
   level: advanced
   desc: Max size in bytes that an extent can be, 0 to disable
   default: 0
-- name: seastore_cache_lru_size
+- name: seastore_cachepin_size_pershard
   type: size
   level: advanced
   desc: Size in bytes of extents to keep in cache (per reactor).

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -9,6 +9,7 @@ set(crimson_seastore_srcs
   transaction_manager.cc
   transaction.cc
   cache.cc
+  extent_pinboard.cc
   root_block.cc
   lba_manager.cc
   async_cleaner.cc

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -727,7 +727,7 @@ void Cache::mark_dirty(CachedExtentRef ref)
 {
   assert(ref->get_paddr().is_absolute());
   if (ref->is_stable_dirty()) {
-    assert(ref->primary_ref_list_hook.is_linked());
+    assert(ref->is_linked_to_list());
     return;
   }
 
@@ -741,7 +741,7 @@ void Cache::add_to_dirty(
     const Transaction::src_t* p_src)
 {
   assert(ref->is_stable_dirty());
-  assert(!ref->primary_ref_list_hook.is_linked());
+  assert(!ref->is_linked_to_list());
   ceph_assert(ref->get_modify_time() != NULL_TIME);
   assert(ref->is_fully_loaded());
   assert(ref->get_paddr().is_absolute() ||
@@ -771,7 +771,7 @@ void Cache::remove_from_dirty(
     const Transaction::src_t* p_src)
 {
   assert(ref->is_stable_dirty());
-  ceph_assert(ref->primary_ref_list_hook.is_linked());
+  ceph_assert(ref->is_linked_to_list());
   assert(ref->is_fully_loaded());
   assert(ref->get_paddr().is_absolute() ||
          ref->get_paddr().is_root());
@@ -803,11 +803,11 @@ void Cache::replace_dirty(
     const Transaction::src_t& src)
 {
   assert(prev->is_stable_dirty());
-  ceph_assert(prev->primary_ref_list_hook.is_linked());
+  ceph_assert(prev->is_linked_to_list());
   assert(prev->is_fully_loaded());
 
   assert(next->is_stable_dirty());
-  assert(!next->primary_ref_list_hook.is_linked());
+  assert(!next->is_linked_to_list());
   ceph_assert(next->get_modify_time() != NULL_TIME);
   assert(next->is_fully_loaded());
 
@@ -833,7 +833,7 @@ void Cache::clear_dirty()
   for (auto i = dirty.begin(); i != dirty.end(); ) {
     auto ptr = &*i;
     assert(ptr->is_stable_dirty());
-    ceph_assert(ptr->primary_ref_list_hook.is_linked());
+    ceph_assert(ptr->is_linked_to_list());
     assert(ptr->is_fully_loaded());
 
     auto extent_length = ptr->get_length();
@@ -889,7 +889,7 @@ void Cache::commit_replace_extent(
   const auto t_src = t.get_src();
   if (is_root_type(prev->get_type())) {
     assert(prev->is_stable_dirty());
-    assert(prev->primary_ref_list_hook.is_linked());
+    assert(prev->is_linked_to_list());
     // add the new dirty root to front
     remove_from_dirty(prev, nullptr/* exclude root */);
     add_to_dirty(next, nullptr/* exclude root */);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1535,7 +1535,7 @@ record_t Cache::prepare_record(
     i->state = CachedExtent::extent_state_t::CLEAN;
     assert(i->is_logical());
     i->clear_modified_region();
-    touch_extent(*i, &trans_src, t.get_cache_hint());
+    touch_extent_fully(*i, &trans_src, t.get_cache_hint());
     DEBUGT("inplace rewrite ool block is commmitted -- {}", t, *i);
   }
 
@@ -1570,7 +1570,7 @@ record_t Cache::prepare_record(
     if (i->is_stable_dirty()) {
       add_to_dirty(i, &t_src);
     } else {
-      touch_extent(*i, &t_src, t.get_cache_hint());
+      touch_extent_fully(*i, &t_src, t.get_cache_hint());
     }
 
     alloc_delta.alloc_blk_ranges.emplace_back(
@@ -1814,7 +1814,7 @@ void Cache::complete_commit(
     i->invalidate_hints();
     add_extent(i);
     const auto t_src = t.get_src();
-    touch_extent(*i, &t_src, t.get_cache_hint());
+    touch_extent_fully(*i, &t_src, t.get_cache_hint());
     i->complete_io();
     epm.commit_space_used(i->get_paddr(), i->get_length());
 
@@ -2083,7 +2083,7 @@ Cache::replay_delta(
             ext.cast<LogicalCachedExtent>()->set_laddr(laddr);
           }
           // replay is not included by the cache hit metrics
-          touch_extent(ext, nullptr, CACHE_HINT_TOUCH);
+          touch_extent_fully(ext, nullptr, CACHE_HINT_TOUCH);
         },
         nullptr) :
       _get_extent_if_cached(

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -70,7 +70,7 @@ std::ostream &operator<<(std::ostream &out, const CachedExtent &ext)
 CachedExtent::~CachedExtent()
 {
   if (parent_index) {
-    assert(is_linked());
+    assert(is_linked_to_index());
     parent_index->erase(*this);
   }
 }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -838,6 +838,15 @@ public:
     cache_state = state;
   }
 
+  extent_len_t get_last_touch_end() const {
+    return last_touch_end;
+  }
+
+  void set_last_touch_end(extent_len_t touch_end) {
+    assert(touch_end != 0);
+    last_touch_end = touch_end;
+  }
+
 private:
   template <typename T>
   friend class read_set_item_t;
@@ -944,6 +953,10 @@ private:
   // the target rewrite generation for the followup rewrite
   // or the rewrite generation for the fresh write
   rewrite_gen_t rewrite_generation = NULL_GENERATION;
+
+  // save the end offset of the most recent of extent touching,
+  // see Cache::touch_extent_by_range() and ExtentPinboardTwoQ.
+  extent_len_t last_touch_end = 0;
 
   // This field is unused when the ExtentPinboard use LRU algorithm
   extent_2q_state_t cache_state = extent_2q_state_t::Fresh;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -840,8 +840,12 @@ private:
   friend class ExtentIndex;
   friend class Transaction;
 
-  bool is_linked() {
+  bool is_linked_to_index() {
     return extent_index_hook.is_linked();
+  }
+
+  bool is_linked_to_list() {
+    return primary_ref_list_hook.is_linked();
   }
 
   /// hook for intrusive ref list (mainly dirty or lru list)
@@ -1272,7 +1276,7 @@ public:
 
   void erase(CachedExtent &extent) {
     assert(extent.parent_index);
-    assert(extent.is_linked());
+    assert(extent.is_linked_to_index());
     [[maybe_unused]] auto erased = extent_index.erase(
       extent_index.s_iterator_to(extent));
     extent.parent_index = nullptr;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1011,6 +1011,7 @@ protected:
   }
 
   friend class Cache;
+  friend class ExtentPinboardLRU;
   template <typename T, typename... Args>
   static TCachedExtentRef<T> make_cached_extent_ref(
     Args&&... args) {

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1011,6 +1011,7 @@ protected:
   }
 
   friend class Cache;
+  friend class ExtentQueue;
   friend class ExtentPinboardLRU;
   template <typename T, typename... Args>
   static TCachedExtentRef<T> make_cached_extent_ref(

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -40,7 +40,7 @@ class ExtentQueue {
     const Transaction::src_t* p_src) {
     assert(extent.is_stable_clean());
     assert(!extent.is_placeholder());
-    assert(extent.primary_ref_list_hook.is_linked());
+    assert(extent.is_linked_to_list());
     assert(list.size() > 0);
     auto extent_loaded_length = extent.get_loaded_length();
     assert(current_size >= extent_loaded_length);
@@ -90,7 +90,7 @@ public:
     assert(extent.is_stable_clean());
     assert(!extent.is_placeholder());
 
-    if (extent.primary_ref_list_hook.is_linked()) {
+    if (extent.is_linked_to_list()) {
       do_remove_from_list(extent, nullptr);
     }
   }
@@ -102,7 +102,7 @@ public:
     assert(!extent.is_placeholder());
 
     auto extent_loaded_length = extent.get_loaded_length();
-    if (extent.primary_ref_list_hook.is_linked()) {
+    if (extent.is_linked_to_list()) {
       // present, move to top (back)
       assert(list.size() > 0);
       assert(current_size >= extent_loaded_length);
@@ -135,7 +135,7 @@ public:
     const Transaction::src_t* p_src) {
     assert(extent.is_data_stable());
 
-    if (extent.primary_ref_list_hook.is_linked()) {
+    if (extent.is_linked_to_list()) {
       assert(extent.is_stable_clean());
       assert(!extent.is_placeholder());
       // present, increase size

--- a/src/crimson/os/seastore/extent_pinboard.cc
+++ b/src/crimson/os/seastore/extent_pinboard.cc
@@ -1,0 +1,289 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/os/seastore/extent_pinboard.h"
+#include "crimson/os/seastore/transaction.h"
+
+SET_SUBSYS(seastore_cache);
+
+namespace crimson::os::seastore {
+
+class ExtentPinboardLRU : public ExtentPinboard {
+  // max size (bytes)
+  const std::size_t capacity = 0;
+
+  // current size (bytes)
+  std::size_t current_size = 0;
+
+  counter_by_extent_t<cache_size_stats_t> sizes_by_ext;
+  cache_io_stats_t overall_io;
+  counter_by_src_t<counter_by_extent_t<cache_io_stats_t> >
+    trans_io_by_src_ext;
+
+  mutable cache_io_stats_t last_overall_io;
+  mutable cache_io_stats_t last_trans_io;
+  mutable counter_by_src_t<counter_by_extent_t<cache_io_stats_t> >
+    last_trans_io_by_src_ext;
+
+  CachedExtent::primary_ref_list lru;
+
+  seastar::metrics::metric_group metrics;
+
+  void do_remove_from_lru(
+    CachedExtent &extent,
+    const Transaction::src_t* p_src) {
+    assert(extent.is_stable_clean());
+    assert(!extent.is_placeholder());
+    assert(extent.primary_ref_list_hook.is_linked());
+    assert(lru.size() > 0);
+    auto extent_loaded_length = extent.get_loaded_length();
+    assert(current_size >= extent_loaded_length);
+
+    lru.erase(lru.s_iterator_to(extent));
+    current_size -= extent_loaded_length;
+    get_by_ext(sizes_by_ext, extent.get_type()).account_out(extent_loaded_length);
+    overall_io.out_sizes.account_in(extent_loaded_length);
+    if (p_src) {
+      get_by_ext(
+        get_by_src(trans_io_by_src_ext, *p_src),
+        extent.get_type()
+      ).out_sizes.account_in(extent_loaded_length);
+    }
+    intrusive_ptr_release(&extent);
+  }
+
+  void trim_to_capacity(
+    const Transaction::src_t* p_src) {
+    while (current_size > capacity) {
+      do_remove_from_lru(lru.front(), p_src);
+    }
+  }
+
+public:
+  ExtentPinboardLRU(std::size_t capacity) : capacity(capacity) {
+    LOG_PREFIX(ExtentPinboardLRU::ExtentPinboardLRU);
+    INFO("created, lru_capacity=0x{:x}B", capacity);
+  }
+
+  std::size_t get_capacity_bytes() const {
+    return capacity;
+  }
+
+  std::size_t get_current_size_bytes() const final {
+    return current_size;
+  }
+
+  std::size_t get_current_num_extents() const final {
+    return lru.size();
+  }
+
+  void register_metrics() final {
+    namespace sm = seastar::metrics;
+    metrics.add_group(
+      "cache",
+      {
+        sm::make_counter(
+          "lru_size_bytes",
+          [this] {
+            return get_current_size_bytes();
+          },
+          sm::description("total bytes pinned by the lru")
+        ),
+        sm::make_counter(
+          "lru_num_extents",
+          [this] {
+            return get_current_num_extents();
+          },
+          sm::description("total extents pinned by the lru")
+        ),
+      }
+    );
+  }
+
+  void get_stats(
+    cache_stats_t &stats,
+    bool report_detail,
+    double seconds) const final;
+
+  void remove(CachedExtent &extent) {
+    assert(extent.is_stable_clean());
+    assert(!extent.is_placeholder());
+
+    if (extent.primary_ref_list_hook.is_linked()) {
+      do_remove_from_lru(extent, nullptr);
+    }
+  }
+
+  void move_to_top(
+    CachedExtent &extent,
+    const Transaction::src_t* p_src) {
+    assert(extent.is_stable_clean());
+    assert(!extent.is_placeholder());
+
+    auto extent_loaded_length = extent.get_loaded_length();
+    if (extent.primary_ref_list_hook.is_linked()) {
+      // present, move to top (back)
+      assert(lru.size() > 0);
+      assert(current_size >= extent_loaded_length);
+      lru.erase(lru.s_iterator_to(extent));
+      lru.push_back(extent);
+    } else {
+      // absent, add to top (back)
+      if (extent_loaded_length > 0) {
+        current_size += extent_loaded_length;
+        overall_io.in_sizes.account_in(extent_loaded_length);
+        if (p_src) {
+          get_by_ext(
+            get_by_src(trans_io_by_src_ext, *p_src),
+            extent.get_type()
+          ).in_sizes.account_in(extent_loaded_length);
+        }
+      } // else: the extent isn't loaded upon touch_extent()/on_cache(),
+        //       account the io later in increase_cached_size() upon read_extent()
+      get_by_ext(sizes_by_ext, extent.get_type()).account_in(extent_loaded_length);
+      intrusive_ptr_add_ref(&extent);
+      lru.push_back(extent);
+
+      trim_to_capacity(p_src);
+    }
+  }
+
+  void increase_cached_size(
+    CachedExtent &extent,
+    extent_len_t increased_length,
+    const Transaction::src_t* p_src) final {
+    assert(extent.is_data_stable());
+
+    if (extent.primary_ref_list_hook.is_linked()) {
+      assert(extent.is_stable_clean());
+      assert(!extent.is_placeholder());
+      // present, increase size
+      assert(lru.size() > 0);
+      current_size += increased_length;
+      get_by_ext(sizes_by_ext, extent.get_type()).account_parital_in(increased_length);
+      overall_io.in_sizes.account_in(increased_length);
+      if (p_src) {
+        get_by_ext(
+          get_by_src(trans_io_by_src_ext, *p_src),
+          extent.get_type()
+        ).in_sizes.account_in(increased_length);
+      }
+
+      trim_to_capacity(nullptr);
+    }
+  }
+
+  void clear() final {
+    LOG_PREFIX(ExtentPinboardLRU::clear);
+    for (auto iter = lru.begin(); iter != lru.end();) {
+      SUBDEBUG(seastore_cache, "clearing {}", *iter);
+      do_remove_from_lru(*(iter++), nullptr);
+    }
+  }
+
+  ~ExtentPinboardLRU() {
+    clear();
+  }
+};
+
+ExtentPinboardRef create_extent_pinboard(std::size_t capacity) {
+  return std::make_unique<ExtentPinboardLRU>(capacity);
+}
+
+void ExtentPinboardLRU::get_stats(
+  cache_stats_t &stats,
+  bool report_detail,
+  double seconds) const
+{
+  LOG_PREFIX(Cache::LRU::get_stats);
+
+  stats.lru_sizes = cache_size_stats_t{current_size, lru.size()};
+  stats.lru_io = overall_io;
+  stats.lru_io.minus(last_overall_io);
+
+  if (report_detail && seconds != 0) {
+    counter_by_src_t<counter_by_extent_t<cache_io_stats_t> >
+      _trans_io_by_src_ext = trans_io_by_src_ext;
+    counter_by_src_t<cache_io_stats_t> trans_io_by_src;
+    cache_io_stats_t trans_io;
+    for (uint8_t _src=0; _src<TRANSACTION_TYPE_MAX; ++_src) {
+      auto src = static_cast<transaction_type_t>(_src);
+      auto& io_by_ext = get_by_src(_trans_io_by_src_ext, src);
+      const auto& last_io_by_ext = get_by_src(last_trans_io_by_src_ext, src);
+      auto& trans_io_per_src = get_by_src(trans_io_by_src, src);
+      for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
+        auto ext = static_cast<extent_types_t>(_ext);
+        auto& extent_io = get_by_ext(io_by_ext, ext);
+        const auto& last_extent_io = get_by_ext(last_io_by_ext, ext);
+        extent_io.minus(last_extent_io);
+        trans_io_per_src.add(extent_io);
+      }
+      trans_io.add(trans_io_per_src);
+    }
+    cache_io_stats_t other_io = stats.lru_io;
+    other_io.minus(trans_io);
+
+    std::ostringstream oss;
+    oss << "\nlru total" << stats.lru_sizes;
+    cache_size_stats_t data_sizes;
+    cache_size_stats_t mdat_sizes;
+    cache_size_stats_t phys_sizes;
+    for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
+      auto ext = static_cast<extent_types_t>(_ext);
+      const auto& extent_sizes = get_by_ext(sizes_by_ext, ext);
+      if (is_data_type(ext)) {
+        data_sizes.add(extent_sizes);
+      } else if (is_logical_metadata_type(ext)) {
+        mdat_sizes.add(extent_sizes);
+      } else if (is_physical_type(ext)) {
+        phys_sizes.add(extent_sizes);
+      }
+    }
+    oss << "\n  data" << data_sizes
+        << "\n  mdat" << mdat_sizes
+        << "\n  phys" << phys_sizes;
+
+    oss << "\nlru io: trans-"
+        << cache_io_stats_printer_t{seconds, trans_io}
+        << "; other-"
+        << cache_io_stats_printer_t{seconds, other_io};
+    for (uint8_t _src=0; _src<TRANSACTION_TYPE_MAX; ++_src) {
+      auto src = static_cast<transaction_type_t>(_src);
+      const auto& trans_io_per_src = get_by_src(trans_io_by_src, src);
+      if (trans_io_per_src.is_empty()) {
+        continue;
+      }
+      cache_io_stats_t data_io;
+      cache_io_stats_t mdat_io;
+      cache_io_stats_t phys_io;
+      const auto& io_by_ext = get_by_src(_trans_io_by_src_ext, src);
+      for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
+        auto ext = static_cast<extent_types_t>(_ext);
+        const auto extent_io = get_by_ext(io_by_ext, ext);
+        if (is_data_type(ext)) {
+          data_io.add(extent_io);
+        } else if (is_logical_metadata_type(ext)) {
+          mdat_io.add(extent_io);
+        } else if (is_physical_type(ext)) {
+          phys_io.add(extent_io);
+        }
+      }
+      oss << "\n  " << src << ": "
+          << cache_io_stats_printer_t{seconds, trans_io_per_src}
+          << "\n    data: "
+          << cache_io_stats_printer_t{seconds, data_io}
+          << "\n    mdat: "
+          << cache_io_stats_printer_t{seconds, mdat_io}
+          << "\n    phys: "
+          << cache_io_stats_printer_t{seconds, phys_io};
+    }
+
+    INFO("{}", oss.str());
+
+    last_trans_io_by_src_ext = trans_io_by_src_ext;
+  }
+
+  last_overall_io = overall_io;
+}
+
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/extent_pinboard.h
+++ b/src/crimson/os/seastore/extent_pinboard.h
@@ -13,7 +13,9 @@ struct ExtentPinboard {
   virtual void register_metrics() = 0;
   virtual void move_to_top(
     CachedExtent &extent,
-    const Transaction::src_t *p_src) = 0;
+    const Transaction::src_t *p_src,
+    extent_len_t load_start,
+    extent_len_t load_length) = 0;
   virtual void remove(CachedExtent &extent) = 0;
   virtual void get_stats(
     cache_stats_t &stats,

--- a/src/crimson/os/seastore/extent_pinboard.h
+++ b/src/crimson/os/seastore/extent_pinboard.h
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/os/seastore/cached_extent.h"
+#include "crimson/os/seastore/transaction.h"
+
+namespace crimson::os::seastore {
+
+struct ExtentPinboard {
+  virtual ~ExtentPinboard() = default;
+  virtual void register_metrics() = 0;
+  virtual void move_to_top(
+    CachedExtent &extent,
+    const Transaction::src_t *p_src) = 0;
+  virtual void remove(CachedExtent &extent) = 0;
+  virtual void get_stats(
+    cache_stats_t &stats,
+    bool report_detail,
+    double seconds) const = 0;
+  virtual std::size_t get_current_size_bytes() const = 0;
+  virtual std::size_t get_current_num_extents() const = 0;
+  virtual void increase_cached_size(
+    CachedExtent &extent,
+    extent_len_t increased_length,
+    const Transaction::src_t *p_src) = 0;
+  virtual void clear() = 0;
+};
+using ExtentPinboardRef = std::unique_ptr<ExtentPinboard>;
+ExtentPinboardRef create_extent_pinboard(std::size_t capacity);
+
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -787,15 +787,15 @@ seastar::future<> SeaStore::report_stats()
       cache_total.add(s);
     }
 
-    cache_size_stats_t lru_sizes_ps = cache_total.lru_sizes;
-    lru_sizes_ps.divide_by(seastar::smp::count);
-    cache_io_stats_t lru_io_ps = cache_total.lru_io;
-    lru_io_ps.divide_by(seastar::smp::count);
-    INFO("cache lru: total{} {}; per-shard: total{} {}",
-         cache_total.lru_sizes,
-         cache_io_stats_printer_t{seconds, cache_total.lru_io},
-         lru_sizes_ps,
-         cache_io_stats_printer_t{seconds, lru_io_ps});
+    cache_size_stats_t queue_sizes_ps = cache_total.pinboard_sizes;
+    queue_sizes_ps.divide_by(seastar::smp::count);
+    cache_io_stats_t queue_io_ps = cache_total.pinboard_io;
+    queue_io_ps.divide_by(seastar::smp::count);
+    INFO("cache pinboard: total{} {}; per-shard: total{} {}",
+         cache_total.pinboard_sizes,
+         cache_io_stats_printer_t{seconds, cache_total.pinboard_io},
+         queue_sizes_ps,
+         cache_io_stats_printer_t{seconds, queue_io_ps});
 
     cache_size_stats_t dirty_sizes_ps = cache_total.dirty_sizes;
     dirty_sizes_ps.divide_by(seastar::smp::count);

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1294,7 +1294,6 @@ using laddr_offset_t = laddr_t::laddr_offset_t;
 constexpr laddr_t L_ADDR_MAX = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX);
 constexpr laddr_t L_ADDR_MIN = laddr_t::from_raw_uint(0);
 constexpr laddr_t L_ADDR_NULL = L_ADDR_MAX;
-constexpr laddr_t L_ADDR_ROOT = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX - 1);
 
 struct __attribute__((packed)) laddr_le_t {
   ceph_le64 laddr;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1278,6 +1278,11 @@ public:
   friend struct laddr_le_t;
   friend struct pladdr_le_t;
 
+  struct laddr_hash_t {
+    std::size_t operator()(const laddr_t &laddr) const {
+      return static_cast<std::size_t>(laddr.value);
+    }
+  };
 private:
   // Prevent direct construction of laddr_t with an integer,
   // always use laddr_t::from_raw_uint instead.
@@ -3138,3 +3143,19 @@ template <> struct fmt::formatter<crimson::os::seastore::write_result_t> : fmt::
 template <> struct fmt::formatter<crimson::os::seastore::omap_type_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<ceph::buffer::list> : fmt::ostream_formatter {};
 #endif
+
+template <>
+struct std::hash<crimson::os::seastore::laddr_t> {
+  using Laddr = crimson::os::seastore::laddr_t;
+  std::size_t operator()(const Laddr &laddr) const {
+    return Laddr::laddr_hash_t()(laddr);
+  }
+};
+
+template <>
+struct boost::hash<crimson::os::seastore::laddr_t> {
+  using Laddr = crimson::os::seastore::laddr_t;
+  std::size_t operator()(const Laddr &laddr) const {
+    return Laddr::laddr_hash_t()(laddr);
+  }
+};

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -3066,15 +3066,15 @@ struct cache_access_stats_printer_t {
 std::ostream& operator<<(std::ostream&, const cache_access_stats_printer_t&);
 
 struct cache_stats_t {
-  cache_size_stats_t lru_sizes;
-  cache_io_stats_t lru_io;
+  cache_size_stats_t pinboard_sizes;
+  cache_io_stats_t pinboard_io;
   cache_size_stats_t dirty_sizes;
   dirty_io_stats_t dirty_io;
   cache_access_stats_t access;
 
   void add(const cache_stats_t& o) {
-    lru_sizes.add(o.lru_sizes);
-    lru_io.add(o.lru_io);
+    pinboard_sizes.add(o.pinboard_sizes);
+    pinboard_io.add(o.pinboard_io);
     dirty_sizes.add(o.dirty_sizes);
     dirty_io.add(o.dirty_io);
     access.add(o.access);


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
