### PR TITLE
rgw: Add parameter to `get_storage` to indicate radosgw-admin call

### DIFF
--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -36,15 +36,15 @@ static inline Object* nextObject(Object* t)
   return dynamic_cast<FilterObject*>(t)->get_next();
 }
 
-D4NFilterDriver::D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context) : FilterDriver(_next),
-                                                                                       io_context(io_context) 
+D4NFilterDriver::D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context, bool admin) : FilterDriver(_next),
+												   io_context(io_context) 
 {
   rgw::cache::Partition partition_info;
   partition_info.location = g_conf()->rgw_d4n_l1_datacache_persistent_path;
   partition_info.name = "d4n";
   partition_info.type = "read-cache";
   partition_info.size = g_conf()->rgw_d4n_l1_datacache_size;
-  cacheDriver = std::make_unique<rgw::cache::SSDDriver>(partition_info);
+  cacheDriver = std::make_unique<rgw::cache::SSDDriver>(partition_info, admin);
 }
 
 D4NFilterDriver::~D4NFilterDriver() = default;
@@ -3102,9 +3102,9 @@ int D4NFilterMultipartUpload::complete(const DoutPrefixProvider *dpp,
 
 extern "C" {
 
-rgw::sal::Driver* newD4NFilter(rgw::sal::Driver* next, void* io_context)
+rgw::sal::Driver* newD4NFilter(rgw::sal::Driver* next, void* io_context, bool admin)
 {
-  rgw::sal::D4NFilterDriver* driver = new rgw::sal::D4NFilterDriver(next, *static_cast<boost::asio::io_context*>(io_context));
+  rgw::sal::D4NFilterDriver* driver = new rgw::sal::D4NFilterDriver(next, *static_cast<boost::asio::io_context*>(io_context), admin);
 
   return driver;
 }

--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -62,7 +62,7 @@ class D4NFilterDriver : public FilterDriver {
     boost::asio::io_context& io_context;
 
   public:
-    D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context);
+    D4NFilterDriver(Driver* _next, boost::asio::io_context& io_context, bool admin);
     virtual ~D4NFilterDriver();
 
     virtual int initialize(CephContext *cct, const DoutPrefixProvider *dpp) override;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -4616,7 +4616,7 @@ int main(int argc, const char **argv)
     if (raw_storage_op) {
       site = rgw::SiteConfig::make_fake();
       driver = DriverManager::get_raw_storage(dpp(), g_ceph_context,
-					      cfg, context_pool, *site, cfgstore.get());
+					      cfg, context_pool, *site, cfgstore.get(), true);
     } else {
       site = std::make_unique<rgw::SiteConfig>();
       auto r = site->load(dpp(), null_yield, cfgstore.get(), localzonegroup_op);
@@ -4640,7 +4640,7 @@ int main(int argc, const char **argv)
                                         null_yield,
 					cfgstore.get(),
 					need_cache && g_conf()->rgw_cache_enabled,
-					need_gc);
+					need_gc, true);
     }
     if (!driver) {
       cerr << "couldn't init storage provider" << std::endl;

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -63,7 +63,7 @@ extern rgw::sal::Driver* newPOSIXDriver(rgw::sal::Driver* next);
 #endif
 extern rgw::sal::Driver* newBaseFilter(rgw::sal::Driver* next);
 #ifdef WITH_RADOSGW_D4N
-extern rgw::sal::Driver* newD4NFilter(rgw::sal::Driver* next, boost::asio::io_context& io_context);
+extern rgw::sal::Driver* newD4NFilter(rgw::sal::Driver* next, boost::asio::io_context& io_context, bool admin);
 #endif
 }
 
@@ -81,7 +81,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
 						     bool use_cache,
 						     bool use_gc,
 						     bool background_tasks,
-						    optional_yield y, rgw::sal::ConfigStore* cfgstore)
+						    optional_yield y, rgw::sal::ConfigStore* cfgstore, bool admin)
 {
   rgw::sal::Driver* driver{nullptr};
 
@@ -206,7 +206,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
 #ifdef WITH_RADOSGW_D4N 
   else if (cfg.filter_name.compare("d4n") == 0) {
     rgw::sal::Driver* next = driver;
-    driver = newD4NFilter(next, io_context);
+    driver = newD4NFilter(next, io_context, admin);
 
     if (driver->initialize(cct, dpp) < 0) {
       delete driver;
@@ -234,7 +234,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
 
 rgw::sal::Driver* DriverManager::init_raw_storage_provider(const DoutPrefixProvider* dpp, CephContext* cct,
 							   const Config& cfg, boost::asio::io_context& io_context,
-							   const rgw::SiteConfig& site_config, rgw::sal::ConfigStore* cfgstore)
+							   const rgw::SiteConfig& site_config, rgw::sal::ConfigStore* cfgstore, bool admin)
 {
   rgw::sal::Driver* driver = nullptr;
   if (cfg.store_name.compare("rados") == 0) {

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1893,7 +1893,8 @@ public:
 				      optional_yield y,
               rgw::sal::ConfigStore* cfgstore,
 				      bool use_cache = true,
-				      bool use_gc = true) {
+				      bool use_gc = true,
+                                      bool admin = false) {
     rgw::sal::Driver* driver = init_storage_provider(dpp, cct, cfg, io_context,
 						   site_config,
 						   use_gc_thread,
@@ -1903,7 +1904,7 @@ public:
 						   run_reshard_thread,
                run_notification_thread,
 						   use_cache, use_gc,
-						   background_tasks, y, cfgstore);
+						   background_tasks, y, cfgstore, admin);
     return driver;
   }
   /** Get a stripped down driver by service name */
@@ -1911,11 +1912,12 @@ public:
 					  CephContext* cct, const Config& cfg,
 					  boost::asio::io_context& io_context,
 					  const rgw::SiteConfig& site_config,
-            rgw::sal::ConfigStore* cfgstore) {
+            rgw::sal::ConfigStore* cfgstore, 
+                                          bool admin = false) {
     rgw::sal::Driver* driver = init_raw_storage_provider(dpp, cct, cfg,
 							 io_context,
 							 site_config,
-               cfgstore);
+               cfgstore, admin);
     return driver;
   }
   /** Initialize a new full Driver */
@@ -1932,14 +1934,14 @@ public:
             bool run_notification_thread,
 						bool use_metadata_cache,
 						bool use_gc, bool background_tasks,
-						optional_yield y, rgw::sal::ConfigStore* cfgstore);
+						optional_yield y, rgw::sal::ConfigStore* cfgstore, bool admin);
   /** Initialize a new raw Driver */
   static rgw::sal::Driver* init_raw_storage_provider(const DoutPrefixProvider* dpp,
 						    CephContext* cct,
 						    const Config& cfg,
 						    boost::asio::io_context& io_context,
 						    const rgw::SiteConfig& site_config,
-                rgw::sal::ConfigStore* cfgstore);
+                rgw::sal::ConfigStore* cfgstore, bool admin);
   /** Close a Driver when it's no longer needed */
   static void close_storage(rgw::sal::Driver* driver);
 

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -116,59 +116,61 @@ int SSDDriver::initialize(const DoutPrefixProvider* dpp)
       partition_info.location += "/";
     }
 
-    try {
-        if (efs::exists(partition_info.location)) {
-            if (dpp->get_cct()->_conf->rgw_d4n_l1_evict_cache_on_start) {
-                ldpp_dout(dpp, 5) << "initialize: evicting the persistent storage directory on start" << dendl;
+    if (!admin) { // Only initialize or evict cache if radosgw-admin is not responsible for call 
+      try {
+	  if (efs::exists(partition_info.location)) {
+	      if (dpp->get_cct()->_conf->rgw_d4n_l1_evict_cache_on_start) {
+		  ldpp_dout(dpp, 5) << "initialize: evicting the persistent storage directory on start" << dendl;
 
-		uid_t uid = dpp->get_cct()->get_set_uid();
-		gid_t gid = dpp->get_cct()->get_set_gid();
+		  uid_t uid = dpp->get_cct()->get_set_uid();
+		  gid_t gid = dpp->get_cct()->get_set_gid();
 
-		ldpp_dout(dpp, 5) << "initialize:: uid is " << uid << " and gid is " << gid << dendl;
-		ldpp_dout(dpp, 5) << "initialize:: changing permissions for datacache directory." << dendl;
+		  ldpp_dout(dpp, 5) << "initialize:: uid is " << uid << " and gid is " << gid << dendl;
+		  ldpp_dout(dpp, 5) << "initialize:: changing permissions for datacache directory." << dendl;
 
-		if (uid) { 
-                  if (chown(partition_info.location.c_str(), uid, gid) == -1) {
-		    ldpp_dout(dpp, 5) << "initialize: chown return error: " << strerror(errno) << dendl;
-                  }
+		  if (uid) { 
+		    if (chown(partition_info.location.c_str(), uid, gid) == -1) {
+		      ldpp_dout(dpp, 5) << "initialize: chown return error: " << strerror(errno) << dendl;
+		    }
 
-                  if (chmod(partition_info.location.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) == -1) {
-		    ldpp_dout(dpp, 5) << "initialize: chmod return error: " << strerror(errno) << dendl;
-                  }
-		}
+		    if (chmod(partition_info.location.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) == -1) {
+		      ldpp_dout(dpp, 5) << "initialize: chmod return error: " << strerror(errno) << dendl;
+		    }
+		  }
 
-                for (auto& p : efs::directory_iterator(partition_info.location)) {
-                    efs::remove_all(p.path());
-                }
-            }
-        } else {
-            ldpp_dout(dpp, 5) << "initialize:: creating the persistent storage directory on start: " << partition_info.location << dendl;
-            std::error_code ec;
-            if (!efs::create_directories(partition_info.location, ec)) {
-                ldpp_dout(dpp, 0) << "initialize::: ERROR initializing the cache storage directory: '" << partition_info.location <<
-                                "' : " << ec.value() << dendl;
-            } else {
-		uid_t uid = dpp->get_cct()->get_set_uid();
-		gid_t gid = dpp->get_cct()->get_set_gid();
+		  for (auto& p : efs::directory_iterator(partition_info.location)) {
+		      efs::remove_all(p.path());
+		  }
+	      }
+	  } else {
+	      ldpp_dout(dpp, 5) << "initialize:: creating the persistent storage directory on start: " << partition_info.location << dendl;
+	      std::error_code ec;
+	      if (!efs::create_directories(partition_info.location, ec)) {
+		  ldpp_dout(dpp, 0) << "initialize::: ERROR initializing the cache storage directory: '" << partition_info.location <<
+				  "' : " << ec.value() << dendl;
+	      } else {
+		  uid_t uid = dpp->get_cct()->get_set_uid();
+		  gid_t gid = dpp->get_cct()->get_set_gid();
 
-		ldpp_dout(dpp, 5) << "initialize:: uid is " << uid << " and gid is " << gid << dendl;
-		ldpp_dout(dpp, 5) << "initialize:: changing permissions for datacache directory." << dendl;
-		
-		if (uid) { 
-                  if (chown(partition_info.location.c_str(), uid, gid) == -1) {
-		    ldpp_dout(dpp, 5) << "initialize: chown return error: " << strerror(errno) << dendl;
-                  }
+		  ldpp_dout(dpp, 5) << "initialize:: uid is " << uid << " and gid is " << gid << dendl;
+		  ldpp_dout(dpp, 5) << "initialize:: changing permissions for datacache directory." << dendl;
+		  
+		  if (uid) { 
+		    if (chown(partition_info.location.c_str(), uid, gid) == -1) {
+		      ldpp_dout(dpp, 5) << "initialize: chown return error: " << strerror(errno) << dendl;
+		    }
 
-                  if (chmod(partition_info.location.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) == -1) {
-		    ldpp_dout(dpp, 5) << "initialize: chmod return error: " << strerror(errno) << dendl;
-                  }
-		}
-            }
-        }
-    } catch (const efs::filesystem_error& e) {
-        ldpp_dout(dpp, 0) << "initialize::: ERROR initializing the cache storage directory '" << partition_info.location <<
-                                "' : " << e.what() << dendl;
-        //return -EINVAL; Should return error from here?
+		    if (chmod(partition_info.location.c_str(), S_IRWXU|S_IRWXG|S_IRWXO) == -1) {
+		      ldpp_dout(dpp, 5) << "initialize: chmod return error: " << strerror(errno) << dendl;
+		    }
+		  }
+	      }
+	  }
+      } catch (const efs::filesystem_error& e) {
+	  ldpp_dout(dpp, 0) << "initialize::: ERROR initializing the cache storage directory '" << partition_info.location <<
+				  "' : " << e.what() << dendl;
+	  //return -EINVAL; Should return error from here?
+      }
     }
 
     #if defined(HAVE_LIBAIO) && defined(__GLIBC__)

--- a/src/rgw/rgw_ssd_driver.h
+++ b/src/rgw/rgw_ssd_driver.h
@@ -8,7 +8,7 @@ namespace rgw { namespace cache {
 
 class SSDDriver : public CacheDriver {
 public:
-  SSDDriver(Partition& partition_info) : partition_info(partition_info) {}
+  SSDDriver(Partition& partition_info, bool admin) : partition_info(partition_info), admin(admin) {}
   virtual ~SSDDriver() {}
 
   virtual int initialize(const DoutPrefixProvider* dpp) override;
@@ -39,6 +39,7 @@ private:
   uint64_t free_space;
   CephContext* cct;
   std::mutex cache_lock;
+  bool admin;
 
   struct libaio_read_handler {
     rgw::Aio* throttle = nullptr;


### PR DESCRIPTION
Prevents SSDDriver from unnecessarily re-initializing the D4N cache (effectively clearing it) during radosgw-admin calls 


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
