### PR TITLE
squid: osd/scrub: clarify that osd_scrub_auto_repair_num_errors counts objects

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -473,15 +473,17 @@ options:
   desc: Automatically repair damaged objects detected during scrub
   fmt_desc: Setting this to ``true`` will enable automatic PG repair when errors
     are found by scrubs or deep-scrubs.  However, if more than
-    ``osd_scrub_auto_repair_num_errors`` errors are found a repair is NOT performed.
+    ``osd_scrub_auto_repair_num_errors`` damaged objects are found
+    a repair is NOT performed.
   default: false
   with_legacy: true
 # only auto-repair when number of errors is below this threshold
 - name: osd_scrub_auto_repair_num_errors
   type: uint
   level: advanced
-  desc: Maximum number of detected errors to automatically repair
-  fmt_desc: Auto repair will not occur if more than this many errors are found.
+  desc: Maximum number of damaged objects to automatically repair
+  fmt_desc: Scrub will not perform automatic repair if more than this many
+    damaged objects are found.
   default: 5
   see_also:
   - osd_scrub_auto_repair

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1789,8 +1789,8 @@ void PgScrubber::scrub_finish()
 
   m_planned_scrub = requested_scrub_t{};
 
-  // if the repair request comes from auto-repair and large number of errors,
-  // we would like to cancel auto-repair
+  // if the repair request comes from auto-repair and there is a large
+  // number of objects known to be damaged, we cancel the auto-repair
   if (m_is_repair && m_flags.auto_repair &&
       m_be->authoritative_peers_count() >
 	static_cast<int>(m_pg->cct->_conf->osd_scrub_auto_repair_num_errors)) {
@@ -1803,8 +1803,8 @@ void PgScrubber::scrub_finish()
 
   m_be->update_repair_status(m_is_repair);
 
-  // if a regular scrub had errors within the limit, do a deep scrub to auto
-  // repair
+  // if the count of damaged objects found in shallow-scrubbing is not
+  // too high - do a deep scrub to auto repair
   bool do_auto_scrub = false;
   if (m_flags.deep_scrub_on_error && m_be->authoritative_peers_count() &&
       m_be->authoritative_peers_count() <=


### PR DESCRIPTION
'osd_scrub_auto_repair_num_errors' limits the number of damaged objects that we will try to auto-repair during a scrub. Its documentation referred to "number of errors", which did not fit the implementation.

Original tracker: https://tracker.ceph.com/issues/71754
Backport tracker: https://tracker.ceph.com/issues/71771
Backported from https://github.com/ceph/ceph/pull/64048

(cherry picked from commit 680b58ffd0bf5b213ec525f8d783297fb0b14343)
