### PR TITLE
tentacle: cephadm: don't collect image ids for daemons with no container info

### DIFF
--- a/src/cephadm/cephadmlib/container_lookup.py
+++ b/src/cephadm/cephadmlib/container_lookup.py
@@ -132,7 +132,9 @@ def infer_local_ceph_image(
     ]
     # collect the running ceph daemon image ids
     images_in_use_by_daemon = set(
-        d.image_id for d, n in matching_daemons if n == daemon_name
+        d.image_id
+        for d, n in matching_daemons
+        if (n == daemon_name and d is not None)
     )
     images_in_use = set(
         d.image_id for d, _ in matching_daemons if d is not None


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71571

---

backport of https://github.com/ceph/ceph/pull/62935
parent tracker: https://tracker.ceph.com/issues/70989

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh