### PR TITLE
tentacle: src/pybind/mgr/cephadm/service_discovery: fixed HAProxy labels

### DIFF
--- a/src/pybind/mgr/cephadm/service_discovery.py
+++ b/src/pybind/mgr/cephadm/service_discovery.py
@@ -228,7 +228,7 @@ class Root(Server):
                     addr = self.mgr.inventory.get_addr(dd.hostname)
                     srv_entries.append({
                         'targets': [f"{build_url(host=addr, port=spec.monitor_port).lstrip('/')}"],
-                        'labels': {'instance': dd.service_name()}
+                        'labels': {'ingress': dd.service_name(), 'instance': dd.hostname}
                     })
         return srv_entries
 

--- a/src/pybind/mgr/cephadm/tests/test_service_discovery.py
+++ b/src/pybind/mgr/cephadm/tests/test_service_discovery.py
@@ -170,7 +170,8 @@ class TestServiceDiscovery:
 
         # check content
         assert cfg[0]['targets'] == ['1.2.3.4:9049']
-        assert cfg[0]['labels'] == {'instance': 'ingress'}
+        assert cfg[0]['labels'] == {'instance': 'node0', 'ingress': 'ingress'}
+        assert cfg[1]['labels'] == {'instance': 'node1', 'ingress': 'ingress'}
 
     def test_get_sd_config_ceph_exporter(self):
         mgr = FakeMgr()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71665

---

backport of https://github.com/ceph/ceph/pull/62299
parent tracker: https://tracker.ceph.com/issues/70477

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh