### PR TITLE
reef: rbd-mirror: release lock before calling m_async_op_tracker.finish_op()

### DIFF
--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -366,12 +366,9 @@ void InstanceReplayer<I>::queue_start_image_replayers() {
 }
 
 template <typename I>
-void InstanceReplayer<I>::start_image_replayers(int r) {
-  dout(10) << dendl;
-
-  std::lock_guard locker{m_lock};
+void InstanceReplayer<I>::start_image_replayers(
+    const std::unique_lock<ceph::mutex>&) {
   if (m_on_shut_down != nullptr) {
-    m_async_op_tracker.finish_op();
     return;
   }
 
@@ -403,7 +400,15 @@ void InstanceReplayer<I>::start_image_replayers(int r) {
   m_service_daemon->add_or_update_namespace_attribute(
     m_local_io_ctx.get_id(), m_local_io_ctx.get_namespace(),
     SERVICE_DAEMON_ERROR_COUNT_KEY, error_count);
+}
 
+template <typename I>
+void InstanceReplayer<I>::start_image_replayers(int r) {
+  dout(10) << dendl;
+  {
+    std::unique_lock locker{m_lock};
+    start_image_replayers(locker);
+  }
   m_async_op_tracker.finish_op();
 }
 

--- a/src/tools/rbd_mirror/InstanceReplayer.h
+++ b/src/tools/rbd_mirror/InstanceReplayer.h
@@ -118,6 +118,7 @@ private:
 
   void start_image_replayer(ImageReplayer<ImageCtxT> *image_replayer);
   void queue_start_image_replayers();
+  void start_image_replayers(const std::unique_lock<ceph::mutex>&);
   void start_image_replayers(int r);
 
   void stop_image_replayer(ImageReplayer<ImageCtxT> *image_replayer,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70978

---

backport of https://github.com/ceph/ceph/pull/62849
parent tracker: https://tracker.ceph.com/issues/70951