### PR TITLE
tentacle: librbd, tools: migrate from boost::variant to std::variant

### DIFF
--- a/src/librbd/MirroringWatcher.cc
+++ b/src/librbd/MirroringWatcher.cc
@@ -108,8 +108,8 @@ void MirroringWatcher<I>::handle_notify(uint64_t notify_id, uint64_t handle,
     return;
   }
 
-  apply_visitor(watcher::util::HandlePayloadVisitor<MirroringWatcher<I>>(
-                  this, notify_id, handle), notify_message.payload);
+  std::visit(watcher::util::HandlePayloadVisitor<MirroringWatcher<I>>(
+      this, notify_id, handle), notify_message.payload);
 }
 
 template <typename I>

--- a/src/librbd/TrashWatcher.cc
+++ b/src/librbd/TrashWatcher.cc
@@ -83,7 +83,7 @@ void TrashWatcher<I>::handle_notify(uint64_t notify_id, uint64_t handle,
     return;
   }
 
-  apply_visitor(watcher::util::HandlePayloadVisitor<TrashWatcher<I>>(
+  std::visit(watcher::util::HandlePayloadVisitor<TrashWatcher<I>>(
     this, notify_id, handle), notify_message.payload);
 }
 

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -12,7 +12,6 @@
 #include <list>
 #include <memory>
 #include <string>
-#include <boost/variant.hpp>
 
 namespace ceph {
 class Formatter;

--- a/src/librbd/api/Snapshot.cc
+++ b/src/librbd/api/Snapshot.cc
@@ -13,8 +13,6 @@
 #include "include/Context.h"
 #include "common/Cond.h"
 
-#include <boost/variant.hpp>
-
 #include <shared_mutex> // for std::shared_lock
 
 #define dout_subsys ceph_subsys_rbd

--- a/src/librbd/io/ImageDispatchSpec.cc
+++ b/src/librbd/io/ImageDispatchSpec.cc
@@ -6,7 +6,6 @@
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageRequest.h"
 #include "librbd/io/ImageDispatcherInterface.h"
-#include <boost/variant.hpp>
 
 namespace librbd {
 namespace io {

--- a/src/librbd/io/ObjectDispatchSpec.cc
+++ b/src/librbd/io/ObjectDispatchSpec.cc
@@ -4,7 +4,6 @@
 #include "librbd/io/ObjectDispatchSpec.h"
 #include "include/Context.h"
 #include "librbd/io/ObjectDispatcherInterface.h"
-#include <boost/variant.hpp>
 
 namespace librbd {
 namespace io {

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -11,7 +11,7 @@
 #include "common/zipkin_trace.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
-#include <boost/variant/variant.hpp>
+#include <variant>
 
 namespace librbd {
 namespace io {
@@ -144,13 +144,13 @@ public:
     }
   };
 
-  typedef boost::variant<ReadRequest,
-                         DiscardRequest,
-                         WriteRequest,
-                         WriteSameRequest,
-                         CompareAndWriteRequest,
-                         FlushRequest,
-                         ListSnapsRequest> Request;
+  typedef std::variant<ReadRequest,
+		       DiscardRequest,
+		       WriteRequest,
+		       WriteSameRequest,
+		       CompareAndWriteRequest,
+		       FlushRequest,
+		       ListSnapsRequest> Request;
 
   C_Dispatcher dispatcher_ctx;
 

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -10,7 +10,6 @@
 #include "librbd/asio/ContextWQ.h"
 #include "librbd/io/ObjectDispatch.h"
 #include "librbd/io/ObjectDispatchSpec.h"
-#include <boost/variant.hpp>
 
 #include <shared_mutex> // for std::shared_lock
 
@@ -35,7 +34,7 @@ struct ObjectDispatcher<I>::C_ResetExistenceCache : public C_LayerIterator {
 };
 
 template <typename I>
-struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
+struct ObjectDispatcher<I>::SendVisitor {
   ObjectDispatchInterface* object_dispatch;
   ObjectDispatchSpec* object_dispatch_spec;
 
@@ -199,7 +198,7 @@ template <typename I>
 bool ObjectDispatcher<I>::send_dispatch(
     ObjectDispatchInterface* object_dispatch,
     ObjectDispatchSpec* object_dispatch_spec) {
-  return boost::apply_visitor(
+  return std::visit(
     SendVisitor{object_dispatch, object_dispatch_spec},
     object_dispatch_spec->request);
 }

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -11,7 +11,7 @@
 #include "librbd/io/Types.h"
 #include "osdc/Striper.h"
 #include <sys/uio.h>
-#include <boost/variant/variant.hpp>
+#include <variant>
 
 
 namespace librbd {
@@ -60,7 +60,7 @@ public:
       void finish(int r) override;
   };
 
-  ReadResult();
+  ReadResult() = default;
   ReadResult(char *buf, size_t buf_len);
   ReadResult(const struct iovec *iov, int iov_count);
   ReadResult(ceph::bufferlist *bl);
@@ -71,9 +71,6 @@ public:
   void assemble_result(CephContext *cct);
 
 private:
-  struct Empty {
-  };
-
   struct Linear {
     char *buf;
     size_t buf_len;
@@ -109,11 +106,11 @@ private:
     }
   };
 
-  typedef boost::variant<Empty,
-                         Linear,
-                         Vector,
-                         Bufferlist,
-                         SparseBufferlist> Buffer;
+  typedef std::variant<std::monostate,
+		       Linear,
+		       Vector,
+		       Bufferlist,
+		       SparseBufferlist> Buffer;
   struct SetImageExtentsVisitor;
   struct AssembleResultVisitor;
 

--- a/src/librbd/journal/Replay.h
+++ b/src/librbd/journal/Replay.h
@@ -10,7 +10,6 @@
 #include "common/ceph_mutex.h"
 #include "librbd/io/Types.h"
 #include "librbd/journal/Types.h"
-#include <boost/variant.hpp>
 #include <list>
 #include <unordered_set>
 #include <unordered_map>
@@ -102,7 +101,7 @@ private:
     }
   };
 
-  struct EventVisitor : public boost::static_visitor<void> {
+  struct EventVisitor {
     Replay *replay;
     Context *on_ready;
     Context *on_safe;

--- a/src/librbd/mirroring_watcher/Types.cc
+++ b/src/librbd/mirroring_watcher/Types.cc
@@ -12,7 +12,7 @@ namespace mirroring_watcher {
 
 namespace {
 
-class DumpPayloadVisitor : public boost::static_visitor<void> {
+class DumpPayloadVisitor {
 public:
   explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
@@ -80,7 +80,7 @@ void UnknownPayload::dump(Formatter *f) const {
 
 void NotifyMessage::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);
-  boost::apply_visitor(watcher::util::EncodePayloadVisitor(bl), payload);
+  std::visit(watcher::util::EncodePayloadVisitor(bl), payload);
   ENCODE_FINISH(bl);
 }
 
@@ -103,12 +103,12 @@ void NotifyMessage::decode(bufferlist::const_iterator& iter) {
     break;
   }
 
-  apply_visitor(watcher::util::DecodePayloadVisitor(struct_v, iter), payload);
+  std::visit(watcher::util::DecodePayloadVisitor(struct_v, iter), payload);
   DECODE_FINISH(iter);
 }
 
 void NotifyMessage::dump(Formatter *f) const {
-  apply_visitor(DumpPayloadVisitor(f), payload);
+  std::visit(DumpPayloadVisitor(f), payload);
 }
 
 void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {

--- a/src/librbd/mirroring_watcher/Types.h
+++ b/src/librbd/mirroring_watcher/Types.h
@@ -11,7 +11,7 @@
 #include <iosfwd>
 #include <list>
 #include <string>
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace ceph { class Formatter; }
 
@@ -72,9 +72,9 @@ struct UnknownPayload {
   void dump(Formatter *f) const;
 };
 
-typedef boost::variant<ModeUpdatedPayload,
-                       ImageUpdatedPayload,
-                       UnknownPayload> Payload;
+typedef std::variant<ModeUpdatedPayload,
+		     ImageUpdatedPayload,
+		     UnknownPayload> Payload;
 
 struct NotifyMessage {
   NotifyMessage(const Payload &payload = UnknownPayload()) : payload(payload) {

--- a/src/librbd/trash_watcher/Types.cc
+++ b/src/librbd/trash_watcher/Types.cc
@@ -12,7 +12,7 @@ namespace trash_watcher {
 
 namespace {
 
-class DumpPayloadVisitor : public boost::static_visitor<void> {
+class DumpPayloadVisitor {
 public:
   explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
@@ -74,7 +74,7 @@ void UnknownPayload::dump(Formatter *f) const {
 
 void NotifyMessage::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);
-  boost::apply_visitor(watcher::util::EncodePayloadVisitor(bl), payload);
+  std::visit(watcher::util::EncodePayloadVisitor(bl), payload);
   ENCODE_FINISH(bl);
 }
 
@@ -97,12 +97,12 @@ void NotifyMessage::decode(bufferlist::const_iterator& iter) {
     break;
   }
 
-  apply_visitor(watcher::util::DecodePayloadVisitor(struct_v, iter), payload);
+  std::visit(watcher::util::DecodePayloadVisitor(struct_v, iter), payload);
   DECODE_FINISH(iter);
 }
 
 void NotifyMessage::dump(Formatter *f) const {
-  apply_visitor(DumpPayloadVisitor(f), payload);
+  std::visit(DumpPayloadVisitor(f), payload);
 }
 
 void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {

--- a/src/librbd/trash_watcher/Types.h
+++ b/src/librbd/trash_watcher/Types.h
@@ -11,7 +11,7 @@
 #include <iosfwd>
 #include <list>
 #include <string>
-#include <boost/variant.hpp>
+#include <variant>
 
 
 namespace librbd {
@@ -67,9 +67,9 @@ struct UnknownPayload {
   void dump(Formatter *f) const;
 };
 
-typedef boost::variant<ImageAddedPayload,
-                       ImageRemovedPayload,
-                       UnknownPayload> Payload;
+typedef std::variant<ImageAddedPayload,
+		     ImageRemovedPayload,
+		     UnknownPayload> Payload;
 
 struct NotifyMessage {
   NotifyMessage(const Payload &payload = UnknownPayload()) : payload(payload) {

--- a/src/rbd_replay/ActionTypes.cc
+++ b/src/rbd_replay/ActionTypes.cc
@@ -7,7 +7,6 @@
 #include "include/stringify.h"
 #include "common/Formatter.h"
 #include <iostream>
-#include <boost/variant.hpp>
 
 namespace rbd_replay {
 namespace action {
@@ -35,7 +34,7 @@ void decode_big_endian_string(std::string &str, bufferlist::const_iterator &it) 
 #endif
 }
 
-class EncodeVisitor : public boost::static_visitor<void> {
+class EncodeVisitor {
 public:
   explicit EncodeVisitor(bufferlist &bl) : m_bl(bl) {
   }
@@ -50,7 +49,7 @@ private:
   bufferlist &m_bl;
 };
 
-class DecodeVisitor : public boost::static_visitor<void> {
+class DecodeVisitor {
 public:
   DecodeVisitor(__u8 version, bufferlist::const_iterator &iter)
     : m_version(version), m_iter(iter) {
@@ -65,7 +64,7 @@ private:
   bufferlist::const_iterator &m_iter;
 };
 
-class DumpVisitor : public boost::static_visitor<void> {
+class DumpVisitor {
 public:
   explicit DumpVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
@@ -270,7 +269,7 @@ void UnknownAction::dump(Formatter *f) const {
 
 void ActionEntry::encode(bufferlist &bl) const {
   ENCODE_START(1, 1, bl);
-  boost::apply_visitor(EncodeVisitor(bl), action);
+  std::visit(EncodeVisitor(bl), action);
   ENCODE_FINISH(bl);
 }
 
@@ -329,11 +328,11 @@ void ActionEntry::decode_versioned(__u8 version, bufferlist::const_iterator &it)
     break;
   }
 
-  boost::apply_visitor(DecodeVisitor(version, it), action);
+  std::visit(DecodeVisitor(version, it), action);
 }
 
 void ActionEntry::dump(Formatter *f) const {
-  boost::apply_visitor(DumpVisitor(f), action);
+  std::visit(DumpVisitor(f), action);
 }
 
 void ActionEntry::generate_test_instances(std::list<ActionEntry *> &o) {

--- a/src/rbd_replay/ActionTypes.h
+++ b/src/rbd_replay/ActionTypes.h
@@ -11,7 +11,7 @@
 #include <list>
 #include <string>
 #include <vector>
-#include <boost/variant/variant.hpp>
+#include <variant>
 
 namespace ceph { class Formatter; }
 
@@ -294,19 +294,19 @@ struct UnknownAction {
   void dump(Formatter *f) const;
 };
 
-typedef boost::variant<StartThreadAction,
-                       StopThreadAction,
-                       ReadAction,
-                       WriteAction,
-                       DiscardAction,
-                       AioReadAction,
-                       AioWriteAction,
-                       AioDiscardAction,
-                       OpenImageAction,
-                       CloseImageAction,
-                       AioOpenImageAction,
-                       AioCloseImageAction,
-                       UnknownAction> Action;
+typedef std::variant<StartThreadAction,
+		     StopThreadAction,
+		     ReadAction,
+		     WriteAction,
+		     DiscardAction,
+		     AioReadAction,
+		     AioWriteAction,
+		     AioDiscardAction,
+		     OpenImageAction,
+		     CloseImageAction,
+		     AioOpenImageAction,
+		     AioCloseImageAction,
+		     UnknownAction> Action;
 
 class ActionEntry {
 public:

--- a/src/rbd_replay/BoundedBuffer.hpp
+++ b/src/rbd_replay/BoundedBuffer.hpp
@@ -5,6 +5,7 @@
 #define _INCLUDED_BOUNDED_BUFFER_HPP
 
 #include <boost/bind/bind.hpp>
+#include <boost/call_traits.hpp>
 #include <boost/circular_buffer.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>

--- a/src/rbd_replay/actions.cc
+++ b/src/rbd_replay/actions.cc
@@ -33,7 +33,7 @@ std::string create_fake_data() {
   return std::string(data, sizeof(data));
 }
 
-struct ConstructVisitor : public boost::static_visitor<Action::ptr> {
+struct ConstructVisitor {
   inline Action::ptr operator()(const action::StartThreadAction &action) const {
     return Action::ptr(new StartThreadAction(action));
   }
@@ -94,7 +94,7 @@ std::ostream& rbd_replay::operator<<(std::ostream& o, const Action& a) {
 }
 
 Action::ptr Action::construct(const action::ActionEntry &action_entry) {
-  return boost::apply_visitor(ConstructVisitor(), action_entry.action);
+  return std::visit(ConstructVisitor(), action_entry.action);
 }
 
 void StartThreadAction::perform(ActionCtx &ctx) {

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -157,7 +157,7 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
     EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, send(_))
             .WillOnce(Invoke([this, extents,
                               version](io::ObjectDispatchSpec* spec) {
-                auto* read = boost::get<io::ObjectDispatchSpec::ReadRequest>(
+                auto* read = std::get_if<io::ObjectDispatchSpec::ReadRequest>(
                         &spec->request);
                 ASSERT_TRUE(read != nullptr);
 
@@ -193,7 +193,7 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
     EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, send(_))
             .WillOnce(Invoke([this, object_off, data, write_flags,
                               assert_version](io::ObjectDispatchSpec* spec) {
-                auto* write = boost::get<io::ObjectDispatchSpec::WriteRequest>(
+                auto* write = std::get_if<io::ObjectDispatchSpec::WriteRequest>(
                         &spec->request);
                 ASSERT_TRUE(write != nullptr);
 
@@ -210,7 +210,7 @@ struct TestMockCryptoCryptoObjectDispatch : public TestMockFixture {
   void expect_object_write_same() {
     EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, send(_))
             .WillOnce(Invoke([this](io::ObjectDispatchSpec* spec) {
-                auto* write_same = boost::get<
+                auto* write_same = std::get_if<
                         io::ObjectDispatchSpec::WriteSameRequest>(
                                 &spec->request);
                 ASSERT_TRUE(write_same != nullptr);

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -137,7 +137,7 @@ struct TestMockIoImageRequest : public TestMockFixture {
     EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, send(_))
       .WillOnce(Invoke([&mock_image_ctx, object_no, offset, length, r]
                 (ObjectDispatchSpec* spec) {
-                  auto* discard_spec = boost::get<ObjectDispatchSpec::DiscardRequest>(&spec->request);
+                  auto* discard_spec = std::get_if<ObjectDispatchSpec::DiscardRequest>(&spec->request);
                   ASSERT_TRUE(discard_spec != nullptr);
                   ASSERT_EQ(object_no, discard_spec->object_no);
                   ASSERT_EQ(offset, discard_spec->object_off);
@@ -165,7 +165,7 @@ struct TestMockIoImageRequest : public TestMockFixture {
       .WillOnce(
         Invoke([&mock_image_ctx, object_no, snap_delta, r]
                (ObjectDispatchSpec* spec) {
-                  auto request = boost::get<
+                  auto request = std::get_if<
                     librbd::io::ObjectDispatchSpec::ListSnapsRequest>(
                       &spec->request);
                   ASSERT_TRUE(request != nullptr);

--- a/src/test/librbd/operation/test_mock_TrimRequest.cc
+++ b/src/test/librbd/operation/test_mock_TrimRequest.cc
@@ -14,7 +14,6 @@
 #include "librbd/operation/TrimRequest.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include <boost/variant.hpp>
 
 #include <shared_mutex> // for std::shared_lock
 
@@ -69,8 +68,7 @@ struct AsyncRequest<librbd::MockTestImageCtx> {
 
 namespace io {
 
-struct DiscardVisitor
-  : public boost::static_visitor<ObjectDispatchSpec::DiscardRequest*> {
+struct DiscardVisitor {
   ObjectDispatchSpec::DiscardRequest*
   operator()(ObjectDispatchSpec::DiscardRequest& discard) const {
     return &discard;
@@ -196,7 +194,7 @@ public:
     EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, send(_))
       .WillOnce(Invoke([&mock_image_ctx, offset, length, update_object_map, r]
                        (io::ObjectDispatchSpec* spec) {
-                  auto discard = boost::apply_visitor(io::DiscardVisitor(), spec->request);
+                  auto discard = std::visit(io::DiscardVisitor(), spec->request);
                   ASSERT_TRUE(discard != nullptr);
                   ASSERT_EQ(offset, discard->object_off);
                   ASSERT_EQ(length, discard->object_len);

--- a/src/tools/rbd_mirror/InstanceWatcher.cc
+++ b/src/tools/rbd_mirror/InstanceWatcher.cc
@@ -1093,8 +1093,8 @@ void InstanceWatcher<I>::handle_notify(uint64_t notify_id, uint64_t handle,
     return;
   }
 
-  apply_visitor(HandlePayloadVisitor(this, stringify(notifier_id), ctx),
-                notify_message.payload);
+  std::visit(HandlePayloadVisitor(this, stringify(notifier_id), ctx),
+	     notify_message.payload);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/LeaderWatcher.cc
+++ b/src/tools/rbd_mirror/LeaderWatcher.cc
@@ -1015,7 +1015,7 @@ void LeaderWatcher<I>::handle_notify(uint64_t notify_id, uint64_t handle,
     return;
   }
 
-  apply_visitor(HandlePayloadVisitor(this, ctx), notify_message.payload);
+  std::visit(HandlePayloadVisitor(this, ctx), notify_message.payload);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_map/Types.cc
+++ b/src/tools/rbd_mirror/image_map/Types.cc
@@ -16,7 +16,7 @@ const std::string UNMAPPED_INSTANCE_ID("");
 namespace {
 
 template <typename E>
-class GetTypeVisitor : public boost::static_visitor<E> {
+class GetTypeVisitor {
 public:
   template <typename T>
   inline E operator()(const T&) const {
@@ -24,7 +24,7 @@ public:
   }
 };
 
-class EncodeVisitor : public boost::static_visitor<void> {
+class EncodeVisitor {
 public:
   explicit EncodeVisitor(bufferlist &bl) : m_bl(bl) {
   }
@@ -39,7 +39,7 @@ private:
   bufferlist &m_bl;
 };
 
-class DecodeVisitor : public boost::static_visitor<void> {
+class DecodeVisitor {
 public:
   DecodeVisitor(__u8 version, bufferlist::const_iterator &iter)
     : m_version(version), m_iter(iter) {
@@ -54,7 +54,7 @@ private:
   bufferlist::const_iterator &m_iter;
 };
 
-class DumpVisitor : public boost::static_visitor<void> {
+class DumpVisitor {
 public:
   explicit DumpVisitor(Formatter *formatter, const std::string &key)
     : m_formatter(formatter), m_key(key) {}
@@ -73,12 +73,12 @@ private:
 } // anonymous namespace
 
 PolicyMetaType PolicyData::get_policy_meta_type() const {
-  return boost::apply_visitor(GetTypeVisitor<PolicyMetaType>(), policy_meta);
+  return std::visit(GetTypeVisitor<PolicyMetaType>(), policy_meta);
 }
 
 void PolicyData::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);
-  boost::apply_visitor(EncodeVisitor(bl), policy_meta);
+  std::visit(EncodeVisitor(bl), policy_meta);
   ENCODE_FINISH(bl);
 }
 
@@ -97,12 +97,12 @@ void PolicyData::decode(bufferlist::const_iterator& it) {
     break;
   }
 
-  boost::apply_visitor(DecodeVisitor(struct_v, it), policy_meta);
+  std::visit(DecodeVisitor(struct_v, it), policy_meta);
   DECODE_FINISH(it);
 }
 
 void PolicyData::dump(Formatter *f) const {
-  boost::apply_visitor(DumpVisitor(f, "policy_meta_type"), policy_meta);
+  std::visit(DumpVisitor(f, "policy_meta_type"), policy_meta);
 }
 
 void PolicyData::generate_test_instances(std::list<PolicyData *> &o) {

--- a/src/tools/rbd_mirror/image_map/Types.h
+++ b/src/tools/rbd_mirror/image_map/Types.h
@@ -8,7 +8,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include <boost/variant.hpp>
+#include <variant>
 
 #include "include/buffer.h"
 #include "include/encoding.h"
@@ -97,8 +97,8 @@ struct PolicyMetaUnknown {
   }
 };
 
-typedef boost::variant<PolicyMetaNone,
-                       PolicyMetaUnknown> PolicyMeta;
+typedef std::variant<PolicyMetaNone,
+		     PolicyMetaUnknown> PolicyMeta;
 
 struct PolicyData {
   PolicyData()

--- a/src/tools/rbd_mirror/image_replayer/journal/EventPreprocessor.h
+++ b/src/tools/rbd_mirror/image_replayer/journal/EventPreprocessor.h
@@ -9,7 +9,6 @@
 #include "librbd/journal/TypeTraits.h"
 #include <map>
 #include <string>
-#include <boost/variant/static_visitor.hpp>
 
 struct Context;
 namespace journal { class Journaler; }
@@ -72,7 +71,7 @@ private:
 
   typedef std::map<uint64_t, uint64_t> SnapSeqs;
 
-  class PreprocessEventVisitor : public boost::static_visitor<int> {
+  class PreprocessEventVisitor {
   public:
     EventPreprocessor *event_preprocessor;
 

--- a/src/tools/rbd_mirror/instance_watcher/Types.cc
+++ b/src/tools/rbd_mirror/instance_watcher/Types.cc
@@ -12,7 +12,7 @@ namespace instance_watcher {
 
 namespace {
 
-class EncodePayloadVisitor : public boost::static_visitor<void> {
+class EncodePayloadVisitor {
 public:
   explicit EncodePayloadVisitor(bufferlist &bl) : m_bl(bl) {}
 
@@ -27,7 +27,7 @@ private:
   bufferlist &m_bl;
 };
 
-class DecodePayloadVisitor : public boost::static_visitor<void> {
+class DecodePayloadVisitor {
 public:
   DecodePayloadVisitor(__u8 version, bufferlist::const_iterator &iter)
     : m_version(version), m_iter(iter) {}
@@ -42,7 +42,7 @@ private:
   bufferlist::const_iterator &m_iter;
 };
 
-class DumpPayloadVisitor : public boost::static_visitor<void> {
+class DumpPayloadVisitor {
 public:
   explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
@@ -139,7 +139,7 @@ void UnknownPayload::dump(Formatter *f) const {
 
 void NotifyMessage::encode(bufferlist& bl) const {
   ENCODE_START(2, 2, bl);
-  boost::apply_visitor(EncodePayloadVisitor(bl), payload);
+  std::visit(EncodePayloadVisitor(bl), payload);
   ENCODE_FINISH(bl);
 }
 
@@ -171,12 +171,12 @@ void NotifyMessage::decode(bufferlist::const_iterator& iter) {
     break;
   }
 
-  apply_visitor(DecodePayloadVisitor(struct_v, iter), payload);
+  std::visit(DecodePayloadVisitor(struct_v, iter), payload);
   DECODE_FINISH(iter);
 }
 
 void NotifyMessage::dump(Formatter *f) const {
-  apply_visitor(DumpPayloadVisitor(f), payload);
+  std::visit(DumpPayloadVisitor(f), payload);
 }
 
 void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {

--- a/src/tools/rbd_mirror/instance_watcher/Types.h
+++ b/src/tools/rbd_mirror/instance_watcher/Types.h
@@ -6,7 +6,7 @@
 
 #include <string>
 #include <set>
-#include <boost/variant.hpp>
+#include <variant>
 
 #include "include/buffer_fwd.h"
 #include "include/encoding.h"
@@ -143,12 +143,12 @@ struct UnknownPayload {
   void dump(Formatter *f) const;
 };
 
-typedef boost::variant<ImageAcquirePayload,
-                       ImageReleasePayload,
-                       PeerImageRemovedPayload,
-                       SyncRequestPayload,
-                       SyncStartPayload,
-                       UnknownPayload> Payload;
+typedef std::variant<ImageAcquirePayload,
+		     ImageReleasePayload,
+		     PeerImageRemovedPayload,
+		     SyncRequestPayload,
+		     SyncStartPayload,
+		     UnknownPayload> Payload;
 
 struct NotifyMessage {
   NotifyMessage(const Payload &payload = UnknownPayload()) : payload(payload) {

--- a/src/tools/rbd_mirror/leader_watcher/Types.cc
+++ b/src/tools/rbd_mirror/leader_watcher/Types.cc
@@ -12,7 +12,7 @@ namespace leader_watcher {
 
 namespace {
 
-class EncodePayloadVisitor : public boost::static_visitor<void> {
+class EncodePayloadVisitor {
 public:
   explicit EncodePayloadVisitor(bufferlist &bl) : m_bl(bl) {}
 
@@ -27,7 +27,7 @@ private:
   bufferlist &m_bl;
 };
 
-class DecodePayloadVisitor : public boost::static_visitor<void> {
+class DecodePayloadVisitor {
 public:
   DecodePayloadVisitor(__u8 version, bufferlist::const_iterator &iter)
     : m_version(version), m_iter(iter) {}
@@ -42,7 +42,7 @@ private:
   bufferlist::const_iterator &m_iter;
 };
 
-class DumpPayloadVisitor : public boost::static_visitor<void> {
+class DumpPayloadVisitor {
 public:
   explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
 
@@ -98,7 +98,7 @@ void UnknownPayload::dump(Formatter *f) const {
 
 void NotifyMessage::encode(bufferlist& bl) const {
   ENCODE_START(1, 1, bl);
-  boost::apply_visitor(EncodePayloadVisitor(bl), payload);
+  std::visit(EncodePayloadVisitor(bl), payload);
   ENCODE_FINISH(bl);
 }
 
@@ -124,12 +124,12 @@ void NotifyMessage::decode(bufferlist::const_iterator& iter) {
     break;
   }
 
-  apply_visitor(DecodePayloadVisitor(struct_v, iter), payload);
+  std::visit(DecodePayloadVisitor(struct_v, iter), payload);
   DECODE_FINISH(iter);
 }
 
 void NotifyMessage::dump(Formatter *f) const {
-  apply_visitor(DumpPayloadVisitor(f), payload);
+  std::visit(DumpPayloadVisitor(f), payload);
 }
 
 void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {

--- a/src/tools/rbd_mirror/leader_watcher/Types.h
+++ b/src/tools/rbd_mirror/leader_watcher/Types.h
@@ -8,8 +8,8 @@
 #include "include/buffer_fwd.h"
 #include "include/encoding.h"
 #include <string>
+#include <variant>
 #include <vector>
-#include <boost/variant.hpp>
 
 struct Context;
 
@@ -85,10 +85,10 @@ struct UnknownPayload {
   void dump(Formatter *f) const;
 };
 
-typedef boost::variant<HeartbeatPayload,
-                       LockAcquiredPayload,
-                       LockReleasedPayload,
-                       UnknownPayload> Payload;
+typedef std::variant<HeartbeatPayload,
+		     LockAcquiredPayload,
+		     LockReleasedPayload,
+		     UnknownPayload> Payload;
 
 struct NotifyMessage {
   NotifyMessage(const Payload &payload = UnknownPayload()) : payload(payload) {

--- a/src/tools/rbd_mirror/service_daemon/Types.h
+++ b/src/tools/rbd_mirror/service_daemon/Types.h
@@ -7,7 +7,7 @@
 #include "include/int_types.h"
 #include <iosfwd>
 #include <string>
-#include <boost/variant.hpp>
+#include <variant>
 
 namespace rbd {
 namespace mirror {
@@ -24,7 +24,7 @@ enum CalloutLevel {
 
 std::ostream& operator<<(std::ostream& os, const CalloutLevel& callout_level);
 
-typedef boost::variant<bool, uint64_t, std::string> AttributeValue;
+typedef std::variant<bool, uint64_t, std::string> AttributeValue;
 
 } // namespace service_daemon
 } // namespace mirror


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/63001 to tentacle.