### PR TITLE
tentacle: cls/rbd: use default values for non-decoded fields in test instances

### DIFF
--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -227,17 +227,17 @@ struct cls_rbd_snap {
 
   static void generate_test_instances(std::list<cls_rbd_snap*>& o) {
     o.push_back(new cls_rbd_snap{});
+    // the parent field is ignored in v8 and up, so let's avoid setting it.
+    // otherwise check-generated.sh would fail due to the disprepancies between
+    // the original dump and re-encoded dump
     o.push_back(new cls_rbd_snap{1, "snap", 123456,
-                                 RBD_PROTECTION_STATUS_PROTECTED,
-                                 {{1, "", "image", 123}, 234}, 31, {},
+                                 RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
                                  cls::rbd::UserSnapshotNamespace{}, 543, {}});
     o.push_back(new cls_rbd_snap{1, "snap", 123456,
-                                 RBD_PROTECTION_STATUS_PROTECTED,
-                                 {{1, "", "image", 123}, 234}, 31, {},
+                                 RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
                                  cls::rbd::UserSnapshotNamespace{}, 543, {0}});
     o.push_back(new cls_rbd_snap{1, "snap", 123456,
-                                 RBD_PROTECTION_STATUS_PROTECTED,
-                                 {{1, "ns", "image", 123}, 234}, 31, {},
+                                 RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
                                  cls::rbd::UserSnapshotNamespace{}, 543,
                                  {123}});
   }


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/63933 to tentacle.