### PR TITLE
tentacle: rgw/logging: log only object ACls in journal mode

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6317,6 +6317,22 @@ void RGWPutACLs::execute(optional_yield y)
     return;
   }
 
+  if (!rgw::sal::Object::empty(s->object)) {
+    // in journal mode we log only object ACLs
+    const auto etag = s->object->get_attrs()[RGW_ATTR_ETAG].to_str();
+    op_ret = rgw::bucketlogging::log_record(driver,
+        rgw::bucketlogging::LoggingType::Journal,
+        s->object.get(),
+        s,
+        canonical_name(),
+        etag,
+        s->object->get_size(),
+        this, y, false, false);
+    if (op_ret < 0) {
+      return;
+    }
+  }
+
   bufferlist bl;
   new_policy.encode(bl);
   map<string, bufferlist> attrs;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71604

---

backport of https://github.com/ceph/ceph/pull/63750
parent tracker: https://tracker.ceph.com/issues/71563

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh