### PR TITLE
tentacle: mgr/dashboard: Add --force flag for listeners

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
@@ -102,6 +102,7 @@ export class NvmeofListenersListComponent implements OnInit {
     this.modalService.show(DeleteConfirmationModalComponent, {
       itemDescription: $localize`Listener`,
       actionDescription: 'delete',
+      infoMessage: $localize`This action will delete listener despite any active connections.`,
       itemNames: [
         $localize`listener` + ' ' + `${listener.host_name} (${listener.traddr}:${listener.trsvcid})`
       ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -133,7 +133,7 @@ describe('NvmeofService', () => {
         .deleteListener(mockNQN, mockGroupName, request.host_name, request.traddr, request.trsvcid)
         .subscribe();
       const req = httpTesting.expectOne(
-        `${API_PATH}/subsystem/${mockNQN}/listener/${request.host_name}/${request.traddr}?gw_group=${mockGroupName}&trsvcid=${request.trsvcid}`
+        `${API_PATH}/subsystem/${mockNQN}/listener/${request.host_name}/${request.traddr}?gw_group=${mockGroupName}&trsvcid=${request.trsvcid}&force=true`
       );
       expect(req.request.method).toBe('DELETE');
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -157,7 +157,8 @@ export class NvmeofService {
         observe: 'response',
         params: {
           gw_group: group,
-          trsvcid
+          trsvcid,
+          force: 'true'
         }
       }
     );


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71809

---

backport of https://github.com/ceph/ceph/pull/63961
parent tracker: https://tracker.ceph.com/issues/71685

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh