### PR TITLE
tentacle: test/osd: Improve readability of errors in ceph_test_rados_io_sequence

### DIFF
--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -21,6 +21,7 @@ install(TARGETS
 
 add_executable(ceph_test_rados_io_sequence
   ${CMAKE_CURRENT_SOURCE_DIR}/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc)
+add_dependencies(ceph_test_rados_io_sequence erasure_code_plugins)
 target_link_libraries(ceph_test_rados_io_sequence
   librados global object_io_exerciser json_structures)
 install(TARGETS

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -318,7 +318,15 @@ ceph::io_sequence::tester::lrc::SelectMappingAndLayers::SelectMappingAndLayers(
       sma{mapping_rng, vm, "mapping", first_use},
       sly{layers_rng, vm, "layers", first_use} {
   if (sma.isForced() != sly.isForced()) {
-    ceph_abort_msg("Mapping and layers must be used together when one is used");
+    std::string forced_parameter = "mapping";
+    std::string unforced_parameter = "layers";
+    if (sly.isForced()) {
+      std::swap(forced_parameter, unforced_parameter);
+    }
+
+    throw std::invalid_argument(fmt::format("The parameter --{} can only be used"
+                                " when a --{} parameter is also supplied.",
+                                forced_parameter, unforced_parameter));
   }
 }
 
@@ -555,10 +563,9 @@ ceph::io_sequence::tester::SelectErasureProfile::SelectErasureProfile(
 
     for (std::string& option : disallowed_options) {
       if (vm.count(option) > 0) {
-        ceph_abort_msg(
-            fmt::format("{} option not allowed "
-                        "if profile is specified",
-                        option));
+        throw std::invalid_argument(fmt::format("{} option not allowed "
+                                                "if profile is specified",
+                                                option));
       }
     }
   }
@@ -638,7 +645,9 @@ ceph::io_sequence::tester::SelectErasureProfile::select() {
     instance.factory(std::string(profile.plugin),
                      cct->_conf.get_val<std::string>("erasure_code_dir"),
                      erasure_code_profile, &ec_impl, &ss);
-    ceph_assert(ec_impl);
+    if (!ec_impl) {
+      throw std::runtime_error(ss.str());
+    }
 
     SelectErasureChunkSize scs{rng, vm, ec_impl, first_use};
     profile.chunk_size = scs.select();
@@ -784,10 +793,9 @@ ceph::io_sequence::tester::SelectErasurePool::SelectErasurePool(
 
     for (std::string& option : disallowed_options) {
       if (vm.count(option) > 0) {
-        ceph_abort_msg(
-            fmt::format("{} option not allowed "
-                        "if pool is specified",
-                        option));
+        throw std::invalid_argument(fmt::format("{} option not allowed "
+                                    "if pool is specified",
+                                    option));
       }
     }
   }
@@ -1381,10 +1389,16 @@ bool ceph::io_sequence::tester::TestRunner::run_automated_test() {
     } else {
       name = object_name + std::to_string(obj);
     }
-    test_objects.push_back(
-        std::make_shared<ceph::io_sequence::tester::TestObject>(
-            name, rados, asio, sbs, spo, sos, snt, ssr, rng, lock, cond, dryrun,
-            verbose, seqseed, testrecovery));
+    try {
+      test_objects.push_back(
+          std::make_shared<ceph::io_sequence::tester::TestObject>(
+              name, rados, asio, sbs, spo, sos, snt, ssr, rng, lock, cond,
+              dryrun, verbose, seqseed, testrecovery));
+    }
+    catch (const std::runtime_error &e) {
+      std::cerr << "Error: " << e.what() << std::endl;
+      return false;
+    }
   }
   if (!dryrun) {
     rados.wait_for_latest_osdmap();
@@ -1468,8 +1482,14 @@ int main(int argc, char** argv) {
         std::make_unique<ceph::io_sequence::tester::TestRunner>(cct, vm, rados);
   } catch (const po::error& e) {
     return 1;
+  } catch (const std::invalid_argument& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
   }
-  runner->run_test();
+
+  if (!runner->run_test()) {
+    return 1;
+  }
 
   return 0;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71798

---

backport of https://github.com/ceph/ceph/pull/64046
parent tracker: https://tracker.ceph.com/issues/71644

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh