### PR TITLE
test/osd: Fix pack for minor issues in ceph_test_rados_io_sequence

### DIFF
--- a/src/common/json/OSDStructures.cc
+++ b/src/common/json/OSDStructures.cc
@@ -184,3 +184,20 @@ void InjectECClearParityRead::decode_json(JSONObj* obj) {
   JSONDecoder::decode_json("pool", pool, obj);
   JSONDecoder::decode_json("objname", objname, obj);
 }
+
+void OSDEnableApplicationRequest::dump(Formatter* f) const {
+  encode_json("prefix", "osd pool application enable", f);
+  encode_json("pool", pool, f);
+  encode_json("app", app, f);
+  encode_json("yes_i_really_mean_it", yes_i_really_mean_it, f);
+  encode_json("key", key, f);
+  encode_json("value", value, f);
+}
+
+void OSDEnableApplicationRequest::decode_json(JSONObj* obj) {
+  JSONDecoder::decode_json("pool", pool, obj);
+  JSONDecoder::decode_json("app", app, obj);
+  JSONDecoder::decode_json("yes_i_really_mean_it", yes_i_really_mean_it, obj);
+  JSONDecoder::decode_json("key", key, obj);
+  JSONDecoder::decode_json("value", value, obj);
+}

--- a/src/common/json/OSDStructures.h
+++ b/src/common/json/OSDStructures.h
@@ -113,6 +113,17 @@ struct OSDSetRequest {
   void decode_json(JSONObj* obj);
 };
 
+  struct OSDEnableApplicationRequest {
+    std::string pool;
+    std::string app;
+    std::optional<bool> yes_i_really_mean_it;
+    std::optional<std::string> key;
+    std::optional<std::string> value;
+
+    void dump(Formatter* f) const;
+    void decode_json(JSONObj* obj);
+  };
+
 // These structures are sent directly to the relevant OSD
 // rather than the monitor
 template <io_exerciser::InjectOpType op_type>

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -1098,7 +1098,7 @@ ceph::io_sequence::tester::TestRunner::TestRunner(
           vm.contains("allow_pool_balancer"),
           vm.contains("allow_pool_deep_scrubbing"),
           vm.contains("allow_pool_scrubbing"),
-          vm.contains("test_recovery"),
+          vm.contains("testrecovery"),
           vm.contains("disable_pool_ec_optimizations")},
       snt{rng, vm, "threads", true},
       ssr{vm} {

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -847,6 +847,8 @@ const std::string ceph::io_sequence::tester::SelectErasurePool::select() {
       configureServices(allow_pool_autoscaling, allow_pool_balancer,
                         allow_pool_deep_scrubbing, allow_pool_scrubbing,
                         test_recovery);
+
+      setApplication(created_pool_name);
     }
   }
 
@@ -870,6 +872,21 @@ std::string ceph::io_sequence::tester::SelectErasurePool::create() {
   ceph_assert(rc == 0);
 
   return pool_name;
+}
+
+void ceph::io_sequence::tester::SelectErasurePool::setApplication(
+    const std::string& pool_name) {
+  bufferlist inbl, outbl;
+  auto formatter = std::make_shared<JSONFormatter>(false);
+
+  ceph::messaging::osd::OSDEnableApplicationRequest
+  enableApplicationRequest{pool_name, "rados"};
+
+  int rc = send_mon_command(enableApplicationRequest, rados,
+                            "OSDEnableApplicationRequest", inbl, &outbl,
+                            formatter.get());
+
+  ceph_assert(rc == 0);
 }
 
 void ceph::io_sequence::tester::SelectErasurePool::configureServices(

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -1122,6 +1122,11 @@ ceph::io_sequence::tester::TestRunner::TestRunner(
   allow_pool_scrubbing = vm.contains("allow_pool_scrubbing");
   disable_pool_ec_optimizations = vm.contains("disable_pool_ec_optimizations");
 
+  if (testrecovery && (num_objects > 1)) {
+    throw std::invalid_argument("testrecovery option not allowed if parallel is"
+                                " specified, except when parallel=1 is used");
+  }
+
   if (!dryrun) {
     guard.emplace(boost::asio::make_work_guard(asio));
     thread = make_named_thread("io_thread", [&asio = asio] { asio.run(); });

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -161,8 +161,11 @@ constexpr std::string_view usage[] = {
     "\t\t read|write|failedwrite <off> <len>",
     "\t\t read2|write2|failedwrite2 <off> <len> <off> <len>",
     "\t\t read3|write3|failedwrite3 <off> <len> <off> <len> <off> <len>",
-    "\t\t injecterror <type> <shard> <good_count> <fail_count>",
-    "\t\t clearinject <type> <shard>",
+    "\t\t append",
+    "\t\t truncate",
+    "\t\t injecterror <io_type> <shard> <type> <good_count> <fail_count>",
+    "\t\t clearinject <io_type> <shard> <type>",
+    "\t\t sleep",
     "\t\t done"};
 
 po::options_description get_options_description() {

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -392,11 +392,6 @@ class SelectErasurePool : public ProgramOptionReader<std::string> {
                     bool disable_pool_ec_optimizations);
   const std::string select() override;
   std::string create();
-  void configureServices(bool allow_pool_autoscaling,
-                         bool allow_pool_balancer,
-                         bool allow_pool_deep_scrubbing,
-                         bool allow_pool_scrubbing,
-                         bool test_recovery);
 
   inline bool get_allow_pool_autoscaling() { return allow_pool_autoscaling; }
   inline bool get_allow_pool_balancer() { return allow_pool_balancer; }
@@ -425,6 +420,14 @@ class SelectErasurePool : public ProgramOptionReader<std::string> {
   SelectErasureProfile sep;
 
   std::optional<Profile> profile;
+
+  void configureServices(bool allow_pool_autoscaling,
+                         bool allow_pool_balancer,
+                         bool allow_pool_deep_scrubbing,
+                         bool allow_pool_scrubbing,
+                         bool test_recovery);
+
+ void setApplication(const std::string& pool_name);
 };
 
 class TestObject {


### PR DESCRIPTION
Fix preventing sequence 10 working correctly in ceph_test_rados_io_sequence due to test_recovery not being passed through correctly. Also adds an error message for when trying to use the --parallel command with --testrecovery due to the two not being compatible.

Finally adds a small change to set an application for any pools created by the IO Sequence tool to prevent Ceph giving warnings that no application is set.

Fixes issue introduced in commit d8712e67221d4ca27c024adad4628829df425970

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
