### PR TITLE
doc/_ext: cleanups

### DIFF
--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -11,7 +11,11 @@ from docutils.statemachine import StringList
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
 from sphinx.locale import _
-from sphinx.util import logging, status_iterator, ws_re
+from sphinx.util import logging, ws_re
+try:
+    from sphinx.util.display import status_iterator
+except ImportError:
+    from sphinx.util import status_iterator
 from sphinx.util.docutils import switch_source_input, SphinxDirective
 from sphinx.util.docfields import Field
 from sphinx.util.nodes import make_id

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -84,7 +84,7 @@ TEMPLATE = '''
 def eval_size(value) -> int:
     try:
         return int(value)
-    except ValueError:
+    except ValueError as ex:
         times = dict(_K=1 << 10,
                      _M=1 << 20,
                      _G=1 << 30,
@@ -92,7 +92,7 @@ def eval_size(value) -> int:
         for unit, m in times.items():
             if value.endswith(unit):
                 return int(value[:-len(unit)]) * m
-        raise ValueError(f'unknown value: {value}')
+        raise ValueError(f'unknown value: {value}') from ex
 
 
 def readable_duration(value: str, typ: str) -> str:
@@ -105,7 +105,7 @@ def readable_duration(value: str, typ: str) -> str:
             return str(float(value))
         else:
             return str(int(value))
-    except ValueError:
+    except ValueError as ex:
         times = dict(_min=['minute', 'minutes'],
                      _hr=['hour', 'hours'],
                      _day=['day', 'days'])
@@ -114,7 +114,7 @@ def readable_duration(value: str, typ: str) -> str:
                 v = int(value[:-len(unit)])
                 postfix = readables[0 if v == 1 else 1]
                 return f'{v} {postfix}'
-        raise ValueError(f'unknown value: {value}')
+        raise ValueError(f'unknown value: {value}') from ex
 
 
 def do_plain_num(value: str, typ: str) -> str:

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -163,7 +163,7 @@ def literal(name) -> str:
     if name:
         return f'``{name}``'
     else:
-        return f'<empty string>'
+        return '<empty string>'
 
 
 def ref_confval(name) -> str:

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -10,8 +10,6 @@ from docutils.statemachine import StringList
 
 from sphinx import addnodes
 from sphinx.directives import ObjectDescription
-from sphinx.domains.python import PyField
-from sphinx.environment import BuildEnvironment
 from sphinx.locale import _
 from sphinx.util import logging, status_iterator, ws_re
 from sphinx.util.docutils import switch_source_input, SphinxDirective


### PR DESCRIPTION
this changeset contains following changes:

1. **Fix Sphinx compatibility** - Update `status_iterator` import to use the new location (`sphinx.util.display`) while maintaining backward compatibility with older Sphinx versions used in our CI environments (Ubuntu Jammy 4.3.2, CentOS 3.4.3).

2. **Improve exception handling** - Use `raise ... from` statements to preserve exception chains, providing better debugging context when errors occur.

3. **Code cleanup** - Remove unused imports (`PyField`, `BuildEnvironment`) and unnecessary f-string formatting where no variable interpolation is needed.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
