### PR TITLE
pybind: fix callback function type compatibility for GCC 14/15

### DIFF
--- a/src/pybind/rados/mock_rados.pxi
+++ b/src/pybind/rados/mock_rados.pxi
@@ -441,7 +441,7 @@ cdef nogil:
         pass
     void rados_read_op_set_flags(rados_read_op_t read_op, int flags):
         pass
-    int rados_omap_get_next(rados_omap_iter_t iter, const char * const* key, const char * const* val, size_t * len):
+    int rados_omap_get_next(rados_omap_iter_t iter, char ** key, char ** val, size_t * len):
         pass
     void rados_omap_get_end(rados_omap_iter_t iter):
         pass

--- a/src/pybind/rgw/c_rgw.pxd
+++ b/src/pybind/rgw/c_rgw.pxd
@@ -102,7 +102,7 @@ cdef extern from "rados/rgw_file.h" nogil:
 
     int rgw_readdir(rgw_fs *fs,
                     rgw_file_handle *parent_fh, uint64_t *offset,
-                    bool (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
+                    int (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
                     void *cb_arg, bool *eof, uint32_t flags) except? -9000
 
     int rgw_getattr(rgw_fs *fs,

--- a/src/pybind/rgw/mock_rgw.pxi
+++ b/src/pybind/rgw/mock_rgw.pxi
@@ -116,7 +116,7 @@ cdef nogil:
 
     int rgw_readdir(rgw_fs *fs,
                     rgw_file_handle *parent_fh, uint64_t *offset,
-                    libcpp.bool (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
+                    int (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
                     void *cb_arg, libcpp.bool *eof, uint32_t flags) except? -9000:
         pass
 

--- a/src/pybind/rgw/rgw.pyx
+++ b/src/pybind/rgw/rgw.pyx
@@ -166,12 +166,12 @@ cdef make_ex(ret, msg):
         return Error(msg + (": error code %d" % ret))
 
 
-cdef bint readdir_cb(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) \
+cdef int readdir_cb(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) \
 except? -9000 with gil:
     if exc.PyErr_Occurred():
-        return False
+        return 0
     (<object>arg)(name, offset, flags)
-    return True
+    return 1
 
 
 class LibCephFSStateError(Error):


### PR DESCRIPTION
The callback function types in Cython source files were inconsistent with the corresponding librados and librgw API declarations, causing build failures with GCC 14 and 15.

GCC 14 introduced stricter pointer type checking and no longer allows implicit casting between incompatible pointer types. This resulted in -Wincompatible-pointer-types errors where char** arguments were passed to functions expecting const char* const*.

Example error:

```
      rados.c: In function ‘__pyx_pf_5rados_12OmapIterator_4__next__’:
      rados.c:32423:76: error: passing argument 2 of ‘__pyx_f_5rados_rados_omap_get_next’ from incompatible pointer type [-Wincompatible-pointer-types]
      32423 |         __pyx_t_1 = __pyx_f_5rados_rados_omap_get_next(__pyx_v_self->ctx, (&__pyx_v_key_), (&__pyx_v_val_), (&__pyx_v_len_)); if (unlikely(__pyx_t_1 == ((int)-1) && __Pyx_ErrOccurredWithGIL())) __PYX_ERR(0, 1394, __pyx_L4_error)
            |                                                                           ~^~~~~~~~~~~~~~
            |                                                                            |
            |                                                                            char **
      rados.c:9172:141: note: expected ‘const char * const*’ but argument is of type ‘char **’
       9172 | static int __pyx_f_5rados_rados_omap_get_next(CYTHON_UNUSED __pyx_t_5rados_rados_omap_iter_t __pyx_v_iter, CYTHON_UNUSED char const *const *__pyx_v_key, CYTHON_UNUSED char const *const *__pyx_v_val, CYTHON_UNUSED size_t *__pyx_v_len) {
            |                                                                                                                                             ^
      rados.c:32423:93: error: passing argument 3 of ‘__pyx_f_5rados_rados_omap_get_next’ from incompatible pointer type [-Wincompatible-pointer-types]
      32423 |         __pyx_t_1 = __pyx_f_5rados_rados_omap_get_next(__pyx_v_self->ctx, (&__pyx_v_key_), (&__pyx_v_val_), (&__pyx_v_len_)); if (unlikely(__pyx_t_1 == ((int)-1) && __Pyx_ErrOccurredWithGIL())) __PYX_ERR(0, 1394, __pyx_L4_error)
            |                                                                                            ~^~~~~~~~~~~~~~
            |                                                                                             |
            |                                                                                             char **
      rados.c:9172:187: note: expected ‘const char * const*’ but argument is of type ‘char **’
       9172 | static int __pyx_f_5rados_rados_omap_get_next(CYTHON_UNUSED __pyx_t_5rados_rados_omap_iter_t __pyx_v_iter, CYTHON_UNUSED char const *const *__pyx_v_key, CYTHON_UNUSED char const *const *__pyx_v_val, CYTHON_UNUSED size_t *__pyx_v_len) {
            |                                                                                                                                                                                           ^
      error: command '/usr/bin/gcc' failed with exit code 1`
```

This change corrects the mock function implementations used during Sphinx documentation builds to match the actual API signatures. The public API remains unchanged to avoid requiring a major version bump.

See also
https://gcc.gnu.org/gcc-14/porting_to.html#incompatible-pointer-types





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
