### PR TITLE
tentacle: src: fix NDEBUG typo

### DIFF
--- a/src/crimson/osd/lsan_suppressions.cc
+++ b/src/crimson/osd/lsan_suppressions.cc
@@ -1,4 +1,4 @@
-#ifndef _NDEBUG
+#ifndef NDEBUG
 // The callbacks we define here will be called from the sanitizer runtime, but
 // aren't referenced from the Chrome executable. We must ensure that those
 // callbacks are not sanitizer-instrumented, and that they aren't stripped by
@@ -17,4 +17,4 @@ static char kLSanDefaultSuppressions[] =
 SANITIZER_HOOK_ATTRIBUTE const char *__lsan_default_suppressions() {
   return kLSanDefaultSuppressions;
 }
-#endif // ! _NDEBUG
+#endif // !NDEBUG

--- a/src/include/function2.hpp
+++ b/src/include/function2.hpp
@@ -756,7 +756,7 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
             // Just swap both pointers if we allocated on the heap
             to->ptr_ = from->ptr_;
 
-#ifndef _NDEBUG
+#ifndef NDEBUG
             // We don't need to null the pointer since we know that
             // we don't own the data anymore through the vtable
             // which is set to empty.

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -728,7 +728,7 @@ static uint32_t crc32_netstring(const uint32_t orig_crc, std::string_view data)
   auto crc = ceph_crc32c(orig_crc, (unsigned char*)&len, sizeof(len));
   crc = ceph_crc32c(crc, (unsigned char*)data.data(), data.length());
 
-#ifndef _NDEBUG
+#ifndef NDEBUG
   // let's verify the compatibility but, due to performance penalty,
   // only in debug builds.
   ceph::bufferlist bl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71821

---

backport of https://github.com/ceph/ceph/pull/63486
parent tracker: https://tracker.ceph.com/issues/71456

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh