### PR TITLE
mgr/dasboard: Carbonised Toast Notification

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
@@ -4,8 +4,6 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { ToastrModule } from 'ngx-toastr';
-
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CephModule } from './ceph/ceph.module';
@@ -21,11 +19,6 @@ import { SharedModule } from './shared/shared.module';
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
-    ToastrModule.forRoot({
-      positionClass: 'toast-top-right',
-      preventDuplicates: true,
-      enableHtml: true
-    }),
     AppRoutingModule,
     CoreModule,
     SharedModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.html
@@ -17,4 +17,6 @@
       <cds-placeholder></cds-placeholder>
     </div>
   </cd-navigation>
+  <!--  Toast Notification -->
+  <cd-toast></cd-toast>
 </block-ui>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -90,6 +90,7 @@ import { ChartsModule } from '@carbon/charts-angular';
 import { InlineMessageComponent } from './inline-message/inline-message.component';
 import { IconComponent } from './icon/icon.component';
 import { DetailsCardComponent } from './details-card/details-card.component';
+import { ToastComponent } from './notification-toast/notification-toast.component';
 
 // Icons
 import InfoIcon from '@carbon/icons/es/information/16';
@@ -186,7 +187,8 @@ import CloseIcon from '@carbon/icons/es/close/16';
     SidePanelComponent,
     IconComponent,
     InlineMessageComponent,
-    DetailsCardComponent
+    DetailsCardComponent,
+    ToastComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())],
   exports: [
@@ -228,7 +230,8 @@ import CloseIcon from '@carbon/icons/es/close/16';
     SidePanelComponent,
     IconComponent,
     InlineMessageComponent,
-    DetailsCardComponent
+    DetailsCardComponent,
+    ToastComponent
   ]
 })
 export class ComponentsModule {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.ts
@@ -1,9 +1,15 @@
 import { Component, HostListener, Input } from '@angular/core';
 
 import { detect } from 'detect-browser';
-import { ToastrService } from 'ngx-toastr';
 
 import { Icons } from '~/app/shared/enum/icons.enum';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+import { NotificationService } from '~/app/shared/services/notification.service';
+
+const ERROR_TITLE = $localize`Error`;
+const CLIPBOARD_ERROR_MESSAGE = $localize`Failed to copy text to the clipboard.`;
+const SUCCESS_TITLE = $localize`Success`;
+const CLIPBOARD_SUCCESS_MESSAGE = $localize`Copied text to the clipboard successfully.`;
 
 @Component({
   selector: 'cd-copy-2-clipboard-button',
@@ -29,7 +35,7 @@ export class Copy2ClipboardButtonComponent {
 
   icons = Icons;
 
-  constructor(private toastr: ToastrService) {}
+  constructor(private notificationService: NotificationService) {}
 
   private getText(): string {
     const element = document.getElementById(this.source) as HTMLInputElement;
@@ -41,25 +47,39 @@ export class Copy2ClipboardButtonComponent {
     try {
       const browser = detect();
       const text = this.byId ? this.getText() : this.source;
-      const toastrFn = () => {
-        this.toastr.success('Copied text to the clipboard successfully.');
+      const showSuccess = () => {
+        this.notificationService.show(
+          NotificationType.success,
+          SUCCESS_TITLE,
+          CLIPBOARD_SUCCESS_MESSAGE
+        );
+      };
+      const showError = () => {
+        this.notificationService.show(NotificationType.error, ERROR_TITLE, CLIPBOARD_ERROR_MESSAGE);
       };
       if (['firefox', 'ie', 'ios', 'safari'].includes(browser.name)) {
         // Various browsers do not support the `Permissions API`.
         // https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#Browser_compatibility
-        navigator.clipboard.writeText(text).then(() => toastrFn());
+        navigator.clipboard
+          .writeText(text)
+          .then(() => showSuccess())
+          .catch(() => showError());
       } else {
         // Checking if we have the clipboard-write permission
         navigator.permissions
           .query({ name: 'clipboard-write' as PermissionName })
           .then((result: any) => {
             if (result.state === 'granted' || result.state === 'prompt') {
-              navigator.clipboard.writeText(text).then(() => toastrFn());
+              navigator.clipboard
+                .writeText(text)
+                .then(() => showSuccess())
+                .catch(() => showError());
             }
-          });
+          })
+          .catch(() => showError());
       }
     } catch (_) {
-      this.toastr.error('Failed to copy text to the clipboard.');
+      this.notificationService.show(NotificationType.error, ERROR_TITLE, CLIPBOARD_ERROR_MESSAGE);
     }
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.html
@@ -1,0 +1,16 @@
+<div class="cds--toast-notification-container">
+  @for (toast of activeToasts$ | async; track $index) {
+  <cds-toast
+    [@toastAnimation]="'in'"
+    [notificationObj]="{
+      type: toast.type,
+      title: toast.title,
+      subtitle: toast.subtitle,
+      caption: toast.caption,
+      lowContrast: toast.lowContrast,
+      showClose: toast.showClose
+    }"
+    (close)="onToastClose(toast)">
+  </cds-toast>
+  }
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.scss
@@ -1,0 +1,77 @@
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/layer' as *;
+@use '@carbon/styles/scss/type' as *;
+
+.cds--toast-notification-container {
+  position: fixed;
+  top: $spacing-10;
+  right: $spacing-04;
+  max-width: $spacing-13 * 8;
+  z-index: 9000;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+
+  cds-toast {
+    pointer-events: all;
+    margin-bottom: $spacing-03;
+    transform-origin: top right;
+
+    ::ng-deep {
+      .cds--toast-notification__title,
+      .cds--toast-notification__subtitle,
+      .cds--toast-notification__caption {
+        color: $text-primary;
+      }
+
+      .cds--toast-notification__close-button {
+        color: $icon-primary;
+      }
+
+      .cds--toast-notification__close-button:hover {
+        background-color: transparent;
+      }
+
+      .cds--toast-notification__close-icon {
+        fill: currentcolor;
+      }
+
+      .toast-caption-container {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        width: 100%;
+      }
+
+      .toast-caption-container .date {
+        flex-shrink: 0;
+      }
+    }
+  }
+}
+
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes toast-slide-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { ToastContent } from 'carbon-components-angular';
+
+import { ToastComponent } from './notification-toast.component';
+import { NotificationService } from '../../services/notification.service';
+import { configureTestBed } from '~/testing/unit-test-helper';
+
+describe('ToastComponent', () => {
+  let component: ToastComponent;
+  let fixture: ComponentFixture<ToastComponent>;
+  let mockToasts: ToastContent[];
+
+  const mockNotificationService = {
+    activeToasts$: of([]),
+    removeToast: jest.fn()
+  };
+
+  configureTestBed({
+    declarations: [ToastComponent],
+    imports: [NoopAnimationsModule],
+    providers: [
+      {
+        provide: NotificationService,
+        useValue: mockNotificationService
+      }
+    ]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ToastComponent);
+    component = fixture.componentInstance;
+
+    mockToasts = [
+      {
+        type: 'success',
+        title: 'Test Title',
+        subtitle: 'Test Message',
+        caption: 'Test Caption',
+        lowContrast: false,
+        showClose: true
+      }
+    ];
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize with activeToasts$ Observable', () => {
+    fixture.detectChanges();
+    expect(component.activeToasts$).toBeDefined();
+  });
+
+  it('should update activeToasts$ when notification service emits new toasts', () => {
+    mockNotificationService.activeToasts$ = of(mockToasts);
+    fixture.detectChanges();
+
+    component.activeToasts$.subscribe((toasts) => {
+      expect(toasts).toEqual(mockToasts);
+    });
+  });
+
+  it('should call removeToast when onToastClose is called', () => {
+    const toast = mockToasts[0];
+    component.onToastClose(toast);
+    expect(mockNotificationService.removeToast).toHaveBeenCalledWith(toast);
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notification-toast/notification-toast.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { animate, style, transition, trigger } from '@angular/animations';
+import { Observable } from 'rxjs';
+import { ToastContent } from 'carbon-components-angular';
+import { NotificationService } from '../../services/notification.service';
+
+@Component({
+  selector: 'cd-toast',
+  templateUrl: './notification-toast.component.html',
+  styleUrls: ['./notification-toast.component.scss'],
+  animations: [
+    trigger('toastAnimation', [
+      transition(
+        ':enter',
+        [
+          style({ opacity: 0, transform: 'translateX(100%)' }),
+          animate('{{duration}} {{easing}}', style({ opacity: 1, transform: 'translateX(0)' }))
+        ],
+        { params: { duration: '240ms', easing: 'cubic-bezier(0.2, 0, 0.38, 0.9)' } }
+      ),
+      transition(
+        ':leave',
+        [
+          style({ opacity: 1, transform: 'translateX(0)' }),
+          animate('{{duration}} {{easing}}', style({ opacity: 0, transform: 'translateX(100%)' }))
+        ],
+        { params: { duration: '240ms', easing: 'cubic-bezier(0.2, 0, 0.38, 0.9)' } }
+      )
+    ])
+  ]
+})
+export class ToastComponent implements OnInit {
+  activeToasts$: Observable<ToastContent[]>;
+
+  constructor(private notificationService: NotificationService) {}
+
+  ngOnInit() {
+    this.activeToasts$ = this.notificationService.activeToasts$;
+  }
+
+  onToastClose(toast: ToastContent) {
+    this.notificationService.removeToast(toast);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/notification-type.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/notification-type.enum.ts
@@ -1,5 +1,6 @@
 export enum NotificationType {
   error,
   info,
-  success
+  success,
+  warning
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.spec.ts
@@ -2,8 +2,10 @@ import { NotificationType } from '../enum/notification-type.enum';
 import { CdNotification, CdNotificationConfig } from './cd-notification';
 
 describe('cd-notification classes', () => {
-  const expectObject = (something: object, expected: object) => {
-    Object.keys(expected).forEach((key) => expect(something[key]).toBe(expected[key]));
+  const expectObject = (something: any, expected: any) => {
+    (Object.keys(expected) as (keyof typeof expected)[]).forEach((key) =>
+      expect(something[key]).toEqual(expected[key])
+    );
   };
 
   // As these Models have a view methods they need to be tested
@@ -13,7 +15,13 @@ describe('cd-notification classes', () => {
         application: 'Ceph',
         applicationClass: 'ceph-icon',
         message: undefined,
-        options: undefined,
+        options: {
+          lowContrast: true,
+          type: undefined,
+          title: '',
+          subtitle: '',
+          caption: ''
+        },
         title: undefined,
         type: 1
       });
@@ -32,7 +40,13 @@ describe('cd-notification classes', () => {
           application: 'Prometheus',
           applicationClass: 'prometheus-icon',
           message: 'Something failed',
-          options: undefined,
+          options: {
+            lowContrast: true,
+            type: undefined,
+            title: '',
+            subtitle: '',
+            caption: ''
+          },
           title: 'Some Alert',
           type: 0
         }
@@ -52,7 +66,13 @@ describe('cd-notification classes', () => {
         applicationClass: 'ceph-icon',
         iconClass: 'information',
         message: undefined,
-        options: undefined,
+        options: {
+          lowContrast: true,
+          type: undefined,
+          title: '',
+          subtitle: '',
+          caption: ''
+        },
         textClass: 'text-info',
         timestamp: '2022-02-22T00:00:00.000Z',
         title: undefined,
@@ -76,7 +96,13 @@ describe('cd-notification classes', () => {
           applicationClass: 'prometheus-icon',
           iconClass: 'warning--alt--filled',
           message: 'Something failed',
-          options: undefined,
+          options: {
+            lowContrast: true,
+            type: undefined,
+            title: '',
+            subtitle: '',
+            caption: ''
+          },
           textClass: 'text-danger',
           timestamp: '2022-02-22T00:00:00.000Z',
           title: 'Some Alert',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
@@ -1,11 +1,17 @@
-import { IndividualConfig } from 'ngx-toastr';
-
 import { Icons } from '../enum/icons.enum';
 import { NotificationType } from '../enum/notification-type.enum';
+import { ToastContent } from 'carbon-components-angular';
 
 export class CdNotificationConfig {
   applicationClass: string;
   isFinishedTask = false;
+  options: ToastContent = {
+    lowContrast: true,
+    type: undefined,
+    title: '',
+    subtitle: '',
+    caption: ''
+  };
 
   private classes = {
     Ceph: 'ceph-icon',
@@ -16,10 +22,14 @@ export class CdNotificationConfig {
     public type: NotificationType = NotificationType.info,
     public title?: string,
     public message?: string, // Use this for additional information only
-    public options?: any | IndividualConfig,
+    options?: ToastContent,
     public application: string = 'Ceph'
   ) {
-    this.applicationClass = this.classes[this.application];
+    this.applicationClass =
+      this.classes[this.application as keyof typeof this.classes] || 'ceph-icon';
+    if (options) {
+      this.options = { ...this.options, ...options };
+    }
   }
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
@@ -82,4 +82,5 @@ export class PrometheusCustomAlert {
   url: string;
   description: string;
   fingerprint?: string | boolean;
+  severity?: string;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick, flush } from '@angular/core/testing';
 import { Router } from '@angular/router';
 
 import { ToastrService } from 'ngx-toastr';
@@ -192,6 +192,7 @@ describe('ApiInterceptorService', () => {
     it('should show default behaviour', fakeAsync(() => {
       httpError(undefined, { status: 500 });
       expectSaveToHaveBeenCalled(true);
+      flush();
     }));
 
     it('should prevent the default behaviour with preventDefault', fakeAsync(() => {
@@ -219,8 +220,14 @@ describe('ApiInterceptorService', () => {
         (resp.application = 'Prometheus'), (resp.message = msg);
       });
       expectSaveToHaveBeenCalled(true);
+      flush();
       expect(notificationService.save).toHaveBeenCalledWith(
-        createCdNotification(0, '500 - Unknown Error', msg, undefined, 'Prometheus')
+        jasmine.objectContaining({
+          type: 0,
+          title: '500 - Unknown Error',
+          message: msg,
+          application: 'Prometheus'
+        })
       );
     }));
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -1,8 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 
 import _ from 'lodash';
-import { IndividualConfig, ToastrService } from 'ngx-toastr';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
+import {
+  ToastContent,
+  NotificationType as CarbonNotificationType
+} from 'carbon-components-angular';
 
 import { NotificationType } from '../enum/notification-type.enum';
 import { CdNotification, CdNotificationConfig } from '../models/cd-notification';
@@ -14,29 +17,39 @@ import { TaskMessageService } from './task-message.service';
   providedIn: 'root'
 })
 export class NotificationService {
+  private readonly NOTIFICATION_TYPE_MAP: Record<NotificationType, CarbonNotificationType> = {
+    [NotificationType.error]: 'error',
+    [NotificationType.info]: 'info',
+    [NotificationType.success]: 'success',
+    [NotificationType.warning]: 'warning'
+  };
+
   private hideToasties = false;
 
-  // Data observable
   private dataSource = new BehaviorSubject<CdNotification[]>([]);
   private panelStateSource = new BehaviorSubject<{ isOpen: boolean; useNewPanel: boolean }>({
     isOpen: false,
     useNewPanel: true
   });
   private muteStateSource = new BehaviorSubject<boolean>(false);
+  private activeToastsSource = new BehaviorSubject<ToastContent[]>([]);
+  sidebarSubject = new Subject();
 
   data$ = this.dataSource.asObservable();
   panelState$ = this.panelStateSource.asObservable();
   muteState$ = this.muteStateSource.asObservable();
+  activeToasts$ = this.activeToastsSource.asObservable();
 
   private queued: CdNotificationConfig[] = [];
   private queuedTimeoutId: number;
+  private activeToasts: ToastContent[] = [];
   KEY = 'cdNotifications';
   MUTE_KEY = 'cdNotificationsMuted';
 
   constructor(
-    public toastr: ToastrService,
     private taskMessageService: TaskMessageService,
-    private cdDatePipe: CdDatePipe
+    private cdDatePipe: CdDatePipe,
+    private ngZone: NgZone
   ) {
     const stringNotifications = localStorage.getItem(this.KEY);
     let notifications: CdNotification[] = [];
@@ -104,7 +117,7 @@ export class NotificationService {
     type: NotificationType,
     title: string,
     message?: string,
-    options?: any | IndividualConfig,
+    options?: ToastContent,
     application?: string
   ): number;
   show(config: CdNotificationConfig | (() => CdNotificationConfig)): number;
@@ -112,7 +125,7 @@ export class NotificationService {
     arg: NotificationType | CdNotificationConfig | (() => CdNotificationConfig),
     title?: string,
     message?: string,
-    options?: any | IndividualConfig,
+    options?: ToastContent,
     application?: string
   ): number {
     return window.setTimeout(() => {
@@ -182,27 +195,51 @@ export class NotificationService {
     if (this.hideToasties) {
       return;
     }
-    const toastrFn =
-      notification.type === NotificationType.error
-        ? this.toastr.error.bind(this.toastr)
-        : notification.type === NotificationType.info
-        ? this.toastr.info.bind(this.toastr)
-        : this.toastr.success.bind(this.toastr);
 
-    toastrFn(
-      (notification.message ? notification.message + '<br>' : '') +
-        this.renderTimeAndApplicationHtml(notification),
-      notification.title,
-      notification.options
-    );
+    // Map notification types to Carbon types
+    const carbonType = this.NOTIFICATION_TYPE_MAP[notification.type] || 'info';
+    const lowContrast = notification.options?.lowContrast || false;
+
+    const toast: ToastContent = {
+      title: notification.title,
+      subtitle: notification.message || '',
+      caption: this.renderTimeAndApplicationHtml(notification),
+      type: carbonType,
+      lowContrast: lowContrast,
+      showClose: true,
+      duration: notification.options?.timeOut || 5000
+    };
+
+    // Add new toast to the beginning of the array
+    this.activeToasts.unshift(toast);
+    this.activeToastsSource.next(this.activeToasts);
+
+    // Handle duration-based auto-dismissal
+    if (toast.duration && toast.duration > 0) {
+      this.ngZone.runOutsideAngular(() => {
+        setTimeout(() => {
+          this.ngZone.run(() => {
+            this.removeToast(toast);
+          });
+        }, toast.duration);
+      });
+    }
+  }
+
+  /**
+   * Remove a toast
+   */
+  removeToast(toast: ToastContent) {
+    this.activeToasts = this.activeToasts.filter((t) => !_.isEqual(t, toast));
+    this.activeToastsSource.next(this.activeToasts);
   }
 
   renderTimeAndApplicationHtml(notification: CdNotification): string {
-    return `<small class="date">${this.cdDatePipe.transform(
-      notification.timestamp
-    )}</small><i class="float-end custom-icon ${notification.applicationClass}" title="${
-      notification.application
-    }"></i>`;
+    let html = `<div class="toast-caption-container">
+      <small class="date">${this.cdDatePipe.transform(notification.timestamp)}</small>`;
+
+    html += '</div>';
+    return html;
   }
 
   notifyTask(finishedTask: FinishedTask, success: boolean = true): number {
@@ -261,5 +298,10 @@ export class NotificationService {
       isOpen: isOpen,
       useNewPanel: useNewPanel
     });
+  }
+
+  clearAllToasts() {
+    this.activeToasts = [];
+    this.activeToastsSource.next(this.activeToasts);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.spec.ts
@@ -53,7 +53,8 @@ describe('PrometheusAlertFormatter', () => {
           name: 'Something',
           description: 'Something is active',
           url: 'http://Something',
-          fingerprint: 'Something'
+          fingerprint: 'Something',
+          severity: 'someSeverity'
         } as PrometheusCustomAlert
       ]);
     });
@@ -67,7 +68,8 @@ describe('PrometheusAlertFormatter', () => {
           status: 'active',
           name: 'Something',
           description: 'Something is firing',
-          url: 'http://Something'
+          url: 'http://Something',
+          severity: undefined
         } as PrometheusCustomAlert
       ]);
     });
@@ -79,13 +81,35 @@ describe('PrometheusAlertFormatter', () => {
       name: 'Some alert',
       description: 'Some alert is active',
       url: 'http://some-alert',
-      fingerprint: '42'
+      fingerprint: '42',
+      severity: 'critical'
     };
     expect(service.convertAlertToNotification(alert)).toEqual(
       new CdNotificationConfig(
         NotificationType.error,
         'Some alert (active)',
         'Some alert is active <a href="http://some-alert" target="_blank">' +
+          '<svg cdsIcon="analytics" size="16" ></svg></a>',
+        undefined,
+        'Prometheus'
+      )
+    );
+  });
+
+  it('converts warning alert into warning notification', () => {
+    const alert: PrometheusCustomAlert = {
+      status: 'active',
+      name: 'Warning alert',
+      description: 'Warning alert is active',
+      url: 'http://warning-alert',
+      fingerprint: '43',
+      severity: 'warning'
+    };
+    expect(service.convertAlertToNotification(alert)).toEqual(
+      new CdNotificationConfig(
+        NotificationType.warning,
+        'Warning alert (active)',
+        'Warning alert is active <a href="http://warning-alert" target="_blank">' +
           '<svg cdsIcon="analytics" size="16" ></svg></a>',
         undefined,
         'Prometheus'

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.ts
@@ -34,7 +34,8 @@ export class PrometheusAlertFormatter {
           name: alert.labels.alertname,
           url: alert.generatorURL,
           description: alert.annotations.description,
-          fingerprint: _.isObject(alert.status) && (alert as AlertmanagerAlert).fingerprint
+          fingerprint: _.isObject(alert.status) && (alert as AlertmanagerAlert).fingerprint,
+          severity: alert.labels.severity
         };
       }),
       _.isEqual
@@ -51,7 +52,7 @@ export class PrometheusAlertFormatter {
 
   convertAlertToNotification(alert: PrometheusCustomAlert): CdNotificationConfig {
     return new CdNotificationConfig(
-      this.formatType(alert.status),
+      this.formatType(alert.status, alert.severity),
       `${alert.name} (${alert.status})`,
       this.appendSourceLink(alert, alert.description),
       undefined,
@@ -59,7 +60,11 @@ export class PrometheusAlertFormatter {
     );
   }
 
-  private formatType(status: string): NotificationType {
+  private formatType(status: string, severity?: string): NotificationType {
+    if (status === 'active' && severity === 'warning') {
+      return NotificationType.warning;
+    }
+
     const types = {
       error: ['firing', 'active'],
       info: ['suppressed', 'unprocessed'],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-notification.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick, flush } from '@angular/core/testing';
 
 import { ToastrModule, ToastrService } from 'ngx-toastr';
 import { of, throwError } from 'rxjs';
@@ -109,8 +109,10 @@ describe('PrometheusNotificationService', () => {
     const expectShown = (expected: object[]) => {
       tick(500);
       expect(shown.length).toBe(expected.length);
-      expected.forEach((e, i) =>
-        Object.keys(e).forEach((key) => expect(shown[i][key]).toEqual(expected[i][key]))
+      (expected as CdNotificationConfig[]).forEach((e, i) =>
+        (Object.keys(e) as (keyof CdNotificationConfig)[]).forEach((key) =>
+          expect(shown[i][key]).toEqual(e[key])
+        )
       );
     };
 
@@ -125,6 +127,7 @@ describe('PrometheusNotificationService', () => {
 
     it('notify looks on single notification with single alert like', fakeAsync(() => {
       asyncRefresh();
+      flush();
       expectShown([
         new CdNotificationConfig(
           NotificationType.error,
@@ -140,6 +143,7 @@ describe('PrometheusNotificationService', () => {
       asyncRefresh();
       notifications[0].alerts.push(prometheus.createNotificationAlert('alert1', 'resolved'));
       asyncRefresh();
+      flush();
       expectShown([
         new CdNotificationConfig(
           NotificationType.error,
@@ -163,6 +167,7 @@ describe('PrometheusNotificationService', () => {
       notifications.push(prometheus.createNotification());
       notifications[1].alerts.push(prometheus.createNotificationAlert('alert2'));
       asyncRefresh();
+      flush();
       expectShown([
         new CdNotificationConfig(
           NotificationType.error,
@@ -212,7 +217,7 @@ describe('PrometheusNotificationService', () => {
       notifications[1].alerts.push(prometheus.createNotificationAlert('alert0'));
       notifications[1].notified = 'by somebody else';
       asyncRefresh();
-
+      flush();
       expectShown([
         new CdNotificationConfig(
           NotificationType.error,


### PR DESCRIPTION
# mgr/dashboard: Toast Notification Carbonised

This PR replaces the existing `ngx-toastr` implementation with Carbon Design System toast notifications to maintain UI consistency across the Ceph dashboard application.
 
![Screenshot From 2025-06-26 20-16-24](https://github.com/user-attachments/assets/64f576cb-94bc-4fb1-9aea-9435e6fd1a3c)




https://github.com/user-attachments/assets/2ff6f3c9-2c00-412c-8fcf-fbbb7ffdf851


### New Feature  
[https://tracker.ceph.com/issues/71735](https://tracker.ceph.com/issues/71735)



### Background

The Ceph dashboard previously used `ngx-toastr` for toast notifications. To align with the Carbon Design System a these have now been replaced with Carbon-compliant toast components.


### Changes by File

#### New `carbon-toast` Component
- Introduces a reusable `carbon-toast` Angular component encapsulating Carbon-style toast UI.
- Handles:
  - Message rendering
  - Toast types: success, error, info
  - Auto-dismiss behavior


####  Toast Service Refactor
- Refactors the existing notification service to delegate toast handling to the Carbon toast component.
- Updates service providers and dependency injection across modules.

####  Dashboard Module Updates
- Imports and integrates the new `CarbonToastModule`.
- Updates all injection points where toast notifications are used.


Signed-off-by: Anikait Sehwag anikaitsehwag.amg@gmail.com

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
