### PR TITLE
tentacle: rgw: make keystone work without admin token(service ac requirement)

### DIFF
--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -78,7 +78,12 @@ admin_token_retry:
     throw -EINVAL;
   }
 
-  validate.append_header("X-Auth-Token", admin_token);
+  if (allow_expired) {
+    validate.append_header("X-Auth-Token", admin_token);
+  } else {
+    validate.append_header("X-Auth-Token", token);
+  }
+
   validate.set_send_length(0);
 
   validate.set_url(url);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71154

---

backport of https://github.com/ceph/ceph/pull/60515
parent tracker: https://tracker.ceph.com/issues/68327

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh