### PR TITLE
osd/scrub: 'starts' messages should name PGs, not shards

### DIFF
--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -319,7 +319,7 @@ ActiveScrubbing::ActiveScrubbing(my_context ctx)
 
   session.m_osd_counters->inc(session.m_counters_idx->active_started_cnt);
   scrbr->get_clog()->debug()
-      << fmt::format("{} {} starts", pg_id, scrbr->get_op_mode_text());
+      << fmt::format("{} {} starts", pg_id.pgid, scrbr->get_op_mode_text());
 
   scrbr->on_init();
 }


### PR DESCRIPTION
By mistake, the 'scrub starts' log message included the (irrelevant) shard ID of the primary OSD, instead of just the PG ID.

Fixes: https://tracker.ceph.com/issues/71780
