### PR TITLE
Propose a config history trimming logic that trims the old config his…

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -616,6 +616,7 @@ Miscellaneous
 .. confval:: mon_mds_skip_sanity
 .. confval:: mon_max_mdsmap_epochs
 .. confval:: mon_config_key_max_entry_size
+.. confval:: mon_config_history_size
 .. confval:: mon_scrub_interval
 .. confval:: mon_scrub_max_keys
 .. confval:: mon_compact_on_start

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1888,6 +1888,15 @@ options:
   services:
   - mon
   with_legacy: true
+- name: mon_config_history_size
+  type: size
+  level: advanced
+  desc: Defines the number of config history entries to be kept in the Monitors' store 
+  fmt_desc: The maximum number of config history entries to be kept
+  default: 5
+  services:
+  - mon
+  with_legacy: true
 - name: mon_sync_timeout
   type: float
   level: advanced

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -34,6 +34,10 @@ using std::make_pair;
 using std::ostream;
 using std::ostringstream;
 using std::pair;
+using std::regex;
+using std::regex_match;
+using std::smatch;
+using std::stoi;
 using std::set;
 using std::setfill;
 using std::string;
@@ -763,6 +767,8 @@ void ConfigMonitor::tick()
     paxos.unplug();
     propose_pending();
   }
+
+  _trim_config_history();
 }
 
 void ConfigMonitor::on_active()
@@ -979,4 +985,78 @@ void ConfigMonitor::check_all_subs()
     }
   }
   dout(10) << __func__ << " updated " << updated << " / " << total << dendl;
+}
+
+void ConfigMonitor::_trim_config_history() {
+  dout(10) << __func__ << " trimming old config-history versions" << dendl;
+
+  const string history_prefix = "config-history/";
+  const regex key_re(history_prefix + R"((\d+)/[+-]([^/]+/[^/]+))");
+  const regex marker_re(history_prefix + R"((\d+)/)");
+
+  map<string, map<int, vector<string>>> config_versions;
+  set<string> version_markers;
+
+  auto iter = mon.store->get_iterator(KV_PREFIX);
+  iter->lower_bound(history_prefix);
+
+  while (iter->valid() && iter->key().starts_with(history_prefix)) {
+    const string& key = iter->key();
+    if (key.back() == '/') {
+      version_markers.insert(key);
+    } else if (smatch match; regex_match(key, match, key_re)) {
+      int version = stoi(match[1]);
+      string config_key = match[2];
+      config_versions[config_key][version].push_back(key);
+    }
+    iter->next();
+  }
+
+  set<string> keys_to_delete;
+  map<int, int> version_key_deletion_count;
+
+  const size_t mon_config_history_size = g_conf()->mon_config_history_size;
+  const size_t max_entries_to_remove = 100; // num of records to be removed in a single tick
+  size_t entries_removed = 0;
+
+  auto should_stop = [&]() {
+    return entries_removed >= max_entries_to_remove;
+  };
+
+  auto mark_for_deletion = [&](const string& key, int version) {
+    dout(10) << __func__ << " removing old key: " << key << dendl;
+    keys_to_delete.insert(key);
+    version_key_deletion_count[version]++;
+    ++entries_removed;
+  };
+
+  for (auto& [config_key, version_map] : config_versions) {
+    if (version_map.size() <= mon_config_history_size) continue;
+    size_t remove_count = version_map.size() - mon_config_history_size;
+    auto it = version_map.begin();
+
+    for (size_t i = 0; i < remove_count && it != version_map.end() && !should_stop(); ++i, ++it) {
+      int version = it->first;
+      for (const auto& key : it->second) {
+        mark_for_deletion(key, version);
+        if (should_stop()) break;
+      }
+    }
+    if (should_stop()) break;
+  }
+
+  for (const auto& marker : version_markers) {
+    if (smatch m; regex_match(marker, m, marker_re)) {
+      int version = stoi(m[1]);
+      if (version_key_deletion_count.count(version)) {
+        dout(10) << __func__ << " removing version marker: " << marker << dendl;
+        keys_to_delete.insert(marker);
+      }
+    }
+  }
+
+  for (const auto& key : keys_to_delete) {
+    mon.kvmon()->enqueue_rm(key);
+  }
+  mon.kvmon()->propose_pending();
 }

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -23,6 +23,7 @@ class ConfigMonitor : public PaxosService
   std::map<std::string,ceph::buffer::list> current;
 
   void encode_pending_to_kvmon();
+  void _trim_config_history();
 
 public:
   ConfigMonitor(Monitor &m, Paxos &p, const std::string& service_name);


### PR DESCRIPTION
Remove the old config history entries that can accumulate in the mon.store which causes the MON_DISK_BIG issue. This is the same PR as https://github.com/ceph/ceph/pull/62923 to test if the jenkins test fails still happens. 

Fixes: https://tracker.ceph.com/issues/67453





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
