### PR TITLE
squid: rgw: trigger resharding of versioned buckets sooner

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10532,6 +10532,10 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
     max_objs_per_shard /= 3;
   }
 
+  // make sure it's at least 1, as in some testing scenarios it's artificially low
+  constexpr uint64_t min_max_objs_per_shard = 1;
+  max_objs_per_shard = std::max(min_max_objs_per_shard, max_objs_per_shard);
+
   // TODO: consider per-bucket sync policy here?
   const bool is_multisite = svc.zone->need_to_log_data();
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10522,8 +10522,15 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
   }
 
   uint32_t suggested_num_shards = 0;
-  const uint64_t max_objs_per_shard =
+  uint64_t max_objs_per_shard =
     cct->_conf.get_val<uint64_t>("rgw_max_objs_per_shard");
+
+  if (bucket_info.versioning_enabled()) {
+    // Since each versioned bucket requires 4 entries for the first object
+    // and 2 additional entries for each additional object, we want to
+    // trigger resharding sooner.
+    max_objs_per_shard /= 3;
+  }
 
   // TODO: consider per-bucket sync policy here?
   const bool is_multisite = svc.zone->need_to_log_data();

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10525,7 +10525,7 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
   uint64_t max_objs_per_shard =
     cct->_conf.get_val<uint64_t>("rgw_max_objs_per_shard");
 
-  if (bucket_info.versioning_enabled()) {
+  if (bucket_info.versioned()) {
     // Since each versioned bucket requires 4 entries for the first object
     // and 2 additional entries for each additional object, we want to
     // trigger resharding sooner.


### PR DESCRIPTION
NOTE: this is an attempt to get a clean PR that matches https://github.com/ceph/ceph/pull/63567

backport tracker: https://tracker.ceph.com/issues/70374

backport of https://github.com/ceph/ceph/pull/60403
parent tracker: https://tracker.ceph.com/issues/68206

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh