### PR TITLE
tentacle: mgr/dashboard: align response of subsystem add and ns add with old cli

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -177,7 +177,7 @@ else:
         )
         @empty_response
         @NvmeofCLICommand("nvmeof subsystem add", model.RequestStatus)
-        @convert_to_model(model.RequestStatus)
+        @convert_to_model(model.SubsystemStatus)
         @handle_nvmeof_error
         def create(self, nqn: str, enable_ha: bool = True, max_namespaces: int = 1024,
                    gw_group: Optional[str] = None, traddr: Optional[str] = None):
@@ -384,7 +384,7 @@ else:
             nqn: str,
             rbd_image_name: str,
             rbd_pool: str = "rbd",
-            create_image: Optional[bool] = True,
+            create_image: Optional[bool] = False,
             size: Optional[int] = 1024,
             rbd_image_size: Optional[int] = None,
             trash_image: Optional[bool] = False,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.spec.ts
@@ -121,6 +121,7 @@ describe('NvmeofNamespacesFormComponent', () => {
         gw_group: MOCK_GROUP,
         rbd_image_name: `nvme_rbd_default_${MOCK_RANDOM_STRING}`,
         rbd_pool: 'rbd',
+        create_image: true,
         rbd_image_size: 1073741824
       });
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-namespaces-form/nvmeof-namespaces-form.component.ts
@@ -152,7 +152,8 @@ export class NvmeofNamespacesFormComponent implements OnInit {
       const request: NamespaceCreateRequest = {
         gw_group: this.group,
         rbd_image_name: `nvme_${pool}_${this.group}_${this.randomString()}`,
-        rbd_pool: pool
+        rbd_pool: pool,
+        create_image: true
       };
       if (rbdImageSize) {
         request['rbd_image_size'] = rbdImageSize;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -160,6 +160,7 @@ describe('NvmeofService', () => {
         rbd_image_name: 'nvme_ns_image:12345678',
         rbd_pool: 'rbd',
         rbd_image_size: 1024,
+        create_image: true,
         gw_group: mockGroupName
       };
       service.createNamespace(mockNQN, mockNamespaceObj).subscribe();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -30,6 +30,7 @@ export type NamespaceCreateRequest = NvmeofRequest & {
   rbd_image_name: string;
   rbd_pool: string;
   rbd_image_size?: number;
+  create_image: boolean;
 };
 
 export type NamespaceUpdateRequest = NvmeofRequest & {

--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -80,6 +80,12 @@ class SubsystemList(NamedTuple):
     subsystems: Annotated[List[Subsystem], CliFlags.EXCLUSIVE_LIST]
 
 
+class SubsystemStatus(NamedTuple):
+    status: int
+    error_message: str
+    nqn: str
+
+
 class Connection(NamedTuple):
     traddr: str
     trsvcid: int

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9082,7 +9082,7 @@ paths:
                   description: NVMeoF namespace block size
                   type: integer
                 create_image:
-                  default: true
+                  default: false
                   description: Create RBD image
                   type: boolean
                 force:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71884

---

backport of https://github.com/ceph/ceph/pull/63410
parent tracker: https://tracker.ceph.com/issues/71393

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh