### PR TITLE
test/erasure-code: fix stack-use-after-scope by replacing initializer_list with array

### DIFF
--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -41,7 +41,8 @@ unsigned int value_count = 0;
 
 map<shard_id_set,set<shard_id_set>> shec_table;
 
-constexpr int getint(std::initializer_list<int> is) {
+template<size_t N>
+constexpr int getint(const std::array<int, N>& is) {
   int a = 0;
   for (const auto i : is) {
     a |= 1 << i;
@@ -74,8 +75,8 @@ void create_table_shec432() {
         }
         if (std::popcount(avails) == 2 &&
             std::popcount(want) == 1) {
-	  if (std::cmp_equal(want | avails, getint({0,1,5})) ||
-	      std::cmp_equal(want | avails, getint({2,3,6}))) {
+	  if (std::cmp_equal(want | avails, getint(std::to_array({0,1,5}))) ||
+	      std::cmp_equal(want | avails, getint(std::to_array({2,3,6})))) {
             vec.push_back(avails);
           }
         }
@@ -86,14 +87,14 @@ void create_table_shec432() {
           continue;
         }
         if (std::popcount(avails) == 4) {
-	  auto a = to_array<std::initializer_list<int>>({
+	  auto a = std::to_array<std::array<int, 4>>({
 	      {0,1,2,3}, {0,1,2,4}, {0,1,2,6}, {0,1,3,4}, {0,1,3,6}, {0,1,4,6},
 	      {0,2,3,4}, {0,2,3,5}, {0,2,4,5}, {0,2,4,6}, {0,2,5,6}, {0,3,4,5},
 	      {0,3,4,6}, {0,3,5,6}, {0,4,5,6}, {1,2,3,4}, {1,2,3,5}, {1,2,4,5},
 	      {1,2,4,6}, {1,2,5,6}, {1,3,4,5}, {1,3,4,6}, {1,3,5,6}, {1,4,5,6},
 	      {2,3,4,5}, {2,4,5,6}, {3,4,5,6}});
-          if (ranges::any_of(a, std::bind_front(cmp_equal<uint, int>, avails),
-			     getint)) {
+          if (ranges::any_of(a, [avails] (int n) { return cmp_equal(avails, n); },
+			     getint<4>)) {
 	    vec.push_back(avails);
 	  }
 	}


### PR DESCRIPTION
Previously, we used std::array<std::initializer_list<int>, 27> to store a multi-dimensional array. However, initializer_list objects only hold pointers to their underlying data, not the data itself. When initialized with brace-enclosed lists like {0,1,2,3}, the temporary arrays created by these literals are destroyed after the initialization expression completes, leaving the initializer_list objects pointing to deallocated memory.

This caused AddressSanitizer to detect stack-use-after-scope errors when getint() attempted to iterate over the initializer_list contents:

```
==2085499==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f5fe9803580 at pc 0x55d851bea586 bp 0x7ffc9816a5b0 sp 0x7ffc9816a5a8
READ of size 4 at 0x7f5fe9803580 thread T0
    #0 0x55d851bea585 in getint(std::initializer_list<int>) /home/jenkins-build/build/workspace/ceph-pull-requests/src/test/erasure-code/TestErasureCodeShec_arguments.cc:46:21
    #1 0x55d851bf0258 in int std::__invoke_impl<int, int (*&)(std::initializer_list<int>), std::initializer_list<int>&>(std::__invoke_other, int (*&)(std::initializer_list<int>), std::initializer_list<int>&) /usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
...
Address 0x7f5fe9803580 is located in stack of thread T0 at offset 1408 in frame
    #0 0x55d851bdd07f in create_table_shec432() /home/jenkins-build/build/workspace/ceph-pull-requests/src/test/erasure-code/TestErasureCodeShec_arguments.cc:52
```

Fix this by using std::array<std::array<int, 4>, 27> instead, which actually owns and stores the data rather than just pointing to it.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
