### PR TITLE
tentacle: test/librados/aio_cxx: skip EIO boundary assertion when no in-flight I/Os

### DIFF
--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -2349,7 +2349,7 @@ void pool_io_callback(completion_t cb, void *arg /* Actually AioCompletion* */)
     ASSERT_EQ(0, info->c->wait_for_complete());
   }
   int r = info->c->get_return_value();
-  cout << "finish " << i << " r = " << r << std::endl;
+  //cout << "finish " << i << " r = " << r << std::endl;
 
   std::scoped_lock l(my_lock);
   inflight.erase(i);
@@ -2426,8 +2426,8 @@ TEST(LibRadosAio, PoolEIOFlag) {
   }
 
   if (!missed_eio) {
-    GTEST_SKIP() << "eio flag missed all ios that already completed";
     my_lock.unlock();
+    GTEST_SKIP() << "eio flag missed all ios that already completed";
   }
   cout << "max_success " << max_success << ", min_failed " << min_failed << std::endl;
   ASSERT_TRUE(max_success + 1 == min_failed);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71867

---

backport of https://github.com/ceph/ceph/pull/63177
parent tracker: https://tracker.ceph.com/issues/70852

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh