### PR TITLE
tentacle: nvmeofgw: fix sending acks during upgrade

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -267,6 +267,11 @@ void  NVMeofGwMap::gw_performed_startup(const NvmeGwId &gw_id,
 void NVMeofGwMap::increment_gw_epoch(const NvmeGroupKey& group_key)
 {
   if (HAVE_FEATURE(mon->get_quorum_con_features(), NVMEOFHAMAP)) {
+    if (gw_epoch.find(group_key) == gw_epoch.end()) {
+      gw_epoch[group_key] = epoch;
+      dout(4) << "recreated GW epoch of " << group_key
+           << " " << gw_epoch[group_key] << dendl;
+    }
     gw_epoch[group_key] ++;
     dout(4) << "incremented epoch of " << group_key
          << " " << gw_epoch[group_key] << dendl;

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -158,7 +158,8 @@ version_t NVMeofGwMon::get_trim_to() const
  * function called during new paxos epochs
  * function called to restore in pending map all data that is not serialized
  * to paxos peons. Othervise it would be overriden in "pending_map = map"
- * currently "allow_failovers_ts" and "last_gw_down_ts" variables restored
+ * currently "allow_failovers_ts", "last_gw_down_ts",
+ * "last_gw_map_epoch_valid" variables are restored
  */
 void NVMeofGwMon::restore_pending_map_info(NVMeofGwMap & tmp_map) {
   std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
@@ -175,6 +176,8 @@ void NVMeofGwMon::restore_pending_map_info(NVMeofGwMap & tmp_map) {
       }
       pending_map.created_gws[group_key][gw_id].last_gw_down_ts =
           gw_created_pair.second.last_gw_down_ts;
+      pending_map.created_gws[group_key][gw_id].last_gw_map_epoch_valid =
+	  gw_created_pair.second.last_gw_map_epoch_valid;
     }
   }
 }
@@ -806,12 +809,13 @@ bool NVMeofGwMon::prepare_beacon(MonOpRequestRef op)
     send_ack = true;
     if (apply_ack_logic) {
       dout(20) << "ack sent: beacon index "
-       << pending_map.created_gws[group_key][gw_id].beacon_index
-       << " gw " << gw_id <<dendl;
+      << pending_map.created_gws[group_key][gw_id].beacon_index
+      << " gw " << gw_id << " epoch-filter  " << epoch_filter_enabled
+      << " propose " << propose << " gw-propose " << gw_propose << dendl;
     }
   }
   if (send_ack && ((!gw_propose && epoch_filter_enabled) ||
-                    (propose && !epoch_filter_enabled) ||
+                    (!propose && !epoch_filter_enabled) ||
                     (avail == gw_availability_t::GW_CREATED)) ) {
           /* always send beacon ack to gw in Created state,
            * it should be temporary state


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71894

---

backport of https://github.com/ceph/ceph/pull/63883
parent tracker: https://tracker.ceph.com/issues/71890

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh