### PR TITLE
crimson/osd: put PGBackend/RecoveryBackend/PGRecovery and other related classes into the crimson::osd  namespace

### DIFF
--- a/src/crimson/osd/ec_backend.cc
+++ b/src/crimson/osd/ec_backend.cc
@@ -2,6 +2,8 @@
 
 #include "crimson/osd/shard_services.h"
 
+namespace crimson::osd {
+
 ECBackend::ECBackend(shard_id_t shard,
                      ECBackend::CollectionRef coll,
                      crimson::osd::ShardServices& shard_services,
@@ -34,4 +36,6 @@ ECBackend::submit_transaction(const std::set<pg_shard_t> &pg_shards,
 {
   // todo
   return make_ready_future<rep_op_ret_t>(seastar::now(), seastar::now());
+}
+
 }

--- a/src/crimson/osd/ec_backend.h
+++ b/src/crimson/osd/ec_backend.h
@@ -9,6 +9,8 @@
 #include "osd/osd_types.h"
 #include "pg_backend.h"
 
+namespace crimson::osd {
+
 class ECBackend : public PGBackend
 {
 public:
@@ -39,3 +41,5 @@ private:
     return seastar::now();
   }
 };
+
+}

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -47,8 +47,6 @@
 
 class MQuery;
 class OSDMap;
-class PGBackend;
-class ReplicatedBackend;
 class PGPeeringEvent;
 class osd_op_params_t;
 
@@ -68,6 +66,8 @@ namespace crimson::osd {
 class OpsExecuter;
 class SnapTrimEvent;
 class PglogBasedRecovery;
+class PGBackend;
+class ReplicatedBackend;
 
 class PG : public boost::intrusive_ref_counter<
   PG,
@@ -1014,7 +1014,7 @@ private:
 
 private:
   friend class IOInterruptCondition;
-  friend class ::ReplicatedBackend;
+  friend class ReplicatedBackend;
   struct log_update_t {
     std::set<pg_shard_t> waiting_on;
     seastar::shared_promise<> all_committed;

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -43,6 +43,8 @@ using std::string;
 using std::string_view;
 using crimson::common::local_conf;
 
+namespace crimson::osd {
+
 std::unique_ptr<PGBackend>
 PGBackend::create(pg_t pgid,
 		  const pg_shard_t pg_shard,
@@ -1854,3 +1856,4 @@ void PGBackend::clone_for_write(
   txn.rmattr(coll->get_cid(), ghobject_t{to}, SS_ATTR);
 }
 
+}

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -29,10 +29,9 @@ namespace ceph::os {
 }
 
 namespace crimson::osd {
-  class ShardServices;
-  class PG;
-  class ObjectContextLoader;
-}
+class ShardServices;
+class PG;
+class ObjectContextLoader;
 
 class PGBackend
 {
@@ -517,3 +516,5 @@ private:
 
   friend class RecoveryBackend;
 };
+
+}

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -22,7 +22,8 @@ SET_SUBSYS(osd);
 
 using std::map;
 using std::set;
-using PglogBasedRecovery = crimson::osd::PglogBasedRecovery;
+
+namespace crimson::osd {
 
 void PGRecovery::start_pglogbased_recovery()
 {
@@ -710,4 +711,6 @@ void PGRecovery::on_backfill_reserved()
   // (but stopped one).
   backfill_state->process_event(
     BackfillState::Triggered{}.intrusive_from_this());
+}
+
 }

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -15,12 +15,11 @@
 
 #include "osd/object_state.h"
 
+class MOSDPGBackfillRemove;
+
 namespace crimson::osd {
 class UrgentRecovery;
 class PglogBasedRecovery;
-}
-
-class MOSDPGBackfillRemove;
 class PGBackend;
 
 class PGRecovery : public crimson::osd::BackfillState::BackfillListener {
@@ -148,3 +147,5 @@ private:
   friend crimson::osd::PG;
   // backfill end
 };
+
+}

--- a/src/crimson/osd/pg_recovery_listener.h
+++ b/src/crimson/osd/pg_recovery_listener.h
@@ -10,10 +10,8 @@
 #include "osd/osd_types.h"
 
 namespace crimson::osd {
-  class ShardServices;
-  class PglogBasedRecovery;
-};
-
+class ShardServices;
+class PglogBasedRecovery;
 class RecoveryBackend;
 class PGRecovery;
 
@@ -45,3 +43,5 @@ public:
   virtual void reset_pglog_based_recovery_op() = 0;
   virtual void schedule_event_after(PGPeeringEventRef evt, float delay) = 0;
 };
+
+}

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -16,6 +16,8 @@
 
 SET_SUBSYS(osd);
 
+namespace crimson::osd {
+
 hobject_t RecoveryBackend::get_temp_recovery_object(
   const hobject_t& target,
   eversion_t version) const
@@ -458,4 +460,6 @@ RecoveryBackend::handle_backfill_op(
 	std::invalid_argument(fmt::format("invalid request type: {}",
 					  (uint16_t)m->get_header().type)));
   }
+}
+
 }

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -19,9 +19,8 @@
 #include "osd/recovery_types.h"
 #include "osd/osd_types.h"
 
-namespace crimson::osd{
-  class PG;
-}
+namespace crimson::osd {
+class PG;
 
 class RecoveryBackend {
 public:
@@ -306,3 +305,5 @@ private:
     crimson::net::ConnectionXcoreRef conn);
   interruptible_future<> handle_backfill_remove(MOSDPGBackfillRemove& m);
 };
+
+}

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -15,6 +15,8 @@
 
 SET_SUBSYS(osd);
 
+namespace crimson::osd {
+
 ReplicatedBackend::ReplicatedBackend(pg_t pgid,
                                      pg_shard_t whoami,
 				     crimson::osd::PG& pg,
@@ -354,4 +356,6 @@ void ReplicatedBackend::do_pct(const MOSDPGPCT &m)
   LOG_PREFIX(ReplicatedBackend::do_pct);
   DEBUGDPP("{}", dpp, m);
   pg.peering_state.update_pct(m.pg_committed_to);
+}
+
 }

--- a/src/crimson/osd/replicated_backend.h
+++ b/src/crimson/osd/replicated_backend.h
@@ -14,9 +14,8 @@
 #include "pg_backend.h"
 
 namespace crimson::osd {
-  class ShardServices;
-  class PG;
-}
+class ShardServices;
+class PG;
 
 class ReplicatedBackend : public PGBackend
 {
@@ -104,3 +103,5 @@ public:
   /// Handle MOSDPGPCT message
   void do_pct(const MOSDPGPCT &m);
 };
+
+}

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -19,6 +19,8 @@ using std::less;
 using std::map;
 using std::string;
 
+namespace crimson::osd {
+
 RecoveryBackend::interruptible_future<>
 ReplicatedRecoveryBackend::recover_object(
   const hobject_t& soid,
@@ -1378,4 +1380,6 @@ ReplicatedRecoveryBackend::get_md_from_push_op(PushOp &push_op)
     }
   }
   return std::make_pair(std::move(oi), std::move(ssc));
+}
+
 }

--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -15,6 +15,8 @@
 #include "messages/MOSDPGRecoveryDeleteReply.h"
 #include "os/ObjectStore.h"
 
+namespace crimson::osd {
+
 class ReplicatedRecoveryBackend : public RecoveryBackend {
 public:
   ReplicatedRecoveryBackend(crimson::osd::PG& pg,
@@ -179,3 +181,5 @@ private:
   std::pair<object_info_t, crimson::osd::SnapSetContextRef>
   get_md_from_push_op(PushOp &push_op);
 };
+
+}


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
