### PR TITLE
[AGENT OPTIMIZATION] Add Jitter and Startup Delay to Smooth Agent Metadata Reporting and Prevent Spikes

### DIFF
--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -146,6 +146,21 @@ class AgentEndpoint:
         else:
             return self.mgr.agent_initial_startup_delay_max
 
+    def get_jitter(self) -> int:
+        """
+        Compute the jitter window (in seconds) applied before agents send metadata.
+
+        - If agent_jitter_seconds is -1 (auto), compute it as:
+            jitter = num_agents / avg_concurrency (M)
+        - This spreads agent reports evenly across the window.
+        - Uses a min jitter of 2s to prevent tight clustering in very small clusters.
+        """
+        if self.mgr.agent_jitter_seconds == -1:  # auto-jitter mode
+            agents_refresh_rate = self.compute_agents_refrsh_rate()
+            return max(2, int(agents_refresh_rate * 0.5))
+        else:
+            return self.mgr.agent_jitter_seconds
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -85,6 +85,51 @@ class AgentEndpoint:
                 self.server_port += 1
         self.mgr.log.error(f'Cephadm agent could not find free port in range {max_port - 150}-{max_port} and failed to start')
 
+    def compute_agents_avg_concurrency(self) -> int:
+        """
+        Compute the average number of agents allowed to report metadata per second (M).
+
+        - If user-specified value is -1, use an adaptive formula: sqrt(N)/2 (capped at 10).
+        - Ensures a minimum of 2 agents/sec to avoid unnecessary serialization.
+        - This helps spread load while avoiding bursts, especially on small clusters.
+        """
+        if self.mgr.agent_avg_concurrency == -1:  # auto-concurrency mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_concurrency = min(20, int(num_agents ** 0.5 / 2))
+        else:
+            agents_concurrency = self.mgr.agent_avg_concurrency
+        # We force a minimum of 2 agents per seconds
+        return max(2, agents_concurrency)
+
+    def compute_agents_refrsh_rate(self) -> int:
+        """
+        Compute the refresh rate (in seconds) for agent metadata reporting.
+
+        - If the user has specified a fixed `agent_refresh_rate`, use that.
+        - If `agent_refresh_rate` is set to -1 (auto mode), compute it dynamically as:
+            refresh_rate = num_agents // avg_concurrency
+            where:
+              - num_agents = total number of agents in the cluster
+              - avg_concurrency = average number of agents allowed to report per second,
+                computed using a separate heuristic (sqrt(N)/2, capped).
+        - This ensures that agent updates are spread evenly and that the manager is not overwhelmed.
+
+        Notes:
+        - A minimum refresh rate of 20 seconds is enforced to avoid excessive agent churn and load.
+        - The dynamic mode adapts automatically as the cluster grows.
+
+        Returns:
+            int: The agent refresh rate in seconds.
+        """
+        if self.mgr.agent_refresh_rate == -1:  # auto-refresh rate
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            refresh_rate = num_agents // agents_avg_concurrency
+        else:
+            refresh_rate = self.mgr.agent_refresh_rate
+
+        return max(20, refresh_rate)
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)
@@ -886,10 +931,11 @@ class CephadmAgentHelpers:
             if host in self.mgr.offline_hosts:
                 return False
             self.mgr.agent_cache.agent_timestamp[host] = datetime_now()
-        # agent hasn't reported in down multiplier * it's refresh rate. Something is likely wrong with it.
+        # agent hasn't reported in:  down_multiplier * it's refresh rate + jitter. Something is likely wrong with it.
+        jitter: float = self.agent.get_jitter()
         down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
         time_diff = datetime_now() - self.mgr.agent_cache.agent_timestamp[host]
-        if time_diff.total_seconds() > down_mult * float(self.mgr.agent_refresh_rate):
+        if time_diff.total_seconds() > down_mult * float(self.mgr.http_server.agent.compute_agents_refrsh_rate() + jitter):
             return True
         return False
 
@@ -900,7 +946,7 @@ class CephadmAgentHelpers:
             down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
             for agent in down_agent_hosts:
                 detail.append((f'Cephadm agent on host {agent} has not reported in '
-                              f'{down_mult * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
+                              f'{down_mult * self.mgr.http_server.agent.compute_agents_refrsh_rate()} seconds. Agent is assumed '
                                'down and host may be offline.'))
             for dd in [d for d in self.mgr.cache.get_daemons_by_type('agent') if d.hostname in down_agent_hosts]:
                 dd.status = DaemonDescriptionStatus.error

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -139,7 +139,7 @@ class AgentEndpoint:
         - This prevents bursts of all agents from reporting immediately at startup.
         - Enforces a minimum of 10s to avoid early tight clustering.
         """
-        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+        if self.mgr.agent_initial_startup_delay_max == -1:  # auto-delay mode
             num_agents = len(self.mgr.cache.get_hosts())
             agents_avg_concurrency = self.compute_agents_avg_concurrency()
             return max(10, num_agents // agents_avg_concurrency)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -130,6 +130,22 @@ class AgentEndpoint:
 
         return max(20, refresh_rate)
 
+    def get_initial_delay(self) -> int:
+        """
+        Compute the maximum initial random startup delay (in seconds) before an agent starts reporting.
+
+        - If agent_initial_startup_delay_max is -1 (auto), compute as:
+            delay = num_agents / avg_concurrency (M)
+        - This prevents bursts of all agents from reporting immediately at startup.
+        - Enforces a minimum of 10s to avoid early tight clustering.
+        """
+        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            return max(10, num_agents // agents_avg_concurrency)
+        else:
+            return self.mgr.agent_initial_startup_delay_max
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -366,9 +366,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ),
         Option(
             'agent_refresh_rate',
-            type='secs',
-            default=20,
-            desc='How often agent on each host will try to gather and send metadata'
+            type='int',
+            default=-1,
+            desc='How often each agent sends metadata. Use -1 to auto-adjust based on cluster size.'
+        ),
+        Option(
+            'agent_avg_concurrency',
+            type='int',
+            default=-1,
+            desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
             'agent_starting_port',
@@ -566,6 +572,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.ssh_cert: Optional[str] = None
             self.use_agent = False
             self.agent_refresh_rate = 0
+            self.agent_avg_concurrency = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -383,6 +383,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
         ),
         Option(
+            'agent_jitter_seconds',
+            type='int',
+            default=-1,
+            desc='Max random delay before agent sends metadata; set -1 for auto (default), 0 to disable'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -580,6 +586,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
             self.agent_initial_startup_delay_max = 0
+            self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3325,6 +3325,18 @@ Then run the following:
                 'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
+    def show_agent_config(self) -> Dict[str, str]:
+        agent = self.http_server.agent
+        return {
+            'agent_refresh_rate': str(agent.compute_agents_refrsh_rate()),
+            'agent_avg_concurrency': str(agent.compute_agents_avg_concurrency()),
+            'agent_initial_startup_delay_max': str(agent.get_initial_delay()),
+            'agent_jitter_seconds': str(agent.get_jitter()),
+            'agent_down_multiplier': str(self.agent_down_multiplier),
+            'agent_starting_port': str(self.agent_starting_port)
+        }
+
+    @handle_orch_error
     def cert_store_cert_ls(self, show_details: bool = False) -> Dict[str, Any]:
         return self.cert_mgr.cert_ls(show_details)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -377,6 +377,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
+            'agent_initial_startup_delay_max',
+            type='int',
+            default=-1,
+            desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -573,6 +579,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.use_agent = False
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
+            self.agent_initial_startup_delay_max = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1545,7 +1545,7 @@ class CephadmAgent(CephService):
 
         cfg = {'target_ip': self.mgr.get_mgr_ip(),
                'target_port': agent.server_port,
-               'refresh_period': self.mgr.agent_refresh_rate,
+               'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1548,7 +1548,8 @@ class CephadmAgent(CephService):
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
-               'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}
+               'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'initial_startup_delay_max': agent.get_initial_delay()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1549,7 +1549,8 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
-               'initial_startup_delay_max': agent.get_initial_delay()}
+               'initial_startup_delay_max': agent.get_initial_delay(),
+               'jitter_seconds': agent.get_jitter()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/tests/test_agent.py
+++ b/src/pybind/mgr/cephadm/tests/test_agent.py
@@ -1,0 +1,196 @@
+from cephadm.agent import AgentEndpoint
+
+
+class FakeCache:
+    def __init__(self, num_hosts):
+        self._hosts = ['host{}'.format(i) for i in range(num_hosts)]
+
+    def get_hosts(self):
+        return self._hosts
+
+
+class FakeMgr:
+    def __init__(self, num_hosts=10):
+        self.agent_avg_concurrency = -1
+        self.agent_refresh_rate = -1
+        self.agent_initial_startup_delay_max = -1
+        self.agent_jitter_seconds = -1
+        self.cache = FakeCache(num_hosts)
+
+    def get_mgr_ip(self):
+        return ''
+
+
+class TestAgentEndpoint:
+
+    def test_concurrency_auto_small(self):
+        # Test that even for very small clusters (1 host),
+        # the minimum concurrency of 2 is enforced
+        mgr = FakeMgr(num_hosts=1)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+
+    def test_concurrency_auto_exact_boundary(self):
+        # Test that concurrency is capped at 20 even when sqrt(N)/2 exceeds 20
+        mgr = FakeMgr(num_hosts=1600)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 20
+
+    def test_refresh_auto_typical(self):
+        # Test refresh rate computed dynamically in auto mode for a typical cluster size
+        # 100 agents → concurrency = 5 and refresh_rate = (100*2)//5 = 40
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 40
+
+    def test_refresh_auto_zero_agents(self):
+        # Test refresh rate fallback for 0 agents (should enforce minimum of 20s)
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_auto_with_manual_concurrency(self):
+        # Test refresh rate in auto mode with manually overridden high concurrency
+        # Should still honor the lower bound of 20s
+        mgr = FakeMgr(num_hosts=1000)
+        mgr.agent_avg_concurrency = 100
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_min_refresh_rate(self):
+        # Test that manually specified refresh rates below the lower bound are clamped to 20s
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 5
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_manual_valid(self):
+        # Test that manually specified valid refresh rate is used as-is
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 60
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 60
+
+    def test_initial_delay_auto_small(self):
+        # Test auto delay with a small number of agents returns minimum 10s
+        mgr = FakeMgr(num_hosts=2)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_auto_zero_agents(self):
+        # Test auto delay with 0 agents still enforces the minimum 10s delay
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_manual_below_min(self):
+        # Test that manual delay below the minimum is respected (no clamping here)
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 5
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 5
+
+    def test_initial_delay_manual_valid(self):
+        # Test that a valid manual delay value is used directly
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 30
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 30
+
+    def test_jitter_auto_zero_refresh(self):
+        # Test jitter in auto mode with 0 agents; fallback refresh_rate is 20 and jitter = 10
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 10
+
+    def test_jitter_auto_typical(self):
+        # Test jitter in auto mode for a typical cluster (100 agents)
+        # refresh_rate = 40 an jitter = 20
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        jitter = config.get_jitter()
+        assert jitter == 20
+
+    def test_jitter_manual(self):
+        # Test that manual jitter override is respected (even if < 2)
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 1
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 1
+
+    def test_jitter_manual_high(self):
+        # Test that a high manual jitter value is used as-is
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 60
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 60
+
+
+class TestAgentEndpointAuto:
+
+    def test_auto_minimum_values(self):
+        # Test system behavior with 0 agents in full auto mode.
+        # All computed values should fall back to their enforced minimums.
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2  # Enforced minimum
+        assert config.compute_agents_refrsh_rate() == 20     # Enforced minimum
+        assert config.get_initial_delay() == 10              # Enforced minimum
+        assert config.get_jitter() == 10                     # 50% of refresh rate (20)
+
+    def test_auto_4_hosts(self):
+        # Test computed values for a very small cluster (4 agents).
+        # sqrt(4)/2 = 1 -> clamped to 2 concurrency
+        # Refresh rate = (4*2)//2 = 4 -> clamped to 20
+        mgr = FakeMgr(num_hosts=4)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10              # 4//2 = 2 -> clamped to 10
+        assert config.get_jitter() == 10                     # 50% of refresh rate
+
+    def test_auto_16_hosts(self):
+        # Test computed values for 16 agents.
+        # sqrt(16)/2 = 2 → meets minimum concurrency
+        # Refresh rate = (16*2)//2 = 16 → clamped to 20
+        mgr = FakeMgr(num_hosts=16)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10              # 16//2 = 8 → clamped to 10
+        assert config.get_jitter() == 10                     # 50% of refresh rate
+
+    def test_auto_100_hosts(self):
+        # Test computed values for 100 agents.
+        # sqrt(100)/2 = 5 -> concurrency = 5
+        # Refresh rate = (100*2)//5 = 40
+        # Initial delay = 100//5 = 20
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 5
+        assert config.compute_agents_refrsh_rate() == 40
+        assert config.get_initial_delay() == 20
+        assert config.get_jitter() == 20  # 50% of refresh rate
+
+    def test_auto_200_hosts(self):
+        # Test computed values for 200 agents.
+        # sqrt(200)/2 ≈ 7.07 -> concurrency = 7
+        # Refresh rate = (200*2)//7 = ~57
+        # Initial delay = 200//7 ~ 28
+        mgr = FakeMgr(num_hosts=200)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 7
+        assert config.compute_agents_refrsh_rate() == 57
+        assert config.get_jitter() == 28  # 50% of refresh rate
+
+    def test_auto_1000_hosts(self):
+        # Test computed values for 1000 agents.
+        # sqrt(1000)/2 ≈ 15.81 → concurrency = 15
+        # Refresh rate = (1000*2)//15 ~ 133
+        # Initial delay = 1000//15 ~ 66
+        mgr = FakeMgr(num_hosts=1000)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 15
+        assert config.compute_agents_refrsh_rate() == 133
+        assert config.get_initial_delay() == 66
+        assert config.get_jitter() == 66  # 50% of refresh rate

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3670,7 +3670,7 @@ class TestAgent:
     def test_deploy_cephadm_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         agent_spec = ServiceSpec(service_type="agent", placement=PlacementSpec(count=1))
-        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"refresh_period\": 20, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\"}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
+        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\", \"refresh_period\": 20, \"initial_startup_delay_max\": 10, \"jitter_seconds\": 10}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, agent_spec):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -904,6 +904,9 @@ class Orchestrator(object):
         """remove prometheus target for multi-cluster"""
         raise NotImplementedError()
 
+    def show_agent_config(self) -> OrchResult[Dict[str, str]]:
+        raise NotImplementedError()
+
     def get_alertmanager_access_info(self) -> OrchResult[Dict[str, str]]:
         """get alertmanager access information"""
         raise NotImplementedError()

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1425,6 +1425,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         result = raise_if_exception(completion)
         return HandleCommandResult(stdout=json.dumps(result))
 
+    @_cli_read_command('orch agent show-config')
+    def _show_cephadm_agent_config(self) -> HandleCommandResult:
+        completion = self.show_agent_config()
+        result = raise_if_exception(completion)
+        return HandleCommandResult(stdout=json.dumps(result))
+
     @_cli_write_command('orch alertmanager set-credentials')
     def _set_alertmanager_access_info(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> HandleCommandResult:
         try:


### PR DESCRIPTION
## Enhancements to Prevent Spikes in Cephadm Agent Metadata Reporting

This PR introduces several improvements to the Cephadm Agent to make metadata reporting more efficient, scalable, and customizable. In large clusters, synchronized reporting can cause traffic spikes and overload the cephadm module and hence the ceph-manager. To address this, the agent now uses adaptive logic to automatically determine reporting intervals (`agent_refresh_rate`), jitter windows, and startup delays based on cluster size. These enhancements help smooth network load, reduce reporting bursts, and improve overall scalability.

### Motivation
Static refresh rates and missing jitter logic previously led to uneven traffic and potential burstiness, especially during agent restarts or in large clusters. This change introduces a more scalable, self-tuning model that adjusts automatically to the cluster size.

### Key Enhancements

- **Automatic refresh rate**: User now can use automatic refresh rate calculation adjusting the behavior to the cluster size.
- **Smarter Jittering**: Agents now support jitter mechanism to spread metadata sending over time, reducing bursts.
- **Configurable Startup Behavior**: Agents can be configured with randomized startup delays to avoid startup bursts.

### Jitter calculation key Changes
- Automatically derive `avg_concurrency` as `sqrt(N)/2`  with a minimum of 2 agents/sec.
- Dynamically compute `agent_refresh_rate` based on `num_agents // avg_concurrency`, with a minimum of 20s.
- Set jitter to 50% of the refresh rate to evenly spread metadata reports across time.
- Apply the same heuristic to the startup delay to avoid initial burst load.

### Theoretical Behavior

Agent metadata activity follows a [binomial](https://randombooks.org/the-binomial-distribution.html) concurrency model, where each of the `N` agents is independently active with probability `p = D / T` at any given moment, where:

- `N`: Number of agents  
- `D`: Average task duration (seconds)  
- `T`: Agent refresh interval (seconds)  

The expected number of concurrent agents is:

`μ = N × (D / T)`

The 99th percentile can be used to estimate the maximum concurrency as following:

`P99 ≈ μ + 2.33 × sqrt(N × p × (1 - p))`

Simulation confirm that this model provides a reliable upper bound for burst behavior, with observed peaks consistently less than **< 2×Average** when number of agents is higher than 100. This enables safe, efficient provisioning without requiring significant over-provisioning.

With the new (default) configuration, we get the following numbers for `D = 2sec`:

| Num Agents | Avg Concurrency Heuristic | Refresh Rate (s) | Expected Avg Concurrency | Std Dev | Max Estimated Concurrency (P99) | P99 / Avg Ratio |
|------------|----------------------------|------------------|---------------------------|---------|---------------------------|------------------|
| 10         | 2                          | 20               | 1.00                      | 0.95    | 3.21                      | 3.21             |
| 50         | 3                          | 34               | 2.94                      | 1.62    | 6.72                      | 2.29             |
| 100        | 5                          | 40               | 5.00                      | 2.18    | 10.08                     | 2.02             |
| 200        | 7                          | 57               | 7.02                      | 2.38    | 12.56                     | 1.79             |
| 500        | 11                         | 90               | 11.11                     | 2.47    | 16.88                     | 1.52             |
| 1000       | 15                         | 133              | 15.04                     | 2.57    | 20.03                     | 1.33             |


### 🛠️ New Configuration Options

All newly introduced configuration parameters follow a consistent convention: setting them to `-1 enables an automatic mode`, where the agent derives optimal values based on the cluster context; setting them to `0 disables the corresponding feature` entirely. The goal is to provide sensible, auto-tuned defaults that scale gracefully with the cluster size, ensuring good performance and robustness out of the box without requiring manual tuning or expert knowledge from the user.

#### `agent_avg_concurrency` (int, default: `-1`)
> Target average number of agents sending per second. Used to compute jitter window.
> 
> **Purpose:** Helps distribute agent metadata sends across time by targeting a desired average number of agents sending per second.
> **Why:** Prevents all agents from sending at the same moment, especially in large clusters.
> 

#### `agent_refresh_rate` (int, default: -1)  
> How often (in seconds) each agent sends metadata to the manager.  
> Use `-1` to auto-adjust the rate based on the total number of agents in the cluster.

> **Purpose**: Dynamically control the metadata reporting frequency.  
> **Why**: Automatically scales the refresh rate to avoid metadata spikes in large clusters while maintaining responsiveness in small ones.
> 

#### `agent_jitter_seconds` (int, default: `-1`)
> Maximum random delay before agent sends metadata. 
>
> **Purpose**: Adds a random delay before each metadata send cycle.
> **Why**: Introduces variability to avoid synchronized submissions and reduce traffic bursts.

#### `agent_initial_startup_delay_max` (int, default: `-1`)
> Maximum random startup delay (in seconds) before the agent starts sending metadata.
>
> **Purpose**: Adds a randomized delay once, at agent startup, before sending any metadata.
> **Why**: Prevents thundering herds during cluster boot or agent restarts.

---

These features are all backward-compatible and disabled or set to automatic behavior by default unless explicitly configured.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
