### PR TITLE
tentacle: qa/rgw: fix perl tests missing Amazon::S3 module 

### DIFF
--- a/qa/suites/rgw/multifs/0-install.yaml
+++ b/qa/suites/rgw/multifs/0-install.yaml
@@ -1,5 +1,8 @@
 tasks:
 - install:
+    extra_system_packages:
+      deb: ['cpanminus', 'libxml-simple-perl']
+      rpm: ['cpanminus', 'perl-XML-Simple', 'perl-LWP-Protocol-https', 'perl-ExtUtils-Config', 'perl-ExtUtils-Helpers', 'perl-ExtUtils-InstallPaths', 'perl-Module-Build-Tiny']
 - ceph:
 - rgw: [client.0]
 - tox: [client.0]

--- a/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
@@ -2,4 +2,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_bucket_quota.pl
+        - rgw/s3_bucket_quota-run.sh

--- a/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
@@ -2,4 +2,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_multipart_upload.pl
+        - rgw/s3_multipart_upload-run.sh

--- a/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
@@ -2,4 +2,4 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_user_quota.pl
+        - rgw/s3_user_quota-run.sh

--- a/qa/suites/rgw/thrash/install.yaml
+++ b/qa/suites/rgw/thrash/install.yaml
@@ -1,5 +1,8 @@
 tasks:
 - install:
+    extra_system_packages:
+      deb: ['cpanminus', 'libxml-simple-perl']
+      rpm: ['cpanminus', 'perl-XML-Simple', 'perl-LWP-Protocol-https', 'perl-ExtUtils-Config', 'perl-ExtUtils-Helpers', 'perl-ExtUtils-InstallPaths', 'perl-Module-Build-Tiny']
 - ceph:
 - rgw: [client.0]
 

--- a/qa/suites/rgw/thrash/workload/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_bucket_quota.yaml
@@ -2,7 +2,7 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_bucket_quota.pl
+        - rgw/s3_bucket_quota-run.sh
 overrides:
   ceph:
     conf:

--- a/qa/suites/rgw/thrash/workload/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_multipart_upload.yaml
@@ -2,7 +2,7 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_multipart_upload.pl
+        - rgw/s3_multipart_upload-run.sh
 overrides:
   ceph:
     conf:

--- a/qa/suites/rgw/thrash/workload/rgw_user_quota.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_user_quota.yaml
@@ -2,7 +2,7 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - rgw/s3_user_quota.pl
+        - rgw/s3_user_quota-run.sh
 overrides:
   ceph:
     conf:

--- a/qa/workunits/rgw/s3_bucket_quota-run.sh
+++ b/qa/workunits/rgw/s3_bucket_quota-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+cpanm --sudo Amazon::S3
+exec perl $(dirname $0)/s3_bucket_quota.pl

--- a/qa/workunits/rgw/s3_multipart_upload-run.sh
+++ b/qa/workunits/rgw/s3_multipart_upload-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+cpanm --sudo Amazon::S3
+exec perl $(dirname $0)/s3_multipart_upload.pl

--- a/qa/workunits/rgw/s3_user_quota-run.sh
+++ b/qa/workunits/rgw/s3_user_quota-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+cpanm --sudo Amazon::S3
+exec perl $(dirname $0)/s3_user_quota.pl

--- a/qa/workunits/rgw/s3_utilities.pm
+++ b/qa/workunits/rgw/s3_utilities.pm
@@ -32,6 +32,7 @@ sub get_status {
     if ($status =~ /\d+/ ){
         return 0;
     }
+    warn "ERROR: $service is not running\n";
     return 1;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71906

---

backport of https://github.com/ceph/ceph/pull/63760
parent tracker: https://tracker.ceph.com/issues/71577

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh