### PR TITLE
[WIP] [AGENT OPTIMIZATION]  Adding configurable Payload Compression for Agent Metadata

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1384,10 +1384,12 @@ class CephadmAgent(DaemonForm):
                 self.target_port = config['target_port']
                 self.loop_interval = int(config['refresh_period'])
                 self.starting_port = int(config['listener_port'])
+                self.metadata_compresion_enabled = bool(config.get('metadata_compresion_enabled', False))
                 self.initial_startup_delay_max = int(config.get('initial_startup_delay_max', 0))
                 self.jitter_seconds = int(config.get('jitter_seconds', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
+                logger.info(f"Agent configuration at startup: {config}")
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
@@ -1468,7 +1470,8 @@ class CephadmAgent(DaemonForm):
                                               port=self.target_port,
                                               data=data,
                                               endpoint='/data',
-                                              ssl_ctx=self.ssl_ctx)
+                                              ssl_ctx=self.ssl_ctx,
+                                              compress=self.metadata_compresion_enabled)
                 if status != 200:
                     logger.error(f'HTTP error {status} while querying agent endpoint: {response}')
                     raise RuntimeError(f'non-200 response <{status}> from agent endpoint: {response}')

--- a/src/cephadm/cephadmlib/agent.py
+++ b/src/cephadm/cephadmlib/agent.py
@@ -1,9 +1,34 @@
+import gzip
+import json
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen, Request
 from typing import Optional, Any, Tuple
 import logging
 
 logger = logging.getLogger()
+
+
+def make_json_request(url: str, payload: dict, compress: bool) -> Request:
+    """
+    Create a JSON POST request, optionally gzip-compressed.
+    """
+    body = json.dumps(payload).encode('utf-8')
+    original_size = len(body)
+    if compress:
+        body = gzip.compress(body)
+        compressed_size = len(body)
+        compression_ratio = 100 * (1 - compressed_size / original_size)
+        logger.info(f"Compression reduced payload size by {compression_ratio:.1f}% ({original_size} → {compressed_size} bytes)")
+        headers = {
+            'Content-Type': 'application/json',
+            'Content-Encoding': 'gzip',
+            'Accept-Encoding': 'gzip',
+        }
+    else:
+        headers = {
+            'Content-Type': 'application/json',
+        }
+    return Request(url, data=body, headers=headers)
 
 
 def http_query(
@@ -13,11 +38,22 @@ def http_query(
     endpoint: str = '',
     ssl_ctx: Optional[Any] = None,
     timeout: Optional[int] = 10,
+    compress: bool = False,
 ) -> Tuple[int, str]:
+    """
+    Perform an HTTPS POST request with optional gzip-compressed JSON payload.
+
+    `data` should be a JSON-encoded bytes object (not already compressed).
+    """
     url = f'https://{addr}:{port}{endpoint}'
-    logger.debug(f'sending query to {url}')
+    logger.debug(f'sending query to {url} (compression={compress})')
     try:
-        req = Request(url, data, {'Content-Type': 'application/json'})
+        if data:
+            payload = json.loads(data.decode('utf-8'))
+            req = make_json_request(url, payload, compress)
+        else:
+            req = Request(url)
+
         with urlopen(req, context=ssl_ctx, timeout=timeout) as response:
             response_str = response.read()
             response_status = response.status
@@ -28,7 +64,9 @@ def http_query(
     except URLError as e:
         logger.debug(f'{e.reason}')
         response_status = -1
-        response_str = e.reason
-    except Exception:
+        response_str = str(e.reason)
+    except Exception as e:
+        logger.error(f'Unexpected error: {e}')
         raise
-    return (response_status, response_str)
+
+    return (response_status, response_str.decode('utf-8') if isinstance(response_str, bytes) else response_str)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -146,6 +146,21 @@ class AgentEndpoint:
         else:
             return self.mgr.agent_initial_startup_delay_max
 
+    def get_jitter(self) -> int:
+        """
+        Compute the jitter window (in seconds) applied before agents send metadata.
+
+        - If agent_jitter_seconds is -1 (auto), compute it as:
+            jitter = num_agents / avg_concurrency (M)
+        - This spreads agent reports evenly across the window.
+        - Uses a min jitter of 2s to prevent tight clustering in very small clusters.
+        """
+        if self.mgr.agent_jitter_seconds == -1:  # auto-jitter mode
+            agents_refresh_rate = self.compute_agents_refrsh_rate()
+            return max(2, int(agents_refresh_rate * 0.5))
+        else:
+            return self.mgr.agent_jitter_seconds
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -85,6 +85,51 @@ class AgentEndpoint:
                 self.server_port += 1
         self.mgr.log.error(f'Cephadm agent could not find free port in range {max_port - 150}-{max_port} and failed to start')
 
+    def compute_agents_avg_concurrency(self) -> int:
+        """
+        Compute the average number of agents allowed to report metadata per second (M).
+
+        - If user-specified value is -1, use an adaptive formula: sqrt(N)/2 (capped at 10).
+        - Ensures a minimum of 2 agents/sec to avoid unnecessary serialization.
+        - This helps spread load while avoiding bursts, especially on small clusters.
+        """
+        if self.mgr.agent_avg_concurrency == -1:  # auto-concurrency mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_concurrency = min(20, int(num_agents ** 0.5 / 2))
+        else:
+            agents_concurrency = self.mgr.agent_avg_concurrency
+        # We force a minimum of 2 agents per seconds
+        return max(2, agents_concurrency)
+
+    def compute_agents_refrsh_rate(self) -> int:
+        """
+        Compute the refresh rate (in seconds) for agent metadata reporting.
+
+        - If the user has specified a fixed `agent_refresh_rate`, use that.
+        - If `agent_refresh_rate` is set to -1 (auto mode), compute it dynamically as:
+            refresh_rate = num_agents // avg_concurrency
+            where:
+              - num_agents = total number of agents in the cluster
+              - avg_concurrency = average number of agents allowed to report per second,
+                computed using a separate heuristic (sqrt(N)/2, capped).
+        - This ensures that agent updates are spread evenly and that the manager is not overwhelmed.
+
+        Notes:
+        - A minimum refresh rate of 20 seconds is enforced to avoid excessive agent churn and load.
+        - The dynamic mode adapts automatically as the cluster grows.
+
+        Returns:
+            int: The agent refresh rate in seconds.
+        """
+        if self.mgr.agent_refresh_rate == -1:  # auto-refresh rate
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            refresh_rate = num_agents // agents_avg_concurrency
+        else:
+            refresh_rate = self.mgr.agent_refresh_rate
+
+        return max(20, refresh_rate)
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)
@@ -886,10 +931,11 @@ class CephadmAgentHelpers:
             if host in self.mgr.offline_hosts:
                 return False
             self.mgr.agent_cache.agent_timestamp[host] = datetime_now()
-        # agent hasn't reported in down multiplier * it's refresh rate. Something is likely wrong with it.
+        # agent hasn't reported in:  down_multiplier * it's refresh rate + jitter. Something is likely wrong with it.
+        jitter: float = self.agent.get_jitter()
         down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
         time_diff = datetime_now() - self.mgr.agent_cache.agent_timestamp[host]
-        if time_diff.total_seconds() > down_mult * float(self.mgr.agent_refresh_rate):
+        if time_diff.total_seconds() > down_mult * float(self.mgr.http_server.agent.compute_agents_refrsh_rate() + jitter):
             return True
         return False
 
@@ -900,7 +946,7 @@ class CephadmAgentHelpers:
             down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
             for agent in down_agent_hosts:
                 detail.append((f'Cephadm agent on host {agent} has not reported in '
-                              f'{down_mult * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
+                              f'{down_mult * self.mgr.http_server.agent.compute_agents_refrsh_rate()} seconds. Agent is assumed '
                                'down and host may be offline.'))
             for dd in [d for d in self.mgr.cache.get_daemons_by_type('agent') if d.hostname in down_agent_hosts]:
                 dd.status = DaemonDescriptionStatus.error

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -139,7 +139,7 @@ class AgentEndpoint:
         - This prevents bursts of all agents from reporting immediately at startup.
         - Enforces a minimum of 10s to avoid early tight clustering.
         """
-        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+        if self.mgr.agent_initial_startup_delay_max == -1:  # auto-delay mode
             num_agents = len(self.mgr.cache.get_hosts())
             agents_avg_concurrency = self.compute_agents_avg_concurrency()
             return max(10, num_agents // agents_avg_concurrency)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -130,6 +130,22 @@ class AgentEndpoint:
 
         return max(20, refresh_rate)
 
+    def get_initial_delay(self) -> int:
+        """
+        Compute the maximum initial random startup delay (in seconds) before an agent starts reporting.
+
+        - If agent_initial_startup_delay_max is -1 (auto), compute as:
+            delay = num_agents / avg_concurrency (M)
+        - This prevents bursts of all agents from reporting immediately at startup.
+        - Enforces a minimum of 10s to avoid early tight clustering.
+        """
+        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            return max(10, num_agents // agents_avg_concurrency)
+        else:
+            return self.mgr.agent_initial_startup_delay_max
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -366,9 +366,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ),
         Option(
             'agent_refresh_rate',
-            type='secs',
-            default=20,
-            desc='How often agent on each host will try to gather and send metadata'
+            type='int',
+            default=-1,
+            desc='How often each agent sends metadata. Use -1 to auto-adjust based on cluster size.'
+        ),
+        Option(
+            'agent_avg_concurrency',
+            type='int',
+            default=-1,
+            desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
             'agent_starting_port',
@@ -566,6 +572,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.ssh_cert: Optional[str] = None
             self.use_agent = False
             self.agent_refresh_rate = 0
+            self.agent_avg_concurrency = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -395,6 +395,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='First port agent will try to bind to (will also try up to next 1000 subsequent ports if blocked)'
         ),
         Option(
+            'agent_metadata_compresion_enabled',
+            type='bool',
+            default=True,
+            desc='Enable compression of metadata sent from agent to reduce payload size'
+        ),
+        Option(
             'agent_down_multiplier',
             type='float',
             default=3.0,
@@ -589,6 +595,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
+            self.agent_metadata_compresion_enabled = True
             self.hw_monitoring = False
             self.service_discovery_port = 0
             self.secure_monitoring_stack = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -383,6 +383,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
         ),
         Option(
+            'agent_jitter_seconds',
+            type='int',
+            default=-1,
+            desc='Max random delay before agent sends metadata; set -1 for auto (default), 0 to disable'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -580,6 +586,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
             self.agent_initial_startup_delay_max = 0
+            self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3325,6 +3325,18 @@ Then run the following:
                 'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
+    def show_agent_config(self) -> Dict[str, str]:
+        agent = self.http_server.agent
+        return {
+            'agent_refresh_rate': str(agent.compute_agents_refrsh_rate()),
+            'agent_avg_concurrency': str(agent.compute_agents_avg_concurrency()),
+            'agent_initial_startup_delay_max': str(agent.get_initial_delay()),
+            'agent_jitter_seconds': str(agent.get_jitter()),
+            'agent_down_multiplier': str(self.agent_down_multiplier),
+            'agent_starting_port': str(self.agent_starting_port)
+        }
+
+    @handle_orch_error
     def cert_store_cert_ls(self, show_details: bool = False) -> Dict[str, Any]:
         return self.cert_mgr.cert_ls(show_details)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -377,6 +377,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
+            'agent_initial_startup_delay_max',
+            type='int',
+            default=-1,
+            desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -573,6 +579,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.use_agent = False
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
+            self.agent_initial_startup_delay_max = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1508,13 +1508,23 @@ class CephadmAgent(CephService):
     def get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
-        agent = mgr.http_server.agent
+
+        agent_options = [
+            'device_enhanced_scan',
+            'agent_refresh_rate',
+            'agent_avg_concurrency',
+            'agent_jitter_seconds',
+            'agent_initial_startup_delay_max',
+            'agent_starting_port',
+        ]
+
+        agent_cfg_deps = [f"{opt}: {mgr.get_module_option(opt)}" for opt in agent_options]
         return sorted(
             [
                 str(mgr.get_mgr_ip()),
-                str(agent.server_port),
+                str(mgr.http_server.agent.server_port),
                 mgr.cert_mgr.get_root_ca(),
-                str(mgr.get_module_option("device_enhanced_scan")),
+                *agent_cfg_deps,
             ]
         )
 
@@ -1561,6 +1571,4 @@ class CephadmAgent(CephService):
             'listener.key': listener_key,
         }
 
-        return config, sorted([str(self.mgr.get_mgr_ip()), str(agent.server_port),
-                               self.mgr.cert_mgr.get_root_ca(),
-                               str(self.mgr.get_module_option('device_enhanced_scan'))])
+        return config, self.get_dependencies(self.mgr)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1545,7 +1545,7 @@ class CephadmAgent(CephService):
 
         cfg = {'target_ip': self.mgr.get_mgr_ip(),
                'target_port': agent.server_port,
-               'refresh_period': self.mgr.agent_refresh_rate,
+               'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1548,7 +1548,8 @@ class CephadmAgent(CephService):
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
-               'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}
+               'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'initial_startup_delay_max': agent.get_initial_delay()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1515,6 +1515,7 @@ class CephadmAgent(CephService):
             'agent_avg_concurrency',
             'agent_jitter_seconds',
             'agent_initial_startup_delay_max',
+            'agent_metadata_compresion_enabled',
             'agent_starting_port',
         ]
 
@@ -1559,6 +1560,7 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'metadata_compresion_enabled': self.mgr.agent_metadata_compresion_enabled,
                'initial_startup_delay_max': agent.get_initial_delay(),
                'jitter_seconds': agent.get_jitter()}
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1549,7 +1549,8 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
-               'initial_startup_delay_max': agent.get_initial_delay()}
+               'initial_startup_delay_max': agent.get_initial_delay(),
+               'jitter_seconds': agent.get_jitter()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/tests/test_agent.py
+++ b/src/pybind/mgr/cephadm/tests/test_agent.py
@@ -1,0 +1,173 @@
+
+from unittest.mock import MagicMock
+import pytest
+
+from cephadm.agent import AgentEndpoint
+
+class FakeCache:
+    def __init__(self, num_hosts):
+        self._hosts = ['host{}'.format(i) for i in range(num_hosts)]
+
+    def get_hosts(self):
+        return self._hosts
+
+class FakeMgr:
+    def __init__(self, num_hosts=10):
+        self.agent_avg_concurrency = -1
+        self.agent_refresh_rate = -1
+        self.agent_initial_startup_delay_max = -1
+        self.agent_jitter_seconds = -1
+        self.cache = FakeCache(num_hosts)
+
+    def get_mgr_ip(self):
+        return ''
+
+class TestAgentEndpoint:
+
+    def test_concurrency_auto_small(self):
+        mgr = FakeMgr(num_hosts=1)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+
+    def test_concurrency_auto_exact_boundary(self):
+        mgr = FakeMgr(num_hosts=1600)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 20
+
+    def test_concurrency_manual_zero(self):
+        mgr = FakeMgr()
+        mgr.agent_avg_concurrency = 0
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+
+    def test_concurrency_manual_high(self):
+        mgr = FakeMgr()
+        mgr.agent_avg_concurrency = 999
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 999
+
+    def test_refresh_auto_typical(self):
+        mgr = FakeMgr(num_hosts=40)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_auto_zero_agents(self):
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_auto_with_high_concurrency(self):
+        mgr = FakeMgr(num_hosts=1000)
+        mgr.agent_avg_concurrency = 100
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_min_refresh_rate(self):
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 5
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_manual_valid(self):
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 60
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 60
+
+    def test_initial_delay_auto_small(self):
+        mgr = FakeMgr(num_hosts=2)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_auto_zero_agents(self):
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_manual_below_min(self):
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 5
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 5
+
+    def test_initial_delay_manual_valid(self):
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 30
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 30
+
+    def test_jitter_auto_zero_refresh(self):
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 10
+
+    def test_jitter_auto_typical(self):
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        jitter = config.get_jitter()
+        assert jitter >= 2
+        assert isinstance(jitter, int)
+
+    def test_jitter_manual(self):
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 1
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 1
+
+    def test_jitter_manual_high(self):
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 60
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 60
+
+
+class TestAgentEndpointAuto:
+
+    def test_auto_minimum_values(self):
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10
+        assert config.get_jitter() == 10
+
+    def test_auto_4_hosts(self):
+        mgr = FakeMgr(num_hosts=4)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10
+        assert config.get_jitter() == 10
+
+    def test_auto_16_hosts(self):
+
+        mgr = FakeMgr(num_hosts=16)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10
+        assert config.get_jitter() == 10
+
+    def test_auto_100_hosts(self):
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 5
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 20
+        assert config.get_jitter() == 10
+
+    def test_auto_200_hosts(self):
+        mgr = FakeMgr(num_hosts=200)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 7
+        assert config.compute_agents_refrsh_rate() == 28
+        assert config.get_initial_delay() == 28
+        assert config.get_jitter() == 14
+
+    def test_auto_1000_hosts(self):
+        mgr = FakeMgr(num_hosts=1000)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 15
+        assert config.compute_agents_refrsh_rate() == 66
+        assert config.get_initial_delay() == 66
+        assert config.get_jitter() == 33

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -904,6 +904,9 @@ class Orchestrator(object):
         """remove prometheus target for multi-cluster"""
         raise NotImplementedError()
 
+    def show_agent_config(self) -> OrchResult[Dict[str, str]]:
+        raise NotImplementedError()
+
     def get_alertmanager_access_info(self) -> OrchResult[Dict[str, str]]:
         """get alertmanager access information"""
         raise NotImplementedError()

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1425,6 +1425,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         result = raise_if_exception(completion)
         return HandleCommandResult(stdout=json.dumps(result))
 
+    @_cli_read_command('orch agent show-config')
+    def _show_cephadm_agent_config(self) -> HandleCommandResult:
+        completion = self.show_agent_config()
+        result = raise_if_exception(completion)
+        return HandleCommandResult(stdout=json.dumps(result))
+
     @_cli_write_command('orch alertmanager set-credentials')
     def _set_alertmanager_access_info(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> HandleCommandResult:
         try:


### PR DESCRIPTION

This PR adds support for optional compression of Cephadm Agent metadata payloads to reduce bandwidth consumption. This is especially beneficial in large clusters where frequent metadata reporting can result in significant network overhead.  

Testing has shown that enabling compression yields a reduction of over 80% in payload size, significantly improving efficiency without impacting functionality.

### 🛠️ New Cephadm Configuration Option

#### `agent_metadata_compresion_enabled` (bool, default: `True`)
> Enable compression of metadata sent from agent to reduce payload size.
>
> **Purpose**: Enables compression of metadata before it’s sent.
> **Why**: Saves bandwidth and improves performance over slow links or at scale.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
