### PR TITLE
tentacle: rgw: make sure max_objs_per_shard is appropriate in debugging scenarios

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11147,6 +11147,10 @@ void RGWRados::calculate_preferred_shards(const DoutPrefixProvider* dpp,
     max_objs_per_shard /= 3;
   }
 
+  // make sure it's at least 1, as in some testing scenarios it's artificially low
+  constexpr uint64_t min_max_objs_per_shard = 1;
+  max_objs_per_shard = std::max(min_max_objs_per_shard, max_objs_per_shard);
+
   const bool is_multisite = svc.zone->need_to_log_data();
 
   RGWBucketReshard::calculate_preferred_shards(dpp,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71777

---

backport of https://github.com/ceph/ceph/pull/63443
parent tracker: https://tracker.ceph.com/issues/71423

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh