### PR TITLE
reef: rgw: fix empty storage class on display of multipart uploads

### DIFF
--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -180,7 +180,9 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
   utime_t ut(mtime);
   encode_json("mtime", ut, f);
   encode_json("etag", etag, f);
-  encode_json("storage_class", storage_class, f);
+  encode_json("storage_class",
+	      rgw_placement_rule::get_canonical_storage_class(storage_class),
+	      f);
   encode_json("owner", owner, f);
   encode_json("owner_display_name", owner_display_name, f);
   encode_json("content_type", content_type, f);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69409

---

backport of https://github.com/ceph/ceph/pull/60430
parent tracker: https://tracker.ceph.com/issues/68659

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh