### PR TITLE
mgr/cephadm: Update service name as userId for nfs cluster, to keep it same across nfs cluster

### DIFF
--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -17,7 +17,7 @@ from orchestrator import OrchestratorError, DaemonDescription
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 10
+LAST_MIGRATION = 11
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +133,11 @@ class Migrations:
             logger.info('Running migration 9 -> 10')
             if self.migrate_9_10():
                 self.set(10)
+
+        if self.mgr.migration_current == 10 and not startup:
+            logger.info('Running migration 10 -> 11')
+            if self.migrate_10_11():
+                self.set(11)
 
     def migrate_0_1(self) -> bool:
         """
@@ -612,6 +617,49 @@ class Migrations:
             # Using set_store() directly avoids triggering _needs_configuration
             # and a spurious 'service was created' event via SpecStore.save().
             self.mgr.set_store(store_key, json.dumps(stored_data, sort_keys=True))
+        return True
+
+    def migrate_10_11(self) -> bool:
+        # For NFS, only services still using old per-daemon userid (nfs.<daemon_id>)
+        # are recorded so they keep that userid after upgrade. Specs that already
+        # use the shared service_name userid are skipped.
+        def nfs_service_uses_old_userid(service_name: str, auth_out: str) -> bool:
+            # Match the exact per-daemon auth entity for each known NFS daemon.
+            # auth ls prints entities as [client.nfs.<daemon_id>].
+            for dd in self.mgr.cache.get_daemons_by_service(service_name):
+                if dd.daemon_id is None:
+                    continue
+                old_entity = f'client.nfs.{dd.daemon_id}'
+                if re.search(rf'\[{re.escape(old_entity)}\]', auth_out):
+                    return True
+            return False
+
+        nfs_services = []
+        service_specs = self.mgr.spec_store.get_specs_by_type('nfs')
+        if not service_specs:
+            return True
+        try:
+            ret, out, err = self.mgr.mon_command({
+                'prefix': 'auth ls',
+            })
+            if ret:
+                raise OrchestratorError(f'auth ls failed: {err}')
+            auth_out = out or ''
+            for service_name, spec in service_specs.items():
+                if nfs_service_uses_old_userid(service_name, auth_out):
+                    nfs_services.append(service_name)
+                    logger.info(
+                        f'NFS service {service_name} needs to maintain old userid after upgrade'
+                    )
+        except Exception as e:
+            logger.exception(f'Got error while detecting NFS old userid: {e}')
+            self.mgr.set_health_warning('CEPHADM_MIGRATION_FAILURE',
+                                        f'Cephadm migration failed: {e}',
+                                        1, [str(e)])
+            return False
+        if nfs_services:
+            self.mgr.set_store('nfs_services_with_old_userid', ','.join(nfs_services))
+        self.mgr.remove_health_warning('CEPHADM_MIGRATION_FAILURE')
         return True
 
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3344,15 +3344,6 @@ Then run the following:
                     msg += f'\thost {h}: {" ".join([f"osd.{id}" for id in ls])}'
                 raise OrchestratorError(
                     f'If {service_name} is removed then the following OSDs will remain, --force to proceed anyway\n{msg}')
-        elif service_name.startswith('nfs.'):
-            # check if its using old node id style and remove from mon store
-            nfs_services = self.get_store('nfs_services_with_old_nodeid')
-            if nfs_services:
-                nfs_services = nfs_services.split(',')
-                if service_name in nfs_services:
-                    nfs_services.remove(service_name)
-                    val = ','.join(nfs_services) if nfs_services else None
-                    self.set_store('nfs_services_with_old_nodeid', val)
 
         spec = self.spec_store[service_name].spec
         CephadmServe(self)._remove_service_config(spec)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -60,7 +60,7 @@ def get_auth_entity(daemon_type: str, daemon_id: str, host: str = "") -> AuthEnt
     """
     # despite this mapping entity names to daemons, self.TYPE within
     # the CephService class refers to service types, not daemon types
-    if daemon_type in ['rgw', 'rbd-mirror', 'cephfs-mirror', 'nfs', "iscsi", 'nvmeof', 'ingress', 'ceph-exporter']:
+    if daemon_type in ['rgw', 'rbd-mirror', 'cephfs-mirror', "iscsi", 'nvmeof', 'ingress', 'ceph-exporter']:
         return AuthEntity(f'client.{daemon_type}.{daemon_id}')
     elif daemon_type in ['crash', 'agent', 'node-proxy']:
         if host == "":
@@ -1006,9 +1006,10 @@ class CephService(CephadmService):
 
     def post_remove(self, daemon: DaemonDescription, is_failed_deploy: bool) -> None:
         super().post_remove(daemon, is_failed_deploy=is_failed_deploy)
-        self.remove_keyring(daemon)
+        if daemon.daemon_type != 'nfs':
+            self.remove_keyring(daemon)
 
-    def get_auth_entity(self, daemon_id: str, host: str = "") -> AuthEntity:
+    def get_auth_entity(self, daemon_id: str, host: str = "", rados_user: str = '') -> AuthEntity:
         return get_auth_entity(self.TYPE, daemon_id, host=host)
 
     def get_config_and_keyring(self,

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -87,11 +87,21 @@ class NFSService(CephService):
             val = ','.join(updated) if updated else None
             self.mgr.set_store('nfs_fencing_failed_services', val)
 
-    def fence(self, daemon_id: str) -> None:
+    def fence(self, service_name: str, daemon_id: str) -> None:
         logger.info(f'Fencing old nfs.{daemon_id}')
+
+        rados_user = self.get_daemon_user(service_name, daemon_id)
+        entity = self.get_auth_entity(daemon_id, rados_user=rados_user)
+
+        # as new auth entity is common across cluster, we will need to delete it for last daemon
+        if rados_user == service_name and self.mgr.cache.get_daemons_by_service(service_name):
+            logger.debug(f'Not removing key for {entity} as daemons still exists')
+            return
+
+        logger.info(f'Removing key for {entity}')
         ret, out, err = self.mgr.mon_command({
             'prefix': 'auth rm',
-            'entity': f'client.nfs.{daemon_id}',
+            'entity': entity,
         })
 
         # TODO: block/fence this entity (in case it is still running somewhere)
@@ -106,7 +116,7 @@ class NFSService(CephService):
             if rank >= num_ranks:
                 for daemon_id in m.values():
                     if daemon_id is not None:
-                        self.fence(daemon_id)
+                        self.fence(spec.service_name(), daemon_id)
                 nodeid = self.get_daemon_nodeid(spec.service_name(), rank)
                 self.mgr.log.info(
                     "Removing %s from the ganesha grace table for service %s", nodeid, service_name
@@ -124,7 +134,7 @@ class NFSService(CephService):
                 for gen, daemon_id in list(m.items()):
                     if gen < max_gen:
                         if daemon_id is not None:
-                            self.fence(daemon_id)
+                            self.fence(spec.service_name(), daemon_id)
                         del rank_map[rank][gen]
                         self.mgr.spec_store.save_rank_map(service_name, rank_map)
         self._update_failed_fencing_services(service_name, fence_failed, not fence_failed)
@@ -176,6 +186,12 @@ class NFSService(CephService):
             return f'{service_name}.{rank}'
         return str(rank)
 
+    def get_daemon_user(self, service_name: str, daemon_id: str) -> str:
+        out = self.mgr.get_store('nfs_services_with_old_userid')
+        if out and service_name in out.split(','):
+            return f'nfs.{daemon_id}'
+        return f'{service_name}'
+
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         super().prepare_certificates(daemon_spec)
@@ -189,8 +205,8 @@ class NFSService(CephService):
         nfs_idmap_conf = '/etc/ganesha/idmap.conf'
 
         # create the RADOS recovery pool keyring
-        rados_user = f'{daemon_type}.{daemon_id}'
-        rados_keyring = self.create_keyring(daemon_spec)
+        rados_user = self.get_daemon_user(daemon_spec.service_name, daemon_id)
+        rados_keyring = self.create_keyring(daemon_spec, rados_user)
 
         # ensure rank is known to ganesha
         self.mgr.log.info(
@@ -202,7 +218,7 @@ class NFSService(CephService):
         monitoring_ip, monitoring_port = self.get_monitoring_details(daemon_spec.service_name, host, daemon_spec)
 
         # create the RGW keyring
-        rgw_user = f'{rados_user}-rgw'
+        rgw_user = f'{daemon_type}.{daemon_id}-rgw'
         rgw_keyring = self.create_rgw_keyring(daemon_spec)
         bind_addr = ''
 
@@ -412,10 +428,15 @@ class NFSService(CephService):
                 update_existing_obj=update_obj
             )
 
-    def create_keyring(self, daemon_spec: CephadmDaemonDeploySpec) -> str:
+    def get_auth_entity(self, daemon_id: str, host: str = "", rados_user: str = '') -> AuthEntity:
+        if rados_user:
+            return AuthEntity(f'client.{rados_user}')
+        return AuthEntity(f'client.{self.TYPE}.{daemon_id}')
+
+    def create_keyring(self, daemon_spec: CephadmDaemonDeploySpec, rados_user: str) -> str:
         daemon_id = daemon_spec.daemon_id
         spec = cast(NFSServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
-        entity: AuthEntity = self.get_auth_entity(daemon_id)
+        entity: AuthEntity = self.get_auth_entity(daemon_id, rados_user=rados_user)
 
         osd_caps = 'allow rw pool=%s namespace=%s' % (POOL_NAME, spec.service_id)
 
@@ -504,9 +525,32 @@ class NFSService(CephService):
             'entity': entity,
         })
 
+    def remove_nfs_keyring(self, service_name: str, daemon_id: str) -> None:
+        rados_user = self.get_daemon_user(service_name, daemon_id)
+        entity = self.get_auth_entity(daemon_id, rados_user=rados_user)
+
+        # as new auth entity is common across cluster, we will need to delete it for last daemon
+        if rados_user == service_name and self.mgr.cache.get_daemons_by_service(service_name):
+            logger.debug(f'Not removing key for {entity} as daemons still exists')
+            return
+
+        logger.info(f'Removing key for {entity}')
+        ret, out, err = self.mgr.mon_command({
+            'prefix': 'auth rm',
+            'entity': entity,
+        })
+
+    def remove_keyring(self, daemon: DaemonDescription) -> None:
+        assert daemon.daemon_id is not None
+        daemon_id: str = daemon.daemon_id
+        service_name = daemon.service_name()
+
+        self.remove_nfs_keyring(service_name, daemon_id)
+
     def post_remove(self, daemon: DaemonDescription, is_failed_deploy: bool) -> None:
         super().post_remove(daemon, is_failed_deploy=is_failed_deploy)
         self.remove_rgw_keyring(daemon)
+        self.remove_keyring(daemon)
 
     def ok_to_stop(self,
                    daemon_ids: List[str],
@@ -526,7 +570,23 @@ class NFSService(CephService):
         warn_message = "WARNING: Removing NFS daemons can cause clients to lose connectivity. "
         return HandleCommandResult(-errno.EBUSY, '', warn_message)
 
+    def _clear_legacy_nfs_store_markers(self, service_name: str) -> None:
+        # Keep these markers until daemon post_remove has finished so
+        # get_daemon_user()/get_daemon_nodeid() still resolve legacy entities.
+        mon_keys = ['nfs_services_with_old_nodeid', 'nfs_services_with_old_userid']
+        for key in mon_keys:
+            nfs_services = self.mgr.get_store(key)
+            if nfs_services:
+                nfs_services = nfs_services.split(',')
+                if service_name in nfs_services:
+                    nfs_services.remove(service_name)
+                    val = ','.join(nfs_services) if nfs_services else None
+                    self.mgr.set_store(key, val)
+
     def purge(self, service_name: str) -> None:
+        # Clear after all daemons are gone (post_remove already cleaned keys).
+        self._clear_legacy_nfs_store_markers(service_name)
+
         if service_name not in self.mgr.spec_store:
             return
         spec = cast(NFSServiceSpec, self.mgr.spec_store[service_name].spec)

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -329,7 +329,7 @@ class SMBService(CephService):
         # TODO ???
         logger.warning('config_dashboard is a no-op')
 
-    def get_auth_entity(self, daemon_id: str, host: str = "") -> AuthEntity:
+    def get_auth_entity(self, daemon_id: str, host: str = "", rados_user: str = '') -> AuthEntity:
         # We want a clear, distinct auth entity for fetching the config versus
         # data path access.
         return AuthEntity(f'client.{self.TYPE}.config.{daemon_id}')

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -57,18 +57,6 @@ RADOS_URLS {
         watch_url = "{{ url }}";
 }
 
-CEPH {
-        Ceph_Conf = "/etc/ceph/ceph.conf";
-        umask = 0000;
-        client_oc = false;
-        async = false;
-        zerocopy = false;
-        use_old_uuid = false;
-
-        register_service = true;
-        nodeid = "{{ nodeid }}";
-}
-
 RGW {
         cluster = "ceph";
         name = "client.{{ rgw_user }}";

--- a/src/pybind/mgr/cephadm/tests/services/test_ingress.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_ingress.py
@@ -1208,7 +1208,7 @@ class TestIngressService:
             '}\n'
             '\n'
             'RADOS_KV {\n'
-            '        UserId = "nfs.foo.test.0.0";\n'
+            '        UserId = "nfs.foo";\n'
             '        nodeid = "0";\n'
             '        pool = ".nfs";\n'
             '        namespace = "foo";\n'
@@ -1219,21 +1219,9 @@ class TestIngressService:
             '}\n'
             '\n'
             'RADOS_URLS {\n'
-            '        UserId = "nfs.foo.test.0.0";\n'
+            '        UserId = "nfs.foo";\n'
             '        watch_url = '
             '"rados://.nfs/foo/conf-nfs.foo";\n'
-            '}\n'
-            '\n'
-            'CEPH {\n'
-            '        Ceph_Conf = "/etc/ceph/ceph.conf";\n'
-            '        umask = 0000;\n'
-            '        client_oc = false;\n'
-            '        async = false;\n'
-            '        zerocopy = false;\n'
-            '        use_old_uuid = false;\n'
-            '\n'
-            '        register_service = true;\n'
-            '        nodeid = "0";\n'
             '}\n'
             '\n'
             'RGW {\n'
@@ -1249,7 +1237,7 @@ class TestIngressService:
             'enable_rdma': False,
             'extra_args': ['-N', 'NIV_EVENT'],
             'keyring': (
-                '[client.nfs.foo.test.0.0]\n'
+                '[client.nfs.foo]\n'
                 'key = None\n'
             ),
             'namespace': 'foo',
@@ -1262,7 +1250,7 @@ class TestIngressService:
                 ),
                 'user': 'nfs.foo.test.0.0-rgw',
             },
-            'userid': 'nfs.foo.test.0.0',
+            'userid': 'nfs.foo',
         }
 
         nfs_daemons = [

--- a/src/pybind/mgr/cephadm/tests/services/test_nfs.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_nfs.py
@@ -922,6 +922,39 @@ def test_check_daemons_starts_keepalived_when_stopped_and_haproxy_running(
         assert keepalived_started
 
 
+def test_nfs_purge_clears_legacy_store_markers(cephadm_module: CephadmOrchestrator):
+    nfs_svc = service_registry.get_service('nfs')
+    cephadm_module.set_store('nfs_services_with_old_userid', 'nfs.foo,nfs.bar')
+    cephadm_module.set_store('nfs_services_with_old_nodeid', 'nfs.foo')
+
+    # service not in spec_store: purge clears markers then returns early
+    nfs_svc.purge('nfs.foo')
+
+    assert cephadm_module.get_store('nfs_services_with_old_userid') == 'nfs.bar'
+    assert cephadm_module.get_store('nfs_services_with_old_nodeid') is None
+
+
+@patch("cephadm.serve.CephadmServe._run_cephadm")
+@patch("cephadm.services.nfs.NFSService.fence_old_ranks", MagicMock())
+@patch("cephadm.services.nfs.NFSService.run_grace_tool", MagicMock())
+@patch("cephadm.services.nfs.NFSService.purge", MagicMock())
+@patch("cephadm.services.nfs.NFSService.create_rados_config_obj", MagicMock())
+def test_remove_service_keeps_legacy_markers_until_purge(
+        _run_cephadm, cephadm_module: CephadmOrchestrator):
+    # Markers must remain through remove_service so post_remove can still
+    # resolve legacy client.nfs.<daemon_id> entities via get_daemon_user().
+    _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
+    with with_host(cephadm_module, 'test'):
+        nfs_spec = NFSServiceSpec(service_id='foo',
+                                  placement=PlacementSpec(hosts=['test']))
+        with with_service(cephadm_module, nfs_spec):
+            cephadm_module.set_store('nfs_services_with_old_userid', 'nfs.foo')
+            cephadm_module.set_store('nfs_services_with_old_nodeid', 'nfs.foo')
+
+        assert cephadm_module.get_store('nfs_services_with_old_userid') == 'nfs.foo'
+        assert cephadm_module.get_store('nfs_services_with_old_nodeid') == 'nfs.foo'
+
+
 def test_nfs_choose_next_action_skips_legacy_default_deps():
     nfs_svc = service_registry.get_service('nfs')
     legacy_deps = [

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1768,7 +1768,7 @@ class TestCephadm(object):
                 placement=PlacementSpec(hosts=[HostPlacementSpec('test', '', 'x')], count=1),
                 unmanaged=True)
             ),  # noqa: E124
-            ('client.nfs.x', True, ServiceSpec(
+            ('client.nfs.id', True, ServiceSpec(
                 service_type='nfs',
                 service_id='id',
                 placement=PlacementSpec(hosts=[HostPlacementSpec('test', '', 'x')], count=1),

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -9,7 +9,8 @@ from ceph.deployment.service_spec import (
     IngressSpec,
     IscsiServiceSpec,
     GrafanaSpec,
-    CertificateSource
+    CertificateSource,
+    NFSServiceSpec,
 )
 from ceph.utils import datetime_to_str, datetime_now
 from cephadm import CephadmOrchestrator
@@ -403,6 +404,59 @@ def test_migrate_rgw_spec(cephadm_module: CephadmOrchestrator, rgw_spec_store_en
             # if it was migrated, so we can use this to test the spec
             # was untouched
             assert 'rgw.foo' not in cephadm_module.spec_store.all_specs
+
+
+def test_migrate_nfs_old_userid_only_old_format(cephadm_module: CephadmOrchestrator):
+    """migrate_10_11 should only record NFS services that still have old per-daemon auth entities."""
+    old_daemon_id = 'foo.0.0.host1.abc123'
+    new_daemon_id = 'bar.0.0.host1.def456'
+    old_service = 'nfs.foo'
+    new_service = 'nfs.bar'
+
+    cephadm_module.spec_store._specs = {
+        old_service: NFSServiceSpec(service_id='foo', placement=PlacementSpec(hosts=['host1'])),
+        new_service: NFSServiceSpec(service_id='bar', placement=PlacementSpec(hosts=['host1'])),
+    }
+    cephadm_module.cache.daemons = {
+        'host1': {
+            f'nfs.{old_daemon_id}': DaemonDescription('nfs', old_daemon_id, 'host1', service_name=old_service),
+            f'nfs.{new_daemon_id}': DaemonDescription('nfs', new_daemon_id, 'host1', service_name=new_service),
+        }
+    }
+
+    # auth ls lists the old per-daemon entity for nfs.foo only; nfs.bar uses shared userid
+    cephadm_module._mon_command_mock_auth_ls = lambda cmd: (
+        f'[client.nfs.{old_daemon_id}]\n\tkey = AQFake==\n'
+        f'[client.{new_service}]\n\tkey = AQFake==\n'
+        f'[client.nfs.{new_daemon_id}-rgw]\n\tkey = AQFake==\n'
+    )
+
+    assert cephadm_module.migration.migrate_10_11() is True
+    stored = cephadm_module.get_store('nfs_services_with_old_userid')
+    assert stored == old_service
+    assert new_service not in (stored or '').split(',')
+
+
+def test_migrate_nfs_old_userid_skips_when_no_old_entities(cephadm_module: CephadmOrchestrator):
+    """Services that already use the shared service_name userid must not be recorded."""
+    daemon_id = 'foo.host1.abc123'
+    service_name = 'nfs.foo'
+
+    cephadm_module.spec_store._specs = {
+        service_name: NFSServiceSpec(service_id='foo', placement=PlacementSpec(hosts=['host1'])),
+    }
+    cephadm_module.cache.daemons = {
+        'host1': {
+            f'nfs.{daemon_id}': DaemonDescription('nfs', daemon_id, 'host1'),
+        }
+    }
+    cephadm_module._mon_command_mock_auth_ls = lambda cmd: (
+        f'client.{service_name}\n'
+        f'client.nfs.{daemon_id}-rgw\n'
+    )
+
+    assert cephadm_module.migration.migrate_10_11() is True
+    assert cephadm_module.get_store('nfs_services_with_old_userid') is None
 
 
 @mock.patch('cephadm.migrations.get_cert_issuer_info')


### PR DESCRIPTION
PR changes:
1. NFS cluster deploy will use service_name as userId to generate ganesha.conf. Along with that, only one keyring will be created for nfs cluster client.<service_name>.
2. Changes in upgarde to keep using old userid for cluster created before upgrade

Tracker: https://tracker.ceph.com/issues/71872

Testing done:
1. created NFS service on newly created cluster
2. Redeploy on upgraded cluster


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
