### PR TITLE
mgr/dashboard: Add generic component for icons

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-list/cephfs-snapshotschedule-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-snapshotschedule-list/cephfs-snapshotschedule-list.component.html
@@ -38,19 +38,14 @@
   </ng-template>
 
   <ng-template #fullpathForSelectionTpl>
-    <span
-      data-toggle="tooltip"
-      [title]="row.pathForSelection"
-      class="font-monospace"
-      >{{ row.pathForSelection?.split?.("@")?.[0] }}
-      <cd-copy-2-clipboard-button
-        *ngIf="row.pathForSelection"
-        [source]="row.pathForSelection?.split?.('@')?.[0]"
-        [byId]="false"
-        [showIconOnly]="true"
-      >
-      </cd-copy-2-clipboard-button>
-    </span>
+    <cd-copy-2-clipboard-button
+      *ngIf="row.pathForSelection"
+      [source]="row.pathForSelection?.split?.('@')?.[0]"
+      [byId]="false"
+      [size]="lg"
+      [text]="row.pathForSelection?.split?.('@')?.[0]"
+    >
+    </cd-copy-2-clipboard-button>
   </ng-template>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/card-row/card-row.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/card-row/card-row.component.html
@@ -52,18 +52,18 @@
     <span *ngIf="data.categoryPgAmount?.clean">
       {{ data.categoryPgAmount?.clean }}
     </span>
-    <i class="text-success"
-       [ngClass]="[icons.success]">
-    </i>
+    <cd-icon
+       type="success">
+    </cd-icon >
   </span>
   <span *ngIf="data.info"
         class="ms-2">
     <span *ngIf="data.info">
       {{ data.info }}
     </span>
-    <i class="text-info"
-       [ngClass]="[icons.danger]">
-    </i>
+    <cd-icon
+       type="info">
+    </cd-icon >
   </span>
   <span *ngIf="data.warn || data.categoryPgAmount?.warning"
         class="ms-2">
@@ -73,9 +73,9 @@
     <span *ngIf="data.categoryPgAmount?.warning">
       {{ data.categoryPgAmount?.warning }}
     </span>
-    <i class="text-warning"
-       [ngClass]="[icons.warning]">
-    </i>
+    <cd-icon
+       type="warning">
+    </cd-icon >
   </span>
   <span *ngIf="data.error || data.categoryPgAmount?.unknown"
         class="ms-2">
@@ -85,9 +85,9 @@
     <span *ngIf="data.categoryPgAmount?.unknown">
       {{ data.categoryPgAmount?.unknown }}
     </span>
-    <i class="text-danger"
-       [ngClass]="[icons.danger]">
-    </i>
+    <cd-icon
+       type="danger">
+    </cd-icon >
   </span>
   <span *ngIf="data.categoryPgAmount?.working"
         class="ms-2">
@@ -99,13 +99,15 @@
     </i>
   </span>
 </ng-template>
-
+<cd-icon
+       type="progress">
+    </cd-icon >
 <ng-template #osdSummary>
   <span *ngIf="data.up === data.in">
     {{ data.up }}
-    <i class="text-success"
-       [ngClass]="[icons.success]">
-    </i>
+    <cd-icon
+       type="success">
+    </cd-icon >
   </span>
   <span *ngIf="data.up !== data.in">
     {{ data.up }}
@@ -151,36 +153,36 @@
 <ng-template #iscsiSummary>
   <span>
     {{ data.up }}
-    <i class="text-success"
+    <cd-icon
        *ngIf="data.up || data.up === 0"
-       [ngClass]="[icons.success]">
-    </i>
+       type="success">
+    </cd-icon >
   </span>
   <span *ngIf="data.down"
         class="ms-2">
         {{ data.down }}
-    <i class="text-danger"
-       [ngClass]="[icons.danger]">
-    </i>
+    <cd-icon
+       type="danger">
+    </cd-icon >
   </span>
 </ng-template>
 
 <ng-template #simplifiedSummary>
   <span *ngIf="!dropdownTotalError else showErrorNum">
     {{ data }}
-    <i class="text-success"
-       [ngClass]="[icons.success]"></i>
+    <cd-icon
+       type="success"></cd-icon >
   </span>
   <ng-template #showErrorNum>
     <span *ngIf="data - dropdownTotalError  > 0">
       {{ data - dropdownTotalError  }}
-    <i class="text-success"
-       [ngClass]="[icons.success]"></i>
+    <cd-icon
+      type="success"></cd-icon >
     </span>
     <span>
       {{ dropdownTotalError  }}
-      <i class="text-danger"
-         [ngClass]="[icons.danger]"></i>
+      <cd-icon
+        type="danger"></cd-icon >
     </span>
   </ng-template>
 </ng-template>
@@ -211,17 +213,17 @@
         </div>
         <span [ngClass]="data.value.error ? 'me-2' : 'me-4'">
           {{ data.value.ok }}
-          <i class="text-success"
+          <cd-icon
              *ngIf="data.value.ok"
-             [ngClass]="[icons.success]">
-          </i>
+             type="success">
+          </cd-icon >
         </span>
         <span *ngIf="data.value.error"
               class="me-4 ms-2">
               {{ data.value.error }}
-          <i class="text-danger"
-             [ngClass]="[icons.danger]">
-          </i>
+          <cd-icon
+             type="danger">
+          </cd-icon >
         </span>
       </div>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/card-row/card-row.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/card-row/card-row.component.html
@@ -62,7 +62,7 @@
       {{ data.info }}
     </span>
     <cd-icon
-       type="info">
+       type="infoCircle">
     </cd-icon >
   </span>
   <span *ngIf="data.warn || data.categoryPgAmount?.warning"
@@ -99,9 +99,7 @@
     </i>
   </span>
 </ng-template>
-<cd-icon
-       type="progress">
-    </cd-icon >
+
 <ng-template #osdSummary>
   <span *ngIf="data.up === data.in">
     {{ data.up }}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -89,6 +89,7 @@ import InfoIcon from '@carbon/icons/es/information/16';
 import CopyIcon from '@carbon/icons/es/copy/32';
 import downloadIcon from '@carbon/icons/es/download/16';
 import { ChartsModule } from '@carbon/charts-angular';
+import { IconComponent } from './icon/icon.component';
 
 @NgModule({
   imports: [
@@ -172,7 +173,8 @@ import { ChartsModule } from '@carbon/charts-angular';
     FormAdvancedFieldsetComponent,
     UpgradableComponent,
     ProgressComponent,
-    SidePanelComponent
+    SidePanelComponent,
+    IconComponent
   ],
   providers: [provideCharts(withDefaultRegisterables())],
   exports: [
@@ -212,7 +214,8 @@ import { ChartsModule } from '@carbon/charts-angular';
     FormAdvancedFieldsetComponent,
     UpgradableComponent,
     ProgressComponent,
-    SidePanelComponent
+    SidePanelComponent,
+    IconComponent
   ]
 })
 export class ComponentsModule {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.html
@@ -1,20 +1,15 @@
 
-<svg [cdsIcon]="icons.clipboard"
-     [size]="icons.size16"
-     (click)="onClick()"
-     class="text-primary ms-2"
-     title="Copy to Clipboard"
-     i18n-title
-     *ngIf="showIconOnly; else withButtonTpl"></svg>
-
-<ng-template #withButtonTpl>
-
-  <cds-icon-button kind="tertiary"
-                   size="md"
-                   title="Copy to Clipboard"
-                   (click)="onClick()">
-    <svg [cdsIcon]="icons.copy"
-         [size]="icons.size16"
-         class="cds--btn__icon"></svg>
-  </cds-icon-button>
-</ng-template>
+<button cdsButton="ghost"
+        class="clipboard-btn"
+        [ngClass]="{'clipboard-btn-with-text': text}"
+        [size]="size"
+        description="Copy to Clipboard"
+        i18n-description
+        (click)="onClick()">
+  @if(text) {
+  <span data-toggle="tooltip"
+        [title]="text"
+        class="cds--type-mono">{{text}}</span>
+  }
+  <cd-icon type="copy"></cd-icon>
+</button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.scss
@@ -1,0 +1,9 @@
+.clipboard-btn {
+  border: none;
+  box-shadow: none;
+  outline: none;
+}
+
+.clipboard-btn-with-text {
+  color: inherit;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.ts
@@ -11,14 +11,21 @@ import { Icons } from '~/app/shared/enum/icons.enum';
   styleUrls: ['./copy2clipboard-button.component.scss']
 })
 export class Copy2ClipboardButtonComponent {
+  // The text to be copied
   @Input()
   private source: string;
 
+  // Optional: Extracts text to be copied by "id" attribute
   @Input()
   byId = true;
 
+  // Size of the button
   @Input()
-  showIconOnly = false;
+  size = 'md';
+
+  // Optional: Adds text to the left of copy icon
+  @Input()
+  text?: string;
 
   icons = Icons;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.html
@@ -1,23 +1,3 @@
-@if (type === ICON_TYPE.danger) {
-    <svg class = "danger-icon"
-         [cdsIcon]="ICONS.danger"
-         [size]="size"></svg>
-}
-
-@if (type === ICON_TYPE.info) {
-    <svg class = "info-icon"
-         [cdsIcon]="ICONS.infoCircle"
-         [size]="size"></svg>
-}
-
-@if (type === ICON_TYPE.success) {
-    <svg class = "success-icon"
-         [cdsIcon]="ICONS.success"
-         [size]="size"></svg>
-}
-
-@if (type === ICON_TYPE.warning) {
-    <svg class = "warning-icon"
-         [cdsIcon]="ICONS.warning"
-         [size]="size"></svg>
-}
+<svg  [cdsIcon]="icon"
+      [size]="size"
+      [class]="type+'-icon'"></svg>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.html
@@ -1,0 +1,23 @@
+@if (type === ICON_TYPE.danger) {
+    <svg class = "danger-icon"
+         [cdsIcon]="ICONS.danger"
+         [size]="size"></svg>
+}
+
+@if (type === ICON_TYPE.info) {
+    <svg class = "info-icon"
+         [cdsIcon]="ICONS.infoCircle"
+         [size]="size"></svg>
+}
+
+@if (type === ICON_TYPE.success) {
+    <svg class = "success-icon"
+         [cdsIcon]="ICONS.success"
+         [size]="size"></svg>
+}
+
+@if (type === ICON_TYPE.warning) {
+    <svg class = "warning-icon"
+         [cdsIcon]="ICONS.warning"
+         [size]="size"></svg>
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.scss
@@ -1,0 +1,17 @@
+@use '@carbon/styles/scss/theme';
+
+.success-icon {
+  color: theme.$support-success;
+}
+
+.danger-icon {
+  color: theme.$support-error;
+}
+
+.info-icon {
+  color: theme.$support-info;
+}
+
+.warning-icon {
+  color: theme.$support-caution-major;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.scss
@@ -8,7 +8,9 @@
   color: theme.$support-error;
 }
 
-.info-icon {
+//@TODO: this naming needs to be changed
+// Do this after converting Icons enum to const
+.infoCircle-icon {
   color: theme.$support-info;
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IconComponent } from './icon.component';
+
+describe('IconComponent', () => {
+  let component: IconComponent;
+  let fixture: ComponentFixture<IconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IconComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(IconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.spec.ts
@@ -1,16 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '~/testing/unit-test-helper';
 import { IconComponent } from './icon.component';
 
 describe('IconComponent', () => {
   let component: IconComponent;
   let fixture: ComponentFixture<IconComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [IconComponent]
-    }).compileComponents();
+  configureTestBed({
+    declarations: [IconComponent],
+    imports: []
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(IconComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.ts
@@ -1,15 +1,18 @@
-import { Component, Input } from '@angular/core';
-import { ICON_TYPE, Icons, IconsSize } from '../../enum/icons.enum';
+import { Component, Input, OnInit } from '@angular/core';
+import { ICON_TYPE, Icons, IconSize } from '../../enum/icons.enum';
 
 @Component({
   selector: 'cd-icon',
   templateUrl: './icon.component.html',
   styleUrl: './icon.component.scss'
 })
-export class IconComponent {
+export class IconComponent implements OnInit {
   @Input() type!: keyof typeof ICON_TYPE;
-  @Input() size: IconsSize = IconsSize.size16;
+  @Input() size: IconSize = IconSize.size16;
 
-  readonly ICONS = Icons;
-  readonly ICON_TYPE = ICON_TYPE;
+  icon: string;
+
+  ngOnInit() {
+    this.icon = Icons[this.type];
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/icon/icon.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { ICON_TYPE, Icons, IconsSize } from '../../enum/icons.enum';
+
+@Component({
+  selector: 'cd-icon',
+  templateUrl: './icon.component.html',
+  styleUrl: './icon.component.scss'
+})
+export class IconComponent {
+  @Input() type!: keyof typeof ICON_TYPE;
+  @Input() size: IconsSize = IconsSize.size16;
+
+  readonly ICONS = Icons;
+  readonly ICON_TYPE = ICON_TYPE;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -379,23 +379,20 @@
 
 <ng-template #pathTpl
              let-value="data.value">
-  <span data-toggle="tooltip"
-        [title]="value"
-        class="font-monospace">{{ value | path }}
-    <cd-copy-2-clipboard-button *ngIf="value"
-                                [source]="value"
-                                [byId]="false"
-                                [showIconOnly]="true">
-    </cd-copy-2-clipboard-button>
-  </span>
+  <cd-copy-2-clipboard-button *ngIf="value"
+                              [source]="value"
+                              [byId]="false"
+                              size="lg"
+                              text="{{ value | path }}">
+  </cd-copy-2-clipboard-button>
 </ng-template>
 
 <ng-template #copyTpl
              let-value="data.value">
-  <span class="font-monospace">{{value}}</span>
   <cd-copy-2-clipboard-button *ngIf="value"
                               [source]="value"
                               [byId]="false"
-                              [showIconOnly]="true">
+                              [size]="lg"
+                              [text]="value">
   </cd-copy-2-clipboard-button>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -36,7 +36,6 @@ export enum Icons {
   infoCircle = 'information--filled', // Info on landing page
   questionCircle = 'help',
   danger = 'warning--filled',
-  // success = 'fa fa-check-circle',
   success = 'checkmark--filled',
   check = 'checkmark', // Notification check
   show = 'view', // Show
@@ -99,3 +98,17 @@ export enum Icons {
   spin = 'fa fa-spin', //  To get any icon to rotate
   inverse = 'fa fa-inverse' // To get an alternative icon color
 }
+
+export enum IconsSize {
+  size16 = '16',
+  size20 = '20',
+  size24 = '24',
+  size32 = '32'
+}
+
+export const ICON_TYPE = {
+  danger: 'danger',
+  info: 'info',
+  success: 'success',
+  warning: 'warning'
+} as const;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -99,7 +99,7 @@ export enum Icons {
   inverse = 'fa fa-inverse' // To get an alternative icon color
 }
 
-export enum IconsSize {
+export enum IconSize {
   size16 = '16',
   size20 = '20',
   size24 = '24',
@@ -107,8 +107,9 @@ export enum IconsSize {
 }
 
 export const ICON_TYPE = {
+  copy: 'copy',
   danger: 'danger',
-  info: 'info',
+  infoCircle: 'info-circle',
   success: 'success',
   warning: 'warning'
 } as const;

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -177,10 +177,6 @@ Tabs
   background: var(--cds-layer-01);
 }
 
-.cds-success-color {
-  fill: theme.$support-success;
-}
-
 .cds-danger-color {
   fill: theme.$support-error;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -41,6 +41,10 @@ Custom theme
 Datatable
 ******************************************/
 
+:root {
+  @include type.type-classes();
+}
+
 tr.cds--expandable-row > td:first-of-type {
   background-color: vv.$white !important;
   padding-inline-start: 1rem !important;


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/71947
Fixes https://tracker.ceph.com/issues/71933

#### Usage

```html
<cd-icon type="success" [size]="Iconsize.size32"></cd-icon >
<cd-icon type="danger"></cd-icon >
<cd-icon type="info"></cd-icon >
```
```typescript
export const ICON_TYPE = {
  danger: 'danger',
  info: 'info',
  success: 'success',
  warning: 'warning'
} as const;
```

#### Previous


https://github.com/user-attachments/assets/5b6c1229-4ce6-476d-8a17-a2eb9a4fff3b



#### Pr scope

- updated icons in inventory card
- adds a type const which needs to be updated further covering more pages in future Prs
- clipboard icon not displaying breaking several places
- clipboard icon on click gets filed primary green color losing the visibility of icon. The icon now remain visible on click
- clipboard button for path and copy in tables on mouseover does not give `hand` but `cursor`. which was not ideal from a usability standpoint. This behavior has been updated to use the hand cursor making the interaction semantically correct and more intuitive for users.

PS: The screenshots cannot capture mouseover event (hand cursor/pointer cursor)

![Screenshot From 2025-07-03 16-06-32](https://github.com/user-attachments/assets/3e7a76de-1572-49d8-a664-e23f3369cf02)


<img width="1121" height="162" alt="image" src="https://github.com/user-attachments/assets/9a7508ea-1ab7-4f84-92f2-40be4f1f08eb" />


https://github.com/user-attachments/assets/833d1fca-112b-4424-9fd4-546ca824914a







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
