### PR TITLE
[DNM] unittest_bluefs bus error

### DIFF
--- a/src/extblkdev/ExtBlkDevPlugin.cc
+++ b/src/extblkdev/ExtBlkDevPlugin.cc
@@ -225,6 +225,7 @@ namespace ceph {
       int rc = -ENOENT;
       std::string plg_name;
       auto registry = cct->get_plugin_registry();
+      ceph_assert(registry != nullptr);
       std::lock_guard l(registry->lock);
       auto ptype = registry->plugins.find("extblkdev");
       if (ptype == registry->plugins.end()) {


### PR DESCRIPTION
The offset of member variables of different modules may be inconsistent due to the interference of some compiler packages.
add ceph_assert to check the value.

  ceph::PluginRegistry *get_plugin_registry() {
    return _plugin_registry;
  }

The offset of the _plugin_registry relative to CephContext in ExtBlkDevPlugin.cc.o is 8 bytes less than the other modules in ARM64 CI. Need more time to confirm the problem.

DO NOT REVIEW.