### PR TITLE
squid: rgw: allow specifying ssl certificate for radosgw-admin operations

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -316,6 +316,17 @@ std::ostream& RGWHTTPClient::gen_prefix(std::ostream& out) const
 
 void RGWHTTPClient::init()
 {
+  char* ca_bundle = std::getenv("CURL_CA_BUNDLE");
+  if (ca_bundle) {
+    size_t ca_bundle_len = strlen(ca_bundle);
+    size_t max_len = PATH_MAX + NAME_MAX;
+    if (ca_bundle_len > max_len) {
+      ldout(cct, 0) << "ERROR: " << __func__ << "(): CURL_CA_BUNDLE length exceeds the allowed maximum (" << max_len << " chars)" << dendl;
+    } else {
+      set_ca_path(ca_bundle);
+    }
+  }
+
   auto pos = url.find("://");
   if (pos == string::npos) {
     host = url;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71957

---

backport of https://github.com/ceph/ceph/pull/44283
parent tracker: https://tracker.ceph.com/issues/53588

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh