### PR TITLE
mgr/dashboard: differentiate account users from rgw users in bucket form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -67,38 +67,67 @@
       </ng-template>
     </div>
 
-    <!-- Owner -->
-    <div class="form-item">
-      <cds-select label="Owner"
-                  for="owner"
-                  formControlName="owner"
-                  name="owner"
-                  id="owner"
-                  [invalidText]="ownerError"
-                  [invalid]="!bucketForm.controls.owner.valid && bucketForm.controls.owner.dirty"
-                  cdRequiredField="Owner"
-                  i18n>Owner
-        <option *ngIf="owners === null"
-                [ngValue]="null">Loading...</option>
-        <option *ngIf="owners !== null"
-                value="">-- Select a user --</option>
-        <option *ngFor="let owner of owners"
-                [value]="owner">{{ owner }}</option>
-      </cds-select>
-      <ng-template #ownerError>
-        <span class="invalid-feedback"
-              *ngIf="bucketForm.showError('owner', frm, 'required')"
-              i18n>This field is required.</span>
-      </ng-template>
-      <cd-alert-panel
-        type="info"
-        *ngIf="bucketForm.get('owner').disabled"
-        spacingClass="me-1 mt-1"
-        i18n>
-          The bucket is owned by an account. UI does not support changing
-          the ownership of bucket owned by an account.
-      </cd-alert-panel>
-    </div>
+    <!-- Accounts -->
+    @if(accounts.length && accountUsers.length > 0){
+      <cds-checkbox formControlName="isAccountOwner"
+                    i18n>Select account user
+      </cds-checkbox>
+    }
+
+    @if (bucketForm.get('isAccountOwner').value) {
+      <!-- Account user -->
+      <div class="form-item">
+        <cds-select label="Account user"
+                    id="acc_user"
+                    formControlName="accountUser"
+                    [invalidText]="accountUserError"
+                    [invalid]="!bucketForm.controls.accountUser.valid && bucketForm.controls.accountUser.dirty"
+                    cdRequiredField="Account user"
+                    i18n>Account user
+          <option *ngIf="accountusers === null"
+                  [ngValue]="null">Loading...</option>
+          <option *ngIf="accountusers !== null"
+                  value="">-- Select a user --</option>
+          <option *ngFor="let user of accountUsers"
+                  [value]="user.uid">{{ user.uid }}</option>
+        </cds-select>
+        <ng-template #accountUserError>
+          <span class="invalid-feedback"
+                *ngIf="bucketForm.showError('accountUser', frm, 'required')"
+                i18n>This field is required.</span>
+        </ng-template>
+        <cd-alert-panel
+          type="info"
+          *ngIf="bucketForm.get('accountUser').disabled"
+          i18n>
+            The bucket is owned by an account. UI does not support changing
+            the ownership of bucket owned by an account.
+        </cd-alert-panel>
+      </div>
+    } @else {
+      <!-- Owner -->
+      <div class="form-item">
+        <cds-select label="Owner"
+                    formControlName="owner"
+                    id="owner"
+                    [invalidText]="ownerError"
+                    [invalid]="!bucketForm.controls.owner.valid && bucketForm.controls.owner.dirty"
+                    cdRequiredField="Owner"
+                    i18n>Owner
+          <option *ngIf="owners === null"
+                  [ngValue]="null">Loading...</option>
+          <option *ngIf="owners !== null"
+                  value="">-- Select a user --</option>
+          <option *ngFor="let owner of owners"
+                  [value]="owner.uid">{{ owner.uid }}</option>
+        </cds-select>
+        <ng-template #ownerError>
+          <span class="invalid-feedback"
+                *ngIf="bucketForm.showError('owner', frm, 'required')"
+                i18n>This field is required.</span>
+        </ng-template>
+      </div>
+    }
 
     <!-- Versioning -->
     <fieldset *ngIf="editing">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -23,6 +23,7 @@ import { CheckboxModule, SelectModule } from 'carbon-components-angular';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { LoadingStatus } from '~/app/shared/forms/cd-form';
+import { RgwUserAccountsService } from '~/app/shared/api/rgw-user-accounts.service';
 
 describe('RgwBucketFormComponent', () => {
   let component: RgwBucketFormComponent;
@@ -31,6 +32,7 @@ describe('RgwBucketFormComponent', () => {
   let getPlacementTargetsSpy: jasmine.Spy;
   let rgwBucketServiceGetSpy: jasmine.Spy;
   let enumerateSpy: jasmine.Spy;
+  let accountListSpy: jasmine.Spy;
   let formHelper: FormHelper;
   let childComponent: RgwRateLimitComponent;
 
@@ -55,6 +57,7 @@ describe('RgwBucketFormComponent', () => {
     rgwBucketServiceGetSpy = spyOn(rgwBucketService, 'get');
     getPlacementTargetsSpy = spyOn(TestBed.inject(RgwSiteService), 'get');
     enumerateSpy = spyOn(TestBed.inject(RgwUserService), 'enumerate');
+    accountListSpy = spyOn(TestBed.inject(RgwUserAccountsService), 'list');
     formHelper = new FormHelper(component.bucketForm);
   });
 
@@ -85,6 +88,7 @@ describe('RgwBucketFormComponent', () => {
       };
       getPlacementTargetsSpy.and.returnValue(observableOf(payload));
       enumerateSpy.and.returnValue(observableOf([]));
+      accountListSpy.and.returnValue(observableOf([]));
       fixture.detectChanges();
 
       expect(component.zonegroup).toBe(payload.zonegroup);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
@@ -34,7 +34,9 @@ describe('RgwUserService', () => {
     service.list().subscribe((resp) => {
       result = resp;
     });
-    const req = httpTesting.expectOne(`api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}`);
+    const req = httpTesting.expectOne(
+      `api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}&detailed=false`
+    );
     expect(req.request.method).toBe('GET');
     req.flush([]);
     expect(result).toEqual([]);
@@ -45,7 +47,7 @@ describe('RgwUserService', () => {
     service.list().subscribe((resp) => {
       result = resp;
     });
-    let req = httpTesting.expectOne(`api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}`);
+    let req = httpTesting.expectOne(`api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}&detailed=false`);
     expect(req.request.method).toBe('GET');
     req.flush(['foo', 'bar']);
 
@@ -62,7 +64,9 @@ describe('RgwUserService', () => {
 
   it('should call enumerate', () => {
     service.enumerate().subscribe();
-    const req = httpTesting.expectOne(`api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}`);
+    const req = httpTesting.expectOne(
+      `api/rgw/user?${RgwHelper.DAEMON_QUERY_PARAM}&detailed=false`
+    );
     expect(req.request.method).toBe('GET');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
@@ -41,9 +41,10 @@ export class RgwUserService {
    * Get the list of usernames.
    * @return {Observable<string[]>}
    */
-  enumerate() {
+  enumerate(detailed: boolean = false) {
     return this.rgwDaemonService.request((params: HttpParams) => {
-      return this.http.get(this.url, { params: params });
+      params = params.append('detailed', detailed);
+      return this.http.get(this.url, { params });
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -5,6 +5,7 @@ import { environment } from '~/environments/environment';
 export class AppConstants {
   public static readonly organization = 'ceph';
   public static readonly projectName = 'Ceph Dashboard';
+  public static readonly defaultUser = 'dashboard';
   public static readonly license = 'Free software (LGPL 2.1).';
   public static readonly copyright = 'Copyright(c) ' + environment.year + ' Ceph contributors.';
   public static readonly cephLogo = 'assets/Ceph_Logo.svg';

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -13816,6 +13816,13 @@ paths:
         name: daemon_name
         schema:
           type: string
+      - default: false
+        description: If true, returns complete user details for each user. If false,
+          returns only the list of usernames.
+        in: query
+        name: detailed
+        schema:
+          type: boolean
       responses:
         '200':
           content:

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1097,7 +1097,7 @@ class RgwClient(RestClient):
         destination = ET.SubElement(rule, 'Destination')
 
         bucket = ET.SubElement(destination, 'Bucket')
-        bucket.text = bucket_name
+        bucket.text = 'arn:aws:s3:::'f'{bucket_name}'
 
         replication_config = ET.tostring(root, encoding='utf-8', method='xml').decode()
 


### PR DESCRIPTION
fixes: https://tracker.ceph.com/issues/71523

commit includes:
1) Added checkbox to select account user and another dropdown to show account users 
2) Also fixed bucket replication as it was throwing error for 'invalidBucketARN'



https://github.com/user-attachments/assets/46b21fc0-2193-454c-966e-d17a6d0ec03c




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
