### PR TITLE
mgr/dashboard: nvmeof cli feedback fixes

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -32,8 +32,9 @@ else:
     @APIRouter("/nvmeof/gateway", Scope.NVME_OF)
     @APIDoc("NVMe-oF Gateway Management API", "NVMe-oF Gateway")
     class NVMeoFGateway(RESTController):
-
-        @NvmeofCLICommand("nvmeof gw info", model.GatewayInfo)
+        @NvmeofCLICommand(
+            "nvmeof gateway info", model.GatewayInfo, alias="nvmeof gw info"
+        )
         @EndpointDoc("Get information about the NVMeoF gateway")
         @convert_to_model(model.GatewayInfo)
         @handle_nvmeof_error
@@ -57,7 +58,9 @@ else:
 
         @ReadPermission
         @Endpoint('GET', '/version')
-        @NvmeofCLICommand("nvmeof gw version", model.GatewayVersion)
+        @NvmeofCLICommand(
+            "nvmeof gateway version", model.GatewayVersion, alias="nvmeof gw version"
+        )
         @EndpointDoc("Get the version of the NVMeoF gateway")
         @convert_to_model(model.GatewayVersion)
         @handle_nvmeof_error
@@ -71,7 +74,10 @@ else:
 
         @ReadPermission
         @Endpoint('GET', '/log_level')
-        @NvmeofCLICommand("nvmeof gw get_log_level", model.GatewayLogLevelInfo)
+        @NvmeofCLICommand(
+            "nvmeof gateway get_log_level", model.GatewayLogLevelInfo,
+            alias="nvmeof gw get_log_level"
+        )
         @EndpointDoc("Get NVMeoF gateway log level information")
         @convert_to_model(model.GatewayLogLevelInfo)
         @handle_nvmeof_error
@@ -84,7 +90,8 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '/log_level')
-        @NvmeofCLICommand("nvmeof gw set_log_level", model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof gateway set_log_level", model.RequestStatus, alias="nvmeof gw set_log_level")
         @EndpointDoc("Set NVMeoF gateway log levels")
         @convert_to_model(model.RequestStatus)
         @handle_nvmeof_error
@@ -195,11 +202,15 @@ else:
         )
         @convert_to_model(model.SubsystemStatus)
         @handle_nvmeof_error
-        def create(self, nqn: str, enable_ha: bool = True, max_namespaces: int = 4096,
+        def create(self, nqn: str, enable_ha: Optional[bool] = True,
+                   max_namespaces: Optional[int] = 4096, no_group_append: Optional[bool] = True,
+                   serial_number: Optional[str] = None, dhchap_key: Optional[str] = None,
                    gw_group: Optional[str] = None, traddr: Optional[str] = None):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
-                    subsystem_nqn=nqn, max_namespaces=max_namespaces, enable_ha=enable_ha
+                    subsystem_nqn=nqn, serial_number=serial_number,
+                    max_namespaces=max_namespaces, enable_ha=enable_ha,
+                    no_group_append=no_group_append, dhchap_key=dhchap_key
                 )
             )
 
@@ -356,7 +367,9 @@ else:
     @APIDoc("NVMe-oF Subsystem Namespace Management API", "NVMe-oF Subsystem Namespace")
     class NVMeoFNamespace(RESTController):
         @pick("namespaces")
-        @NvmeofCLICommand("nvmeof ns list", model.NamespaceList)
+        @NvmeofCLICommand(
+            "nvmeof namespace list", model.NamespaceList, alias="nvmeof ns list"
+        )
         @EndpointDoc(
             "List all NVMeoF namespaces in a subsystem",
             parameters={
@@ -372,7 +385,8 @@ else:
             )
 
         @pick("namespaces", first=True)
-        @NvmeofCLICommand("nvmeof ns get", model.NamespaceList)
+        @NvmeofCLICommand(
+            "nvmeof namespace get", model.NamespaceList, alias="nvmeof ns get")
         @EndpointDoc(
             "Get info from specified NVMeoF namespace",
             parameters={
@@ -391,7 +405,10 @@ else:
 
         @ReadPermission
         @Endpoint('GET', '{nsid}/io_stats')
-        @NvmeofCLICommand("nvmeof ns get_io_stats", model.NamespaceIOStats)
+        @NvmeofCLICommand(
+            "nvmeof namespace get_io_stats", model.NamespaceIOStats,
+            alias="nvmeof ns get_io_stats"
+        )
         @EndpointDoc(
             "Get IO stats from specified NVMeoF namespace",
             parameters={
@@ -409,7 +426,9 @@ else:
                     subsystem_nqn=nqn, nsid=int(nsid))
             )
 
-        @NvmeofCLICommand("nvmeof ns add", model.NamespaceCreation)
+        @NvmeofCLICommand(
+            "nvmeof namespace add", model.NamespaceCreation, alias="nvmeof ns add"
+        )
         @EndpointDoc(
             "Create a new NVMeoF namespace",
             parameters={
@@ -472,7 +491,8 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/set_qos')
-        @NvmeofCLICommand("nvmeof ns set_qos", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace set_qos", model=model.RequestStatus, alias="nvmeof ns set_qos")
         @EndpointDoc(
             "set QOS for specified NVMeoF namespace",
             parameters={
@@ -521,7 +541,10 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/change_load_balancing_group')
-        @NvmeofCLICommand("nvmeof ns change_load_balancing_group", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace change_load_balancing_group", model=model.RequestStatus,
+            alias="nvmeof ns change_load_balancing_group"
+        )
         @EndpointDoc(
             "set the load balancing group for specified NVMeoF namespace",
             parameters={
@@ -553,7 +576,9 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/resize')
-        @NvmeofCLICommand("nvmeof ns resize", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace resize", model=model.RequestStatus, alias="nvmeof ns resize"
+        )
         @EndpointDoc(
             "resize the specified NVMeoF namespace",
             parameters={
@@ -585,7 +610,9 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/add_host')
-        @NvmeofCLICommand("nvmeof ns add_host", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace add_host", model=model.RequestStatus, alias="nvmeof ns add_host"
+        )
         @EndpointDoc(
             "Adds a host to the specified NVMeoF namespace",
             parameters={
@@ -621,7 +648,9 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/del_host')
-        @NvmeofCLICommand("nvmeof ns del_host", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace del_host", model=model.RequestStatus, alias="nvmeof ns del_host"
+        )
         @EndpointDoc(
             "Removes a host from the specified NVMeoF namespace",
             parameters={
@@ -652,7 +681,10 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/change_visibility')
-        @NvmeofCLICommand("nvmeof ns change_visibility", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace change_visibility", model=model.RequestStatus,
+            alias="nvmeof ns change_visibility"
+        )
         @EndpointDoc(
             "changes the visibility of the specified NVMeoF namespace to all or selected hosts",
             parameters={
@@ -685,7 +717,10 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/set_auto_resize')
-        @NvmeofCLICommand("nvmeof ns set_auto_resize", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace set_auto_resize", model=model.RequestStatus,
+            alias="nvmeof ns set_auto_resize"
+        )
         @EndpointDoc(
             "Enable or disable namespace auto resize when RBD image is resized",
             parameters={
@@ -720,7 +755,10 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/set_rbd_trash_image')
-        @NvmeofCLICommand("nvmeof ns set_rbd_trash_image", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace set_rbd_trash_image", model=model.RequestStatus,
+            alias="nvmeof ns set_rbd_trash_image"
+        )
         @EndpointDoc(
             "changes the trash image on delete of the specified NVMeoF \
                 namespace to all or selected hosts",
@@ -755,7 +793,10 @@ else:
 
         @ReadPermission
         @Endpoint('PUT', '{nsid}/refresh_size')
-        @NvmeofCLICommand("nvmeof ns refresh_size", model=model.RequestStatus)
+        @NvmeofCLICommand(
+            "nvmeof namespace refresh_size", model=model.RequestStatus,
+            alias="nvmeof ns refresh_size"
+        )
         @EndpointDoc(
             "refresh the specified NVMeoF namespace to current RBD image size",
             parameters={
@@ -783,7 +824,9 @@ else:
             )
 
         @pick("namespaces", first=True)
-        @NvmeofCLICommand("nvmeof ns update", model.NamespaceList)
+        @NvmeofCLICommand(
+            "nvmeof namespace update", model.NamespaceList, alias="nvmeof ns update"
+        )
         @EndpointDoc(
             "Update an existing NVMeoF namespace",
             parameters={
@@ -873,7 +916,7 @@ else:
             return response
 
         @empty_response
-        @NvmeofCLICommand("nvmeof ns del", model.RequestStatus)
+        @NvmeofCLICommand("nvmeof namespace del", model.RequestStatus, alias="nvmeof ns del")
         @EndpointDoc(
             "Delete an existing NVMeoF namespace",
             parameters={
@@ -924,7 +967,7 @@ else:
         @convert_to_model(model.HostsInfo, finalize=_update_hosts)
         @handle_nvmeof_error
         def list(
-            self, nqn: str, clear_alerts: Optional[bool],
+            self, nqn: str, clear_alerts: Optional[bool] = None,
             gw_group: Optional[str] = None, traddr: Optional[str] = None
         ):
             return NVMeoFClient(gw_group=gw_group, traddr=traddr).stub.list_hosts(

--- a/src/pybind/mgr/dashboard/model/nvmeof.py
+++ b/src/pybind/mgr/dashboard/model/nvmeof.py
@@ -15,7 +15,7 @@ class CliHeader:
 
 
 class GatewayInfo(NamedTuple):
-    bool_status: bool
+    bool_status: Annotated[bool, CliFlags.DROP]
     status: int
     error_message: str
     hostname: str
@@ -26,11 +26,11 @@ class GatewayInfo(NamedTuple):
     addr: str
     port: int
     load_balancing_group: Annotated[int, CliHeader('LB Group')]
-    max_hosts: int
-    max_hosts_per_subsystem: int
-    max_namespaces: int
-    max_namespaces_per_subsystem: int
-    max_subsystems: int
+    max_hosts: Annotated[int, CliFlags.DROP]
+    max_hosts_per_subsystem: Annotated[int, CliFlags.DROP]
+    max_namespaces: Annotated[int, CliFlags.DROP]
+    max_namespaces_per_subsystem: Annotated[int, CliFlags.DROP]
+    max_subsystems: Annotated[int, CliFlags.DROP]
     spdk_version: Optional[str] = ""
 
 
@@ -189,7 +189,7 @@ class Host(NamedTuple):
     nqn: str
     use_psk: Optional[bool]
     use_dhchap: Optional[bool]
-    disconnected_due_to_keepalive_timeout: Optional[bool]
+    disconnected_due_to_keepalive_timeout: Annotated[Optional[bool], CliFlags.DROP]
 
 
 class HostsInfo(NamedTuple):
@@ -197,7 +197,7 @@ class HostsInfo(NamedTuple):
     error_message: str
     allow_any_host: bool
     subsystem_nqn: str
-    hosts: List[Host]
+    hosts: Annotated[List[Host], CliFlags.EXCLUSIVE_LIST]
 
 
 class RequestStatus(NamedTuple):

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -8557,6 +8557,8 @@ paths:
           application/json:
             schema:
               properties:
+                dhchap_key:
+                  type: string
                 enable_ha:
                   default: true
                   description: Enable high availability
@@ -8568,9 +8570,14 @@ paths:
                   default: 4096
                   description: Maximum number of namespaces
                   type: integer
+                no_group_append:
+                  default: true
+                  type: boolean
                 nqn:
                   description: NVMeoF subsystem NQN
                   type: string
+                serial_number:
+                  type: integer
                 traddr:
                   type: string
               required:
@@ -8740,10 +8747,10 @@ paths:
         required: true
         schema:
           type: string
-      - description: Clear any host alert signal after getting its value
+      - allowEmptyValue: true
+        description: Clear any host alert signal after getting its value
         in: query
         name: clear_alerts
-        required: true
         schema:
           type: boolean
       - allowEmptyValue: true

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -97,23 +97,26 @@ class AnnotatedDataTextOutputFormatter(OutputFormatter):
             return self._get_list_text_output(data)
         return self._get_object_text_output(data)
 
+    def _get_row(self, columns, data_obj):
+        row = []
+        for col in columns:
+            col_val = data_obj.get(col)
+            if col_val is None:
+                col_val = ''
+            row.append(str(col_val))
+        return row
+
     def _get_list_text_output(self, data):
         columns = list(dict.fromkeys([key for obj in data for key in obj.keys()]))
         table = self._create_table(columns)
         for d in data:
-            row = []
-            for col in columns:
-                row.append(str(d.get(col)))
-            table.add_row(row)
+            table.add_row(self._get_row(columns, d))
         return table.get_string()
 
     def _get_object_text_output(self, data):
         columns = [k for k in data.keys() if k not in ["status", "error_message"]]
         table = self._create_table(columns)
-        row = []
-        for col in columns:
-            row.append(str(data.get(col)))
-        table.add_row(row)
+        table.add_row(self._get_row(columns, data))
         return table.get_string()
 
     def _is_list_of_complex_type(self, value):
@@ -200,27 +203,22 @@ class AnnotatedDataTextOutputFormatter(OutputFormatter):
 class NvmeofCLICommand(CLICommand):
     desc: str
 
-    def __init__(self, prefix, model: Type[NamedTuple], perm='rw', poll=False):
+    def __init__(self, prefix, model: Type[NamedTuple], alias=None, perm='rw', poll=False):
         super().__init__(prefix, perm, poll)
         self._output_formatter = AnnotatedDataTextOutputFormatter()
         self._model = model
+        self._alias = alias
 
     def _use_api_endpoint_desc_if_available(self, func):
         if not self.desc and hasattr(func, 'doc_info'):
             self.desc = func.doc_info.get('summary', '')
 
     def __call__(self, func) -> HandlerFuncType:  # type: ignore
-        # pylint: disable=useless-super-delegation
-        """
-        This method is being overriden solely to be able to disable the linters checks for typing.
-        The NvmeofCLICommand decorator assumes a different type returned from the
-        function it wraps compared to CLICmmand, breaking a Liskov substitution principal,
-        hence triggering linters alerts.
-        """
+        if self._alias:
+            NvmeofCLICommand(self._alias, model=self._model)._register_handler(func)
+
         resp = super().__call__(func)
-
         self._use_api_endpoint_desc_if_available(func)
-
         return resp
 
     def call(self,

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -473,11 +473,14 @@ class CLICommand(object):
         self.desc, self.arg_spec, self.first_default, self.args = \
             self._load_func_metadata(f)
 
-    def __call__(self, func: HandlerFuncType) -> HandlerFuncType:
+    def _register_handler(self, func: HandlerFuncType) -> HandlerFuncType:
         self.store_func_metadata(func)
         self.func = func
         self.COMMANDS[self.prefix] = self
         return self.func
+
+    def __call__(self, func: HandlerFuncType) -> HandlerFuncType:
+        return self._register_handler(func)
 
     def _get_arg_value(self, kwargs_switch: bool, key: str, val: Any) -> Tuple[bool, str, Any]:
         def start_kwargs() -> bool:


### PR DESCRIPTION
Fixed early feedback from @caroav 
* remove not neededceph `gateway info` columns
* add missing parameters to `subsystem add` command
* change `host list` to use  exclusive list annotation and remove not needed column
* change gw to gateway in related commands
* change ns to namespace in related commands
* in text fomat show '' instead of the string 'None' in columns values
* nvme alias commands support

fixes: https://tracker.ceph.com/issues/71980

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
