### PR TITLE
tentacle: objecter: request OSDMap after idle ticks

### DIFF
--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2519,6 +2519,9 @@ public:
   ceph::timespan mon_timeout;
   ceph::timespan osd_timeout;
 
+  // last time osdmap was requested
+  ceph::coarse_mono_time last_osdmap_request_time;
+
   MOSDOp *_prepare_osd_op(Op *op);
   void _send_op(Op *op);
   void _send_op_account(Op *op);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71959

---

backport of https://github.com/ceph/ceph/pull/63425
parent tracker: https://tracker.ceph.com/issues/71261

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh