### PR TITLE
squid: objecter: request OSDMap after idle ticks

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2032,6 +2032,7 @@ void Objecter::maybe_request_map()
 
 void Objecter::_maybe_request_map()
 {
+  last_osdmap_request_time = ceph::coarse_mono_clock::now();
   // rwlock is locked
   int flag = 0;
   if (_osdmap_full_flag()
@@ -2218,8 +2219,20 @@ void Objecter::tick()
     if (found)
       toping.insert(s);
   }
+
   if (num_homeless_ops || !toping.empty()) {
     _maybe_request_map();
+  } else if (last_osdmap_request_time != ceph::coarse_mono_clock::time_point()) {
+    auto now = ceph::coarse_mono_clock::now();
+    auto elapsed = now - last_osdmap_request_time;
+    auto stale_window = ceph::make_timespan(cct->_conf->objecter_tick_interval) * 2;
+    if (elapsed > stale_window) {
+      double elapsed_s = std::chrono::duration<double>(elapsed).count();
+      double thresh_s  = std::chrono::duration<double>(stale_window).count();
+      ldout(cct, 10) << __func__ << ": osdmap stale: " << elapsed_s 
+        << "s > " << thresh_s << "s, maybe requesting map" << dendl;
+      _maybe_request_map();
+    }
   }
 
   logger->set(l_osdc_op_laggy, laggy_ops);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2558,6 +2558,9 @@ public:
   ceph::timespan mon_timeout;
   ceph::timespan osd_timeout;
 
+  // last time osdmap was requested
+  ceph::coarse_mono_time last_osdmap_request_time;
+
   MOSDOp *_prepare_osd_op(Op *op);
   void _send_op(Op *op);
   void _send_op_account(Op *op);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71960

---

backport of https://github.com/ceph/ceph/pull/63425
parent tracker: https://tracker.ceph.com/issues/71261

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh