### PR TITLE
bluestore: Faster allocation recovery - evolution

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5375,6 +5375,19 @@ options:
   desc: Remove allocation info from RocksDB and store the info in a new allocation file
   default: true
   with_legacy: true
+- name: bluestore_allocation_recovery_threads
+  type: uint
+  level: basic
+  desc: Amount of threads for allocation recovery after OSD crash.
+  long_desc: The optimal value varies. For NVMe DBs may be as large as 8.
+    Value 0 selects legacy recovery.
+    Value 1 denotes new recovery but on single thread.
+  default: 0
+  with_legacy: false
+  flags:
+    - startup
+  see_also:
+    - bluestore_allocation_from_file
 - name: bluestore_debug_inject_allocation_from_file_failure
   type: float
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5388,6 +5388,19 @@ options:
     - startup
   see_also:
     - bluestore_allocation_from_file
+- name: bluestore_debug_fast_recovery_compare_chance
+  type: float
+  level: dev
+  desc: For testing only. Compare legacy and multithread allocation recovery.
+  long_desc: Chance to perform compare between procedures.
+    Value in range <0..1>; defines chance to perform comparision between legacy
+    and multithreaded allocation recovery. 0 means never compare. 1 means always compare.
+  default: 0
+  with_legacy: false
+  flags:
+    - startup
+  see_also:
+    - bluestore_allocation_recovery_threads
 - name: bluestore_debug_inject_allocation_from_file_failure
   type: float
   level: dev

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -62,6 +62,7 @@ set(alien_store_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/Compression.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueStore_debug.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueAdmin.cc
+  ${PROJECT_SOURCE_DIR}/src/os/bluestore/OnodeScan.cc
   ${PROJECT_SOURCE_DIR}/src/os/memstore/MemStore.cc)
 
 add_library(crimson-alienstore STATIC

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -410,6 +410,13 @@ public:
 				       const std::string& key_prefix) {
     return 0;
   }
+  /// estimate space utilization for a specified range (in bytes)
+  virtual int64_t estimate_range_size(
+    const std::string& prefix,
+    const std::string& key_from,
+    const std::string& key_to) {
+      return 0;
+  };
 
   /// compact the underlying store
   virtual void compact() {}

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -485,7 +485,25 @@ protected:
   /// List of matching prefixes/ColumnFamilies and merge operators
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
-
+public:
+  struct keyrange_t {
+    std::string first_key;    // is in the range if exists
+    std::string upper_bound;  // is not in the range even if exists
+  };
+  /// splits a key range into multiple chunks of more or less equal size
+  virtual void util_divide_key_range(
+    const std::string& prefix,        // table to operate on
+    const std::string& starting_key,  // included if exists
+    const std::string& guardrail_key, // excluded if exists
+    uint64_t chunk_count,             // desired chunk count, but fewer can happen
+    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    float accepted_variance,          // +/- fluctuation of produced chunk size,
+                                      // smaller value requires more work, use 0.1 ?
+    std::vector<keyrange_t>& chunks){ // out: chunks
+      chunks.clear();
+      chunks.emplace_back(starting_key, guardrail_key);
+      return;
+    }
 };
 
 #endif

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -3648,3 +3648,184 @@ bool RocksDBStore::get_sharding(std::string& sharding) {
   }
   return result;
 }
+
+// Find a key that is lexicographically between low and high.
+// Try to select "midpoint".
+// If high is a direct successor to low, return "".
+static string key_between(const string& low, const string& high)
+{
+  string result;
+  ceph_assert(low.compare(high) < 0);
+  size_t same = 0;
+  while (same < std::min(low.length(), high.length()) &&
+         low[same] == high[same]) {
+    same++;
+  }
+  if (same == low.length()) {
+    //
+    size_t i = same;
+    while (i < high.length() && high[i] == '\0') {
+      i++;
+    }
+    if (i == high.length()) {
+      // special case that "high"="len00..000"; halfway formula does not work
+      if (i == same + 1) {
+        // just "high" = "len0", no key in-between
+        return string();
+      } else {
+        // add half zeros
+        result = low;
+        result.append(string((same + 1 - i) / 2, '\0'));
+        return result;
+      }
+    }
+  }
+  const std::string &shorter = low.length() < high.length() ? low : high;
+  const std::string &longer = low.length() < high.length() ? high : low;
+
+  result = shorter;
+  result.resize(longer.length() + 1);
+  uint16_t carry = 0;
+  // "+"
+  for (size_t i = longer.length() - 1; i + 1 > same; i--) {
+    uint8_t a = i < shorter.length() ? shorter[i] : 0;
+    uint8_t b = longer[i];
+    uint16_t v = ((uint16_t)a + (uint16_t)b + carry);
+    carry = v >> 8;
+    result[i + 1] = v;
+  }
+  result[same] = carry;
+  //  ">>1"
+  for (size_t i = same; i < longer.length(); i++) {
+    uint16_t v =
+        ((uint16_t)(uint8_t)result[i] << 8) | (uint16_t)(uint8_t)result[i + 1];
+    result[i] = v >> 1;
+  }
+  result[longer.length()] = (uint8_t)result[longer.length()] >> 7;
+  return result;
+};
+
+void RocksDBStore::util_divide_key_range(
+  const string& prefix,
+  const string& starting_key,   //included if exists
+  const string& guardrail_key,  //excluded if exists
+  uint64_t chunk_count,
+  uint64_t min_chunk_size,
+  float accepted_variance,
+  vector<keyrange_t>& chunks)
+{
+  dout(10) << __func__ << " chunks=" << chunk_count
+    << " start=" << pretty_binary_string(starting_key)
+    << " end=" << pretty_binary_string(guardrail_key) << dendl;
+  chunks.clear();
+  map<uint64_t, string> cs_map;
+  string key_from, key_to;
+  auto db_it = get_iterator(prefix);
+  db_it->lower_bound(starting_key);
+  if (!db_it) return; //empty range
+  key_from = db_it->key();
+  db_it->lower_bound(guardrail_key);
+  if (!db_it->valid()) {
+    db_it->seek_to_last();
+    ceph_assert(db_it->valid());
+    key_to = db_it->key();
+    key_to.push_back('\0');
+  } else {
+    key_to = db_it->key();
+    if (key_to <= key_from) return;
+  }
+  uint64_t full_size = estimate_range_size(prefix, key_from, key_to);
+  cs_map[0] = key_from;
+  cs_map[full_size] = key_to;
+  uint64_t target_chunk_size = full_size / chunk_count;
+  uint64_t chunk_min = target_chunk_size * (1 - accepted_variance);
+  uint64_t chunk_max = target_chunk_size * (1 + accepted_variance);
+  if (full_size <= chunk_max) {
+    chunks.emplace_back(key_from, key_to);
+    return;
+  }
+  if (target_chunk_size < chunk_min) {
+    chunk_count = std::min<uint64_t>(chunk_count, full_size / chunk_min + 1);
+    target_chunk_size = full_size / chunk_count;
+    chunk_min = target_chunk_size * (1 - accepted_variance);
+    chunk_max = target_chunk_size * (1 + accepted_variance);
+  }
+  dout(10) << __func__ << " chunks=" << chunk_count
+    << " key_from=" << pretty_binary_string(key_from)
+    << " key_to=" << pretty_binary_string(key_to) << dendl;
+
+  ceph_assert(chunk_count >= 2);
+  dout(20) << "target_chunk_size=" << target_chunk_size
+    << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+  // Algorithm idea:
+  // Have a mapping MAP with elements: estimated_db_size[key_from .. x] -> x.
+  // Keep bisecting [key_from .. key_to].
+  // When MAP[last] - MAP[current_candidate] is in acceptable range for chunk size
+  //   emit the range and move forward.
+  auto it = cs_map.begin();
+  uint64_t cs_anchor = it->first;
+  string cs_key = it->second;
+  uint32_t bisect_actions = 0;
+  while(true) {
+    ceph_assert(it != cs_map.end());
+    it++;
+    ceph_assert(cs_map.end() != it);
+    dout(20) << "trying   " << it->first << " " << pretty_binary_string(it->second) << dendl;
+    if (it->first - cs_anchor > chunk_max) {
+      if (bisect_actions == 100) {
+        chunks.clear();
+        chunks.emplace_back(key_from, key_to);
+        return;
+      }
+      bisect_actions++;
+      // it is too far, need to roll back and divide
+      auto key_e = it->second;
+      it--;
+      auto key_b = it->second;
+      auto imagined_key = key_between(key_b, key_e);
+      dout(20) << pretty_binary_string(key_b) << "..." << pretty_binary_string(key_e)
+        << "-> midpoint=" << pretty_binary_string(imagined_key) << dendl;
+      ceph_assert( key_b < imagined_key);
+      ceph_assert(imagined_key < key_e);
+      db_it->upper_bound(imagined_key);
+      ceph_assert(db_it->valid());
+      auto real_key = db_it->key();
+      if (real_key == key_e) {
+        db_it->prev();
+        real_key = db_it->key();
+      }
+      uint64_t cs_size = estimate_range_size(prefix, key_from, real_key);
+      if (cs_size > it->first) {
+        cs_map[cs_size] = real_key;
+        dout(20) << "newpoint " << cs_size << " " << pretty_binary_string(real_key) << dendl;
+        ceph_assert(key_b < real_key);
+        ceph_assert(real_key <= key_e);
+        continue;
+      } else {
+        // this seems to be limit for precision, no reason to attempt biseciton further
+        // fell out and emit region
+      }
+    } else if (it->first - cs_anchor < chunk_min) {
+      continue;
+    }
+
+    bisect_actions = 0;
+    // we are satisfied enough
+    chunks.emplace_back(cs_key, it->second);
+    dout(10) << "produced chunk size=" << it->first - cs_anchor << " "
+      << pretty_binary_string(cs_key) << " " << pretty_binary_string(it->second) << dendl;
+    if (chunks.size() == chunk_count - 1) {
+      chunks.emplace_back(it->second, key_to);
+      dout(10) << "produced chunk size=" << full_size - it->first << " "
+        << pretty_binary_string(it->second) << " " << pretty_binary_string(key_to) << dendl;
+      break;
+    }
+    cs_anchor = it->first;
+    cs_key = it->second;
+    target_chunk_size = (full_size - cs_anchor) / (chunk_count - chunks.size());
+    chunk_min = target_chunk_size * (1 - accepted_variance);
+    chunk_max = target_chunk_size * (1 + accepted_variance);
+    dout(20) << "target_chunk_size=" << target_chunk_size
+      << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+  }
+}

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1433,6 +1433,36 @@ int64_t RocksDBStore::estimate_prefix_size(const string& prefix,
   return size;
 }
 
+int64_t RocksDBStore::estimate_range_size(
+  const string& prefix,
+  const string& key_from,
+  const string& key_to)
+{
+  // The default mode is to derive estimates based on
+  // sst files alone (INCLUDE_FILES).
+  // This gives an irritating result when a batch of keys is
+  // just commited but estimate keeps showing 0.
+  rocksdb::DB::SizeApproximationFlags flags(
+    rocksdb::DB::SizeApproximationFlags::INCLUDE_FILES |
+    rocksdb::DB::SizeApproximationFlags::INCLUDE_MEMTABLES);
+  uint64_t size = 0;
+  auto p_iter = cf_handles.find(prefix);
+  if (p_iter != cf_handles.end()) {
+    for (const auto cf : p_iter->second.handles) {
+      uint64_t s = 0;
+      rocksdb::Range r(key_from, key_to);
+      db->GetApproximateSizes(cf, &r, 1, &s, flags);
+      size += s;
+    }
+  } else {
+    string start = combine_strings(prefix , key_from);
+    string limit = combine_strings(prefix , key_to);
+    rocksdb::Range r(start, limit);
+    db->GetApproximateSizes(default_cf, &r, 1, &size, flags);
+  }
+  return size;
+}
+
 void RocksDBStore::get_statistics(Formatter *f)
 {
   if (!cct->_conf->rocksdb_perf)  {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -3654,36 +3654,32 @@ bool RocksDBStore::get_sharding(std::string& sharding) {
 // If high is a direct successor to low, return "".
 static string key_between(const string& low, const string& high)
 {
-  string result;
   ceph_assert(low.compare(high) < 0);
-  size_t same = 0;
-  while (same < std::min(low.length(), high.length()) &&
-         low[same] == high[same]) {
-    same++;
-  }
-  if (same == low.length()) {
-    //
-    size_t i = same;
-    while (i < high.length() && high[i] == '\0') {
-      i++;
-    }
-    if (i == high.length()) {
+
+  const auto [divergent_low_it, divergent_high_it] =
+    std::mismatch(low.begin(), low.end(), high.begin(), high.end());
+  if (divergent_low_it == low.end()) {
+    const auto non_zero_it = std::find_if(divergent_high_it, high.end(), [](char c) {
+      return c != '\0';
+    });
+    if (non_zero_it == high.end()) {
       // special case that "high"="len00..000"; halfway formula does not work
-      if (i == same + 1) {
+      size_t zero_count = std::distance(divergent_high_it, non_zero_it);
+      if (zero_count == 1) {
         // just "high" = "len0", no key in-between
         return string();
-      } else {
-        // add half zeros
-        result = low;
-        result.append(string((same + 1 - i) / 2, '\0'));
-        return result;
       }
+      // Add roughly half the trailing zeros.
+      return low + string((zero_count + 1) / 2, '\0');
     }
   }
-  const std::string &shorter = low.length() < high.length() ? low : high;
-  const std::string &longer = low.length() < high.length() ? high : low;
 
-  result = shorter;
+  size_t same = std::distance(low.begin(), divergent_low_it);
+  const bool low_is_shorter = low.length() < high.length();
+  const std::string& shorter = low_is_shorter ? low : high;
+  const std::string& longer = low_is_shorter ? high : low;
+
+  string result = shorter;
   result.resize(longer.length() + 1);
   uint16_t carry = 0;
   // "+"
@@ -3695,15 +3691,15 @@ static string key_between(const string& low, const string& high)
     result[i + 1] = v;
   }
   result[same] = carry;
-  //  ">>1"
+  // ">>1"
   for (size_t i = same; i < longer.length(); i++) {
-    uint16_t v =
-        ((uint16_t)(uint8_t)result[i] << 8) | (uint16_t)(uint8_t)result[i + 1];
+    uint16_t v = ((uint16_t)(uint8_t)result[i] << 8) |
+                 (uint16_t)(uint8_t)result[i + 1];
     result[i] = v >> 1;
   }
   result[longer.length()] = (uint8_t)result[longer.length()] >> 7;
   return result;
-};
+}
 
 void RocksDBStore::util_divide_key_range(
   const string& prefix,
@@ -3714,18 +3710,20 @@ void RocksDBStore::util_divide_key_range(
   float accepted_variance,
   vector<keyrange_t>& chunks)
 {
+  ceph_assert(chunk_count > 0);
+  ceph_assert(min_chunk_size > 0);
+  ceph_assert(accepted_variance >= 0.0f);
   dout(10) << __func__ << " chunks=" << chunk_count
     << " start=" << pretty_binary_string(starting_key)
     << " end=" << pretty_binary_string(guardrail_key) << dendl;
   chunks.clear();
-  map<uint64_t, string> cs_map;
   string key_from, key_to;
   auto db_it = get_iterator(prefix);
   db_it->lower_bound(starting_key);
-  if (!db_it) return; //empty range
+  if (!db_it->valid()) return; //empty range
   key_from = db_it->key();
   db_it->lower_bound(guardrail_key);
-  if (!db_it->valid()) {
+  if (!db_it->valid() || guardrail_key.empty()) {
     db_it->seek_to_last();
     ceph_assert(db_it->valid());
     key_to = db_it->key();
@@ -3734,98 +3732,108 @@ void RocksDBStore::util_divide_key_range(
     key_to = db_it->key();
     if (key_to <= key_from) return;
   }
-  uint64_t full_size = estimate_range_size(prefix, key_from, key_to);
-  cs_map[0] = key_from;
-  cs_map[full_size] = key_to;
-  uint64_t target_chunk_size = full_size / chunk_count;
-  uint64_t chunk_min = target_chunk_size * (1 - accepted_variance);
-  uint64_t chunk_max = target_chunk_size * (1 + accepted_variance);
-  if (full_size <= chunk_max) {
-    chunks.emplace_back(key_from, key_to);
-    return;
-  }
-  if (target_chunk_size < chunk_min) {
-    chunk_count = std::min<uint64_t>(chunk_count, full_size / chunk_min + 1);
-    target_chunk_size = full_size / chunk_count;
-    chunk_min = target_chunk_size * (1 - accepted_variance);
-    chunk_max = target_chunk_size * (1 + accepted_variance);
+  // Using set as map; allows for named "first"="key" and "second"="size".
+  struct probe_t {
+    string key;
+    int64_t size;
+    struct compare {
+      bool operator()(const probe_t& l, const probe_t& r) const {
+        return l.key < r.key;
+      }
+    };
+  };
+  set<probe_t, probe_t::compare> db_samples;
+  int64_t full_size = estimate_range_size(prefix, key_from, key_to);
+  db_samples.emplace(key_from, 0);
+  db_samples.emplace(key_to, full_size);
+
+  if (full_size / chunk_count < min_chunk_size) {
+    chunk_count = full_size / min_chunk_size + 1;
   }
   dout(10) << __func__ << " chunks=" << chunk_count
     << " key_from=" << pretty_binary_string(key_from)
     << " key_to=" << pretty_binary_string(key_to) << dendl;
 
-  ceph_assert(chunk_count >= 2);
-  dout(20) << "target_chunk_size=" << target_chunk_size
-    << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
   // Algorithm idea:
-  // Have a mapping MAP with elements: estimated_db_size[key_from .. x] -> x.
-  // Keep bisecting [key_from .. key_to].
-  // When MAP[last] - MAP[current_candidate] is in acceptable range for chunk size
-  //   emit the range and move forward.
-  auto it = cs_map.begin();
-  uint64_t cs_anchor = it->first;
-  string cs_key = it->second;
+  // Have a scan over database with keys mapping to value of
+  //   estimate_range_size between key_from and respective key.
+  // The initial range will be successively scanned by bisecting key ranges.
+  // When scanned point is smaller than desired chunk incorporate it;
+  //   when it is larger attempt to bisect and reevaluate.
+  // Once chunk is large enough, emit it and start with next one.
+  // Extra care is taken to protect against RocksDB providing non-monotonic size estimate.
+  auto base = db_samples.begin();
   uint32_t bisect_actions = 0;
-  while(true) {
-    ceph_assert(it != cs_map.end());
-    it++;
-    ceph_assert(cs_map.end() != it);
-    dout(20) << "trying   " << it->first << " " << pretty_binary_string(it->second) << dendl;
-    if (it->first - cs_anchor > chunk_max) {
-      if (bisect_actions == 100) {
-        chunks.clear();
-        chunks.emplace_back(key_from, key_to);
-        return;
-      }
-      bisect_actions++;
-      // it is too far, need to roll back and divide
-      auto key_e = it->second;
-      it--;
-      auto key_b = it->second;
-      auto imagined_key = key_between(key_b, key_e);
-      dout(20) << pretty_binary_string(key_b) << "..." << pretty_binary_string(key_e)
-        << "-> midpoint=" << pretty_binary_string(imagined_key) << dendl;
-      ceph_assert( key_b < imagined_key);
-      ceph_assert(imagined_key < key_e);
-      db_it->upper_bound(imagined_key);
-      ceph_assert(db_it->valid());
-      auto real_key = db_it->key();
-      if (real_key == key_e) {
-        db_it->prev();
-        real_key = db_it->key();
-      }
-      uint64_t cs_size = estimate_range_size(prefix, key_from, real_key);
-      if (cs_size > it->first) {
-        cs_map[cs_size] = real_key;
-        dout(20) << "newpoint " << cs_size << " " << pretty_binary_string(real_key) << dendl;
-        ceph_assert(key_b < real_key);
-        ceph_assert(real_key <= key_e);
-        continue;
-      } else {
-        // this seems to be limit for precision, no reason to attempt biseciton further
-        // fell out and emit region
-      }
-    } else if (it->first - cs_anchor < chunk_min) {
-      continue;
-    }
-
-    bisect_actions = 0;
-    // we are satisfied enough
-    chunks.emplace_back(cs_key, it->second);
-    dout(10) << "produced chunk size=" << it->first - cs_anchor << " "
-      << pretty_binary_string(cs_key) << " " << pretty_binary_string(it->second) << dendl;
-    if (chunks.size() == chunk_count - 1) {
-      chunks.emplace_back(it->second, key_to);
-      dout(10) << "produced chunk size=" << full_size - it->first << " "
-        << pretty_binary_string(it->second) << " " << pretty_binary_string(key_to) << dendl;
-      break;
-    }
-    cs_anchor = it->first;
-    cs_key = it->second;
-    target_chunk_size = (full_size - cs_anchor) / (chunk_count - chunks.size());
-    chunk_min = target_chunk_size * (1 - accepted_variance);
-    chunk_max = target_chunk_size * (1 + accepted_variance);
+  while(chunks.size() < chunk_count - 1 && // Loop until we get enough chunks, except last.
+        base != db_samples.end() &&        // Extra stop if we just incorporated end() into last range.
+        full_size > base->size)            // And protection against non-monotonic RocksDB size estimation.
+  {
+    // Calculate targets
+    int64_t target_chunk_size = (full_size - base->size) / (chunk_count - chunks.size());
+    int64_t chunk_min = target_chunk_size * (1 - accepted_variance);
+    int64_t chunk_max = target_chunk_size * (1 + accepted_variance);
     dout(20) << "target_chunk_size=" << target_chunk_size
       << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+    auto curr = base;
+    while(curr->size - base->size < chunk_min) {
+      auto next = curr; next++;
+      if (next == db_samples.end()) {
+        // This should not happen: end()->size == full_size and base->size were
+        // used to calculate chunk_target, chunk_min and chunk_max.
+        // But if it happens, just abruptly finish.
+        goto emit_and_exit;
+      }
+      dout(20) << "trying   " << next->size << " " << pretty_binary_string(next->key) << dendl;
+      if (next->size - base->size < chunk_max) {
+        curr++; //just take it
+      } else {
+        // split
+        if (bisect_actions == 100) {
+          goto emit_and_exit;
+        }
+        bisect_actions++;
+        // it is too far, need to roll back and divide
+        auto key_b = curr->key;
+        auto key_e = next->key;
+        auto imagined_key = key_between(key_b, key_e);
+        dout(20) << pretty_binary_string(key_b) << "..." << pretty_binary_string(key_e)
+          << "-> midpoint=" << pretty_binary_string(imagined_key) << dendl;
+        if (imagined_key.empty()) {
+          // Very very unlikely: key_e is direct successor of key_b.
+          curr++;
+          continue;
+        }
+        ceph_assert(key_b < imagined_key && imagined_key < key_e);
+        db_it->upper_bound(imagined_key);
+        ceph_assert(db_it->valid());
+        auto real_key = db_it->key();
+        if (real_key == key_e) {
+          // It means there is nothing between imagined_key and key_e.
+          // Go back one key so next bisect can be better.
+          db_it->prev();
+          real_key = db_it->key();
+          if (key_b == real_key) {
+            // It means we cannot hope to narrow the gap between key_b and key_e.
+            // Take the range.
+            curr++;
+            continue;
+          }
+        }
+        ceph_assert(key_b < real_key && real_key < key_e);
+        uint64_t cs_size = estimate_range_size(prefix, key_from, real_key);
+        dout(20) << "newpoint " << cs_size << " " << pretty_binary_string(real_key) << dendl;
+        db_samples.emplace(real_key, cs_size);
+      }
+    }
+    //emit chunk
+    bisect_actions = 0;
+    chunks.emplace_back(base->key, curr->key);
+    dout(10) << "produced chunk size=" << curr->size - base->size << " "
+      << pretty_binary_string(base->key) << " " << pretty_binary_string(curr->key) << dendl;
+    base = curr;
   }
+  emit_and_exit:
+  chunks.emplace_back(base->key, key_to);
+  dout(10) << "produced chunk size=" << full_size - base->size << " "
+    << pretty_binary_string(base->key) << " " << pretty_binary_string(key_to) << dendl;
 }

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -291,6 +291,9 @@ public:
 
   int64_t estimate_prefix_size(const std::string& prefix,
 			       const std::string& key_prefix) override;
+  int64_t estimate_range_size(const std::string& prefix,
+                              const std::string& key_from,
+                              const std::string& key_to) override;
   struct RocksWBHandler;
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -566,7 +566,15 @@ public:
   };
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
   bool get_sharding(std::string& sharding);
-
+  void util_divide_key_range(
+    const std::string& prefix,        // table to operate on
+    const std::string& starting_key,  // included if exists
+    const std::string& guardrail_key, // excluded if exists
+    uint64_t chunk_count,             // desired chunk count, but fewer can happen
+    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    float accepted_variance,          // +/- fluctuation of produced chunk size,
+                                      // smaller value requires more work, use 0.1 ?
+    std::vector<keyrange_t>& chunks) override;
 };
 
 #endif

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -567,13 +567,13 @@ public:
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
   bool get_sharding(std::string& sharding);
   void util_divide_key_range(
-    const std::string& prefix,        // table to operate on
-    const std::string& starting_key,  // included if exists
-    const std::string& guardrail_key, // excluded if exists
-    uint64_t chunk_count,             // desired chunk count, but fewer can happen
-    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    const std::string& prefix,        // Table to operate on.
+    const std::string& starting_key,  // Included if exists.
+    const std::string& guardrail_key, // Excluded if exists; but "" means up until table end
+    uint64_t chunk_count,             // Desired chunk count, can produce fewer when not enough data.
+    uint64_t min_chunk_size,          // Do not produce chunk smaller than this bytes.
     float accepted_variance,          // +/- fluctuation of produced chunk size,
-                                      // smaller value requires more work, use 0.1 ?
+                                      // there is a limit to prediction quality, recommended 0.05.
     std::vector<keyrange_t>& chunks) override;
 };
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -20875,6 +20875,23 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
       ++stats.shard_count;
     }
   }
+  return 0;
+}
+
+//---------------------------------------------------------
+int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &stats)
+{
+  // first set space used by superblock
+  auto super_length = std::max<uint64_t>(min_alloc_size, SUPER_RESERVED);
+  set_allocation_in_simple_bmap(sbmap, 0, super_length);
+  stats.extent_count++;
+
+  // then set all space taken by Objects
+  int ret = read_allocation_from_onodes(sbmap, stats);
+  if (ret < 0) {
+    derr << "failed read_allocation_from_onodes()" << dendl;
+    return ret;
+  }
 
   std::lock_guard l(vstatfs_lock);
   store_statfs_t s;
@@ -20896,23 +20913,6 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
   vstatfs.publish(&s);
   dout(5) << __func__ << " recovered " << s
           << dendl;
-  return 0;
-}
-
-//---------------------------------------------------------
-int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &stats)
-{
-  // first set space used by superblock
-  auto super_length = std::max<uint64_t>(min_alloc_size, SUPER_RESERVED);
-  set_allocation_in_simple_bmap(sbmap, 0, super_length);
-  stats.extent_count++;
-
-  // then set all space taken by Objects
-  int ret = read_allocation_from_onodes(sbmap, stats);
-  if (ret < 0) {
-    derr << "failed read_allocation_from_onodes()" << dendl;
-    return ret;
-  }
 
   return 0;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -21143,6 +21143,77 @@ int BlueStore::read_allocation_from_drive_for_bluestore_tool()
   return ret;
 }
 
+int BlueStore::compare_allocation_recovery_for_bluestore_tool()
+{
+  dout(5) << __func__ << dendl;
+  int ret = 0;
+  ret = _open_db_and_around(true, false);
+  if (ret < 0) {
+    return ret;
+  }
+
+  ret = _open_collections();
+  if (ret < 0) {
+    _close_db_and_around();
+    return ret;
+  }
+  auto shutdown_cache = make_scope_guard([&] {
+    _shutdown_cache();
+    _close_db_and_around();
+  });
+
+  SimpleBitmap old_bitmap(cct, (bdev->get_size()/ min_alloc_size));
+  SimpleBitmap mt_bitmap(cct, (bdev->get_size()/ min_alloc_size));
+  utime_t start;
+  utime_t duration;
+  read_alloc_stats_t old_stats = {};
+  read_alloc_stats_t mt_stats = {};
+
+  if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") != 0) {
+    dout(0) << "New recovery start" << dendl;
+    start = ceph_clock_now();
+    ret = read_allocation_from_onodes_mt(&mt_bitmap, mt_stats);
+    duration = ceph_clock_now() - start;
+    dout(0) << "New recovery result=" << ret << " took " << duration << " seconds" << dendl;
+    dout(0) << "New recovery stats=" << std::endl << mt_stats << dendl;
+  }
+
+  dout(0) << "Legacy recovery start" << dendl;
+  start = ceph_clock_now();
+  ret = read_allocation_from_onodes(&old_bitmap, old_stats);
+  duration = ceph_clock_now() - start;
+  dout(0) << "Legacy recovery result=" << ret << " took " << duration << " seconds" << dendl;
+  dout(0) << "Legacy recovery stats=" << std::endl << old_stats << dendl;
+
+  if (old_stats.actual_pool_vstatfs == mt_stats.actual_pool_vstatfs)
+    dout(0) << "FSstats the same." << dendl;
+  else {
+    dout(0) << "FSTATS DIFFERENT !" << dendl;
+    ret = -1;
+  }
+
+  extent_t ext_a;
+  extent_t ext_b;
+  uint64_t offset = 0;
+  do {
+    ext_a = mt_bitmap.get_next_set_extent(offset);
+    ext_b = old_bitmap.get_next_set_extent(offset);
+    if (ext_a != ext_b) {
+      dout(0) << "ALLOCATOR DIFFERENT !, first:" << dendl;
+      dout(0) << ext_a.offset << "~" << ext_a.length << dendl;
+      dout(0) << ext_b.offset << "~" << ext_b.length << dendl;
+      offset = 1;
+      ret = -1;
+      break;
+    }
+    offset = ext_a.offset + ext_a.length;
+  } while (offset != 0);
+  if (offset == 0) {
+    dout(0) << "Allocators the same." << dendl;
+  }
+  return ret;
+}
+
 //---------------------------------------------------------
 Allocator* BlueStore::clone_allocator_without_bluefs(Allocator *src_allocator)
 {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -353,7 +353,7 @@ static void get_shared_blob_key(uint64_t sbid, string *key)
   _key_encode_u64(sbid, key);
 }
 
-static int get_key_shared_blob(const string& key, uint64_t *sbid)
+int get_key_shared_blob(const string& key, uint64_t *sbid)
 {
   const char *p = key.c_str();
   if (key.length() < sizeof(uint64_t))
@@ -439,7 +439,7 @@ static int _get_key_object(const char *p, ghobject_t *oid)
 }
 
 template<typename S>
-static int get_key_object(const S& key, ghobject_t *oid)
+int get_key_object(const S& key, ghobject_t *oid)
 {
   if (key.length() < ENCODED_KEY_PREFIX_LEN)
     return -1;
@@ -448,6 +448,8 @@ static int get_key_object(const S& key, ghobject_t *oid)
   const char *p = key.c_str();
   return _get_key_object(p, oid);
 }
+
+template int get_key_object(const string& key, ghobject_t *oid);
 
 template<typename S>
 static void _get_object_key(const ghobject_t& oid, S *key)
@@ -556,7 +558,7 @@ int get_key_extent_shard(const string& key, string *onode_key, uint32_t *offset)
   return 0;
 }
 
-static bool is_extent_shard_key(const string& key)
+bool is_extent_shard_key(const string& key)
 {
   return *key.rbegin() == EXTENT_SHARD_KEY_SUFFIX;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -21168,7 +21168,7 @@ int BlueStore::read_allocation_from_drive_for_bluestore_tool()
   return ret;
 }
 
-int BlueStore::compare_allocation_recovery_for_bluestore_tool()
+int BlueStore::compare_allocation_recovery_for_bluestore_tool(ostream& out)
 {
   dout(5) << __func__ << dendl;
   int ret = 0;
@@ -21189,13 +21189,14 @@ int BlueStore::compare_allocation_recovery_for_bluestore_tool()
 
   SimpleBitmap old_bitmap(cct, (bdev->get_size()/ min_alloc_size));
   read_alloc_stats_t old_stats = {};
-  ret = allocation_recover_and_compare(&old_bitmap, old_stats);
+  ret = allocation_recover_and_compare(&old_bitmap, old_stats, &out);
   return ret;
 }
 
 int BlueStore::allocation_recover_and_compare(
   SimpleBitmap *sbmap,
-  read_alloc_stats_t &stats)
+  read_alloc_stats_t &stats,
+  ostream* extra_out)
 {
   int ret = 0;
   SimpleBitmap& old_bitmap = *sbmap;
@@ -21204,27 +21205,41 @@ int BlueStore::allocation_recover_and_compare(
   read_alloc_stats_t mt_stats = {};
   utime_t start;
   utime_t duration;
+  ostringstream out;
+  auto flushl = [&]() {
+    dout(0) << out.str() << dendl;
+    if (extra_out) {
+      (*extra_out) << out.str() << std::endl;
+      std::flush(*extra_out);
+    }
+    out.str("");
+  };
 
   if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") != 0) {
-    dout(0) << "New recovery start" << dendl;
+    out << "New recovery start"; flushl();
     start = ceph_clock_now();
     ret = read_allocation_from_onodes_mt(&mt_bitmap, mt_stats);
     duration = ceph_clock_now() - start;
-    dout(0) << "New recovery result=" << ret << " took " << duration << " seconds" << dendl;
-    dout(0) << "New recovery stats=" << std::endl << mt_stats << dendl;
+    out << "New recovery result=" << ret << " took " << duration << " seconds"; flushl();
+    out << "New recovery stats=" << std::endl << mt_stats; flushl();
   }
 
-  dout(0) << "Legacy recovery start" << dendl;
+  out << "Legacy recovery start"; flushl();
   start = ceph_clock_now();
   ret = read_allocation_from_onodes(&old_bitmap, old_stats);
   duration = ceph_clock_now() - start;
-  dout(0) << "Legacy recovery result=" << ret << " took " << duration << " seconds" << dendl;
-  dout(0) << "Legacy recovery stats=" << std::endl << old_stats << dendl;
+  out << "Legacy recovery result=" << ret << " took " << duration << " seconds"; flushl();
+  out << "Legacy recovery stats=" << std::endl << old_stats; flushl();
 
-  if (old_stats.actual_pool_vstatfs == mt_stats.actual_pool_vstatfs)
-    dout(0) << "FSstats the same." << dendl;
-  else {
-    dout(0) << "FSTATS DIFFERENT !" << dendl;
+  if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") == 0) {
+    out << "bluestore_allocation_recovery_threads = 0"; flushl();
+    out << "No multithread recovery to compare."; flushl();
+    return 0;
+  }
+  if (old_stats.actual_pool_vstatfs == mt_stats.actual_pool_vstatfs) {
+    out << "FSstats the same."; flushl();
+  } else {
+    out << "FSTATS DIFFERENT !"; flushl();
     ret = -1;
   }
 
@@ -21235,9 +21250,9 @@ int BlueStore::allocation_recover_and_compare(
     ext_a = mt_bitmap.get_next_set_extent(offset);
     ext_b = old_bitmap.get_next_set_extent(offset);
     if (ext_a != ext_b) {
-      dout(0) << "ALLOCATOR DIFFERENT !, first:" << dendl;
-      dout(0) << ext_a.offset << "~" << ext_a.length << dendl;
-      dout(0) << ext_b.offset << "~" << ext_b.length << dendl;
+      out << "ALLOCATOR DIFFERENT !, first:"; flushl();
+      out << ext_a.offset << "~" << ext_a.length; flushl();
+      out << ext_b.offset << "~" << ext_b.length; flushl();
       offset = 1;
       ret = -1;
       break;
@@ -21245,7 +21260,7 @@ int BlueStore::allocation_recover_and_compare(
     offset = ext_a.offset + ext_a.length;
   } while (offset != 0);
   if (offset == 0) {
-    dout(0) << "Allocators the same." << dendl;
+    out << "Allocators the same."; flushl();
   }
   return ret;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -14,6 +14,7 @@
  */
 
 #include <bit>
+#include <random>
 #include <utility>
 #include <memory>
 #include <unistd.h>
@@ -29,6 +30,7 @@
 #include <boost/random/uniform_real.hpp>
 
 #include "common/dout.h"
+#include "include/ceph_assert.h"
 #include "include/cpp-btree/btree_set.h"
 
 #include "BlueStore.h"
@@ -20883,22 +20885,40 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
 //---------------------------------------------------------
 int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &stats)
 {
-  // first set space used by superblock
-  auto super_length = std::max<uint64_t>(min_alloc_size, SUPER_RESERVED);
-  set_allocation_in_simple_bmap(sbmap, 0, super_length);
-  stats.extent_count++;
-
-  // then set all space taken by Objects
   int ret;
+  double chance = cct->_conf.get_val<double>("bluestore_debug_fast_recovery_compare_chance");
   if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") == 0) {
-    ret = read_allocation_from_onodes(sbmap, stats);
-  } else {
-    ret = read_allocation_from_onodes_mt(sbmap, stats);
+    // do not compare if multithread is disabled
+    chance = 0;
   }
+  double roll = 0;
+  if (chance > 0) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dis(0.0, 1.0);
+    roll = dis(gen);
+  }
+
+  // first set all space taken by Objects
+  if (chance > 0 && chance > roll) {
+    ret = allocation_recover_and_compare(sbmap, stats);
+    ceph_assert((ret == 0) && "comparing allocator recovery failed");
+  } else {
+    if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") == 0) {
+      ret = read_allocation_from_onodes(sbmap, stats);
+    } else {
+      ret = read_allocation_from_onodes_mt(sbmap, stats);
+    }
+  }
+
   if (ret < 0) {
     derr << "failed read_allocation_from_onodes()" << dendl;
     return ret;
   }
+  // then set space used by superblock
+  auto super_length = std::max<uint64_t>(min_alloc_size, SUPER_RESERVED);
+  set_allocation_in_simple_bmap(sbmap, 0, super_length);
+  stats.extent_count++;
 
   std::lock_guard l(vstatfs_lock);
   store_statfs_t s;
@@ -21168,11 +21188,22 @@ int BlueStore::compare_allocation_recovery_for_bluestore_tool()
   });
 
   SimpleBitmap old_bitmap(cct, (bdev->get_size()/ min_alloc_size));
+  read_alloc_stats_t old_stats = {};
+  ret = allocation_recover_and_compare(&old_bitmap, old_stats);
+  return ret;
+}
+
+int BlueStore::allocation_recover_and_compare(
+  SimpleBitmap *sbmap,
+  read_alloc_stats_t &stats)
+{
+  int ret = 0;
+  SimpleBitmap& old_bitmap = *sbmap;
+  read_alloc_stats_t& old_stats = stats;
   SimpleBitmap mt_bitmap(cct, (bdev->get_size()/ min_alloc_size));
+  read_alloc_stats_t mt_stats = {};
   utime_t start;
   utime_t duration;
-  read_alloc_stats_t old_stats = {};
-  read_alloc_stats_t mt_stats = {};
 
   if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") != 0) {
     dout(0) << "New recovery start" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2945,36 +2945,6 @@ void BlueStore::Blob::maybe_prune_tail() {
   }
 }
 
-void BlueStore::Blob::decode(
-  bufferptr::const_iterator& p,
-  uint64_t struct_v,
-  uint64_t* sbid,
-  bool include_ref_map,
-  Collection *coll)
-{
-  denc(blob, p, struct_v);
-  if (blob.is_shared()) {
-    denc(*sbid, p);
-  }
-  if (include_ref_map) {
-    if (struct_v > 1) {
-      used_in_blob.decode(p);
-    } else {
-      used_in_blob.clear();
-      bluestore_extent_ref_map_t legacy_ref_map;
-      legacy_ref_map.decode(p);
-      if (coll) {
-        for (auto r : legacy_ref_map.ref_map) {
-          get_ref(
-            coll,
-            r.first,
-            r.second.refs * r.second.length);
-        }
-      }
-    }
-  }
-}
-
 // Extent
 
 void BlueStore::Extent::dump(Formatter* f) const
@@ -4150,9 +4120,8 @@ void BlueStore::ExtentMap::ExtentDecoder::decode_extent(
       consume_blobid(le, false, blobid - 1);
     } else {
       // dummy onodes might not have collections, we need a check for it.
-      BlobRef b = c ? c->new_blob() : new Blob(nullptr);
       uint64_t sbid = 0;
-      b->decode(p, struct_v, &sbid, false, c);
+      BlobRef b = decode_create_blob(p, struct_v, &sbid, false, c);
       consume_blob(le, extent_pos, sbid, b);
     }
   }
@@ -4198,15 +4167,29 @@ void BlueStore::ExtentMap::ExtentDecoder::decode_spanning_blobs(
   unsigned n;
   denc_varint(n, p);
   while (n--) {
-    BlobRef b = c ? c->new_blob() : new Blob(nullptr);
-    denc_varint(b->id, p);
+    decltype(Blob::id) id;
+    denc_varint(id, p);
+
     uint64_t sbid = 0;
-    b->decode(p, struct_v, &sbid, true, c);
+    BlobRef b = decode_create_blob(p, struct_v, &sbid, true, c);
+    b->id = id;
     consume_spanning_blob(sbid, b);
   }
 }
 
 /////////////////// BlueStore::ExtentMap::DecoderExtentFull ///////////
+
+BlueStore::BlobRef BlueStore::ExtentMap::ExtentDecoderFull::decode_create_blob(
+  bptr_c_it_t& p,
+  __u8 struct_v,
+  uint64_t* sbid,
+  bool include_ref_map,
+  Collection* c) {
+  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
+  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  return b;
+}
+
 void BlueStore::ExtentMap::ExtentDecoderFull::consume_blobid(
   BlueStore::Extent* le, bool spanning, uint64_t blobid) {
   ceph_assert(le);
@@ -20667,6 +20650,16 @@ void BlueStore::set_allocation_in_simple_bmap(SimpleBitmap* sbmap, uint64_t offs
   sbmap->set(offset >> min_alloc_size_order, length >> min_alloc_size_order);
 }
 
+BlueStore::BlobRef BlueStore::ExtentDecoderPartial::decode_create_blob(
+  bptr_c_it_t& p,
+  __u8 struct_v,
+  uint64_t* sbid,
+  bool include_ref_map,
+  Collection* c) {
+  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
+  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  return b;
+}
 void BlueStore::ExtentDecoderPartial::_consume_new_blob(bool spanning,
                                                         uint64_t extent_no,
                                                         uint64_t sbid,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -20889,7 +20889,12 @@ int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &
   stats.extent_count++;
 
   // then set all space taken by Objects
-  int ret = read_allocation_from_onodes(sbmap, stats);
+  int ret;
+  if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") == 0) {
+    ret = read_allocation_from_onodes(sbmap, stats);
+  } else {
+    ret = read_allocation_from_onodes_mt(sbmap, stats);
+  }
   if (ret < 0) {
     derr << "failed read_allocation_from_onodes()" << dendl;
     return ret;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4115,6 +4115,8 @@ public:
   int  push_allocation_to_rocksdb();
   int  read_allocation_from_drive_for_bluestore_tool();
 #endif
+  int compare_allocation_recovery_for_bluestore_tool();
+
   void set_allocation_in_simple_bmap(SimpleBitmap* sbmap, uint64_t offset, uint64_t length);
 
 private:
@@ -4186,18 +4188,24 @@ private:
   };
 
   friend std::ostream& operator<<(std::ostream& out, const read_alloc_stats_t& stats) {
+    out << "==========================================================" << std::endl
+        << "onode_count             = " ;out.width(10);out << stats.onode_count << std::endl
+        << "shard_count             = " ;out.width(10);out << stats.shard_count << std::endl
+        << "shared_blob_count       = " ;out.width(10);out << stats.shared_blob_count << std::endl
+        << "compressed_blob_count   = " ;out.width(10);out << stats.compressed_blob_count << std::endl
+        << "spanning_blob_count     = " ;out.width(10);out << stats.spanning_blob_count << std::endl
+        << "skipped_illegal_extent  = " ;out.width(10);out << stats.skipped_illegal_extent << std::endl
+        << "extent_count            = " ;out.width(10);out << stats.extent_count << std::endl
+        << "insert_count            = " ;out.width(10);out << stats.insert_count << std::endl;
+    store_statfs_t s;
+    stats.actual_store_vstatfs.publish(&s);
+    out << "store " << s << std::endl;
+    for (auto& ps :stats.actual_pool_vstatfs) {
+      store_statfs_t s;
+      ps.second.publish(&s);
+      out << "pool " << ps.first << " " << s << std::endl;
+    }
     out << "==========================================================" << std::endl;
-    out << "NCB::onode_count             = " ;out.width(10);out << stats.onode_count << std::endl
-	<< "NCB::shard_count             = " ;out.width(10);out << stats.shard_count << std::endl
-	<< "NCB::shared_blob_count      = " ;out.width(10);out << stats.shared_blob_count << std::endl
-	<< "NCB::compressed_blob_count   = " ;out.width(10);out << stats.compressed_blob_count << std::endl
-	<< "NCB::spanning_blob_count     = " ;out.width(10);out << stats.spanning_blob_count << std::endl
-	<< "NCB::skipped_illegal_extent  = " ;out.width(10);out << stats.skipped_illegal_extent << std::endl
-	<< "NCB::extent_count            = " ;out.width(10);out << stats.extent_count << std::endl
-	<< "NCB::insert_count            = " ;out.width(10);out << stats.insert_count << std::endl;
-
-    out << "==========================================================" << std::endl;
-
     return out;
   }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4133,6 +4133,7 @@ private:
     std::map<uint64_t, volatile_statfs> actual_pool_vstatfs;
     volatile_statfs actual_store_vstatfs;
   };
+  class Decoder_AllocationsAndStatFS;
   class ExtentDecoderPartial : public ExtentMap::ExtentDecoder {
     BlueStore& store;
     read_alloc_stats_t& stats;
@@ -4214,6 +4215,7 @@ private:
   int  read_allocation_from_drive_on_startup();
   int  reconstruct_allocations(SimpleBitmap *smbmp, read_alloc_stats_t &stats);
   int  read_allocation_from_onodes(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
+  int  read_allocation_from_onodes_mt(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
   int  commit_freelist_type();
   int  commit_to_null_manager();
   int  commit_to_real_manager();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4224,6 +4224,8 @@ private:
   int  reconstruct_allocations(SimpleBitmap *smbmp, read_alloc_stats_t &stats);
   int  read_allocation_from_onodes(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
   int  read_allocation_from_onodes_mt(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
+  class OnodeScanMT;
+  friend OnodeScanMT;
   int  commit_freelist_type();
   int  commit_to_null_manager();
   int  commit_to_real_manager();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -825,13 +825,37 @@ public:
 	used_in_blob.encode(p);
       }
     }
+    template <bool decode_csum = true>
     void decode(
       ceph::buffer::ptr::const_iterator& p,
       uint64_t struct_v,
       uint64_t* sbid,
       bool include_ref_map,
-      Collection *coll);
+      Collection *coll) {
+      if constexpr (decode_csum)
+        blob.decode<true>(p, struct_v);
+      else
+        blob.decode<false>(p, struct_v);
+      if (blob.is_shared()) {
+        denc(*sbid, p);
+      }
+      if (include_ref_map) {
+        if (struct_v > 1) {
+          used_in_blob.decode(p);
+        } else {
+          used_in_blob.clear();
+          bluestore_extent_ref_map_t legacy_ref_map;
+          legacy_ref_map.decode(p);
+          if (coll) {
+            for (const auto& r : legacy_ref_map.ref_map) {
+              get_ref(coll, r.first, r.second.refs * r.second.length);
+            }
+          }
+        }
+      }
+    }
   };
+
   typedef boost::intrusive_ptr<Blob> BlobRef;
   typedef mempool::bluestore_cache_meta::map<int,BlobRef> blob_map_t;
 
@@ -1024,6 +1048,15 @@ public:
       uint64_t prev_len = 0;
       uint64_t extent_pos = 0;
     protected:
+      // Decodes Blob from bitstream.
+      // The returned Blob is then used in \ref consume_blob or \ref consume_spanning_blob
+      virtual BlobRef decode_create_blob(
+        bptr_c_it_t& p,
+        __u8 struct_v,
+        uint64_t* sbid,      // shared blobid, is Blob turns out to be shared blob
+        bool include_ref_map, // only spanning blobs have references stored
+        Collection* c) = 0;
+
       virtual void consume_blobid(Extent* le,
                                   bool spanning,
                                   uint64_t blobid) = 0;
@@ -1051,6 +1084,13 @@ public:
       ExtentMap& extent_map;
       std::vector<BlobRef> blobs;
     protected:
+      BlobRef decode_create_blob(
+        bptr_c_it_t& p,
+        __u8 struct_v,
+        uint64_t* sbid,
+        bool include_ref_map,
+        Collection* c) override;
+
       void consume_blobid(Extent* le, bool spanning, uint64_t blobid) override;
       void consume_blob(Extent* le,
                         uint64_t extent_no,
@@ -4104,7 +4144,12 @@ private:
     volatile_statfs* per_pool_statfs = nullptr;
     blob_map_t blobs;
     blob_map_t spanning_blobs;
-
+    virtual BlobRef decode_create_blob(
+      bptr_c_it_t& p,
+      __u8 struct_v,
+      uint64_t* sbid,
+      bool include_ref_map,
+      Collection* c) override;
     void _consume_new_blob(bool spanning,
                            uint64_t extent_no,
                            uint64_t sbid,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4135,6 +4135,8 @@ private:
     std::map<uint64_t, volatile_statfs> actual_pool_vstatfs;
     volatile_statfs actual_store_vstatfs;
   };
+  int allocation_recover_and_compare(SimpleBitmap *sbmap, read_alloc_stats_t &stats);
+
   class Decoder_AllocationsAndStatFS;
   class ExtentDecoderPartial : public ExtentMap::ExtentDecoder {
     BlueStore& store;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4115,7 +4115,7 @@ public:
   int  push_allocation_to_rocksdb();
   int  read_allocation_from_drive_for_bluestore_tool();
 #endif
-  int compare_allocation_recovery_for_bluestore_tool();
+  int compare_allocation_recovery_for_bluestore_tool(std::ostream& out);
 
   void set_allocation_in_simple_bmap(SimpleBitmap* sbmap, uint64_t offset, uint64_t length);
 
@@ -4135,7 +4135,10 @@ private:
     std::map<uint64_t, volatile_statfs> actual_pool_vstatfs;
     volatile_statfs actual_store_vstatfs;
   };
-  int allocation_recover_and_compare(SimpleBitmap *sbmap, read_alloc_stats_t &stats);
+  int allocation_recover_and_compare(
+    SimpleBitmap *sbmap,
+    read_alloc_stats_t &stats,
+    std::ostream* extra_out = nullptr);
 
   class Decoder_AllocationsAndStatFS;
   class ExtentDecoderPartial : public ExtentMap::ExtentDecoder {

--- a/src/os/bluestore/CMakeLists.txt
+++ b/src/os/bluestore/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(bluestore OBJECT
   HybridAllocator.cc
   Writer.cc
   Compression.cc
+  OnodeScan.cc
   BlueAdmin.cc
   BlueEnv.cc)
 

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -1,0 +1,240 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+#include "BlueStore.h"
+#include "common/pretty_binary.h"
+#include "simple_bitmap.h"
+#include "common/debug.h"
+using namespace std;
+
+// kv store prefixes, copied from BlueStore.cc
+const string PREFIX_OBJ = "O";         // object name -> onode_t
+
+#undef dout_prefix
+#define dout_prefix *_dout << "bs.onode_scan "
+#undef dout_context
+#define dout_context cct
+#define dout_subsys ceph_subsys_bluestore
+
+int get_key_shared_blob(const string& key, uint64_t *sbid);
+bool is_extent_shard_key(const string& key);
+template<typename S>
+  int get_key_object(const S& key, ghobject_t *oid);
+int get_key_extent_shard(const string& key, string *onode_key, uint32_t *offset);
+
+struct bool_vector_t {
+  static constexpr uint8_t null_gen = 0;
+  std::vector<uint8_t> gen_markers;
+  uint8_t current_gen = 1;
+  void mark(uint32_t pos) {
+    if (gen_markers.size() <= pos) {
+      gen_markers.resize(pos * 5 / 4 + 1);
+    }
+    gen_markers[pos] = current_gen;
+  }
+  bool check(uint32_t pos) {
+    return pos < gen_markers.size() && gen_markers[pos] == current_gen;
+  }
+  void reset() {
+    current_gen++;
+    if (current_gen == null_gen) {
+      // visited all possible generation markers, we need to clear table
+      memset(gen_markers.data(), null_gen, gen_markers.size());
+      current_gen++; // step out of invalid generation
+    }
+  }
+};
+
+class BlueStore::Decoder_AllocationsAndStatFS : public BlueStore::ExtentMap::ExtentDecoder {
+  using Extent = BlueStore::Extent;
+  BlueStore &store;
+  read_alloc_stats_t &stats;
+  SimpleBitmap &sbmap;
+  uint8_t min_alloc_size_order;
+  Extent extent;
+  ghobject_t oid;
+  volatile_statfs *per_pool_statfs = nullptr;
+  bool_vector_t is_local_blob_compressed;
+  bool_vector_t is_spanning_blob_compressed;
+
+  void _consume_new_blob(bool spanning, uint64_t extent_no, uint64_t sbid, BlobRef b);
+
+protected:
+  void consume_blobid(Extent *, bool spanning, uint64_t blobid) override;
+  void consume_blob(Extent *le, uint64_t extent_no, uint64_t sbid, BlobRef b) override;
+  void consume_spanning_blob(uint64_t sbid, BlobRef b) override;
+  Extent *get_next_extent() override {
+    ++stats.extent_count;
+    extent = Extent();
+    return &extent;
+  }
+  void add_extent(Extent *) override {}
+
+public:
+  Decoder_AllocationsAndStatFS(
+    BlueStore &_store,
+    read_alloc_stats_t &_stats,
+    SimpleBitmap &_sbmap,
+    uint8_t _min_alloc_size_order)
+    : store(_store), stats(_stats), sbmap(_sbmap), min_alloc_size_order(_min_alloc_size_order) {}
+  const ghobject_t &get_oid() const { return oid; }
+  void reset(const ghobject_t _oid, volatile_statfs *_per_pool_statfs);
+  void reset_new_shard();
+};
+
+void BlueStore::Decoder_AllocationsAndStatFS::_consume_new_blob(
+  bool spanning,
+  uint64_t extent_no,
+  uint64_t sbid,
+  BlobRef b)
+{
+  [[maybe_unused]] auto cct = store.cct;
+  ceph_assert(per_pool_statfs);
+  ceph_assert(oid != ghobject_t());
+
+  auto &blob = b->get_blob();
+  bool compressed = blob.is_compressed();
+  if(spanning) {
+    dout(20) << __func__ << " spanning " << b->id << dendl;
+    ceph_assert(b->id >= 0);
+    if (compressed) {
+      is_spanning_blob_compressed.mark(b->id);
+    }
+    ++stats.spanning_blob_count;
+  } else {
+    dout(20) << __func__ << " local " << extent_no << dendl;
+    if (compressed) {
+      is_local_blob_compressed.mark(extent_no);
+    }
+  }
+
+  uint64_t new_marked_allocations = 0;
+  for (auto &pe : blob.get_extents()) {
+    if (pe.offset != bluestore_pextent_t::INVALID_OFFSET) {
+      new_marked_allocations += sbmap.set_atomic(
+        pe.offset >> min_alloc_size_order, pe.length >> min_alloc_size_order);
+    }
+  }
+  per_pool_statfs->allocated() += new_marked_allocations
+                                  << min_alloc_size_order;
+  if (compressed) {
+    per_pool_statfs->compressed_allocated() +=
+        new_marked_allocations << min_alloc_size_order;
+    per_pool_statfs->compressed() += blob.get_compressed_payload_length();
+    ++stats.compressed_blob_count;
+  }
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::consume_blobid(
+  Extent* le, bool spanning, uint64_t blobid)
+{
+  [[maybe_unused]] auto cct = store.cct;
+  dout(20) << __func__ << " " << spanning << " " << blobid << dendl;
+  auto& vec = spanning ? is_spanning_blob_compressed : is_local_blob_compressed;
+  per_pool_statfs->stored() += le->length;
+  if (vec.check(blobid)) {
+    per_pool_statfs->compressed_original() += le->length;
+  }
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::consume_blob(
+  Extent* le, uint64_t extent_no, uint64_t sbid, BlobRef b)
+{
+  _consume_new_blob(false, extent_no, sbid, b);
+  per_pool_statfs->stored() += le->length;
+  if (b->get_blob().is_compressed()) {
+    per_pool_statfs->compressed_original() += le->length;
+  }
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::consume_spanning_blob(
+  uint64_t sbid, BlobRef b)
+{
+  _consume_new_blob(true, 0/*doesn't matter*/, sbid, b);
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::reset(
+  const ghobject_t _oid, volatile_statfs* _per_pool_statfs)
+{
+  oid = _oid;
+  per_pool_statfs = _per_pool_statfs;
+  is_local_blob_compressed.reset();
+  is_spanning_blob_compressed.reset();
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::reset_new_shard() {
+  is_local_blob_compressed.reset();
+}
+
+
+int BlueStore::read_allocation_from_onodes_mt(SimpleBitmap *sbmap, read_alloc_stats_t& stats)
+{
+  auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
+  if (!it) {
+    derr << "failed getting onode's iterator" << dendl;
+    return -ENOENT;
+  }
+
+  uint64_t            kv_count       = 0;
+  uint64_t            count_interval = 1'000'000;
+  Decoder_AllocationsAndStatFS edecoder(*this, stats, *sbmap, min_alloc_size_order);
+
+  // iterate over all ONodes stored in RocksDB
+  for (it->lower_bound(string()); it->valid(); it->next(), kv_count++) {
+    // trace an even after every million processed objects (typically every 5-10 seconds)
+    if (kv_count && (kv_count % count_interval == 0) ) {
+      dout(5) << __func__ << " processed objects count = " << kv_count << dendl;
+    }
+
+    auto key = it->key();
+    auto okey = key;
+    dout(20) << __func__ << " decode onode " << pretty_binary_string(key) << dendl;
+    ghobject_t oid;
+    if (!is_extent_shard_key(it->key())) {
+      int r = get_key_object(okey, &oid);
+      if (r != 0) {
+        derr << __func__ << " failed to decode onode key = "
+             << pretty_binary_string(okey) << dendl;
+        return -EIO;
+      }
+      edecoder.reset(oid,
+        &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
+      Onode dummy_on(cct);
+      Onode::decode_raw(&dummy_on,
+        it->value(),
+        edecoder,
+        segment_size != 0);
+      ++stats.onode_count;
+    } else {
+      edecoder.reset_new_shard();
+      uint32_t offset;
+      int r = get_key_extent_shard(key, &okey, &offset);
+      if (r != 0) {
+        derr << __func__ << " failed to decode onode extent key = "
+             << pretty_binary_string(key) << dendl;
+        return -EIO;
+      }
+      r = get_key_object(okey, &oid);
+      if (r != 0) {
+        derr << __func__
+             << " failed to decode onode key= " << pretty_binary_string(okey)
+             << " from extent key= " << pretty_binary_string(key)
+             << dendl;
+        return -EIO;
+      }
+      ceph_assert(oid == edecoder.get_oid());
+      edecoder.decode_some(it->value(), nullptr);
+      ++stats.shard_count;
+    }
+  }
+  return 0;
+}

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -100,7 +100,7 @@ BlueStore::BlobRef BlueStore::Decoder_AllocationsAndStatFS::decode_create_blob(
   bool include_ref_map,
   Collection* c) {
   BlobRef b = c ? c->new_blob() : new Blob(nullptr);
-  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  b->decode<false>(p, struct_v, sbid, include_ref_map, c);
   return b;
 }
 

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -65,6 +65,7 @@ class BlueStore::Decoder_AllocationsAndStatFS : public BlueStore::ExtentMap::Ext
   volatile_statfs *per_pool_statfs = nullptr;
   bool_vector_t is_local_blob_compressed;
   bool_vector_t is_spanning_blob_compressed;
+  BlobRef blob = new Blob(nullptr);
 
   void _consume_new_blob(bool spanning, uint64_t extent_no, uint64_t sbid, BlobRef b);
 
@@ -99,9 +100,9 @@ BlueStore::BlobRef BlueStore::Decoder_AllocationsAndStatFS::decode_create_blob(
   uint64_t* sbid,
   bool include_ref_map,
   Collection* c) {
-  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
-  b->decode<false>(p, struct_v, sbid, include_ref_map, c);
-  return b;
+  // reuse same blob all over
+  blob->decode<false>(p, struct_v, sbid, include_ref_map, c);
+  return blob;
 }
 
 void BlueStore::Decoder_AllocationsAndStatFS::_consume_new_blob(

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -176,65 +176,175 @@ void BlueStore::Decoder_AllocationsAndStatFS::reset_new_shard() {
 }
 
 
+class BlueStore::OnodeScanMT {
+  BlueStore& store;
+  SimpleBitmap *sbmap;
+  read_alloc_stats_t& stats;
+  vector<KeyValueDB::keyrange_t> chunks;
+  uint32_t chunk_pos = 0;
+  uint64_t total = 0;
+  uint64_t interval = 1'000'000;
+  ceph::mutex lock = ceph::make_mutex("BlueStore::OnodeScanMT::lock");
+  void report_progress(uint32_t thread_no, uint64_t no_completed) {
+    auto &cct = store.cct;
+    std::lock_guard l(lock);
+    if (total / interval != (total + no_completed) / interval) {
+      dout(5) << __func__ << " processed objects count = "
+        << (total + no_completed) / interval * interval << dendl;
+    }
+    total += no_completed;
+  }
+
+  bool ask_for_work(
+    string& start_key,
+    string& upper_bound_key) {
+    std::lock_guard l(lock);
+    if (chunk_pos < chunks.size()) {
+      start_key = chunks[chunk_pos].first_key;
+      upper_bound_key = chunks[chunk_pos].upper_bound;
+      chunk_pos++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  int scan_onodes_range(
+    read_alloc_stats_t& stats,
+    const string& start_key,
+    const string& upper_bound_key)
+  {
+    auto& db = store.db;
+    auto& cct = store.cct;
+    auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
+    if (!it) {
+      derr << "failed getting onode's iterator" << dendl;
+      return -ENOENT;
+    }
+
+    uint64_t kv_count = 0;
+    uint64_t last_completed = 0;
+    uint64_t count_interval = 100'000;
+    Decoder_AllocationsAndStatFS edecoder(store, stats, *sbmap,
+                                          store.min_alloc_size_order);
+    it->lower_bound(start_key);
+    // skip to first key that is beginning of Onode
+    while (it->valid() && is_extent_shard_key(it->key())) {
+      it->next();
+    }
+    // iterate over all onodes in requested range
+    for (; it->valid(); it->next(), kv_count++) {
+      if (kv_count && (kv_count % count_interval == 0)) {
+        report_progress(0, kv_count - last_completed);
+        last_completed = kv_count;
+      }
+      auto key = it->key();
+      auto okey = key;
+      dout(20) << __func__ << " decode onode " << pretty_binary_string(key) << dendl;
+      ghobject_t oid;
+      if (!is_extent_shard_key(it->key())) {
+        if (it->key() >= upper_bound_key) {
+          // Drag iteration after upper bound until new onode is found.
+          break;
+        }
+        int r = get_key_object(okey, &oid);
+        if (r != 0) {
+          derr << __func__
+               << " failed to decode onode key = " << pretty_binary_string(okey)
+               << dendl;
+          continue;
+        }
+        edecoder.reset(oid,
+                       &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
+        Onode dummy_on(cct);
+        Onode::decode_raw(&dummy_on, it->value(), edecoder, store.segment_size != 0);
+        ++stats.onode_count;
+      } else {
+        edecoder.reset_new_shard();
+        uint32_t offset;
+        get_key_extent_shard(key, &okey, &offset);
+        int r = get_key_object(okey, &oid);
+        if (r != 0) {
+          derr << __func__
+               << " failed to decode onode key= " << pretty_binary_string(okey)
+               << " from extent key= " << pretty_binary_string(key) << dendl;
+          continue;
+        }
+        if (oid != edecoder.get_oid()) {
+          continue;
+        }
+        edecoder.decode_some(it->value(), nullptr);
+        ++stats.shard_count;
+      }
+    }
+    report_progress(0, kv_count - last_completed);
+    return 0;
+  }
+
+  void scanner_thread(
+    uint32_t thread_no,
+    read_alloc_stats_t& stats)
+  {
+    [[maybe_unused]] auto& cct = store.cct;
+    string start_key;
+    string upper_bound_key;
+    while(ask_for_work(start_key, upper_bound_key)) {
+      dout(10) << "thread " << thread_no << " runs: " << pretty_binary_string(start_key)
+        << "..." << pretty_binary_string(upper_bound_key) << dendl;
+      scan_onodes_range(stats, start_key, upper_bound_key);
+    }
+  }
+
+public:
+  OnodeScanMT(BlueStore& store, SimpleBitmap *sbmap, read_alloc_stats_t& stats)
+  : store(store), sbmap(sbmap), stats(stats) {}
+
+  int scan() {
+    [[maybe_unused]] auto& cct = store.cct;
+    std::vector<read_alloc_stats_t> thr_stats;
+    std::vector<thread> thr;
+
+    //bluestore_allocation_recovery_threads
+    size_t num_threads = cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads");
+    ceph_assert(num_threads > 0);
+    std::vector<double> timers;
+    store.db->util_divide_key_range(
+      PREFIX_OBJ, "", string(100, '\377'), num_threads, 50'000'000, 0.05, chunks);
+    for (size_t i = 0; i < chunks.size(); i++) {
+      dout(10) << i << ": " << pretty_binary_string(chunks[i].first_key)
+        << "..." << pretty_binary_string(chunks[i].upper_bound) << dendl;
+    }
+
+    num_threads = std::min(num_threads, chunks.size());
+    thr_stats.resize(num_threads);
+    thr.resize(num_threads);
+    timers.resize(num_threads);
+    for (size_t i = 0; i < num_threads; i++) {
+      thr[i] = std::thread(
+        &BlueStore::OnodeScanMT::scanner_thread, this, i, std::ref(thr_stats[i]));
+    }
+    for (size_t i = 0; i < num_threads; i++) {
+      thr[i].join();
+      stats.onode_count += thr_stats[i].onode_count;
+      stats.shard_count += thr_stats[i].shard_count;
+      stats.shared_blob_count += thr_stats[i].shared_blob_count;
+      stats.compressed_blob_count += thr_stats[i].compressed_blob_count;
+      stats.spanning_blob_count += thr_stats[i].spanning_blob_count;
+      stats.skipped_illegal_extent += thr_stats[i].skipped_illegal_extent;
+      stats.extent_count += thr_stats[i].extent_count;
+      stats.insert_count += thr_stats[i].insert_count;
+      for (auto &k : thr_stats[i].actual_pool_vstatfs) {
+        stats.actual_pool_vstatfs[k.first] += k.second;
+      }
+    }
+    return 0;
+  }
+};
+
 int BlueStore::read_allocation_from_onodes_mt(SimpleBitmap *sbmap, read_alloc_stats_t& stats)
 {
-  auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
-  if (!it) {
-    derr << "failed getting onode's iterator" << dendl;
-    return -ENOENT;
-  }
-
-  uint64_t            kv_count       = 0;
-  uint64_t            count_interval = 1'000'000;
-  Decoder_AllocationsAndStatFS edecoder(*this, stats, *sbmap, min_alloc_size_order);
-
-  // iterate over all ONodes stored in RocksDB
-  for (it->lower_bound(string()); it->valid(); it->next(), kv_count++) {
-    // trace an even after every million processed objects (typically every 5-10 seconds)
-    if (kv_count && (kv_count % count_interval == 0) ) {
-      dout(5) << __func__ << " processed objects count = " << kv_count << dendl;
-    }
-
-    auto key = it->key();
-    auto okey = key;
-    dout(20) << __func__ << " decode onode " << pretty_binary_string(key) << dendl;
-    ghobject_t oid;
-    if (!is_extent_shard_key(it->key())) {
-      int r = get_key_object(okey, &oid);
-      if (r != 0) {
-        derr << __func__ << " failed to decode onode key = "
-             << pretty_binary_string(okey) << dendl;
-        return -EIO;
-      }
-      edecoder.reset(oid,
-        &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
-      Onode dummy_on(cct);
-      Onode::decode_raw(&dummy_on,
-        it->value(),
-        edecoder,
-        segment_size != 0);
-      ++stats.onode_count;
-    } else {
-      edecoder.reset_new_shard();
-      uint32_t offset;
-      int r = get_key_extent_shard(key, &okey, &offset);
-      if (r != 0) {
-        derr << __func__ << " failed to decode onode extent key = "
-             << pretty_binary_string(key) << dendl;
-        return -EIO;
-      }
-      r = get_key_object(okey, &oid);
-      if (r != 0) {
-        derr << __func__
-             << " failed to decode onode key= " << pretty_binary_string(okey)
-             << " from extent key= " << pretty_binary_string(key)
-             << dendl;
-        return -EIO;
-      }
-      ceph_assert(oid == edecoder.get_oid());
-      edecoder.decode_some(it->value(), nullptr);
-      ++stats.shard_count;
-    }
-  }
+  OnodeScanMT scaner(*this, sbmap, stats);
+  scaner.scan();
   return 0;
 }
+

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -69,6 +69,8 @@ class BlueStore::Decoder_AllocationsAndStatFS : public BlueStore::ExtentMap::Ext
   void _consume_new_blob(bool spanning, uint64_t extent_no, uint64_t sbid, BlobRef b);
 
 protected:
+  BlobRef decode_create_blob(
+  bptr_c_it_t& p, __u8 struct_v, uint64_t* sbid, bool include_ref_map, Collection* c) override;
   void consume_blobid(Extent *, bool spanning, uint64_t blobid) override;
   void consume_blob(Extent *le, uint64_t extent_no, uint64_t sbid, BlobRef b) override;
   void consume_spanning_blob(uint64_t sbid, BlobRef b) override;
@@ -90,6 +92,17 @@ public:
   void reset(const ghobject_t _oid, volatile_statfs *_per_pool_statfs);
   void reset_new_shard();
 };
+
+BlueStore::BlobRef BlueStore::Decoder_AllocationsAndStatFS::decode_create_blob(
+  bptr_c_it_t& p,
+  __u8 struct_v,
+  uint64_t* sbid,
+  bool include_ref_map,
+  Collection* c) {
+  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
+  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  return b;
+}
 
 void BlueStore::Decoder_AllocationsAndStatFS::_consume_new_blob(
   bool spanning,

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -344,6 +344,7 @@ int main(int argc, char **argv)
     ("command", po::value<string>(&action),
         "fsck, "
         "qfsck, "
+        "recovery-compare, "
         "allocmap, "
         "restore_cfb, "
         "repair, "
@@ -491,6 +492,7 @@ int main(int argc, char **argv)
   if (action == "fsck" || action == "repair" ||
       action == "quick-fix" || action == "allocmap" ||
       action == "qfsck" || action == "restore_cfb" ||
+      action == "recovery-compare" ||
       action == "revert-wal-to-plain") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
@@ -713,6 +715,18 @@ int main(int argc, char **argv)
       cout << action << " success" << std::endl;
     }
 #endif
+  }
+  else if( action == "recovery-compare" ) {
+    cout << action << " bluestore compare new and legacy onode recovery" << std::endl;
+    validate_path(cct.get(), path, false);
+    BlueStore bluestore(cct.get(), path);
+    int r = bluestore.compare_allocation_recovery_for_bluestore_tool();
+    if (r < 0) {
+      cerr << action << " failed: " << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      cout << action << " success" << std::endl;
+    }
   }
   else if (action == "fsck" ||
       action == "repair" ||

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -720,7 +720,7 @@ int main(int argc, char **argv)
     cout << action << " bluestore compare new and legacy onode recovery" << std::endl;
     validate_path(cct.get(), path, false);
     BlueStore bluestore(cct.get(), path);
-    int r = bluestore.compare_allocation_recovery_for_bluestore_tool();
+    int r = bluestore.compare_allocation_recovery_for_bluestore_tool(cout);
     if (r < 0) {
       cerr << action << " failed: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);

--- a/src/os/bluestore/simple_bitmap.h
+++ b/src/os/bluestore/simple_bitmap.h
@@ -50,6 +50,18 @@ public:
   // returns a copy of the next clear extent starting at @offset
   extent_t get_next_clr_extent(uint64_t offset);
 
+  // Sets a bit range (@length~@offset).
+  // This variant is safe for multithread operations.
+  // Can be intermixed with clr_atomic, but not with set or clr.
+  // Returns: count of bits set
+  uint64_t set_atomic(uint64_t offset, uint64_t length);
+
+  // Clears a bit range (@length~@offset).
+  // This variant is safe for multithread operations.
+  // Can be intermixed with set_atomic, but not with set or clr.
+  // Returns: count of bits set
+  uint64_t clr_atomic(uint64_t offset, uint64_t length);
+
   //----------------------------------------------------------------------------
   inline uint64_t get_size() {
     return m_num_bits;
@@ -138,6 +150,7 @@ private:
   constexpr static uint64_t      BITS_IN_WORD        = (BYTES_IN_WORD * 8);
   constexpr static uint64_t      BITS_IN_WORD_MASK   = (BITS_IN_WORD - 1);
   constexpr static uint64_t      BITS_IN_WORD_SHIFT  = 6;
+  constexpr static uint64_t      MAX_BIT_NO          = BITS_IN_WORD - 1;
   constexpr static uint64_t      FULL_MASK           = (~((uint64_t)0));
 
   CephContext *cct;

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -13,9 +13,12 @@
  *
  */
 
+#include <common/pretty_binary.h>
 #include <stdio.h>
 #include <string.h>
 #include <iostream>
+#include <string>
+#include <random>
 #include <time.h>
 #include <sys/mount.h>
 #include "kv/KeyValueDB.h"
@@ -28,6 +31,7 @@
 #include "common/errno.h"
 #include "include/stringify.h"
 #include <gtest/gtest.h>
+#include <fmt/format.h>
 
 using namespace std;
 
@@ -1284,6 +1288,425 @@ TEST_F(RocksDBResharding, change_reshard) {
     check_db();
     db->close();
   }
+}
+
+typedef std::mt19937 gen_type;
+
+class RocksDBSplitRange : public ::testing::Test {
+public:
+  boost::scoped_ptr<RocksDBStore> db;
+  gen_type rng = gen_type(0);
+  RocksDBSplitRange() : db(0) {}
+
+  string _bl_to_str(bufferlist val) {
+    string str(val.c_str(), val.length());
+    return str;
+  }
+
+  void rm_r(string path) {
+    string cmd = string("rm -r ") + path;
+    if (verbose)
+      cout << "==> " << cmd << std::endl;
+    int r = ::system(cmd.c_str());
+    if (r) {
+      cerr << "failed with exit code " << r
+        << ", continuing anyway" << std::endl;
+    }
+  }
+
+  void SetUp() override {
+    verbose = getenv("VERBOSE") && strcmp(getenv("VERBOSE"), "1") == 0;
+
+    int r = ::mkdir("kv_test_temp_dir", 0777);
+    if (r < 0 && errno != EEXIST) {
+      r = -errno;
+      cerr << __func__ << ": unable to create kv_test_temp_dir: "
+        << cpp_strerror(r) << std::endl;
+      return;
+    }
+
+    KeyValueDB* db_kv = KeyValueDB::create(g_ceph_context, "rocksdb", "kv_test_temp_dir");
+    RocksDBStore* db_rocks = dynamic_cast<RocksDBStore*>(db_kv);
+    ceph_assert(db_rocks);
+    db.reset(db_rocks);
+    ASSERT_EQ(0, db->init(g_conf()->bluestore_rocksdb_options));
+  }
+
+  void TearDown() override {
+    db.reset(nullptr);
+    rm_r("kv_test_temp_dir");
+  }
+
+  bool is_jenkins() {
+    return (getenv("JENKINS_HOME") != nullptr);
+  }
+
+  bool verbose;
+  std::vector<std::string> random_words = {
+    "found", "brain", "fully", "pen", "worth", "race",
+    "stand", "nodded", "whenever", "surrounded", "industrial", "skin",
+    "this", "direction", "family", "beginning", "whenever", "held",
+    "metal", "year", "like", "valuable", "softly", "whistle",
+    "perfectly", "broken", "idea", "also", "coffee", "branch",
+    "tongue", "immediately", "bent", "partly", "burn", "include",
+    "certain", "burst", "final", "smoke", "positive", "perfectly"
+  };
+  uniform_int_distribution<> uniform_random_words =
+    uniform_int_distribution<>(0, random_words.size() - 1);
+  uniform_int_distribution<> random_byte =
+    uniform_int_distribution<>('!', '~');
+  std::map<std::string, std::string> data;
+
+  std::string random_string(uint32_t msg_size, uint32_t compress_target)
+  {
+    std::string result;
+    uint32_t s = 0; // accumulated message
+    uint32_t c = 0; // estimated compressed size
+    // pick words
+    while (s < msg_size && (msg_size - s) > (compress_target - c)) {
+      uint32_t idx = uniform_random_words(rng);
+      result += random_words[idx];
+      s += random_words[idx].length();
+      c += 2; //~1 = random byte, ~2 = ref message
+    }
+    // fillup with full random bytes
+    while (s < msg_size) {
+      result.push_back(random_byte(rng));
+      s++;
+    }
+    return result;
+  }
+
+  struct DataToDB {
+    KeyValueDB* db;
+    std::string prefix;
+    KeyValueDB::Transaction t;
+    uint32_t cnt = 0;
+    DataToDB(KeyValueDB* db, const std::string& prefix)
+    : db(db), prefix(prefix)
+    {
+      t = db->get_transaction();
+    }
+    void add(const std::string& key, const std::string& value)
+    {
+      bufferlist v;
+      v.append(value);
+      t->set(prefix, key, v);
+      cnt++;
+      if ((cnt % 1000) == 0) {
+        ASSERT_EQ(db->submit_transaction_sync(t), 0);
+        t.reset();
+        t = db->get_transaction();
+      }
+    }
+    void rm(const std::string& key)
+    {
+      t->rmkey(prefix, key);
+      cnt++;
+      if ((cnt % 1000) == 0) {
+        ASSERT_EQ(db->submit_transaction_sync(t), 0);
+        t.reset();
+        t = db->get_transaction();
+      }
+    }
+    void flush()
+    {
+      ASSERT_EQ(db->submit_transaction_sync(t), 0);
+      t.reset();
+      t = db->get_transaction();
+    }
+  };
+
+  struct TreeGen {
+    uint32_t left_w;
+    uint32_t right_w;
+    std::string left_name;
+    std::string right_name;
+    bool sub_tree_branch(int& n) const
+    {
+      uint32_t count_left = (n * left_w) / (left_w + right_w);
+      uint32_t rem = (n * left_w) % (left_w + right_w);
+      uint32_t count_right = n - count_left;
+      if (rem >= right_w) {
+        n = count_left;
+        return false; //left
+      } else {
+        n = count_right - 1; //right
+        return true;
+      }
+    }
+    std::string get_branch_name(int n) const
+    {
+      std::string result;
+      while (n > 0) {
+        bool do_right = sub_tree_branch(n);
+        if (do_right)
+          result.append(right_name);
+        else
+          result.append(left_name);
+      }
+      return result;
+    }
+    TreeGen(
+      uint32_t left_weight,
+      uint32_t right_weight,
+      const std::string& left_name,
+      const std::string& right_name)
+      : left_w(left_weight)
+      , right_w(right_weight)
+      , left_name(left_name)
+      , right_name(right_name)
+    {
+      if (left_weight < right_weight) {
+        std::swap(this->left_name, this->right_name);
+        std::swap(left_weight, right_weight);
+      }
+    }
+  };
+
+  void grow_tree(
+    const TreeGen& t, DataToDB& data_to_db,
+    uint32_t key_from, uint32_t key_to,
+    const std::string& key_tail,
+    uint32_t value_size, uint32_t value_comp_size)
+  {
+    for(uint32_t i = key_from; i < key_to; i++) {
+      std::string key = t.get_branch_name(i) + key_tail;
+      std::string value = random_string(value_size, value_comp_size);
+      data_to_db.add(key, value);
+    }
+    data_to_db.flush();
+  }
+
+  void prune_tree(
+    const TreeGen& t, DataToDB& data_to_db,
+    uint32_t key_from, uint32_t key_to,
+    const std::string& key_tail)
+  {
+    for(uint32_t i = key_from; i < key_to; i++) {
+      std::string key = t.get_branch_name(i) + key_tail;
+      data_to_db.rm(key);
+    }
+    data_to_db.flush();
+  }
+
+  std::pair<uint64_t, uint64_t> get_split_quality(
+    const std::string& prefix,
+    const std::vector<KeyValueDB::keyrange_t>& chunks)
+  {
+    uint64_t all_keys = 0;
+    uint64_t max_keys = 0;
+    KeyValueDB::Iterator it;
+    it = db->get_iterator(prefix);
+    if (verbose) std::cout << "keys_in_shards: ";
+    for (const auto& c : chunks) {
+      uint64_t keys = 0;
+      it->lower_bound(c.first_key);
+      while(it->valid() && it->key() < c.upper_bound) {
+        keys++;
+        all_keys++;
+        it->next();
+      }
+      if (verbose) std::cout << keys << " " << std::flush;
+      if (max_keys < keys) {
+        max_keys = keys;
+      }
+    }
+    if (verbose) std::cout << std::endl;
+    return make_pair(all_keys, max_keys);
+  }
+
+  void scan_split_quality(
+    const std::string& prefix)
+  {
+    if (!verbose) return;
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    auto c_set = {1, 3, 5, 10, 20, 30};
+    auto p_set = {0.2, 0.1, 0.05, 0.02, 0.01};
+    std::cout << fmt::format("{:6}","");
+    for (uint32_t c: c_set) {
+      std::cout << fmt::format("{:10}",c);
+    }
+    std::cout << std::endl;
+    for (double prec: p_set) {
+      std::cout << fmt::format("{:5.2f} ",prec);
+      for (uint32_t c: c_set) {
+        utime_t start = ceph_clock_now();
+        db->util_divide_key_range(
+          prefix, "", std::string(20, '\377'),
+          c, 1000000, prec, chunks);
+        utime_t end = ceph_clock_now();
+        std::cout << fmt::format("{:7.3f}/{:2}", double(end - start) * 1000, chunks.size());
+      }
+      std::cout << std::endl;
+    }
+  }
+};
+
+TEST_F(RocksDBSplitRange, grow_tree) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(70, 30, "l", "r");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "a", 1000, 300);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    utime_t start = ceph_clock_now();
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.1, chunks);
+    utime_t end = ceph_clock_now();
+    if (verbose) std::cout << "time=" << end - start << std::endl;
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 8);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_tree_high_quality) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(70, 30, "l", "r");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "a", 1000, 300);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.02, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 8);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_two_trees) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t1(70, 30, "left", "right");
+  TreeGen t2(60, 40, "left", "right");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t1, to_db, keys, keys_end, "a", 1000, 300);
+    grow_tree(t2, to_db, keys, keys_end, "b", 500, 150);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.1, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys * 2);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 5);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_prune_tree) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(70, 30, "l", "r");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000};
+  if (is_jenkins()) keys_to_test = {1'000'000};
+  uint64_t keys = 0;
+  uint64_t pruned_keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow  " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "a", 1000, 300);
+    if (verbose) std::cout << "prune " << pruned_keys << "->" << keys / 2 << std::endl;
+    prune_tree(t, to_db, pruned_keys, keys / 2, "a");
+    pruned_keys = keys / 2;
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.1, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys - pruned_keys);
+    if (all_keys > 1000000) {
+      EXPECT_GT(speedup, 5);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
+}
+
+TEST_F(RocksDBSplitRange, grow_tree_small_leaves) {
+  ASSERT_EQ(0, db->create_and_open(cout, "O"));
+
+  TreeGen t(7, 3, "0", "1");
+  DataToDB to_db(db.get(), "O");
+  vector<uint32_t> keys_to_test = {
+    0, 1000, 10000, 100000, 1'000'000, 2'000'000, 5'000'000, 10'000'000, 20'000'000, 50'000'000};
+  if (is_jenkins()) keys_to_test = {2'500'000};
+
+  uint64_t keys = 0;
+  for (auto keys_end : keys_to_test) {
+    if (verbose) std::cout << "grow " << keys << "->" << keys_end << std::endl;
+    grow_tree(t, to_db, keys, keys_end, "aaaa", 100, 30);
+    keys = keys_end;
+    keys_end = keys_end * 2;
+
+    std::vector<KeyValueDB::keyrange_t> chunks;
+    db->util_divide_key_range(
+      "O", "", "",
+      10, 10000000, 0.05, chunks);
+    auto [all_keys, max_keys] = get_split_quality("O", chunks);
+    double speedup = double(all_keys) / max_keys;
+    if (verbose) std::cout << "quality=" << double(all_keys) / max_keys / chunks.size()
+      << " speedup=" << speedup << std::endl;
+    EXPECT_EQ(all_keys, keys);
+    if (all_keys > 2000000) {
+      EXPECT_GT(speedup, 6);
+    }
+    scan_split_quality("O");
+  }
+  db->close();
 }
 
 


### PR DESCRIPTION
A continuation of #64330 .
Includes #64354 .

Whole work now consists of 3 parts:
| | PR | role |
| -- | -- | -- |
| 1 | https://github.com/ceph/ceph/pull/68981 | RocksDB split range |
| 2 | https://github.com/ceph/ceph/pull/64369 | Fast recovery |
| 3 | https://github.com/ceph/ceph/pull/68984 | Testing |


Example timings of recovery of 2TB slightly thrashed RBD data.
new = baseline multithread optimization
-csum = multithread with checksum decoding skipped
-Blob = multithread that reuses 1 Blob during decoding


| threads      | new     | - csum | - Blob |
| ------------- | ------------- | -------- | ------- |
| 1  | 90.1s | 75.5s | 60.6s |  
| 2  | 48.1s | 38.8s | 29.6s | 
| 4  | 36.8s | 26.4s | 17.1s | 
| 8  | 28.2s | 17.5s | 10.1s | 
| 12 | 23.3s | 14.1s |  6.8s | 
| 16 | 21.0s | 12.2s |  5.4s | 
| 24 | 19.6s | 11.1s |  4.1s | 
| 32 | 19.8s | 10.8s |  3.5s | 
| 64 | 17.9s |  9.8s |  3.0s | 

Presented timings DO NOT include time required for RocksDB to replay WAL files.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
