### PR TITLE
mgr/dashboard: Carbonised Notification Header

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { NgbCollapseModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
@@ -12,7 +12,9 @@ import {
   DialogModule,
   GridModule,
   BreadcrumbModule,
-  ModalModule
+  ModalModule,
+  ToggleModule,
+  ButtonModule
 } from 'carbon-components-angular';
 
 import { AppRoutingModule } from '~/app/app-routing.module';
@@ -26,6 +28,8 @@ import { DashboardHelpComponent } from './dashboard-help/dashboard-help.componen
 import { IdentityComponent } from './identity/identity.component';
 import { NavigationComponent } from './navigation/navigation.component';
 import { NotificationsComponent } from './notifications/notifications.component';
+import { NotificationPanelComponent } from './notification-panel/notification-panel.component';
+import { NotificationHeaderComponent } from './notification-panel/header/notification-header.component';
 
 // Icons
 import UserFilledIcon from '@carbon/icons/es/user--filled/20';
@@ -61,7 +65,9 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
     DialogModule,
     GridModule,
     BreadcrumbModule,
-    ModalModule
+    ModalModule,
+    ToggleModule,
+    ButtonModule
   ],
   declarations: [
     AboutComponent,
@@ -69,12 +75,15 @@ import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
     BreadcrumbsComponent,
     NavigationComponent,
     NotificationsComponent,
+    NotificationPanelComponent,
+    NotificationHeaderComponent,
     DashboardHelpComponent,
     AdministrationComponent,
     IdentityComponent
   ],
-  providers: [ModalCdsService],
-  exports: [NavigationComponent, BreadcrumbsComponent]
+  exports: [NavigationComponent, BreadcrumbsComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  providers: [ModalCdsService]
 })
 export class NavigationModule {
   constructor(private iconService: IconService) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -209,7 +209,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
     );
   }
   toggleSidebar() {
-    this.notificationService.toggleSidebar();
+    this.notificationService.toggleSidebar(true, true);
   }
   trackByFn(item: any) {
     return item;

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.html
@@ -1,0 +1,27 @@
+<div class="notification-header">
+  <div class="notification-header__top">
+    <div class="notification-header__title">
+      <cds-text i18n>Tasks and Notifications</cds-text>
+    </div>
+
+    <button
+      i18n
+      cdsButton="ghost"
+      size="sm"
+      (click)="onDismissAll()"
+      class="notification-header__dismiss-btn">
+      Dismiss all
+    </button>
+  </div>
+
+  <div class="notification-header__toggle">
+    <cds-toggle
+      [checked]="isMuted"
+      size="sm"
+      (checkedChange)="onToggleMute()"
+      label="Mute notifications"
+      i18n-label
+      hideLabel="true"> <!--hides the toggle state values (like "On/Off" in the toggle button)-->
+    </cds-toggle>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.scss
@@ -1,0 +1,56 @@
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/theme';
+
+.notification-header {
+  display: flex;
+  flex-direction: column;
+  padding: spacing.$spacing-04;
+  border-bottom: 1px solid theme.$border-subtle-01;
+  background-color: theme.$layer-01;
+
+  &__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    margin-bottom: spacing.$spacing-03;
+  }
+
+  &__title {
+    h4 {
+      @include type.type-style('heading-compact-01');
+
+      color: theme.$text-primary;
+      margin: 0;
+    }
+  }
+
+  &__dismiss-btn {
+    color: theme.$text-primary;
+
+    &:hover {
+      color: theme.$link-primary;
+    }
+  }
+
+  &__toggle {
+    cds-toggle {
+      margin: 0;
+
+      ::ng-deep {
+        .cds--toggle__label-text {
+          color: theme.$text-primary;
+        }
+
+        .cds--toggle__label {
+          color: theme.$text-primary;
+        }
+
+        .cds--toggle__text {
+          color: theme.$text-primary;
+        }
+      }
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NotificationHeaderComponent } from './notification-header.component';
+import { NotificationService } from '../../../../shared/services/notification.service';
+import { BehaviorSubject } from 'rxjs';
+
+describe('NotificationHeaderComponent', () => {
+  let component: NotificationHeaderComponent;
+  let fixture: ComponentFixture<NotificationHeaderComponent>;
+  let notificationService: NotificationService;
+  let muteStateSubject: BehaviorSubject<boolean>;
+
+  beforeEach(async () => {
+    muteStateSubject = new BehaviorSubject<boolean>(false);
+    await TestBed.configureTestingModule({
+      declarations: [NotificationHeaderComponent],
+      providers: [
+        {
+          provide: NotificationService,
+          useValue: {
+            muteState$: muteStateSubject.asObservable(),
+            removeAll: jasmine.createSpy('removeAll'),
+            suspendToasties: jasmine.createSpy('suspendToasties')
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotificationHeaderComponent);
+    component = fixture.componentInstance;
+    notificationService = TestBed.inject(NotificationService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize with default mute state', () => {
+    expect(component.isMuted).toBe(false);
+  });
+
+  it('should update mute state when subscription emits', () => {
+    muteStateSubject.next(true);
+    fixture.detectChanges();
+    expect(component.isMuted).toBe(true);
+  });
+
+  it('should emit dismissAll event and call removeAll on dismiss', () => {
+    spyOn(component.dismissAll, 'emit');
+
+    component.onDismissAll();
+
+    expect(component.dismissAll.emit).toHaveBeenCalled();
+    expect(notificationService.removeAll).toHaveBeenCalled();
+  });
+
+  it('should toggle mute state', () => {
+    component.isMuted = false;
+    component.onToggleMute();
+    expect(notificationService.suspendToasties).toHaveBeenCalledWith(true);
+
+    component.isMuted = true;
+    component.onToggleMute();
+    expect(notificationService.suspendToasties).toHaveBeenCalledWith(false);
+  });
+
+  it('should unsubscribe on destroy', () => {
+    spyOn(component['subs'], 'unsubscribe');
+    component.ngOnDestroy();
+    expect(component['subs'].unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/header/notification-header.component.ts
@@ -1,0 +1,38 @@
+import { Component, Output, EventEmitter, OnInit, OnDestroy } from '@angular/core';
+import { NotificationService } from '../../../../shared/services/notification.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'cd-notification-header',
+  templateUrl: './notification-header.component.html',
+  styleUrls: ['./notification-header.component.scss']
+})
+export class NotificationHeaderComponent implements OnInit, OnDestroy {
+  @Output() dismissAll = new EventEmitter<void>();
+
+  isMuted = false;
+  private subs = new Subscription();
+
+  constructor(private notificationService: NotificationService) {}
+
+  ngOnInit(): void {
+    this.subs.add(
+      this.notificationService.muteState$.subscribe((isMuted) => {
+        this.isMuted = isMuted;
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subs.unsubscribe();
+  }
+
+  onDismissAll(): void {
+    this.dismissAll.emit();
+    this.notificationService.removeAll();
+  }
+
+  onToggleMute(): void {
+    this.notificationService.suspendToasties(!this.isMuted);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.html
@@ -1,0 +1,4 @@
+<div class="notification-panel">
+  <cd-notification-header></cd-notification-header>
+  <!-- Body and footer components will be added here later -->
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.scss
@@ -1,0 +1,18 @@
+@use '@carbon/styles/scss/theme';
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/theme' as *;
+
+.notification-panel {
+  @include theme.theme(themes.$g10);
+
+  position: absolute;
+  top: spacing.$spacing-09;
+  right: 0;
+  width: 400px; // Keep original width as it doesn't map to a spacing token
+  background-color: $layer-01;
+  box-shadow: $shadow;
+  border: 1px solid $border-subtle-01;
+  z-index: 6000;
+  color: $text-primary;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NotificationPanelComponent } from './notification-panel.component';
+import { NotificationService } from '../../../shared/services/notification.service';
+
+describe('NotificationPanelComponent', () => {
+  let component: NotificationPanelComponent;
+  let fixture: ComponentFixture<NotificationPanelComponent>;
+  let notificationService: NotificationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotificationPanelComponent],
+      providers: [
+        {
+          provide: NotificationService,
+          useValue: {
+            toggleSidebar: jasmine.createSpy('toggleSidebar')
+          }
+        }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NotificationPanelComponent);
+    component = fixture.componentInstance;
+    notificationService = TestBed.inject(NotificationService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('handleClickOutside', () => {
+    it('should close sidebar when clicking outside', () => {
+      // Create a click event outside the component
+      const outsideClickEvent = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true
+      });
+      document.dispatchEvent(outsideClickEvent);
+
+      expect(notificationService.toggleSidebar).toHaveBeenCalledWith(false, true);
+    });
+
+    it('should not close sidebar when clicking inside', () => {
+      // Create a click event inside the component
+      const insideClickEvent = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true
+      });
+
+      const componentElement = fixture.nativeElement;
+      componentElement.dispatchEvent(insideClickEvent);
+
+      expect(notificationService.toggleSidebar).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notification-panel/notification-panel.component.ts
@@ -1,0 +1,19 @@
+import { Component, ElementRef, HostListener } from '@angular/core';
+import { NotificationService } from '../../../shared/services/notification.service';
+
+@Component({
+  selector: 'cd-notification-panel',
+  templateUrl: './notification-panel.component.html',
+  styleUrls: ['./notification-panel.component.scss']
+})
+export class NotificationPanelComponent {
+  constructor(public notificationService: NotificationService, private elementRef: ElementRef) {}
+
+  @HostListener('document:click', ['$event'])
+  handleClickOutside(event: Event) {
+    const clickedInside = this.elementRef.nativeElement.contains(event.target);
+    if (!clickedInside) {
+      this.notificationService.toggleSidebar(false, true);
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.html
@@ -1,13 +1,19 @@
 <a i18n-title
    title="Tasks and Notifications"
    [ngClass]="{ 'running': hasRunningTasks }"
-   >
-  <svg cdsIcon="notification"
-       size="20"
-       title="notification"></svg>
-  <span class="dot"
-        *ngIf="hasNotifications">
-  </span>
+   (click)="togglePanel($event)">
+  <div class="notification-icon-wrapper">
+    <svg cdsIcon="notification"
+         size="20"
+         title="notification"></svg>
+    <span class="notification-count"
+          *ngIf="notificationCount > 0">
+      {{ notificationCount }}
+    </span>
+  </div>
   <span class="d-md-none"
         i18n>Tasks and Notifications</span>
 </a>
+
+<cd-notification-panel *ngIf="isPanelOpen && useNewPanel"></cd-notification-panel>
+<cd-notifications-sidebar *ngIf="isPanelOpen && !useNewPanel"></cd-notifications-sidebar>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.scss
@@ -1,4 +1,7 @@
 @use './src/styles/vendor/variables' as vv;
+@use '@carbon/styles/scss/spacing';
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/type';
 
 .running i {
   color: vv.$primary;
@@ -24,4 +27,29 @@ a {
     background-color: vv.$white;
     border-color: vv.$primary-500;
   }
+}
+
+.notification-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+  padding: spacing.$spacing-04;
+  cursor: pointer;
+  border-radius: spacing.$spacing-01;
+  transition: background-color 0.2s ease;
+}
+
+.notification-count {
+  position: absolute;
+  top: spacing.$spacing-01;
+  right: spacing.$spacing-01;
+  min-width: spacing.$spacing-04;
+  height: spacing.$spacing-04;
+  padding: 0 spacing.$spacing-01;
+  border-radius: spacing.$spacing-02;
+  background-color: $support-error;
+  color: $text-on-color;
+  font-size: spacing.$spacing-04;
+  line-height: spacing.$spacing-04;
+  text-align: center;
+  font-weight: 500;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
@@ -16,6 +16,9 @@ export class NotificationsComponent implements OnInit, OnDestroy {
   icons = Icons;
   hasRunningTasks = false;
   hasNotifications = false;
+  isPanelOpen = false;
+  useNewPanel = true;
+  notificationCount = 0;
   private subs = new Subscription();
 
   constructor(
@@ -33,8 +36,22 @@ export class NotificationsComponent implements OnInit, OnDestroy {
     this.subs.add(
       this.notificationService.data$.subscribe((notifications: CdNotification[]) => {
         this.hasNotifications = notifications.length > 0;
+        this.notificationCount = notifications.length;
       })
     );
+
+    this.subs.add(
+      this.notificationService.panelState$.subscribe((state) => {
+        this.isPanelOpen = state.isOpen;
+        this.useNewPanel = state.useNewPanel;
+      })
+    );
+  }
+
+  togglePanel(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.notificationService.toggleSidebar(!this.isPanelOpen, this.useNewPanel);
   }
 
   ngOnDestroy(): void {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.spec.ts
@@ -180,14 +180,14 @@ describe('NotificationsSidebarComponent', () => {
     it('should always close if sidebarSubject value is true', fakeAsync(() => {
       // Closed before next value
       expect(component.isSidebarOpened).toBeFalsy();
-      notificationService.sidebarSubject.next(true);
+      notificationService.toggleSidebar(true, true);
       tick();
       expect(component.isSidebarOpened).toBeFalsy();
 
       // Opened before next value
       component.isSidebarOpened = true;
       expect(component.isSidebarOpened).toBeTruthy();
-      notificationService.sidebarSubject.next(true);
+      notificationService.toggleSidebar(true, true);
       tick();
       expect(component.isSidebarOpened).toBeFalsy();
     }));
@@ -195,13 +195,13 @@ describe('NotificationsSidebarComponent', () => {
     it('should toggle sidebar visibility if sidebarSubject value is false', () => {
       // Closed before next value
       expect(component.isSidebarOpened).toBeFalsy();
-      notificationService.sidebarSubject.next(false);
+      notificationService.toggleSidebar(true, false);
       expect(component.isSidebarOpened).toBeTruthy();
 
       // Opened before next value
       component.isSidebarOpened = true;
       expect(component.isSidebarOpened).toBeTruthy();
-      notificationService.sidebarSubject.next(false);
+      notificationService.toggleSidebar(false, false);
       expect(component.isSidebarOpened).toBeFalsy();
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
@@ -102,17 +102,9 @@ export class NotificationsSidebarComponent implements OnInit, OnDestroy {
     );
 
     this.subs.add(
-      this.notificationService.sidebarSubject.subscribe((forceClose) => {
-        if (forceClose) {
-          this.isSidebarOpened = false;
-        } else {
-          this.isSidebarOpened = !this.isSidebarOpened;
-        }
-
-        window.clearTimeout(this.timeout);
-        this.timeout = window.setTimeout(() => {
-          this.cdRef.detectChanges();
-        }, 0);
+      this.notificationService.panelState$.subscribe((state) => {
+        this.isSidebarOpened = state.isOpen && !state.useNewPanel;
+        this.cdRef.detectChanges();
       })
     );
 
@@ -167,7 +159,7 @@ export class NotificationsSidebarComponent implements OnInit, OnDestroy {
   }
 
   closeSidebar() {
-    this.isSidebarOpened = false;
+    this.notificationService.toggleSidebar(false, false);
   }
 
   trackByFn(index: number) {


### PR DESCRIPTION
# Implement New Notification Panel with Carbon Design System Integration

## Summary
This PR introduces a new notification panel component built with Carbon Design System (CDS) components, providing a  alternative to the existing notification sidebar. The implementation includes a boolean flag system to toggle between the new panel and legacy sidebar.
Also added unread notification counter on bell icon.

## Reference
![Screenshot From 2025-07-07 12-05-41](https://github.com/user-attachments/assets/6f0c0534-c5d3-45a4-aca2-a41f56efc3eb)

## g10 theme
<img width="777" height="286" alt="Screenshot From 2025-07-11 11-39-33" src="https://github.com/user-attachments/assets/2e14fe31-20bc-4a9e-9ffa-0ce4a0ed7163" />


https://github.com/user-attachments/assets/033a0f5f-2475-45ee-a8a2-da017e56faf0



## Boolean Flag System
- Panel behavior: New panel is shown (`useNewPanel: true`)
In the NotificationService - to set the  panel type:
Go to src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
Find line ~26 where useNewPanel: true is set
Change it to `useNewPanel: false` to use the old sidebar 

- In the NavigationComponent - to control which panel opens when clicking the notification icon:
Go to src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
Find the toggleSidebar() method around line 212
Change the second parameter from true to false  to use the old sidebar 


Fixes: https://tracker.ceph.com/issues/71732

This commit carbonises the notification header






## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
