### PR TITLE
mgr/cephadm/nvmeof: Add susbsystem cache expiration field to NVMeOF spec file

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -41,6 +41,7 @@ max_hosts = {{ spec.max_hosts }}
 max_namespaces = {{ spec.max_namespaces }}
 max_namespaces_per_subsystem = {{ spec.max_namespaces_per_subsystem }}
 max_hosts_per_subsystem = {{ spec.max_hosts_per_subsystem }}
+subsystem_cache_expiration = {{ spec.subsystem_cache_expiration }}
 
 [gateway-logs]
 log_level = {{ spec.log_level }}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -390,6 +390,7 @@ max_hosts = 2048
 max_namespaces = 2048
 max_namespaces_per_subsystem = 256
 max_hosts_per_subsystem = 128
+subsystem_cache_expiration = 5
 
 [gateway-logs]
 log_level = INFO

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1410,6 +1410,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  max_namespaces: Optional[int] = 2048,
                  max_namespaces_per_subsystem: Optional[int] = 256,
                  max_hosts_per_subsystem: Optional[int] = 128,
+                 subsystem_cache_expiration: Optional[int] = 5,
                  server_key: Optional[str] = None,
                  server_cert: Optional[str] = None,
                  client_key: Optional[str] = None,
@@ -1537,6 +1538,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.max_namespaces_per_subsystem = max_namespaces_per_subsystem
         #: ``max_hosts_per_subsystem`` max number of hosts per subsystems
         self.max_hosts_per_subsystem = max_hosts_per_subsystem
+        #: ``subsystem_cache_expiration`` number of seconds before subsystems cache expires
+        self.subsystem_cache_expiration = subsystem_cache_expiration
         #: ``allowed_consecutive_spdk_ping_failures`` # of ping failures before aborting gateway
         self.allowed_consecutive_spdk_ping_failures = allowed_consecutive_spdk_ping_failures
         #: ``spdk_ping_interval_in_seconds`` sleep interval in seconds between SPDK pings
@@ -1739,6 +1742,8 @@ class NvmeofServiceSpec(ServiceSpec):
         verify_positive_int(self.max_namespaces, "Max namespaces")
         verify_positive_int(self.max_namespaces_per_subsystem, "Max namespaces per subsystem")
         verify_positive_int(self.max_hosts_per_subsystem, "Max hosts per subsystem")
+        verify_non_negative_number(self.subsystem_cache_expiration,
+                                   "Subsystem cache expiration period")
         verify_non_negative_number(self.monitor_timeout, "Monitor timeout")
         verify_non_negative_int(self.port, "Port")
         verify_non_negative_int(self.discovery_port, "Discovery port")


### PR DESCRIPTION
mgr/cephadm/nvmeof: Add susbsystem cache expiration field to NVMeOF spec file

Fixes https://tracker.ceph.com/issues/72019
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>