### PR TITLE
mgr/cephadm: adding new command to get cephadm default images

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1683,6 +1683,7 @@ def command_agent(ctx: CephadmContext) -> None:
 
 ##################################
 
+
 @executes_early
 def command_version(ctx):
     # type: (CephadmContext) -> int
@@ -4277,13 +4278,20 @@ def command_rescan_disks(ctx: CephadmContext) -> str:
     return f'Ok. {len(all_scan_files)} adapters detected: {len(scan_files)} rescanned, {len(skipped)} skipped, {len(failures)} failed ({elapsed:.2f}s)'
 
 
+@executes_early
 def command_list_images(ctx: CephadmContext) -> None:
     """this function will list the default images used by different services"""
-    cp_obj = ConfigParser()
-    cp_obj['mgr'] = get_mgr_images()
-    # print default images
-    cp_obj.write(sys.stdout)
-
+    from ceph.cephadm.images import DefaultImages
+    if ctx.format == 'json':
+        print(json.dumps(DefaultImages.as_dict(), indent=2))
+    elif ctx.format == 'yaml':
+        import yaml
+        print(yaml.dump(DefaultImages.as_dict(), sort_keys=True))
+    else:
+        cp_obj = ConfigParser()
+        cp_obj['mgr'] = get_mgr_images()
+        # print default images
+        cp_obj.write(sys.stdout)
 
 def update_service_for_daemon(ctx: CephadmContext,
                               available_daemons: list,
@@ -5192,6 +5200,11 @@ def _get_parser():
     parser_list_images = subparsers.add_parser(
         'list-images', help='list all the default images')
     parser_list_images.set_defaults(func=command_list_images)
+    parser_list_images.add_argument(
+        '--format',
+        choices=['json', 'yaml'],
+        default=None,
+        help='Specifies output format (json or yaml)')
 
     parser_update_service = subparsers.add_parser(
         'update-osd-service', help='update service for provided daemon')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3288,6 +3288,10 @@ Then run the following:
                 'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
+    def list_default_images(self) -> Dict:
+        return DefaultImages.as_dict()
+
+    @handle_orch_error
     def get_security_config(self) -> Dict[str, bool]:
         security_enabled, mgmt_gw_enabled, _ = self._get_security_config()
         return {'security_enabled': security_enabled,

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -880,6 +880,10 @@ class Orchestrator(object):
         """get security config"""
         raise NotImplementedError()
 
+    def list_default_images(self) -> OrchResult[Dict[str, str]]:
+        """get cephadm default images"""
+        raise NotImplementedError()
+
     def set_alertmanager_access_info(self, user: str, password: str) -> OrchResult[str]:
         """set alertmanager access information"""
         raise NotImplementedError()

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1403,6 +1403,15 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         except ArgumentError as e:
             return HandleCommandResult(-errno.EINVAL, "", (str(e)))
 
+    @_cli_read_command('orch list-images')
+    def _list_default_images(self) -> HandleCommandResult:
+        try:
+            completion = self.list_default_images()
+            result = raise_if_exception(completion)
+            return HandleCommandResult(stdout=json.dumps(result, indent=2))
+        except ArgumentError as e:
+            return HandleCommandResult(-errno.EINVAL, "", (str(e)))
+
     @_cli_write_command('orch prometheus set-credentials')
     def _set_prometheus_access_info(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> HandleCommandResult:
         try:

--- a/src/python-common/ceph/cephadm/images.py
+++ b/src/python-common/ceph/cephadm/images.py
@@ -56,6 +56,16 @@ class DefaultImages(Enum):
     def desc(self) -> str:
         return self.value.desc
 
+    @classmethod
+    def as_dict(cls) -> dict:
+        return {
+            item.name: {
+                'key': item.key,
+                'image_ref': item.image_ref,
+                'desc': item.desc
+            }
+            for item in cls
+        }
 
 class NonCephImageServiceTypes(Enum):
     prometheus = 'prometheus'


### PR DESCRIPTION

https://tracker.ceph.com/issues/72021

Adding support both in the cephadm binary as in the cephadm CLI to get default images:

```
./cephadm get-default-images | jq                                                                 ✔ 
{
  "PROMETHEUS": {
    "key": "container_image_prometheus",
    "image_ref": "quay.io/prometheus/prometheus:v2.51.0",
    "desc": "Prometheus container image"
  },
  "LOKI": {
    "key": "container_image_loki",
    "image_ref": "docker.io/grafana/loki:3.0.0",
    "desc": "Loki container image"
  },
  "PROMTAIL": {
    "key": "container_image_promtail",
    "image_ref": "docker.io/grafana/promtail:3.0.0",
    "desc": "Promtail container image"
  },

```

From cephadm CLI:

```
[ceph: root@ceph-node-0 /]# ceph orch get-default-images | jq
{
  "PROMETHEUS": {
    "key": "container_image_prometheus",
    "image_ref": "quay.io/prometheus/prometheus:v2.51.0",
    "desc": "Prometheus container image"
  },
  "LOKI": {
    "key": "container_image_loki",
    "image_ref": "docker.io/grafana/loki:3.0.0",
    "desc": "Loki container image"
  },
  "PROMTAIL": {
    "key": "container_image_promtail",
    "image_ref": "docker.io/grafana/promtail:3.0.0",
    "desc": "Promtail container image"
  },
  "NODE_EXPORTER": {
    "key": "container_image_node_exporter",
    "image_ref": "quay.io/prometheus/node-exporter:v1.7.0",
    "desc": "Node exporter container image"
  },

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
