### PR TITLE
tentacle: mon/MgrStatMonitor.cc: cleanup pool_availability

### DIFF
--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -205,7 +205,7 @@ void MgrStatMonitor::calc_pool_availability()
       avail.last_uptime = reset_availability_last_uptime_downtime_val.value();
     }
   }
-  pending_pool_availability.swap(pool_availability);
+  pending_pool_availability = pool_availability;
   reset_availability_last_uptime_downtime_val.reset();
 }
 
@@ -242,7 +242,11 @@ void MgrStatMonitor::update_from_paxos(bool *need_bootstrap)
   check_subs();
   update_logger();
   mon.osdmon()->notify_new_pg_digest();
-  calc_pool_availability();
+
+  // only calculate pool_availability within leader mon
+  if (mon.is_leader()) {
+      calc_pool_availability();
+  }
 }
 
 void MgrStatMonitor::update_logger()

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -56,7 +56,6 @@ public:
 
   void calc_pool_availability();
   bool enable_availability_tracking = g_conf().get_val<bool>("enable_availability_tracking"); ///< tracking availability score feature 
-  std::optional<utime_t> reset_availability_last_uptime_downtime_val;
   
   void clear_pool_availability(int64_t poolid);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72027

---

backport of https://github.com/ceph/ceph/pull/64004
parent tracker: https://tracker.ceph.com/issues/71857

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh