### PR TITLE
squid: doc: Document ceph-mgr module configuration options

### DIFF
--- a/doc/dev/config.rst
+++ b/doc/dev/config.rst
@@ -96,6 +96,8 @@ the configuration. Just like with set_val, you should call apply_changes after
 calling these functions to make sure your changes get applied.
 
 
+.. _dev config defining options:
+
 Defining config options
 =======================
 
@@ -103,6 +105,13 @@ Config options are defined in ``common/options/*.yaml.in``. The options are cate
 by their consumers. If an option is only used by ceph-osd, it should go to
 ``osd.yaml.in``. All the ``.yaml.in`` files are translated into ``.cc`` and ``.h`` files
 at build time by ``y2c.py``.
+
+.. note::
+   Ceph-mgr modules use the same configuration system as other Ceph components,
+   but their configuration options are defined within each module's Python
+   implementation. For details on defining mgr module configuration options,
+   see :ref:`mgr module dev configuration options`.
+
 
 Each option is represented using a YAML mapping (dictionary). A typical option looks like
 

--- a/doc/mgr/modules.rst
+++ b/doc/mgr/modules.rst
@@ -400,6 +400,7 @@ be automatically processed. Example:
 
 .. _`Rule of Silence`: http://www.linfo.org/rule_of_silence.html
 
+.. _mgr module dev configuration options:
 
 Configuration options
 ---------------------
@@ -412,14 +413,70 @@ Modules can load and store configuration options using the
    certificates). If you want to persist module-internal data or
    binary configuration data consider using the `KV store`_.
 
-You must declare your available configuration options in the
-``MODULE_OPTIONS`` class attribute, like this:
+Configuration options must be declared in the ``MODULE_OPTIONS`` class attribute:
 
 .. code-block:: python
 
     MODULE_OPTIONS = [
-        Option(name="my_option")
+        Option(name="check_interval",
+               level=OptionLevel.ADVANCED,
+               default=60,
+               type="secs",
+               desc="The interval in seconds to check the inbox",
+               long_desc="The interval in seconds to check the inbox. Set to 0 to disable the check",
+               min=0,
+               runtime=True)
     ]
+
+The example above demonstrates most supported properties, though typically only
+a subset is needed. The following properties are supported:
+
+**name**
+    The option's name. This is the only required property.
+
+**type** (optional, default: ``str``)
+    The option's data type. Supported types:
+
+    * ``uint`` - unsigned 64-bit integer
+    * ``int`` - signed 64-bit integer
+    * ``str`` - string
+    * ``float`` - double-precision floating point
+    * ``bool`` - boolean
+    * ``addr`` - Ceph messenger address for peer communication
+    * ``addrvec`` - comma-separated list of Ceph messenger addresses
+    * ``uuid`` - UUID as defined by `RFC 4122 <https://www.ietf.org/rfc/rfc4122.txt>`_
+    * ``size`` - size value (stored as uint64_t)
+    * ``secs`` - timespan in format ``"<number><unit>..."``, e.g., ``"3h 2m 1s"`` or ``"3weeks"``
+
+      Supported units: ``s``, ``sec``, ``second(s)``, ``m``, ``min``, ``minute(s)``,
+      ``h``, ``hr``, ``hour(s)``, ``d``, ``day(s)``, ``w``, ``wk``, ``week(s)``,
+      ``mo``, ``month(s)``, ``y``, ``yr``, ``year(s)``
+
+    * ``millisecs`` - timespan in milliseconds
+
+**desc**
+    Short description (can be a sentence fragment).
+
+**long_desc**
+    Detailed description using complete sentences or paragraphs.
+
+**default**
+    Default value for the option.
+
+**min** / **max**
+    Minimum and maximum allowed values.
+
+**enum_allowed**
+    For ``str`` type options, a list of allowed string values. Values outside this set are rejected.
+
+**see_also**
+    List of related option names (used in documentation only).
+
+**tags**
+    List of tags for categorizing the option (used in documentation only).
+
+**runtime** (default: ``False``)
+    Whether the option can be updated after module loading.
 
 If you try to use ``set_module_option`` or ``get_module_option`` on options
 not declared in ``MODULE_OPTIONS``, an exception will be raised.


### PR DESCRIPTION
Add comprehensive documentation for defining configuration options in ceph-mgr modules, including all supported properties and their usage.

Previously, the documentation did not explain how to define ceph-mgr module configuration options, despite subtle differences from other Ceph components. This change documents all supported Option properties, their types, and provides clear examples to help module developers properly configure their options.


(cherry picked from commit 121192f4c95df0ee282cecc7237c8ca788e9cfba)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
