### PR TITLE
tentacle: mgr/dashboard: rm requirements-extra file

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-extra.txt
+++ b/src/pybind/mgr/dashboard/requirements-extra.txt
@@ -1,1 +1,0 @@
-python3-saml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72036

---

backport of https://github.com/ceph/ceph/pull/64380
parent tracker: https://tracker.ceph.com/issues/70937

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh