### PR TITLE
RFC: generic inode capability related debug information

### DIFF
--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -302,9 +302,11 @@ void Capability::dump(ceph::Formatter *f) const
   if (inode)
     f->dump_stream("ino") << inode->ino();
   f->dump_unsigned("last_sent", last_sent);
+  f->dump_unsigned("last_issue", last_issue);
   f->dump_stream("last_issue_stamp") << last_issue_stamp;
   f->dump_stream("wanted") << ccap_string(_wanted);
   f->dump_stream("pending") << ccap_string(_pending);
+  f->dump_stream("issued") << ccap_string(_issued);
 
   f->open_array_section("revokes");
   for (const auto &r : _revokes) {

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -308,13 +308,18 @@ void Capability::dump(ceph::Formatter *f) const
   f->dump_stream("pending") << ccap_string(_pending);
   f->dump_stream("issued") << ccap_string(_issued);
 
-  f->open_array_section("revokes");
-  for (const auto &r : _revokes) {
-    f->open_object_section("revoke");
-    r.dump(f);
+  if (int _revoking = revoking()) {
+    f->dump_unsigned("revoking", _revoking);
+    f->dump_stream("last_revoke_stamp") << last_revoke_stamp;
+    // dump revocation list (in-flight revokes)
+    f->open_array_section("revokes");
+    for (const auto &r : _revokes) {
+      f->open_object_section("revoke");
+      r.dump(f);
+      f->close_section();
+    }
     f->close_section();
   }
-  f->close_section();
 }
 
 void Capability::generate_test_instances(std::list<Capability*>& ls)

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -133,8 +133,8 @@ void Capability::revoke_info::decode(ceph::buffer::list::const_iterator& bl)
 
 void Capability::revoke_info::dump(ceph::Formatter *f) const
 {
-  f->dump_unsigned("before", before);
-  f->dump_unsigned("seq", seq);
+  f->dump_unsigned("prior_pending", before);
+  f->dump_unsigned("last_sent", seq);
   f->dump_unsigned("last_issue", last_issue);
 }
 

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2546,6 +2546,22 @@ int Locker::get_allowed_caps(CInode *in, Capability *cap,
   return allowed;
 }
 
+void Locker::dump_in_flight_cap_revokes(client_t client, Formatter *f) {
+  dout(20) << ": client=" << client << dendl;
+
+  auto it = revoking_caps_by_client.find(client);
+  if (it == revoking_caps_by_client.end()) {
+    return;
+  }
+
+  f->open_object_section("revoking_caps");
+  for (elist<Capability*>::iterator iter = it->second.begin(); !iter.end(); ++iter) {
+    Capability *cap = *iter;
+    cap->dump(f);
+  }
+  f->close_section();
+}
+
 int Locker::issue_caps(CInode *in, Capability *only_cap)
 {
   dout(20) << __func__ << ": " << *in;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3729,11 +3729,17 @@ void Locker::process_request_cap_release(const MDRequestRef& mdr, client_t clien
     
   if (ceph_seq_cmp(mseq, cap->get_mseq()) < 0) {
     dout(7) << " mseq " << mseq << " < " << cap->get_mseq() << ", dropping" << dendl;
+    if (mds->logger) {
+      mds->logger->inc(l_mdsss_request_cap_release_dropped);
+    }
     return;
   }
 
   if (cap->get_cap_id() != cap_id) {
     dout(7) << " cap_id " << cap_id << " != " << cap->get_cap_id() << ", dropping" << dendl;
+    if (mds->logger) {
+      mds->logger->inc(l_mdsss_request_cap_release_dropped);
+    }
     return;
   }
 

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -211,6 +211,9 @@ public:
   void revoke_client_leases(SimpleLock *lock);
   void encode_lease(bufferlist& bl, const session_info_t& info, const LeaseStat& ls);
 
+  // dump revoking caps
+  void dump_in_flight_cap_revokes(client_t client, Formatter *f);
+
 protected:
   void send_lock_message(SimpleLock *lock, int msg);
   void send_lock_message(SimpleLock *lock, int msg, const bufferlist &data);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -559,6 +559,9 @@ void MDSDaemon::set_up_admin_socket()
     "dump stray",
     asok_hook,
     "dump stray folder content");
+  r = admin_socket->register_command("dump_in_flight_cap_revokes name=client_id,type=CephString,req=true",
+				     asok_hook,
+				     "dump in-flight cap revoke messages sent to a client");
   ceph_assert(r == 0);
 }
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3097,6 +3097,22 @@ void MDSRankDispatcher::handle_asok_command(
      dout(10) << "dump_stray wait" << dendl;
     }
     return;
+  } else if (command == "dump_in_flight_cap_revokes") {
+    std::string client_id;
+    if (!cmd_getval(cmdmap, "client_id", client_id)) {
+      *css << "Invalid client_id specified";
+      r = -ENOENT;
+      goto out;
+    }
+    std::lock_guard l(mds_lock);
+    Session *session = sessionmap.get_session(
+      entity_name_t(CEPH_ENTITY_TYPE_CLIENT, strtol(client_id.c_str(), 0, 10)));
+    if (!session) {
+      *css << "cannot find client session";
+      r = -ENOENT;
+      goto out;
+    }
+    locker->dump_in_flight_cap_revokes(session->get_client(), f);
   } else {
     r = -ENOSYS;
   }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3722,6 +3722,8 @@ void MDSRank::create_logger()
                            "Client cap release msg", "hccr", PerfCountersBuilder::PRIO_INTERESTING);
     mds_plb.add_u64_counter(l_mdss_process_request_cap_release, "process_request_cap_release",
                            "Process request cap release", "prcr", PerfCountersBuilder::PRIO_INTERESTING);
+    mds_plb.add_u64_counter(l_mdsss_request_cap_release_dropped, "process_request_cap_release_dropped",
+			    "Process request cap release dropped", "prcd", PerfCountersBuilder::PRIO_INTERESTING);
     mds_plb.add_u64_counter(l_mdss_ceph_cap_op_revoke, "ceph_cap_op_revoke",
                            "Revoke caps", "crev", PerfCountersBuilder::PRIO_INTERESTING);
     mds_plb.add_u64_counter(l_mdss_ceph_cap_op_grant, "ceph_cap_op_grant",

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -100,6 +100,7 @@ enum {
   l_mdss_handle_client_caps_dirty,
   l_mdss_handle_client_cap_release,
   l_mdss_process_request_cap_release,
+  l_mdsss_request_cap_release_dropped,
   l_mds_last,
 };
 


### PR DESCRIPTION
This is an initial step to be able to gather enough information when issues like "client not responding to cap revoke request" show up as health warnings. We would want to add more. Starting with:

- dump release caps from request (MclientRequest::releases) [Credit: Patrick]
- OpTracker with MClientCaps (in the client - is there a kernel driver equivalent?)
- binary tracing integration with qa suite (to be able to dump the logs when tests fail or health warnings are generated)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
