### PR TITLE
tentacle: qa/suites/crimson-rados/singleton: add install task

### DIFF
--- a/qa/suites/crimson-rados/singleton/all/osd-backfill.yaml
+++ b/qa/suites/crimson-rados/singleton/all/osd-backfill.yaml
@@ -11,6 +11,7 @@ openstack:
       count: 3
       size: 10 # GB
 tasks:
+- install:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72029

---

backport of https://github.com/ceph/ceph/pull/64370
parent tracker: https://tracker.ceph.com/issues/71990

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh