### PR TITLE
mgr/cephadm: unset MON flag during upgrade

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -518,7 +518,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         Option(
             'upgrade_unset_mon_flags',
             type='str',
-            default='',
+            default='enable_availability_tracking',
             desc='Comma separated list of mon flags to unset when --unset-mon-flags '
             'is passed to the upgrade command'
         ),

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -515,6 +515,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             default='169.254.1.1',
             desc="Default IP address for RedFish API (OOB management)."
         ),
+        Option(
+            'upgrade_unset_mon_flags',
+            type='str',
+            default='',
+            desc='Comma separated list of mon flags to unset when --unset-mon-flags '
+            'is passed to the upgrade command'
+        ),
     ]
     for image in DefaultImages:
         MODULE_OPTIONS.append(Option(image.key, default=image.image_ref, desc=image.desc))
@@ -622,6 +629,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.certificate_automated_rotation_enabled = False
             self.certificate_check_debug_mode = False
             self.certificate_check_period = 0
+            self.upgrade_unset_mon_flags: str = ''
 
         self.notify(NotifyType.mon_map, None)
         self.config_notify()
@@ -3056,6 +3064,65 @@ Then run the following:
 
         return osd[0]
 
+    def set_global_mon_flag(self, flag: str) -> None:
+        # attempt to set a mon flag. If we get a nonzero return code,
+        # raise an OrchestratorError
+        rc, out, err = self.mon_command({
+            'prefix': 'config set',
+            'who': 'mon', 
+            'name': f'{flag}',
+            'value': 'true', 
+        })
+        if rc:
+            self.log.warning(
+                f"Setting mon flag {flag} failed with return code {rc}: {err}")
+            raise OrchestratorError(
+                f"Setting mon flag {flag} failed with return code {rc}: {err}")
+        else:
+            self.log.info(
+                f"Set global mon flag {flag}")
+
+    def unset_global_mon_flag(self, flag: str) -> None:
+        # attempt to unset an mon flag. If we get a nonzero return code,
+        # raise an OrchestratorError
+        rc, out, err = self.mon_command({
+            'prefix': 'config set',
+            'who': 'mon', 
+            'name': f'{flag}',
+            'value': 'false', 
+        })
+        if rc:
+            self.log.warning(
+                f"Unsetting mon flag {flag} failed with return code {rc}: {err}")
+            raise OrchestratorError(
+                f"Unsetting mon flag {flag} failed with return code {rc}: {err}")
+        else:
+            self.log.info(
+                f"Unset global mon flag {flag}")
+
+    def is_global_mon_flag_set(self, flag: str) -> bool:
+        # returns if the given mon flag is set or not. If we get a
+        # nonzero return code, raise an OrchestratorError
+        rc, out, err = self.mon_command({
+            'prefix': 'config get',
+            'who': 'mon',
+            'key': f'{flag}',
+        })
+        if rc:
+            self.log.warning(
+                f"Failed trying to find set mon flags with `ceph config get mon` (rc: {rc}): {err}")
+            raise OrchestratorError(
+                f"Failed trying to find set mon flags with `ceph config get mon` (rc: {rc}): {err}")
+
+        try:
+            s = (out or "").strip().lower()
+            if s in {"true", "yes", "on", "enabled", "enable", "set"}:
+                return True
+            if s in {"false", "no", "off", "disabled", "disable", "unset"}:
+                return False
+        except Exception as e:
+            raise OrchestratorError(f'Failed to get set mon flags: {e}')
+
     def _trigger_preview_refresh(self,
                                  specs: Optional[List[DriveGroupSpec]] = None,
                                  service_name: Optional[str] = None,
@@ -4328,7 +4395,8 @@ Then run the following:
     @handle_orch_error
     def upgrade_start(self, image: str, version: str, daemon_types: Optional[List[str]] = None, host_placement: Optional[str] = None,
                       services: Optional[List[str]] = None, limit: Optional[int] = None,
-                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> str:
+                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None,
+                      unset_mon_flags: bool = False) -> str:
         if self.inventory.get_host_with_state("maintenance"):
             raise OrchestratorError("Upgrade aborted - you have host(s) in maintenance state")
         if self.offline_hosts:
@@ -4372,7 +4440,7 @@ Then run the following:
                     f'Upgrade aborted - --limit arg must be a positive integer, not {limit}')
 
         return self.upgrade.upgrade_start(
-            image, version, daemon_types, hosts, services, limit, bucket_type, bucket_name)
+            image, version, daemon_types, hosts, services, limit, bucket_type, bucket_name, unset_mon_flags)
 
     @handle_orch_error
     def upgrade_pause(self) -> str:

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -204,6 +204,7 @@ class UpgradeState:
                  crush_bucket_name: Optional[str] = None,
                  noautoscale_set: Optional[bool] = False,
                  prior_autoscale: Optional[bool] = True,
+                 mon_flags: Optional[List[str]] = None,
                  ):
 
         self._target_name: str = target_name  # Use CephadmUpgrade.target_image instead.
@@ -226,6 +227,7 @@ class UpgradeState:
         self.crush_bucket_name = crush_bucket_name
         self.noautoscale_set = noautoscale_set
         self.prior_autoscale = prior_autoscale
+        self.mon_flags = mon_flags
 
     def to_json(self) -> dict:
         return {
@@ -248,6 +250,7 @@ class UpgradeState:
             'crush_bucket_name': self.crush_bucket_name,
             'noautoscale_set': self.noautoscale_set,
             'prior_autoscale': self.prior_autoscale,
+            'mon_flags': self.mon_flags,
         }
 
     @classmethod
@@ -272,6 +275,7 @@ class CephadmUpgrade:
         'UPGRADE_OFFLINE_HOST',
         'UPGRADE_INVALID_CRUSH_BUCKET',
         'UPGRADE_OSD_NO_VERSION',
+        'UPGRADE_FAILED_UNSETTING_MON_FLAGS',
     ]
 
     def __init__(self, mgr: "CephadmOrchestrator"):
@@ -553,7 +557,7 @@ class CephadmUpgrade:
 
     def upgrade_start(self, image: str, version: str, daemon_types: Optional[List[str]] = None,
                       hosts: Optional[List[str]] = None, services: Optional[List[str]] = None, limit: Optional[int] = None,
-                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> str:
+                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None, unset_mon_flags: bool = False) -> str:
         fail_fs_value = cast(bool, self.mgr.get_module_option_ex(
             'orchestrator', 'fail_fs', False))
         if self.mgr.mode != 'root':
@@ -596,6 +600,7 @@ class CephadmUpgrade:
         if running_mgr_count < 2:
             raise OrchestratorError('Need at least 2 running mgr daemons for upgrade')
 
+        mon_flags = None if unset_mon_flags else [f.strip() for f in self.mgr.upgrade_unset_mon_flags.split(',')]
         self.mgr.log.info('Upgrade: Started with target %s' % target_name)
         self.upgrade_state = UpgradeState(
             target_name=target_name,
@@ -608,6 +613,7 @@ class CephadmUpgrade:
             remaining_count=limit,
             crush_bucket_type=bucket_type,
             crush_bucket_name=bucket_name,
+            mon_flags=mon_flags,
         )
         # One-time PG autoscaling decision when upgrade includes OSDs
         if self._upgrade_includes_osds(daemon_types, hosts, services):
@@ -628,6 +634,27 @@ class CephadmUpgrade:
                     self.upgrade_state.noautoscale_set = True
                     # Store prior state from current OSD noautoscale status for restore
                     self.upgrade_state.prior_autoscale = prior_autoscale
+
+        # unset mon flags for upgrade
+        if self.upgrade_state.mon_flags:
+            try:
+                flags_toggled = list()
+                for flag in self.upgrade_state.mon_flags:
+                    if self.mgr.is_global_mon_flag_set(flag):
+                        self.mgr.unset_global_mon_flag(flag)
+                        flags_toggled.append(flag)
+                # set mon_flags to the list of flags actually unset before upgrade.
+                # this is to ensure we only re-set these flags at end of upgrade 
+                # and don't mistakenly set any flag that wasn't set before upgrade. 
+                self.upgrade_state.mon_flags = flags_toggled
+            except OrchestratorError as e:
+                self._fail_upgrade('UPGRADE_FAILED_UNSETTING_MON_FLAGS', {
+                    'severity': 'error',
+                    'summary': 'Upgrade: Failed to unset mon flags for upgrade',
+                    'count': 1,
+                    'detail': [f'Upgrade: Failed to unset mon flags for upgrade: {str(e)}'],
+                })
+
         self._update_upgrade_progress(0.0)
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()
@@ -768,6 +795,7 @@ class CephadmUpgrade:
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()
         self.mgr.event.set()
+        self._reset_upgrade_mon_flags()
         return 'Stopped upgrade to %s' % target_image
 
     def update_service(self, service_type: str, service_image: str, image: str) -> List[str]:
@@ -1107,6 +1135,7 @@ class CephadmUpgrade:
 
         logger.error('Upgrade: Paused due to %s: %s' % (alert_id,
                                                         alert['summary']))
+        self._reset_upgrade_mon_flags() 
         self.upgrade_state.error = alert_id + ': ' + alert['summary']
         self.upgrade_state.paused = True
         # Do not restore PG autoscaling here: upgrade is only paused. Restore
@@ -1135,6 +1164,19 @@ class CephadmUpgrade:
             self.mgr.set_store('upgrade_state', None)
             return
         self.mgr.set_store('upgrade_state', json.dumps(self.upgrade_state.to_json()))
+
+    def _reset_upgrade_mon_flags(self) -> None: 
+        # Upgrade is complete. Reset mon flags
+        if self.upgrade_state.mon_flags:
+            try:
+                for flag in self.upgrade_state.mon_flags:
+                    if not self.mgr.is_global_mon_flag_set(flag):
+                        self.mgr.set_global_mon_flag(flag)
+            except OrchestratorError as e:
+                # the upgrade is already basically complete here
+                # so it doesn't make sense to mark it failed if we can't
+                # unset the OSD flags. Just log an error?
+                self.mgr.log.error(f'Failed to set MON flags at end of upgrade: {str(e)}') 
 
     def get_distinct_container_image_settings(self) -> Dict[str, str]:
         # get all distinct container_image settings
@@ -1699,6 +1741,7 @@ class CephadmUpgrade:
         if getattr(self.upgrade_state, 'noautoscale_set', False):
             self._unset_noautoscale()
             self.upgrade_state.noautoscale_set = False
+        self._reset_upgrade_mon_flags()
         logger.info('Upgrade: Complete!')
         if self.upgrade_state.progress_id:
             self.mgr.remote('progress', 'complete',

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -961,7 +961,8 @@ class Orchestrator(object):
 
     def upgrade_start(self, image: Optional[str], version: Optional[str], daemon_types: Optional[List[str]],
                       hosts: Optional[str], services: Optional[List[str]], limit: Optional[int],
-                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None) -> OrchResult[str]:
+                      bucket_type: Optional[str] = None, bucket_name: Optional[str] = None,
+                      unset_mon_flags: bool = False) -> OrchResult[str]:
         raise NotImplementedError()
 
     def upgrade_pause(self) -> OrchResult[str]:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2623,7 +2623,8 @@ Usage:
                        limit: Optional[int] = None,
                        ceph_version: Optional[str] = None,
                        crush_bucket_type: Optional[str] = None,
-                       crush_bucket_name: Optional[str] = None) -> HandleCommandResult:
+                       crush_bucket_name: Optional[str] = None, 
+                       unset_mon_flags: bool = False)  -> HandleCommandResult:
         """Initiate upgrade"""
         self._upgrade_check_image_name(image, ceph_version)
 


### PR DESCRIPTION
This PR unsets the specified mon flags before an upgrade starts and sets them after an upgrade. This will be used to disable availability tracking before an upgrade and enable it again after the upgrade is complete. The code is written in an extensible way, such that any further usecases will only have to make a single line change to achieve the same. 

Scenarios handled: 


|Type|Resolution|
|-----|-----------|
| Full upgrade | flag unset before upgrade; flag reset after upgrade. |
|Staggered upgrade| flag unset and reset for each upgrade step triggered by user.|
|Upgrade stopped by user manually using `ceph orch upgrade stop`| flag is reset before command exits|
|Upgrade fails| flag is reset before command exits|

Fixes: https://tracker.ceph.com/issues/72489

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
