### PR TITLE
bluestore: Faster allocation recovery - evolution (2)

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5296,6 +5296,19 @@ options:
   desc: Remove allocation info from RocksDB and store the info in a new allocation file
   default: true
   with_legacy: true
+- name: bluestore_allocation_recovery_threads
+  type: uint
+  level: basic
+  desc: Amount of threads for allocation recovery after OSD crash.
+  long_desc: The optimal value varies. For NVMe DBs may be as large as 8.
+    Value of 0 means one wants to use legacy recovery procedure.
+    Value of 1 means singlethreaded recovery with new procedure.
+  default: 0
+  with_legacy: false
+  flags:
+    - startup
+  see_also:
+    - bluestore_allocation_from_file
 - name: bluestore_debug_inject_allocation_from_file_failure
   type: float
   level: dev

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -66,6 +66,7 @@ set(alien_store_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/Compression.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueStore_debug.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueAdmin.cc
+  ${PROJECT_SOURCE_DIR}/src/os/bluestore/OnodeScan.cc
   ${PROJECT_SOURCE_DIR}/src/os/memstore/MemStore.cc)
 
 add_library(crimson-alienstore STATIC

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -187,7 +187,13 @@ struct error_code;
 	  end_ptr(p->end_c_str()),
 	  deep(d)
       {}
-
+      iterator_impl(const char* start, const char* end_ptr)
+        : bp(nullptr),
+          start(start),
+          pos(start),
+          end_ptr(end_ptr),
+          deep(true)
+      {}
       friend class ptr;
 
     public:
@@ -262,7 +268,12 @@ struct error_code;
     const_iterator begin_deep(size_t offset=0) const {
       return const_iterator(this, offset, true);
     }
-
+    // A specific iterator that is just pointing memory, and not attached to any buffer::ptr.
+    // The use for it is decoding using denc data coming from RocksDB keys without a need to
+    // pack it into buffer::ptr.
+    static const_iterator begin_deep_detached(const char* start, const char* end_ptr) {
+      return const_iterator(start, end_ptr);
+    }
     // misc
     bool is_aligned(unsigned align) const {
       return ((uintptr_t)c_str() & (align-1)) == 0;

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -409,6 +409,13 @@ public:
 				       const std::string& key_prefix) {
     return 0;
   }
+  /// estimate space utilization for a specified range (in bytes)
+  virtual int64_t estimate_range_size(
+    const std::string& prefix,
+    const std::string& key_from,
+    const std::string& key_to) {
+      return 0;
+  };
 
   /// compact the underlying store
   virtual void compact() {}

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -484,7 +484,25 @@ protected:
   /// List of matching prefixes/ColumnFamilies and merge operators
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
-
+public:
+  struct keyrange_t {
+    std::string first_key;    // is in the range if exists
+    std::string upper_bound;  // is not in the range even if exists
+  };
+  /// splits a key range into multiple chunks of more or less equal size
+  virtual void util_divide_key_range(
+    const std::string& prefix,        // table to operate on
+    const std::string& starting_key,  // included if exists
+    const std::string& guardrail_key, // excluded if exists
+    uint64_t chunk_count,             // desired chunk count, but fewer can happen
+    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    float accepted_variance,          // +/- fluctuation of produced chunk size,
+                                      // smaller value requires more work, use 0.1 ?
+    std::vector<keyrange_t>& chunks){ // out: chunks
+      chunks.clear();
+      chunks.emplace_back(starting_key, guardrail_key);
+      return;
+    }
 };
 
 #endif

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -3647,3 +3647,184 @@ bool RocksDBStore::get_sharding(std::string& sharding) {
   }
   return result;
 }
+
+// Find a key that is lexicographically between low and high.
+// Try to select "midpoint".
+// If high is a direct successor to low, return "".
+static string key_between(const string& low, const string& high)
+{
+  string result;
+  ceph_assert(low.compare(high) < 0);
+  size_t same = 0;
+  while (same < std::min(low.length(), high.length()) &&
+         low[same] == high[same]) {
+    same++;
+  }
+  if (same == low.length()) {
+    //
+    size_t i = same;
+    while (i < high.length() && high[i] == '\0') {
+      i++;
+    }
+    if (i == high.length()) {
+      // special case that "high"="len00..000"; halfway formula does not work
+      if (i == same + 1) {
+        // just "high" = "len0", no key in-between
+        return string();
+      } else {
+        // add half zeros
+        result = low;
+        result.append(string((same + 1 - i) / 2, '\0'));
+        return result;
+      }
+    }
+  }
+  const std::string &shorter = low.length() < high.length() ? low : high;
+  const std::string &longer = low.length() < high.length() ? high : low;
+
+  result = shorter;
+  result.resize(longer.length() + 1);
+  uint16_t carry = 0;
+  // "+"
+  for (size_t i = longer.length() - 1; i + 1 > same; i--) {
+    uint8_t a = i < shorter.length() ? shorter[i] : 0;
+    uint8_t b = longer[i];
+    uint16_t v = ((uint16_t)a + (uint16_t)b + carry);
+    carry = v >> 8;
+    result[i + 1] = v;
+  }
+  result[same] = carry;
+  //  ">>1"
+  for (size_t i = same; i < longer.length(); i++) {
+    uint16_t v =
+        ((uint16_t)(uint8_t)result[i] << 8) | (uint16_t)(uint8_t)result[i + 1];
+    result[i] = v >> 1;
+  }
+  result[longer.length()] = (uint8_t)result[longer.length()] >> 7;
+  return result;
+};
+
+void RocksDBStore::util_divide_key_range(
+  const string& prefix,
+  const string& starting_key,   //included if exists
+  const string& guardrail_key,  //excluded if exists
+  uint64_t chunk_count,
+  uint64_t min_chunk_size,
+  float accepted_variance,
+  vector<keyrange_t>& chunks)
+{
+  dout(10) << __func__ << " chunks=" << chunk_count
+    << " start=" << pretty_binary_string(starting_key)
+    << " end=" << pretty_binary_string(guardrail_key) << dendl;
+  chunks.clear();
+  map<uint64_t, string> cs_map;
+  string key_from, key_to;
+  auto db_it = get_iterator(prefix);
+  db_it->lower_bound(starting_key);
+  if (!db_it) return; //empty range
+  key_from = db_it->key();
+  db_it->lower_bound(guardrail_key);
+  if (!db_it->valid()) {
+    db_it->seek_to_last();
+    ceph_assert(db_it->valid());
+    key_to = db_it->key();
+    key_to.push_back('\0');
+  } else {
+    key_to = db_it->key();
+    if (key_to <= key_from) return;
+  }
+  uint64_t full_size = estimate_range_size(prefix, key_from, key_to);
+  cs_map[0] = key_from;
+  cs_map[full_size] = key_to;
+  uint64_t target_chunk_size = full_size / chunk_count;
+  uint64_t chunk_min = target_chunk_size * (1 - accepted_variance);
+  uint64_t chunk_max = target_chunk_size * (1 + accepted_variance);
+  if (full_size <= chunk_max) {
+    chunks.emplace_back(key_from, key_to);
+    return;
+  }
+  if (target_chunk_size < chunk_min) {
+    chunk_count = std::min<uint64_t>(chunk_count, full_size / chunk_min + 1);
+    target_chunk_size = full_size / chunk_count;
+    chunk_min = target_chunk_size * (1 - accepted_variance);
+    chunk_max = target_chunk_size * (1 + accepted_variance);
+  }
+  dout(10) << __func__ << " chunks=" << chunk_count
+    << " key_from=" << pretty_binary_string(key_from)
+    << " key_to=" << pretty_binary_string(key_to) << dendl;
+
+  ceph_assert(chunk_count >= 2);
+  dout(20) << "target_chunk_size=" << target_chunk_size
+    << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+  // Algorithm idea:
+  // Have a mapping MAP with elements: estimated_db_size[key_from .. x] -> x.
+  // Keep bisecting [key_from .. key_to].
+  // When MAP[last] - MAP[current_candidate] is in acceptable range for chunk size
+  //   emit the range and move forward.
+  auto it = cs_map.begin();
+  uint64_t cs_anchor = it->first;
+  string cs_key = it->second;
+  uint32_t bisect_actions = 0;
+  while(true) {
+    ceph_assert(it != cs_map.end());
+    it++;
+    ceph_assert(cs_map.end() != it);
+    dout(20) << "trying   " << it->first << " " << pretty_binary_string(it->second) << dendl;
+    if (it->first - cs_anchor > chunk_max) {
+      if (bisect_actions == 100) {
+        chunks.clear();
+        chunks.emplace_back(key_from, key_to);
+        return;
+      }
+      bisect_actions++;
+      // it is too far, need to roll back and divide
+      auto key_e = it->second;
+      it--;
+      auto key_b = it->second;
+      auto imagined_key = key_between(key_b, key_e);
+      dout(20) << pretty_binary_string(key_b) << "..." << pretty_binary_string(key_e)
+        << "-> midpoint=" << pretty_binary_string(imagined_key) << dendl;
+      ceph_assert( key_b < imagined_key);
+      ceph_assert(imagined_key < key_e);
+      db_it->upper_bound(imagined_key);
+      ceph_assert(db_it->valid());
+      auto real_key = db_it->key();
+      if (real_key == key_e) {
+        db_it->prev();
+        real_key = db_it->key();
+      }
+      uint64_t cs_size = estimate_range_size(prefix, key_from, real_key);
+      if (cs_size > it->first) {
+        cs_map[cs_size] = real_key;
+        dout(20) << "newpoint " << cs_size << " " << pretty_binary_string(real_key) << dendl;
+        ceph_assert(key_b < real_key);
+        ceph_assert(real_key <= key_e);
+        continue;
+      } else {
+        // this seems to be limit for precision, no reason to attempt biseciton further
+        // fell out and emit region
+      }
+    } else if (it->first - cs_anchor < chunk_min) {
+      continue;
+    }
+
+    bisect_actions = 0;
+    // we are satisfied enough
+    chunks.emplace_back(cs_key, it->second);
+    dout(10) << "produced chunk size=" << it->first - cs_anchor << " "
+      << pretty_binary_string(cs_key) << " " << pretty_binary_string(it->second) << dendl;
+    if (chunks.size() == chunk_count - 1) {
+      chunks.emplace_back(it->second, key_to);
+      dout(10) << "produced chunk size=" << full_size - it->first << " "
+        << pretty_binary_string(it->second) << " " << pretty_binary_string(key_to) << dendl;
+      break;
+    }
+    cs_anchor = it->first;
+    cs_key = it->second;
+    target_chunk_size = (full_size - cs_anchor) / (chunk_count - chunks.size());
+    chunk_min = target_chunk_size * (1 - accepted_variance);
+    chunk_max = target_chunk_size * (1 + accepted_variance);
+    dout(20) << "target_chunk_size=" << target_chunk_size
+      << " chunk_min=" << chunk_min << " chunk_max=" << chunk_max << dendl;
+  }
+}

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -285,6 +285,9 @@ public:
 
   int64_t estimate_prefix_size(const std::string& prefix,
 			       const std::string& key_prefix) override;
+  int64_t estimate_range_size(const std::string& prefix,
+                              const std::string& key_from,
+                              const std::string& key_to) override;
   struct RocksWBHandler;
   class RocksDBTransactionImpl : public KeyValueDB::TransactionImpl {
   public:

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -560,7 +560,15 @@ public:
   };
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
   bool get_sharding(std::string& sharding);
-
+  void util_divide_key_range(
+    const std::string& prefix,        // table to operate on
+    const std::string& starting_key,  // included if exists
+    const std::string& guardrail_key, // excluded if exists
+    uint64_t chunk_count,             // desired chunk count, but fewer can happen
+    uint64_t min_chunk_size,          // do not produce chunk smaller than this
+    float accepted_variance,          // +/- fluctuation of produced chunk size,
+                                      // smaller value requires more work, use 0.1 ?
+    std::vector<keyrange_t>& chunks) override;
 };
 
 #endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2939,7 +2939,6 @@ void BlueStore::Blob::maybe_prune_tail() {
   }
 }
 
-#ifndef CACHE_BLOB_BL
 void BlueStore::Blob::decode(
   bufferptr::const_iterator& p,
   uint64_t struct_v,
@@ -2969,7 +2968,6 @@ void BlueStore::Blob::decode(
     }
   }
 }
-#endif
 
 // Extent
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -20661,6 +20661,23 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
       ++stats.shard_count;
     }
   }
+  return 0;
+}
+
+//---------------------------------------------------------
+int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &stats)
+{
+  // first set space used by superblock
+  auto super_length = std::max<uint64_t>(min_alloc_size, SUPER_RESERVED);
+  set_allocation_in_simple_bmap(sbmap, 0, super_length);
+  stats.extent_count++;
+
+  // then set all space taken by Objects
+  int ret = read_allocation_from_onodes(sbmap, stats);
+  if (ret < 0) {
+    derr << "failed read_allocation_from_onodes()" << dendl;
+    return ret;
+  }
 
   std::lock_guard l(vstatfs_lock);
   store_statfs_t s;
@@ -20682,23 +20699,6 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
   vstatfs.publish(&s);
   dout(5) << __func__ << " recovered " << s
           << dendl;
-  return 0;
-}
-
-//---------------------------------------------------------
-int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &stats)
-{
-  // first set space used by superblock
-  auto super_length = std::max<uint64_t>(min_alloc_size, SUPER_RESERVED);
-  set_allocation_in_simple_bmap(sbmap, 0, super_length);
-  stats.extent_count++;
-
-  // then set all space taken by Objects
-  int ret = read_allocation_from_onodes(sbmap, stats);
-  if (ret < 0) {
-    derr << "failed read_allocation_from_onodes()" << dendl;
-    return ret;
-  }
 
   return 0;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -347,7 +347,7 @@ static void get_shared_blob_key(uint64_t sbid, string *key)
   _key_encode_u64(sbid, key);
 }
 
-static int get_key_shared_blob(const string& key, uint64_t *sbid)
+int get_key_shared_blob(const string& key, uint64_t *sbid)
 {
   const char *p = key.c_str();
   if (key.length() < sizeof(uint64_t))
@@ -433,7 +433,7 @@ static int _get_key_object(const char *p, ghobject_t *oid)
 }
 
 template<typename S>
-static int get_key_object(const S& key, ghobject_t *oid)
+int get_key_object(const S& key, ghobject_t *oid)
 {
   if (key.length() < ENCODED_KEY_PREFIX_LEN)
     return -1;
@@ -442,6 +442,8 @@ static int get_key_object(const S& key, ghobject_t *oid)
   const char *p = key.c_str();
   return _get_key_object(p, oid);
 }
+
+template int get_key_object(const string& key, ghobject_t *oid);
 
 template<typename S>
 static void _get_object_key(const ghobject_t& oid, S *key)
@@ -550,7 +552,7 @@ int get_key_extent_shard(const string& key, string *onode_key, uint32_t *offset)
   return 0;
 }
 
-static bool is_extent_shard_key(const string& key)
+bool is_extent_shard_key(const string& key)
 {
   return *key.rbegin() == EXTENT_SHARD_KEY_SUFFIX;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2939,36 +2939,6 @@ void BlueStore::Blob::maybe_prune_tail() {
   }
 }
 
-void BlueStore::Blob::decode(
-  bufferptr::const_iterator& p,
-  uint64_t struct_v,
-  uint64_t* sbid,
-  bool include_ref_map,
-  Collection *coll)
-{
-  denc(blob, p, struct_v);
-  if (blob.is_shared()) {
-    denc(*sbid, p);
-  }
-  if (include_ref_map) {
-    if (struct_v > 1) {
-      used_in_blob.decode(p);
-    } else {
-      used_in_blob.clear();
-      bluestore_extent_ref_map_t legacy_ref_map;
-      legacy_ref_map.decode(p);
-      if (coll) {
-        for (auto r : legacy_ref_map.ref_map) {
-          get_ref(
-            coll,
-            r.first,
-            r.second.refs * r.second.length);
-        }
-      }
-    }
-  }
-}
-
 // Extent
 
 void BlueStore::Extent::dump(Formatter* f) const
@@ -4081,9 +4051,8 @@ void BlueStore::ExtentMap::ExtentDecoder::decode_extent(
       consume_blobid(le, false, blobid - 1);
     } else {
       // dummy onodes might not have collections, we need a check for it.
-      BlobRef b = c ? c->new_blob() : new Blob(nullptr);
       uint64_t sbid = 0;
-      b->decode(p, struct_v, &sbid, false, c);
+      BlobRef b = decode_create_blob(p, struct_v, &sbid, false, c);
       consume_blob(le, extent_pos, sbid, b);
     }
   }
@@ -4129,15 +4098,29 @@ void BlueStore::ExtentMap::ExtentDecoder::decode_spanning_blobs(
   unsigned n;
   denc_varint(n, p);
   while (n--) {
-    BlobRef b = c ? c->new_blob() : new Blob(nullptr);
-    denc_varint(b->id, p);
+    decltype(Blob::id) id;
+    denc_varint(id, p);
+
     uint64_t sbid = 0;
-    b->decode(p, struct_v, &sbid, true, c);
+    BlobRef b = decode_create_blob(p, struct_v, &sbid, true, c);
+    b->id = id;
     consume_spanning_blob(sbid, b);
   }
 }
 
 /////////////////// BlueStore::ExtentMap::DecoderExtentFull ///////////
+
+BlueStore::BlobRef BlueStore::ExtentMap::ExtentDecoderFull::decode_create_blob(
+  bptr_c_it_t& p,
+  __u8 struct_v,
+  uint64_t* sbid,
+  bool include_ref_map,
+  Collection* c) {
+  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
+  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  return b;
+}
+
 void BlueStore::ExtentMap::ExtentDecoderFull::consume_blobid(
   BlueStore::Extent* le, bool spanning, uint64_t blobid) {
   ceph_assert(le);
@@ -20458,6 +20441,16 @@ void BlueStore::set_allocation_in_simple_bmap(SimpleBitmap* sbmap, uint64_t offs
   sbmap->set(offset >> min_alloc_size_order, length >> min_alloc_size_order);
 }
 
+BlueStore::BlobRef BlueStore::ExtentDecoderPartial::decode_create_blob(
+  bptr_c_it_t& p,
+  __u8 struct_v,
+  uint64_t* sbid,
+  bool include_ref_map,
+  Collection* c) {
+  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
+  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  return b;
+}
 void BlueStore::ExtentDecoderPartial::_consume_new_blob(bool spanning,
                                                         uint64_t extent_no,
                                                         uint64_t sbid,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -20675,7 +20675,12 @@ int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &
   stats.extent_count++;
 
   // then set all space taken by Objects
-  int ret = read_allocation_from_onodes(sbmap, stats);
+  int ret;
+  if (cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads") == 0) {
+    ret = read_allocation_from_onodes(sbmap, stats);
+  } else {
+    ret = read_allocation_from_onodes_mt(sbmap, stats);
+  }
   if (ret < 0) {
     derr << "failed read_allocation_from_onodes()" << dendl;
     return ret;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4070,6 +4070,7 @@ private:
     std::map<uint64_t, volatile_statfs> actual_pool_vstatfs;
     volatile_statfs actual_store_vstatfs;
   };
+  class Decoder_AllocationsAndStatFS;
   class ExtentDecoderPartial : public ExtentMap::ExtentDecoder {
     BlueStore& store;
     read_alloc_stats_t& stats;
@@ -4151,6 +4152,7 @@ private:
   int  read_allocation_from_drive_on_startup();
   int  reconstruct_allocations(SimpleBitmap *smbmp, read_alloc_stats_t &stats);
   int  read_allocation_from_onodes(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
+  int  read_allocation_from_onodes_mt(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
   int  commit_freelist_type();
   int  commit_to_null_manager();
   int  commit_to_real_manager();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4052,6 +4052,8 @@ public:
   int  push_allocation_to_rocksdb();
   int  read_allocation_from_drive_for_bluestore_tool();
 #endif
+  int compare_allocation_recovery_for_bluestore_tool();
+
   void set_allocation_in_simple_bmap(SimpleBitmap* sbmap, uint64_t offset, uint64_t length);
 
 private:
@@ -4123,18 +4125,24 @@ private:
   };
 
   friend std::ostream& operator<<(std::ostream& out, const read_alloc_stats_t& stats) {
+    out << "==========================================================" << std::endl
+        << "onode_count             = " ;out.width(10);out << stats.onode_count << std::endl
+        << "shard_count             = " ;out.width(10);out << stats.shard_count << std::endl
+        << "shared_blob_count       = " ;out.width(10);out << stats.shared_blob_count << std::endl
+        << "compressed_blob_count   = " ;out.width(10);out << stats.compressed_blob_count << std::endl
+        << "spanning_blob_count     = " ;out.width(10);out << stats.spanning_blob_count << std::endl
+        << "skipped_illegal_extent  = " ;out.width(10);out << stats.skipped_illegal_extent << std::endl
+        << "extent_count            = " ;out.width(10);out << stats.extent_count << std::endl
+        << "insert_count            = " ;out.width(10);out << stats.insert_count << std::endl;
+    store_statfs_t s;
+    stats.actual_store_vstatfs.publish(&s);
+    out << "store " << s << std::endl;
+    for (auto& ps :stats.actual_pool_vstatfs) {
+      store_statfs_t s;
+      ps.second.publish(&s);
+      out << "pool " << ps.first << " " << s << std::endl;
+    }
     out << "==========================================================" << std::endl;
-    out << "NCB::onode_count             = " ;out.width(10);out << stats.onode_count << std::endl
-	<< "NCB::shard_count             = " ;out.width(10);out << stats.shard_count << std::endl
-	<< "NCB::shared_blob_count      = " ;out.width(10);out << stats.shared_blob_count << std::endl
-	<< "NCB::compressed_blob_count   = " ;out.width(10);out << stats.compressed_blob_count << std::endl
-	<< "NCB::spanning_blob_count     = " ;out.width(10);out << stats.spanning_blob_count << std::endl
-	<< "NCB::skipped_illegal_extent  = " ;out.width(10);out << stats.skipped_illegal_extent << std::endl
-	<< "NCB::extent_count            = " ;out.width(10);out << stats.extent_count << std::endl
-	<< "NCB::insert_count            = " ;out.width(10);out << stats.insert_count << std::endl;
-
-    out << "==========================================================" << std::endl;
-
     return out;
   }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -4161,6 +4161,8 @@ private:
   int  reconstruct_allocations(SimpleBitmap *smbmp, read_alloc_stats_t &stats);
   int  read_allocation_from_onodes(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
   int  read_allocation_from_onodes_mt(SimpleBitmap *smbmp, read_alloc_stats_t& stats);
+  class OnodeScanMT;
+  friend OnodeScanMT;
   int  commit_freelist_type();
   int  commit_to_null_manager();
   int  commit_to_real_manager();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1057,6 +1057,7 @@ public:
       }
 
       unsigned decode_some(const ceph::buffer::list& bl, Collection* c);
+      unsigned decode_some(std::string_view sv, Collection* c);
       void decode_spanning_blobs(bptr_c_it_t& p, Collection* c);
     };
 
@@ -1405,6 +1406,11 @@ public:
     static void decode_raw(
       BlueStore::Onode* on,
       const bufferlist& v,
+      ExtentMap::ExtentDecoder& dencoder,
+      bool use_onode_segmentation);
+    static void decode_raw(
+      BlueStore::Onode* on,
+      std::string_view v,
       ExtentMap::ExtentDecoder& dencoder,
       bool use_onode_segmentation);
 

--- a/src/os/bluestore/CMakeLists.txt
+++ b/src/os/bluestore/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(bluestore OBJECT
   HybridAllocator.cc
   Writer.cc
   Compression.cc
+  OnodeScan.cc
   BlueAdmin.cc
   BlueEnv.cc)
 

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -281,7 +281,7 @@ class BlueStore::OnodeScanMT {
         edecoder.reset(oid,
                        &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
         Onode dummy_on(cct);
-        Onode::decode_raw(&dummy_on, it->value(), edecoder, store.segment_size != 0);
+        Onode::decode_raw(&dummy_on, it->value_as_sv(), edecoder, store.segment_size != 0);
         ++stats.onode_count;
       } else {
         edecoder.reset_new_shard();
@@ -297,7 +297,7 @@ class BlueStore::OnodeScanMT {
         if (oid != edecoder.get_oid()) {
           continue;
         }
-        edecoder.decode_some(it->value(), nullptr);
+        edecoder.decode_some(it->value_as_sv(), nullptr);
         ++stats.shard_count;
       }
     }

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -1,0 +1,250 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2025 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+#include "BlueStore.h"
+#include "common/pretty_binary.h"
+#include "simple_bitmap.h"
+using namespace std;
+
+// kv store prefixes, copied from BlueStore.cc
+const string PREFIX_SUPER = "S";       // field -> value
+const string PREFIX_STAT = "T";        // field -> value(int64 array)
+const string PREFIX_COLL = "C";        // collection name -> cnode_t
+const string PREFIX_OBJ = "O";         // object name -> onode_t
+const string PREFIX_OMAP = "M";        // u64 + keyname -> value
+const string PREFIX_PGMETA_OMAP = "P"; // u64 + keyname -> value(for meta coll)
+const string PREFIX_PERPOOL_OMAP = "m"; // s64 + u64 + keyname -> value
+const string PREFIX_PERPG_OMAP = "p";   // u64(pool) + u32(hash) + u64(id) + keyname -> value
+const string PREFIX_DEFERRED = "L";    // id -> deferred_transaction_t
+const string PREFIX_ALLOC = "B";       // u64 offset -> u64 length (freelist)
+const string PREFIX_ALLOC_BITMAP = "b";// (see BitmapFreelistManager)
+const string PREFIX_SHARED_BLOB = "X"; // u64 SB id -> shared_blob_t
+
+#undef dout_prefix
+#define dout_prefix *_dout << "bs.onode_scan "
+#undef dout_context
+#define dout_context cct
+#define dout_subsys ceph_subsys_bluestore
+
+int get_key_shared_blob(const string& key, uint64_t *sbid);
+bool is_extent_shard_key(const string& key);
+template<typename S>
+  int get_key_object(const S& key, ghobject_t *oid);
+int get_key_extent_shard(const string& key, string *onode_key, uint32_t *offset);
+
+struct bool_vector_t {
+  static constexpr uint8_t null_gen = 0;
+  std::vector<uint8_t> gen_markers;
+  uint8_t current_gen = 1;
+  void mark(uint32_t pos) {
+    if (gen_markers.size() <= pos) {
+      gen_markers.resize(pos * 5 / 4 + 1);
+    }
+    gen_markers[pos] = current_gen;
+  }
+  bool check(uint32_t pos) {
+    return pos < gen_markers.size() && gen_markers[pos] == current_gen;
+  }
+  void reset() {
+    current_gen++;
+    if (current_gen == null_gen) {
+      // visited all possible generation markers, we need to clear table
+      memset(gen_markers.data(), null_gen, gen_markers.size());
+      current_gen++; // step out of invalid generation
+    }
+  }
+};
+
+class BlueStore::Decoder_AllocationsAndStatFS : public BlueStore::ExtentMap::ExtentDecoder {
+  using Extent = BlueStore::Extent;
+  BlueStore &store;
+  read_alloc_stats_t &stats;
+  SimpleBitmap &sbmap;
+  uint8_t min_alloc_size_order;
+  Extent extent;
+  ghobject_t oid;
+  volatile_statfs *per_pool_statfs = nullptr;
+  bool_vector_t is_local_blob_compressed;
+  bool_vector_t is_spanning_blob_compressed;
+
+  void _consume_new_blob(bool spanning, uint64_t extent_no, uint64_t sbid, BlobRef b);
+
+protected:
+  void consume_blobid(Extent *, bool spanning, uint64_t blobid) override;
+  void consume_blob(Extent *le, uint64_t extent_no, uint64_t sbid, BlobRef b) override;
+  void consume_spanning_blob(uint64_t sbid, BlobRef b) override;
+  Extent *get_next_extent() override {
+    ++stats.extent_count;
+    extent = Extent();
+    return &extent;
+  }
+  void add_extent(Extent *) override {}
+
+public:
+  Decoder_AllocationsAndStatFS(
+    BlueStore &_store,
+    read_alloc_stats_t &_stats,
+    SimpleBitmap &_sbmap,
+    uint8_t _min_alloc_size_order)
+    : store(_store), stats(_stats), sbmap(_sbmap), min_alloc_size_order(_min_alloc_size_order) {}
+  const ghobject_t &get_oid() const { return oid; }
+  void reset(const ghobject_t _oid, volatile_statfs *_per_pool_statfs);
+  void reset_new_shard();
+};
+
+void BlueStore::Decoder_AllocationsAndStatFS::_consume_new_blob(
+  bool spanning,
+  uint64_t extent_no,
+  uint64_t sbid,
+  BlobRef b)
+{
+  [[maybe_unused]] auto cct = store.cct;
+  ceph_assert(per_pool_statfs);
+  ceph_assert(oid != ghobject_t());
+
+  auto &blob = b->get_blob();
+  bool compressed = blob.is_compressed();
+  if(spanning) {
+    dout(20) << __func__ << " spanning " << b->id << dendl;
+    ceph_assert(b->id >= 0);
+    if (compressed) {
+      is_spanning_blob_compressed.mark(b->id);
+    }
+    ++stats.spanning_blob_count;
+  } else {
+    dout(20) << __func__ << " local " << extent_no << dendl;
+    if (compressed) {
+      is_local_blob_compressed.mark(extent_no);
+    }
+  }
+
+  uint64_t new_marked_allocations = 0;
+  for (auto &pe : blob.get_extents()) {
+    if (pe.offset != bluestore_pextent_t::INVALID_OFFSET) {
+      new_marked_allocations += sbmap.set_atomic(
+        pe.offset >> min_alloc_size_order, pe.length >> min_alloc_size_order);
+    }
+  }
+  per_pool_statfs->allocated() += new_marked_allocations
+                                  << min_alloc_size_order;
+  if (compressed) {
+    per_pool_statfs->compressed_allocated() +=
+        new_marked_allocations << min_alloc_size_order;
+    per_pool_statfs->compressed() += blob.get_compressed_payload_length();
+    ++stats.compressed_blob_count;
+  }
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::consume_blobid(
+  Extent* le, bool spanning, uint64_t blobid)
+{
+  [[maybe_unused]] auto cct = store.cct;
+  dout(20) << __func__ << " " << spanning << " " << blobid << dendl;
+  auto& vec = spanning ? is_spanning_blob_compressed : is_local_blob_compressed;
+  per_pool_statfs->stored() += le->length;
+  if (vec.check(blobid)) {
+    per_pool_statfs->compressed_original() += le->length;
+  }
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::consume_blob(
+  Extent* le, uint64_t extent_no, uint64_t sbid, BlobRef b)
+{
+  _consume_new_blob(false, extent_no, sbid, b);
+  per_pool_statfs->stored() += le->length;
+  if (b->get_blob().is_compressed()) {
+    per_pool_statfs->compressed_original() += le->length;
+  }
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::consume_spanning_blob(
+  uint64_t sbid, BlobRef b)
+{
+  _consume_new_blob(true, 0/*doesn't matter*/, sbid, b);
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::reset(
+  const ghobject_t _oid, volatile_statfs* _per_pool_statfs)
+{
+  oid = _oid;
+  per_pool_statfs = _per_pool_statfs;
+  is_local_blob_compressed.reset();
+  is_spanning_blob_compressed.reset();
+}
+
+void BlueStore::Decoder_AllocationsAndStatFS::reset_new_shard() {
+  is_local_blob_compressed.reset();
+}
+
+
+int BlueStore::read_allocation_from_onodes_mt(SimpleBitmap *sbmap, read_alloc_stats_t& stats)
+{
+  auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
+  if (!it) {
+    derr << "failed getting onode's iterator" << dendl;
+    return -ENOENT;
+  }
+
+  uint64_t            kv_count       = 0;
+  uint64_t            count_interval = 1'000'000;
+  Decoder_AllocationsAndStatFS edecoder(*this, stats, *sbmap, min_alloc_size_order);
+
+  // iterate over all ONodes stored in RocksDB
+  for (it->lower_bound(string()); it->valid(); it->next(), kv_count++) {
+    // trace an even after every million processed objects (typically every 5-10 seconds)
+    if (kv_count && (kv_count % count_interval == 0) ) {
+      dout(5) << __func__ << " processed objects count = " << kv_count << dendl;
+    }
+
+    auto key = it->key();
+    auto okey = key;
+    dout(20) << __func__ << " decode onode " << pretty_binary_string(key) << dendl;
+    ghobject_t oid;
+    if (!is_extent_shard_key(it->key())) {
+      int r = get_key_object(okey, &oid);
+      if (r != 0) {
+        derr << __func__ << " failed to decode onode key = "
+             << pretty_binary_string(okey) << dendl;
+        return -EIO;
+      }
+      edecoder.reset(oid,
+        &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
+      Onode dummy_on(cct);
+      Onode::decode_raw(&dummy_on,
+        it->value(),
+        edecoder,
+        segment_size != 0);
+      ++stats.onode_count;
+    } else {
+      edecoder.reset_new_shard();
+      uint32_t offset;
+      int r = get_key_extent_shard(key, &okey, &offset);
+      if (r != 0) {
+        derr << __func__ << " failed to decode onode extent key = "
+             << pretty_binary_string(key) << dendl;
+        return -EIO;
+      }
+      r = get_key_object(okey, &oid);
+      if (r != 0) {
+        derr << __func__
+             << " failed to decode onode key= " << pretty_binary_string(okey)
+             << " from extent key= " << pretty_binary_string(key)
+             << dendl;
+        return -EIO;
+      }
+      ceph_assert(oid == edecoder.get_oid());
+      edecoder.decode_some(it->value(), nullptr);
+      ++stats.shard_count;
+    }
+  }
+  return 0;
+}

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -79,6 +79,8 @@ class BlueStore::Decoder_AllocationsAndStatFS : public BlueStore::ExtentMap::Ext
   void _consume_new_blob(bool spanning, uint64_t extent_no, uint64_t sbid, BlobRef b);
 
 protected:
+  BlobRef decode_create_blob(
+  bptr_c_it_t& p, __u8 struct_v, uint64_t* sbid, bool include_ref_map, Collection* c) override;
   void consume_blobid(Extent *, bool spanning, uint64_t blobid) override;
   void consume_blob(Extent *le, uint64_t extent_no, uint64_t sbid, BlobRef b) override;
   void consume_spanning_blob(uint64_t sbid, BlobRef b) override;
@@ -100,6 +102,17 @@ public:
   void reset(const ghobject_t _oid, volatile_statfs *_per_pool_statfs);
   void reset_new_shard();
 };
+
+BlueStore::BlobRef BlueStore::Decoder_AllocationsAndStatFS::decode_create_blob(
+  bptr_c_it_t& p,
+  __u8 struct_v,
+  uint64_t* sbid,
+  bool include_ref_map,
+  Collection* c) {
+  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
+  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  return b;
+}
 
 void BlueStore::Decoder_AllocationsAndStatFS::_consume_new_blob(
   bool spanning,

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -75,6 +75,7 @@ class BlueStore::Decoder_AllocationsAndStatFS : public BlueStore::ExtentMap::Ext
   volatile_statfs *per_pool_statfs = nullptr;
   bool_vector_t is_local_blob_compressed;
   bool_vector_t is_spanning_blob_compressed;
+  BlobRef blob = new Blob(nullptr);
 
   void _consume_new_blob(bool spanning, uint64_t extent_no, uint64_t sbid, BlobRef b);
 
@@ -109,9 +110,9 @@ BlueStore::BlobRef BlueStore::Decoder_AllocationsAndStatFS::decode_create_blob(
   uint64_t* sbid,
   bool include_ref_map,
   Collection* c) {
-  BlobRef b = c ? c->new_blob() : new Blob(nullptr);
-  b->decode<false>(p, struct_v, sbid, include_ref_map, c);
-  return b;
+  // reuse same blob all over
+  blob->decode<false>(p, struct_v, sbid, include_ref_map, c);
+  return blob;
 }
 
 void BlueStore::Decoder_AllocationsAndStatFS::_consume_new_blob(

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -110,7 +110,7 @@ BlueStore::BlobRef BlueStore::Decoder_AllocationsAndStatFS::decode_create_blob(
   bool include_ref_map,
   Collection* c) {
   BlobRef b = c ? c->new_blob() : new Blob(nullptr);
-  b->decode<true>(p, struct_v, sbid, include_ref_map, c);
+  b->decode<false>(p, struct_v, sbid, include_ref_map, c);
   return b;
 }
 

--- a/src/os/bluestore/OnodeScan.cc
+++ b/src/os/bluestore/OnodeScan.cc
@@ -186,65 +186,175 @@ void BlueStore::Decoder_AllocationsAndStatFS::reset_new_shard() {
 }
 
 
+class BlueStore::OnodeScanMT {
+  BlueStore& store;
+  SimpleBitmap *sbmap;
+  read_alloc_stats_t& stats;
+  vector<KeyValueDB::keyrange_t> chunks;
+  uint32_t chunk_pos = 0;
+  uint64_t total = 0;
+  uint64_t interval = 1'000'000;
+  ceph::mutex lock = ceph::make_mutex("BlueStore::OnodeScanMT::lock");
+  void report_progress(uint32_t thread_no, uint64_t no_completed) {
+    auto &cct = store.cct;
+    std::lock_guard l(lock);
+    if (total / interval != (total + no_completed) / interval) {
+      dout(5) << __func__ << " processed objects count = "
+        << (total + no_completed) / interval * interval << dendl;
+    }
+    total += no_completed;
+  }
+
+  bool ask_for_work(
+    string& start_key,
+    string& upper_bound_key) {
+    std::lock_guard l(lock);
+    if (chunk_pos < chunks.size()) {
+      start_key = chunks[chunk_pos].first_key;
+      upper_bound_key = chunks[chunk_pos].upper_bound;
+      chunk_pos++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  int scan_onodes_range(
+    read_alloc_stats_t& stats,
+    const string& start_key,
+    const string& upper_bound_key)
+  {
+    auto& db = store.db;
+    auto& cct = store.cct;
+    auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
+    if (!it) {
+      derr << "failed getting onode's iterator" << dendl;
+      return -ENOENT;
+    }
+
+    uint64_t kv_count = 0;
+    uint64_t last_completed = 0;
+    uint64_t count_interval = 100'000;
+    Decoder_AllocationsAndStatFS edecoder(store, stats, *sbmap,
+                                          store.min_alloc_size_order);
+    it->lower_bound(start_key);
+    // skip to first key that is beginning of Onode
+    while (it->valid() && is_extent_shard_key(it->key())) {
+      it->next();
+    }
+    // iterate over all onodes in requested range
+    for (; it->valid(); it->next(), kv_count++) {
+      if (kv_count && (kv_count % count_interval == 0)) {
+        report_progress(0, kv_count - last_completed);
+        last_completed = kv_count;
+      }
+      auto key = it->key();
+      auto okey = key;
+      dout(20) << __func__ << " decode onode " << pretty_binary_string(key) << dendl;
+      ghobject_t oid;
+      if (!is_extent_shard_key(it->key())) {
+        if (it->key() >= upper_bound_key) {
+          // Drag iteration after upper bound until new onode is found.
+          break;
+        }
+        int r = get_key_object(okey, &oid);
+        if (r != 0) {
+          derr << __func__
+               << " failed to decode onode key = " << pretty_binary_string(okey)
+               << dendl;
+          continue;
+        }
+        edecoder.reset(oid,
+                       &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
+        Onode dummy_on(cct);
+        Onode::decode_raw(&dummy_on, it->value(), edecoder, store.segment_size != 0);
+        ++stats.onode_count;
+      } else {
+        edecoder.reset_new_shard();
+        uint32_t offset;
+        get_key_extent_shard(key, &okey, &offset);
+        int r = get_key_object(okey, &oid);
+        if (r != 0) {
+          derr << __func__
+               << " failed to decode onode key= " << pretty_binary_string(okey)
+               << " from extent key= " << pretty_binary_string(key) << dendl;
+          continue;
+        }
+        if (oid != edecoder.get_oid()) {
+          continue;
+        }
+        edecoder.decode_some(it->value(), nullptr);
+        ++stats.shard_count;
+      }
+    }
+    report_progress(0, kv_count - last_completed);
+    return 0;
+  }
+
+  void scanner_thread(
+    uint32_t thread_no,
+    read_alloc_stats_t& stats)
+  {
+    [[maybe_unused]] auto& cct = store.cct;
+    string start_key;
+    string upper_bound_key;
+    while(ask_for_work(start_key, upper_bound_key)) {
+      dout(10) << "thread " << thread_no << " runs: " << pretty_binary_string(start_key)
+        << "..." << pretty_binary_string(upper_bound_key) << dendl;
+      scan_onodes_range(stats, start_key, upper_bound_key);
+    }
+  }
+
+public:
+  OnodeScanMT(BlueStore& store, SimpleBitmap *sbmap, read_alloc_stats_t& stats)
+  : store(store), sbmap(sbmap), stats(stats) {}
+
+  int scan() {
+    [[maybe_unused]] auto& cct = store.cct;
+    std::vector<read_alloc_stats_t> thr_stats;
+    std::vector<thread> thr;
+
+    //bluestore_allocation_recovery_threads
+    size_t num_threads = cct->_conf.get_val<uint64_t>("bluestore_allocation_recovery_threads");
+    ceph_assert(num_threads > 0);
+    std::vector<double> timers;
+    store.db->util_divide_key_range(
+      PREFIX_OBJ, "", string(100, '\377'), num_threads, 50'000'000, 0.05, chunks);
+    for (size_t i = 0; i < chunks.size(); i++) {
+      dout(10) << i << ": " << pretty_binary_string(chunks[i].first_key)
+        << "..." << pretty_binary_string(chunks[i].upper_bound) << dendl;
+    }
+
+    num_threads = std::min(num_threads, chunks.size());
+    thr_stats.resize(num_threads);
+    thr.resize(num_threads);
+    timers.resize(num_threads);
+    for (size_t i = 0; i < num_threads; i++) {
+      thr[i] = std::thread(
+        &BlueStore::OnodeScanMT::scanner_thread, this, i, std::ref(thr_stats[i]));
+    }
+    for (size_t i = 0; i < num_threads; i++) {
+      thr[i].join();
+      stats.onode_count += thr_stats[i].onode_count;
+      stats.shard_count += thr_stats[i].shard_count;
+      stats.shared_blob_count += thr_stats[i].shared_blob_count;
+      stats.compressed_blob_count += thr_stats[i].compressed_blob_count;
+      stats.spanning_blob_count += thr_stats[i].spanning_blob_count;
+      stats.skipped_illegal_extent += thr_stats[i].skipped_illegal_extent;
+      stats.extent_count += thr_stats[i].extent_count;
+      stats.insert_count += thr_stats[i].insert_count;
+      for (auto &k : thr_stats[i].actual_pool_vstatfs) {
+        stats.actual_pool_vstatfs[k.first] += k.second;
+      }
+    }
+    return 0;
+  }
+};
+
 int BlueStore::read_allocation_from_onodes_mt(SimpleBitmap *sbmap, read_alloc_stats_t& stats)
 {
-  auto it = db->get_iterator(PREFIX_OBJ, KeyValueDB::ITERATOR_NOCACHE);
-  if (!it) {
-    derr << "failed getting onode's iterator" << dendl;
-    return -ENOENT;
-  }
-
-  uint64_t            kv_count       = 0;
-  uint64_t            count_interval = 1'000'000;
-  Decoder_AllocationsAndStatFS edecoder(*this, stats, *sbmap, min_alloc_size_order);
-
-  // iterate over all ONodes stored in RocksDB
-  for (it->lower_bound(string()); it->valid(); it->next(), kv_count++) {
-    // trace an even after every million processed objects (typically every 5-10 seconds)
-    if (kv_count && (kv_count % count_interval == 0) ) {
-      dout(5) << __func__ << " processed objects count = " << kv_count << dendl;
-    }
-
-    auto key = it->key();
-    auto okey = key;
-    dout(20) << __func__ << " decode onode " << pretty_binary_string(key) << dendl;
-    ghobject_t oid;
-    if (!is_extent_shard_key(it->key())) {
-      int r = get_key_object(okey, &oid);
-      if (r != 0) {
-        derr << __func__ << " failed to decode onode key = "
-             << pretty_binary_string(okey) << dendl;
-        return -EIO;
-      }
-      edecoder.reset(oid,
-        &stats.actual_pool_vstatfs[oid.hobj.get_logical_pool()]);
-      Onode dummy_on(cct);
-      Onode::decode_raw(&dummy_on,
-        it->value(),
-        edecoder,
-        segment_size != 0);
-      ++stats.onode_count;
-    } else {
-      edecoder.reset_new_shard();
-      uint32_t offset;
-      int r = get_key_extent_shard(key, &okey, &offset);
-      if (r != 0) {
-        derr << __func__ << " failed to decode onode extent key = "
-             << pretty_binary_string(key) << dendl;
-        return -EIO;
-      }
-      r = get_key_object(okey, &oid);
-      if (r != 0) {
-        derr << __func__
-             << " failed to decode onode key= " << pretty_binary_string(okey)
-             << " from extent key= " << pretty_binary_string(key)
-             << dendl;
-        return -EIO;
-      }
-      ceph_assert(oid == edecoder.get_oid());
-      edecoder.decode_some(it->value(), nullptr);
-      ++stats.shard_count;
-    }
-  }
+  OnodeScanMT scaner(*this, sbmap, stats);
+  scaner.scan();
   return 0;
 }
+

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -343,6 +343,7 @@ int main(int argc, char **argv)
     ("command", po::value<string>(&action),
         "fsck, "
         "qfsck, "
+        //"hidden_recovery_compare, "
         "allocmap, "
         "restore_cfb, "
         "repair, "
@@ -490,6 +491,7 @@ int main(int argc, char **argv)
   if (action == "fsck" || action == "repair" ||
       action == "quick-fix" || action == "allocmap" ||
       action == "qfsck" || action == "restore_cfb" ||
+      action == "hidden_recovery_compare" ||
       action == "revert-wal-to-plain") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
@@ -712,6 +714,18 @@ int main(int argc, char **argv)
       cout << action << " success" << std::endl;
     }
 #endif
+  }
+  else if( action == "hidden_recovery_compare" ) {
+    cout << action << " bluestore compare new and legacy onode recovery" << std::endl;
+    validate_path(cct.get(), path, false);
+    BlueStore bluestore(cct.get(), path);
+    int r = bluestore.compare_allocation_recovery_for_bluestore_tool();
+    if (r < 0) {
+      cerr << action << " failed: " << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    } else {
+      cout << action << " success" << std::endl;
+    }
   }
   else if (action == "fsck" ||
       action == "repair" ||

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -559,8 +559,10 @@ public:
       denc(unused, p);
     }
   }
-
-  void decode(ceph::buffer::ptr::const_iterator& p, uint64_t struct_v) {
+  struct empty_context_t {};
+  template <bool decode_csum = true, typename context_t = empty_context_t>
+  void decode(ceph::buffer::ptr::const_iterator& p, uint64_t struct_v,
+    context_t context = empty_context_t()) {
     ceph_assert(struct_v == 1 || struct_v == 2);
     denc(extents, p);
     denc_varint(flags, p);
@@ -575,8 +577,12 @@ public:
       denc(csum_chunk_order, p);
       int len;
       denc_varint(len, p);
-      csum_data = p.get_ptr(len);
-      csum_data.reassign_to_mempool(mempool::mempool_bluestore_cache_other);
+      if (decode_csum) {
+        csum_data = p.get_ptr(len);
+        csum_data.reassign_to_mempool(mempool::mempool_bluestore_cache_other);
+      } else {
+        p += len;
+      }
     }
     if (has_unused()) {
       denc(unused, p);

--- a/src/os/bluestore/simple_bitmap.cc
+++ b/src/os/bluestore/simple_bitmap.cc
@@ -17,6 +17,7 @@
 #include "include/ceph_assert.h"
 #include "bluestore_types.h"
 #include "common/debug.h"
+#include <atomic>
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
@@ -273,4 +274,96 @@ extent_t SimpleBitmap::get_next_clr_extent(uint64_t offset)
   uint64_t      soffset = words_to_bits(word_idx) + ffs;
   ext.length = (soffset - ext.offset);
   return ext;
+}
+
+//----------------------------------------------------------------------------
+uint64_t SimpleBitmap::set_atomic(uint64_t offset, uint64_t length)
+{
+  if (offset >= m_num_bits) {
+    return 0;
+  }
+  if (offset + length >= m_num_bits) {
+    length = m_num_bits - offset;
+  }
+  if (length == 0) {
+    return 0;
+  }
+
+  auto apply_mask = [&](uint64_t word, uint64_t mask) -> uint64_t {
+    // Bits are completely unrelated to each other
+    // Plus, we do not care who sets the which bits if 2 chains of sets overlap.
+    // So, going for relaxed.
+    uint64_t old_val = std::atomic_ref<uint64_t>(m_arr[word]).fetch_or(mask, std::memory_order::relaxed);
+    // We set b if mask[b] = 1 and old_val[b] = 0.
+    uint64_t we_set_those = ~old_val & mask;
+    return std::popcount(we_set_those);
+  };
+  auto [word_start, bit_start] = split(offset);
+  auto [word_end, bit_end] = split(offset + length - 1);
+
+  uint64_t mask;
+  if (word_start == word_end) {
+    mask = (FULL_MASK << bit_start) &
+           (FULL_MASK >> (MAX_BIT_NO - bit_end));
+    return apply_mask(word_start, mask);
+  }
+  uint64_t bit_set_count = 0;
+  uint64_t word = word_start;
+  mask = FULL_MASK << bit_start;
+  bit_set_count += apply_mask(word, mask);
+  word++;
+  while (word < word_end) {
+    mask = FULL_MASK;
+    bit_set_count += apply_mask(word, mask);
+    word++;
+  }
+  mask = FULL_MASK >> (MAX_BIT_NO - bit_end);
+  bit_set_count += apply_mask(word, mask);
+  return bit_set_count;
+}
+
+//----------------------------------------------------------------------------
+uint64_t SimpleBitmap::clr_atomic(uint64_t offset, uint64_t length)
+{
+  if (offset >= m_num_bits) {
+    return 0;
+  }
+  if (offset + length >= m_num_bits) {
+    length = m_num_bits - offset;
+  }
+  if (length == 0) {
+    return 0;
+  }
+
+  auto apply_mask = [&](uint64_t word, uint64_t mask) -> uint64_t {
+    // Bits are completely unrelated to each other
+    // Plus, we do not care who clears the which bits if 2 chains of sets overlap.
+    // So, going for relaxed.
+    uint64_t old_val = std::atomic_ref<uint64_t>(m_arr[word]).fetch_and(~mask, std::memory_order::relaxed);
+    // We cleared b if mask[b] = 1 and old_val[b] = 1.
+    uint64_t we_cleared_those = old_val & mask;
+    return std::popcount(we_cleared_those);
+  };
+  auto [word_start, bit_start] = split(offset);
+  auto [word_end, bit_end] = split(offset + length - 1);
+
+  uint64_t mask;
+  if (word_start == word_end) {
+    mask = (FULL_MASK << bit_start) &
+           (FULL_MASK >> (MAX_BIT_NO - bit_end));
+    return apply_mask(word_start, mask);
+  }
+  uint64_t bit_set_count = 0;
+  uint64_t word = word_start;
+  mask = FULL_MASK << bit_start;
+  bit_set_count += apply_mask(word, mask);
+  word++;
+  while (word < word_end) {
+    mask = FULL_MASK;
+    bit_set_count += apply_mask(word, mask);
+    word++;
+  }
+  mask = FULL_MASK >> (MAX_BIT_NO - bit_end);
+  bit_set_count += apply_mask(word, mask);
+  return bit_set_count;
 }

--- a/src/os/bluestore/simple_bitmap.h
+++ b/src/os/bluestore/simple_bitmap.h
@@ -49,6 +49,18 @@ public:
   // returns a copy of the next clear extent starting at @offset
   extent_t get_next_clr_extent(uint64_t offset);
 
+  // Sets a bit range (@length~@offset).
+  // This variant is safe for multithread operations.
+  // Can be intermixed with clr_atomic, but not with set or clr.
+  // Returns: count of bits set
+  uint64_t set_atomic(uint64_t offset, uint64_t length);
+
+  // Clears a bit range (@length~@offset).
+  // This variant is safe for multithread operations.
+  // Can be intermixed with set_atomic, but not with set or clr.
+  // Returns: count of bits set
+  uint64_t clr_atomic(uint64_t offset, uint64_t length);
+
   //----------------------------------------------------------------------------
   inline uint64_t get_size() {
     return m_num_bits;
@@ -137,6 +149,7 @@ private:
   constexpr static uint64_t      BITS_IN_WORD        = (BYTES_IN_WORD * 8);
   constexpr static uint64_t      BITS_IN_WORD_MASK   = (BITS_IN_WORD - 1);
   constexpr static uint64_t      BITS_IN_WORD_SHIFT  = 6;
+  constexpr static uint64_t      MAX_BIT_NO          = BITS_IN_WORD - 1;
   constexpr static uint64_t      FULL_MASK           = (~((uint64_t)0));
 
   CephContext *cct;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -15,9 +15,12 @@
 #include "perfglue/heap_profiler.h"
 #include "os/bluestore/Writer.h"
 #include "common/pretty_binary.h"
-
 #include <bitset>
 #include <sstream>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int.hpp>
+
+typedef boost::mt11213b generator_type;
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
@@ -3877,6 +3880,50 @@ TEST(SimpleBitmap, boundaries2) {
     sbmap.clr(0, bit_count);
     ASSERT_TRUE(sbmap.get_next_set_extent(0) == null_extent);
     ASSERT_TRUE(sbmap.get_next_clr_extent(0) == full_extent);
+  }
+}
+
+TEST(SimpleBitmap, multithread) {
+  generator_type rng(1234567);
+  // 2^10 = 1K * 4KB = 4MB
+  // 2^20 = 1M * 4KB = 4GB
+  // 2^30 = 1G * 4KB = 4TB
+  for (uint64_t scale = 10; scale < 30; scale++) {
+    uint64_t bit_count = boost::uniform_int<uint64_t>(1 << scale, 2 << scale)(rng);
+    std::cout << "bit_count=" << bit_count << std::endl;
+    SimpleBitmap sbmap(g_ceph_context, bit_count);
+
+    auto randomer = [&](int thread_nr, int64_t* overall_set) {
+      generator_type local_rng(thread_nr);
+      boost::uniform_int<> size_gen(1, 100);
+      boost::uniform_int<> set_clear_gen(0,1);
+      int64_t overall_set_counter = 0;
+      for (int i = 0; i < 100000; i++) {
+        uint64_t size = size_gen(local_rng);
+        uint64_t location = boost::uniform_int<uint64_t>(0, bit_count - size)(local_rng);
+        int d = set_clear_gen(local_rng);
+        if (d) {
+          overall_set_counter += sbmap.set_atomic(location, size);
+        } else {
+          overall_set_counter -= sbmap.clr_atomic(location, size);
+        }
+      }
+      *overall_set = overall_set_counter;
+    };
+    static constexpr uint8_t thread_count = 8;
+    thread thr[thread_count];
+    int64_t overall_set[thread_count] = {0};
+    for (int t = 0; t < thread_count; t++) {
+      thr[t] = thread(randomer, t, &overall_set[t]);
+    }
+    int64_t bits_set_in_threads = 0;
+    for (int t = 0; t < thread_count; t++) {
+      thr[t].join();
+      bits_set_in_threads += overall_set[t];
+    }
+
+    uint64_t bits_cleared = sbmap.clr_atomic(0, bit_count);
+    EXPECT_EQ(bits_cleared, bits_set_in_threads);
   }
 }
 


### PR DESCRIPTION
This is a work to research faster decode for BlueStore primitives.
Allocation recovery is a good place because it performs a lot of repetitive decoding of Onodes, Blobs, Extents etc.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
