### PR TITLE
[AGENT OPTIMIZATION] mgr/cephadm: Add load distribution and compression for agent metadata

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1384,10 +1384,12 @@ class CephadmAgent(DaemonForm):
                 self.target_port = config['target_port']
                 self.loop_interval = int(config['refresh_period'])
                 self.starting_port = int(config['listener_port'])
+                self.metadata_compresion_enabled = bool(config.get('metadata_compresion_enabled', False))
                 self.initial_startup_delay_max = int(config.get('initial_startup_delay_max', 0))
                 self.jitter_seconds = int(config.get('jitter_seconds', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
+                logger.info(f"Agent configuration at startup: {config}")
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
@@ -1468,7 +1470,8 @@ class CephadmAgent(DaemonForm):
                                               port=self.target_port,
                                               data=data,
                                               endpoint='/data',
-                                              ssl_ctx=self.ssl_ctx)
+                                              ssl_ctx=self.ssl_ctx,
+                                              compress=self.metadata_compresion_enabled)
                 if status != 200:
                     logger.error(f'HTTP error {status} while querying agent endpoint: {response}')
                     raise RuntimeError(f'non-200 response <{status}> from agent endpoint: {response}')

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1733,6 +1733,7 @@ class CephadmAgent(DaemonForm):
                 self.loop_interval = int(config['refresh_period'])
                 self.starting_port = int(config['listener_port'])
                 self.initial_startup_delay_max = int(config.get('initial_startup_delay_max', 0))
+                self.jitter_seconds = int(config.get('jitter_seconds', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
         except Exception as e:
@@ -1831,7 +1832,10 @@ class CephadmAgent(DaemonForm):
             self.recent_iteration_index = (self.recent_iteration_index + 1) % 3
             run_time_average = sum(self.recent_iteration_run_times, 0.0) / len([t for t in self.recent_iteration_run_times if t])
 
-            self.event.wait(max(self.loop_interval - int(run_time_average), 0))
+            # Add ± jitter_seconds to introduce randomness
+            jitter = random.uniform(-self.jitter_seconds, self.jitter_seconds)
+            delay = max(self.loop_interval - int(run_time_average) + jitter, 0)
+            self.event.wait(delay)
             self.event.clear()
 
     def _ceph_volume(self, enhanced: bool = False) -> Tuple[str, bool]:

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1732,10 +1732,12 @@ class CephadmAgent(DaemonForm):
                 self.target_port = config['target_port']
                 self.loop_interval = int(config['refresh_period'])
                 self.starting_port = int(config['listener_port'])
+                self.metadata_compresion_enabled = bool(config.get('metadata_compresion_enabled', False))
                 self.initial_startup_delay_max = int(config.get('initial_startup_delay_max', 0))
                 self.jitter_seconds = int(config.get('jitter_seconds', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
+                logger.info(f"Agent configuration at startup: {config}")
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
@@ -1816,7 +1818,8 @@ class CephadmAgent(DaemonForm):
                                               port=self.target_port,
                                               data=data,
                                               endpoint='/data',
-                                              ssl_ctx=self.ssl_ctx)
+                                              ssl_ctx=self.ssl_ctx,
+                                              compress=self.metadata_compresion_enabled)
                 if status != 200:
                     logger.error(f'HTTP error {status} while querying agent endpoint: {response}')
                     raise RuntimeError(f'non-200 response <{status}> from agent endpoint: {response}')

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1613,6 +1613,7 @@ class CephadmAgent(DaemonForm):
         self.target_ip = ''
         self.target_port = ''
         self.host = ''
+        self.target_changed = False
         self.daemon_dir = os.path.join(ctx.data_dir, self.fsid, f'{self.daemon_type}.{self.daemon_id}')
         self.config_path = os.path.join(self.daemon_dir, 'agent.json')
         self.keyring_path = os.path.join(self.daemon_dir, 'keyring')
@@ -1725,6 +1726,7 @@ class CephadmAgent(DaemonForm):
         self.event.set()
 
     def pull_conf_settings(self) -> None:
+        previous_target = (self.target_ip, self.target_port)
         try:
             with open(self.config_path, 'r') as f:
                 config = json.load(f)
@@ -1741,6 +1743,15 @@ class CephadmAgent(DaemonForm):
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
+
+        current_target = (self.target_ip, self.target_port)
+        if previous_target[0] and previous_target != current_target:
+            self.target_changed = True
+            logger.info(
+                f'Target mgr changed from '
+                f'{previous_target[0]}:{previous_target[1]} to '
+                f'{self.target_ip}:{self.target_port}'
+            )
 
         try:
             with open(self.keyring_path, 'r') as f:
@@ -1788,6 +1799,15 @@ class CephadmAgent(DaemonForm):
             self.volume_gatherer.start()
 
         while not self.stop:
+            if self.target_changed:
+                self.target_changed = False
+                delay = random.uniform(0, self.jitter_seconds)
+                logger.info(
+                    f'Target mgr changed, delaying next metadata report '
+                    f'for {delay:.2f} seconds'
+                )
+                time.sleep(delay)
+
             start_time = time.monotonic()
             ack = self.ack
 

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1732,6 +1732,7 @@ class CephadmAgent(DaemonForm):
                 self.target_port = config['target_port']
                 self.loop_interval = int(config['refresh_period'])
                 self.starting_port = int(config['listener_port'])
+                self.initial_startup_delay_max = int(config.get('initial_startup_delay_max', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
         except Exception as e:
@@ -1753,8 +1754,15 @@ class CephadmAgent(DaemonForm):
         self.volume_gatherer.update_func(lambda: self._ceph_volume(enhanced=self.device_enhanced_scan))
 
     def run(self) -> None:
+
         self.pull_conf_settings()
         self.ssl_ctx.load_verify_locations(self.ca_path)
+
+        # Introduce the randomness in the initialization (up to initial_startup_delay_max delay)
+        if self.initial_startup_delay_max:
+            delay = random.uniform(0, self.initial_startup_delay_max)
+            logger.debug(f"Delaying startup for {delay} seconds.")
+            time.sleep(delay)
 
         try:
             for _ in range(1001):

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1737,7 +1737,7 @@ class CephadmAgent(DaemonForm):
                 self.jitter_seconds = int(config.get('jitter_seconds', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
-                logger.info(f"Agent configuration at startup: {config}")
+                logger.info(f'Agent configuration at startup: {config}')
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
@@ -1764,7 +1764,7 @@ class CephadmAgent(DaemonForm):
         # Introduce the randomness in the initialization (up to initial_startup_delay_max delay)
         if self.initial_startup_delay_max:
             delay = random.uniform(0, self.initial_startup_delay_max)
-            logger.debug(f"Delaying startup for {delay} seconds.")
+            logger.debug(f'Delaying startup for {delay} seconds.')
             time.sleep(delay)
 
         try:

--- a/src/cephadm/cephadmlib/agent.py
+++ b/src/cephadm/cephadmlib/agent.py
@@ -1,9 +1,37 @@
+import gzip
+import json
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen, Request
 from typing import Optional, Any, Tuple
 import logging
 
 logger = logging.getLogger()
+
+
+def make_json_request(url: str, json_bytes: bytes, compress: bool) -> Optional[Request]:
+    """
+    Create a JSON POST request, optionally gzip-compressed. `json_bytes` must be JSON-encoded bytes.
+    """
+    if not json_bytes:
+        logger.error("Cannot send empty JSON payload — returning empty Request.")
+        return None
+
+    if compress:
+        original_size = len(json_bytes)
+        json_bytes = gzip.compress(json_bytes)
+        compressed_size = len(json_bytes)
+        compression_ratio = 100 * (1 - compressed_size / original_size)
+        logger.debug(f"Compression reduced payload size by {compression_ratio:.1f}% ({original_size} → {compressed_size} bytes)")
+        headers = {
+            'Content-Type': 'application/json',
+            'Content-Encoding': 'gzip',
+            'Accept-Encoding': 'gzip',
+        }
+    else:
+        headers = {
+            'Content-Type': 'application/json',
+        }
+    return Request(url, data=json_bytes, headers=headers)
 
 
 def http_query(
@@ -13,14 +41,24 @@ def http_query(
     endpoint: str = '',
     ssl_ctx: Optional[Any] = None,
     timeout: Optional[int] = 10,
+    compress: bool = False,
 ) -> Tuple[int, str]:
+    """
+    Perform an HTTPS POST request with optional gzip-compressed JSON payload.
+
+    `data` should be a JSON-encoded bytes object (not already compressed).
+    """
     url = f'https://{addr}:{port}{endpoint}'
-    logger.debug(f'sending query to {url}')
+    logger.debug(f'Sending query to {url} (compression={compress})')
     try:
-        req = Request(url, data, {'Content-Type': 'application/json'})
-        with urlopen(req, context=ssl_ctx, timeout=timeout) as response:
-            response_str = response.read()
-            response_status = response.status
+        req = make_json_request(url, data, compress) if data else Request(url)
+        if req is not None:
+            with urlopen(req, context=ssl_ctx, timeout=timeout) as response:
+                response_str = response.read()
+                response_status = response.status
+        else:
+            return (-1, "Empty payload — request not sent")
+
     except HTTPError as e:
         logger.debug(f'{e.code} {e.reason}')
         response_status = e.code
@@ -28,7 +66,9 @@ def http_query(
     except URLError as e:
         logger.debug(f'{e.reason}')
         response_status = -1
-        response_str = e.reason
-    except Exception:
+        response_str = str(e.reason)
+    except Exception as e:
+        logger.error(f'Unexpected error: {e}')
         raise
-    return (response_status, response_str)
+
+    return (response_status, response_str.decode('utf-8') if isinstance(response_str, bytes) else response_str)

--- a/src/cephadm/cephadmlib/agent.py
+++ b/src/cephadm/cephadmlib/agent.py
@@ -1,5 +1,4 @@
 import gzip
-import json
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen, Request
 from typing import Optional, Any, Tuple
@@ -13,7 +12,7 @@ def make_json_request(url: str, json_bytes: bytes, compress: bool) -> Optional[R
     Create a JSON POST request, optionally gzip-compressed. `json_bytes` must be JSON-encoded bytes.
     """
     if not json_bytes:
-        logger.error("Cannot send empty JSON payload — returning empty Request.")
+        logger.error('Cannot send empty JSON payload — returning empty Request.')
         return None
 
     if compress:
@@ -21,7 +20,7 @@ def make_json_request(url: str, json_bytes: bytes, compress: bool) -> Optional[R
         json_bytes = gzip.compress(json_bytes)
         compressed_size = len(json_bytes)
         compression_ratio = 100 * (1 - compressed_size / original_size)
-        logger.debug(f"Compression reduced payload size by {compression_ratio:.1f}% ({original_size} → {compressed_size} bytes)")
+        logger.debug(f'Compression reduced payload size by {compression_ratio:.1f}% ({original_size} → {compressed_size} bytes)')
         headers = {
             'Content-Type': 'application/json',
             'Content-Encoding': 'gzip',
@@ -57,7 +56,7 @@ def http_query(
                 response_str = response.read()
                 response_status = response.status
         else:
-            return (-1, "Empty payload — request not sent")
+            return (-1, 'Empty payload — request not sent')
 
     except HTTPError as e:
         logger.debug(f'{e.code} {e.reason}')

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -146,6 +146,21 @@ class AgentEndpoint:
         else:
             return self.mgr.agent_initial_startup_delay_max
 
+    def get_jitter(self) -> int:
+        """
+        Compute the jitter window (in seconds) applied before agents send metadata.
+
+        - If agent_jitter_seconds is -1 (auto), compute it as:
+            jitter = num_agents / avg_concurrency (M)
+        - This spreads agent reports evenly across the window.
+        - Uses a min jitter of 2s to prevent tight clustering in very small clusters.
+        """
+        if self.mgr.agent_jitter_seconds == -1:  # auto-jitter mode
+            agents_refresh_rate = self.compute_agents_refrsh_rate()
+            return max(2, int(agents_refresh_rate * 0.5))
+        else:
+            return self.mgr.agent_jitter_seconds
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -85,6 +85,51 @@ class AgentEndpoint:
                 self.server_port += 1
         self.mgr.log.error(f'Cephadm agent could not find free port in range {max_port - 150}-{max_port} and failed to start')
 
+    def compute_agents_avg_concurrency(self) -> int:
+        """
+        Compute the average number of agents allowed to report metadata per second (M).
+
+        - If user-specified value is -1, use an adaptive formula: sqrt(N)/2 (capped at 10).
+        - Ensures a minimum of 2 agents/sec to avoid unnecessary serialization.
+        - This helps spread load while avoiding bursts, especially on small clusters.
+        """
+        if self.mgr.agent_avg_concurrency == -1:  # auto-concurrency mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_concurrency = min(20, int(num_agents ** 0.5 / 2))
+        else:
+            agents_concurrency = self.mgr.agent_avg_concurrency
+        # We force a minimum of 2 agents per seconds
+        return max(2, agents_concurrency)
+
+    def compute_agents_refrsh_rate(self) -> int:
+        """
+        Compute the refresh rate (in seconds) for agent metadata reporting.
+
+        - If the user has specified a fixed `agent_refresh_rate`, use that.
+        - If `agent_refresh_rate` is set to -1 (auto mode), compute it dynamically as:
+            refresh_rate = num_agents // avg_concurrency
+            where:
+              - num_agents = total number of agents in the cluster
+              - avg_concurrency = average number of agents allowed to report per second,
+                computed using a separate heuristic (sqrt(N)/2, capped).
+        - This ensures that agent updates are spread evenly and that the manager is not overwhelmed.
+
+        Notes:
+        - A minimum refresh rate of 20 seconds is enforced to avoid excessive agent churn and load.
+        - The dynamic mode adapts automatically as the cluster grows.
+
+        Returns:
+            int: The agent refresh rate in seconds.
+        """
+        if self.mgr.agent_refresh_rate == -1:  # auto-refresh rate
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            refresh_rate = num_agents // agents_avg_concurrency
+        else:
+            refresh_rate = self.mgr.agent_refresh_rate
+
+        return max(20, refresh_rate)
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)
@@ -886,10 +931,11 @@ class CephadmAgentHelpers:
             if host in self.mgr.offline_hosts:
                 return False
             self.mgr.agent_cache.agent_timestamp[host] = datetime_now()
-        # agent hasn't reported in down multiplier * it's refresh rate. Something is likely wrong with it.
+        # agent hasn't reported in:  down_multiplier * it's refresh rate + jitter. Something is likely wrong with it.
+        jitter: float = self.agent.get_jitter()
         down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
         time_diff = datetime_now() - self.mgr.agent_cache.agent_timestamp[host]
-        if time_diff.total_seconds() > down_mult * float(self.mgr.agent_refresh_rate):
+        if time_diff.total_seconds() > down_mult * float(self.mgr.http_server.agent.compute_agents_refrsh_rate() + jitter):
             return True
         return False
 
@@ -900,7 +946,7 @@ class CephadmAgentHelpers:
             down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
             for agent in down_agent_hosts:
                 detail.append((f'Cephadm agent on host {agent} has not reported in '
-                              f'{down_mult * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
+                              f'{down_mult * self.mgr.http_server.agent.compute_agents_refrsh_rate()} seconds. Agent is assumed '
                                'down and host may be offline.'))
             for dd in [d for d in self.mgr.cache.get_daemons_by_type('agent') if d.hostname in down_agent_hosts]:
                 dd.status = DaemonDescriptionStatus.error

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -139,7 +139,7 @@ class AgentEndpoint:
         - This prevents bursts of all agents from reporting immediately at startup.
         - Enforces a minimum of 10s to avoid early tight clustering.
         """
-        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+        if self.mgr.agent_initial_startup_delay_max == -1:  # auto-delay mode
             num_agents = len(self.mgr.cache.get_hosts())
             agents_avg_concurrency = self.compute_agents_avg_concurrency()
             return max(10, num_agents // agents_avg_concurrency)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -130,6 +130,22 @@ class AgentEndpoint:
 
         return max(20, refresh_rate)
 
+    def get_initial_delay(self) -> int:
+        """
+        Compute the maximum initial random startup delay (in seconds) before an agent starts reporting.
+
+        - If agent_initial_startup_delay_max is -1 (auto), compute as:
+            delay = num_agents / avg_concurrency (M)
+        - This prevents bursts of all agents from reporting immediately at startup.
+        - Enforces a minimum of 10s to avoid early tight clustering.
+        """
+        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            return max(10, num_agents // agents_avg_concurrency)
+        else:
+            return self.mgr.agent_initial_startup_delay_max
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -18,7 +18,6 @@ from cephadm.services.service_registry import service_registry
 from cephadm.services.cephadmservice import CephadmAgent
 from cephadm.tlsobject_types import TLSCredentials
 from cephadm.utils import get_node_proxy_status_value
-import cephadm.cherrypy_compression_in
 
 from urllib.error import HTTPError, URLError
 from typing import Any, Dict, List, Set, TYPE_CHECKING, Optional, MutableMapping, IO, Tuple

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -149,6 +149,21 @@ class AgentEndpoint:
         else:
             return self.mgr.agent_initial_startup_delay_max
 
+    def get_jitter(self) -> int:
+        """
+        Compute the jitter window (in seconds) applied before agents send metadata.
+
+        - If agent_jitter_seconds is -1 (auto), compute it as:
+            jitter = num_agents / avg_concurrency (M)
+        - This spreads agent reports evenly across the window.
+        - Uses a min jitter of 2s to prevent tight clustering in very small clusters.
+        """
+        if self.mgr.agent_jitter_seconds == -1:  # auto-jitter mode
+            agents_refresh_rate = self.compute_agents_refrsh_rate()
+            return max(2, int(agents_refresh_rate * 0.5))
+        else:
+            return self.mgr.agent_jitter_seconds
+
     def configure(self) -> Tuple[Dict, Dict, List[tuple], tuple]:
         self.host_data = HostData(self.mgr)
         ssl_info = self.configure_tls()

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -88,6 +88,51 @@ class AgentEndpoint:
                 self.server_port += 1
         self.mgr.log.error(f'Cephadm agent could not find free port in range {max_port - 150}-{max_port} and failed to start')
 
+    def compute_agents_avg_concurrency(self) -> int:
+        """
+        Compute the average number of agents allowed to report metadata per second (M).
+
+        - If user-specified value is -1, use an adaptive formula: sqrt(N)/2 (capped at 10).
+        - Ensures a minimum of 2 agents/sec to avoid unnecessary serialization.
+        - This helps spread load while avoiding bursts, especially on small clusters.
+        """
+        if self.mgr.agent_avg_concurrency == -1:  # auto-concurrency mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_concurrency = min(20, int(num_agents ** 0.5 / 2))
+        else:
+            agents_concurrency = self.mgr.agent_avg_concurrency
+        # We force a minimum of 2 agents per seconds
+        return max(2, agents_concurrency)
+
+    def compute_agents_refrsh_rate(self) -> int:
+        """
+        Compute the refresh rate (in seconds) for agent metadata reporting.
+
+        - If the user has specified a fixed `agent_refresh_rate`, use that.
+        - If `agent_refresh_rate` is set to -1 (auto mode), compute it dynamically as:
+            refresh_rate = num_agents // avg_concurrency
+            where:
+              - num_agents = total number of agents in the cluster
+              - avg_concurrency = average number of agents allowed to report per second,
+                computed using a separate heuristic (sqrt(N)/2, capped).
+        - This ensures that agent updates are spread evenly and that the manager is not overwhelmed.
+
+        Notes:
+        - A minimum refresh rate of 20 seconds is enforced to avoid excessive agent churn and load.
+        - The dynamic mode adapts automatically as the cluster grows.
+
+        Returns:
+            int: The agent refresh rate in seconds.
+        """
+        if self.mgr.agent_refresh_rate == -1:  # auto-refresh rate
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            refresh_rate = num_agents // agents_avg_concurrency
+        else:
+            refresh_rate = self.mgr.agent_refresh_rate
+
+        return max(20, refresh_rate)
+
     def configure(self) -> Tuple[Dict, Dict, List[tuple], tuple]:
         self.host_data = HostData(self.mgr)
         ssl_info = self.configure_tls()
@@ -923,10 +968,11 @@ class CephadmAgentHelpers:
             if host in self.mgr.offline_hosts:
                 return False
             self.mgr.agent_cache.agent_timestamp[host] = datetime_now()
-        # agent hasn't reported in down multiplier * it's refresh rate. Something is likely wrong with it.
+        # agent hasn't reported in:  down_multiplier * it's refresh rate + jitter. Something is likely wrong with it.
+        jitter: float = self.agent.get_jitter()
         down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
         time_diff = datetime_now() - self.mgr.agent_cache.agent_timestamp[host]
-        if time_diff.total_seconds() > down_mult * float(self.mgr.agent_refresh_rate):
+        if time_diff.total_seconds() > down_mult * float(self.mgr.http_server.agent.compute_agents_refrsh_rate() + jitter):
             return True
         return False
 
@@ -937,7 +983,7 @@ class CephadmAgentHelpers:
             down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
             for agent in down_agent_hosts:
                 detail.append((f'Cephadm agent on host {agent} has not reported in '
-                              f'{down_mult * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
+                              f'{down_mult * self.mgr.http_server.agent.compute_agents_refrsh_rate()} seconds. Agent is assumed '
                                'down and host may be offline.'))
             for dd in [d for d in self.mgr.cache.get_daemons_by_type(CephadmAgent.TYPE) if d.hostname in down_agent_hosts]:
                 dd.status = DaemonDescriptionStatus.error

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -133,6 +133,22 @@ class AgentEndpoint:
 
         return max(20, refresh_rate)
 
+    def get_initial_delay(self) -> int:
+        """
+        Compute the maximum initial random startup delay (in seconds) before an agent starts reporting.
+
+        - If agent_initial_startup_delay_max is -1 (auto), compute as:
+            delay = num_agents / avg_concurrency (M)
+        - This prevents bursts of all agents from reporting immediately at startup.
+        - Enforces a minimum of 10s to avoid early tight clustering.
+        """
+        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            return max(10, num_agents // agents_avg_concurrency)
+        else:
+            return self.mgr.agent_initial_startup_delay_max
+
     def configure(self) -> Tuple[Dict, Dict, List[tuple], tuple]:
         self.host_data = HostData(self.mgr)
         ssl_info = self.configure_tls()

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -31,6 +31,8 @@ CEPHADM_AGENT_CERT_DURATION = (365 * 5)
 
 class AgentEndpoint:
 
+    DEFAULT_AGENT_TASK_DURATION_SECONDS = 2
+
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
         self.mgr = mgr
         self.server_port = 7150
@@ -92,7 +94,7 @@ class AgentEndpoint:
         """
         Compute the average number of agents allowed to report metadata per second (M).
 
-        - If user-specified value is -1, use an adaptive formula: sqrt(N)/2 (capped at 10).
+        - If user-specified value is -1, use an adaptive formula: sqrt(N)/2 (capped at 20).
         - Ensures a minimum of 2 agents/sec to avoid unnecessary serialization.
         - This helps spread load while avoiding bursts, especially on small clusters.
         """
@@ -110,7 +112,7 @@ class AgentEndpoint:
 
         - If the user has specified a fixed `agent_refresh_rate`, use that.
         - If `agent_refresh_rate` is set to -1 (auto mode), compute it dynamically as:
-            refresh_rate = num_agents // avg_concurrency
+            refresh_rate = (num_agents × task_duration) // avg_concurrency
             where:
               - num_agents = total number of agents in the cluster
               - avg_concurrency = average number of agents allowed to report per second,
@@ -127,7 +129,7 @@ class AgentEndpoint:
         if self.mgr.agent_refresh_rate == -1:  # auto-refresh rate
             num_agents = len(self.mgr.cache.get_hosts())
             agents_avg_concurrency = self.compute_agents_avg_concurrency()
-            refresh_rate = num_agents // agents_avg_concurrency
+            refresh_rate = (num_agents * self.DEFAULT_AGENT_TASK_DURATION_SECONDS) // agents_avg_concurrency
         else:
             refresh_rate = self.mgr.agent_refresh_rate
 

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -18,6 +18,7 @@ from cephadm.services.service_registry import service_registry
 from cephadm.services.cephadmservice import CephadmAgent
 from cephadm.tlsobject_types import TLSCredentials
 from cephadm.utils import get_node_proxy_status_value
+import cephadm.cherrypy_compression_in
 
 from urllib.error import HTTPError, URLError
 from typing import Any, Dict, List, Set, TYPE_CHECKING, Optional, MutableMapping, IO, Tuple
@@ -747,12 +748,25 @@ class HostData:
     def __init__(self, mgr: "CephadmOrchestrator"):
         self.mgr = mgr
 
+    def get_data(self) -> Optional[dict]:
+        try:
+            remote_ip = cherrypy.request.remote.ip
+            content_encoding = cherrypy.request.headers.get('Content-Encoding', 'identity')
+            raw_body = cherrypy.request.body.read()
+            self.mgr.log.debug(f">>> Received payload from {remote_ip}, Content-Encoding: {content_encoding}")
+            return json.loads(raw_body.decode('utf-8'))
+        except Exception as e:
+            self.mgr.log.error(f"Failed to read request body: {e}")
+            return None
+
     @cherrypy.tools.allow(methods=['POST'])
-    @cherrypy.tools.json_in()
+    @cherrypy.tools.compression_in()
     @cherrypy.tools.json_out()
     @cherrypy.expose
     def index(self) -> Dict[str, Any]:
-        data: Dict[str, Any] = cherrypy.request.json
+        data: Optional[Dict[str, Any]] = self.get_data()
+        if data is None:
+            return {}
         results: Dict[str, Any] = {}
         try:
             self.check_request_fields(data)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -142,7 +142,7 @@ class AgentEndpoint:
         - This prevents bursts of all agents from reporting immediately at startup.
         - Enforces a minimum of 10s to avoid early tight clustering.
         """
-        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+        if self.mgr.agent_initial_startup_delay_max == -1:  # auto-delay mode
             num_agents = len(self.mgr.cache.get_hosts())
             agents_avg_concurrency = self.compute_agents_avg_concurrency()
             return max(10, num_agents // agents_avg_concurrency)

--- a/src/pybind/mgr/cephadm/cherrypy_compression_in.py
+++ b/src/pybind/mgr/cephadm/cherrypy_compression_in.py
@@ -1,0 +1,39 @@
+import cherrypy
+import io
+import gzip
+from typing import Callable, Dict
+
+
+class CompressionDecoderTool:
+    """
+    CherryPy tool that transparently decompresses incoming request bodies
+    based on the Content-Encoding header.
+    Supports: gzip
+    """
+    decompressors: Dict[str, Callable[[bytes], bytes]] = {
+        "gzip": lambda b: gzip.decompress(b),
+    }
+
+    def __call__(self) -> None:
+        encoding = cherrypy.request.headers.get('Content-Encoding', '').lower()
+        if encoding in self.decompressors:
+            remote_ip = cherrypy.request.remote.ip
+            cherrypy.log(f"[compression_in] Decompressing {encoding} request from {remote_ip}", severity=10)  # DEBUG
+            try:
+                raw_body = cherrypy.request.rfile.read()
+                original_size = len(raw_body)
+                decompressed = self.decompressors[encoding](raw_body)
+                decompressed_size = len(decompressed)
+                cherrypy.request.body = io.BytesIO(decompressed)
+                cherrypy.request.headers['Content-Encoding'] = 'identity'
+                cherrypy.log(f"[compression_in] {encoding} decompressed {original_size} → {decompressed_size} bytes", severity=10)  # DEBUG
+            except Exception as e:
+                cherrypy.log(f"[compression_in] Failed to decompress {encoding}: {e}", severity=40)
+                raise cherrypy.HTTPError(400, f"Invalid {encoding} request body")
+        elif encoding and encoding != 'identity':
+            cherrypy.log(f"[compression_in] Unsupported Content-Encoding: {encoding}", severity=30)
+            raise cherrypy.HTTPError(415, f"Unsupported Content-Encoding: {encoding}")
+
+
+# Register the tool
+cherrypy.tools.compression_in = cherrypy.Tool('before_handler', CompressionDecoderTool())

--- a/src/pybind/mgr/cephadm/cherrypy_compression_in.py
+++ b/src/pybind/mgr/cephadm/cherrypy_compression_in.py
@@ -31,8 +31,11 @@ class CompressionDecoderTool:
                 cherrypy.log(f"[compression_in] Failed to decompress {encoding}: {e}", severity=40)
                 raise cherrypy.HTTPError(400, f"Invalid {encoding} request body")
         elif encoding and encoding != 'identity':
-            cherrypy.log(f"[compression_in] Unsupported Content-Encoding: {encoding}", severity=30)
-            raise cherrypy.HTTPError(415, f"Unsupported Content-Encoding: {encoding}")
+            supported_encodings = ', '.join(list(self.decompressors.keys()) + ['identity'])
+            cherrypy.log(f"[compression_in] Unsupported Content-Encoding: {encoding} (supported: {supported_encodings})", severity=30)  # WARNING
+            raise cherrypy.HTTPError(415,
+                                     f"Unsupported Content-Encoding: {encoding}",
+                                     headers=[("Accept-Encoding", supported_encodings)])
 
 
 # Register the tool

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -366,9 +366,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ),
         Option(
             'agent_refresh_rate',
-            type='secs',
-            default=20,
-            desc='How often agent on each host will try to gather and send metadata'
+            type='int',
+            default=-1,
+            desc='How often each agent sends metadata. Use -1 to auto-adjust based on cluster size.'
+        ),
+        Option(
+            'agent_avg_concurrency',
+            type='int',
+            default=-1,
+            desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
             'agent_starting_port',
@@ -566,6 +572,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.ssh_cert: Optional[str] = None
             self.use_agent = False
             self.agent_refresh_rate = 0
+            self.agent_avg_concurrency = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -395,6 +395,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='First port agent will try to bind to (will also try up to next 1000 subsequent ports if blocked)'
         ),
         Option(
+            'agent_metadata_compresion_enabled',
+            type='bool',
+            default=True,
+            desc='Enable compression of metadata sent from agent to reduce payload size'
+        ),
+        Option(
             'agent_down_multiplier',
             type='float',
             default=3.0,
@@ -589,6 +595,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
+            self.agent_metadata_compresion_enabled = True
             self.hw_monitoring = False
             self.service_discovery_port = 0
             self.secure_monitoring_stack = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -383,6 +383,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
         ),
         Option(
+            'agent_jitter_seconds',
+            type='int',
+            default=-1,
+            desc='Max random delay before agent sends metadata; set -1 for auto (default), 0 to disable'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -580,6 +586,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
             self.agent_initial_startup_delay_max = 0
+            self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3331,6 +3331,18 @@ Then run the following:
                 'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
+    def show_agent_config(self) -> Dict[str, str]:
+        agent = self.http_server.agent
+        return {
+            'agent_refresh_rate': str(agent.compute_agents_refrsh_rate()),
+            'agent_avg_concurrency': str(agent.compute_agents_avg_concurrency()),
+            'agent_initial_startup_delay_max': str(agent.get_initial_delay()),
+            'agent_jitter_seconds': str(agent.get_jitter()),
+            'agent_down_multiplier': str(self.agent_down_multiplier),
+            'agent_starting_port': str(self.agent_starting_port)
+        }
+
+    @handle_orch_error
     def cert_store_cert_ls(self, show_details: bool = False) -> Dict[str, Any]:
         return self.cert_mgr.cert_ls(show_details)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -377,6 +377,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
+            'agent_initial_startup_delay_max',
+            type='int',
+            default=-1,
+            desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -573,6 +579,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.use_agent = False
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
+            self.agent_initial_startup_delay_max = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -418,6 +418,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
         ),
         Option(
+            'agent_jitter_seconds',
+            type='int',
+            default=-1,
+            desc='Max random delay before agent sends metadata; set -1 for auto (default), 0 to disable'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -674,6 +680,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
             self.agent_initial_startup_delay_max = 0
+            self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -412,6 +412,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
+            'agent_initial_startup_delay_max',
+            type='int',
+            default=-1,
+            desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -667,6 +673,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.use_agent = False
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
+            self.agent_initial_startup_delay_max = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4152,14 +4152,17 @@ Then run the following:
                 'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
-    def cert_store_cert_ls(self,
-                        filter_by: str = '',
-                        show_details: bool = False,
-                        include_cephadm_signed: bool = False) -> Dict[str, Any]:
+    def cert_store_cert_ls(
+        self,
+        filter_by: str = '',
+        show_details: bool = False,
+        include_cephadm_signed: bool = False
+    ) -> Dict[str, Any]:
         return self.cert_mgr.cert_ls(
             filter_by, show_details, include_cephadm_signed
         )
 
+    @handle_orch_error
     def show_agent_config(self) -> Dict[str, str]:
         agent = self.http_server.agent
         return {
@@ -4168,7 +4171,7 @@ Then run the following:
             'agent_initial_startup_delay_max': str(agent.get_initial_delay()),
             'agent_jitter_seconds': str(agent.get_jitter()),
             'agent_down_multiplier': str(self.agent_down_multiplier),
-            'agent_starting_port': str(self.agent_starting_port)
+            'agent_starting_port': str(self.agent_starting_port),
         }
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -4146,10 +4146,23 @@ Then run the following:
 
     @handle_orch_error
     def cert_store_cert_ls(self,
-                           filter_by: str = '',
-                           show_details: bool = False,
-                           include_cephadm_signed: bool = False) -> Dict[str, Any]:
-        return self.cert_mgr.cert_ls(filter_by, show_details, include_cephadm_signed)
+                        filter_by: str = '',
+                        show_details: bool = False,
+                        include_cephadm_signed: bool = False) -> Dict[str, Any]:
+        return self.cert_mgr.cert_ls(
+            filter_by, show_details, include_cephadm_signed
+        )
+
+    def show_agent_config(self) -> Dict[str, str]:
+        agent = self.http_server.agent
+        return {
+            'agent_refresh_rate': str(agent.compute_agents_refrsh_rate()),
+            'agent_avg_concurrency': str(agent.compute_agents_avg_concurrency()),
+            'agent_initial_startup_delay_max': str(agent.get_initial_delay()),
+            'agent_jitter_seconds': str(agent.get_jitter()),
+            'agent_down_multiplier': str(self.agent_down_multiplier),
+            'agent_starting_port': str(self.agent_starting_port)
+        }
 
     @handle_orch_error
     def cert_store_bindings_ls(self) -> Dict[str, Dict[str, List[str]]]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -401,9 +401,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         ),
         Option(
             'agent_refresh_rate',
-            type='secs',
-            default=20,
-            desc='How often the agent on each host will gather and send metadata'
+            type='int',
+            default=-1,
+            desc='How often each agent sends metadata. Use -1 to auto-adjust based on cluster size.'
+        ),
+        Option(
+            'agent_avg_concurrency',
+            type='int',
+            default=-1,
+            desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
             'agent_starting_port',
@@ -660,6 +666,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.ssh_cert: Optional[str] = None
             self.use_agent = False
             self.agent_refresh_rate = 0
+            self.agent_avg_concurrency = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -430,6 +430,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             desc='The first TCP port the agent will try to bind to. Up to 1000 subsequent ports will be attempted if this port cannot be bound'
         ),
         Option(
+            'agent_metadata_compresion_enabled',
+            type='bool',
+            default=True,
+            desc='Enable compression of metadata sent from agent to reduce payload size'
+        ),
+        Option(
             'agent_down_multiplier',
             type='float',
             default=3.0,
@@ -683,6 +689,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
             self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
+            self.agent_metadata_compresion_enabled = True
             self.hw_monitoring = False
             self.hw_monitoring_vendor = 'generic'
             self.service_discovery_port = 0

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1545,7 +1545,7 @@ class CephadmAgent(CephService):
 
         cfg = {'target_ip': self.mgr.get_mgr_ip(),
                'target_port': agent.server_port,
-               'refresh_period': self.mgr.agent_refresh_rate,
+               'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1511,6 +1511,7 @@ class CephadmAgent(CephService):
 
         agent_options = [
             'device_enhanced_scan',
+            'agent_metadata_compresion_enabled',
             'agent_starting_port',
         ]
         agent_static_cfg_opts = [f"{opt}: {mgr.get_module_option(opt)}" for opt in agent_options]
@@ -1562,6 +1563,7 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'metadata_compresion_enabled': self.mgr.agent_metadata_compresion_enabled,
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'initial_startup_delay_max': agent.get_initial_delay(),
                'jitter_seconds': agent.get_jitter()}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1548,7 +1548,8 @@ class CephadmAgent(CephService):
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
-               'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}
+               'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'initial_startup_delay_max': agent.get_initial_delay()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1549,7 +1549,8 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
-               'initial_startup_delay_max': agent.get_initial_delay()}
+               'initial_startup_delay_max': agent.get_initial_delay(),
+               'jitter_seconds': agent.get_jitter()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -2079,6 +2079,7 @@ class CephadmAgent(CephService):
 
         agent_options = [
             'device_enhanced_scan',
+            'agent_metadata_compresion_enabled',
             'agent_starting_port',
         ]
         agent_static_cfg_opts = [f"{opt}: {mgr.get_module_option(opt)}" for opt in agent_options]
@@ -2131,6 +2132,7 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'metadata_compresion_enabled': self.mgr.agent_metadata_compresion_enabled,
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'initial_startup_delay_max': agent.get_initial_delay(),
                'jitter_seconds': agent.get_jitter()}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -2118,7 +2118,8 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
-               'initial_startup_delay_max': agent.get_initial_delay()}
+               'initial_startup_delay_max': agent.get_initial_delay(),
+               'jitter_seconds': agent.get_jitter()}
 
         tls_creds = self.get_certificates(daemon_spec)
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -2117,7 +2117,8 @@ class CephadmAgent(CephService):
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
-               'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}
+               'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'initial_startup_delay_max': agent.get_initial_delay()}
 
         tls_creds = self.get_certificates(daemon_spec)
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -2114,7 +2114,7 @@ class CephadmAgent(CephService):
 
         cfg = {'target_ip': self.mgr.get_mgr_ip(),
                'target_port': agent.server_port,
-               'refresh_period': self.mgr.agent_refresh_rate,
+               'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -2147,6 +2147,7 @@ class CephadmAgent(CephService):
         }
         return config, self.get_dependencies(self.mgr)
 
+
 def next_action_for_mgmt_stack_service(
     scheduled_action: utils.Action,
     daemon_type: Optional[str],

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -2076,13 +2076,27 @@ class CephadmAgent(CephService):
     def get_dependencies(cls, mgr: "CephadmOrchestrator",
                          spec: Optional[ServiceSpec] = None,
                          daemon_type: Optional[str] = None) -> List[str]:
+
+        agent_options = [
+            'device_enhanced_scan',
+            'agent_starting_port',
+        ]
+        agent_static_cfg_opts = [f"{opt}: {mgr.get_module_option(opt)}" for opt in agent_options]
+
         agent = mgr.http_server.agent
+        agent_dynamic_cfg_opts = [
+            f'refresh_period: {agent.compute_agents_refrsh_rate()}',
+            f'initial_startup_delay_max: {agent.get_initial_delay()}',
+            f'jitter_seconds: {agent.get_jitter()}'
+        ]
+
         return sorted(
             [
                 str(mgr.get_mgr_ip()),
-                str(agent.server_port),
+                str(mgr.http_server.agent.server_port),
                 mgr.cert_mgr.get_root_ca(),
-                str(mgr.get_module_option("device_enhanced_scan")),
+                *agent_static_cfg_opts,
+                *agent_dynamic_cfg_opts,
             ]
         )
 
@@ -2114,10 +2128,10 @@ class CephadmAgent(CephService):
 
         cfg = {'target_ip': self.mgr.get_mgr_ip(),
                'target_port': agent.server_port,
-               'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'refresh_period': agent.compute_agents_refrsh_rate(),
                'initial_startup_delay_max': agent.get_initial_delay(),
                'jitter_seconds': agent.get_jitter()}
 
@@ -2129,11 +2143,7 @@ class CephadmAgent(CephService):
             'listener.crt': tls_creds.cert,
             'listener.key': tls_creds.key,
         }
-
-        return config, sorted([str(self.mgr.get_mgr_ip()), str(agent.server_port),
-                               self.mgr.cert_mgr.get_root_ca(),
-                               str(self.mgr.get_module_option('device_enhanced_scan'))])
-
+        return config, self.get_dependencies(self.mgr)
 
 def next_action_for_mgmt_stack_service(
     scheduled_action: utils.Action,

--- a/src/pybind/mgr/cephadm/tests/test_agent.py
+++ b/src/pybind/mgr/cephadm/tests/test_agent.py
@@ -1,0 +1,196 @@
+from cephadm.agent import AgentEndpoint
+
+
+class FakeCache:
+    def __init__(self, num_hosts):
+        self._hosts = ['host{}'.format(i) for i in range(num_hosts)]
+
+    def get_hosts(self):
+        return self._hosts
+
+
+class FakeMgr:
+    def __init__(self, num_hosts=10):
+        self.agent_avg_concurrency = -1
+        self.agent_refresh_rate = -1
+        self.agent_initial_startup_delay_max = -1
+        self.agent_jitter_seconds = -1
+        self.cache = FakeCache(num_hosts)
+
+    def get_mgr_ip(self):
+        return ''
+
+
+class TestAgentEndpoint:
+
+    def test_concurrency_auto_small(self):
+        # Test that even for very small clusters (1 host),
+        # the minimum concurrency of 2 is enforced
+        mgr = FakeMgr(num_hosts=1)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+
+    def test_concurrency_auto_exact_boundary(self):
+        # Test that concurrency is capped at 20 even when sqrt(N)/2 exceeds 20
+        mgr = FakeMgr(num_hosts=1600)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 20
+
+    def test_refresh_auto_typical(self):
+        # Test refresh rate computed dynamically in auto mode for a typical cluster size
+        # 100 agents → concurrency = 5 and refresh_rate = (100*2)//5 = 40
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 40
+
+    def test_refresh_auto_zero_agents(self):
+        # Test refresh rate fallback for 0 agents (should enforce minimum of 20s)
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_auto_with_manual_concurrency(self):
+        # Test refresh rate in auto mode with manually overridden high concurrency
+        # Should still honor the lower bound of 20s
+        mgr = FakeMgr(num_hosts=1000)
+        mgr.agent_avg_concurrency = 100
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_min_refresh_rate(self):
+        # Test that manually specified refresh rates below the lower bound are clamped to 20s
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 5
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_manual_valid(self):
+        # Test that manually specified valid refresh rate is used as-is
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 60
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 60
+
+    def test_initial_delay_auto_small(self):
+        # Test auto delay with a small number of agents returns minimum 10s
+        mgr = FakeMgr(num_hosts=2)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_auto_zero_agents(self):
+        # Test auto delay with 0 agents still enforces the minimum 10s delay
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_manual_below_min(self):
+        # Test that manual delay below the minimum is respected (no clamping here)
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 5
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 5
+
+    def test_initial_delay_manual_valid(self):
+        # Test that a valid manual delay value is used directly
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 30
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 30
+
+    def test_jitter_auto_zero_refresh(self):
+        # Test jitter in auto mode with 0 agents; fallback refresh_rate is 20 and jitter = 10
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 10
+
+    def test_jitter_auto_typical(self):
+        # Test jitter in auto mode for a typical cluster (100 agents)
+        # refresh_rate = 40 an jitter = 20
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        jitter = config.get_jitter()
+        assert jitter == 20
+
+    def test_jitter_manual(self):
+        # Test that manual jitter override is respected (even if < 2)
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 1
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 1
+
+    def test_jitter_manual_high(self):
+        # Test that a high manual jitter value is used as-is
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 60
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 60
+
+
+class TestAgentEndpointAuto:
+
+    def test_auto_minimum_values(self):
+        # Test system behavior with 0 agents in full auto mode.
+        # All computed values should fall back to their enforced minimums.
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2  # Enforced minimum
+        assert config.compute_agents_refrsh_rate() == 20     # Enforced minimum
+        assert config.get_initial_delay() == 10              # Enforced minimum
+        assert config.get_jitter() == 10                     # 50% of refresh rate (20)
+
+    def test_auto_4_hosts(self):
+        # Test computed values for a very small cluster (4 agents).
+        # sqrt(4)/2 = 1 -> clamped to 2 concurrency
+        # Refresh rate = (4*2)//2 = 4 -> clamped to 20
+        mgr = FakeMgr(num_hosts=4)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10              # 4//2 = 2 -> clamped to 10
+        assert config.get_jitter() == 10                     # 50% of refresh rate
+
+    def test_auto_16_hosts(self):
+        # Test computed values for 16 agents.
+        # sqrt(16)/2 = 2 → meets minimum concurrency
+        # Refresh rate = (16*2)//2 = 16 → clamped to 20
+        mgr = FakeMgr(num_hosts=16)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10              # 16//2 = 8 → clamped to 10
+        assert config.get_jitter() == 10                     # 50% of refresh rate
+
+    def test_auto_100_hosts(self):
+        # Test computed values for 100 agents.
+        # sqrt(100)/2 = 5 -> concurrency = 5
+        # Refresh rate = (100*2)//5 = 40
+        # Initial delay = 100//5 = 20
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 5
+        assert config.compute_agents_refrsh_rate() == 40
+        assert config.get_initial_delay() == 20
+        assert config.get_jitter() == 20  # 50% of refresh rate
+
+    def test_auto_200_hosts(self):
+        # Test computed values for 200 agents.
+        # sqrt(200)/2 ≈ 7.07 -> concurrency = 7
+        # Refresh rate = (200*2)//7 = ~57
+        # Initial delay = 200//7 ~ 28
+        mgr = FakeMgr(num_hosts=200)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 7
+        assert config.compute_agents_refrsh_rate() == 57
+        assert config.get_jitter() == 28  # 50% of refresh rate
+
+    def test_auto_1000_hosts(self):
+        # Test computed values for 1000 agents.
+        # sqrt(1000)/2 ≈ 15.81 → concurrency = 15
+        # Refresh rate = (1000*2)//15 ~ 133
+        # Initial delay = 1000//15 ~ 66
+        mgr = FakeMgr(num_hosts=1000)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 15
+        assert config.compute_agents_refrsh_rate() == 133
+        assert config.get_initial_delay() == 66
+        assert config.get_jitter() == 66  # 50% of refresh rate

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3984,7 +3984,7 @@ class TestAgent:
     def test_deploy_cephadm_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         agent_spec = ServiceSpec(service_type="agent", placement=PlacementSpec(count=1))
-        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\", \"refresh_period\": 20, \"initial_startup_delay_max\": 10, \"jitter_seconds\": 10}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
+        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\", \"metadata_compresion_enabled\": true, \"refresh_period\": 20, \"initial_startup_delay_max\": 10, \"jitter_seconds\": 10}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, agent_spec):

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3984,7 +3984,7 @@ class TestAgent:
     def test_deploy_cephadm_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         agent_spec = ServiceSpec(service_type="agent", placement=PlacementSpec(count=1))
-        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"refresh_period\": 20, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\"}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
+        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\", \"refresh_period\": 20, \"initial_startup_delay_max\": 10, \"jitter_seconds\": 10}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, agent_spec):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -904,6 +904,9 @@ class Orchestrator(object):
         """remove prometheus target for multi-cluster"""
         raise NotImplementedError()
 
+    def show_agent_config(self) -> OrchResult[Dict[str, str]]:
+        raise NotImplementedError()
+
     def get_alertmanager_access_info(self) -> OrchResult[Dict[str, str]]:
         """get alertmanager access information"""
         raise NotImplementedError()

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -881,6 +881,9 @@ class Orchestrator(object):
         """remove prometheus remote write url and allowed metrics for multi-cluster"""
         raise NotImplementedError()
 
+    def show_agent_config(self) -> OrchResult[Dict[str, str]]:
+        raise NotImplementedError()
+
     def get_alertmanager_access_info(self) -> OrchResult[Dict[str, str]]:
         """get alertmanager access information"""
         raise NotImplementedError()

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1425,6 +1425,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         result = raise_if_exception(completion)
         return HandleCommandResult(stdout=json.dumps(result))
 
+    @_cli_read_command('orch agent show-config')
+    def _show_cephadm_agent_config(self) -> HandleCommandResult:
+        completion = self.show_agent_config()
+        result = raise_if_exception(completion)
+        return HandleCommandResult(stdout=json.dumps(result))
+
     @_cli_write_command('orch alertmanager set-credentials')
     def _set_alertmanager_access_info(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> HandleCommandResult:
         try:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1462,15 +1462,30 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule):
         result = raise_if_exception(completion)
         return HandleCommandResult(stdout=json.dumps(result))
 
+    @OrchestratorCLICommand.Read('orch agent show-config')
+    def _show_cephadm_agent_config(self) -> HandleCommandResult:
+        completion = self.show_agent_config()
+        result = raise_if_exception(completion)
+        return HandleCommandResult(stdout=json.dumps(result))
+
     @OrchestratorCLICommand.Write('orch alertmanager set-credentials')
-    def _set_alertmanager_access_info(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> HandleCommandResult:
+    def _set_alertmanager_access_info(
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        inbuf: Optional[str] = None,
+    ) -> HandleCommandResult:
         try:
-            username, password = self._get_credentials(username, password, inbuf)
-            completion = self.set_alertmanager_access_info(username, password)
+            username, password = self._get_credentials(
+                username, password, inbuf
+            )
+            completion = self.set_alertmanager_access_info(
+                username, password
+            )
             result = raise_if_exception(completion)
             return HandleCommandResult(stdout=json.dumps(result))
         except ArgumentError as e:
-            return HandleCommandResult(-errno.EINVAL, "", (str(e)))
+            return HandleCommandResult(-errno.EINVAL, '', str(e))
 
     @OrchestratorCLICommand.Write('orch prometheus get-credentials')
     def _get_prometheus_access_info(self) -> HandleCommandResult:


### PR DESCRIPTION
This PR adds support for optional compression of Cephadm Agent metadata payloads to reduce bandwidth consumption. This is especially beneficial in large clusters where frequent metadata reporting can result in significant network overhead.  

Testing has shown that enabling compression yields a reduction of over 80% in payload size, significantly improving efficiency without impacting functionality.

### 🛠️ New Cephadm Configuration Option

#### `agent_metadata_compresion_enabled` (bool, default: `True`)
> Enable compression of metadata sent from agent to reduce payload size.
>
> **Purpose**: Enables compression of metadata before it’s sent.
> **Why**: Saves bandwidth and improves performance over slow links or at scale.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
