### PR TITLE
[AGENT OPTIMIZATION] mgr/cephadm: Optimize Agent Payloads by Skipping Unchanged Metadata Sections

### DIFF
--- a/doc/cephadm/agent.rst
+++ b/doc/cephadm/agent.rst
@@ -1,0 +1,159 @@
+.. _orchestrator-cli-agent-management:
+
+=================
+Cephadm Agent
+=================
+
+Introduction
+============
+
+The `cephadm` Agent is a lightweight daemon designed to run on each node in a Ceph cluster. Its role is to periodically gather and send host
+metadata to the cephadm orchestrator (running in the Ceph Manager). This decentralized approach reduces the burden on the central Ceph manager,
+especially in large-scale deployments. Hence, using the agent is **recommended for large clusters** to improve scalability and reduce metadata
+collection latency.
+
+Agent Operation Overview
+=========================
+
+When enabled, each `cephadm` agent performs the following:
+
+- Gathers host-specific metadata such as services, storage, networking, and services state.
+- Compresses and optimizes metadata to reduce transmission size and network overhead.
+- Sends metadata back to the manager at intervals based on configuration or auto-adjusted parameters.
+
+This design supports both scalability and performance in dense distributed environments.
+
+Configuration
+=============
+
+Several Ceph configuration options are available to control agent behavior and performance:
+
+- ``mgr/cephadm/use_agent`` (default: ``False``):
+
+  Enables the use of `cephadm` agents on each host to send metadata to the manager. This must be explicitly
+  set to ``True`` to activate agent functionality.
+
+- ``mgr/cephadm/agent_refresh_rate`` (default: ``-1``):
+
+  Controls how frequently (in seconds) each agent sends metadata. If set to ``-1``, the system automatically
+  adjusts the refresh rate based on the cluster size to balance responsiveness and overhead.
+
+- ``mgr/cephadm/agent_avg_concurrency`` (default: ``-1``):
+
+  Sets the target average number of agents reporting per second. Used to compute a jitter window to avoid request
+  bursts. Set to ``-1`` to allow automatic tuning based on cluster scale.
+
+- ``mgr/cephadm/agent_initial_startup_delay_max`` (default: ``-1``):
+
+  Specifies the maximum random startup delay (in seconds) before an agent begins sending metadata. A value
+  of ``-1`` enables automatic behavior. Set to ``0`` to disable the startup delay.
+
+- ``mgr/cephadm/agent_jitter_seconds`` (default: ``-1``):
+
+  Adds a random delay (in seconds) before each metadata transmission to prevent synchronized bursts
+  across hosts. ``-1`` enables automatic jitter; ``0`` disables jitter.
+
+- ``mgr/cephadm/agent_starting_port`` (default: ``4721``):
+
+  Defines the first TCP port an agent attempts to bind to for communication. If that port is in use, the agent
+  will try the next 1,000 subsequent ports until successful.
+
+- ``mgr/cephadm/agent_metadata_compresion_enabled`` (default: ``True``):
+
+  When enabled, agents compress metadata before transmission to reduce payload size and network usage. This is particularly
+  helpful for clusters with big number of nodes or fewer dense nodes.
+
+- ``mgr/cephadm/agent_metadata_payload_optimization_enabled`` (default: ``True``):
+
+  Optimizes metadata payloads by excluding unchanged sections (e.g., volume lists, network interfaces). This minimizes data sent
+  across the network and reduces processing overhead on the manager side.
+
+- ``mgr/cephadm/agent_down_multiplier`` (default: ``3.0``):
+
+  Determines how long a manager will wait before marking an agent as "down." This is calculated as `agent_refresh_rate * agent_down_multiplier`.
+
+
+.. note::
+
+   When manually configuring these parameters, it is important to choose consistent values that work well together:
+
+   - If you set ``agent_refresh_rate`` to a fixed value (e.g., ``10``), you should **also** set a
+     fixed ``agent_avg_concurrency`` and ``agent_jitter_seconds``. This ensures the system doesn't mix auto-tuned
+     jitter or concurrency with a fixed refresh rate, which could lead to uneven metadata reporting patterns.
+
+   - If you leave ``agent_refresh_rate`` as ``-1`` (auto), it is recommended to also leave ``agent_avg_concurrency``
+     and ``agent_jitter_seconds`` set to ``-1`` so that the manager can tune them together as a group.
+
+   - ``agent_initial_startup_delay_max`` can typically remain on ``-1`` (auto) unless you are testing, debugging, or
+     need agents to begin reporting immediately, in which case you may set it to ``0``.
+
+   - In general, for **large clusters**, it is safest to leave all four parameters set to ``-1`` to let Cephadm
+     auto-tune them based on the size and behavior of the cluster.
+
+   Mixing auto and manual values is allowed but **discouraged**, as it may lead to suboptimal behavior unless you
+   fully understand the implications of each setting.
+
+
+Agent Health Monitoring
+=======================
+
+Cephadm monitors the activity of each registered agent. If a host agent fails to report within the expected timeframe
+(based on `refresh_rate` and `down_multiplier`), the host will be flagged as stale or down. This ensures administrators
+are alerted when a node is not communicating and can investigate connectivity or daemon health issues proactively.
+
+
+Managing Agent Behavior
+=======================
+
+Reloading Agent Configuration
+-----------------------------
+
+To reload the cephadm agent configuration on the manager:
+
+.. prompt:: bash #
+
+   ceph orch reconfig agent
+
+This command reconfigure all the running agents so they can reload their configuration such as port binding and refresh rates, without needing a manager restart.
+
+Get Agent Configuration
+-----------------------
+
+Several agent parameters support auto-tuning by using a value of ``-1``. To view the effective values currently in
+use (including those automatically computed), run the following command:
+
+.. prompt:: bash #
+
+   ceph orch agent show-config
+
+
+Listing Agent Status
+--------------------
+
+To list all agents and their statuses:
+
+.. prompt:: bash #
+
+   ceph orch ps --service-name agent
+
+This command provides the current status of agents, including last report time and daemons status.
+
+
+Agent Use Case Scenarios
+========================
+
+- **Small Clusters (<10 hosts):**
+  - Using agents is optional. The manager can gather metadata efficiently in small environments.
+
+- **Large Clusters (100+ hosts):**
+  - Strongly recommended to use agents to avoid manager overload and to enable scalable metadata collection.
+
+- **Geographically Distributed Clusters:**
+  - Agents reduce cross-site metadata pull latency by pushing data asynchronously.
+
+Summary
+=======
+
+The `cephadm` agent provides a scalable, efficient mechanism for metadata collection and monitoring across large Ceph clusters.
+With flexible configuration, built-in optimization, and proactive health tracking, it is a critical component for managing large
+and complex Ceph deployments.

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1384,10 +1384,12 @@ class CephadmAgent(DaemonForm):
                 self.target_port = config['target_port']
                 self.loop_interval = int(config['refresh_period'])
                 self.starting_port = int(config['listener_port'])
+                self.metadata_compresion_enabled = bool(config.get('metadata_compresion_enabled', False))
                 self.initial_startup_delay_max = int(config.get('initial_startup_delay_max', 0))
                 self.jitter_seconds = int(config.get('jitter_seconds', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
+                logger.info(f"Agent configuration at startup: {config}")
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
@@ -1468,7 +1470,8 @@ class CephadmAgent(DaemonForm):
                                               port=self.target_port,
                                               data=data,
                                               endpoint='/data',
-                                              ssl_ctx=self.ssl_ctx)
+                                              ssl_ctx=self.ssl_ctx,
+                                              compress=self.metadata_compresion_enabled)
                 if status != 200:
                     logger.error(f'HTTP error {status} while querying agent endpoint: {response}')
                     raise RuntimeError(f'non-200 response <{status}> from agent endpoint: {response}')

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import errno
 import ssl
+import hashlib
 from typing import Dict, List, Tuple, Optional, Union, Any, Callable, Sequence, TypeVar, cast
 
 import re
@@ -208,6 +209,76 @@ FuncT = TypeVar('FuncT', bound=Callable)
 
 
 logger = logging.getLogger()
+
+
+def deep_sort(data):
+    if isinstance(data, dict):
+        return {k: deep_sort(v) for k, v in sorted(data.items())}
+    elif isinstance(data, list):
+        # Try to sort if all elements are the same primitive type
+        try:
+            return sorted(deep_sort(v) for v in data)
+        except TypeError:
+            # Mixed types or uncomparable — just recurse
+            return [deep_sort(v) for v in data]
+    else:
+        return data
+
+
+def fuzzy_changed(prev: dict, current: dict, mem_threshold: int = 10 * 1024 * 1024, cpu_threshold: float = 1.0) -> bool:
+    for key in current:
+        if key not in prev:
+            return True
+        if key == 'memory_usage':
+            try:
+                prev_val = int(prev[key])
+                curr_val = int(current[key])
+                if abs(curr_val - prev_val) > mem_threshold:
+                    return True
+            except Exception:
+                return True
+        elif key == 'cpu_percentage':
+            try:
+                prev_val = float(prev[key].strip('%'))
+                curr_val = float(current[key].strip('%'))
+                if abs(curr_val - prev_val) > cpu_threshold:
+                    return True
+            except Exception:
+                return True
+        else:
+            try:
+                prev_val = prev[key]
+                curr_val = current[key]
+                if isinstance(prev_val, list) and isinstance(curr_val, list):
+                    if sorted(prev_val) != sorted(curr_val):
+                        return True
+                else:
+                    if prev_val != curr_val:
+                        return True
+            except Exception as e:
+                logger.warning(f"Exception comparing key '{key}': {e}")
+                return True
+
+    # Detect keys removed in current
+    for key in prev:
+        if key not in current:
+            return True
+
+    return False
+
+
+def stable_hash(obj: Any) -> Optional[str]:
+    try:
+        if isinstance(obj, bytes):
+            encoded = obj
+        elif isinstance(obj, str):
+            encoded = obj.encode('utf-8')
+        else:
+            encoded = json.dumps(obj, sort_keys=True, separators=(',', ':')).encode('utf-8')
+        return hashlib.sha256(encoded).hexdigest()
+    except Exception as e:
+        logger.error(f"Failed to calculate stable hash for {type(obj).__name__}: {e}")
+        return None
 
 
 ##################################
@@ -1311,6 +1382,18 @@ class CephadmAgent(DaemonForm):
         self.ssl_ctx = ssl.create_default_context()
         self.ssl_ctx.check_hostname = True
         self.ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+        # Stores the last sent value for each section.
+        # For 'ls' and 'facts', we store the raw list of dicts instead of a hash,
+        # because these structures contain dynamic fields (such as CPU, memory usage, etc)
+        # that would cause frequent unnecessary updates if hashed directly.
+        # For other sections like 'volume' and 'networks', we store a stable hash
+        # to efficiently detect meaningful changes.
+        self.last_sent_values: Dict[str, Optional[Any]] = {
+            'ls': None,
+            'volume': None,
+            'facts': None,
+            'networks': None,
+        }
 
     def validate(self, config: Dict[str, str] = {}) -> None:
         # check for the required files
@@ -1380,16 +1463,28 @@ class CephadmAgent(DaemonForm):
         try:
             with open(self.config_path, 'r') as f:
                 config = json.load(f)
+                prev_target_ip = self.target_ip
                 self.target_ip = config['target_ip']
                 self.target_port = config['target_port']
                 self.loop_interval = int(config['refresh_period'])
                 self.starting_port = int(config['listener_port'])
                 self.metadata_compresion_enabled = bool(config.get('metadata_compresion_enabled', False))
+                self.metadata_payload_optimization_enabled = bool(config.get('metadata_payload_optimization_enabled', False))
                 self.initial_startup_delay_max = int(config.get('initial_startup_delay_max', 0))
                 self.jitter_seconds = int(config.get('jitter_seconds', 0))
                 self.host = config['host']
                 use_lsm = config['device_enhanced_scan']
                 logger.info(f"Agent configuration at startup: {config}")
+
+                # if active mgr ip has changed then invalidate cached hashes
+                if prev_target_ip != config['target_ip']:
+                    self.last_sent_values = {
+                        'ls': None,
+                        'volume': None,
+                        'facts': None,
+                        'networks': None,
+                    }
+
         except Exception as e:
             self.shutdown()
             raise Error(f'Failed to get agent target ip and port from config: {e}')
@@ -1407,6 +1502,38 @@ class CephadmAgent(DaemonForm):
         if use_lsm.lower() == 'true':
             self.device_enhanced_scan = True
         self.volume_gatherer.update_func(lambda: self._ceph_volume(enhanced=self.device_enhanced_scan))
+
+    def update_section_if_changed(self, name: str, value: Any, payload: dict) -> None:
+        if value is None:
+            return
+
+        if name in ['ls', 'facts'] and isinstance(value, list):
+            prev = self.last_sent_values.get(name)
+            changed = False
+            if not isinstance(prev, list) or len(prev) != len(value):
+                changed = True
+            else:
+                for i, cur_entry in enumerate(value):
+                    prev_entry = prev[i]
+                    if fuzzy_changed(prev_entry, cur_entry):
+                        changed = True
+                        break
+
+            if changed:
+                payload[name] = value
+                self.last_sent_values[name] = value
+                logger.debug(f"{name} changed. Included in payload.")
+            else:
+                logger.debug(f"{name} has not changed significantly. Skipped.")
+        else:
+            # fallback to stable hash comparison for other fields
+            value_hash = stable_hash(value)
+            if value_hash and value_hash != self.last_sent_values.get(name):
+                payload[name] = value
+                self.last_sent_values[name] = value_hash
+                logger.debug(f"{name} changed. Included in payload.")
+            else:
+                logger.debug(f"{name} has not changed. Skipped.")
 
     def run(self) -> None:
 
@@ -1452,17 +1579,35 @@ class CephadmAgent(DaemonForm):
                 for k, v in networks[key].items():
                     networks_list[key][k] = list(v)
 
-            data = json.dumps({'host': self.host,
-                               'ls': (self.ls_gatherer.data if self.ack == self.ls_gatherer.ack
-                                      and self.ls_gatherer.data is not None else []),
-                               'networks': networks_list,
-                               'facts': HostFacts(self.ctx).dump(),
-                               'volume': (self.volume_gatherer.data if self.ack == self.volume_gatherer.ack
-                                          and self.volume_gatherer.data is not None else ''),
-                               'ack': str(ack),
-                               'keyring': self.keyring,
-                               'port': self.listener_port})
-            data = data.encode('ascii')
+            if self.metadata_payload_optimization_enabled:
+                payload = {
+                    'host': self.host,
+                    'ack': str(ack),
+                    'keyring': self.keyring,
+                    'port': self.listener_port,
+                }
+                facts = HostFacts(self.ctx).dump()
+                self.update_section_if_changed('facts', facts, payload)
+                self.update_section_if_changed('networks', networks_list, payload)
+
+                if self.ack == self.ls_gatherer.ack:
+                    self.update_section_if_changed('ls', self.ls_gatherer.data, payload)
+
+                if self.ack == self.volume_gatherer.ack:
+                    self.update_section_if_changed('volume', self.volume_gatherer.data, payload)
+
+                data = json.dumps(payload).encode('ascii')
+            else:
+                data = json.dumps({'host': self.host,
+                       'ls': (self.ls_gatherer.data if self.ack == self.ls_gatherer.ack
+                              and self.ls_gatherer.data is not None else []),
+                       'networks': networks_list,
+                       'facts': HostFacts(self.ctx).dump(),
+                       'volume': (self.volume_gatherer.data if self.ack == self.volume_gatherer.ack
+                                  and self.volume_gatherer.data is not None else ''),
+                       'ack': str(ack),
+                       'keyring': self.keyring,
+                       'port': self.listener_port}).encode('ascii')
 
             try:
                 send_time = time.monotonic()
@@ -1504,6 +1649,10 @@ class CephadmAgent(DaemonForm):
             command_ceph_volume(self.ctx)
 
         stdout = stream.getvalue()
+
+        #TODO(redo): remove this additioonal steps, this must be done in side the ceph-volume
+        ceph_volume_dict = json.loads(stdout)
+        stdout = json.dumps(deep_sort(ceph_volume_dict))
 
         if stdout:
             return (stdout, False)

--- a/src/cephadm/cephadmlib/agent.py
+++ b/src/cephadm/cephadmlib/agent.py
@@ -1,9 +1,34 @@
+import gzip
+import json
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen, Request
 from typing import Optional, Any, Tuple
 import logging
 
 logger = logging.getLogger()
+
+
+def make_json_request(url: str, payload: dict, compress: bool) -> Request:
+    """
+    Create a JSON POST request, optionally gzip-compressed.
+    """
+    body = json.dumps(payload).encode('utf-8')
+    original_size = len(body)
+    if compress:
+        body = gzip.compress(body)
+        compressed_size = len(body)
+        compression_ratio = 100 * (1 - compressed_size / original_size)
+        logger.info(f"Compression reduced payload size by {compression_ratio:.1f}% ({original_size} → {compressed_size} bytes)")
+        headers = {
+            'Content-Type': 'application/json',
+            'Content-Encoding': 'gzip',
+            'Accept-Encoding': 'gzip',
+        }
+    else:
+        headers = {
+            'Content-Type': 'application/json',
+        }
+    return Request(url, data=body, headers=headers)
 
 
 def http_query(
@@ -13,11 +38,22 @@ def http_query(
     endpoint: str = '',
     ssl_ctx: Optional[Any] = None,
     timeout: Optional[int] = 10,
+    compress: bool = False,
 ) -> Tuple[int, str]:
+    """
+    Perform an HTTPS POST request with optional gzip-compressed JSON payload.
+
+    `data` should be a JSON-encoded bytes object (not already compressed).
+    """
     url = f'https://{addr}:{port}{endpoint}'
-    logger.debug(f'sending query to {url}')
+    logger.debug(f'sending query to {url} (compression={compress})')
     try:
-        req = Request(url, data, {'Content-Type': 'application/json'})
+        if data:
+            payload = json.loads(data.decode('utf-8'))
+            req = make_json_request(url, payload, compress)
+        else:
+            req = Request(url)
+
         with urlopen(req, context=ssl_ctx, timeout=timeout) as response:
             response_str = response.read()
             response_status = response.status
@@ -28,7 +64,9 @@ def http_query(
     except URLError as e:
         logger.debug(f'{e.reason}')
         response_status = -1
-        response_str = e.reason
-    except Exception:
+        response_str = str(e.reason)
+    except Exception as e:
+        logger.error(f'Unexpected error: {e}')
         raise
-    return (response_status, response_str)
+
+    return (response_status, response_str.decode('utf-8') if isinstance(response_str, bytes) else response_str)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -146,6 +146,21 @@ class AgentEndpoint:
         else:
             return self.mgr.agent_initial_startup_delay_max
 
+    def get_jitter(self) -> int:
+        """
+        Compute the jitter window (in seconds) applied before agents send metadata.
+
+        - If agent_jitter_seconds is -1 (auto), compute it as:
+            jitter = num_agents / avg_concurrency (M)
+        - This spreads agent reports evenly across the window.
+        - Uses a min jitter of 2s to prevent tight clustering in very small clusters.
+        """
+        if self.mgr.agent_jitter_seconds == -1:  # auto-jitter mode
+            agents_refresh_rate = self.compute_agents_refrsh_rate()
+            return max(2, int(agents_refresh_rate * 0.5))
+        else:
+            return self.mgr.agent_jitter_seconds
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -85,6 +85,51 @@ class AgentEndpoint:
                 self.server_port += 1
         self.mgr.log.error(f'Cephadm agent could not find free port in range {max_port - 150}-{max_port} and failed to start')
 
+    def compute_agents_avg_concurrency(self) -> int:
+        """
+        Compute the average number of agents allowed to report metadata per second (M).
+
+        - If user-specified value is -1, use an adaptive formula: sqrt(N)/2 (capped at 10).
+        - Ensures a minimum of 2 agents/sec to avoid unnecessary serialization.
+        - This helps spread load while avoiding bursts, especially on small clusters.
+        """
+        if self.mgr.agent_avg_concurrency == -1:  # auto-concurrency mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_concurrency = min(20, int(num_agents ** 0.5 / 2))
+        else:
+            agents_concurrency = self.mgr.agent_avg_concurrency
+        # We force a minimum of 2 agents per seconds
+        return max(2, agents_concurrency)
+
+    def compute_agents_refrsh_rate(self) -> int:
+        """
+        Compute the refresh rate (in seconds) for agent metadata reporting.
+
+        - If the user has specified a fixed `agent_refresh_rate`, use that.
+        - If `agent_refresh_rate` is set to -1 (auto mode), compute it dynamically as:
+            refresh_rate = num_agents // avg_concurrency
+            where:
+              - num_agents = total number of agents in the cluster
+              - avg_concurrency = average number of agents allowed to report per second,
+                computed using a separate heuristic (sqrt(N)/2, capped).
+        - This ensures that agent updates are spread evenly and that the manager is not overwhelmed.
+
+        Notes:
+        - A minimum refresh rate of 20 seconds is enforced to avoid excessive agent churn and load.
+        - The dynamic mode adapts automatically as the cluster grows.
+
+        Returns:
+            int: The agent refresh rate in seconds.
+        """
+        if self.mgr.agent_refresh_rate == -1:  # auto-refresh rate
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            refresh_rate = num_agents // agents_avg_concurrency
+        else:
+            refresh_rate = self.mgr.agent_refresh_rate
+
+        return max(20, refresh_rate)
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)
@@ -886,10 +931,11 @@ class CephadmAgentHelpers:
             if host in self.mgr.offline_hosts:
                 return False
             self.mgr.agent_cache.agent_timestamp[host] = datetime_now()
-        # agent hasn't reported in down multiplier * it's refresh rate. Something is likely wrong with it.
+        # agent hasn't reported in:  down_multiplier * it's refresh rate + jitter. Something is likely wrong with it.
+        jitter: float = self.agent.get_jitter()
         down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
         time_diff = datetime_now() - self.mgr.agent_cache.agent_timestamp[host]
-        if time_diff.total_seconds() > down_mult * float(self.mgr.agent_refresh_rate):
+        if time_diff.total_seconds() > down_mult * float(self.mgr.http_server.agent.compute_agents_refrsh_rate() + jitter):
             return True
         return False
 
@@ -900,7 +946,7 @@ class CephadmAgentHelpers:
             down_mult: float = max(self.mgr.agent_down_multiplier, 1.5)
             for agent in down_agent_hosts:
                 detail.append((f'Cephadm agent on host {agent} has not reported in '
-                              f'{down_mult * self.mgr.agent_refresh_rate} seconds. Agent is assumed '
+                              f'{down_mult * self.mgr.http_server.agent.compute_agents_refrsh_rate()} seconds. Agent is assumed '
                                'down and host may be offline.'))
             for dd in [d for d in self.mgr.cache.get_daemons_by_type('agent') if d.hostname in down_agent_hosts]:
                 dd.status = DaemonDescriptionStatus.error

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -139,7 +139,7 @@ class AgentEndpoint:
         - This prevents bursts of all agents from reporting immediately at startup.
         - Enforces a minimum of 10s to avoid early tight clustering.
         """
-        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+        if self.mgr.agent_initial_startup_delay_max == -1:  # auto-delay mode
             num_agents = len(self.mgr.cache.get_hosts())
             agents_avg_concurrency = self.compute_agents_avg_concurrency()
             return max(10, num_agents // agents_avg_concurrency)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -719,12 +719,34 @@ class HostData(Server):
         self.unsubscribe()
         super().stop()
 
+    def get_data(self) -> Optional[dict]:
+        import io
+        import gzip
+        try:
+            content_encoding = cherrypy.request.headers.get('Content-Encoding', '')
+            remote_ip = cherrypy.request.remote.ip
+            raw_body = cherrypy.request.body.read()
+            if content_encoding == 'gzip':
+                self.mgr.log.info(f">>> Received gzipped payload from {remote_ip}")
+                buf = io.BytesIO(raw_body)
+                with gzip.GzipFile(fileobj=buf) as gz:
+                    decompressed = gz.read()
+                data = json.loads(decompressed.decode('utf-8'))
+            else:
+                self.mgr.log.info(f">>> Received plain payload from {remote_ip}")
+                data = json.loads(raw_body.decode('utf-8'))
+            return data
+        except Exception as e:
+            self.mgr.log.error(f"Failed to read request body: {e}")
+            return None
+
     @cherrypy.tools.allow(methods=['POST'])
-    @cherrypy.tools.json_in()
     @cherrypy.tools.json_out()
     @cherrypy.expose
     def index(self) -> Dict[str, Any]:
-        data: Dict[str, Any] = cherrypy.request.json
+        data: Optional[Dict[str, Any]] = self.get_data()
+        if data is None:
+            return {}
         results: Dict[str, Any] = {}
         try:
             self.check_request_fields(data)

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -786,11 +786,12 @@ class HostData(Server):
         except Exception as e:
             raise Exception(
                 f'Counter value from agent on host {host} could not be converted to an integer: {e}')
-        metadata_types = ['ls', 'networks', 'facts', 'volume']
-        metadata_types_str = '{' + ', '.join(metadata_types) + '}'
-        if not all(item in data.keys() for item in metadata_types):
-            self.mgr.log.warning(
-                f'Agent on host {host} reported incomplete metadata. Not all of {metadata_types_str} were present. Received fields {fields}')
+        if not self.mgr.agent_metadata_payload_optimization_enabled:
+            metadata_types = ['ls', 'networks', 'facts', 'volume']
+            metadata_types_str = '{' + ', '.join(metadata_types) + '}'
+            if not all(item in data.keys() for item in metadata_types):
+                self.mgr.log.warning(
+                    f'Agent on host {host} reported incomplete metadata. Not all of {metadata_types_str} were present. Received fields {fields}')
 
     def handle_metadata(self, data: Dict[str, Any]) -> str:
         try:

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -130,6 +130,22 @@ class AgentEndpoint:
 
         return max(20, refresh_rate)
 
+    def get_initial_delay(self) -> int:
+        """
+        Compute the maximum initial random startup delay (in seconds) before an agent starts reporting.
+
+        - If agent_initial_startup_delay_max is -1 (auto), compute as:
+            delay = num_agents / avg_concurrency (M)
+        - This prevents bursts of all agents from reporting immediately at startup.
+        - Enforces a minimum of 10s to avoid early tight clustering.
+        """
+        if self.mgr.agent_initial_startup_delay_max == -1: # auto-delay mode
+            num_agents = len(self.mgr.cache.get_hosts())
+            agents_avg_concurrency = self.compute_agents_avg_concurrency()
+            return max(10, num_agents // agents_avg_concurrency)
+        else:
+            return self.mgr.agent_initial_startup_delay_max
+
     def configure(self) -> None:
         self.host_data = HostData(self.mgr, self.server_port, self.server_addr)
         self.configure_tls(self.host_data)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -366,9 +366,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ),
         Option(
             'agent_refresh_rate',
-            type='secs',
-            default=20,
-            desc='How often agent on each host will try to gather and send metadata'
+            type='int',
+            default=-1,
+            desc='How often each agent sends metadata. Use -1 to auto-adjust based on cluster size.'
+        ),
+        Option(
+            'agent_avg_concurrency',
+            type='int',
+            default=-1,
+            desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
             'agent_starting_port',
@@ -566,6 +572,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.ssh_cert: Optional[str] = None
             self.use_agent = False
             self.agent_refresh_rate = 0
+            self.agent_avg_concurrency = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -401,6 +401,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Enable compression of metadata sent from agent to reduce payload size'
         ),
         Option(
+            'agent_metadata_payload_optimization_enabled',
+            type='bool',
+            default=True,
+            desc='Reduce agent-produced metadata payload by excluding sections that have not changed (such as ls, networks, and volumes).'
+        ),
+        Option(
             'agent_down_multiplier',
             type='float',
             default=3.0,
@@ -593,6 +599,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_avg_concurrency = 0
             self.agent_initial_startup_delay_max = 0
             self.agent_jitter_seconds = 0
+            self.agent_metadata_payload_optimization_enabled = True
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.agent_metadata_compresion_enabled = True

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -395,6 +395,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='First port agent will try to bind to (will also try up to next 1000 subsequent ports if blocked)'
         ),
         Option(
+            'agent_metadata_compresion_enabled',
+            type='bool',
+            default=True,
+            desc='Enable compression of metadata sent from agent to reduce payload size'
+        ),
+        Option(
             'agent_down_multiplier',
             type='float',
             default=3.0,
@@ -589,6 +595,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
+            self.agent_metadata_compresion_enabled = True
             self.hw_monitoring = False
             self.service_discovery_port = 0
             self.secure_monitoring_stack = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -383,6 +383,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
         ),
         Option(
+            'agent_jitter_seconds',
+            type='int',
+            default=-1,
+            desc='Max random delay before agent sends metadata; set -1 for auto (default), 0 to disable'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -580,6 +586,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
             self.agent_initial_startup_delay_max = 0
+            self.agent_jitter_seconds = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3325,6 +3325,18 @@ Then run the following:
                 'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
+    def show_agent_config(self) -> Dict[str, str]:
+        agent = self.http_server.agent
+        return {
+            'agent_refresh_rate': str(agent.compute_agents_refrsh_rate()),
+            'agent_avg_concurrency': str(agent.compute_agents_avg_concurrency()),
+            'agent_initial_startup_delay_max': str(agent.get_initial_delay()),
+            'agent_jitter_seconds': str(agent.get_jitter()),
+            'agent_down_multiplier': str(self.agent_down_multiplier),
+            'agent_starting_port': str(self.agent_starting_port)
+        }
+
+    @handle_orch_error
     def cert_store_cert_ls(self, show_details: bool = False) -> Dict[str, Any]:
         return self.cert_mgr.cert_ls(show_details)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -377,6 +377,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Target average number of agents sending per second. Used to compute jitter window. Set -1 for auto.'
         ),
         Option(
+            'agent_initial_startup_delay_max',
+            type='int',
+            default=-1,
+            desc='Max random startup delay (sec) before agent start sending metadata. Set to -1 for auto (default), or 0 to disable.'
+        ),
+        Option(
             'agent_starting_port',
             type='int',
             default=4721,
@@ -573,6 +579,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.use_agent = False
             self.agent_refresh_rate = 0
             self.agent_avg_concurrency = 0
+            self.agent_initial_startup_delay_max = 0
             self.agent_down_multiplier = 0.0
             self.agent_starting_port = 0
             self.hw_monitoring = False

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1512,6 +1512,7 @@ class CephadmAgent(CephService):
         agent_options = [
             'device_enhanced_scan',
             'agent_metadata_compresion_enabled',
+            'agent_metadata_payload_optimization_enabled',
             'agent_starting_port',
         ]
         agent_static_cfg_opts = [f"{opt}: {mgr.get_module_option(opt)}" for opt in agent_options]
@@ -1564,6 +1565,7 @@ class CephadmAgent(CephService):
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
                'metadata_compresion_enabled': self.mgr.agent_metadata_compresion_enabled,
+               'metadata_payload_optimization_enabled': self.mgr.agent_metadata_payload_optimization_enabled,
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'initial_startup_delay_max': agent.get_initial_delay(),
                'jitter_seconds': agent.get_jitter()}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1545,7 +1545,7 @@ class CephadmAgent(CephService):
 
         cfg = {'target_ip': self.mgr.get_mgr_ip(),
                'target_port': agent.server_port,
-               'refresh_period': self.mgr.agent_refresh_rate,
+               'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1511,6 +1511,7 @@ class CephadmAgent(CephService):
 
         agent_options = [
             'device_enhanced_scan',
+            'agent_metadata_compresion_enabled',
             'agent_starting_port',
         ]
         agent_static_cfg_opts = [f"{opt}: {mgr.get_module_option(opt)}" for opt in agent_options]
@@ -1562,6 +1563,7 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'metadata_compresion_enabled': self.mgr.agent_metadata_compresion_enabled,
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'initial_startup_delay_max': agent.get_initial_delay(),
                'jitter_seconds': agent.get_jitter()}

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1548,7 +1548,8 @@ class CephadmAgent(CephService):
                'refresh_period': agent.compute_agents_refrsh_rate(),
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
-               'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}
+               'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
+               'initial_startup_delay_max': agent.get_initial_delay()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1549,7 +1549,8 @@ class CephadmAgent(CephService):
                'listener_port': self.mgr.agent_starting_port,
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan),
-               'initial_startup_delay_max': agent.get_initial_delay()}
+               'initial_startup_delay_max': agent.get_initial_delay(),
+               'jitter_seconds': agent.get_jitter()}
 
         listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {

--- a/src/pybind/mgr/cephadm/tests/test_agent.py
+++ b/src/pybind/mgr/cephadm/tests/test_agent.py
@@ -1,0 +1,196 @@
+from cephadm.agent import AgentEndpoint
+
+
+class FakeCache:
+    def __init__(self, num_hosts):
+        self._hosts = ['host{}'.format(i) for i in range(num_hosts)]
+
+    def get_hosts(self):
+        return self._hosts
+
+
+class FakeMgr:
+    def __init__(self, num_hosts=10):
+        self.agent_avg_concurrency = -1
+        self.agent_refresh_rate = -1
+        self.agent_initial_startup_delay_max = -1
+        self.agent_jitter_seconds = -1
+        self.cache = FakeCache(num_hosts)
+
+    def get_mgr_ip(self):
+        return ''
+
+
+class TestAgentEndpoint:
+
+    def test_concurrency_auto_small(self):
+        # Test that even for very small clusters (1 host),
+        # the minimum concurrency of 2 is enforced
+        mgr = FakeMgr(num_hosts=1)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+
+    def test_concurrency_auto_exact_boundary(self):
+        # Test that concurrency is capped at 20 even when sqrt(N)/2 exceeds 20
+        mgr = FakeMgr(num_hosts=1600)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 20
+
+    def test_refresh_auto_typical(self):
+        # Test refresh rate computed dynamically in auto mode for a typical cluster size
+        # 100 agents → concurrency = 5 and refresh_rate = (100*2)//5 = 40
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 40
+
+    def test_refresh_auto_zero_agents(self):
+        # Test refresh rate fallback for 0 agents (should enforce minimum of 20s)
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_auto_with_manual_concurrency(self):
+        # Test refresh rate in auto mode with manually overridden high concurrency
+        # Should still honor the lower bound of 20s
+        mgr = FakeMgr(num_hosts=1000)
+        mgr.agent_avg_concurrency = 100
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_min_refresh_rate(self):
+        # Test that manually specified refresh rates below the lower bound are clamped to 20s
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 5
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 20
+
+    def test_refresh_manual_valid(self):
+        # Test that manually specified valid refresh rate is used as-is
+        mgr = FakeMgr()
+        mgr.agent_refresh_rate = 60
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_refrsh_rate() == 60
+
+    def test_initial_delay_auto_small(self):
+        # Test auto delay with a small number of agents returns minimum 10s
+        mgr = FakeMgr(num_hosts=2)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_auto_zero_agents(self):
+        # Test auto delay with 0 agents still enforces the minimum 10s delay
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 10
+
+    def test_initial_delay_manual_below_min(self):
+        # Test that manual delay below the minimum is respected (no clamping here)
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 5
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 5
+
+    def test_initial_delay_manual_valid(self):
+        # Test that a valid manual delay value is used directly
+        mgr = FakeMgr()
+        mgr.agent_initial_startup_delay_max = 30
+        config = AgentEndpoint(mgr)
+        assert config.get_initial_delay() == 30
+
+    def test_jitter_auto_zero_refresh(self):
+        # Test jitter in auto mode with 0 agents; fallback refresh_rate is 20 and jitter = 10
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 10
+
+    def test_jitter_auto_typical(self):
+        # Test jitter in auto mode for a typical cluster (100 agents)
+        # refresh_rate = 40 an jitter = 20
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        jitter = config.get_jitter()
+        assert jitter == 20
+
+    def test_jitter_manual(self):
+        # Test that manual jitter override is respected (even if < 2)
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 1
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 1
+
+    def test_jitter_manual_high(self):
+        # Test that a high manual jitter value is used as-is
+        mgr = FakeMgr()
+        mgr.agent_jitter_seconds = 60
+        config = AgentEndpoint(mgr)
+        assert config.get_jitter() == 60
+
+
+class TestAgentEndpointAuto:
+
+    def test_auto_minimum_values(self):
+        # Test system behavior with 0 agents in full auto mode.
+        # All computed values should fall back to their enforced minimums.
+        mgr = FakeMgr(num_hosts=0)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2  # Enforced minimum
+        assert config.compute_agents_refrsh_rate() == 20     # Enforced minimum
+        assert config.get_initial_delay() == 10              # Enforced minimum
+        assert config.get_jitter() == 10                     # 50% of refresh rate (20)
+
+    def test_auto_4_hosts(self):
+        # Test computed values for a very small cluster (4 agents).
+        # sqrt(4)/2 = 1 -> clamped to 2 concurrency
+        # Refresh rate = (4*2)//2 = 4 -> clamped to 20
+        mgr = FakeMgr(num_hosts=4)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10              # 4//2 = 2 -> clamped to 10
+        assert config.get_jitter() == 10                     # 50% of refresh rate
+
+    def test_auto_16_hosts(self):
+        # Test computed values for 16 agents.
+        # sqrt(16)/2 = 2 → meets minimum concurrency
+        # Refresh rate = (16*2)//2 = 16 → clamped to 20
+        mgr = FakeMgr(num_hosts=16)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 2
+        assert config.compute_agents_refrsh_rate() == 20
+        assert config.get_initial_delay() == 10              # 16//2 = 8 → clamped to 10
+        assert config.get_jitter() == 10                     # 50% of refresh rate
+
+    def test_auto_100_hosts(self):
+        # Test computed values for 100 agents.
+        # sqrt(100)/2 = 5 -> concurrency = 5
+        # Refresh rate = (100*2)//5 = 40
+        # Initial delay = 100//5 = 20
+        mgr = FakeMgr(num_hosts=100)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 5
+        assert config.compute_agents_refrsh_rate() == 40
+        assert config.get_initial_delay() == 20
+        assert config.get_jitter() == 20  # 50% of refresh rate
+
+    def test_auto_200_hosts(self):
+        # Test computed values for 200 agents.
+        # sqrt(200)/2 ≈ 7.07 -> concurrency = 7
+        # Refresh rate = (200*2)//7 = ~57
+        # Initial delay = 200//7 ~ 28
+        mgr = FakeMgr(num_hosts=200)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 7
+        assert config.compute_agents_refrsh_rate() == 57
+        assert config.get_jitter() == 28  # 50% of refresh rate
+
+    def test_auto_1000_hosts(self):
+        # Test computed values for 1000 agents.
+        # sqrt(1000)/2 ≈ 15.81 → concurrency = 15
+        # Refresh rate = (1000*2)//15 ~ 133
+        # Initial delay = 1000//15 ~ 66
+        mgr = FakeMgr(num_hosts=1000)
+        config = AgentEndpoint(mgr)
+        assert config.compute_agents_avg_concurrency() == 15
+        assert config.compute_agents_refrsh_rate() == 133
+        assert config.get_initial_delay() == 66
+        assert config.get_jitter() == 66  # 50% of refresh rate

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3670,7 +3670,7 @@ class TestAgent:
     def test_deploy_cephadm_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         agent_spec = ServiceSpec(service_type="agent", placement=PlacementSpec(count=1))
-        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"refresh_period\": 20, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\"}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
+        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\", \"refresh_period\": 20, \"initial_startup_delay_max\": 10, \"jitter_seconds\": 10}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, agent_spec):

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3670,7 +3670,7 @@ class TestAgent:
     def test_deploy_cephadm_agent(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         agent_spec = ServiceSpec(service_type="agent", placement=PlacementSpec(count=1))
-        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\", \"refresh_period\": 20, \"initial_startup_delay_max\": 10, \"jitter_seconds\": 10}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
+        agent_config = {"agent.json": "{\"target_ip\": \"::1\", \"target_port\": 7150, \"listener_port\": 4721, \"host\": \"test\", \"device_enhanced_scan\": \"False\", \"metadata_compresion_enabled\": true, \"metadata_payload_optimization_enabled\": true, \"refresh_period\": 20, \"initial_startup_delay_max\": 10, \"jitter_seconds\": 10}", "keyring": "[client.agent.test]\nkey = None\n", "root_cert.pem": f"{cephadm_root_ca}", "listener.crt": f"{ceph_generated_cert}", "listener.key": f"{ceph_generated_key}"}
 
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, agent_spec):

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -904,6 +904,9 @@ class Orchestrator(object):
         """remove prometheus target for multi-cluster"""
         raise NotImplementedError()
 
+    def show_agent_config(self) -> OrchResult[Dict[str, str]]:
+        raise NotImplementedError()
+
     def get_alertmanager_access_info(self) -> OrchResult[Dict[str, str]]:
         """get alertmanager access information"""
         raise NotImplementedError()

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1425,6 +1425,12 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         result = raise_if_exception(completion)
         return HandleCommandResult(stdout=json.dumps(result))
 
+    @_cli_read_command('orch agent show-config')
+    def _show_cephadm_agent_config(self) -> HandleCommandResult:
+        completion = self.show_agent_config()
+        result = raise_if_exception(completion)
+        return HandleCommandResult(stdout=json.dumps(result))
+
     @_cli_write_command('orch alertmanager set-credentials')
     def _set_alertmanager_access_info(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> HandleCommandResult:
         try:


### PR DESCRIPTION

This PR introduces configurable metadata payload optimization for Cephadm Agents by allowing them to skip sending unchanged metadata sections. This reduces payload size and minimizes unnecessary data transmission, especially in stable or idle environments.

This optimization is particularly useful in large clusters, where redundant metadata can contribute to bandwidth waste and unnecessary processing on the manager side. Testing has shown significant reductions in payload size when metadata changes are sparse, further improving reporting efficiency.

#### `agent_metadata_payload_optimization_enabled` (bool, default: `True`)
> Reduce agent-produced metadata payload by excluding sections that have not changed  
> (such as `ls`, `networks`, and `volumes`).
>
> **Purpose**: Avoids resending unchanged sections of metadata.
> **Why**: Reduces redundant data transfer and unnecessary processing on the manager side.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
