### PR TITLE
squid: qa: increase the wait time to prevent check_counter failing

### DIFF
--- a/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
+++ b/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
@@ -30,6 +30,6 @@ tasks:
       mon.a:
         # Ensure that we have some snaps which get deleted (so check-counters does not fail)
         - date +%s > END_TIME
-        - START_TIME=$(cat START_TIME); END_TIME=$(cat END_TIME); DIFF_TIME=$((600-(END_TIME-START_TIME))); if [ "$DIFF_TIME" -gt 0 ]; then sleep "$DIFF_TIME"; fi
+        - START_TIME=$(cat START_TIME); END_TIME=$(cat END_TIME); DIFF_TIME=$((800-(END_TIME-START_TIME))); if [ "$DIFF_TIME" -gt 0 ]; then sleep "$DIFF_TIME"; fi
         - ceph fs snap-schedule status --fs=cephfs --path=/
         - ceph fs snap-schedule list --fs=cephfs --path=/ --recursive=true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72084

---

backport of https://github.com/ceph/ceph/pull/64305
parent tracker: https://tracker.ceph.com/issues/70441

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh