### PR TITLE
cephadm: Bind mount /var/lib/samba with 0755

### DIFF
--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -753,7 +753,7 @@ class SMB(ContainerDaemonForm):
         ddir = pathlib.Path(data_dir)
         etc_samba_ctr = ddir / 'etc-samba-container'
         file_utils.makedirs(etc_samba_ctr, uid, gid, 0o770)
-        file_utils.makedirs(ddir / 'lib-samba', uid, gid, 0o770)
+        file_utils.makedirs(ddir / 'lib-samba', uid, gid, 0o755)
         file_utils.makedirs(ddir / 'run', uid, gid, 0o770)
         if self._files:
             file_utils.populate_files(data_dir, self._files, uid, gid)


### PR DESCRIPTION
To start with, all this while, `testparm -s` used to spit out the following lines:

> WARNING: state directory /var/lib/samba should have permissions 0755  for browsing to work
> WARNING: cache directory /var/lib/samba should have permissions 0755 for browsing to work

Putting aside security sensitive stuff like secrets.tdb inside state directory, others by design are expected to be accessed by configured samba users and thus permissions differ between the directory and its contents. With **0770** we denied the access for others and in certain scenarios this denial resulted in real world problems like failure to close file handles and other not so obvious return statuses.

Going by the design and corresponding warning emitted by the `testparm` tool, it is safe and correct to change the mode from **0770** to **0755** while preparing lib-samba bind mount for _/var/lib/samba_.

Fixes: https://tracker.ceph.com/issues/72089