### PR TITLE
squid: deb/mgr: remove deprecated distutils from ceph-mgr.requires

### DIFF
--- a/debian/ceph-mgr.requires
+++ b/debian/ceph-mgr.requires
@@ -3,4 +3,3 @@ pyOpenSSL
 cephfs
 ceph-argparse
 pyyaml
-distutils


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72090

---

backport of https://github.com/ceph/ceph/pull/64386
parent tracker: https://tracker.ceph.com/issues/72020

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh