### PR TITLE
monitoring: fix MTU Mismatch alert rule and expr

### DIFF
--- a/monitoring/ceph-mixin/prometheus_alerts.yml
+++ b/monitoring/ceph-mixin/prometheus_alerts.yml
@@ -515,7 +515,7 @@ groups:
         annotations:
           description: "Node {{ $labels.instance }} has a different MTU size ({{ $value }}) than the median of devices named {{ $labels.device }}."
           summary: "MTU settings across Ceph hosts are inconsistent on cluster {{ $labels.cluster }}"
-        expr: "node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0) ==  scalar(    max by (cluster,device) (node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0)) !=      quantile by (cluster,device) (.5, node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0))  )or node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0) ==  scalar(    min by (cluster,device) (node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0)) !=      quantile by (cluster,device) (.5, node_network_mtu_bytes * (node_network_up{device!=\"lo\"} > 0))  )"
+        expr: "(node_network_mtu_bytes{device!=\"lo\"} * (node_network_up{device!=\"lo\"} > 0))!=on(cluster, device)group_left()quantile by (cluster, device) (0.5,node_network_mtu_bytes{device!=\"lo\"} * (node_network_up{device!=\"lo\"} > 0))"
         labels:
           severity: "warning"
           type: "ceph_default"

--- a/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
+++ b/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
@@ -146,7 +146,7 @@ tests:
        exp_samples:
          - labels: '{ceph_daemon="osd.0", hostname="ceph", instance="ceph:9283",
             job="ceph",cluster="mycluster"}'
-           value: 1.2200000000000001E+01
+           value: 1.21E+01
    alert_rule_test:
      - eval_time: 5m
        alertname: CephOSDFlapping
@@ -508,77 +508,116 @@ tests:
  # MTU Mismatch
  - interval: 1m
    input_series:
-    - series: 'node_network_mtu_bytes{device="eth0",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
+    # Test 1: All MTUs match (NO alert)
+    - series: 'node_network_mtu_bytes{device="eth0",instance="host1",cluster="c"}'
       values: '1500 1500 1500 1500 1500'
-    - series: 'node_network_mtu_bytes{device="eth1",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
+    - series: 'node_network_mtu_bytes{device="eth0",instance="host2",cluster="c"}'
       values: '1500 1500 1500 1500 1500'
-    - series: 'node_network_mtu_bytes{device="eth2",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
-      values: '1500 1500 1500 1500 1500'
-    - series: 'node_network_mtu_bytes{device="eth3",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
-      values: '1500 1500 1500 1500 1500'
-    - series: 'node_network_mtu_bytes{device="eth4",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
+    - series: 'node_network_up{device="eth0",instance="host1",cluster="c"}'
+      values: '1 1 1 1 1'
+    - series: 'node_network_up{device="eth0",instance="host2",cluster="c"}'
+      values: '1 1 1 1 1'
+
+    # Test 2: One host has different MTU
+    - series: 'node_network_mtu_bytes{device="eth1",instance="host1",cluster="c"}'
       values: '9000 9000 9000 9000 9000'
-    - series: 'node_network_mtu_bytes{device="eth4",instance="hostname1",job="node-exporter",cluster="mycluster"}'
-      values: '2200 2200 2200 2200 2200'
-    - series: 'node_network_mtu_bytes{device="eth4",instance="hostname2",job="node-exporter",cluster="mycluster"}'
+    - series: 'node_network_mtu_bytes{device="eth1",instance="host2",cluster="c"}'
+      values: '9000 9000 9000 9000 9000'
+    - series: 'node_network_mtu_bytes{device="eth1",instance="host3",cluster="c"}'
+      values: '9200 9200 9200 9200 9200'
+    - series: 'node_network_up{device="eth1",instance="host1",cluster="c"}'
+      values: '1 1 1 1 1'
+    - series: 'node_network_up{device="eth1",instance="host2",cluster="c"}'
+      values: '1 1 1 1 1'
+    - series: 'node_network_up{device="eth1",instance="host3",cluster="c"}'
+      values: '1 1 1 1 1'
+
+    # Test 3: Down host should not alert
+    - series: 'node_network_mtu_bytes{device="eth2",instance="host1",cluster="c"}'
       values: '2400 2400 2400 2400 2400'
-    - series: 'node_network_up{device="eth0",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
+    - series: 'node_network_mtu_bytes{device="eth2",instance="host2",cluster="c"}'
+      values: '2400 2400 2400 2400 2400'
+    - series: 'node_network_mtu_bytes{device="eth2",instance="host3",cluster="c"}'
+      values: '9000 9000 9000 9000 9000'
+    - series: 'node_network_up{device="eth2",instance="host1",cluster="c"}'
+      values: '1 1 1 1 1'
+    - series: 'node_network_up{device="eth2",instance="host2",cluster="c"}'
+      values: '1 1 1 1 1'
+    - series: 'node_network_up{device="eth2",instance="host3",cluster="c"}'
       values: '0 0 0 0 0'
-    - series: 'node_network_up{device="eth1",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
-      values: '0 0 0 0 0'
-    - series: 'node_network_up{device="eth2",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
+
+    # Test 4: All different MTUs, odd count, median = 2400
+    - series: 'node_network_mtu_bytes{device="eth3",instance="host1",cluster="c"}'
+      values: '1500 1500 1500 1500 1500'
+    - series: 'node_network_mtu_bytes{device="eth3",instance="host2",cluster="c"}'
+      values: '2400 2400 2400 2400 2400'
+    - series: 'node_network_mtu_bytes{device="eth3",instance="host3",cluster="c"}'
+      values: '9000 9000 9000 9000 9000'
+    - series: 'node_network_up{device="eth3",instance="host1",cluster="c"}'
       values: '1 1 1 1 1'
-    - series: 'node_network_up{device="eth3",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
+    - series: 'node_network_up{device="eth3",instance="host2",cluster="c"}'
       values: '1 1 1 1 1'
-    - series: 'node_network_up{device="eth4",instance="node-exporter",job="node-exporter",cluster="mycluster"}'
+    - series: 'node_network_up{device="eth3",instance="host3",cluster="c"}'
       values: '1 1 1 1 1'
-    - series: 'node_network_up{device="eth4",instance="hostname1",job="node-exporter",cluster="mycluster"}'
-      values: '1 1 1 1 1'
-    - series: 'node_network_up{device="eth4",instance="hostname2",job="node-exporter",cluster="mycluster"}'
-      values: '0 0 0 0 0'
+
    promql_expr_test:
-     - expr: |
-          node_network_mtu_bytes * (node_network_up{device!="lo"} > 0) ==
-            scalar(
-              max by (cluster,device) (node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)) !=
-                quantile by (cluster,device) (.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0))
-            )
-          or
-          node_network_mtu_bytes * (node_network_up{device!="lo"} > 0) ==
-            scalar(
-              min by (cluster,device) (node_network_mtu_bytes * (node_network_up{device!="lo"} > 0)) !=
-                quantile by (cluster,device) (.5, node_network_mtu_bytes * (node_network_up{device!="lo"} > 0))
-            )
-       eval_time: 1m
-       exp_samples:
-         - labels: '{device="eth4", instance="node-exporter", job="node-exporter", cluster="mycluster"}'
-           value: 9000
-         - labels: '{device="eth4", instance="hostname1", job="node-exporter", cluster="mycluster"}'
-           value: 2200
+    - expr: |
+        (
+          node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0)
+        )
+        !=
+        on(cluster, device)
+        group_left()
+        quantile by (cluster, device) (
+          0.5,
+          node_network_mtu_bytes{device!="lo"} * (node_network_up{device!="lo"} > 0)
+        )
+      eval_time: 1m
+      exp_samples:
+        # eth1: host3 deviates from 9000 (median)
+        - labels: '{device="eth1", instance="host3", cluster="c"}'
+          value: 9200
+
+        # eth3: median is 2400, host1 and host3 differ
+        - labels: '{device="eth3", instance="host1", cluster="c"}'
+          value: 1500
+        - labels: '{device="eth3", instance="host3", cluster="c"}'
+          value: 9000
+
    alert_rule_test:
-     - eval_time: 1m
-       alertname: CephNodeInconsistentMTU
-       exp_alerts:
-       - exp_labels:
-           device: eth4
-           instance: hostname1
-           job: node-exporter
-           severity: warning
-           type: ceph_default
-           cluster: "mycluster"
-         exp_annotations:
-           summary: MTU settings across Ceph hosts are inconsistent on cluster mycluster
-           description: "Node hostname1 has a different MTU size (2200) than the median of devices named eth4."
-       - exp_labels:
-           device: eth4
-           instance: node-exporter
-           job: node-exporter
-           severity: warning
-           type: ceph_default
-           cluster: "mycluster"
-         exp_annotations:
-           summary: MTU settings across Ceph hosts are inconsistent on cluster mycluster
-           description: "Node node-exporter has a different MTU size (9000) than the median of devices named eth4."
+    - eval_time: 1m
+      alertname: CephNodeInconsistentMTU
+      exp_alerts:
+        # Test 2 - host3 has wrong MTU
+        - exp_labels:
+            device: eth1
+            instance: host3
+            cluster: c
+            severity: warning
+            type: ceph_default
+          exp_annotations:
+            summary: MTU settings across Ceph hosts are inconsistent on cluster c
+            description: "Node host3 has a different MTU size (9200) than the median of devices named eth1."
+
+        # Test 4 - host1 and host3 deviate from median 2400
+        - exp_labels:
+            device: eth3
+            instance: host1
+            cluster: c
+            severity: warning
+            type: ceph_default
+          exp_annotations:
+            summary: MTU settings across Ceph hosts are inconsistent on cluster c
+            description: "Node host1 has a different MTU size (1500) than the median of devices named eth3."
+        - exp_labels:
+            device: eth3
+            instance: host3
+            cluster: c
+            severity: warning
+            type: ceph_default
+          exp_annotations:
+            summary: MTU settings across Ceph hosts are inconsistent on cluster c
+            description: "Node host3 has a different MTU size (9000) than the median of devices named eth3."
 
  # pool full, data series has 6 but using topk(5) so to ensure the
  # results are working as expected


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
