### PR TITLE
mailmap, githubmap, organizationmap: Add Kautilya

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -80,6 +80,7 @@ josephsawaya Joseph Sawaya <jsawaya@redhat.com>
 jschmid1 Joshua Schmid <jschmid@suse.de>
 jtlayton Jeff Layton <jlayton@redhat.com>
 kalaspuffar Daniel Persson <mailto.woden@gmail.com>
+knrt10 Kautilya Tripathi <kautilya.tripathi@ibm.com>
 kotreshhr Kotresh Hiremath Ravishankar <khiremat@redhat.com>
 kshtsk Kyr Shatskyy <kyrylo.shatskyy@suse.com>
 ktdreyer Ken Dreyer <kdreyer@redhat.com>

--- a/.mailmap
+++ b/.mailmap
@@ -386,6 +386,7 @@ Kamoltat Sirivadhna <ksirivad@redhat.com> Kamoltat <ksirivad@redhat.com>
 Kanika Murarka <kmurarka@redhat.com> <murarkakanika@gmail.com>
 Kapil Sharma <ksharma@suse.com>
 Karol Mroz <kmroz@suse.com> <kmroz@suse.de>
+Kautilya Tripathi <kautilya.tripathi@ibm.com>
 Kefu Chai <kchai@redhat.com> <kefu@redhat.com>
 Kefu Chai <tchaikov@gmail.com> <tchaikov@gmail.com>
 Ken Dreyer <kdreyer@redhat.com> <ktdreyer@redhat.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -354,6 +354,7 @@ IBM <contact@IBM.com> Anuradha Gadge <Anuradha.Gadge@ibm.com>
 IBM <contact@IBM.com> Dnyaneshwari talwekar <Dnyaneshwari.Talwekar@ibm.com>
 IBM <contact@IBM.com> Guillaume Abrioux <gabrioux@ibm.com>
 IBM <contact@IBM.com> Jonas Pfefferle <jpf@ibm.com>
+IBM <contact@IBM.com> Kautilya Tripathi <kautilya.tripathi@ibm.com>
 IBM <contact@IBM.com> Laura Flores <lflores@ibm.com>
 IBM <contact@IBM.com> Martin Ohmacht <mohmacht@us.ibm.com>
 IBM <contact@IBM.com> Michel Normand <normand@linux.vnet.ibm.com>


### PR DESCRIPTION
## Description 

Adding Kautilya Tripathi (@knrt10) to mailmap, githubmap and organizationmap as per the onboarding docs: https://pad.ceph.com/p/ceph-team-onboarding#L49. 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
