### PR TITLE
squid: doc/radosgw: Improve rgw-cache.rst

### DIFF
--- a/doc/radosgw/rgw-cache.rst
+++ b/doc/radosgw/rgw-cache.rst
@@ -1,6 +1,6 @@
-==========================
-RGW Data caching and CDN
-==========================
+========================
+RGW Data Caching and CDN
+========================
 
 .. versionadded:: Octopus
 
@@ -9,106 +9,104 @@ RGW Data caching and CDN
 This feature adds to RGW the ability to securely cache objects and offload the workload from the cluster, using Nginx.
 After an object is accessed the first time it will be stored in the Nginx cache directory.
 When data is already cached, it need not be fetched from RGW. A permission check will be made against RGW to ensure the requesting user has access.
-This feature is based on some Nginx modules, ngx_http_auth_request_module, https://github.com/kaltura/nginx-aws-auth-module, Openresty for Lua capabilities.
+This feature is based on the Nginx modules ``ngx_http_auth_request_module`` and `nginx-aws-auth-module <https://github.com/kaltura/nginx-aws-auth-module>`_, and OpenResty for Lua capabilities.
 
-Currently, this feature will cache only AWSv4 requests (only s3 requests), caching-in the output of the 1st GET request
-and caching-out on subsequent GET requests, passing thru transparently PUT,POST,HEAD,DELETE and COPY requests.
+Currently this feature will cache only AWSv4 requests (only S3 requests), caching-in the output of the first GET request
+and caching-out on subsequent GET requests, passing through transparently PUT,POST,HEAD,DELETE and COPY requests.
 
 
 The feature introduces 2 new APIs: Auth and Cache.
 
-    NOTE: The `D3N RGW Data Cache`_ is an alternative data caching mechanism implemented natively in the Rados Gateway.
+.. note:: The `D3N RGW Data Cache`_ is an alternative data caching mechanism implemented natively in the RADOS Gateway.
 
 New APIs
--------------------------
+--------
 
 There are 2 new APIs for this feature:
 
-Auth API - The cache uses this to validate that a user can access the cached data
-
-Cache API - Adds the ability to override securely Range header, that way Nginx can use it is own smart cache on top of S3:
-https://www.nginx.com/blog/smart-efficient-byte-range-caching-nginx/
-Using this API gives the ability to read ahead objects when clients asking a specific range from the object.
-On subsequent accesses to the cached object, Nginx will satisfy requests for already-cached ranges from the cache. Uncached ranges will be read from RGW (and cached).
+- **Auth API:** The cache uses this to validate that a user can access the cached data.
+- **Cache API:** Adds the ability to override securely ``Range`` header so that Nginx can use its own `smart cache <https://www.nginx.com/blog/smart-efficient-byte-range-caching-nginx/>`_ on top of S3.
+  Using this API gives the ability to read ahead objects when client is asking a specific range from the object.
+  On subsequent accesses to the cached object, Nginx will satisfy requests for already-cached ranges from the cache. Uncached ranges will be read from RGW (and cached).
 
 Auth API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~
 
-This API Validates a specific authenticated access being made to the cache, using RGW's knowledge of the client credentials and stored access policy.
+This API validates a specific authenticated access being made to the cache, using RGW's knowledge of the client credentials and stored access policy.
 Returns success if the encapsulated request would be granted.
 
 Cache API
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~
 
-This API is meant to allow changing signed Range headers using a privileged user, cache user.
+This API is meant to allow changing signed ``Range`` headers using a privileged cache user.
 
-Creating cache user
+Creating the cache user:
 
-::
+.. prompt:: bash #
 
-$ radosgw-admin user create --uid=<uid for cache user> --display-name="cache user" --caps="amz-cache=read"
+   radosgw-admin user create --uid=<uid for cache user> --display-name="cache user" --caps="amz-cache=read"
 
-This user can send to the RGW the Cache API header ``X-Amz-Cache``, this header contains the headers from the original request(before changing the Range header).
-It means that ``X-Amz-Cache`` built from several headers.
-The headers that are building the ``X-Amz-Cache`` header are separated by char with ASCII code 177 and the header name and value are separated by char ASCII code 178.
-The RGW will check that the cache user is an authorized user and if it is a cache user,
-if yes it will use the ``X-Amz-Cache`` to revalidate that the user has permissions, using the headers from the X-Amz-Cache.
-During this flow, the RGW will override the Range header.
+This user can send to the RGW the Cache API header ``X-Amz-Cache``. This header contains the headers from the original request (before changing the ``Range`` header):
+
+- Original headers are separated from each other by a character with ASCII code 177 decimal.
+- Each original header and its value are separated by a character with ASCII code 178 decimal.
+
+The RGW will check that the user is an authorized user and that the value is a cache user.
+If both checks succeed it will use the ``X-Amz-Cache`` to revalidate that the user has permissions, using the original headers stored in the ``X-Amz-Cache`` header.
+During this flow the RGW will override the ``Range`` header.
 
 
 Using Nginx with RGW
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------
 
-Download the source of Openresty:
+Download the source of OpenResty:
 
-::
+.. prompt:: bash $
 
-$ wget https://openresty.org/download/openresty-1.15.8.3.tar.gz
+   wget https://openresty.org/download/openresty-1.15.8.3.tar.gz
 
-git clone the AWS auth Nginx module:
+Use git to clone the Nginx AWS authentication module:
 
-::
+.. prompt:: bash $
 
-$ git clone https://github.com/kaltura/nginx-aws-auth-module
+   git clone https://github.com/kaltura/nginx-aws-auth-module
 
-untar the openresty package:
+Untar the OpenResty package:
 
-::
+.. prompt:: bash $
 
-$ tar xvzf openresty-1.15.8.3.tar.gz
-$ cd openresty-1.15.8.3
+   tar xvzf openresty-1.15.8.3.tar.gz
+   cd openresty-1.15.8.3
 
-Compile openresty, Make sure that you have pcre lib and openssl lib:
+Compile OpenResty, make sure that you have ``pcre`` library and ``openssl`` library:
 
-::
+.. prompt:: bash $
 
-$ sudo yum install pcre-devel openssl-devel gcc curl zlib-devel nginx
-$ ./configure --add-module=<the nginx-aws-auth-module dir> --with-http_auth_request_module --with-http_slice_module --conf-path=/etc/nginx/nginx.conf
-$ gmake -j $(nproc)
-$ sudo gmake install
-$ sudo ln -sf /usr/local/openresty/bin/openresty /usr/bin/nginx
+   sudo yum install pcre-devel openssl-devel gcc curl zlib-devel nginx
+   ./configure --add-module=<the nginx-aws-auth-module dir> --with-http_auth_request_module --with-http_slice_module --conf-path=/etc/nginx/nginx.conf
+   gmake -j $(nproc)
+   sudo gmake install
+   sudo ln -sf /usr/local/openresty/bin/openresty /usr/bin/nginx
 
 Put in-place your Nginx configuration files and edit them according to your environment:
 
-All Nginx conf files are under:
+Example Nginx configuration files are available at
 https://github.com/ceph/ceph/tree/main/examples/rgw/rgw-cache
 
-`nginx.conf` should go to `/etc/nginx/nginx.conf`
+- ``nginx.conf`` should go to ``/etc/nginx/nginx.conf``.
+- ``nginx-lua-file.lua`` should go to ``/etc/nginx/nginx-lua-file.lua``.
+- ``nginx-default.conf`` should go to ``/etc/nginx/conf.d/nginx-default.conf``.
 
-`nginx-lua-file.lua` should go to `/etc/nginx/nginx-lua-file.lua`
+The parameters that are most likely to require adjustment according to the environment are located in the file ``nginx-default.conf``.
 
-`nginx-default.conf` should go to `/etc/nginx/conf.d/nginx-default.conf`
-
-The parameters that are most likely to require adjustment according to the environment are located in the file `nginx-default.conf`
-
-Modify the example values of *proxy_cache_path* and *max_size* at:
+Modify the example values of ``proxy_cache_path`` and ``max_size`` at:
 
 ::
 
  proxy_cache_path /data/cache levels=2:2:2 keys_zone=mycache:999m max_size=20G inactive=1d use_temp_path=off;
 
 
-And modify the example *server* values to point to the RGWs URIs:
+And modify the example ``server`` values to point to the RGWs URIs:
 
 ::
 
@@ -116,41 +114,37 @@ And modify the example *server* values to point to the RGWs URIs:
  server rgw2:8000 max_fails=2 fail_timeout=5s;
  server rgw3:8000 max_fails=2 fail_timeout=5s;
 
-| It is important to substitute the *access key* and *secret key* located in the `nginx.conf` with those belong to the user with the `amz-cache` caps
-| for example, create the `cache` user as following:
+| It is important to substitute the *access key* and *secret key* located in the ``nginx.conf`` file with those belonging to the user with the ``amz-cache`` caps.
+| For example, create the cache user as follows:
 
-::
+.. prompt:: bash #
 
- radosgw-admin user create --uid=cacheuser --display-name="cache user" --caps="amz-cache=read" --access-key <access> --secret <secret>
+   radosgw-admin user create --uid=cacheuser --display-name="cache user" --caps="amz-cache=read" --access-key <access> --secret <secret>
 
-It is possible to use Nginx slicing which is a better method for streaming purposes.
+It is possible to use `Nginx slicing <https://docs.nginx.com/nginx/admin-guide/content-cache/content-caching/#byte-range-caching>`_ which is suitable for streaming purposes.
 
-For using slice you should use `nginx-slicing.conf` and not `nginx-default.conf`
-
-Further information about Nginx slicing:
-
-https://docs.nginx.com/nginx/admin-guide/content-cache/content-caching/#byte-range-caching
+To enable slicing you should use ``nginx-slicing.conf`` instead of ``nginx-default.conf``.
 
 
-If you do not want to use the prefetch caching, It is possible to replace `nginx-default.conf` with `nginx-noprefetch.conf`
-Using `noprefetch` means that if the client is sending range request of 0-4095 and then 0-4096 Nginx will cache those requests separately, So it will need to fetch those requests twice.
+If you do not want to use prefetch caching, it is possible to replace ``nginx-default.conf`` with ``nginx-noprefetch.conf``.
+If prefetch caching is disabled Nginx will cache each range request separately and possible overlap in the range requests will be fetched more than once. For example, if a client is sending a range request of 0-4095 and then 0-4096 both requests are fetched completely from RGW.
 
 
-Run Nginx(openresty):
+Run Nginx (OpenResty):
 
-::
+.. prompt:: bash #
 
-$ sudo systemctl restart nginx
+   systemctl restart nginx
 
 Appendix
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-**A note about performance:** In certain instances like development environment, disabling the authentication by commenting the following line in `nginx-default.conf`:
+--------
+
+**A note about performance:** In certain instances such as a development environment, disabling authentication may (depending on the hardware) increase performance significantly as it forgoes auth API calls to RADOS Gateway.
+This can be done by commenting the following line in ``nginx-default.conf``:
 
 ::
 
  #auth_request /authentication;
-
-may (depending on the hardware) increases the performance significantly as it forgoes the auth API calls to radosgw.
 
 
 .. _D3N RGW Data Cache: ../d3n_datacache/


### PR DESCRIPTION
Try to improve the language by completely rewriting some sentences. Attempt to format the document more like the rest of the docs. Fix several errors in punctuation, capitalization, spaces etc. Use blocks with bash prompts for CLI commands instead of hardcoded prompts.
Fix section hierarchy and section title underline lengths. Use admonition.


(cherry picked from commit 6e836f8f1e1e53bc7f8d8b497960b100e6b625d6)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

