### PR TITLE
squid: mds: `flush journal` asok command should trim only up to the segment created for the flush

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -864,8 +864,6 @@ void MDLog::_trim_expired_segments(auto& locker, MDSContext* ctx)
   ceph_assert(ceph_mutex_is_locked_by_me(submit_mutex));
   ceph_assert(locker.owns_lock());
 
-  uint64_t const oft_committed_seq = mds->mdcache->open_file_table.get_committed_log_seq();
-
   // trim expired segments?
   bool trimmed = false;
   uint64_t end = 0;
@@ -911,12 +909,6 @@ void MDLog::_trim_expired_segments(auto& locker, MDSContext* ctx)
       break;
     }
 
-    if (!mds_is_shutting_down && ls->seq >= oft_committed_seq) {
-      dout(10) << __func__ << " defer expire for open file table committedseq " << oft_committed_seq
-	       << " <= " << ls->seq << "/" << ls->offset << dendl;
-      break;
-    }
-    
     end = seq;
     dout(10) << __func__ << ": maybe expiring " << *ls << dendl;
   }

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -770,17 +770,18 @@ class C_MaybeExpiredSegment : public MDSInternalContext {
  * Like MDLog::trim, but instead of trimming to max_segments, trim all but the latest
  * segment.
  */
-int MDLog::trim_all()
+int MDLog::trim_to(SegmentBoundary::seq_t seq)
 {
   submit_mutex.lock();
 
   dout(10) << __func__ << ": "
-	   << segments.size()
+           << seq
+	   << " " << segments.size()
            << "/" << expiring_segments.size()
            << "/" << expired_segments.size() << dendl;
 
-  uint64_t last_seq = 0;
-  if (!segments.empty()) {
+  uint64_t last_seq = seq;
+  if (last_seq == 0 || !segments.empty()) {
     last_seq = get_last_segment_seq();
     try_to_commit_open_file_table(last_seq);
   }

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -587,17 +587,6 @@ void MDLog::shutdown()
   }
 }
 
-class C_OFT_Committed : public MDSInternalContext {
-  MDLog *mdlog;
-  uint64_t seq;
-public:
-  C_OFT_Committed(MDLog *l, uint64_t s) :
-    MDSInternalContext(l->mds), mdlog(l), seq(s) {}
-  void finish(int ret) override {
-    mdlog->trim_expired_segments();
-  }
-};
-
 void MDLog::try_to_commit_open_file_table(uint64_t last_seq)
 {
   ceph_assert(ceph_mutex_is_locked_by_me(submit_mutex));
@@ -612,8 +601,7 @@ void MDLog::try_to_commit_open_file_table(uint64_t last_seq)
   if (mds->mdcache->open_file_table.is_any_dirty() ||
       last_seq > mds->mdcache->open_file_table.get_committed_log_seq()) {
     submit_mutex.unlock();
-    mds->mdcache->open_file_table.commit(new C_OFT_Committed(this, last_seq),
-                                         last_seq, CEPH_MSG_PRIO_HIGH);
+    mds->mdcache->open_file_table.commit(nullptr, last_seq, CEPH_MSG_PRIO_HIGH);
     submit_mutex.lock();
   }
 }

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -288,6 +288,8 @@ LogSegment* MDLog::_start_new_segment(SegmentBoundary* sb)
   logger->set(l_mdl_seg, segments.size());
   sb->set_seq(event_seq);
 
+  dout(20) << __func__ << ": starting new segment " << *ls << dendl;
+
   // Adjust to next stray dir
   if (!mds->is_stopping()) {
     mds->mdcache->advance_stray();

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -349,7 +349,7 @@ LogSegment* MDLog::_start_new_segment(SegmentBoundary* sb)
   return ls;
 }
 
-void MDLog::_submit_entry(LogEvent *le, MDSLogContextBase* c)
+LogSegment::seq_t MDLog::_submit_entry(LogEvent *le, MDSLogContextBase* c)
 {
   dout(20) << __func__ << " " << *le << dendl;
   ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
@@ -396,6 +396,7 @@ void MDLog::_submit_entry(LogEvent *le, MDSLogContextBase* c)
   }
 
   unflushed++;
+  return event_seq;
 }
 
 void MDLog::_segment_upkeep()

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -147,13 +147,63 @@ class C_MDL_WriteError : public MDSIOContextBase {
 };
 
 
+class C_MDL_WriteHead : public MDSIOContextBase {
+public:
+  explicit C_MDL_WriteHead(MDLog* m)
+    : MDSIOContextBase(true)
+    , mdlog(m)
+    {}
+  void print(ostream& out) const override {
+    out << "mdlog_write_head";
+  }
+protected:
+  void finish(int r) override {
+    mdlog->finish_head_waiters();
+  }
+  MDSRank *get_mds() override {return mdlog->mds;}
+
+  MDLog *mdlog;
+};
+
+void MDLog::finish_head_waiters()
+{
+  ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
+
+  auto&& last_committed = journaler->get_last_committed();
+  auto& expire_pos = last_committed.expire_pos;
+
+  dout(20) << __func__ << " expire_pos=" << std::hex << expire_pos << dendl;
+
+  {
+    auto last = waiting_for_expire.upper_bound(expire_pos);
+    for (auto it = waiting_for_expire.begin(); it != last; it++) {
+      finish_contexts(g_ceph_context, it->second);
+    }
+    waiting_for_expire.erase(waiting_for_expire.begin(), last);
+  }
+}
+
 void MDLog::write_head(MDSContext *c) 
 {
-  Context *fin = NULL;
-  if (c != NULL) {
-    fin = new C_IO_Wrapper(mds, c);
+  ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
+
+  auto&& last_written = journaler->get_last_written();
+  auto expire_pos = journaler->get_expire_pos();
+  dout(10) << __func__ << " last_written=" << last_written << " current expire_pos=" << std::hex << expire_pos << dendl;
+
+  if (last_written.expire_pos < expire_pos) {
+    if (c != NULL) {
+      dout(25) << __func__ << " queueing waiter " << c << dendl;
+      waiting_for_expire[expire_pos].push_back(c);
+    }
+
+    auto* fin = new C_MDL_WriteHead(this);
+    journaler->write_head(fin);
+  } else {
+    if (c) {
+      c->complete(0);
+    }
   }
-  journaler->write_head(fin);
 }
 
 uint64_t MDLog::get_read_pos() const
@@ -175,6 +225,8 @@ uint64_t MDLog::get_safe_pos() const
 
 void MDLog::create(MDSContext *c)
 {
+  ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
+
   dout(5) << "create empty log" << dendl;
 
   C_GatherBuilder gather(g_ceph_context);
@@ -853,7 +905,6 @@ void MDLog::_trim_expired_segments(auto& locker, MDSContext* ctx)
   ceph_assert(locker.owns_lock());
 
   // trim expired segments?
-  bool trimmed = false;
   uint64_t end = 0;
   for (auto it = segments.begin(); it != segments.end(); ++it) {
     auto& [seq, ls] = *it;
@@ -889,7 +940,6 @@ void MDLog::_trim_expired_segments(auto& locker, MDSContext* ctx)
       } else {
         logger->set(l_mdl_expos, jexpire_pos);
       }
-      trimmed = true;
     }
 
     if (!expired_segments.count(ls)) {
@@ -903,13 +953,7 @@ void MDLog::_trim_expired_segments(auto& locker, MDSContext* ctx)
 
   locker.unlock();
 
-  if (trimmed) {
-    write_head(ctx);
-  } else {
-    if (ctx) {
-      ctx->complete(0);
-    }
-  }
+  write_head(ctx);
 }
 
 void MDLog::_expired(LogSegment *ls)

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -147,7 +147,10 @@ public:
   }
 
   void trim_expired_segments();
-  int trim_all();
+  int trim_all() {
+    return trim_to(0);
+  }
+  int trim_to(SegmentBoundary::seq_t);
 
   void create(MDSContext *onfinish);  // fresh, empty log! 
   void open(MDSContext *onopen);      // append() or replay() to follow!

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -133,6 +133,8 @@ public:
   void kick_submitter();
   void shutdown();
 
+  void finish_head_waiters();
+
   void submit_entry(LogEvent *e, MDSLogContextBase* c = 0) {
     std::lock_guard l(submit_mutex);
     _submit_entry(e, c);
@@ -324,5 +326,7 @@ private:
   // guarded by mds_lock
   std::condition_variable_any cond;
   std::atomic<bool> upkeep_log_trim_shutdown{false};
+
+  std::map<uint64_t, std::vector<Context*>> waiting_for_expire; // protected by mds_lock
 };
 #endif

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -146,7 +146,10 @@ public:
     return unflushed == 0;
   }
 
-  void trim_expired_segments();
+  void trim_expired_segments(MDSContext* ctx=nullptr) {
+    std::unique_lock locker(submit_mutex);
+    _trim_expired_segments(locker, ctx);
+  }
   int trim_all() {
     return trim_to(0);
   }
@@ -291,7 +294,7 @@ private:
   void try_expire(LogSegment *ls, int op_prio);
   void _maybe_expired(LogSegment *ls, int op_prio);
   void _expired(LogSegment *ls);
-  void _trim_expired_segments();
+  void _trim_expired_segments(auto& locker, MDSContext* ctx=nullptr);
   void write_head(MDSContext *onfinish);
 
   void trim();

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -135,11 +135,12 @@ public:
 
   void finish_head_waiters();
 
-  void submit_entry(LogEvent *e, MDSLogContextBase* c = 0) {
+  LogSegment::seq_t submit_entry(LogEvent *e, MDSLogContextBase* c = 0) {
     std::lock_guard l(submit_mutex);
-    _submit_entry(e, c);
+    auto seq = _submit_entry(e, c);
     _segment_upkeep();
     submit_cond.notify_all();
+    return seq;
   }
 
   void wait_for_safe(Context* c);
@@ -291,7 +292,7 @@ private:
   void try_to_commit_open_file_table(uint64_t last_seq);
   LogSegment* _start_new_segment(SegmentBoundary* sb);
   void _segment_upkeep();
-  void _submit_entry(LogEvent* e, MDSLogContextBase* c);
+  LogSegment::seq_t _submit_entry(LogEvent* e, MDSLogContextBase* c);
 
   void try_expire(LogSegment *ls, int op_prio);
   void _maybe_expired(LogSegment *ls, int op_prio);

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -137,9 +137,11 @@ void MDSIOContextWrapper::finish(int r)
 void C_IO_Wrapper::complete(int r)
 {
   if (async) {
+    dout(20) << "C_IO_Wrapper::complete " << r << " async" << dendl;
     async = false;
     get_mds()->finisher->queue(this, r);
   } else {
+    dout(20) << "C_IO_Wrapper::complete " << r << " sync" << dendl;
     MDSIOContext::complete(r);
   }
 }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -151,33 +151,21 @@ private:
             << " segments to expire" << dendl;
 
     if (!expiry_gather.has_subs()) {
-      trim_segments();
+      trim_expired_segments();
       return;
     }
 
-    Context *ctx = new LambdaContext([this](int r) {
-        handle_expire_segments(r);
-      });
+    /* Because this context may be finished with the MDLog::submit_mutex held,
+     * complete it in the MDS finisher thread.
+     */
+    Context *ctx = new C_OnFinisher(new LambdaContext([this,mds=mds](int r) {
+        ceph_assert(r == 0); // MDLog is not allowed to raise errors via
+                             // wait_for_expiry
+        std::lock_guard locker(mds->mds_lock);
+        trim_expired_segments();
+      }), mds->finisher);
     expiry_gather.set_finisher(new MDSInternalContextWrapper(mds, ctx));
     expiry_gather.activate();
-  }
-
-  void handle_expire_segments(int r) {
-    dout(20) << __func__ << ": r=" << r << dendl;
-
-    ceph_assert(r == 0); // MDLog is not allowed to raise errors via
-                         // wait_for_expiry
-    trim_segments();
-  }
-
-  void trim_segments() {
-    dout(20) << __func__ << dendl;
-
-    Context *ctx = new C_OnFinisher(new LambdaContext([this](int) {
-          std::lock_guard locker(mds->mds_lock);
-          trim_expired_segments();
-        }), mds->finisher);
-    ctx->complete(0);
   }
 
   void trim_expired_segments() {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -175,25 +175,14 @@ private:
             << mdlog->get_journaler()->get_trimmed_pos() << dendl;
 
     // Now everyone I'm interested in is expired
-    mdlog->trim_expired_segments();
+    auto* ctx = new MDSInternalContextWrapper(mds, new LambdaContext([this](int r) {
+      handle_write_head(r);
+    }));
+    mdlog->trim_expired_segments(ctx);
 
-    dout(5) << __func__ << ": trim complete, expire_pos/trim_pos is now "
+    dout(5) << __func__ << ": trimming is complete; wait for journal head write. Journal expire_pos/trim_pos is now "
             << std::hex << mdlog->get_journaler()->get_expire_pos() << "/"
             << mdlog->get_journaler()->get_trimmed_pos() << dendl;
-
-    write_journal_head();
-  }
-
-  void write_journal_head() {
-    dout(20) << __func__ << dendl;
-
-    Context *ctx = new LambdaContext([this](int r) {
-        std::lock_guard locker(mds->mds_lock);
-        handle_write_head(r);
-      });
-    // Flush the journal header so that readers will start from after
-    // the flushed region
-    mdlog->get_journaler()->write_head(ctx);
   }
 
   void handle_write_head(int r) {
@@ -207,7 +196,10 @@ private:
   }
 
   void finish(int r) override {
-    ceph_assert(!ceph_mutex_is_locked_by_me(mds->mds_lock));
+    /* We don't need the mds_lock but MDLog::write_head takes an MDSContext so
+     * we are expected to have it.
+     */
+    ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
     dout(20) << __func__ << ": r=" << r << dendl;
     on_finish->complete(r);
   }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -70,7 +70,7 @@ public:
   }
 
   void send() {
-    ceph_assert(ceph_mutex_is_locked(mds->mds_lock));
+    ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
 
     dout(20) << __func__ << dendl;
 
@@ -111,6 +111,7 @@ private:
   }
 
   void handle_clear_mdlog(int r) {
+    ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
     dout(20) << __func__ << ": r=" << r << dendl;
 
     if (r != 0) {
@@ -180,6 +181,7 @@ private:
   }
 
   void trim_expired_segments() {
+    ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
     dout(5) << __func__ << ": expiry complete, expire_pos/trim_pos is now "
             << std::hex << mdlog->get_journaler()->get_expire_pos() << "/"
             << mdlog->get_journaler()->get_trimmed_pos() << dendl;
@@ -217,6 +219,7 @@ private:
   }
 
   void finish(int r) override {
+    ceph_assert(!ceph_mutex_is_locked_by_me(mds->mds_lock));
     dout(20) << __func__ << ": r=" << r << dendl;
     on_finish->complete(r);
   }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -110,33 +110,6 @@ private:
     mdlog->wait_for_safe(new MDSInternalContextWrapper(mds, ctx));
   }
 
-  void handle_flush_mdlog(int r) {
-    dout(20) << __func__ << ": r=" << r << dendl;
-
-    if (r != 0) {
-      *ss << "Error " << r << " (" << cpp_strerror(r) << ") while flushing journal";
-      complete(r);
-      return;
-    }
-
-    clear_mdlog();
-  }
-
-  void clear_mdlog() {
-    dout(20) << __func__ << dendl;
-
-    Context *ctx = new LambdaContext([this](int r) {
-        handle_clear_mdlog(r);
-      });
-
-    // Because we may not be the last wait_for_safe context on MDLog,
-    // and subsequent contexts might wake up in the middle of our
-    // later trim_all and interfere with expiry (by e.g. marking
-    // dirs/dentries dirty on previous log segments), we run a second
-    // wait_for_safe here. See #10368
-    mdlog->wait_for_safe(new MDSInternalContextWrapper(mds, ctx));
-  }
-
   void handle_clear_mdlog(int r) {
     dout(20) << __func__ << ": r=" << r << dendl;
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -96,11 +96,12 @@ private:
 
     // I need to seal off the current segment, and then mark all
     // previous segments for expiry
-    auto sle = mdcache->create_subtree_map();
+    auto* sle = mdcache->create_subtree_map();
     mdlog->submit_entry(sle);
+    seq = sle->get_seq();
 
     Context *ctx = new LambdaContext([this](int r) {
-        handle_flush_mdlog(r);
+        handle_clear_mdlog(r);
       });
 
     // Flush initially so that all the segments older than our new one
@@ -152,7 +153,7 @@ private:
     // Put all the old log segments into expiring or expired state
     dout(5) << __func__ << ": beginning segment expiry" << dendl;
 
-    int ret = mdlog->trim_all();
+    int ret = mdlog->trim_to(seq);
     if (ret != 0) {
       *ss << "Error " << ret << " (" << cpp_strerror(ret) << ") while trimming log";
       complete(ret);
@@ -249,6 +250,7 @@ private:
 
   MDCache *mdcache;
   MDLog *mdlog;
+  SegmentBoundary::seq_t seq = 0;
   std::ostream *ss;
   Context *on_finish;
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -97,8 +97,7 @@ private:
     // I need to seal off the current segment, and then mark all
     // previous segments for expiry
     auto* sle = mdcache->create_subtree_map();
-    mdlog->submit_entry(sle);
-    seq = sle->get_seq();
+    seq = mdlog->submit_entry(sle);
 
     Context *ctx = new LambdaContext([this](int r) {
         handle_clear_mdlog(r);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -179,10 +179,6 @@ private:
       handle_write_head(r);
     }));
     mdlog->trim_expired_segments(ctx);
-
-    dout(5) << __func__ << ": trimming is complete; wait for journal head write. Journal expire_pos/trim_pos is now "
-            << std::hex << mdlog->get_journaler()->get_expire_pos() << "/"
-            << mdlog->get_journaler()->get_trimmed_pos() << dendl;
   }
 
   void handle_write_head(int r) {
@@ -201,6 +197,10 @@ private:
      */
     ceph_assert(ceph_mutex_is_locked_by_me(mds->mds_lock));
     dout(20) << __func__ << ": r=" << r << dendl;
+
+    dout(5) << __func__ << ": trimming is complete; wait for journal head write. Journal expire_pos/trim_pos is now "
+            << std::hex << mdlog->get_journaler()->get_expire_pos() << "/"
+            << mdlog->get_journaler()->get_trimmed_pos() << dendl;
     on_finish->complete(r);
   }
 

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -283,6 +283,14 @@ void OpenFileTable::_commit_finish(int r, uint64_t log_seq, MDSContext *fin)
   committed_log_seq = log_seq;
   num_pending_commit--;
 
+  {
+    auto last = waiting_for_commit.upper_bound(log_seq);
+    for (auto it = waiting_for_commit.begin(); it != last; it++) {
+      finish_contexts(g_ceph_context, it->second);
+    }
+    waiting_for_commit.erase(waiting_for_commit.begin(), last);
+  }
+
   if (fin)
     fin->complete(r);
 }

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -50,6 +50,9 @@ public:
     ceph_assert(!load_done);
     waiting_for_load.push_back(c);
   }
+  void wait_for_commit(uint64_t seq, Context* c) {
+    waiting_for_commit[seq].push_back(c);
+  }
 
   bool prefetch_inodes();
   bool is_prefetched() const { return prefetch_state == DONE; }
@@ -149,6 +152,8 @@ protected:
   std::set<inodeno_t> destroyed_inos_set;
 
   std::unique_ptr<PerfCounters> logger;
+
+  std::map<uint64_t, std::vector<Context*>> waiting_for_commit;
 };
 
 #endif

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -225,9 +225,10 @@ void PurgeQueue::open(Context *completion)
       // Journaler only guarantees entries before head write_pos have been
       // fully flushed. Before appending new entries, we need to find and
       // drop any partial written entry.
-      if (journaler.last_committed.write_pos < journaler.get_write_pos()) {
+      auto&& last_committed = journaler.get_last_committed();
+      if (last_committed.write_pos < journaler.get_write_pos()) {
 	dout(4) << "recovering write_pos" << dendl;
-	journaler.set_read_pos(journaler.last_committed.write_pos);
+	journaler.set_read_pos(last_committed.write_pos);
 	_recover();
 	return;
       }
@@ -281,7 +282,8 @@ void PurgeQueue::_recover()
     if (journaler.get_read_pos() == journaler.get_write_pos()) {
       dout(4) << "write_pos recovered" << dendl;
       // restore original read_pos
-      journaler.set_read_pos(journaler.last_committed.expire_pos);
+      auto&& last_committed = journaler.get_last_committed();
+      journaler.set_read_pos(last_committed.expire_pos);
       journaler.set_writeable();
       recovered = true;
       finish_contexts(g_ceph_context, waiting_for_recovery);

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -346,9 +346,10 @@ void LogSegment::try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int o
     (*p)->add_waiter(CInode::WAIT_TRUNC, gather_bld.new_sub());
   }
   // purge inodes
-  dout(10) << "try_to_expire waiting for purge of " << purging_inodes << dendl;
-  if (purging_inodes.size())
+  if (purging_inodes.size()) {
+    dout(10) << "try_to_expire waiting for purge of " << purging_inodes << dendl;
     set_purged_cb(gather_bld.new_sub());
+  }
   
   if (gather_bld.has_subs()) {
     dout(6) << "LogSegment(" << seq << "/" << offset << ").try_to_expire waiting" << dendl;

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -158,7 +158,7 @@ public:
 void Journaler::recover(Context *onread) 
 {
   lock_guard l(lock);
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     onread->complete(-EAGAIN);
     return;
   }
@@ -218,7 +218,7 @@ void Journaler::_reread_head(Context *onfinish)
 void Journaler::_finish_reread_head(int r, bufferlist& bl, Context *finish)
 {
   lock_guard l(lock);
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     finish->complete(-EAGAIN);
     return;
   }
@@ -250,7 +250,7 @@ void Journaler::_finish_reread_head(int r, bufferlist& bl, Context *finish)
 void Journaler::_finish_read_head(int r, bufferlist& bl)
 {
   lock_guard l(lock);
-  if (is_stopping())
+  if (state == STATE_STOPPING)
     return;
 
   ceph_assert(state == STATE_READHEAD);
@@ -342,7 +342,7 @@ void Journaler::_finish_reprobe(int r, uint64_t new_end,
 				C_OnFinisher *onfinish)
 {
   lock_guard l(lock);
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     onfinish->complete(-EAGAIN);
     return;
   }
@@ -359,7 +359,7 @@ void Journaler::_finish_reprobe(int r, uint64_t new_end,
 void Journaler::_finish_probe_end(int r, uint64_t end)
 {
   lock_guard l(lock);
-  if (is_stopping())
+  if (state == STATE_STOPPING)
     return;
 
   ceph_assert(state == STATE_PROBING);
@@ -413,7 +413,7 @@ void Journaler::_finish_reread_head_and_probe(int r, C_OnFinisher *onfinish)
 {
   // Expect to be called back from finish_reread_head, which already takes lock
   // lock is locked
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     onfinish->complete(-EAGAIN);
     return;
   }
@@ -591,7 +591,7 @@ uint64_t Journaler::append_entry(bufferlist& bl)
   write_pos += wrote;
 
   // flush previous object?
-  uint64_t su = get_layout_period();
+  uint64_t su = layout.get_period();
   ceph_assert(su > 0);
   uint64_t write_off = write_pos % su;
   uint64_t write_obj = write_pos / su;
@@ -616,7 +616,7 @@ uint64_t Journaler::append_entry(bufferlist& bl)
 
 void Journaler::_do_flush(unsigned amount)
 {
-  if (is_stopping())
+  if (state == STATE_STOPPING)
     return;
   if (write_pos == flush_pos)
     return;
@@ -631,7 +631,7 @@ void Journaler::_do_flush(unsigned amount)
 
   // zero at least two full periods ahead.  this ensures
   // that the next object will not exist.
-  uint64_t period = get_layout_period();
+  uint64_t period = layout.get_period();
   if (flush_pos + len + 2*period > prezero_pos) {
     _issue_prezero();
 
@@ -704,7 +704,7 @@ void Journaler::_do_flush(unsigned amount)
 void Journaler::wait_for_flush(Context *onsafe)
 {
   lock_guard l(lock);
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     if (onsafe)
       onsafe->complete(-EAGAIN);
     return;
@@ -738,7 +738,7 @@ void Journaler::_wait_for_flush(Context *onsafe)
 void Journaler::flush(Context *onsafe)
 {
   lock_guard l(lock);
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     if (onsafe)
       onsafe->complete(-EAGAIN);
     return;
@@ -798,7 +798,7 @@ void Journaler::_issue_prezero()
    * issue zero requests based on write_pos, even though the invariant
    * is that we zero ahead of flush_pos.
    */
-  uint64_t period = get_layout_period();
+  uint64_t period = layout.get_period();
   uint64_t to = write_pos + period * num_periods  + period - 1;
   to -= to % period;
 
@@ -1048,7 +1048,7 @@ void Journaler::_issue_read(uint64_t len)
   // here because it will wait for all object reads to complete before
   // giving us back any data.  this way we can process whatever bits
   // come in that are contiguous.
-  uint64_t period = get_layout_period();
+  uint64_t period = layout.get_period();
   while (len > 0) {
     uint64_t e = requested_pos + period;
     e -= e % period;
@@ -1065,7 +1065,7 @@ void Journaler::_issue_read(uint64_t len)
 
 void Journaler::_prefetch()
 {
-  if (is_stopping())
+  if (state == STATE_STOPPING)
     return;
 
   ldout(cct, 10) << "_prefetch" << dendl;
@@ -1082,7 +1082,7 @@ void Journaler::_prefetch()
   uint64_t raw_target = read_pos + pf;
 
   // read full log segments, so increase if necessary
-  uint64_t period = get_layout_period();
+  uint64_t period = layout.get_period();
   uint64_t remainder = raw_target % period;
   uint64_t adjustment = remainder ? period - remainder : 0;
   uint64_t target = raw_target + adjustment;
@@ -1201,8 +1201,8 @@ void Journaler::erase(Context *completion)
   lock_guard l(lock);
 
   // Async delete the journal data
-  uint64_t first = trimmed_pos / get_layout_period();
-  uint64_t num = (write_pos - trimmed_pos) / get_layout_period() + 2;
+  uint64_t first = trimmed_pos / layout.get_period();
+  uint64_t num = (write_pos - trimmed_pos) / layout.get_period() + 2;
   filer.purge_range(ino, &layout, SnapContext(), first, num,
 		    ceph::real_clock::now(), 0,
 		    wrap_finisher(new C_EraseFinish(
@@ -1217,7 +1217,7 @@ void Journaler::erase(Context *completion)
 void Journaler::_finish_erase(int data_result, C_OnFinisher *completion)
 {
   lock_guard l(lock);
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     completion->complete(-EAGAIN);
     return;
   }
@@ -1295,7 +1295,7 @@ void Journaler::wait_for_readable(Context *onreadable)
 
 void Journaler::_wait_for_readable(Context *onreadable)
 {
-  if (is_stopping()) {
+  if (state == STATE_STOPPING) {
     finisher->queue(onreadable, -EAGAIN);
     return;
   }
@@ -1340,11 +1340,11 @@ void Journaler::trim()
 
 void Journaler::_trim()
 {
-  if (is_stopping())
+  if (state == STATE_STOPPING)
     return;
 
   ceph_assert(!readonly);
-  uint64_t period = get_layout_period();
+  uint64_t period = layout.get_period();
   uint64_t trim_to = last_committed.expire_pos;
   trim_to -= trim_to % period;
   ldout(cct, 10) << "trim last_commited head was " << last_committed
@@ -1619,8 +1619,8 @@ void Journaler::check_isreadable()
 {
   std::unique_lock l(lock);
   while (!_is_readable() &&
-      get_read_pos() < get_write_pos() &&
-      !get_error()) {
+      read_pos < write_pos &&
+      !error) {
     C_SaferCond readable_waiter;
     _wait_for_readable(&readable_waiter);
     l.unlock();

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -222,10 +222,10 @@ public:
 private:
   // me
   CephContext *cct;
-  std::mutex lock;
+  mutable ceph::mutex lock;
   const std::string name;
-  typedef std::lock_guard<std::mutex> lock_guard;
-  typedef std::unique_lock<std::mutex> unique_lock;
+  typedef std::lock_guard<ceph::mutex> lock_guard;
+  typedef std::unique_lock<ceph::mutex> unique_lock;
   Finisher *finisher;
   Header last_written;
   inodeno_t ino;
@@ -408,7 +408,7 @@ public:
   Journaler(const std::string &name_, inodeno_t ino_, int64_t pool,
       const char *mag, Objecter *obj, PerfCounters *l, int lkey, Finisher *f) :
     last_committed(mag),
-    cct(obj->cct), name(name_), finisher(f), last_written(mag),
+    cct(obj->cct), lock(ceph::make_mutex("Journaler::" + name_)), name(name_), finisher(f), last_written(mag),
     ino(ino_), pg_pool(pool), readonly(true),
     stream_format(-1), journal_stream(-1),
     magic(mag),
@@ -528,24 +528,67 @@ public:
 
   // Synchronous getters
   // ===================
-  // TODO: need some locks on reads for true safety
   uint64_t get_layout_period() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
     return layout.get_period();
   }
-  file_layout_t& get_layout() { return layout; }
-  bool is_active() { return state == STATE_ACTIVE; }
-  bool is_stopping() { return state == STATE_STOPPING; }
-  int get_error() { return error; }
-  bool is_readonly() { return readonly; }
+  file_layout_t get_layout() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return layout;
+  }
+  bool is_active() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return state == STATE_ACTIVE;
+  }
+  bool is_stopping() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return state == STATE_STOPPING;
+  }
+  int get_error() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return error;
+  }
+  bool is_readonly() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return readonly;
+  }
   bool is_readable();
   bool _is_readable();
   bool try_read_entry(bufferlist& bl);
-  uint64_t get_write_pos() const { return write_pos; }
-  uint64_t get_write_safe_pos() const { return safe_pos; }
-  uint64_t get_read_pos() const { return read_pos; }
-  uint64_t get_expire_pos() const { return expire_pos; }
-  uint64_t get_trimmed_pos() const { return trimmed_pos; }
+  uint64_t get_write_pos() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return write_pos;
+  }
+  uint64_t get_write_safe_pos() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return safe_pos;
+  }
+  uint64_t get_read_pos() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return read_pos;
+  }
+  uint64_t get_expire_pos() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return expire_pos;
+  }
+  uint64_t get_trimmed_pos() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return trimmed_pos;
+  }
   size_t get_journal_envelope_size() const { 
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
     return journal_stream.get_envelope_size(); 
   }
   void check_isreadable();

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -217,10 +217,9 @@ public:
     return stream_format;
   }
 
-  Header last_committed;
-
 private:
   // me
+  Header last_committed;
   CephContext *cct;
   mutable ceph::mutex lock;
   const std::string name;
@@ -528,6 +527,18 @@ public:
 
   // Synchronous getters
   // ===================
+
+  Header get_last_committed() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return last_committed;
+  }
+  Header get_last_written() const {
+    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
+    lock_guard l(lock);
+    return last_written;
+  }
+
   uint64_t get_layout_period() const {
     ceph_assert(!ceph_mutex_is_locked_by_me(lock));
     lock_guard l(lock);

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -186,6 +186,16 @@ public:
       f->close_section(); // journal_header
     }
 
+    void print(std::ostream& os) const {
+      os << std::hex
+         << "Journaler::Header"
+            "(t=" << trimmed_pos
+         << " e=" << expire_pos
+         << " w=" << write_pos
+         << ")"
+         << std::dec;
+    }
+
     static void generate_test_instances(std::list<Header*> &ls)
     {
       ls.push_back(new Header());

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -112,6 +112,7 @@ int Dumper::dump(const char *dump_file)
     fsid.print(fsid_str);
     char buf[HEADER_LEN];
     memset(buf, 0, sizeof(buf));
+    auto&& last_committed = journaler.get_last_committed();
     snprintf(buf, HEADER_LEN, "Ceph mds%d journal dump\n start offset %llu (0x%llx)\n\
        length %llu (0x%llx)\n    write_pos %llu (0x%llx)\n    format %llu\n\
        trimmed_pos %llu (0x%llx)\n    stripe_unit %lu (0x%lx)\n    stripe_count %lu (0x%lx)\n\
@@ -119,12 +120,12 @@ int Dumper::dump(const char *dump_file)
 	    role.rank, 
 	    (unsigned long long)start, (unsigned long long)start,
 	    (unsigned long long)len, (unsigned long long)len,
-	    (unsigned long long)journaler.last_committed.write_pos, (unsigned long long)journaler.last_committed.write_pos,
-	    (unsigned long long)journaler.last_committed.stream_format,
-	    (unsigned long long)journaler.last_committed.trimmed_pos, (unsigned long long)journaler.last_committed.trimmed_pos,
-            (unsigned long)journaler.last_committed.layout.stripe_unit, (unsigned long)journaler.last_committed.layout.stripe_unit,
-            (unsigned long)journaler.last_committed.layout.stripe_count, (unsigned long)journaler.last_committed.layout.stripe_count,
-            (unsigned long)journaler.last_committed.layout.object_size, (unsigned long)journaler.last_committed.layout.object_size,
+	    (unsigned long long)last_committed.write_pos, (unsigned long long)last_committed.write_pos,
+	    (unsigned long long)last_committed.stream_format,
+	    (unsigned long long)last_committed.trimmed_pos, (unsigned long long)last_committed.trimmed_pos,
+            (unsigned long)last_committed.layout.stripe_unit, (unsigned long)last_committed.layout.stripe_unit,
+            (unsigned long)last_committed.layout.stripe_count, (unsigned long)last_committed.layout.stripe_count,
+            (unsigned long)last_committed.layout.object_size, (unsigned long)last_committed.layout.object_size,
 	    fsid_str,
 	    4);
     r = safe_write(fd, buf, sizeof(buf));
@@ -156,8 +157,8 @@ int Dumper::dump(const char *dump_file)
 
       C_SaferCond cond;
       lock.lock();
-      filer.read(ino, &journaler.get_layout(), CEPH_NOSNAP,
-                 pos, read_size, &bl, 0, &cond);
+      auto&& layout = journaler.get_layout();
+      filer.read(ino, &layout, CEPH_NOSNAP, pos, read_size, &bl, 0, &cond);
       lock.unlock();
       r = cond.wait();
       if (r < 0) {
@@ -295,23 +296,10 @@ int Dumper::undump(const char *dump_file, bool force)
   }
 
   if (recovered == 0) {
-    //Check if the headers are available in the dump file
-    if (!strstr(buf, "stripe_unit")) {
-      derr  << "Invalid header, no 'stripe_unit' embedded" << dendl;
-      ::close(fd);
-      return -EINVAL;
-    } else if (!strstr(buf, "stripe_count")) {
-      derr  << "Invalid header, no 'stripe_count' embedded" << dendl;
-      ::close(fd);
-      return -EINVAL;
-    } else if (!strstr(buf, "object_size")) {
-      derr  << "Invalid header, no 'object_size' embedded" << dendl;
-      ::close(fd);
-      return -EINVAL;
-    }
-    stripe_unit = journaler.last_committed.layout.stripe_unit;
-    stripe_count = journaler.last_committed.layout.stripe_count;
-    object_size = journaler.last_committed.layout.object_size;
+    auto&& last_committed = journaler.get_last_committed();
+    stripe_unit = last_committed.layout.stripe_unit;
+    stripe_count = last_committed.layout.stripe_count;
+    object_size = last_committed.layout.object_size;
   } else {
     // try to get layout from dump file header, if failed set layout to default
     char *p_stripe_unit = strstr(buf, "stripe_unit");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72115

---

backport of https://github.com/ceph/ceph/pull/58936
parent tracker: https://tracker.ceph.com/issues/59119

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh