### PR TITLE
tentacle: mixed balance read and rwordered in read ops

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2045,6 +2045,15 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     }
   }
 
+  // check for op with rwordered and rebalance or localize reads
+  if ((m->has_flag(CEPH_OSD_FLAG_BALANCE_READS) || m->has_flag(CEPH_OSD_FLAG_LOCALIZE_READS)) &&
+      op->rwordered()) {
+    dout(4) << __func__ << ": rebelance or localized reads with rwordered not allowed "
+       << *m << dendl;
+    osd->reply_op_error(op, -EINVAL);
+    return;
+  }
+
   if ((m->get_flags() & (CEPH_OSD_FLAG_BALANCE_READS |
 			 CEPH_OSD_FLAG_LOCALIZE_READS)) &&
       op->may_read() &&


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72119

---

backport of https://github.com/ceph/ceph/pull/62806
parent tracker: https://tracker.ceph.com/issues/70715

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh