### PR TITLE
reef: mon/OSDMonitor: call no_reply() on ignored osd alive

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3943,6 +3943,7 @@ bool OSDMonitor::preprocess_alive(MonOpRequestRef op)
   return false;
 
  ignore:
+  mon.no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72121

---

backport of https://github.com/ceph/ceph/pull/64135
parent tracker: https://tracker.ceph.com/issues/55101

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh