### PR TITLE
mgr/cephadm: add "ceph orch pause host <hostname>"

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -117,10 +117,9 @@ Ceph daemons traditionally write logs to ``/var/log/ceph``. Ceph daemons log to
 journald by default and Ceph logs are captured by the container runtime
 environment. They are accessible via ``journalctl``.
 
-.. note:: Prior to Quincy, Ceph daemons logged to stderr.
+.. note:: Prior to Quincy, ceph daemons logged to stderr.
 
-
-Example of Logging to Journald
+Example of logging to journald
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For example, to view the logs for the daemon ``mon.foo`` for a cluster
@@ -225,10 +224,9 @@ For example:
   [mgr]
   mgr/cephadm/cephadm_log_destination = syslog
   EOF
-  # cephadm bootstrap --config /tmp/bootstrap.conf # ... other bootstrap arguments ...
+  cephadm bootstrap --config /tmp/bootstrap.conf # ... other bootstrap arguments ...
 
-
-Setting a Cephadm Log Destination on an Existing Cluster
+Setting a cephadm log destination on an existing cluster
 --------------------------------------------------------
 
 An existing Ceph cluster can be configured to use a specific cephadm log
@@ -313,6 +311,28 @@ Resume cephadm work by running the following command:
 
   ceph orch resume
 
+CEPHADM_HOST_PAUSED
+~~~~~~~~~~~~~~~~~~~
+
+This indicates that one or more hosts have been paused with
+``ceph orch host pause <hostname>``. When a host is paused, cephadm
+excludes it from all orchestrator operations and freezes
+any pending cephadm operations until the host is resumed. Existing
+daemons continue to run normally and serve client I/O operations.
+
+This feature is useful for temporarily isolating a host from cephadm's
+background management during troubleshooting or host-level work while
+keeping services operational. For example, ``ceph orch daemon restart osd.5``
+will not execute if the host containing ``osd.5`` is paused.
+
+This is similar to the ``ceph orch pause`` command but instead of pausing
+all orchestrator operations cluster-wide, it only affects the specific host.
+
+To resume orchestrator operations on a paused host:
+
+.. prompt:: bash #
+
+  ceph orch host resume <hostname>
 
 .. _cephadm-stray-host:
 
@@ -476,11 +496,9 @@ This command returns the status of the configuration checker as either "Enabled"
 
 To list all the configuration checks and their current states, run the following command:
 
-.. prompt:: bash #
-
-  ceph cephadm config-check ls
-
 .. code-block:: console
+
+  # ceph cephadm config-check ls
 
   NAME             HEALTHCHECK                      STATUS   DESCRIPTION
   kernel_security  CEPHADM_CHECK_KERNEL_LSM         enabled  check that SELINUX/Apparmor profiles are consistent across cluster hosts
@@ -622,11 +640,10 @@ To see the list of client keyrings are currently under management, run the follo
 
   ceph orch client-keyring ls
 
+Putting a Keyring Under Management
+----------------------------------
 
-Enabling Management of a Keyring File
--------------------------------------
-
-To enable management of a keyring file, run a command of the following form:
+To put a keyring under management, run a command of the following form: 
 
 .. prompt:: bash #
 

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1194,7 +1194,7 @@ class HostCache():
         ``_refresh_host_daemons()`` was called, but *before*
         ``_apply_all_specs()`` was called. thus we end up with a hosts
         where daemons might be running, but we have not yet detected them.
-        
+
         Excludes paused hosts as they should not have new daemons scheduled.
         """
         return [
@@ -1295,7 +1295,7 @@ class HostCache():
     def get_paused_hosts(self) -> List[HostSpec]:
         """
         Return all hosts that are in paused state.
-        
+
         Paused hosts are reachable but administratively paused from
         orchestrator operations.
         """

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2398,7 +2398,7 @@ Then run the following:
     def pause_host(self, hostname: str) -> str:
         """
         Pause orchestrator operations on a host.
-        
+
         This prevents the orchestrator from scheduling new daemons on the host
         and marks it as unreachable for scheduling purposes, but does not stop
         existing daemons like maintenance mode does.
@@ -2428,7 +2428,7 @@ Then run the following:
     def resume_host(self, hostname: str) -> str:
         """
         Resume orchestrator operations on a host.
-        
+
         This allows the orchestrator to schedule daemons on the host again.
         """
         tgt_host = self.inventory._inventory[hostname]

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2383,6 +2383,74 @@ Then run the following:
 
         return f"Ceph cluster {self._cluster_fsid} on {hostname} has exited maintenance mode"
 
+    def update_paused_host_healthcheck(self) -> None:
+        """Raise/update or clear the paused host health check as needed"""
+        paused_hosts = self.inventory.get_host_with_state("paused")
+        if not paused_hosts:
+            self.remove_health_warning('CEPHADM_HOST_PAUSED')
+        else:
+            s = "host is" if len(paused_hosts) == 1 else "hosts are"
+            self.set_health_warning("CEPHADM_HOST_PAUSED", f"{len(paused_hosts)} {s} paused", 1, [
+                                    f"{h} is paused" for h in paused_hosts])
+
+    @handle_orch_error
+    @host_exists()
+    def pause_host(self, hostname: str) -> str:
+        """
+        Pause orchestrator operations on a host.
+        
+        This prevents the orchestrator from scheduling new daemons on the host
+        and marks it as unreachable for scheduling purposes, but does not stop
+        existing daemons like maintenance mode does.
+        """
+        tgt_host = self.inventory._inventory[hostname]
+        current_status = tgt_host.get("status", "").lower()
+
+        if current_status == "paused":
+            raise OrchestratorError(f"Host {hostname} is already paused")
+
+        if current_status == "maintenance":
+            raise OrchestratorError(f"Host {hostname} is in maintenance mode. Exit maintenance mode first")
+
+        # Update the host status in the inventory
+        tgt_host["status"] = "paused"
+        self.inventory._inventory[hostname] = tgt_host
+        self.inventory.save()
+
+        # Set health check for paused hosts
+        self.update_paused_host_healthcheck()
+
+        self.log.info(f'Host {hostname} paused')
+        return f'Host {hostname} paused. Orchestrator operations suspended on this host.'
+
+    @handle_orch_error
+    @host_exists()
+    def resume_host(self, hostname: str) -> str:
+        """
+        Resume orchestrator operations on a host.
+        
+        This allows the orchestrator to schedule daemons on the host again.
+        """
+        tgt_host = self.inventory._inventory[hostname]
+        current_status = tgt_host.get("status", "").lower()
+
+        if current_status != "paused":
+            raise OrchestratorError(f"Host {hostname} is not paused")
+
+        # Clear the host status
+        tgt_host["status"] = ""
+        self.inventory._inventory[hostname] = tgt_host
+        self.inventory.save()
+
+        # Refresh host metadata since it's now available again
+        self._invalidate_all_host_metadata_and_kick_serve(hostname)
+
+        # Update health check for paused hosts
+        self.update_paused_host_healthcheck()
+
+        self.log.info(f'Host {hostname} resumed')
+        return f'Host {hostname} resumed. Orchestrator operations resumed on this host.'
+
     @handle_orch_error
     @host_exists()
     def rescan_host(self, hostname: str) -> str:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -372,6 +372,20 @@ class Orchestrator(object):
     def resume(self) -> None:
         raise NotImplementedError()
 
+    def pause_host(self, hostname: str) -> OrchResult[str]:
+        """
+        Pause orchestrator operations on a host.
+        :param hostname: the name of the host to pause.
+        """
+        raise NotImplementedError()
+
+    def resume_host(self, hostname: str) -> OrchResult[str]:
+        """
+        Resume orchestrator operations on a host.
+        :param hostname: the name of the host to resume.
+        """
+        raise NotImplementedError()
+
     def add_host(self, host_spec: HostSpec) -> OrchResult[str]:
         """
         Add a host to the orchestrator inventory.

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2310,6 +2310,20 @@ Usage:
         self.resume()
         return HandleCommandResult()
 
+    @_cli_write_command('orch pause host')
+    def _pause_host(self, hostname: str) -> HandleCommandResult:
+        """Pause orchestrator operations on a host"""
+        completion = self.pause_host(hostname)
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_cli_write_command('orch resume host')
+    def _resume_host(self, hostname: str) -> HandleCommandResult:
+        """Resume orchestrator operations on a host"""
+        completion = self.resume_host(hostname)
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
     @_cli_write_command('orch unpause')
     def _unpause(self) -> HandleCommandResult:
         """Alias to orch resume"""


### PR DESCRIPTION
mgr/cephadm: Added pause_host() and resume_host() commands to temporarily suspend orchestrator operations on hosts while keeping daemons running. Paused hosts are excluded from scheduling and OSD operations but preserve existing running daemons, unlike maintenance mode.

Fixes: https://tracker.ceph.com/issues/71179
Signed-off-by: Sam Goyal <sam.goyal@clyso.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
