### PR TITLE
doc/radosgw: Small improvements in s3_objects_dedup.rst

### DIFF
--- a/doc/radosgw/s3_objects_dedup.rst
+++ b/doc/radosgw/s3_objects_dedup.rst
@@ -1,79 +1,78 @@
-======================
-Full RGW Object Dedup:
-======================
-Add a radosgw-admin command to collect and report deduplication stats
+=====================
+Full RGW Object Dedup
+=====================
+Adds a ``radosgw-admin`` command to collect and report deduplication stats.
 
-.. note:: This utility doesn’t perform dedup and doesn’t make any
+.. note:: This utility doesn't perform dedup and doesn't make any
           change to the existing system and will only collect
           statistics and report them.
 
-----
-
-***************
-Admin commands:
-***************
+**************
+Admin commands
+**************
 - ``radosgw-admin dedup stats``:
-   Collects & displays last dedup statistics
+   Collects & displays last dedup statistics.
 - ``radosgw-admin dedup pause``:
-   Pauses active dedup session (dedup resources are not released)
+   Pauses an active dedup session (dedup resources are not released).
 - ``radosgw-admin dedup resume``:
-   Resumes a paused dedup session
+   Resumes a paused dedup session.
 - ``radosgw-admin dedup abort``:
-   Aborts active dedup session and release all resources used by it
+   Aborts an active dedup session and release all resources used by it.
 - ``radosgw-admin dedup estimate``
-    Starts a new dedup estimate session (aborting first existing session if exists)
+   Starts a new dedup estimate session (aborting first existing session if exists).
 
-----
+***************
+Skipped Objects
+***************
+Dedup Estimate process skips the following objects:
 
-****************
-Skipped Objects:
-****************
-Dedup Estimates skips the following objects:
+- Objects smaller than 4MB (unless they are multipart).
+- Objects with different placement rules.
+- Objects with different pools.
+- Objects with different storage classes.
 
-- Objects smaller than 4MB (unless they are multipart)
-- Objects with different placement rules
-- Objects with different pools
-- Objects with different same storage-classes
-
-The Dedup process itself (which will be released later) will also skip
+The dedup process itself (which will be released in a later Ceph release) will also skip
 **compressed** and **user-encrypted** objects, but the estimate
 process will accept them (since we don't have access to that
-information during the estimate process)
+information during the estimate process).
 
-----
-
-********************
-Estimate Processing:
-********************
+*******************
+Estimate Processing
+*******************
 The Dedup Estimate process collects all the needed information directly from
-the bucket-indices reading one full bucket-index object with 1000's of
+the bucket indices reading one full bucket index object with thousands of
 entries at a time.
 
-The Bucket-Indices objects are sharded between the participating
-members so every bucket-index object is read exactly one time.
-The sharding allow processing to scale almost linearly spliting the
+The bucket indices objects are sharded between the participating
+members so every bucket index object is read exactly one time.
+The sharding allow processing to scale almost linearly splitting the
 load evenly between the participating members.
 
 The Dedup Estimate process does not access the objects themselves
 (data/metadata) which means its processing time won't be affected by
-the underlined media storing the objects (SSD/HDD) since the bucket-indices are
+the underlying media storing the objects (SSD/HDD) since the bucket indices are
 virtually always stored on a fast medium (SSD with heavy memory
-caching)
+caching).
 
-----
-
-*************
-Memory Usage:
-*************
- +---------------++-----------+
- | RGW Obj Count |  Memory    |
- +===============++===========+
- | | ____1M      | | ___8MB   |
- | | ____4M      | | __16MB   |
- | | ___16M      | | __32MB   |
- | | ___64M      | | __64MB   |
- | | __256M      | | _128MB   |
- | | _1024M( 1G) | | _256MB   |
- | | _4096M( 4G) | | _512MB   |
- | | 16384M(16G) | | 1024MB   |
- +---------------+------------+
+************
+Memory Usage
+************
+ +---------------+----------+
+ | RGW Obj Count |  Memory  |
+ +===============+==========+
+ | 1M            | 8 MB     |
+ +---------------+----------+
+ | 4M            | 16 MB    |
+ +---------------+----------+
+ | 16M           | 32 MB    |
+ +---------------+----------+
+ | 64M           | 64 MB    |
+ +---------------+----------+
+ | 256M          | 128 MB   |
+ +---------------+----------+
+ | 1024M (1G)    | 256 MB   |
+ +---------------+----------+
+ | 4096M (4G)    | 512 MB   |
+ +---------------+----------+
+ | 16384M (16G)  | 1024 MB  |
+ +---------------+----------+


### PR DESCRIPTION
Fix sentence that had "different same" to just "different" (verified the right one from the original author).

Remove colon at the end of section titles.

Remove rendered horizontal lines between sections.

Use double backticks for command name.

Use regular apostrophe in one sentence to be consistent with the rest.

Add missing full stop at the end of several sentences.

Very small language improvements in a few sentences.

Use consistent indent in one line.

Remove hyphens from many word pairs and don't capitalize few terms. For consistency with rest of the docs.

Fix typos "spliting" to "splitting", "underlined" to "underlying".

Spell out "thousands" instead of using an apostrophe after the number.

Reformat table to use row separators like rest of the docs instead of empty columns.
Separate number and unit with a space. Remove rendered underscores that seemed to be an attempt to imprecisely align cell contents to right.

- Before: https://docs.ceph.com/en/latest/radosgw/s3_objects_dedup/
- Rendered PR: https://ceph--64526.org.readthedocs.build/en/64526/radosgw/s3_objects_dedup/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
