### PR TITLE
test/crimson/seastore/test_omap_manager: add unit test for clear

### DIFF
--- a/src/test/crimson/seastore/test_omap_manager.cc
+++ b/src/test/crimson/seastore/test_omap_manager.cc
@@ -419,7 +419,29 @@ TEST_P(omap_manager_test_t, leafnode_split_merge_balancing)
   });
 }
 
-TEST_P(omap_manager_test_t, force_split_listkeys_list_rmkey_range_clear)
+TEST_P(omap_manager_test_t, clear)
+{
+  run_async([this] {
+    omap_root_t omap_root = initialize();
+
+    logger().debug("== filling tree to depth 2");
+    while (omap_root.get_depth() < 2) {
+      auto t = create_mutate_transaction();
+      for (int i = 0; i < 64; i++) {
+        set_random_key(omap_root, *t);
+      }
+      submit_transaction(std::move(t));
+    }
+    check_mappings(omap_root);
+
+    logger().debug("== clearing entire tree");
+    auto t = create_mutate_transaction();
+    clear(omap_root, *t);
+    submit_transaction(std::move(t));
+  });
+}
+
+TEST_P(omap_manager_test_t, force_split_listkeys_list_rmkey_range)
 {
   run_async([this] {
     omap_root_t omap_root = initialize();
@@ -498,12 +520,6 @@ TEST_P(omap_manager_test_t, force_split_listkeys_list_rmkey_range_clear)
       }
       submit_transaction(std::move(t));
     }
-
-    {
-      auto t = create_mutate_transaction();
-      clear(omap_root, *t);
-      submit_transaction(std::move(t));
-    }
   });
 }
 
@@ -570,74 +586,6 @@ TEST_P(omap_manager_test_t, force_inner_node_split_list_rmkey_range)
       }
       submit_transaction(std::move(t));
     }
-
-    {
-      auto t = create_mutate_transaction();
-      clear(omap_root, *t);
-      submit_transaction(std::move(t));
-    }
-  });
-}
-
-TEST_P(omap_manager_test_t, internal_force_split)
-{
-  run_async([this] {
-    omap_root_t omap_root = initialize();
-
-    for (unsigned i = 0; i < 10; i++) {
-      logger().debug("opened split transaction");
-      auto t = create_mutate_transaction();
-
-      for (unsigned j = 0; j < 80; ++j) {
-        set_random_key(omap_root, *t);
-        if ((i % 2 == 0) && (j % 50 == 0)) {
-          check_mappings(omap_root, *t);
-        }
-      }
-      logger().debug("submitting transaction i = {}", i);
-      submit_transaction(std::move(t));
-    }
-    check_mappings(omap_root);
-  });
-}
-
-TEST_P(omap_manager_test_t, internal_force_merge_fullandbalanced)
-{
-  run_async([this] {
-    omap_root_t omap_root = initialize();
-
-    for (unsigned i = 0; i < 8; i++) {
-      logger().debug("opened split transaction");
-      auto t = create_mutate_transaction();
-
-      for (unsigned j = 0; j < 80; ++j) {
-        set_random_key(omap_root, *t);
-        if ((i % 2 == 0) && (j % 50 == 0)) {
-          check_mappings(omap_root, *t);
-        }
-      }
-      logger().debug("submitting transaction");
-      submit_transaction(std::move(t));
-    }
-    auto mkeys = get_mapped_keys();
-    auto t = create_mutate_transaction();
-    for (unsigned i = 0; i < mkeys.size(); i++) {
-      rm_key(omap_root, *t, mkeys[i]);
-
-      if (i % 10 == 0) {
-        logger().debug("submitting transaction i= {}", i);
-        submit_transaction(std::move(t));
-        t = create_mutate_transaction();
-      }
-      if (i % 50 == 0) {
-        logger().debug("check_mappings  i= {}", i);
-        check_mappings(omap_root, *t);
-        check_mappings(omap_root);
-      }
-    }
-    logger().debug("finally submitting transaction ");
-    submit_transaction(std::move(t));
-    check_mappings(omap_root);
   });
 }
 
@@ -687,7 +635,6 @@ TEST_P(omap_manager_test_t, replay)
     }
   });
 }
-
 
 TEST_P(omap_manager_test_t, internal_force_split_to_root)
 {
@@ -762,11 +709,6 @@ TEST_P(omap_manager_test_t, omap_iterate)
       start_from = ObjectStore::omap_iter_seek_t::min_lower_bound();
       auto t = create_read_transaction();
       iterate(omap_root, *t, start_from, callback);
-    }
-    {
-      auto t = create_mutate_transaction();
-      clear(omap_root, *t);
-      submit_transaction(std::move(t));
     }
   });
 }


### PR DESCRIPTION
Like the `replay` test, `clear` has been refactored into a standalone unit test. This makes the test's purpose more explicit and prevents redundant `clear()` calls across other unit tests.

Additionally, the `internal_force_split` and `internal_force_merge_fullandbalanced` tests have been removed, as their coverage is now fully handled by the `leafnode_split_merge_balancing` test.

Test | Previous | This PR
-- | -- | --
unittest-omap-manager.all | 458 s | 399 s

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
