### PR TITLE
tentacle: test/d4n: Change D4N filter test cleaning interval values to ints

### DIFF
--- a/src/test/rgw/test_d4n_filter.cc
+++ b/src/test/rgw/test_d4n_filter.cc
@@ -1397,7 +1397,7 @@ TEST_F(D4NFilterFixture, DeleteVersionedObjectRead)
 TEST_F(D4NFilterFixture, PutObjectWrite)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "PutObjectWrite";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::string version;
@@ -1945,7 +1945,7 @@ TEST_F(D4NFilterFixture, CopyReplaceObjectWrite)
 TEST_F(D4NFilterFixture, DeleteObjectWrite)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "DeleteObjectWrite";
   std::string version;
  
@@ -2026,7 +2026,7 @@ TEST_F(D4NFilterFixture, DeleteObjectWrite)
 TEST_F(D4NFilterFixture, PutVersionedObjectWrite)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "PutVersionedObjectWrite";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::string version, instance;
@@ -2991,7 +2991,7 @@ TEST_F(D4NFilterFixture, CopyReplaceVersionedObjectWrite)
 TEST_F(D4NFilterFixture, DeleteVersionedObjectWrite)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "DeleteVersionedObjectRead";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::string version, instance;
@@ -3096,7 +3096,7 @@ TEST_F(D4NFilterFixture, DeleteVersionedObjectWrite)
 TEST_F(D4NFilterFixture, SimpleDeleteBeforeCleaning)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "SimpleDeleteBeforeCleaning";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::vector<std::string> instances;
@@ -3180,7 +3180,7 @@ TEST_F(D4NFilterFixture, SimpleDeleteBeforeCleaning)
 TEST_F(D4NFilterFixture, VersionedDeleteBeforeCleaning)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "VersionedDeleteBeforeCleaning";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::vector<std::string> instances;
@@ -3291,7 +3291,7 @@ TEST_F(D4NFilterFixture, VersionedDeleteBeforeCleaning)
 TEST_F(D4NFilterFixture, SimpleDeleteAfterCleaning)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "SimpleDeleteAfterCleaning";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::vector<std::string> instances;
@@ -3343,7 +3343,7 @@ TEST_F(D4NFilterFixture, SimpleDeleteAfterCleaning)
 TEST_F(D4NFilterFixture, VersionedDeleteAfterCleaning)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "VersionedDeleteAfterCleaning";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::vector<std::string> instances;
@@ -3439,7 +3439,7 @@ TEST_F(D4NFilterFixture, VersionedDeleteAfterCleaning)
 TEST_F(D4NFilterFixture, ListObjectVersions)
 {
   env->cct->_conf->d4n_writecache_enabled = true;
-  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0.5;
+  env->cct->_conf->rgw_d4n_cache_cleaning_interval = 0;
   const std::string testName = "ListObjectVersions";
   const std::string bucketName = "/tmp/d4n_filter_tests/dbstore-default_ns.1";
   std::string instance;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71993

---

backport of https://github.com/ceph/ceph/pull/64017
parent tracker: https://tracker.ceph.com/issues/71711

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh