### PR TITLE
Fix multifs auth caps check

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -308,6 +308,19 @@ class MdsCapTester:
         log.info('absence of write perm was tested successfully: '
                  f'failed to be write data to file {self.path}.')
 
+    def conduct_neg_test_for_new_file_creation(self, sudo_write=False):
+        possible_errmsgs = ('permission denied', 'operation not permitted')
+        cmdargs = ['sudo', 'touch'] if sudo_write else ['touch']
+
+        # don't use data, cmd args to write are set already above.
+        log.info('test absence of write perm: expect failure '
+                 f'try creating a new "{self.new_file}"')
+        cmdargs.append(self.new_file)
+        self.mount.negtestcmd(args=cmdargs, retval=1, errmsgs=possible_errmsgs)
+        cmdargs.pop(-1)
+        log.info('absence of write perm was tested successfully: '
+                 f'failed to create a new file {self.new_file}.')
+
     def conduct_pos_test_for_new_file_creation(self, sudo_write=False):
         log.info(f'test write perm: try creating a new "{self.new_file}"')
         self.mount.create_file(self.new_file)

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1724,6 +1724,104 @@ class TestFsAuthorize(CephFSTestCase):
         self.captester2.conduct_neg_test_for_chown_caps()
         self.captester2.conduct_neg_test_for_truncate_caps()
 
+    def test_multifs_single_client_cross_access_rw_caps_end(self):
+        """
+        test_multifs_single_client_cross_access_rw_caps_end -
+        A client having 'r' access on a fs (fs1) and 'rw' access on another fs (fs2) :
+          1. It shouldn't have 'rw' access on fs1
+          2. It should have 'rw' access on fs2
+
+        The fs name wasn't considered while validating mds auth caps. As a result,
+        incorrect permissions were granted to a user having access to multiple
+        filesystems. The order too matters as the last mds auth cap in the sequence
+        is considered while validating. This tests the auth caps having 'rw' caps
+        at the end.
+        """
+
+        self.fs1 = self.fs
+        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.mount_b.remount(cephfs_name=self.fs2.name)
+
+        FS1_AUTH_CAPS = (('/', 'r'),)
+        captester_fs1_r = CapTester(self.mount_a, '/')
+        FS2_AUTH_CAPS = (('/', 'rw'),)
+        captester_fs2_rw = CapTester(self.mount_b, '/')
+
+        self.mount_a.umount_wait()
+        self.mount_b.umount_wait()
+
+        # Authorize client to fs1 with 'rw'
+        self.fs1.authorize(self.client_id, FS1_AUTH_CAPS)
+        # Authorize client to fs2 with only 'r'
+        keyring = self.fs2.authorize(self.client_id, FS2_AUTH_CAPS)
+
+        # Mount fs1
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.remount(client_id=self.client_id, client_keyring_path=keyring_path, cephfs_name=self.fs1.name)
+
+        # Mount fs2
+        keyring_path = self.mount_b.client_remote.mktemp(data=keyring)
+        self.mount_b.remount(client_id=self.client_id, client_keyring_path=keyring_path, cephfs_name=self.fs2.name)
+
+        # Client on fs1 should not have 'rw' access
+        captester_fs1_r.conduct_pos_test_for_read_caps()
+        captester_fs1_r.conduct_neg_test_for_write_caps()
+        captester_fs1_r.conduct_neg_test_for_new_file_creation()
+
+        # Client on fs2 - validate 'rw' access
+        captester_fs2_rw.conduct_pos_test_for_read_caps()
+        captester_fs2_rw.conduct_pos_test_for_write_caps()
+        captester_fs2_rw.conduct_pos_test_for_new_file_creation()
+
+    def test_multifs_single_client_cross_access_r_caps_end(self):
+        """
+        test_multifs_single_client_cross_access_r_caps_end -
+        A client having 'rw' access on a fs (fs1) and 'r' access on another fs (fs2) :
+          1. It should have 'rw' access on fs1
+          1. It shouldn't have 'rw' access on fs2
+
+        The fs name wasn't considered while validating mds auth caps. As a result,
+        incorrect permissions were granted to a user having access to multiple
+        filesystems. The order too matters as the last mds auth cap in the sequence
+        is considered while validating. This tests the auth caps having 'r' caps
+        at the end.
+        """
+
+        self.fs1 = self.fs
+        self.fs2 = self.mds_cluster.newfs('testcephfs2')
+        self.mount_b.remount(cephfs_name=self.fs2.name)
+
+        FS1_AUTH_CAPS = (('/', 'rw'),)
+        captester_fs1_rw = CapTester(self.mount_a, '/')
+        FS2_AUTH_CAPS = (('/', 'r'),)
+        captester_fs2_r = CapTester(self.mount_b, '/')
+
+        self.mount_a.umount_wait()
+        self.mount_b.umount_wait()
+
+        # Authorize client to fs1 with 'rw'
+        self.fs1.authorize(self.client_id, FS1_AUTH_CAPS)
+        # Authorize client to fs2 with only 'r'
+        keyring = self.fs2.authorize(self.client_id, FS2_AUTH_CAPS)
+
+        # Mount fs1
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.remount(client_id=self.client_id, client_keyring_path=keyring_path, cephfs_name=self.fs1.name)
+
+        # Mount fs2
+        keyring_path = self.mount_b.client_remote.mktemp(data=keyring)
+        self.mount_b.remount(client_id=self.client_id, client_keyring_path=keyring_path, cephfs_name=self.fs2.name)
+
+        # Client on fs1 - validate 'rw' access
+        captester_fs1_rw.conduct_pos_test_for_read_caps()
+        captester_fs1_rw.conduct_pos_test_for_write_caps()
+        captester_fs1_rw.conduct_pos_test_for_new_file_creation()
+
+        # Client on fs2 should not have 'rw' access
+        captester_fs2_r.conduct_pos_test_for_read_caps()
+        captester_fs2_r.conduct_neg_test_for_write_caps()
+        captester_fs2_r.conduct_neg_test_for_new_file_creation()
+
     def test_multifs_rootsquash_nofeature(self):
         """
         That having root_squash on one fs doesn't prevent access to others.

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1832,8 +1832,10 @@ class TestFsAuthorize(CephFSTestCase):
         # with 'rw' would end up having 'r' caps with the multifs for
         # auth caps used as in this test above.
         if ceph_client_version != "v19.2.2":
-            captester_fs1_rw.conduct_pos_test_for_write_caps()
-            captester_fs1_rw.conduct_pos_test_for_new_file_creation()
+            # The following condition should be removed once the fix lands in kernel
+            if isinstance(self.mount_a, FuseMount):
+                captester_fs1_rw.conduct_pos_test_for_write_caps()
+                captester_fs1_rw.conduct_pos_test_for_new_file_creation()
 
 
     def test_multifs_rootsquash_nofeature(self):

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1812,15 +1812,29 @@ class TestFsAuthorize(CephFSTestCase):
         keyring_path = self.mount_b.client_remote.mktemp(data=keyring)
         self.mount_b.remount(client_id=self.client_id, client_keyring_path=keyring_path, cephfs_name=self.fs2.name)
 
-        # Client on fs1 - validate 'rw' access
-        captester_fs1_rw.conduct_pos_test_for_read_caps()
-        captester_fs1_rw.conduct_pos_test_for_write_caps()
-        captester_fs1_rw.conduct_pos_test_for_new_file_creation()
-
         # Client on fs2 should not have 'rw' access
         captester_fs2_r.conduct_pos_test_for_read_caps()
         captester_fs2_r.conduct_neg_test_for_write_caps()
         captester_fs2_r.conduct_neg_test_for_new_file_creation()
+
+        # Client on fs1 - validate 'rw' access
+        ceph_client_version = None
+        tasks = self.ctx.config.get('tasks', [])
+        for task in tasks:
+            if task.get("install", None):
+                ceph_client_version = task.get("install").get("tag", None)
+                break
+
+        log.info(f"dumping ceph_client_version - {ceph_client_version}")
+        captester_fs1_rw.conduct_pos_test_for_read_caps()
+        # The multifs auth caps bug has a fix both in client and mds
+        # If it's old client (19.2.2) and not patched, we expect that the fs
+        # with 'rw' would end up having 'r' caps with the multifs for
+        # auth caps used as in this test above.
+        if ceph_client_version != "v19.2.2":
+            captester_fs1_rw.conduct_pos_test_for_write_caps()
+            captester_fs1_rw.conduct_pos_test_for_new_file_creation()
+
 
     def test_multifs_rootsquash_nofeature(self):
         """

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6088,11 +6088,12 @@ int Client::mds_check_access(std::string& path, const UserPerm& perms, int mask)
     path = path.substr(1);
   }
 
+  std::string_view fs_name = mdsmap->get_fs_name();
   for (auto& s: cap_auths) {
-    ldout(cct, 20) << __func__ << " auth match path " << s.match.path << " r: " << s.readable
-                   << " w: " << s.writeable << dendl;
+    ldout(cct, 20) << __func__ << " auth match fsname " << s.match.fs_name << " auth match path "
+                   << s.match.path << " r: " << s.readable << " w: " << s.writeable << dendl;
     ldout(cct, 20) << " match.uid " << s.match.uid << dendl;
-    if (s.match.match(path, perms.uid(), perms.gid(), &gid_list)) {
+    if (s.match.match(fs_name, path, perms.uid(), perms.gid(), &gid_list)) {
       ldout(cct, 20) << " is matched" << dendl;
       // always follow the last auth caps' permision
       root_squash_perms = true;

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -130,11 +130,16 @@ void MDSCapMatch::normalize_path()
   // drop ..
 }
 
-bool MDSCapMatch::match(string_view target_path,
+bool MDSCapMatch::match(string_view fs_name,
+                        string_view target_path,
 			const int caller_uid,
 			const int caller_gid,
 			const vector<uint64_t> *caller_gid_list) const
 {
+  if (!match_fs(fs_name)) {
+    return false;
+  }
+
   if (uid != MDS_AUTH_UID_ANY) {
     if (uid != caller_uid)
       return false;
@@ -221,7 +226,8 @@ bool MDSAuthCaps::path_capable(string_view inode_path) const
  * This is true if any of the 'grant' clauses in the capability match the
  * requested path + op.
  */
-bool MDSAuthCaps::is_capable(string_view inode_path,
+bool MDSAuthCaps::is_capable(string_view fs_name,
+                             string_view inode_path,
 			     uid_t inode_uid, gid_t inode_gid,
 			     unsigned inode_mode,
 			     uid_t caller_uid, gid_t caller_gid,
@@ -230,7 +236,7 @@ bool MDSAuthCaps::is_capable(string_view inode_path,
 			     uid_t new_uid, gid_t new_gid,
 			     const entity_addr_t& addr) const
 {
-  ldout(g_ceph_context, 10) << __func__ << " inode(path /" << inode_path
+  ldout(g_ceph_context, 10) << __func__ << "fs_name " << fs_name << " inode(path /" << inode_path
 		 << " owner " << inode_uid << ":" << inode_gid
 		 << " mode 0" << std::oct << inode_mode << std::dec
 		 << ") by caller " << caller_uid << ":" << caller_gid
@@ -248,7 +254,7 @@ bool MDSAuthCaps::is_capable(string_view inode_path,
       continue;
     }
 
-    if (grant.match.match(inode_path, caller_uid, caller_gid, caller_gid_list) &&
+    if (grant.match.match(fs_name, inode_path, caller_uid, caller_gid, caller_gid_list) &&
 	grant.spec.allows(mask & (MAY_READ|MAY_EXECUTE), mask & MAY_WRITE)) {
       if (grant.match.root_squash && ((caller_uid == 0) || (caller_gid == 0)) &&
           (mask & MAY_WRITE)) {

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -143,7 +143,8 @@ struct MDSCapMatch {
   }
 
   // check whether this grant matches against a given file and caller uid:gid
-  bool match(std::string_view target_path,
+  bool match(std::string_view fs_name,
+             std::string_view target_path,
 	     const int caller_uid,
 	     const int caller_gid,
 	     const std::vector<uint64_t> *caller_gid_list) const;
@@ -266,7 +267,8 @@ public:
   bool merge(MDSAuthCaps newcaps);
 
   bool allow_all() const;
-  bool is_capable(std::string_view inode_path,
+  bool is_capable(std::string_view fs_name,
+                  std::string_view inode_path,
 		  uid_t inode_uid, gid_t inode_gid, unsigned inode_mode,
 		  uid_t uid, gid_t gid, const std::vector<uint64_t> *caller_gid_list,
 		  unsigned mask, uid_t new_uid, gid_t new_gid,

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3471,8 +3471,9 @@ void Server::handle_peer_auth_pin_ack(const MDRequestRef& mdr, const cref_t<MMDS
 bool Server::check_access(const MDRequestRef& mdr, CInode *in, unsigned mask)
 {
   if (mdr->session) {
+    std::string_view fs_name = mds->mdsmap->get_fs_name();
     int r = mdr->session->check_access(
-      in, mask,
+      fs_name, in, mask,
       mdr->client_request->get_caller_uid(),
       mdr->client_request->get_caller_gid(),
       &mdr->client_request->get_caller_gid_list(),

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1086,7 +1086,7 @@ void Session::decode(bufferlist::const_iterator &p)
   _update_human_name();
 }
 
-int Session::check_access(CInode *in, unsigned mask,
+int Session::check_access(std::string_view fs_name, CInode *in, unsigned mask,
 			  int caller_uid, int caller_gid,
 			  const vector<uint64_t> *caller_gid_list,
 			  int new_uid, int new_gid)
@@ -1137,7 +1137,7 @@ int Session::check_access(CInode *in, unsigned mask,
     return -EIO;
   }
 
-  if (!auth_caps.is_capable(path, inode->uid, inode->gid, inode->mode,
+  if (!auth_caps.is_capable(fs_name, path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
 			    new_uid, new_gid,
 			    info.inst.addr)) {

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -381,7 +381,7 @@ public:
     completed_requests_dirty = false;
   }
 
-  int check_access(CInode *in, unsigned mask, int caller_uid, int caller_gid,
+  int check_access(std::string_view fs_name, CInode *in, unsigned mask, int caller_uid, int caller_gid,
 		   const std::vector<uint64_t> *gid_list, int new_uid, int new_gid);
 
   bool fs_name_capable(std::string_view fs_name, unsigned mask) const {

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -28,6 +28,7 @@ string pathcap = "path=/dir1";
 string rscap = "root_squash";
 string uidcap = "uid=1000";
 string gidscap = "gids=1000,1001,1002";
+string fsname ="a";
 
 
 vector<string> parse_good = {
@@ -183,7 +184,7 @@ TEST(MDSAuthCaps, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowUid) {
@@ -192,11 +193,11 @@ TEST(MDSAuthCaps, AllowUid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowUidGid) {
@@ -205,24 +206,24 @@ TEST(MDSAuthCaps, AllowUidGid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
 
   // user
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 
   // group
   vector<uint64_t> glist10;
@@ -234,59 +235,59 @@ TEST(MDSAuthCaps, AllowUidGid) {
   glist11.push_back(11);
   vector<uint64_t> glist12;
   glist12.push_back(12);
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr));
 
   // user > group
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
 
   // other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr));
 
   // group > other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
 
   // user > other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowPath) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * path=/sandbox", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowPathChars) {
   MDSAuthCaps unquo_cap;
   ASSERT_TRUE(unquo_cap.parse("allow * path=/sandbox-._foo", NULL));
   ASSERT_FALSE(unquo_cap.allow_all());
-  ASSERT_TRUE(unquo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(unquo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(unquo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(unquo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 
@@ -294,21 +295,21 @@ TEST(MDSAuthCaps, AllowPathCharsQuoted) {
   MDSAuthCaps quo_cap;
   ASSERT_TRUE(quo_cap.parse("allow * path=\"/sandbox-._foo\"", NULL));
   ASSERT_FALSE(quo_cap.allow_all());
-  ASSERT_TRUE(quo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(quo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(quo_cap.is_capable(fsname, "sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(quo_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, RootSquash) {
   MDSAuthCaps rs_cap;
   ASSERT_TRUE(rs_cap.parse("allow rw root_squash, allow rw path=/sandbox", NULL));
-  ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_FALSE(rs_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
-  ASSERT_TRUE(rs_cap.is_capable("sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(rs_cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(rs_cap.is_capable(fsname, "sandbox/foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, OutputParsed) {
@@ -370,7 +371,7 @@ TEST(MDSAuthCaps, network) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, a));
+  ASSERT_TRUE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, b));
+  ASSERT_FALSE(cap.is_capable(fsname, "foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, c));
 }


### PR DESCRIPTION
The fsname is not take into consideration while validating
the access check for the operations. This patch fixes
the same.
    
Fixes: https://tracker.ceph.com/issues/72167
Signed-off-by: Kotresh HR <khiremat@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
