### PR TITLE
tentacle: rgw: fix bucket logging AuthType field

### DIFF
--- a/doc/radosgw/bucket_logging.rst
+++ b/doc/radosgw/bucket_logging.rst
@@ -241,7 +241,7 @@ based on `AWS Logging Record Format`_.
   - host id taken from "x-amz-id-2" (or dash if empty)
   - signature version (or dash if empty)
   - cipher suite (or dash if empty)
-  - authentication type (or dash if empty)
+  - authentication type ("AuthHeader" for regular auth, "QueryString" for presigned URL or dash if unauthenticated)
   - host header (or dash if empty)
   - TLS version (or dash if empty)
   - access point ARN (not supported, always a dash)

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -1759,13 +1759,18 @@ void get_aws_version_and_auth_type(const req_state* s, string& aws_version, stri
       aws_version = "SigV2";
     }
   } else {
-    auth_type = "QueryString";
-    if (s->info.args.get("x-amz-algorithm") == AWS4_HMAC_SHA256_STR) {
+    if (!s->info.args.get("x-amz-credential").empty()) {
+      auth_type = "QueryString";
+      if (s->info.args.get("x-amz-algorithm") == AWS4_HMAC_SHA256_STR) {
       /* AWS v4 */
-      aws_version = "SigV4";
-    } else if (!s->info.args.get("AWSAccessKeyId").empty()) {
+	aws_version = "SigV4";
+      } else if (!s->info.args.get("AWSAccessKeyId").empty()) {
       /* AWS v2 */
-      aws_version = "SigV2";
+	aws_version = "SigV2";
+      }
+    } else {
+      // Unauthenticated
+      auth_type.clear();
     }
   }
 }

--- a/src/rgw/rgw_bucket_logging.cc
+++ b/src/rgw/rgw_bucket_logging.cc
@@ -572,7 +572,7 @@ int log_record(rgw::sal::Driver* driver,
         s->info.x_meta_map.contains("x-amz-id-2") ? s->info.x_meta_map.at("x-amz-id-2") : "-",
         aws_version,
         s->info.env->get("SSL_CIPHER", "-"),
-        auth_type,
+        dash_if_empty(auth_type),
         dash_if_empty(fqdn),
         s->info.env->get("TLS_VERSION", "-"),
         "-", // no access point ARN


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72160

---

backport of https://github.com/ceph/ceph/pull/64349
parent tracker: https://tracker.ceph.com/issues/71731

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh