### PR TITLE
mgr/dashboard: support inline edit for datatable

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/datatable.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/datatable.module.ts
@@ -15,7 +15,9 @@ import {
   DialogModule,
   SelectModule,
   TagModule,
-  LayerModule
+  LayerModule,
+  InputModule,
+  GridModule
 } from 'carbon-components-angular';
 import AddIcon from '@carbon/icons/es/add/16';
 import FilterIcon from '@carbon/icons/es/filter/16';
@@ -26,6 +28,7 @@ import CloseIcon from '@carbon/icons/es/close/16';
 import MaximizeIcon from '@carbon/icons/es/maximize/16';
 import ArrowDown from '@carbon/icons/es/caret--down/16';
 import ChevronDwon from '@carbon/icons/es/chevron--down/16';
+import CheckMarkIcon from '@carbon/icons/es/checkmark/32';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule } from '@ngx-formly/core';
@@ -99,7 +102,9 @@ import { TableDetailDirective } from './directives/table-detail.directive';
     ThemeModule,
     SelectModule,
     TagModule,
-    LayerModule
+    LayerModule,
+    InputModule,
+    GridModule
   ],
   declarations: [
     TableComponent,
@@ -138,7 +143,8 @@ export class DataTableModule {
       CloseIcon,
       MaximizeIcon,
       ArrowDown,
-      ChevronDwon
+      ChevronDwon,
+      CheckMarkIcon
     ]);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -405,3 +405,64 @@
                               [text]="value">
   </cd-copy-2-clipboard-button>
 </ng-template>
+
+<ng-template #editingTpl
+             let-value="data.value"
+             let-row="data.row"
+             let-column="data.column">
+  @if (isCellEditing(row?.id, column?.prop)) {
+  <form [formGroup]="formGroup"
+        #formDir="ngForm">
+    <div cdsRow>
+      <div cdsCol>
+        <cds-text-label [invalid]="formGroup.controls[row?.id + '-' + column?.prop]?.invalid && formGroup.controls[row?.id + '-' + column?.prop]?.dirty"
+                        [invalidText]="errorTpl">
+          <input type="text"
+                 cdsText
+                 size="sm"
+                 [id]="row?.id + '-' + column?.prop"
+                 [formControlName]="row?.id + '-' + column?.prop"
+                 (input)="valueChange(row?.id, column?.prop, $event.target.value)"
+                 [invalid]="formGroup.controls[row?.id + '-' + column?.prop]?.invalid && formGroup.controls[row?.id + '-' + column?.prop]?.dirty">
+        </cds-text-label>
+        <ng-template #errorTpl>
+          <span *ngIf="formGroup?.showError(row?.id + '-' + column?.prop, formDir, 'required')">
+            <ng-container i18n>This field is required.</ng-container>
+          </span>
+          <span *ngIf="column?.customTemplateConfig?.formGroup?.showError(row?.id + '-' + column?.prop, formDir, 'pattern')">
+            <ng-container i18n>The field format is invalid.</ng-container>
+          </span>
+        </ng-template>
+      </div>
+      <div cdsCol
+           [columnNumbers]="{sm:1}"
+           class="cds-p-0 cds-pt-3">
+        <button cdsButton="ghost"
+                size="sm"
+                id="cell-inline-save-btn"
+                type="button"
+                (click)="saveCellItem(row?.id, column?.prop)">
+          <cd-icon type="check"></cd-icon>
+        </button>
+      </div>
+    </div>
+  </form>
+  } @else {
+  <div cdsRow>
+    <div cdsCol
+         class="cds-pt-3">
+      {{ value }}
+    </div>
+    <div cdsCol
+         [columnNumbers]="{lg: 5}"
+         class="edit-btn">
+      <button cdsButton="ghost"
+              size="sm"
+              id="cell-inline-edit-btn"
+              (click)="editCellItem(row?.id, column, value)">
+        <cd-icon type="edit"></cd-icon>
+      </button>
+    </div>
+  </div>
+  }
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -99,3 +99,11 @@
 .scrollable-expanded-row::-webkit-scrollbar-track {
   background: transparent;
 }
+
+tr .edit-btn {
+  opacity: 0;
+}
+
+tr:hover .edit-btn {
+  opacity: 1;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/cell-template.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/cell-template.enum.ts
@@ -79,5 +79,18 @@ export enum CellTemplate {
   //   ...
   //   cellTransformation: CellTemplate.copy,
   */
-  copy = 'copy'
+  copy = 'copy',
+  /*
+  This template will let you edit the cell value inline. You can pass the validators in the
+  customTemplateConfig.
+  // {
+  //    ...
+  //    cellTransformation: CellTemplate.editing,
+  //    customTemplateConfig: {
+  //       validators: [Validators.required]
+  //    }
+  //    ...
+  // }
+  */
+  editing = 'editing'
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -114,5 +114,7 @@ export const ICON_TYPE = {
   danger: 'danger',
   infoCircle: 'info-circle',
   success: 'success',
-  warning: 'warning'
+  warning: 'warning',
+  edit: 'edit',
+  check: 'check'
 } as const;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-editing.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-editing.ts
@@ -1,0 +1,5 @@
+export interface EditState {
+  [rowId: string]: {
+    [field: string]: string;
+  };
+}

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -35,6 +35,7 @@ $grid-breakpoints: (
 @import './src/styles/ceph-custom/icons';
 @import './src/styles/ceph-custom/navs';
 @import './src/styles/ceph-custom/toast';
+@import './src/styles/ceph-custom/spacings';
 
 /* If javascript is disabled. */
 .noscript {

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_index.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_index.scss
@@ -3,3 +3,4 @@
 @forward 'dropdown';
 @forward 'forms';
 @forward 'icons';
+@forward 'spacings';

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_spacings.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_spacings.scss
@@ -1,0 +1,9 @@
+@use '@carbon/layout';
+
+.cds-p-0 {
+  padding: 0;
+}
+
+.cds-pt-3 {
+  padding-top: layout.$spacing-03;
+}


### PR DESCRIPTION
adding a new celltransformation that will transform the cell to a form
control when you click on the edit button which is inside a cell.

Added a new CellTemplate `editing` which if set to a cell, then it'll
add the edit button. You can also add validators to the control by using
the `customTemplateConfig` like
```
customTemplateConfig: {
          validators: [Validators.required]
        }
```

You can add the validations as part of the formGroup and its subsequent control.


Also using a `EditState` to keep track of the different cells I can edit simultaneously in a single time.


https://github.com/user-attachments/assets/554c9ede-81fb-49e9-aa73-2a9627de8be0

Fixes: https://tracker.ceph.com/issues/72171





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
