### PR TITLE
test/osd: Move initialisation of overwrites and optimisation earlier in ceph_test_rados_io_sequence

### DIFF
--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -59,10 +59,6 @@ RadosIo::RadosIo(librados::Rados& rados, boost::asio::io_context& asio,
   int rc;
   rc = rados.ioctx_create(pool.c_str(), io);
   ceph_assert(rc == 0);
-  allow_ec_overwrites(true);
-  if (ec_optimizations) {
-    allow_ec_optimizations();
-  }
 }
 
 RadosIo::~RadosIo() {}
@@ -84,28 +80,6 @@ void RadosIo::wait_for_io(int count) {
   while (outstanding_io > count) {
     cond.wait(l);
   }
-}
-
-void RadosIo::allow_ec_overwrites(bool allow) {
-  int rc;
-  bufferlist inbl, outbl;
-  std::string cmdstr = "{\"prefix\": \"osd pool set\", \"pool\": \"" + pool +
-                       "\", \
-      \"var\": \"allow_ec_overwrites\", \"val\": \"" +
-                       (allow ? "true" : "false") + "\"}";
-  rc = rados.mon_command(cmdstr, inbl, &outbl, nullptr);
-  ceph_assert(rc == 0);
-}
-
-void RadosIo::allow_ec_optimizations()
-{
-  int rc;
-  bufferlist inbl, outbl;
-  std::string cmdstr =
-    "{\"prefix\": \"osd pool set\", \"pool\": \"" + pool + "\", \
-      \"var\": \"allow_ec_optimizations\", \"val\": \"true\"}";
-  rc = rados.mon_command(cmdstr, inbl, &outbl, nullptr);
-  ceph_assert(rc == 0);
 }
 
 template <int N>
@@ -192,11 +166,18 @@ void RadosIo::applyIoOp(IoOp& op) {
     }
 
     case OpType::Consistency: {
-      start_io();
-      bool is_consistent =
-          cc->single_read_and_check_consistency(oid, block_size, 0, 0);
-      ceph_assert(is_consistent);
-      finish_io();
+        start_io();
+        ceph_assert(cc);
+         bool is_consistent =
+            cc->single_read_and_check_consistency(oid, block_size, 0, 0);
+        if (!is_consistent)
+        {
+          std::stringstream strstream;
+          cc->print_results(strstream);
+          std::cerr << strstream.str() << std::endl;
+        }
+        ceph_assert(is_consistent);
+        finish_io();
       break;
     }
 

--- a/src/common/json/OSDStructures.cc
+++ b/src/common/json/OSDStructures.cc
@@ -69,6 +69,21 @@ void OSDPoolGetReply::decode_json(JSONObj* obj) {
   JSONDecoder::decode_json("allow_ec_optimizations", allow_ec_optimizations, obj);
 }
 
+void OSDPoolSetRequest::dump(Formatter* f) const {
+  encode_json("prefix", "osd pool set", f);
+  encode_json("pool", pool, f);
+  encode_json("var", var, f);
+  encode_json("val", val, f);
+  encode_json("yes_i_really_mean_it", yes_i_really_mean_it, f);
+}
+
+void OSDPoolSetRequest::decode_json(JSONObj* obj) {
+  JSONDecoder::decode_json("pool", pool, obj);
+  JSONDecoder::decode_json("var", var, obj);
+  JSONDecoder::decode_json("val", val, obj);
+  JSONDecoder::decode_json("yes_i_really_mean_it", yes_i_really_mean_it, obj);
+}
+
 void OSDECProfileGetRequest::dump(Formatter* f) const {
   encode_json("prefix", "osd erasure-code-profile get", f);
   encode_json("name", name, f);

--- a/src/common/json/OSDStructures.h
+++ b/src/common/json/OSDStructures.h
@@ -55,6 +55,16 @@ struct OSDPoolGetReply {
   void decode_json(JSONObj* obj);
 };
 
+struct OSDPoolSetRequest {
+  std::string pool;
+  std::string var;
+  std::optional<std::string> val;
+  std::optional<bool> yes_i_really_mean_it = std::nullopt;
+
+  void dump(Formatter* f) const;
+  void decode_json(JSONObj* obj);
+};
+
 struct OSDECProfileGetRequest {
   std::string name;
   std::string format = "json";

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.cc
@@ -846,9 +846,10 @@ const std::string ceph::io_sequence::tester::SelectErasurePool::select() {
     }
 
     if (!dry_run) {
-      configureServices(allow_pool_autoscaling, allow_pool_balancer,
+      configureServices(force_value.value_or(created_pool_name),
+                        allow_pool_autoscaling, allow_pool_balancer,
                         allow_pool_deep_scrubbing, allow_pool_scrubbing,
-                        test_recovery);
+                        disable_pool_ec_optimizations, true, test_recovery);
     }
   }
 
@@ -875,10 +876,13 @@ std::string ceph::io_sequence::tester::SelectErasurePool::create() {
 }
 
 void ceph::io_sequence::tester::SelectErasurePool::configureServices(
+    const std::string& pool_name,
     bool allow_pool_autoscaling,
     bool allow_pool_balancer,
     bool allow_pool_deep_scrubbing,
     bool allow_pool_scrubbing,
+    bool disable_pool_ec_optimizations,
+    bool allow_pool_ec_overwrites,
     bool test_recovery) {
   int rc;
   bufferlist inbl, outbl;
@@ -922,9 +926,33 @@ void ceph::io_sequence::tester::SelectErasurePool::configureServices(
 
   if (!allow_pool_scrubbing) {
     ceph::messaging::osd::OSDSetRequest no_scrub_request{"noscrub",
-                                                          std::nullopt};
+                                                         std::nullopt};
     rc = send_mon_command(no_scrub_request, rados, "OSDSetRequest", inbl,
                           &outbl, formatter.get());
+    ceph_assert(rc == 0);
+  }
+
+  if (!disable_pool_ec_optimizations)
+  {
+    ceph::messaging::osd::OSDPoolSetRequest
+        allow_ec_optimisations_request{pool_name,
+                                       "allow_ec_optimizations",
+                                       "true",
+                                       std::nullopt};
+    rc = send_mon_command(allow_ec_optimisations_request, rados,
+                          "OSDPoolSetRequest", inbl, &outbl, formatter.get());
+    ceph_assert(rc == 0);
+  }
+
+  if (allow_pool_ec_overwrites)
+  {
+    ceph::messaging::osd::OSDPoolSetRequest
+        allow_ec_optimisations_request{pool_name,
+                                       "allow_ec_overwrites",
+                                       "true",
+                                       std::nullopt};
+    rc = send_mon_command(allow_ec_optimisations_request, rados,
+                          "OSDPoolSetRequest", inbl, &outbl, formatter.get());
     ceph_assert(rc == 0);
   }
 

--- a/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
+++ b/src/test/osd/ceph_test_rados_io_sequence/ceph_test_rados_io_sequence.h
@@ -392,10 +392,13 @@ class SelectErasurePool : public ProgramOptionReader<std::string> {
                     bool disable_pool_ec_optimizations);
   const std::string select() override;
   std::string create();
-  void configureServices(bool allow_pool_autoscaling,
+  void configureServices(const std::string& pool_name,
+                         bool allow_pool_autoscaling,
                          bool allow_pool_balancer,
                          bool allow_pool_deep_scrubbing,
                          bool allow_pool_scrubbing,
+                         bool disable_pool_ec_optimizations,
+                         bool allow_pool_ec_overwrites,
                          bool test_recovery);
 
   inline bool get_allow_pool_autoscaling() { return allow_pool_autoscaling; }


### PR DESCRIPTION
All other pool initialisation happens straight after pool creation, however these two items happen later on. This is just due to them being the first two rest calls added. We now have better and more logical places for this code and this commit is moving it into this structure.

This addresses an issue introduced in eb6278e441c7a2d652fc78ee25ff26fa8ec5f26b where the consistency checker needs this to be set earlier as it reads and caches the value at initialisation.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
