### PR TITLE
mgr/cephadm: use same tag for all samba images

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -4167,6 +4167,9 @@ class TestCustomContainer:
                 )
 
 
+_SAMBA_METRICS_IMAGE = 'quay.io/samba.org/samba-metrics:devbuilds-centos-amd64'
+
+
 class TestSMB:
     @patch("cephadm.module.CephadmOrchestrator.get_unique_name")
     @patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -4206,7 +4209,7 @@ class TestSMB:
                 'config': '',
                 'keyring': '[client.smb.config.tango.briskly]\nkey = None\n',
                 'config_auth_entity': 'client.smb.config.tango.briskly',
-                'metrics_image': 'quay.io/samba.org/samba-metrics:latest',
+                'metrics_image': _SAMBA_METRICS_IMAGE,
                 'service_ports': {'smb': 445, 'smbmetrics': 9922, 'ctdb': 4379},
             },
         }
@@ -4281,7 +4284,7 @@ class TestSMB:
                     '[client.smb.fs.fs2.share3]\nkey = None\n'
                 ),
                 'config_auth_entity': 'client.smb.config.tango.briskly',
-                'metrics_image': 'quay.io/samba.org/samba-metrics:latest',
+                'metrics_image': _SAMBA_METRICS_IMAGE,
                 'service_ports': {'smb': 445, 'smbmetrics': 9922, 'ctdb': 4379},
             },
         }

--- a/src/python-common/ceph/cephadm/images.py
+++ b/src/python-common/ceph/cephadm/images.py
@@ -40,7 +40,8 @@ class DefaultImages(Enum):
     JAEGER_AGENT = _create_image('quay.io/jaegertracing/jaeger-agent:1.29', 'jaeger_agent')
     JAEGER_QUERY = _create_image('quay.io/jaegertracing/jaeger-query:1.29', 'jaeger_query')
     SAMBA = _create_image('quay.io/samba.org/samba-server:devbuilds-centos-amd64', 'samba')
-    SAMBA_METRICS = _create_image('quay.io/samba.org/samba-metrics:latest', 'samba_metrics')
+    SAMBA_METRICS = _create_image('quay.io/samba.org/samba-metrics:devbuilds-centos-amd64',
+                                  'samba_metrics')
     NGINX = _create_image('quay.io/ceph/nginx:sclorg-nginx-126', 'nginx')
     OAUTH2_PROXY = _create_image('quay.io/oauth2-proxy/oauth2-proxy:v7.6.0', 'oauth2_proxy')
 


### PR DESCRIPTION
Require all samba images to use the same tag (and share the same base image): avoids version-mismatch confusions & bugs.

