### PR TITLE
osd/scrub: allow auto-repair on operator-initiated scrubs

### DIFF
--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -423,5 +423,6 @@ bool ScrubJob::is_autorepair_allowed(urgency_t urgency)
 {
   // note: 'after-repair' scrubs are not allowed to auto-repair
   return urgency == urgency_t::periodic_regular ||
+	 urgency == urgency_t::operator_requested ||
 	 urgency == urgency_t::repairing || urgency == urgency_t::must_repair;
 }


### PR DESCRIPTION
Previously, operator-initiated scrubs would not auto-repair, regardless of the value of the 'osd_scrub_auto_repair' config option.  This was less confusing to the operator than it could have been, as most operator commands would in fact cause a regular periodic scrub to be initiated. However, that quirk is now fixed: operator commands now trigger 'op-initiated' scrubs. Thus the need for this patch.

The original bug was fixed in https://github.com/ceph/ceph/pull/54615, but was unfortunately re-introduced later on.

Backport tracker: 
'main' tracker: https://tracker.ceph.com/issues/72178
A backport of https://github.com/ceph/ceph/pull/64567
(cherry picked from commit 97de817ad1c253ee1c7c9c9302981ad2435301b9)
