### PR TITLE
squid: qa: increase the randomness to trigger the directory import/export

### DIFF
--- a/qa/suites/fs/workload/ranks/multi/balancer/random.yaml
+++ b/qa/suites/fs/workload/ranks/multi/balancer/random.yaml
@@ -2,9 +2,9 @@ overrides:
   ceph:
     conf:
       mds:
-        mds_export_ephemeral_random_max: 0.10
+        mds_export_ephemeral_random_max: 0.20
 tasks:
 - exec:
     mon.a:
       - ceph fs set cephfs balance_automate false
-      - ceph fs subvolumegroup pin cephfs qa random 0.10
+      - ceph fs subvolumegroup pin cephfs qa random 0.20


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72185

---

backport of https://github.com/ceph/ceph/pull/64549
parent tracker: https://tracker.ceph.com/issues/65770

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh