### PR TITLE
doc/radosgw: get caller identity docs

### DIFF
--- a/doc/radosgw/STS.rst
+++ b/doc/radosgw/STS.rst
@@ -60,6 +60,17 @@ The following STS REST APIs have been implemented in Ceph Object Gateway:
     **WebIdentityToken** (String/ Required): The OpenID Connect/ OAuth2.0 token, which the
     application gets in return after authenticating its user with an IDP.
 
+#. GetCallerIdentity: Returns details about the IAM user or role whose credentials are used to call the operation.
+
+   Response:
+    **Account** (The account ID that owns or contains the calling entity.
+
+    **Arn** The ARN associated with the calling entity.
+
+    **UserId** The unique identifier of the calling entity(user or assumed role).
+
+.. note:: No permissions are required to perform GetCallerIdentity.
+
 Before invoking AssumeRoleWithWebIdentity, an OpenID Connect Provider entity (which the web application
 authenticates with), needs to be created in RGW.
 
@@ -227,6 +238,85 @@ Examples
     bucket_name = 'my-bucket'
     s3bucket = s3client.create_bucket(Bucket=bucket_name)
     resp = s3client.list_buckets()
+
+
+#. The following is an example of GetCallerIdentity API call assuming a role, which shows steps to create a role, 
+   assuming a role to get temporary credentials and getting caller identity using those credentials.
+
+   .. code-block:: python
+
+    import boto3
+    import json
+
+    USER_ID = 'tester'
+    ACCESS_KEY = 'TESTER'
+    SECRET_KEY = 'test123'
+    ENDPOINT_URL = 'http://localhost:8000'
+    REGION = 'us-east-1'
+
+    ROLE_NAME = 'S3Access'
+    ROLE_SESSION_NAME = 'Bob'
+    DURATION_SECONDS = 3600
+
+    iam_client = boto3.client('iam',
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        endpoint_url=ENDPOINT_URL,
+        region_name=REGION
+    )
+
+    trust_policy = json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": { "AWS": [f"arn:aws:iam:::user/{USER_ID}"] },
+            "Action": ["sts:AssumeRole"]
+        }]
+    })
+
+    role_response = iam_client.create_role(
+        RoleName=ROLE_NAME,
+        Path='/xxx/policy/',
+        AssumeRolePolicyDocument=trust_policy
+    )
+
+    sts_client = boto3.client('sts',
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        endpoint_url=ENDPOINT_URL,
+        region_name=REGION
+    )
+
+    response = sts_client.assume_role(
+        RoleArn=role_response['Role']['Arn'],
+        RoleSessionName=ROLE_SESSION_NAME,
+        DurationSeconds=DURATION_SECONDS
+    )
+    creds = response['Credentials']
+
+    session_sts = boto3.client('sts',
+        aws_access_key_id=creds['AccessKeyId'],
+        aws_secret_access_key=creds['SecretAccessKey'],
+        aws_session_token=creds['SessionToken'],
+        endpoint_url=ENDPOINT_URL,
+        region_name=REGION
+    )
+    identity = session_sts.get_caller_identity()
+
+#. The following is an example of GetCallerIdentity API call with user credentials
+
+  .. code-block:: python
+
+    import boto3
+
+    sts = boto3.client('sts',
+        aws_access_key_id=<access_key>,
+        aws_secret_access_key=<secret_key>,
+        endpoint_url='http://localhost:8000',
+        region_name='us-east-1'
+    )
+
+    identity = sts.get_caller_identity()
 
 How to obtain thumbprint of an OpenID Connect Provider IDP
 ==========================================================


### PR DESCRIPTION
Tracker: https://tracker.ceph.com/issues/72157





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
