### PR TITLE
squid: qa/rbd/iscsi: ignore MON_DOWN warning in logs

### DIFF
--- a/qa/suites/rbd/iscsi/cluster/fixed-3.yaml
+++ b/qa/suites/rbd/iscsi/cluster/fixed-3.yaml
@@ -17,3 +17,7 @@ roles:
   - osd.7
   - client.2
   - ceph.iscsi.iscsi.b
+overrides:
+  ceph:
+    log-ignorelist:
+      - MON_DOWN


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/63407 to squid.