### PR TITLE
tentacle: deb/cephadm: add explicit --home for cephadm user

### DIFF
--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -28,6 +28,7 @@ case "$1" in
          adduser --quiet \
                  --system \
                  --disabled-password \
+                 --home /var/lib/cephadm \
                  --shell /bin/bash cephadm 2>/dev/null || true
          usermod --comment "cephadm user for mgr/cephadm" cephadm
          echo "..done"

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -28,7 +28,6 @@ case "$1" in
          adduser --quiet \
                  --system \
                  --disabled-password \
-                 --home /home/cephadm \
                  --shell /bin/bash cephadm 2>/dev/null || true
          usermod --comment "cephadm user for mgr/cephadm" cephadm
          echo "..done"
@@ -42,15 +41,15 @@ case "$1" in
        fi
 
        # set up (initially empty) .ssh/authorized_keys file
-       if ! test -d /home/cephadm/.ssh; then
-           mkdir /home/cephadm/.ssh
-           chown --reference /home/cephadm /home/cephadm/.ssh
-           chmod 0700 /home/cephadm/.ssh
+       if ! test -d ~cephadm/.ssh; then
+           mkdir ~cephadm/.ssh
+           chown --reference ~cephadm ~cephadm/.ssh
+           chmod 0700 ~cephadm/.ssh
        fi
-       if ! test -e /home/cephadm/.ssh/authorized_keys; then
-           touch /home/cephadm/.ssh/authorized_keys
-           chown --reference /home/cephadm /home/cephadm/.ssh/authorized_keys
-           chmod 0600 /home/cephadm/.ssh/authorized_keys
+       if ! test -e ~cephadm/.ssh/authorized_keys; then
+           touch ~cephadm/.ssh/authorized_keys
+           chown --reference ~cephadm ~cephadm/.ssh/authorized_keys
+           chmod 0600 ~cephadm/.ssh/authorized_keys
        fi
 
     ;;

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -260,7 +260,7 @@ available options.
 
 * The ``--ssh-user *<user>*`` option makes it possible to designate which SSH
   user cephadm will use to connect to hosts. The associated SSH key will be
-  added to ``/home/*<user>*/.ssh/authorized_keys``. The user that you
+  added to ``~*<user>*/.ssh/authorized_keys``. The user that you
   designate with this option must have passwordless sudo access.
 
 * If you are using a container image from a registry that requires


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72191

---

backport of https://github.com/ceph/ceph/pull/64459
parent tracker: https://tracker.ceph.com/issues/72083

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh