### PR TITLE
reef: doc/cephfs: edit disaster-recovery.rst

### DIFF
--- a/doc/cephfs/disaster-recovery.rst
+++ b/doc/cephfs/disaster-recovery.rst
@@ -22,42 +22,44 @@ separate page: :ref:`disaster-recovery-experts`.
 Data pool damage (files affected by lost data PGs)
 --------------------------------------------------
 
-If a PG is lost in a *data* pool, then the file system will continue
-to operate normally, but some parts of some files will simply
-be missing (reads will return zeros).
+If a PG is lost in a *data* pool, then the file system continues to operate
+normally, but some parts of some files will simply be missing (reads will
+return zeros).
 
-Losing a data PG may affect many files.  Files are split into many objects,
-so identifying which files are affected by loss of particular PGs requires
-a full scan over all object IDs that may exist within the size of a file. 
-This type of scan may be useful for identifying which files require
-restoring from a backup.
+Losing a data PG may affect many files. Files are split into many objects, so
+identifying which files have been affected by the loss of particular PGs
+requires a full scan over all object IDs that may exist within the size of a
+file. This type of scan may be useful for identifying which files must be
+restored from a backup.
 
 .. danger::
 
     This command does not repair any metadata, so when restoring files in
-    this case you must *remove* the damaged file, and replace it in order
-    to have a fresh inode.  Do not overwrite damaged files in place.
+    this case you must *remove* the damaged file and replace it in order
+    to have a fresh inode. Do not overwrite damaged files in place.
 
 If you know that objects have been lost from PGs, use the ``pg_files``
-subcommand to scan for files that may have been damaged as a result:
+subcommand to scan for the files that may have been damaged as a result:
 
 ::
 
     cephfs-data-scan pg_files <path> <pg id> [<pg id>...]
 
-For example, if you have lost data from PGs 1.4 and 4.5, and you would like
-to know which files under /home/bob might have been damaged:
+For example, if you have lost data from PGs 1.4 and 4.5 and you want to know
+which files under ``/home/bob`` have been damaged:
 
 ::
 
     cephfs-data-scan pg_files /home/bob 1.4 4.5
 
-The output will be a list of paths to potentially damaged files, one
+The output is a list of paths to potentially damaged files. One file is listed
 per line.
 
-Note that this command acts as a normal CephFS client to find all the
-files in the file system and read their layouts, so the MDS must be
-up and running.
+.. note:: 
+
+   This command acts as a normal CephFS client to find all the files in the
+   file system and read their layouts. This means that the MDS must be up and
+   running in order for this command to be usable.
 
 Using first-damage.py
 ---------------------


### PR DESCRIPTION
Edit the section "Data Pool Damage" in doc/cephfs/disaster-recovery.rst. This commit is part of the project of improving the data-recovery parts of the CephFS documentation, as requested in the Ceph Power Users Feedback Summary in mid-2025.


(cherry picked from commit 891e9cf2492ad250936171e9b510e8df4996faf9)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
