### PR TITLE
squid: librbd: images aren't closed in group_snap_*_by_record() on error

### DIFF
--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -941,7 +941,7 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
   }
 
   for (auto image: images) {
-    librbd::IoCtx image_io_ctx;
+    librados::IoCtx image_io_ctx;
     r = util::create_ioctx(group_ioctx, "image", image.spec.pool_id, {},
                            &image_io_ctx);
     if (r < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72231

---

backport of https://github.com/ceph/ceph/pull/64505
parent tracker: https://tracker.ceph.com/issues/71961