### PR TITLE
tentacle: librbd: images aren't closed in group_snap_*_by_record() on error

### DIFF
--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -466,7 +466,7 @@ int GroupSnapshot_to_group_snap_info2(
   image_snaps.reserve(cls_group_snap.snaps.size());
 
   for (const auto& snap : cls_group_snap.snaps) {
-    librbd::IoCtx image_ioctx;
+    librados::IoCtx image_ioctx;
     int r = util::create_ioctx(group_ioctx, "image", snap.pool, {},
                                &image_ioctx);
     if (r < 0) {
@@ -978,7 +978,7 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
   }
 
   for (auto image: images) {
-    librbd::IoCtx image_io_ctx;
+    librados::IoCtx image_io_ctx;
     r = util::create_ioctx(group_ioctx, "image", image.spec.pool_id, {},
                            &image_io_ctx);
     if (r < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72229

---

backport of https://github.com/ceph/ceph/pull/64505
parent tracker: https://tracker.ceph.com/issues/71961