### PR TITLE
mgr/dashboard: cypress tests do not fail on failures 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/mirroring.e2e-spec.ts
@@ -60,7 +60,7 @@ describe('Mirroring page', () => {
           cy.get('#password').type('admin');
           cy.get('[type=submit]').click();
 
-          cy.get('input[name=name]').clear().type(name);
+          cy.get('[data-testid="pool-name"]').clear().type(name);
           cy.get(`select[name=poolType]`).select('replicated');
           cy.get(`select[name=poolType] option:checked`).contains('replicated');
           cy.get('.float-start.me-2.select-menu-edit').click();

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/table-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/table-helper.feature.po.ts
@@ -88,7 +88,7 @@ And('I should see row {string} of the expanded row to have a usage bar', (row: s
   cy.get('[data-testid="datatable-row-detail"]').within(() => {
     cy.get('.cds--search-input').first().clear().type(row);
     cy.contains(`[cdstablerow] [cdstabledata]`, row).should('exist');
-    cy.get('[cdstablerow] [cdstabledata] cd-usage-bar .progress').should('exist');
+    cy.get('[cdstablerow] [cdstabledata] cd-usage-bar').should('exist');
   });
 });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/09-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/09-services.e2e-spec.ts
@@ -98,7 +98,6 @@ describe('Services page', () => {
     cy.get('cd-service-details').within(() => {
       services.checkServiceStatus('snmp-gateway');
     });
-    services.clickServiceTab('snmp-gateway', 'Daemons');
 
     services.deleteService('snmp-gateway');
   });
@@ -112,7 +111,6 @@ describe('Services page', () => {
     cy.get('cd-service-details').within(() => {
       services.checkServiceStatus('snmp-gateway');
     });
-    services.clickServiceTab('snmp-gateway', 'Daemons');
 
     services.deleteService('snmp-gateway');
   });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
@@ -26,7 +26,7 @@ export class PoolPageHelper extends PageHelper {
     cy.get('[data-testid="pgNum"]').clear().type(`${placement_groups}`);
     this.setApplications(apps);
     if (mirroring) {
-      cy.get('#rbdMirroring').check({ force: true });
+      cy.get('[data-testid="rbd-mirroring-check"]').check({ force: true });
     }
     cy.get('cd-submit-button').click();
   }
@@ -36,7 +36,7 @@ export class PoolPageHelper extends PageHelper {
     this.navigateEdit(name);
 
     if (mirroring) {
-      cy.get('#rbdMirroring').should('be.checked');
+      cy.get('[data-testid="rbd-mirroring-check"]').should('be.checked');
     }
 
     cy.get('[data-testid="pgNum"]').clear().type(`${new_pg}`);

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
@@ -15,7 +15,7 @@ export class PoolPageHelper extends PageHelper {
 
   @PageHelper.restrictTo(pages.create.url)
   create(name: string, placement_groups: number, apps: string[], mirroring = false) {
-    cy.get('input[name=name]').clear().type(name);
+    cy.get('[data-testid="pool-name"]').clear().type(name);
 
     this.isPowerOf2(placement_groups);
 
@@ -23,7 +23,7 @@ export class PoolPageHelper extends PageHelper {
 
     this.expectSelectOption('pgAutoscaleMode', 'on');
     this.selectOption('pgAutoscaleMode', 'off'); // To show pgNum field
-    cy.get('input[name=pgNum]').clear().type(`${placement_groups}`);
+    cy.get('[data-testid="pgNum"]').clear().type(`${placement_groups}`);
     this.setApplications(apps);
     if (mirroring) {
       cy.get('#rbdMirroring').check({ force: true });
@@ -39,7 +39,7 @@ export class PoolPageHelper extends PageHelper {
       cy.get('#rbdMirroring').should('be.checked');
     }
 
-    cy.get('input[name=pgNum]').clear().type(`${new_pg}`);
+    cy.get('[data-testid="pgNum"]').clear().type(`${new_pg}`);
     cy.get('cd-submit-button').click();
     const str = `${new_pg} active+clean`;
     this.getTableRow(name);

--- a/src/pybind/mgr/dashboard/frontend/cypress/support/e2e.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/support/e2e.ts
@@ -22,5 +22,5 @@ Cypress.on('fail', (err: Error) => {
   if (err.message.includes('xhr') && err.message.includes('canceled')) {
     return false; // Ignore canceled XHR requests
   }
-  return true;
+  throw err;
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -15,7 +15,8 @@
                  for="name"
                  i18n>Name</label>
           <div class="cd-col-form-input">
-            <input id="name"
+            <input data-testid="pool-name"
+                   id="name"
                    type="text"
                    class="form-control"
                    placeholder="Name..."
@@ -87,6 +88,7 @@
             <div class="cd-col-form-input">
               <input class="form-control"
                      id="pgNum"
+                     data-testid="pgNum"
                      formControlName="pgNum"
                      min="1"
                      type="number"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -203,6 +203,7 @@
             <div class="custom-control custom-checkbox">
               <input class="custom-control-input"
                      id="rbdMirroring"
+                     data-testid="rbd-mirroring-check"
                      type="checkbox"
                      formControlName="rbdMirroring">
               <label class="custom-control-label"


### PR DESCRIPTION
- the on 'fail' requires errors to be thrown explicitly
- this is causing all tests to pass as of now irrespective of failures

Ideally we should avoid fail as its discouraged to throw errors but  this require deeper debugging (was introduced for multi-site)
For now, adding this interim fix.




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
