### PR TITLE
tentacle: krbd: "rbd device map" command should use msgr2 by default

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -192,7 +192,8 @@ static int have_minor_attr(void)
 static int build_map_buf(CephContext *cct, const krbd_spec& spec,
                          const string& options, string *pbuf)
 {
-  bool msgr2 = false;
+  bool msgr2 = true;
+  bool ms_mode_specified = false;
   std::ostringstream oss;
   int r;
 
@@ -202,6 +203,7 @@ static int build_map_buf(CephContext *cct, const krbd_spec& spec,
     if (boost::starts_with(t, "ms_mode=")) {
       /* msgr2 unless ms_mode=legacy */
       msgr2 = t.compare(8, t.npos, "legacy");
+      ms_mode_specified = true;
     }
   }
 
@@ -272,6 +274,12 @@ static int build_map_buf(CephContext *cct, const krbd_spec& spec,
 
   if (!options.empty())
     oss << "," << options;
+
+  /* setting default messenger: msgr2 in prefer-crc mode */
+  if (!ms_mode_specified) {
+    oss << ",ms_mode=prefer-crc";
+  }
+
   if (!spec.nspace_name.empty())
     oss << ",_pool_ns=" << spec.nspace_name;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72266

---

backport of https://github.com/ceph/ceph/pull/64635
parent tracker: https://tracker.ceph.com/issues/72134

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh