### PR TITLE
squid: null

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -1413,7 +1413,7 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
     }
 
     if (pending_map.force_disabled_modules.contains(mod)) {
-      ss << "Module \"" << mod << "\"is already disabled";
+      ss << "Module \"" << mod << "\" is already disabled";
       r = 0;
       goto out;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72219

---

backport of https://github.com/ceph/ceph/pull/64186
parent tracker: https://tracker.ceph.com/issues/71262

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh