### PR TITLE
doc/cephfs: edit ceph-dokan.rst (1 of x)

### DIFF
--- a/doc/cephfs/ceph-dokan.rst
+++ b/doc/cephfs/ceph-dokan.rst
@@ -3,15 +3,15 @@
 Mount CephFS on Windows
 =======================
 
-``ceph-dokan`` can be used for mounting CephFS filesystems on Windows.
-It leverages Dokany, a Windows driver that allows implementing filesystems in
-userspace, pretty much like FUSE.
+``ceph-dokan`` is used to mount CephFS filesystems on Windows.  It leverages
+Dokany, a Windows driver that allows implementing filesystems in userspace in a
+manner similar to FUSE.
 
-Please see the `installation guide`_ to get started.
+See the `installation guide`_ to get started.
 
 .. note::
 
-   Please see the `OS recommendations`_ regarding client package support.
+   See the `OS recommendations`_ for information about client package support.
 
 Usage
 =====
@@ -19,18 +19,18 @@ Usage
 Mounting filesystems
 --------------------
 
-In order to mount a ceph filesystem, the following command can be used::
+Run the following command to mount a Ceph filesystem::
 
-    ceph-dokan.exe -c c:\ceph.conf -l x
+   ceph-dokan.exe -c c:\ceph.conf -l x
 
-This will mount the default ceph filesystem using the drive letter ``x``.
-If ``ceph.conf`` is placed at the default location, which is
-``%ProgramData%\ceph\ceph.conf``, then this argument becomes optional.
+This command mounts the default Ceph filesystem using the drive letter ``x``.
+If ``ceph.conf`` is present in the default location
+(``%ProgramData%\ceph\ceph.conf``, then this argument is optional.
 
-The ``-l`` argument also allows using an empty folder as a mount point
+The ``-l`` argument allows the use of an empty folder as the mount point
 instead of a drive letter.
 
-The uid and gid used for mounting the filesystem default to 0 and may be
+The uid and gid used for mounting the filesystem default to ``0`` and can be
 changed using the following ``ceph.conf`` options::
 
     [client]
@@ -38,13 +38,13 @@ changed using the following ``ceph.conf`` options::
     client_mount_uid = 1000
     client_mount_gid = 1000
 
-If you have more than one FS on your Ceph cluster, use the option
-``--client_fs`` to mount the non-default FS::
+If you have more than one file system on your Ceph cluster, use the option
+``--client_fs`` to mount the non-default file system::
 
     mkdir -Force C:\mnt\mycephfs2
     ceph-dokan.exe --mountpoint C:\mnt\mycephfs2 --client_fs mycephfs2
 
-CephFS subdirectories can be mounted using the ``--root-path`` parameter::
+Mount CephFS subdirectories by using the ``--root-path`` parameter::
 
     ceph-dokan -l y --root-path /a
 
@@ -59,7 +59,7 @@ If the ``-o --removable`` flags are set, the mounts will show up in the
               Z Ceph       Ceph
               W Ceph       Ceph - new_fs
 
-Please use ``ceph-dokan --help`` for a full list of arguments.
+Run ``ceph-dokan --help`` for a full list of arguments.
 
 Credentials
 -----------


### PR DESCRIPTION
Edit the first 62 lines of doc/cephfs/ceph-dokan. This is part of a larger project whose goal is the improvement of the CephFS documentation.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
