### PR TITLE
tentacle: mgr/cephadm: include cluster FSID in root CA Common Name (CN)

### DIFF
--- a/src/pybind/mgr/cephadm/ssl_cert_utils.py
+++ b/src/pybind/mgr/cephadm/ssl_cert_utils.py
@@ -137,7 +137,7 @@ class SSLCerts:
         root_public_key = self.root_key.public_key()
         root_builder = x509.CertificateBuilder()
         root_ca_name = x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, u'cephadm-root'),
+            x509.NameAttribute(NameOID.COMMON_NAME, f'cephadm-root-{self.cluster_fsid}'),
         ])
         root_builder = root_builder.subject_name(root_ca_name)
         root_builder = root_builder.issuer_name(root_ca_name)
@@ -198,7 +198,7 @@ class SSLCerts:
 
         builder = x509.CertificateBuilder()
         root_ca_name = x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, u'cephadm-root'),
+            x509.NameAttribute(NameOID.COMMON_NAME, f'cephadm-root-{self.cluster_fsid}'),
         ])
         builder = builder.subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, addrs[0]), ]))
         builder = builder.issuer_name(root_ca_name)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72136

---

backport of https://github.com/ceph/ceph/pull/63162
parent tracker: https://tracker.ceph.com/issues/71234

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh