### PR TITLE
tentacle: cephadm: Bind mount /var/lib/samba with 0755

### DIFF
--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -753,7 +753,7 @@ class SMB(ContainerDaemonForm):
         ddir = pathlib.Path(data_dir)
         etc_samba_ctr = ddir / 'etc-samba-container'
         file_utils.makedirs(etc_samba_ctr, uid, gid, 0o770)
-        file_utils.makedirs(ddir / 'lib-samba', uid, gid, 0o770)
+        file_utils.makedirs(ddir / 'lib-samba', uid, gid, 0o755)
         file_utils.makedirs(ddir / 'run', uid, gid, 0o770)
         if self._files:
             file_utils.populate_files(data_dir, self._files, uid, gid)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72262

---

backport of https://github.com/ceph/ceph/pull/64454
parent tracker: https://tracker.ceph.com/issues/72089

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh