### PR TITLE
tentacle: smb: support custom ip address binds

### DIFF
--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -112,6 +112,21 @@ custom_ports
     ports used by smb for client access and the metrics exporter, but
     not change the port used by the CTDB clustering daemon.
 
+bind_addrs
+    A list of objects indicating what IP address or IP network the
+    SMB and related services may bind to. The fields described for these
+    objects are mutually exclusive, but at least one field is required.
+    Fields:
+
+    address
+        Optional. A single IP address represented as a string. For example,
+        ``192.168.7.50``.
+    network
+        Optional. A single IP network represented as a string. A network
+        can be used to specify a range of many IP addresses. The network
+        string always includes a "/" character before a prefix length.
+        For example, ``192.168.7.0/24``.
+
 include_ceph_users
     A list of cephx user (aka entity) names that the Samba Containers may use.
     The cephx keys for each user in the list will automatically be added to

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -456,6 +456,22 @@ custom_ports
     ports used by smb for client access and the metrics exporter, but
     not change the port used by the CTDB clustering daemon.
     Note - not all SMB clients are able to use alternate port numbers.
+bind_addrs
+    Optional. A list of objects indicating what IP address or IP network the
+    SMB and related services may bind to. The fields described for these
+    objects are mutually exclusive, but at least one field is required.
+    (The behavior of this option changes when used with clustering and
+    ``public_addrs``. See note below.)
+    Fields:
+
+    address
+        Optional. A single IP address represented as a string. For example,
+        ``192.168.7.50``.
+    network
+        Optional. A single IP network represented as a string. A network
+        can be used to specify a range of many IP addresses. The network
+        string always includes a "/" character before a prefix length.
+        For example, ``192.168.7.0/24``.
 placement
     Optional. A Ceph Orchestration :ref:`placement specifier
     <orchestrator-cli-placement-spec>`.  Defaults to one host if not provided
@@ -472,6 +488,8 @@ public_addrs
     Assign "virtual" IP addresses that will be managed by the clustering
     subsystem and may automatically move between nodes running Samba
     containers.
+    (The behavior of this option changes when used with ``bind_addrs``. See
+    note below.)
     Fields:
 
     address
@@ -511,6 +529,16 @@ custom_smb_global_options
    ``clustering`` make sure you understand how clustering interacts with
    placement. In particular, be aware that running multiple instances of the
    same ``smb`` service without clustering enabled can cause unexpected behavior.
+
+.. warning::
+   The behavior of the system when combining ``bind_addrs`` and
+   ``public_addrs`` on a cluster could lead to unexpected results. The ``smbd``
+   process can only dynamically add/remove public addresses when assigned to
+   monitor a network device (e.g. ``eth0``) versus a specific address. If the
+   network device is assigned multiple addresses and those addreses overlap
+   with a different smb cluster it is possible the services may fail to start.
+   Currently, one must manually ensure that the devices used by a IP or network
+   is exclusvely used for that network to ensure SMB services start properly.
 
 
 .. _join-source-fields:

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -2,7 +2,17 @@ import ipaddress
 import hashlib
 import logging
 import random
-from typing import List, Optional, Callable, TypeVar, Tuple, NamedTuple, Dict
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Protocol,
+    Tuple,
+    TypeVar,
+)
 
 import orchestrator
 from ceph.deployment.service_spec import ServiceSpec
@@ -143,6 +153,15 @@ class DaemonPlacement(NamedTuple):
         return rank_map[dd.rank][dd.rank_generation] == dd.daemon_id
 
 
+class HostSelector(Protocol):
+    def filter_host_candidates(
+        self,
+        spec: ServiceSpec,
+        candidates: Iterable[DaemonPlacement],
+    ) -> List[DaemonPlacement]:
+        "Filter candidates for host/ip matching."
+
+
 class HostAssignment(object):
 
     def __init__(self,
@@ -159,7 +178,8 @@ class HostAssignment(object):
                  per_host_daemon_type: Optional[str] = None,
                  rank_map: Optional[Dict[int, Dict[int, Optional[str]]]] = None,
                  blocking_daemon_hosts: Optional[List[orchestrator.HostSpec]] = None,
-                 upgrade_in_progress: bool = False
+                 upgrade_in_progress: bool = False,
+                 host_selector: Optional[HostSelector] = None,
                  ):
         assert spec
         self.spec = spec  # type: ServiceSpec
@@ -178,6 +198,7 @@ class HostAssignment(object):
         self.ports_start = spec.get_port_start()
         self.rank_map = rank_map
         self.upgrade_in_progress = upgrade_in_progress
+        self.host_selector = host_selector
 
     def hosts_by_label(self, label: str) -> List[orchestrator.HostSpec]:
         return [h for h in self.hosts if label in h.labels]
@@ -467,7 +488,9 @@ class HostAssignment(object):
                 "placement spec is empty: no hosts, no label, no pattern, no count")
 
         # allocate an IP?
-        if self.spec.networks:
+        if self.host_selector:
+            ls = self.host_selector.filter_host_candidates(self.spec, ls)
+        elif self.spec.networks:
             orig = ls.copy()
             ls = []
             for p in orig:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -26,7 +26,7 @@ import orchestrator
 from orchestrator import OrchestratorError, set_exception_subject, OrchestratorEvent, \
     DaemonDescriptionStatus, daemon_type_to_service
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
-from cephadm.schedule import HostAssignment
+from cephadm.schedule import HostAssignment, HostSelector
 from cephadm.autotune import MemoryAutotuner
 from cephadm.utils import forall_hosts, cephadmNoImage, is_repo_digest, \
     CephadmNoImage, CEPH_TYPES, ContainerInspectInfo, SpecialHostLabels
@@ -811,6 +811,7 @@ class CephadmServe:
         rank_map = None
         if svc.ranked(spec):
             rank_map = self.mgr.spec_store[spec.service_name()].rank_map or {}
+        host_selector = _host_selector(svc)
         ha = HostAssignment(
             spec=spec,
             hosts=self.mgr.cache.get_non_draining_hosts() if spec.service_name(
@@ -826,7 +827,8 @@ class CephadmServe:
             primary_daemon_type=svc.primary_daemon_type(spec),
             per_host_daemon_type=svc.per_host_daemon_type(spec),
             rank_map=rank_map,
-            upgrade_in_progress=(self.mgr.upgrade.upgrade_state is not None)
+            upgrade_in_progress=(self.mgr.upgrade.upgrade_state is not None),
+            host_selector=host_selector,
         )
 
         try:
@@ -1831,3 +1833,9 @@ class CephadmServe:
         self.log.info(f"Deploying cephadm binary to {host}")
         await self.mgr.ssh._write_remote_file(host, self.mgr.cephadm_binary_path,
                                               self.mgr._cephadm, addr=addr)
+
+
+def _host_selector(svc: Any) -> Optional[HostSelector]:
+    if hasattr(svc, 'filter_host_candidates'):
+        return cast(HostSelector, svc)
+    return None

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -1,6 +1,7 @@
 import errno
+import ipaddress
 import logging
-from typing import Any, Dict, List, Tuple, cast, Optional
+from typing import Any, Dict, List, Tuple, cast, Optional, Iterable, Union
 
 from mgr_module import HandleCommandResult
 
@@ -14,6 +15,7 @@ from .cephadmservice import (
     CephadmDaemonDeploySpec,
     simplified_keyring,
 )
+from ..schedule import DaemonPlacement
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +61,51 @@ class SMBService(CephService):
                         if daemon_id is not None:
                             self.fence(smb_spec.cluster_id)
                         del rank_map[rank][gen]
-                        self.mgr.spec_store.save_rank_map(spec.service_name(), rank_map)
+                        self.mgr.spec_store.save_rank_map(
+                            spec.service_name(), rank_map
+                        )
+
+    def filter_host_candidates(
+        self,
+        spec: ServiceSpec,
+        candidates: Iterable[DaemonPlacement],
+    ) -> List[DaemonPlacement]:
+        logger.debug(
+            'SMBService.filter_host_candidates with candidates: %r',
+            candidates,
+        )
+        smb_spec = cast(SMBSpec, spec)
+        if not smb_spec.bind_addrs:
+            return list(candidates)
+        addr_src = AddressPool.from_spec(smb_spec)
+        filtered = [
+            dc
+            for dc in (self._candidate_in(c, addr_src) for c in candidates)
+            if dc is not None
+        ]
+        if len(filtered) != len(list(candidates)):
+            logger.debug('Filtered host candidates to: %r', filtered)
+        return filtered
+
+    def _candidate_in(
+        self, candidate: DaemonPlacement, addr_src: 'AddressPool'
+    ) -> Optional[DaemonPlacement]:
+        hostnw = self.mgr.cache.networks.get(candidate.hostname, {})
+        if not hostnw:
+            return None
+        ips = set()
+        for net_vals in hostnw.values():
+            for if_vals in net_vals.values():
+                ips.update(if_vals)
+        logger.debug(
+            'Checking if IPs %r from %s are in bindable addrs',
+            ips,
+            candidate.hostname,
+        )
+        for ip in ips:
+            if ip in addr_src:
+                return candidate._replace(ip=ip)
+        return None
 
     def prepare_create(
         self, daemon_spec: CephadmDaemonDeploySpec
@@ -291,3 +337,26 @@ class SMBService(CephService):
         logger.debug("smb daemon map: %r", smb_dmap)
         with clustermeta.rados_object(self.mgr, uri) as cmeta:
             cmeta.sync_ranks(rank_map, smb_dmap)
+
+
+Network = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+
+
+class AddressPool:
+    def __init__(self, nets: Iterable[Network]) -> None:
+        self._nets = set(nets)
+
+    def __contains__(self, other: Union[str, ipaddress.IPv4Address]) -> bool:
+        if isinstance(other, str):
+            addr = ipaddress.ip_address(other)
+        else:
+            addr = other
+        return any((addr in net) for net in self._nets)
+
+    @classmethod
+    def from_spec(cls, spec: SMBSpec) -> 'AddressPool':
+        nets = set()
+        for baddr in spec.bind_addrs or []:
+            for net in baddr.as_networks():
+                nets.add(net)
+        return cls(nets)

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -157,6 +157,8 @@ class SMBService(CephService):
                 '', force_ceph_image=True
             )
         config_blobs['service_ports'] = smb_spec.service_ports()
+        if smb_spec.bind_addrs:
+            config_blobs['bind_networks'] = smb_spec.bind_networks()
 
         logger.debug('smb generate_config: %r', config_blobs)
         self._configure_cluster_meta(smb_spec, daemon_spec)

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -887,6 +887,7 @@ def _generate_smb_service_spec(
         include_ceph_users=user_entities,
         cluster_public_addrs=cluster.service_spec_public_addrs(),
         custom_ports=cluster.custom_ports,
+        bind_addrs=cluster.service_spec_bind_addrs(),
     )
 
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -5,7 +5,13 @@ import enum
 from collections import OrderedDict
 from contextlib import contextmanager
 from functools import wraps
-from ipaddress import ip_network, ip_address, ip_interface
+from ipaddress import (
+    IPv4Network,
+    IPv6Network,
+    ip_address,
+    ip_interface,
+    ip_network,
+)
 from typing import (
     Any,
     Callable,
@@ -3156,6 +3162,117 @@ class SMBClusterPublicIPSpec:
         return out
 
 
+class SMBClusterBindIPSpec:
+    """Control what IPs the SMB services will listen on, not including
+    dynamic IPs that are managed by CTDB.
+    """
+    def __init__(
+        self,
+        # single address
+        address: Optional[str] = None,
+        # >1 address specified as a network
+        network: Optional[str] = None,
+    ) -> None:
+        self.address = address
+        self.network = network
+        self._networks: List[Union[IPv4Network, IPv6Network]] = []
+        self.validate()
+
+    def validate(self) -> None:
+        if self.address and self.network:
+            raise SpecValidationError('only one of address or network may be given')
+        if not (self.address or self.network):
+            raise SpecValidationError('one of address or network is required')
+        if self.address:
+            # verify that address is an address
+            try:
+                ip_address(self.address)
+            except ValueError as err:
+                raise SpecValidationError(
+                    f'Cannot parse address {self.address}'
+                ) from err
+        # but we internallly store a list of networks
+        # this is slight bit of YAGNI violation, but I actually plan on
+        # adding IP ranges soon.
+        addr = self.network if self.network else self.address
+        try:
+            assert addr
+            self._networks = [ip_network(addr)]
+        except ValueError as err:
+            raise SpecValidationError(
+                f'Cannot parse network address {addr}'
+            ) from err
+
+    def as_networks(self) -> List[Union[IPv4Network, IPv6Network]]:
+        """Return a list of one or more IPv4 or IPv6 network objects."""
+        if not self._networks:
+            self.validate()
+        return self._networks
+
+    def as_network_strs(self) -> List[str]:
+        """Return a list of strings containing one or more network (<ip>/<mask>
+        style) values.
+        """
+        return [str(n) for n in self.as_networks()]
+
+    def __eq__(self, other: Any) -> bool:
+        try:
+            return (
+                other.address == self.address
+                and other.network == self.network
+            )
+        except AttributeError:
+            return NotImplemented
+
+    def __repr__(self) -> str:
+        if self.address:
+            return f'SMBClusterBindIPSpec(address={self.address!r})'
+        if self.network:
+            return f'SMBClusterBindIPSpec(network={self.network!r})'
+        raise ValueError('SMBClusterBindIPSpec missing address or network value')
+
+    def to_simplified(self) -> Dict[str, Any]:
+        """Return a serializable representation of SMBClusterBindIPSpec."""
+        if self.address:
+            return {'address': self.address}
+        if self.network:
+            return {'network': self.network}
+        raise ValueError('SMBClusterBindIPSpec missing address or network value')
+
+    def to_json(self) -> Dict[str, Any]:
+        """Return a JSON-compatible dict."""
+        return self.to_simplified()
+
+    @classmethod
+    def from_json(cls, spec: Dict[str, Any]) -> 'SMBClusterBindIPSpec':
+        """Convert value from a JSON-compatible dict."""
+        return cls(**spec)
+
+    @classmethod
+    def convert_list(
+        cls, arg: Optional[List[Any]]
+    ) -> Optional[List['SMBClusterBindIPSpec']]:
+        """Convert a list of values into a list of SMBClusterBindIPSpec objects.
+        Ignores None inputs returning None.
+        """
+        if arg is None:
+            return None
+        assert isinstance(arg, list)
+        out = []
+        for value in arg:
+            if isinstance(value, cls):
+                out.append(value)
+            elif hasattr(value, 'to_json'):
+                out.append(cls.from_json(value.to_json()))
+            elif isinstance(value, dict):
+                out.append(cls.from_json(value))
+            else:
+                raise SpecValidationError(
+                    f"Unknown type for SMBClusterBindIPSpec: {type(value)}"
+                )
+        return out
+
+
 class SMBSpec(ServiceSpec):
     service_type = 'smb'
     _valid_features = {'domain', 'clustered', 'cephfs-proxy'}
@@ -3218,6 +3335,7 @@ class SMBSpec(ServiceSpec):
         # custom_ports - A mapping of services to ports. If a service is
         # not listed the default port will be used.
         custom_ports: Optional[Dict[str, int]] = None,
+        bind_addrs: Optional[List[SMBClusterBindIPSpec]] = None,
         # --- genearal tweaks ---
         extra_container_args: Optional[GeneralArgList] = None,
         extra_entrypoint_args: Optional[GeneralArgList] = None,
@@ -3251,6 +3369,7 @@ class SMBSpec(ServiceSpec):
             cluster_public_addrs
         )
         self.custom_ports = custom_ports
+        self.bind_addrs = SMBClusterBindIPSpec.convert_list(bind_addrs)
         self.validate()
 
     def validate(self) -> None:
@@ -3324,6 +3443,15 @@ class SMBSpec(ServiceSpec):
     def strict_cluster_ip_specs(self) -> List[Dict[str, Any]]:
         return [s.to_strict() for s in (self.cluster_public_addrs or [])]
 
+    def bind_networks(self) -> List[str]:
+        """Return a list of all networks (as an addr/mask) that this service is
+        permitted to bind to.
+        """
+        out = []
+        for ba in self.bind_addrs or []:
+            out.extend(ba.as_network_strs())
+        return out
+
     def to_json(self) -> "OrderedDict[str, Any]":
         obj = super().to_json()
         spec = obj.get('spec')
@@ -3331,6 +3459,8 @@ class SMBSpec(ServiceSpec):
             spec['cluster_public_addrs'] = [
                 a.to_json() for a in spec['cluster_public_addrs']
             ]
+        if spec and spec.get('bind_addrs'):
+            spec['bind_addrs'] = [a.to_json() for a in spec['bind_addrs']]
         return obj
 
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/64142

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
