### PR TITLE
mgr/cephadm: Only allow alphanumeric characters in NVME group name

### DIFF
--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1101,10 +1101,13 @@ class ServiceSpec(object):
                 raise SpecValidationError(
                         f'Service of type \'{self.service_type}\' should not contain a service id')
 
-        if self.service_id:
-            if not re.match('^[a-zA-Z0-9_.-]+$', str(self.service_id)):
+        if self.service_type == 'nvmeof':
+            if self.service_id and not re.match('^[a-zA-Z0-9.]+$', str(self.service_id)):
                 raise SpecValidationError('Service id contains invalid characters, '
-                                          'only [a-zA-Z0-9_.-] allowed')
+                                          'only [a-zA-Z0-9.] allowed for NVMeoF')
+        elif self.service_id and not re.match('^[a-zA-Z0-9_.-]+$', str(self.service_id)):
+            raise SpecValidationError('Service id contains invalid characters, '
+                                      'only [a-zA-Z0-9_.-] allowed')
 
         if self.placement is not None:
             self.placement.validate()
@@ -1733,6 +1736,9 @@ class NvmeofServiceSpec(ServiceSpec):
                 err_msg += 'attribute(s) not set in the spec'
                 raise SpecValidationError(err_msg)
 
+        if self.group and not re.match('^[a-zA-Z0-9]+$', self.group):
+            raise SpecValidationError('Group name contains invalid characters, '
+                                      'only [a-zA-Z0-9] allowed')
         if self.transports not in ['tcp']:
             raise SpecValidationError('Invalid transport. Valid values are tcp')
 


### PR DESCRIPTION
mgr/cephadm: Only allow alphanumeric characters in NVME group name.

Fixes: https://tracker.ceph.com/issues/72239

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test api`
- `jenkins test docs`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>