### PR TITLE
doc/man/8: Fix small errors and small improvements in mount.ceph.rst

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -26,7 +26,7 @@ where "name" is the RADOS client name (referred to hereafter as "RADOS user",
 and meaning any individual or system actor such as an application). 
 
 Mount helper can fill in the cluster FSID by reading the ceph configuration file.
-Its recommended to call the mount helper via mount(8) as per::
+It is recommended to call the mount helper via mount(8) as per::
 
   mount -t ceph name@.fs_name=/ /mnt/mycephfs -o mon_addr=1.2.3.4
 
@@ -37,7 +37,7 @@ RADOS user for authentication, the file system name and a path within CephFS
 that will be mounted at the mount point.
 
 Monitor addresses can be passed using ``mon_addr`` mount option. Multiple monitor
-addresses can be passed by separating addresses with a slash (`/`). Only one
+addresses can be passed by separating addresses with a slash ("/"). Only one
 monitor is needed to mount successfully; the client will learn about all monitors
 from any responsive monitor. However, it is a good idea to specify more than one
 in case the one happens to be down at the time of mount. Monitor addresses takes
@@ -78,49 +78,49 @@ Basic
     Set the connection mode that the client uses for transport. The available
     modes are:
 
-    - ``legacy``: use messenger v1 protocol to talk to the cluster
+    - ``legacy``: Use messenger v1 protocol to talk to the cluster.
 
-    - ``crc``: use messenger v2, without on-the-wire encryption
+    - ``crc``: Use messenger v2, without on-the-wire encryption.
 
-    - ``secure``: use messenger v2, with on-the-wire encryption
+    - ``secure``: Use messenger v2, with on-the-wire encryption.
 
-    - ``prefer-crc``: crc mode, if denied agree to secure mode
+    - ``prefer-crc``: ``crc`` mode, if denied agree to ``secure`` mode.
 
-    - ``prefer-secure``: secure mode, if denied agree to crc mode
+    - ``prefer-secure``: ``secure`` mode, if denied agree to ``crc`` mode.
 
 :command:`mon_addr`
-    Monitor address of the cluster in the form of ip_address[:port]
+    Monitor address of the cluster in the form of ip_address[:port].
 
 :command:`fsid`
     Cluster FSID. This can be found using `ceph fsid` command.
 
 :command:`secret`
-    secret key for use with CephX. This option is insecure because it exposes
-    the secret on the command line. To avoid this, use the secretfile option.
+    Secret key for use with CephX. This option is insecure because it exposes
+    the secret on the command line. To avoid this, use the ``secretfile`` option.
 
 :command:`secretfile`
-    path to file containing the secret key to use with CephX
+    Path to file containing the secret key to use with CephX.
 
 :command:`recover_session=<no|clean>`
     Set auto reconnect mode in the case where the client is blocklisted. The
     available modes are ``no`` and ``clean``. The default is ``no``.
 
-    - ``no``: never attempt to reconnect when client detects that it has been
+    - ``no``: Never attempt to reconnect when client detects that it has been
       blocklisted. Blocklisted clients will not attempt to reconnect and
       their operations will fail too.
 
-    - ``clean``: client reconnects to the Ceph cluster automatically when it
+    - ``clean``: Client reconnects to the Ceph cluster automatically when it
       detects that it has been blocklisted. During reconnect, client drops
       dirty data/metadata, invalidates page caches and writable file handles.
       After reconnect, file locks become stale because the MDS loses track of
       them. If an inode contains any stale file locks, read/write on the inode
       is not allowed until applications release all stale file locks.
 
-:command: `fs=<fs-name>`
+:command:`fs=<fs-name>`
     Specify the non-default file system to be mounted, when using the old syntax.
 
-:command: `mds_namespace=<fs-name>`
-    A synonym of "fs=" (Deprecated).
+:command:`mds_namespace=<fs-name>`
+    A synonym of "fs=" (deprecated).
 
 Advanced
 --------
@@ -149,8 +149,8 @@ Advanced
     no data crc on writes
 
 :command:`noshare`
-    create a new client instance, instead of sharing an existing instance of
-    a client mounting the same cluster
+    Create a new client instance, instead of sharing an existing instance of
+    a client mounting the same cluster.
 
 :command:`osdkeepalive`
     int, Default: 5
@@ -182,7 +182,7 @@ Advanced
     string, set the name of the hidden snapdir. Default: .snap
 
 :command:`write_congestion_kb`
-    int (kb), max writeback in flight. scale with available
+    int (kb), max writeback in flight. Scales with available
     memory. Default: calculated from available memory
 
 :command:`wsize`
@@ -202,8 +202,8 @@ Advanced
 
 :command:`crush_location=x`
     Specify the location of the client in terms of CRUSH hierarchy (since 5.8).
-    This is a set of key-value pairs separated from each other by '|', with
-    keys separated from values by ':'.  Note that '|' may need to be quoted
+    This is a set of key-value pairs separated from each other by "|", with
+    keys separated from values by ":".  Note that "|" may need to be quoted
     or escaped to avoid it being interpreted as a pipe by the shell. The key
     is the bucket type name (e.g. rack, datacenter or region with default
     bucket types) and the value is the bucket name. For example, to indicate
@@ -227,19 +227,19 @@ Advanced
     - ``balance``: When a replicated pool receives a read request, pick a random
       OSD from the PG's acting set to serve it (since 5.8).
 
-      This mode is safe for general use only since Octopus (i.e. after "ceph osd
-      require-osd-release octopus"). Otherwise it should be limited to read-only
+      This mode is safe for general use only since Octopus (i.e. after `ceph osd
+      require-osd-release octopus`). Otherwise it should be limited to read-only
       workloads such as snapshots.
 
     - ``localize``: When a replicated pool receives a read request, pick the most
       local OSD to serve it (since 5.8). The locality metric is calculated against
-      the location of the client given with crush_location; a match with the
+      the location of the client given with ``crush_location``; a match with the
       lowest-valued bucket type wins.  For example, an OSD in a matching rack
       is closer than an OSD in a matching data center, which in turn is closer
       than an OSD in a matching region.
 
-      This mode is safe for general use only since Octopus (i.e. after "ceph osd
-      require-osd-release octopus").  Otherwise it should be limited to read-only
+      This mode is safe for general use only since Octopus (i.e. after `ceph osd
+      require-osd-release octopus`).  Otherwise it should be limited to read-only
       workloads such as snapshots.
 
 
@@ -259,11 +259,11 @@ Pass the monitor host's IP address, optionally::
 
     mount.ceph fs_user@.mycephfs2=/ /mnt/mycephfs -o mon_addr=192.168.0.1
 
-Pass the port along with IP address if it's running on a non-standard port::
+Pass the port along with IP address if it is running on a non-standard port::
 
     mount.ceph fs_user@.mycephfs2=/ /mnt/mycephfs -o mon_addr=192.168.0.1:7000
 
-If there are multiple monitors, pass each address separated by a `/`::
+If there are multiple monitors, pass each address separated by a "/"::
 
    mount.ceph fs_user@.mycephfs2=/ /mnt/mycephfs -o mon_addr=192.168.0.1/192.168.0.2/192.168.0.3
 


### PR DESCRIPTION
Fix two cases of a stray space in the middle of syntax causing invalid rendering (introduced in #49630).

Fix a missing apostrophe in "its" and expand another "it's" to the same "it is".

Harmonize usage of single and double backticks (for ceph commands and parameters respectively) and quotation marks (for reference to single characters in syntax).

Harmonize command parameter descriptions to always begin with capital case and end in full stop.
Other minor capitalization fixes.

Fix "scale with" that supposedly should be "scales with".

- Before: https://docs.ceph.com/en/latest/man/8/mount.ceph/
- Rendered PR: https://ceph--64727.org.readthedocs.build/en/64727/man/8/mount.ceph/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
