### PR TITLE
doc: Fix Sphinx warnings&errors and use labels in 4 files for links

### DIFF
--- a/doc/cephfs/ceph-dokan.rst
+++ b/doc/cephfs/ceph-dokan.rst
@@ -1,4 +1,5 @@
 .. _ceph-dokan:
+
 =======================
 Mount CephFS on Windows
 =======================

--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -108,19 +108,15 @@ Once the file system is created and the MDS is active, you are ready to mount
 the file system.  If you have created more than one file system, you will
 choose which to use when mounting.
 
-  - `Mount CephFS`_
-  - `Mount CephFS as FUSE`_
-  - `Mount CephFS on Windows`_
-
-.. _Mount CephFS: ../../cephfs/mount-using-kernel-driver
-.. _Mount CephFS as FUSE: ../../cephfs/mount-using-fuse
-.. _Mount CephFS on Windows: ../../cephfs/ceph-dokan
+  - :ref:`cephfs_mount_using_kernel_driver`
+  - :ref:`cephfs_mount_using_fuse`
+  - :ref:`ceph-dokan`
 
 If you have created more than one file system, and a client does not
 specify a file system when mounting, you can control which file system
 they will see by using the ``ceph fs set-default`` command.
 
-Adding a Data Pool to the File System 
+Adding a Data Pool to the File System
 -------------------------------------
 
 See :ref:`adding-data-pool-to-file-system`.
@@ -134,7 +130,7 @@ You may use Erasure Coded pools as CephFS data pools as long as they have overwr
 .. code:: bash
 
     ceph osd pool set my_ec_pool allow_ec_overwrites true
-    
+
 Note that EC overwrites are only supported when using OSDs with the BlueStore backend.
 
 If you are storing lots of small files or are frequently modifying files you can improve performance by enabling EC optimizations, which is done as follows:

--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -51,14 +51,13 @@ as needed`_. You can also `create other CephFS volumes`_.
 
 Finally, to mount CephFS on your client nodes, see `Mount CephFS:
 Prerequisites`_ page. Additionally, a command-line shell utility is available
-for interactive access or scripting via the `cephfs-shell`_.
+for interactive access or scripting via the :ref:`cephfs-shell <cephfs-shell>`.
 
 .. _Orchestrator: ../mgr/orchestrator
 .. _deploy MDS manually as needed: add-remove-mds
 .. _create other CephFS volumes: fs-volumes
 .. _Orchestrator deployment table: ../mgr/orchestrator/#current-implementation-status
 .. _Mount CephFS\: Prerequisites: mount-prerequisites
-.. _cephfs-shell: ../man/8/cephfs-shell
 
 
 .. raw:: html
@@ -72,7 +71,7 @@ Administration
 
    --->
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
    :hidden:
 
@@ -106,7 +105,7 @@ Mounting CephFS
 
    --->
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
    :hidden:
 
@@ -134,7 +133,7 @@ CephFS Concepts
 
    --->
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
    :hidden:
 
@@ -163,7 +162,7 @@ Troubleshooting and Disaster Recovery
 
    --->
 
-.. toctree:: 
+.. toctree::
    :hidden:
 
     Client eviction <eviction>
@@ -187,7 +186,7 @@ Developer Guides
 
    --->
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 1
    :hidden:
 

--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -1,4 +1,5 @@
 .. _MDS Config Reference:
+
 ======================
  MDS Config Reference
 ======================

--- a/doc/cephfs/mount-prerequisites.rst
+++ b/doc/cephfs/mount-prerequisites.rst
@@ -2,12 +2,14 @@ Mount CephFS: Prerequisites
 ===========================
 
 You can use CephFS by mounting the file system on a machine or by using
-:ref:`cephfs-shell <cephfs-shell>`. A system mount can be performed using `the
-kernel driver`_ as well as `the FUSE driver`_. Both have their own advantages
-and disadvantages. Read the following section to understand more about both of
-these ways to mount CephFS.
+:ref:`cephfs-shell <cephfs-shell>`. A system mount can be performed using
+:ref:`the kernel driver <cephfs_mount_using_kernel_driver>` as well as
+:ref:`the FUSE driver <cephfs_mount_using_fuse>`. Both have their own
+advantages and disadvantages. Read the following section to understand
+more about both of these ways to mount CephFS.
 
-For Windows CephFS mounts, please check the `ceph-dokan`_ page.
+For Windows CephFS mounts, please check the :ref:`ceph-dokan <ceph-dokan>`
+page.
 
 Which CephFS Client?
 --------------------
@@ -68,7 +70,3 @@ Ceph MON resides.
    individually, please check respective mount documents.
 
 .. _Client Authentication: ../client-auth
-.. _cephfs-shell: ..cephfs-shell
-.. _the kernel driver: ../mount-using-kernel-driver
-.. _the FUSE driver: ../mount-using-fuse
-.. _ceph-dokan: ../ceph-dokan

--- a/doc/cephfs/mount-using-fuse.rst
+++ b/doc/cephfs/mount-using-fuse.rst
@@ -5,7 +5,7 @@
 ========================
 
 `ceph-fuse`_ can be used as an alternative to the :ref:`CephFS kernel
-driver<cephfs-mount-using-kernel-driver>` to mount CephFS file systems.
+driver<cephfs_mount_using_kernel_driver>` to mount CephFS file systems.
 `ceph-fuse`_ mounts are made in userspace. This means that `ceph-fuse`_ mounts
 are less performant than kernel driver mounts, but they are easier to manage
 and easier to upgrade.
@@ -25,7 +25,7 @@ mounts, as listed on the `Mount CephFS: Prerequisites`_ page.
 
 Synopsis
 ========
-This is the general form of the command for mounting CephFS via FUSE: 
+This is the general form of the command for mounting CephFS via FUSE:
 
 .. prompt:: bash #
 

--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -1,4 +1,4 @@
-.. _cephfs-mount-using-kernel-driver:
+.. _cephfs_mount_using_kernel_driver:
 
 =================================
  Mount CephFS using Kernel Driver

--- a/doc/dev/blkin.rst
+++ b/doc/dev/blkin.rst
@@ -9,7 +9,7 @@ if you compile code, please use -DWITH_LTTNG option (default: ON)::
 
   ./do_cmake -DWITH_LTTNG=ON
 
-If your Ceph deployment is package-based (YUM, DNF, APT) vs containerized, install the required software packages according to the module which you want to track， otherwise, it may cause a coredump due to missing *tp.solibrary files::
+If your Ceph deployment is package-based (YUM, DNF, APT) vs containerized, install the required software packages according to the module which you want to track， otherwise, it may cause a coredump due to missing ``*tp.solibrary`` files::
 
   librbd-devel    
   librgw-devel    

--- a/doc/dev/crimson/crimson.rst
+++ b/doc/dev/crimson/crimson.rst
@@ -79,7 +79,7 @@ number of CPU cores (``nproc``) divided by the **number of OSDs on that host**.
 
 For example, for deploying a node with eight CPU cores per OSD:
 
-.. code-block:: bash #
+.. prompt:: bash #
 
    ceph config set osd crimson_cpu_num 8
 
@@ -137,7 +137,7 @@ Native backends perform I/O operations using the **Seastar reactor**. These are 
    CyanStore **does not store data** and should be used only for measuring OSD overhead, without the cost of actually storing data.
 
 Non-Native Backends
-------------------
+-------------------
 
 Non-native backends operate through a **thread pool proxy**, which interfaces with object stores running in **alien threads**—worker threads not managed by Seastar.
 These backends allow Crimson to interact with legacy or external object store implementations:
@@ -187,7 +187,7 @@ The following options can be used with ``vstart.sh``.
     (as determined by `nproc`) will be assigned to the object store.
 
 ``--bluestore``
-    Use the alienized BlueStore as the object store backend. This is the default (see below section on the `object store backend`_ for more details)
+    Use the alienized BlueStore as the object store backend. This is the default (see above section on the `object store backends`_ for more details)
 
 ``--cyanstore``
     Use CyanStore as the object store backend.

--- a/doc/install/windows-install.rst
+++ b/doc/install/windows-install.rst
@@ -79,10 +79,9 @@ Further reading
 ===============
 
 * `RBD Windows documentation`_
-* `CephFS Windows documentation`_
+* :ref:`CephFS Windows documentation <ceph-dokan>`
 * `Windows troubleshooting`_
 
-.. _CephFS Windows documentation: ../../cephfs/ceph-dokan
 .. _Windows configuration sample: ../windows-basic-config
 .. _RBD Windows documentation: ../../rbd/rbd-windows/
 .. _Windows troubleshooting: ../windows-troubleshooting

--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. _man-ceph-fuse: 
+.. _man-ceph-fuse:
 
 =========================================
  ceph-fuse -- FUSE-based client for ceph

--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -793,7 +793,7 @@ Parameters are XML encoded in the body of the request, in the following format:
 |                               |           | between different source buckets writing log records to the same log bucket.         |          |
 +-------------------------------+-----------+--------------------------------------------------------------------------------------+----------+
 | ``LoggingType``               | String    | The type of logging. Valid values are:                                               | No       |
-|                               |           | ``Standard`` (default) all bucket operations are logged after being performed.        |          |
+|                               |           | ``Standard`` (default) all bucket operations are logged after being performed.       |          |
 |                               |           | The log record will contain all fields.                                              |          |
 |                               |           | ``Journal`` only operations that modify and object are logged.                       |          |
 |                               |           | Will record the minimum subset of fields in the log record that is needed            |          |

--- a/doc/releases/squid.rst
+++ b/doc/releases/squid.rst
@@ -20,6 +20,7 @@ Notable Changes
 
    - https://tracker.ceph.com/issues/67179
    - https://tracker.ceph.com/issues/66867
+
 * RBD: Moving an image that is a member of a group to trash is no longer
   allowed.  `rbd trash mv` command now behaves the same way as `rbd rm` in this
   scenario.


### PR DESCRIPTION
Fix Sphinx warning about missing empty line after a label in cephfs/ceph-dokan.rst.

Fix Sphinx error about invalid indentation in releases/squid.rst.

Fix Sphinx error about invalid bash prompt block in dev/crimson/crimson.rst.  
Also fix warning about too short section title text underline and an error about fix an incorrect link name (and use "above" instead of "below").

Fix Sphinx warning about missing strong emphasis closure, put the problematic star inside inline preformatted/code in dev/blkin.rst.

Fix Sphinx warning about explicit markup, add the required empty line in cephfs/mds-config-ref.rst.

Fix Sphinx error about invalid table in radosgw/s3/bucketops.rst.

Use the label at the beginning of the document in cephfs/ceph-dokan.rst for hyperlinking with :ref: instead of using "external links" feature from cephfs/createfs.rst cephfs/mount-prerequisites.rst install/windows-install.rst.

Also use existing label in cephfs/mount-using-kernel-driver.rst similarly from cephfs/createfs.rst cephfs/mount-prerequisites.rst.

Also use existing label in man/8/cephfs-shell.rst similarly from cephfs/index.rst.

Add a label in cephfs/mount-using-fuse.rst and use it from cephfs/createfs.rst cephfs/mount-prerequisites.rst.

Remove space at the end of line in cephfs/createfs.rst cephfs/mount-prerequisites.rst cephfs/mount-using-fuse.rst cephfs/cephfs-fuse.rst cephfs/index.rst.

To make reviewing the multiple files easier I try to give below links to the exact locations of before & rendered PR.  
The changes to remove space at end of lines seems like it might not need linking into.

`doc/cephfs/ceph-dokan.rst`: No change.
- Before: https://docs.ceph.com/en/latest/cephfs/ceph-dokan/
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/cephfs/ceph-dokan/

`doc/dev/crimson/crimson.rst`: Shows the command block that was hidden by the error.
- Before: https://docs.ceph.com/en/latest/dev/crimson/crimson/#crimson-cpu-allocation
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/dev/crimson/crimson/#crimson-cpu-allocation

`doc/dev/crimson/crimson.rst`: Make the link work instead of rendering the RST syntax.
- Before: https://docs.ceph.com/en/latest/dev/crimson/crimson/#vstart-sh
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/dev/crimson/crimson/#vstart-sh

`doc/dev/blkin.rst`: Problem text changed to inline preformatted/code.
- Before: https://docs.ceph.com/en/latest/dev/blkin/
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/dev/blkin/

`doc/cephfs/mds-config-ref.rst`: No change.
- Before: https://docs.ceph.com/en/latest/cephfs/mds-config-ref/
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/cephfs/mds-config-ref/

`doc/radosgw/s3/bucketops.rst`: Show the table that was hidden by the error.
- Before: https://docs.ceph.com/en/latest/radosgw/s3/bucketops/#id32
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/radosgw/s3/bucketops/#id32

`doc/cephfs/createfs.rst`: scroll up 1 page from the links below. Uses auto-generated link texts but otherwise no change.
- Before: https://docs.ceph.com/en/latest/cephfs/createfs/#adding-a-data-pool-to-the-file-system
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/cephfs/createfs/#adding-a-data-pool-to-the-file-system

`doc/cephfs/index.rst`: No change.
- Before: https://docs.ceph.com/en/latest/cephfs/#getting-started-with-cephfs
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/cephfs/#getting-started-with-cephfs

`doc/cephfs/mount-prerequisites.rst`: No change.
- Before: https://docs.ceph.com/en/latest/cephfs/mount-prerequisites/
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/cephfs/mount-prerequisites/

`doc/cephfs/mount-using-fuse.rst`: No change.
- Before: https://docs.ceph.com/en/latest/cephfs/mount-using-fuse/
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/cephfs/mount-using-fuse/

`doc/install/windows-install.rst`: No change.
- Before: https://docs.ceph.com/en/latest/install/windows-install/#further-reading
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/install/windows-install/#further-reading

`doc/man/8/ceph-fuse.rst`: No change.
- Before: https://docs.ceph.com/en/latest/man/8/ceph-fuse/#description
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/man/8/ceph-fuse/#description

`doc/releases/squid.rst`: No change.
- Before: https://docs.ceph.com/en/latest/releases/squid/#notable-changes
- Rendered PR: https://ceph--64729.org.readthedocs.build/en/64729/releases/squid/#notable-changes



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
