### PR TITLE
squid: rgw/lc: stop using merge_and_store_attrs in remove_bucket_config

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -2863,7 +2863,8 @@ int RGWMetadataHandlerPut_BucketInstance::put_post(const DoutPrefixProvider *dpp
 
     } else {
       ldpp_dout(dpp, 20) << "remove lc config for " << bci.info.bucket.name << dendl;
-      ret = lc->remove_bucket_config(bucket.get(), bci.attrs, false /* cannot merge attrs */);
+      constexpr bool update_attrs = false;
+      ret = lc->remove_bucket_config(dpp, y, bucket.get(), update_attrs);
       if (ret < 0) {
 	      ldpp_dout(dpp, 0) << __func__ << " failed to remove lc config for "
 			<< bci.info.bucket.name

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -401,9 +401,9 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
 
   // remove lifecycle config, if any (XXX note could be made generic)
   if (get_attrs().count(RGW_ATTR_LC)) {
-    constexpr bool merge_attrs = false; // don't update xattrs, we're deleting
+    constexpr bool update_attrs = false; // don't update xattrs, we're deleting
     (void) store->getRados()->get_lc()->remove_bucket_config(
-      this, get_attrs(), merge_attrs);
+      dpp, y, this, update_attrs);
   }
 
   // remove bucket-topic mapping

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -656,9 +656,10 @@ public:
   int set_bucket_config(rgw::sal::Bucket* bucket,
                         const rgw::sal::Attrs& bucket_attrs,
                         RGWLifecycleConfiguration *config);
-  int remove_bucket_config(rgw::sal::Bucket* bucket,
-                           const rgw::sal::Attrs& bucket_attrs,
-			   bool merge_attrs = true);
+  // remove a bucket from the lc list, and optionally update the bucket
+  // instance metadata to remove RGW_ATTR_LC
+  int remove_bucket_config(const DoutPrefixProvider* dpp, optional_yield y,
+                           rgw::sal::Bucket* bucket, bool update_attrs);
 
   CephContext *get_cct() const override { return cct; }
   rgw::sal::Lifecycle* get_lc() const { return sal_lc.get(); }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6028,7 +6028,10 @@ void RGWDeleteLC::execute(optional_yield y)
     return;
   }
 
-  op_ret = driver->get_rgwlc()->remove_bucket_config(s->bucket.get(), s->bucket_attrs);
+  // remove RGW_ATTR_LC and remove the bucket from the 'lc list'
+  constexpr bool update_attrs = true;
+  op_ret = driver->get_rgwlc()->remove_bucket_config(this, y, s->bucket.get(),
+                                                     update_attrs);
   if (op_ret < 0) {
     return;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71544

---

backport of https://github.com/ceph/ceph/pull/62980
parent tracker: https://tracker.ceph.com/issues/71083

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh