### PR TITLE
reef: qa/tasks/ceph_manager: population must be a sequence

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -2218,7 +2218,7 @@ class CephManager:
         """
         with self.lock:
             if self.pools:
-                return random.sample(self.pools.keys(), 1)[0]
+                return random.sample(list(self.pools.keys()), 1)[0]
 
     def get_pool_pg_num(self, pool_name):
         """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72328

---

backport of https://github.com/ceph/ceph/pull/62880
parent tracker: https://tracker.ceph.com/issues/71207

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh