### PR TITLE
doc/radosgw: Small fixes and improvements in notifications.rst, part 2

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -394,31 +394,33 @@ The response has the following format:
         </ResponseMetadata>
     </GetTopicAttributesResponse>
 
-- User: the name of the user that created the topic.
-- Name: the name of the topic.
-- EndPoint: The JSON-formatted endpoint parameters, including:
-   - EndpointAddress: The push-endpoint URL.
-   - EndpointArgs: The push-endpoint args.
-   - EndpointTopic: The topic name to be sent to the endpoint (can be different
-     than the above topic name).
-   - HasStoredSecret: This is "true" if the endpoint URL contains user/password
+- ``User``: the name of the user that created the topic
+- ``Name``: the name of the topic
+- ``EndPoint``: the JSON-formatted endpoint parameters, including:
+
+   - ``EndpointAddress``: the push-endpoint URL
+   - ``EndpointArgs``: the push-endpoint arguments
+   - ``EndpointTopic``: the topic name to be sent to the endpoint (can be different
+     than the above topic name)
+   - ``HasStoredSecret``: This is "true" if the endpoint URL contains ``user``/``password``
      information. In this case, the request must be made over HTTPS. The "topic
      get" request will otherwise be rejected.
-   - Persistent: This is "true" if the topic is persistent.
-   - TimeToLive: This will limit the time (in seconds) to retain the notifications.
-   - MaxRetries: This will limit the max retries before expiring notifications.
-   - RetrySleepDuration: This will control the frequency of retrying the notifications.
-- TopicArn: topic `ARN
-  <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`_.
-- OpaqueData: The opaque data set on the topic.
-- Policy: Any access permission set on the topic.
+   - ``Persistent``: This is "true" if the topic is persistent.
+   - ``TimeToLive``: This will limit the time (in seconds) to retain the notifications.
+   - ``MaxRetries``: This will limit the max retries before expiring notifications.
+   - ``RetrySleepDuration``: This will control the frequency of retrying the notifications.
+
+- ``TopicArn``: topic `ARN
+  <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`_
+- ``OpaqueData``: the opaque data set on the topic
+- ``Policy``: any access permission set on the topic
 
 Get Topic Information
 `````````````````````
 
 This returns information about a specific topic. This includes push-endpoint
 information, if provided.  Note that this API is now deprecated in favor of the
-AWS compliant `GetTopicAttributes` API.
+AWS compliant ``GetTopicAttributes`` API.
 
 ::
 
@@ -452,20 +454,20 @@ The response has the following format:
         </ResponseMetadata>
     </GetTopicResponse>
 
-- User: The name of the user that created the topic.
-- Name: The name of the topic.
-- EndpointAddress: The push-endpoint URL.
-- EndpointArgs: The push-endpoint args.
-- EndpointTopic: The topic name to be sent to the endpoint (which can be
-  different than the above topic name).
-- HasStoredSecret: This is "true" if the endpoint URL contains user/password
+- ``User``: the name of the user that created the topic
+- ``Name``: the name of the topic
+- ``EndpointAddress``: the push-endpoint URL
+- ``EndpointArgs``: the push-endpoint arguments
+- ``EndpointTopic``: the topic name to be sent to the endpoint (which can be
+  different than the above topic name)
+- ``HasStoredSecret``: This is "true" if the endpoint URL contains user/password
   information. In this case, the request must be made over HTTPS. The "topic
   get" request will otherwise be rejected.
-- Persistent: "true" if topic is persistent.
-- TopicArn: topic `ARN
-  <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`_.
-- OpaqueData: the opaque data set on the topic.
-- Policy: Any access permission set on the topic.
+- ``Persistent``: "true" if topic is persistent
+- ``TopicArn``: topic `ARN
+  <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`_
+- ``OpaqueData``: the opaque data set on the topic
+- ``Policy``: any access permission set on the topic
 
 Delete Topic
 ````````````
@@ -481,10 +483,10 @@ This deletes the specified topic.
 
 .. note::
 
-  - Deleting an unknown notification (for example, double delete) is not
-    considered an error.
-  - Deleting a topic does not automatically delete all notifications associated
-    with it.
+    - Deleting an unknown notification (for example, double delete) is not
+      considered an error.
+    - Deleting a topic does not automatically delete all notifications associated
+      with it.
 
 The response has the following format:
 
@@ -550,8 +552,9 @@ This allows to set/modify existing attributes on the specified topic.
 
 .. note::
 
-  - The AttributeName passed will either be updated or created (if not exist) with AttributeValue passed.
-  - Any unsupported AttributeName passed will result in error 400.
+    - The ``AttributeName`` passed will either be updated or created (if not
+      exist) with ``AttributeValue`` passed.
+    - Any unsupported ``AttributeName`` passed will result in error 400.
 
 The response has the following format:
 
@@ -563,34 +566,35 @@ The response has the following format:
         </ResponseMetadata>
     </SetTopicAttributesResponse>
 
-Valid AttributeName that can be passed:
+Valid ``AttributeName`` that can be passed:
 
-  - push-endpoint: This is the URI of an endpoint to send push notifications to.
-  - OpaqueData: Opaque data is set in the topic configuration and added to all
-    notifications that are triggered by the topic.
-  - persistent: This indicates whether notifications to this endpoint are
-    persistent (=asynchronous) or not persistent. (This is "false" by default.)
-  - time_to_live: This will limit the time (in seconds) to retain the notifications.
-  - max_retries: This will limit the max retries before expiring notifications.
-  - retry_sleep_duration: This will control the frequency of retrying the notifications.
-  - Policy: This will control who can access the topic other than owner of the topic.
-  - verify-ssl: This indicates whether the server certificates must be validated by
-    the client. This is "true" by default.
-  - ``use-ssl``: If this is set to "true", a secure connection is used to
-    connect to the broker. This is "false" by default.
-  - cloudevents: This indicates whether the HTTP header should contain
-    attributes according to the `S3 CloudEvents Spec`_.
-  - amqp-exchange: The exchanges must exist and must be able to route messages
-    based on topics.
-  - amqp-ack-level: No end2end acknowledgement is required. Messages may persist in the
-    broker before being delivered to their final destinations.
-  - ``ca-location``: If this is provided and a secure connection is used, the
-    specified CA will be used instead of the default CA to authenticate the
-    broker.
-  - mechanism: may be provided together with user/password (default: ``PLAIN``).
-  - kafka-ack-level: No end2end acknowledgement is required. Messages may persist in the
-    broker before being delivered to their final destinations.
-  - kafka-brokers: Set endpoint with broker(s) as a comma-separated list of host or host:port (default port 9092).
+- ``push-endpoint``: This is the URI of an endpoint to send push notifications to.
+- ``OpaqueData``: Opaque data is set in the topic configuration and added to all
+  notifications that are triggered by the topic.
+- ``persistent``: This indicates whether notifications to this endpoint are
+  persistent (=asynchronous) or not persistent. (This is "false" by default.)
+- ``time_to_live``: This will limit the time (in seconds) to retain the notifications.
+- ``max_retries``: This will limit the max retries before expiring notifications.
+- ``retry_sleep_duration``: This will control the frequency of retrying the notifications.
+- ``Policy``: This will control who can access the topic other than owner of the topic.
+- ``verify-ssl``: This indicates whether the server certificates must be validated by
+  the client. This is "true" by default.
+- ``use-ssl``: If this is set to "true", a secure connection is used to
+  connect to the broker. This is "false" by default.
+- ``cloudevents``: This indicates whether the HTTP header should contain
+  attributes according to the `S3 CloudEvents Spec`_.
+- ``amqp-exchange``: The exchanges must exist and must be able to route messages
+  based on topics.
+- ``amqp-ack-level``: No end2end acknowledgement is required. Messages may persist in the
+  broker before being delivered to their final destinations.
+- ``ca-location``: If this is provided and a secure connection is used, the
+  specified CA will be used instead of the default CA to authenticate the
+  broker.
+- ``mechanism``: may be provided together with ``user``/``password`` (default: ``PLAIN``)
+- ``kafka-ack-level``: No end2end acknowledgement is required. Messages may persist in the
+  broker before being delivered to their final destinations.
+- ``kafka-brokers``: Set endpoint with broker(s) as a comma-separated list of
+  ``host`` or ``host:port`` (default port 9092).
 
 Notifications
 ~~~~~~~~~~~~~
@@ -599,8 +603,9 @@ Detailed under: :ref:`radosgw-bucketops`.
 
 .. note::
 
-    - "Abort Multipart Upload" request does not emit a notification
-    - Both "Initiate Multipart Upload" and "POST Object" requests will emit an ``s3:ObjectCreated:Post`` notification
+    - "Abort Multipart Upload" request does not emit a notification.
+    - Both "Initiate Multipart Upload" and "POST Object" requests will emit
+      an ``s3:ObjectCreated:Post`` notification.
 
 Events
 ~~~~~~
@@ -653,36 +658,36 @@ For example:
        }
    ]}
 
-- awsRegion: The zonegroup.
-- eventTime: The timestamp, indicating when the event was triggered.
-- eventName: For the list of supported events see: :ref:`radosgw-s3-notification-compatibility`.
-  Note that eventName values do not start with the `s3:` prefix.
-- userIdentity.principalId: The user that triggered the change.
-- requestParameters.sourceIPAddress: not supported
-- responseElements.x-amz-request-id: The request ID of the original change.
-- responseElements.x_amz_id_2: The RGW on which the change was made.
-- s3.configurationId: The notification ID that created the event.
-- s3.bucket.name: The name of the bucket.
-- s3.bucket.ownerIdentity.principalId: The owner of the bucket.
-- s3.bucket.arn: The ARN of the bucket.
-- s3.bucket.id: The ID of the bucket. (This is an extension to the S3
+- ``awsRegion``: the zonegroup
+- ``eventTime``: the timestamp, indicating when the event was triggered
+- ``eventName``: For a list of supported events, see: :ref:`radosgw-s3-notification-compatibility`.
+  Note that ``eventName`` values do not start with the ``s3:`` prefix.
+- ``userIdentity.principalId``: the user that triggered the change
+- ``requestParameters.sourceIPAddress``: not supported
+- ``responseElements.x-amz-request-id``: the request ID of the original change
+- ``responseElements.x_amz_id_2``: the RGW on which the change was made
+- ``s3.configurationId``: the notification ID that created the event
+- ``s3.bucket.name``: the name of the bucket
+- ``s3.bucket.ownerIdentity.principalId``: the owner of the bucket
+- ``s3.bucket.arn``: the ARN of the bucket
+- ``s3.bucket.id``: the ID of the bucket (This is an extension to the S3
   notification API.)
-- s3.object.key: The object key.
-- s3.object.size: The object size.
-- s3.object.eTag: The object etag.
-- s3.object.versionId: The object version, if the bucket is versioned. When a
-  copy is made, it includes the version of the target object. When a delete
-  marker is created, it includes the version of the delete marker.
-- s3.object.sequencer: The monotonically-increasing identifier of the "change
-  per object" (hexadecimal format).
-- s3.object.metadata: Any metadata set on the object that is sent as
+- ``s3.object.key``: the object key
+- ``s3.object.size``: the object size
+- ``s3.object.eTag``: the object etag
+- ``s3.object.versionId``: This contains the object version, if the bucket is
+  versioned. When a copy is made, it includes the version of the target object.
+  When a delete marker is created, it includes the version of the delete marker.
+- ``s3.object.sequencer``: the monotonically-increasing identifier of the "change
+  per object" (hexadecimal format)
+- ``s3.object.metadata``: Any metadata set on the object that is sent as
   ``x-amz-meta-`` (that is, any metadata set on the object that is sent as an
   extension to the S3 notification API).
-- s3.object.tags: Any tags set on the object. (This is an extension to the S3
+- ``s3.object.tags``: any tags set on the object (This is an extension to the S3
   notification API.)
-- s3.eventId: The unique ID of the event, which could be used for acking. (This
+- ``s3.eventId``: the unique ID of the event, which could be used for acking (This
   is an extension to the S3 notification API.)
-- s3.opaqueData: This means that "opaque data" is set in the topic configuration
+- ``s3.opaqueData``: This means that "opaque data" is set in the topic configuration
   and is added to all notifications triggered by the topic. (This is an
   extension to the S3 notification API.)
 


### PR DESCRIPTION
Use double backticks for data like configuration parameters.

Break very long lines around standard line length.

Don't list same parameter "user/password" in multiple list items, instead just list all concerns under the same list item.

Add missing empty line before child unordered list. Fixes invalid formatting.

Expand "args" in text to "arguments".

Start sentences with capital case and end in full stop consistently.

Remove indent from one whole unordered list that shouldn't be indented (probably a copy-paste from a sub-list).

- Before: https://docs.ceph.com/en/latest/radosgw/notifications/#get-topic-attributes
- Rendered PR: https://ceph--64768.org.readthedocs.build/en/64768/radosgw/notifications/#get-topic-attributes





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
