### PR TITLE
mgr/volumes: allow setting UID/GID for clones during launch

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -8957,6 +8957,10 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
             output = self.mount_a.get_shell_stdout(f'ls -l {CLONE_BASE_PATH} | grep '
                                                    f'{CLONE_UUID} | ' + "awk '{print $3}'")
             self.assertIn(username, output)
+
+            output = self.mount_a.get_shell_stdout(f'ls -l {clone_path} | ' +
+                                                    "awk '{print $3}'")
+            self.assertIn(f'{username}\n{username}\n{username}', output)
         except:
             raise
         # cleanup
@@ -9001,6 +9005,10 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
             output = self.mount_a.get_shell_stdout(f'ls -l {CLONE_BASE_PATH} | grep '
                                                    f'{CLONE_UUID} | ' + "awk '{print $4}'")
             self.assertIn(username, output)
+
+            output = self.mount_a.get_shell_stdout(f'ls -l {clone_path} | ' +
+                                                    "awk '{print $4}'")
+            self.assertIn(f'{username}\n{username}\n{username}', output)
         except:
             raise
         # cleanup
@@ -9049,9 +9057,18 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
             output = self.mount_a.get_shell_stdout(f'ls -l {CLONE_BASE_PATH} | grep '
                                                    f'{CLONE_UUID} | ' + "awk '{print $3}'")
             self.assertIn(username, output)
+
             output = self.mount_a.get_shell_stdout(f'ls -l {CLONE_BASE_PATH} | grep '
                                                    f'{CLONE_UUID} | ' + "awk '{print $4}'")
             self.assertIn(username, output)
+
+            output = self.mount_a.get_shell_stdout(f'ls -l {clone_path} | ' +
+                                                    "awk '{print $3}'")
+            self.assertIn(f'{username}\n{username}\n{username}', output)
+
+            output = self.mount_a.get_shell_stdout(f'ls -l {clone_path} | ' +
+                                                    "awk '{print $4}'")
+            self.assertIn(f'{username}\n{username}\n{username}', output)
         except:
             raise
         # cleanup

--- a/src/pybind/mgr/volumes/fs/operations/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/operations/subvolume.py
@@ -28,7 +28,8 @@ def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, po
     subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark, normalization, casesensitive, enctag)
 
 
-def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, source_subvolume, snapname):
+def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume,
+                 source_subvolume, snapname, uid, gid):
     """
     create a cloned subvolume.
 
@@ -43,7 +44,8 @@ def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, sour
     :return None
     """
     subvolume = loaded_subvolumes.get_subvolume_object_max(mgr, fs, vol_spec, group, subvolname)
-    subvolume.create_clone(pool, source_volume, source_subvolume, snapname)
+    subvolume.create_clone(pool, source_volume, source_subvolume, snapname,
+                           uid, gid)
 
 
 def remove_subvol(mgr, fs, vol_spec, group, subvolname, force=False, retainsnaps=False):

--- a/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/metadata_manager.py
@@ -59,6 +59,8 @@ class MetadataManager(object):
     GLOBAL_META_KEY_PATH    = "path"
     GLOBAL_META_KEY_STATE   = "state"
     GLOBAL_META_KEY_ALLOW_SUBVOLUME_UPGRADE   = "allow_subvolume_upgrade"
+    GLOBAL_META_UID = "uid"
+    GLOBAL_META_GID = "gid"
 
     CLONE_FAILURE_SECTION = "CLONE_FAILURE"
     CLONE_FAILURE_META_KEY_ERRNO = "errno"

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -234,9 +234,9 @@ class SubvolumeV2(SubvolumeV1):
                 attrs["data_pool"] = pool
                 attrs["pool_namespace"] = None
 
-            if uid:
+            if uid is not None:
                 attrs['uid'] = uid
-            if gid:
+            if gid is not None:
                 attrs['gid'] = gid
 
             # create directory and set attributes
@@ -252,6 +252,12 @@ class SubvolumeV2(SubvolumeV1):
                 self.metadata_mgr.init(SubvolumeV2.VERSION, subvolume_type.value, qpath, initial_state.value)
             self.add_clone_source(source_volname, source_subvolume, snapname)
             self.metadata_mgr.flush()
+
+            if uid is not None:
+                self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_UID, uid)
+            if gid is not None:
+                self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_GID, gid)
+            self.metadata_mgr.flush()
         except (VolumeException, MetadataMgrException, cephfs.Error) as e:
             try:
                 self._remove_on_failure(subvol_path, retained)
@@ -264,6 +270,25 @@ class SubvolumeV2(SubvolumeV1):
             elif isinstance(e, cephfs.Error):
                 e = VolumeException(-e.args[0], e.args[1])
             raise e
+
+    def get_uid_gid(self):
+        self.metadata_mgr.refresh()
+
+        try:
+            uid = self.metadata_mgr.get_global_option(MetadataManager.GLOBAL_META_UID)
+            assert uid
+            uid = int(uid)
+        except MetadataMgrException:
+            uid = -1
+
+        try:
+            gid = self.metadata_mgr.get_global_option(MetadataManager.GLOBAL_META_GID)
+            assert gid
+            gid = int(gid)
+        except MetadataMgrException:
+            gid = -1
+
+        return uid, gid
 
     def allowed_ops_by_type(self, vol_type):
         if vol_type == SubvolumeTypes.TYPE_CLONE:

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -206,7 +206,7 @@ class SubvolumeV2(SubvolumeV1):
                 e = VolumeException(-e.args[0], e.args[1])
             raise e
 
-    def create_clone(self, pool, source_volname, source_subvolume, snapname):
+    def create_clone(self, pool, source_volname, source_subvolume, snapname, uid, gid):
         subvolume_type = SubvolumeTypes.TYPE_CLONE
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -233,6 +233,11 @@ class SubvolumeV2(SubvolumeV1):
             if pool is not None:
                 attrs["data_pool"] = pool
                 attrs["pool_namespace"] = None
+
+            if uid:
+                attrs['uid'] = uid
+            if gid:
+                attrs['gid'] = gid
 
             # create directory and set attributes
             self.fs.mkdirs(subvol_path, attrs.get("mode"))

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -1003,8 +1003,11 @@ class VolumeClient(CephfsClient["Module"]):
         s_subvolname        = kwargs['sub_name']
         s_groupname         = kwargs['group_name']
         t_groupname         = kwargs['target_group_name']
+        uid                 = kwargs['uid']
+        gid                 = kwargs['gid']
 
-        create_clone(self.mgr, fs_handle, self.volspec, t_group, t_subvolname, t_pool, volname, s_subvolume, s_snapname)
+        create_clone(self.mgr, fs_handle, self.volspec, t_group, t_subvolname,
+                     t_pool, volname, s_subvolume, s_snapname, uid, gid)
         with open_subvol(self.mgr, fs_handle, self.volspec, t_group, t_subvolname, SubvolumeOpType.CLONE_INTERNAL) as t_subvolume:
             try:
                 if t_groupname == s_groupname and t_subvolname == s_subvolname:

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -582,7 +582,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=target_sub_name,type=CephString '
                    'name=pool_layout,type=CephString,req=false '
                    'name=group_name,type=CephString,req=false '
-                   'name=target_group_name,type=CephString,req=false ',
+                   'name=target_group_name,type=CephString,req=false '
+                   'name=uid,type=CephInt,req=false '
+                   'name=gid,type=CephInt,req=false ',
             'desc': "Clone a snapshot to target subvolume",
             'perm': 'rw'
         },
@@ -1133,7 +1135,9 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.vc.clone_subvolume_snapshot(
             vol_name=cmd['vol_name'], sub_name=cmd['sub_name'], snap_name=cmd['snap_name'],
             group_name=cmd.get('group_name', None), pool_layout=cmd.get('pool_layout', None),
-            target_sub_name=cmd['target_sub_name'], target_group_name=cmd.get('target_group_name', None))
+            target_sub_name=cmd['target_sub_name'],
+            target_group_name=cmd.get('target_group_name', None),
+            uid=cmd.get('uid', None), gid=cmd.get('gid', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_clone_status(self, inbuf, cmd):


### PR DESCRIPTION
IOW, allow (optionally) passing uid and gid to "ceph fs subvolume snapshot
clone" command.

Fixed: https://tracker.ceph.com/issues/72353






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>