### PR TITLE
mgr/dashboard: Stop rules api being polled on every page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
@@ -7,7 +7,7 @@
   the &nbsp;<cd-doc section="prometheus"></cd-doc>.</cd-alert-panel>
 
 <cd-table *ngIf="isPrometheusConfigured"
-          [data]="prometheusAlertService.rules"
+          [data]="rules"
           [columns]="columns"
           [selectionType]="'single'"
           [hasDetails]="true"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.ts
@@ -1,6 +1,7 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnInit, OnDestroy } from '@angular/core';
 
 import _ from 'lodash';
+import { Subscription } from 'rxjs';
 
 import { PrometheusService } from '~/app/shared/api/prometheus.service';
 import { CellTemplate } from '~/app/shared/enum/cell-template.enum';
@@ -16,10 +17,11 @@ import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.s
   templateUrl: './rules-list.component.html',
   styleUrls: ['./rules-list.component.scss']
 })
-export class RulesListComponent extends PrometheusListHelper implements OnInit {
+export class RulesListComponent extends PrometheusListHelper implements OnInit, OnDestroy {
   columns: CdTableColumn[];
   declare expandedRow: PrometheusRule;
   selection = new CdTableSelection();
+  rules: PrometheusRule[] = [];
 
   /**
    * Hide active alerts in details of alerting rules as they are already shown
@@ -27,6 +29,7 @@ export class RulesListComponent extends PrometheusListHelper implements OnInit {
    * always supposed to be 'alerting'.
    */
   hideKeys = ['alerts', 'type'];
+  rulesSubscription: Subscription;
 
   constructor(
     public prometheusAlertService: PrometheusAlertService,
@@ -37,6 +40,10 @@ export class RulesListComponent extends PrometheusListHelper implements OnInit {
 
   ngOnInit() {
     super.ngOnInit();
+    this.prometheusAlertService.getRules();
+    this.rulesSubscription = this.prometheusAlertService.rules$.subscribe((rules) => {
+      this.rules = rules;
+    });
     this.columns = [
       { prop: 'name', name: $localize`Name`, cellClass: 'fw-bold', flexGrow: 2 },
       {
@@ -65,5 +72,9 @@ export class RulesListComponent extends PrometheusListHelper implements OnInit {
 
   updateSelection(selection: CdTableSelection) {
     this.selection = selection;
+  }
+
+  ngOnDestroy() {
+    this.rulesSubscription.unsubscribe();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
@@ -93,13 +93,14 @@ describe('PrometheusAlertService', () => {
     );
 
     service.getRules();
-
-    expect(service.rules as any).toEqual([
-      { name: 'nearly_full', type: 'alerting', group: 'group1' },
-      { name: 'load_0', type: 'alerting', group: 'test' },
-      { name: 'load_1', type: 'alerting', group: 'test' },
-      { name: 'load_2', type: 'alerting', group: 'test' }
-    ]);
+    service.rules$.subscribe((rules) => {
+      expect(rules).toEqual([
+        { name: 'nearly_full', type: 'alerting', group: 'group1' },
+        { name: 'load_0', type: 'alerting', group: 'test' },
+        { name: 'load_1', type: 'alerting', group: 'test' },
+        { name: 'load_2', type: 'alerting', group: 'test' }
+      ]);
+    });
   });
 
   describe('refresh', () => {


### PR DESCRIPTION
- /rules ar epolled every 5 seconds on every page
- it is only required for alerts page where full rules list is shown in `Alerts` tab
- also added observable for getting rules instead of plain array

It has significant perf improvement:

### Before
<img width="750" height="666" alt="original-rules" src="https://github.com/user-attachments/assets/d4067fd5-6cfc-4ae0-b057-baa61695e933" />


### After
<img width="874" height="668" alt="rules-after" src="https://github.com/user-attachments/assets/922291dc-e9a4-4d5b-b77e-36e8d7693780" />


https://github.com/user-attachments/assets/b961e2c3-d4eb-411b-aa8e-2b2be0825dc9


