### PR TITLE
tentacle: osd: Remove all references to hinfo from optimized EC

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -90,10 +90,9 @@ ECBackend::ECBackend(
     rmw_pipeline(cct, ec_impl, this->sinfo, get_parent()->get_eclistener(),
                  *this, ec_extent_cache_lru),
     recovery_backend(cct, switcher->coll, ec_impl, this->sinfo, read_pipeline,
-                     unstable_hashinfo_registry, get_parent(), this),
+                      get_parent(), this),
     ec_impl(ec_impl),
-    sinfo(ec_impl, &(get_parent()->get_pool()), stripe_width),
-    unstable_hashinfo_registry(cct, ec_impl) {
+    sinfo(ec_impl, &(get_parent()->get_pool()), stripe_width) {
 
   /* EC makes some assumptions about how the plugin organises the *data* shards:
    * - The chunk size is constant for a particular profile.
@@ -113,7 +112,6 @@ ECBackend::RecoveryBackend::RecoveryBackend(
   ceph::ErasureCodeInterfaceRef ec_impl,
   const ECUtil::stripe_info_t &sinfo,
   ReadPipeline &read_pipeline,
-  UnstableHashInfoRegistry &unstable_hashinfo_registry,
   ECListener *parent,
   ECBackend *ecbackend)
   : cct(cct),
@@ -121,7 +119,6 @@ ECBackend::RecoveryBackend::RecoveryBackend(
     ec_impl(std::move(ec_impl)),
     sinfo(sinfo),
     read_pipeline(read_pipeline),
-    unstable_hashinfo_registry(unstable_hashinfo_registry),
     parent(parent),
     ecbackend(ecbackend) {}
 
@@ -334,17 +331,6 @@ void ECBackend::RecoveryBackend::handle_recovery_read_complete(
       ceph_assert(op.obc);
       op.recovery_info.size = op.obc->obs.oi.size;
       op.recovery_info.oi = op.obc->obs.oi;
-    }
-
-    if (sinfo.get_is_hinfo_required()) {
-      ECUtil::HashInfo hinfo(sinfo.get_k_plus_m());
-      if (op.obc->obs.oi.size > 0) {
-        ceph_assert(op.xattrs.count(ECUtil::get_hinfo_key()));
-        auto bp = op.xattrs[ECUtil::get_hinfo_key()].cbegin();
-        decode(hinfo, bp);
-      }
-      op.hinfo = unstable_hashinfo_registry.maybe_put_hash_info(
-        hoid, std::move(hinfo));
     }
   }
   ceph_assert(op.xattrs.size());
@@ -561,29 +547,6 @@ void ECBackend::RecoveryBackend::continue_recovery_op(
 
       if (op.recovery_progress.first && op.obc) {
         op.xattrs = op.obc->attr_cache;
-        if (sinfo.get_is_hinfo_required()) {
-          if (auto [r, attrs, size] = ecbackend->get_attrs_n_size_from_disk(
-              op.hoid);
-            r >= 0 || r == -ENOENT) {
-            op.hinfo = unstable_hashinfo_registry.get_hash_info(
-              op.hoid, false, attrs, size);
-          } else {
-            derr << __func__ << ": can't stat-or-getattr on " << op.hoid <<
-          dendl;
-          }
-          if (!op.hinfo) {
-            derr << __func__ << ": " << op.hoid << " has inconsistent hinfo"
-               << dendl;
-            ceph_assert(recovery_ops.count(op.hoid));
-            eversion_t v = recovery_ops[op.hoid].v;
-            recovery_ops.erase(op.hoid);
-            // TODO: not in crimson yet
-            get_parent()->on_failed_pull({get_parent()->whoami_shard()},
-                                         op.hoid, v);
-            return;
-          }
-          encode(*(op.hinfo), op.xattrs[ECUtil::get_hinfo_key()]);
-        }
       }
 
       read_request_t read_request(std::move(want),
@@ -674,6 +637,12 @@ void ECBackend::RecoveryBackend::continue_recovery_op(
           } else {
             dout(10) << __func__ << ": push all attrs (not nonprimary)" << dendl;
             pop.attrset = op.xattrs;
+          }
+
+          // Following an upgrade, or turning of overwrites, we can take this
+          // opportunity to clean up hinfo.
+          if (pop.attrset.contains(ECUtil::get_hinfo_key())) {
+            pop.attrset.erase(ECUtil::get_hinfo_key());
           }
         }
         pop.recovery_info = op.recovery_info;
@@ -1100,53 +1069,6 @@ void ECBackend::handle_sub_read(
           << bl.length() << dendl;
         reply->buffers_read[hoid].push_back(make_pair(offset, bl));
       }
-
-      if (!sinfo.supports_ec_overwrites()) {
-        // This shows that we still need deep scrub because large enough files
-        // are read in sections, so the digest check here won't be done here.
-        // Do NOT check osd_read_eio_on_bad_digest here.  We need to report
-        // the state of our chunk in case other chunks could substitute.
-        ECUtil::HashInfoRef hinfo;
-        map<string, bufferlist, less<>> attrs;
-        struct stat st;
-        int r = object_stat(hoid, &st);
-        if (r >= 0) {
-          dout(10) << __func__ << ": found on disk, size " << st.st_size << dendl;
-          r = switcher->objects_get_attrs_with_hinfo(hoid, &attrs);
-        }
-        if (r >= 0) {
-          hinfo = unstable_hashinfo_registry.get_hash_info(
-            hoid, false, attrs, st.st_size);
-        } else {
-          derr << __func__ << ": access (attrs) on " << hoid << " failed: "
-	       << cpp_strerror(r) << dendl;
-        }
-        if (!hinfo) {
-          r = -EIO;
-          get_parent()->clog_error() << "Corruption detected: object "
-            << hoid << " is missing hash_info";
-          dout(5) << __func__ << ": No hinfo for " << hoid << dendl;
-          goto error;
-        }
-        ceph_assert(hinfo->has_chunk_hash());
-        if ((bl.length() == hinfo->get_total_chunk_size()) &&
-          (offset == 0)) {
-          dout(20) << __func__ << ": Checking hash of " << hoid << dendl;
-          bufferhash h(-1);
-          h << bl;
-          if (h.digest() != hinfo->get_chunk_hash(shard)) {
-            get_parent()->clog_error() << "Bad hash for " << hoid <<
-              " digest 0x"
-              << hex << h.digest() << " expected 0x" << hinfo->
-              get_chunk_hash(shard) << dec;
-            dout(5) << __func__ << ": Bad hash for " << hoid << " digest 0x"
-		    << hex << h.digest() << " expected 0x"
-                    << hinfo->get_chunk_hash(shard) << dec << dendl;
-            r = -EIO;
-            goto error;
-          }
-        }
-      }
     }
     continue;
   error:
@@ -1229,9 +1151,8 @@ void ECBackend::handle_sub_read_reply(
          ++i) {
       if (ECInject::test_read_error0(
         ghobject_t(i->first, ghobject_t::NO_GEN, op.from.shard))) {
-        dout(0) << __func__ << " Error inject - EIO error for shard " << op.from
-                                                                           .shard
- << dendl;
+        dout(0) << __func__ << " Error inject - EIO error for shard "
+                << op.from.shard << dendl;
         op.buffers_read.erase(i->first);
         op.attrs_read.erase(i->first);
         op.errors[i->first] = -EIO;
@@ -1513,14 +1434,6 @@ std::tuple<
   return {0, real_attrs, st.st_size};
 }
 
-ECUtil::HashInfoRef ECBackend::get_hinfo_from_disk(hobject_t oid) {
-  auto [r, attrs, size] = get_attrs_n_size_from_disk(oid);
-  ceph_assert(r >= 0 || r == -ENOENT);
-  ECUtil::HashInfoRef hinfo = unstable_hashinfo_registry.get_hash_info(
-    oid, true, attrs, size);
-  return hinfo;
-}
-
 std::optional<object_info_t> ECBackend::get_object_info_from_obc(
     ObjectContextRef &obc) {
   std::optional<object_info_t> ret;
@@ -1578,21 +1491,12 @@ void ECBackend::submit_transaction(
   op->t->safe_create_traverse(
     [&](std::pair<const hobject_t, PGTransaction::ObjectOperation> &i) {
       const auto &[oid, inner_op] = i;
-      ECUtil::HashInfoRef shinfo;
       auto &obc = obc_map.at(oid);
       object_info_t oi = obc->obs.oi;
       std::optional<object_info_t> soi;
-      ECUtil::HashInfoRef hinfo;
-
-      if (!sinfo.supports_ec_overwrites()) {
-        hinfo = get_hinfo_from_disk(oid);
-      }
 
       hobject_t source;
       if (inner_op.has_source(&source)) {
-        if (!sinfo.supports_ec_overwrites()) {
-          shinfo = get_hinfo_from_disk(source);
-        }
         if (!inner_op.is_rename()) {
           soi = get_object_info_from_obc(obc_map.at(source));
         }
@@ -1619,8 +1523,7 @@ void ECBackend::submit_transaction(
       ECTransaction::WritePlanObj plan(oid, inner_op, sinfo, readable_shards,
                                        writable_shards,
                                        object_in_cache, old_object_size,
-                                       oi, soi, std::move(hinfo),
-                                       std::move(shinfo),
+                                       oi, soi,
                                        rmw_pipeline.ec_pdw_write_mode);
 
       if (plan.to_read) plans.want_read = true;
@@ -1853,53 +1756,7 @@ int ECBackend::be_deep_scrub(
     return -EINPROGRESS;
   }
 
-  if (!sinfo.get_is_hinfo_required()) {
-    o.digest = 0;
-    o.digest_present = true;
-    o.omap_digest = -1;
-    o.omap_digest_present = true;
-    return 0;
-  }
-
-  ECUtil::HashInfoRef hinfo = unstable_hashinfo_registry.get_hash_info(
-    poid, false, o.attrs, o.size);
-  if (!hinfo) {
-    dout(0) << "_scan_list  " << poid << " could not retrieve hash info" << dendl;
-    o.read_error = true;
-    o.digest_present = false;
-    return 0;
-  }
-  if (!hinfo->has_chunk_hash()) {
-    dout(0) << "_scan_list  " << poid << " got invalid hash info" << dendl;
-    o.ec_size_mismatch = true;
-    return 0;
-  }
-  if (hinfo->get_total_chunk_size() != (unsigned)pos.data_pos) {
-    dout(0) << "_scan_list  " << poid << " got incorrect size on read 0x"
-	    << std::hex << pos
-	    << " expected 0x" << hinfo->get_total_chunk_size() << std::dec
-	    << dendl;
-    o.ec_size_mismatch = true;
-    return 0;
-  }
-
-  if (hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
-    pos.data_hash.digest()) {
-    dout(0) << "_scan_list  " << poid << " got incorrect hash on read 0x"
-	    << std::hex << pos.data_hash.digest() << " !=  expected 0x"
-	    << hinfo->get_chunk_hash(get_parent()->whoami_shard().shard)
-	    << std::dec << dendl;
-    o.ec_hash_mismatch = true;
-    return 0;
-  }
-
-  /* We checked above that we match our own stored hash.  We cannot
-   * send a hash of the actual object, so instead we simply send
-   * our locally stored hash of shard 0 on the assumption that if
-   * we match our chunk hash and our recollection of the hash for
-   * chunk 0 matches that of our peers, there is likely no corruption.
-   */
-  o.digest = hinfo->get_chunk_hash(shard_id_t(0));
+  o.digest = 0;
   o.digest_present = true;
   o.omap_digest = -1;
   o.omap_digest_present = true;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -217,7 +217,6 @@ class ECBackend : public ECCommon {
     ceph::ErasureCodeInterfaceRef ec_impl;
     const ECUtil::stripe_info_t &sinfo;
     ReadPipeline &read_pipeline;
-    UnstableHashInfoRegistry &unstable_hashinfo_registry;
     // TODO: lay an interface down here
     ECListener *parent;
     ECBackend *ecbackend;
@@ -244,7 +243,6 @@ class ECBackend : public ECCommon {
                     ceph::ErasureCodeInterfaceRef ec_impl,
                     const ECUtil::stripe_info_t &sinfo,
                     ReadPipeline &read_pipeline,
-                    UnstableHashInfoRegistry &unstable_hashinfo_registry,
                     ECListener *parent,
                     ECBackend *ecbackend);
 
@@ -278,7 +276,6 @@ class ECBackend : public ECCommon {
       // must be filled if state == WRITING
       std::optional<ECUtil::shard_extent_map_t> returned_data;
       std::map<std::string, ceph::buffer::list, std::less<>> xattrs;
-      ECUtil::HashInfoRef hinfo;
       ObjectContextRef obc;
       std::set<pg_shard_t> waiting_on_pushes;
 
@@ -352,12 +349,10 @@ class ECBackend : public ECCommon {
                       ceph::ErasureCodeInterfaceRef ec_impl,
                       const ECUtil::stripe_info_t &sinfo,
                       ReadPipeline &read_pipeline,
-                      UnstableHashInfoRegistry &unstable_hashinfo_registry,
                       PGBackend::Listener *parent,
                       ECBackend *ecbackend)
       : RecoveryBackend(cct, coll, std::move(ec_impl), sinfo, read_pipeline,
-                        unstable_hashinfo_registry, parent->get_eclistener(),
-                        ecbackend),
+                        parent->get_eclistener(), ecbackend),
         parent(parent) {}
 
     void commit_txn_send_replies(
@@ -481,16 +476,11 @@ class ECBackend : public ECCommon {
 
   const ECUtil::stripe_info_t sinfo;
 
-  ECCommon::UnstableHashInfoRegistry unstable_hashinfo_registry;
-
-
   std::tuple<
     int,
     std::map<std::string, ceph::bufferlist, std::less<>>,
     size_t
   > get_attrs_n_size_from_disk(const hobject_t &hoid);
-
-  ECUtil::HashInfoRef get_hinfo_from_disk(hobject_t oid);
 
   std::optional<object_info_t> get_object_info_from_obc(
       ObjectContextRef &obc_map

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -63,12 +63,6 @@ static ostream &_prefix(std::ostream *_dout,
 }
 
 static ostream &_prefix(std::ostream *_dout,
-                        ECCommon::UnstableHashInfoRegistry *
-                        unstable_hash_info_registry) {
-  return *_dout;
-}
-
-static ostream &_prefix(std::ostream *_dout,
                         struct ClientReadCompleter const *read_completer
   );
 
@@ -694,16 +688,6 @@ void ECCommon::RMWPipeline::cache_ready(Op &op) {
 
   dout(20) << __func__ << ": written: " << written << ", op: " << op << dendl;
 
-  if (!sinfo.supports_ec_overwrites()) {
-    for (auto &&i: op.log_entries) {
-      if (i.requires_kraken()) {
-        derr << __func__ << ": log entry " << i << " requires kraken"
-             << " but overwrites are not enabled!" << dendl;
-        ceph_abort();
-      }
-    }
-  }
-
   ObjectStore::Transaction empty;
   bool should_write_local = false;
   ECSubWrite local_write_op;
@@ -914,52 +898,4 @@ void ECCommon::RMWPipeline::on_change2() {
 
 void ECCommon::RMWPipeline::call_write_ordered(std::function<void(void)> &&cb) {
   extent_cache.add_on_write(std::move(cb));
-}
-
-ECUtil::HashInfoRef ECCommon::UnstableHashInfoRegistry::maybe_put_hash_info(
-    const hobject_t &hoid,
-    ECUtil::HashInfo &&hinfo) {
-  return registry.lookup_or_create(hoid, hinfo);
-}
-
-ECUtil::HashInfoRef ECCommon::UnstableHashInfoRegistry::get_hash_info(
-    const hobject_t &hoid,
-    bool create,
-    const map<string, bufferlist, less<>> &attrs,
-    uint64_t size) {
-  dout(10) << __func__ << ": Getting attr on " << hoid << dendl;
-  auto ref = registry.lookup(hoid);
-  if (!ref) {
-    dout(10) << __func__ << ": not in cache " << hoid << dendl;
-    ECUtil::HashInfo hinfo(ec_impl->get_chunk_count());
-    bufferlist bl;
-    if (attrs.contains(ECUtil::get_hinfo_key())) {
-      bl = attrs.at(ECUtil::get_hinfo_key());
-    } else {
-      dout(30) << __func__ << " " << hoid << " missing hinfo attr" << dendl;
-    }
-    if (bl.length() > 0) {
-      auto bp = bl.cbegin();
-      try {
-        decode(hinfo, bp);
-      }
-      catch (...) {
-        dout(0) << __func__ << ": Can't decode hinfo for " << hoid << dendl;
-        return ECUtil::HashInfoRef();
-      }
-      if (hinfo.get_total_chunk_size() != size) {
-        dout(0) << __func__ << ": Mismatch of total_chunk_size "
-      		       << hinfo.get_total_chunk_size() << dendl;
-        return ECUtil::HashInfoRef();
-      }
-      create = true;
-    } else if (size == 0) {
-      // If empty object and no hinfo, create it
-      create = true;
-    }
-    if (create) {
-      ref = registry.lookup_or_create(hoid, hinfo);
-    }
-  }
-  return ref;
 }

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -32,8 +32,6 @@ struct ECTransaction {
     bool invalidates_cache = false; // Yes, both are possible
     std::map<hobject_t,extent_set> to_read;
     std::map<hobject_t,extent_set> will_write;
-
-    std::map<hobject_t,ECUtil::HashInfoRef> hash_infos;
   };
 };
 
@@ -622,30 +620,6 @@ struct ECCommon {
         ec_backend(ec_backend),
         extent_cache(*this, ec_extent_cache_lru, sinfo, cct),
         ec_pdw_write_mode(cct->_conf.get_val<uint64_t>("ec_pdw_write_mode")) {}
-  };
-
-  class UnstableHashInfoRegistry {
-    CephContext *cct;
-    ceph::ErasureCodeInterfaceRef ec_impl;
-    /// If modified, ensure that the ref is held until the update is applied
-    SharedPtrRegistry<hobject_t, ECUtil::HashInfo> registry;
-
-   public:
-    UnstableHashInfoRegistry(
-        CephContext *cct,
-        ceph::ErasureCodeInterfaceRef ec_impl)
-      : cct(cct),
-        ec_impl(std::move(ec_impl)) {}
-
-    ECUtil::HashInfoRef maybe_put_hash_info(
-        const hobject_t &hoid,
-        ECUtil::HashInfo &&hinfo);
-
-    ECUtil::HashInfoRef get_hash_info(
-        const hobject_t &hoid,
-        bool create,
-        const std::map<std::string, ceph::buffer::list, std::less<>> &attrs,
-        uint64_t size);
   };
 };
 

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -26,8 +26,6 @@ class WritePlanObj {
   const hobject_t hoid;
   std::optional<ECUtil::shard_extent_set_t> to_read;
   ECUtil::shard_extent_set_t will_write;
-  const ECUtil::HashInfoRef hinfo;
-  const ECUtil::HashInfoRef shinfo;
   const uint64_t orig_size;
   const uint64_t projected_size;
   bool invalidates_cache;
@@ -43,16 +41,12 @@ class WritePlanObj {
       uint64_t orig_size,
       const std::optional<object_info_t> &oi,
       const std::optional<object_info_t> &soi,
-      const ECUtil::HashInfoRef &&hinfo,
-      const ECUtil::HashInfoRef &&shinfo,
-      const unsigned pdw_write_mode);
+      unsigned pdw_write_mode);
 
   void print(std::ostream &os) const {
     os << "{hoid: " << hoid
        << " to_read: " << to_read
        << " will_write: " << will_write
-       << " hinfo: " << hinfo
-       << " shinfo: " << shinfo
        << " orig_size: " << orig_size
        << " projected_size: " << projected_size
        << " invalidates_cache: " << invalidates_cache
@@ -113,7 +107,6 @@ class Generate {
   void appends_and_clone_ranges();
   void written_and_present_shards();
   void attr_updates();
-  void handle_deletes();
 
  public:
   Generate(PGTransaction &t,

--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -13,6 +13,7 @@
 #include "include/utime_fmt.h"
 #include "messages/MOSDRepScrubMap.h"
 #include "osd/ECUtil.h"
+#include "osd/ECUtilL.h"
 #include "osd/OSD.h"
 #include "osd/PG.h"
 #include "osd/PrimaryLogPG.h"
@@ -664,7 +665,7 @@ shard_as_auth_t ScrubBackend::possible_auth_shard(const hobject_t& obj,
   }
 
   if (m_pg.get_is_hinfo_required()) {
-    auto k = smap_obj.attrs.find(ECUtil::get_hinfo_key());
+    auto k = smap_obj.attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
     if (dup_error_cond(err,
                        false,
                        (k == smap_obj.attrs.end()),
@@ -673,7 +674,7 @@ shard_as_auth_t ScrubBackend::possible_auth_shard(const hobject_t& obj,
                        "candidate had a missing hinfo key"sv,
                        errstream)) {
       const bufferlist& hk_bl = k->second;
-      ECUtil::HashInfo hi;
+      ECLegacy::ECUtilL::HashInfo hi;
       try {
         auto bliter = hk_bl.cbegin();
         decode(hi, bliter);
@@ -1310,11 +1311,11 @@ bool ScrubBackend::compare_obj_details(pg_shard_t auth_shard,
     if (!shard_result.has_hinfo_missing() &&
         !shard_result.has_hinfo_corrupted()) {
 
-      auto can_hi = candidate.attrs.find(ECUtil::get_hinfo_key());
+      auto can_hi = candidate.attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
       ceph_assert(can_hi != candidate.attrs.end());
       const bufferlist& can_bl = can_hi->second;
 
-      auto auth_hi = auth.attrs.find(ECUtil::get_hinfo_key());
+      auto auth_hi = auth.attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
       ceph_assert(auth_hi != auth.attrs.end());
       const bufferlist& auth_bl = auth_hi->second;
 

--- a/src/test/osd/TestECBackend.cc
+++ b/src/test/osd/TestECBackend.cc
@@ -1262,7 +1262,7 @@ TEST(ECCommon, encode)
     bl.append_zero(i>=k?4096:2048);
     semap.insert_in_shard(i, 12*1024, bl);
   }
-  semap.encode(ec_impl, nullptr, 0);
+  semap.encode(ec_impl);
 }
 
 TEST(ECCommon, decode)

--- a/src/test/osd/test_ec_transaction.cc
+++ b/src/test/osd/test_ec_transaction.cc
@@ -57,8 +57,6 @@ TEST(ectransaction, two_writes_separated_append)
     0,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -95,8 +93,6 @@ TEST(ectransaction, two_writes_separated_misaligned_overwrite)
     oi.size,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -135,8 +131,6 @@ TEST(ectransaction, partial_write)
     0,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -177,8 +171,6 @@ TEST(ectransaction, overlapping_write_non_aligned)
     8,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -220,8 +212,6 @@ TEST(ectransaction, test_appending_write_non_aligned)
     8,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -263,8 +253,6 @@ TEST(ectransaction, append_with_large_hole)
     4096,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -306,8 +294,6 @@ TEST(ectransaction, test_append_not_page_aligned_with_large_hole)
     EC_ALIGN_SIZE,
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -351,8 +337,6 @@ TEST(ectransaction, test_overwrite_with_missing)
     42*(EC_ALIGN_SIZE / 4),
     oi,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -392,8 +376,6 @@ TEST(ectransaction, truncate_to_bigger_without_write)
     4096,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -423,8 +405,6 @@ TEST(ectransaction, truncate_to_smalelr_without_write) {
     16*EC_ALIGN_SIZE,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;
@@ -470,8 +450,6 @@ TEST(ectransaction, delete_and_write_misaligned) {
     16*EC_ALIGN_SIZE,
     std::nullopt,
     std::nullopt,
-    ECUtil::HashInfoRef(new ECUtil::HashInfo(1)),
-    nullptr,
     0);
 
   generic_derr << "plan " << plan << dendl;

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -5,7 +5,7 @@ set(rados_srcs
   rados/PoolDump.cc
   ${PROJECT_SOURCE_DIR}/src/common/util.cc
   ${PROJECT_SOURCE_DIR}/src/common/obj_bencher.cc
-  ${PROJECT_SOURCE_DIR}/src/osd/ECUtil.cc)
+  ${PROJECT_SOURCE_DIR}/src/osd/ECUtilL.cc)
 if(WIN32)
   list(APPEND rados_srcs ../common/win32/code_page.rc)
 endif()

--- a/src/tools/ceph-dencoder/osd_types.h
+++ b/src/tools/ceph-dencoder/osd_types.h
@@ -72,9 +72,9 @@ TYPE(eversion_t)
 //TYPE(compact_interval_t) declared in .cc
 //TYPE(pg_missing_t::item)
 
-#include "osd/ECUtil.h"
+#include "osd/ECUtilL.h"
 // TYPE(stripe_info_t) non-standard encoding/decoding functions
-TYPE(ECUtil::HashInfo)
+TYPE(ECLegacy::ECUtilL::HashInfo)
 
 #include "osd/ECMsgTypes.h"
 TYPE_NOCOPY(ECSubWrite)

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -38,7 +38,7 @@
 #include "osd/PGLog.h"
 #include "osd/OSD.h"
 #include "osd/PG.h"
-#include "osd/ECUtil.h"
+#include "osd/ECUtilL.h"
 
 #include "json_spirit/json_spirit_value.h"
 #include "json_spirit/json_spirit_reader.h"
@@ -2899,9 +2899,9 @@ int print_obj_info(ObjectStore *store, coll_t coll, ghobject_t &ghobj, Formatter
     }
   }
   bufferlist hattr;
-  gr = store->getattr(ch, ghobj, ECUtil::get_hinfo_key(), hattr);
+  gr = store->getattr(ch, ghobj, ECLegacy::ECUtilL::get_hinfo_key(), hattr);
   if (gr == 0) {
-    ECUtil::HashInfo hinfo;
+    ECLegacy::ECUtilL::HashInfo hinfo;
     auto hp = hattr.cbegin();
     try {
       decode(hinfo, hp);

--- a/src/tools/erasure-code/ceph-erasure-code-tool.cc
+++ b/src/tools/erasure-code/ceph-erasure-code-tool.cc
@@ -215,7 +215,7 @@ int do_encode(const std::vector<const char*> &args) {
   }
 
   sinfo->ro_range_to_shard_extent_map(0, input_data.length(), input_data, encoded_data);
-  r = encoded_data.encode(ec_impl, nullptr, encoded_data.get_ro_end());
+  r = encoded_data.encode(ec_impl);
   if (r < 0) {
     std::cerr << "failed to encode: " << cpp_strerror(r) << std::endl;
     return 1;

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -60,7 +60,7 @@
 #include "PoolDump.h"
 #include "RadosImport.h"
 
-#include "osd/ECUtil.h"
+#include "osd/ECUtilL.h" // For hinfo in legacy EC
 #include "objclass/objclass.h"
 #include "cls/refcount/cls_refcount_ops.h"
 
@@ -1643,10 +1643,10 @@ static void dump_shard(const shard_info_t& shard,
        || inc.union_shards.has_hinfo_corrupted()
        || inc.has_hinfo_inconsistency()) &&
        !shard.has_hinfo_missing()) {
-    map<std::string, ceph::bufferlist>::iterator k = (const_cast<shard_info_t&>(shard)).attrs.find(ECUtil::get_hinfo_key());
+    map<std::string, ceph::bufferlist>::iterator k = (const_cast<shard_info_t&>(shard)).attrs.find(ECLegacy::ECUtilL::get_hinfo_key());
     ceph_assert(k != shard.attrs.end()); // Can't be missing
     if (!shard.has_hinfo_corrupted()) {
-      ECUtil::HashInfo hi;
+      ECLegacy::ECUtilL::HashInfo hi;
       bufferlist bl;
       auto bliter = k->second.cbegin();
       decode(hi, bliter);  // Can't be corrupted


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72363

---

backport of https://github.com/ceph/ceph/pull/63960
parent tracker: https://tracker.ceph.com/issues/71813

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh