### PR TITLE
rgw: auto-create missing bucket index shards during reindex operations

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4088,6 +4088,39 @@ int RGWRados::reindex_obj(rgw::sal::Driver* driver,
     (void) decode_policy(dpp, acl_bl, &owner);
   }
 
+  rgw_rados_ref bucket_ref;
+  ret = svc.bi_rados->open_bucket_index_shard(dpp, 
+					      bucket_info, 
+					      head_obj.get_hash_object(), 
+					      &bucket_ref, 
+					      nullptr);
+  if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to determine bucket index shard"
+                      << dendl;
+    return ret;
+  }
+
+  // validate bucket index shard existence before attempting reindex
+  ret = bucket_ref.ioctx.stat(bucket_ref.obj.oid, NULL, NULL);
+  if (ret == -ENOENT) {
+    ldpp_dout(dpp, 10) << "INFO: bucket index shard " << bucket_ref.obj.oid
+                       << " missing, creating..." << dendl;
+    int create_ret = svc.bi_rados->init_index(dpp, 
+					      y, 
+					      bucket_info, 
+					      bucket_info.layout.current_index, 
+					      false);
+
+    if (create_ret < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: failed to create bucket index" << dendl;
+      return create_ret;
+    }
+  } else if (ret < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to stat bucket index shard: "
+                      << cpp_strerror(-ret) << dendl;
+    return ret;
+  }
+
   Bucket bkt(this, bucket_info);
   RGWRados::Bucket::UpdateIndex update_idx(&bkt, head_obj);
 


### PR DESCRIPTION
When bucket indexes are purged (e.g., via `radosgw-admin bi purge`), reindex operations fail because they attempt to update non-existent bucket index shards 

update_idx.complete() seems to be calling an async rados operations, causing reindex to fail with -ENOENT when shards are missing. I added this check before to create the missing index shards. 

Fixes: https://tracker.ceph.com/issues/68750



Alternatively the solution was to write the index shards manually into the rados pool for rgw.index then run this rgw-restore-bucket-index tool

Ran into this issue where operator ran radosgw-admin bi purge --bucket="test' and used this rgw-restore-bucket-index tool. Added this debug statement when I was testing and it seemed that update_idx.complete() was returning fine but was failing later on. 

debug print: 
```
20 get_obj_state: setting s->obj_tag to 1ded7ae1-15d2-49e3-894c-5bcecd9490a2.4511.11654195119598695254
20  bucket index object: :.dir.1ded7ae1-15d2-49e3-894c-5bcecd9490a2.4511.1.1
 0 DEBUG: update_idx.complete() returned: 0 ((0) Success)
20 INFO: reindex_obj: reindexing test-bucket:lib/python3.10/site-packages/pip/_internal/models/__pycache__/search_scope.cpython-310.pyc
20 get_obj_state: octx=0x7ffee7b269d0 obj=test-bucket:lib/python3.10/site-packages/pip/_internal/models/__pycache__/search_scope.cpython-310.pyc state=0x559825548e38 s->prefetch_data=0
20 handle_completion(): completion failed with -2 for obj=lib/python3.10/site-packages/pip/_vendor/cachecontrol/__pycache__/controller.cpython-310.pyc
20 handle_completion(): completion failed with -2 for obj=lib/python3.10/site-packages/platformdirs/windows.py
```

with this patch: 
```
2025-08-01T18:44:59.666+0000 7ff8b662bc00 20 get_obj_state: setting s->obj_tag to c9e293af-c02d-4722-81ad-815bdf5980bb.4509.17556354692236455728
2025-08-01T18:44:59.666+0000 7ff8b662bc00 10 INFO: bucket index shard .dir.c9e293af-c02d-4722-81ad-815bdf5980bb.4509.1.6 missing, creating...
2025-08-01T18:44:59.670+0000 7ff8b662bc00 20  bucket index object: :.dir.c9e293af-c02d-4722-81ad-815bdf5980bb.4509.1.6
2025-08-01T18:44:59.670+0000 7ff8b662bc00 20 INFO: reindex_obj: reindexing test-bucket:lib/python3.10/site-packages/setuptools/command/upload_docs.py
2025-08-01T18:44:59.670+0000 7ff8b662bc00 20 get_obj_state: octx=0x7fff0edf4b80 obj=test-bucket:lib/python3.10/site-packages/setuptools/command/upload_docs.py state=0x55cc863bbf68 s->prefetch_data=0
```


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
