### PR TITLE
doc: Use ref instead of full URLs for intra-docs links

### DIFF
--- a/doc/jaegertracing/index.rst
+++ b/doc/jaegertracing/index.rst
@@ -72,6 +72,7 @@ For single node testing Jaeger opentelemetry can be deployed using:
   to port the configured 6799. Use the option "--processor.jaeger-compact.server-host-port=6799" for manual Jaeger
   deployments.
 
+.. _jaegertracing-enable:
 
 HOW TO ENABLE TRACING IN CEPH
 -----------------------------

--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -305,6 +305,7 @@ Usage::
 
 	ceph config-key set <key> {<val>}
 
+.. _man-ceph-daemon:
 
 daemon
 ------

--- a/doc/rados/operations/devices.rst
+++ b/doc/rados/operations/devices.rst
@@ -57,10 +57,9 @@ information, run the following command:
 The ``[ident|fault]`` parameter determines which kind of light will blink.  By
 default, the `identification` light is used.
 
-.. note:: This command works only if the Cephadm or the Rook `orchestrator
-   <https://docs.ceph.com/docs/master/mgr/orchestrator/#orchestrator-cli-module>`_
-   module is enabled.  To see which orchestrator module is enabled, run the
-   following command:
+.. note:: This command works only if the Cephadm or the Rook
+   :ref:`orchestrator <orchestrator-cli-module>` module is enabled.  To see
+   which orchestrator module is enabled, run the following command:
 
    .. prompt:: bash $
 

--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -187,9 +187,9 @@ following conditions are true:
 - a fatal signal has been raised or
 - an assertion within Ceph code has been triggered or
 - sending in-memory logs to the output log has been manually triggered.
-  Consult `the portion of the "Ceph Administration Tool documentation
+  Consult :ref:`the portion of the "Ceph Administration Tool" documentation
   that provides an example of how to submit admin socket commands
-  <http://docs.ceph.com/en/latest/man/8/ceph/#daemon>`_ for more detail.
+  <man-ceph-daemon>` for more detail.
 
 Log levels and memory levels can be set either together or separately. If a
 subsystem is assigned a single value, then that value determines both the log

--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -511,7 +511,7 @@ Tracing is disabled by default, so we should enable tracing for this specific bu
   end
 
 
-If `tracing is enabled <https://docs.ceph.com/en/latest/jaegertracing/#how-to-enable-tracing-in-ceph/>`_ on the RGW, the value of Request.Trace.Enable is true, so we should disable tracing for all other requests that do not match the bucket name.
+If :ref:`tracing is enabled <jaegertracing-enable>` on the RGW, the value of Request.Trace.Enable is true, so we should disable tracing for all other requests that do not match the bucket name.
 In the ``prerequest`` context:
 
 .. code-block:: lua

--- a/doc/radosgw/multisite.rst
+++ b/doc/radosgw/multisite.rst
@@ -1536,9 +1536,8 @@ Setting a Zone
 
 Configuring a zone involves specifying a series of Ceph Object Gateway
 pools. For consistency, we recommend using a pool prefix that is the
-same as the zone name. See
-`Pools <http://docs.ceph.com/en/latest/rados/operations/pools/#pools>`__
-for details of configuring pools.
+same as the zone name. See :ref:`rados_pools` for details of
+configuring pools.
 
 To set a zone, create a JSON object consisting of the pools, save the
 object to a file (e.g., ``zone.json``); then, run the following

--- a/doc/radosgw/pools.rst
+++ b/doc/radosgw/pools.rst
@@ -15,9 +15,8 @@ When ``radosgw`` first tries to operate on a zone pool that does not exist, it
 will create that pool with the default values from ``osd pool default pg num``
 and ``osd pool default pgp num``. These defaults are sufficient for some pools,
 but others (especially those listed in ``placement_pools`` for the bucket index
-and data) will require additional tuning. See `Pools
-<http://docs.ceph.com/en/latest/rados/operations/pools/#pools>`__ for details
-on pool creation.
+and data) will require additional tuning. See :ref:`rados_pools` for details on
+pool creation.
 
 .. _radosgw-pool-namespaces:
 

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -89,8 +89,7 @@ For rpm based instructions execute the following commands:
       ceph osd lspools
 
    If it does not exist instructions for creating pools can be found on the
-   `RADOS pool operations page
-   <http://docs.ceph.com/en/latest/rados/operations/pools/>`_.
+   :ref:`RADOS pool operations page <rados_pools>`.
 
 #. As ``root``, on a iSCSI gateway node, create a file named
    ``iscsi-gateway.cfg`` in the ``/etc/ceph/`` directory:

--- a/doc/start/hardware-recommendations.rst
+++ b/doc/start/hardware-recommendations.rst
@@ -173,8 +173,8 @@ drives:
 
 For more
 information on how to effectively use a mix of fast drives and slow drives in
-your Ceph cluster, see the `block and block.db`_ section of the Bluestore
-Configuration Reference.
+your Ceph cluster, see the :ref:`block and block.db <bluestore-mixed-device-config>`
+section of the Bluestore Configuration Reference.
 
 Hard Disk Drives
 ----------------
@@ -613,7 +613,6 @@ found above and elsewhere within this documentation.
 
 
 
-.. _block and block.db: https://docs.ceph.com/en/latest/rados/configuration/bluestore-config-ref/#block-and-block-db
 .. _Ceph blog: https://ceph.com/community/blog/
 .. _Ceph Write Throughput 1: http://ceph.com/community/ceph-performance-part-1-disk-controller-write-throughput/
 .. _Ceph Write Throughput 2: http://ceph.com/community/ceph-performance-part-2-write-throughput-without-ssd-journals/


### PR DESCRIPTION
Labels mostly existed already but add labels in 2 files.

Add missing closing quotation mark in `rados/troubleshooting/log-and-debug.rst`.

Also fixes the link in `doc/radosgw/lua-scripting.rst` to anchor in `doc/jaegertracing/index.rst` that used a wrong anchor.

Links to each individual hunk of the patch, hopefully this makes reviewing faster:
`doc/jaegertracing/index.rst` `doc/man/8/ceph.rst` just adding a label, no change in rendered docs:
- https://ceph--64803.org.readthedocs.build/en/64803/jaegertracing/
- https://ceph--64803.org.readthedocs.build/en/64803/man/8/ceph/

`doc/rados/operations/devices.rst`:
- Before: https://docs.ceph.com/en/latest/rados/operations/devices/#identifying-physical-devices
- Rendered PR: https://ceph--64803.org.readthedocs.build/en/64803/rados/operations/devices/#identifying-physical-devices

`doc/rados/troubleshooting/log-and-debug.rst`:
- Before: https://docs.ceph.com/en/latest/rados/troubleshooting/log-and-debug/#ceph-subsystems
- Rendered PR: https://ceph--64803.org.readthedocs.build/en/64803/rados/troubleshooting/log-and-debug/#ceph-subsystems

`doc/radosgw/lua-scripting.rst`: scroll down 3 pages.
- Before: https://docs.ceph.com/en/latest/radosgw/lua-scripting/#lua-code-samples
- Rendered PR: https://ceph--64803.org.readthedocs.build/en/64803/radosgw/lua-scripting/#lua-code-samples

`doc/radosgw/multisite.rst`:
- Before: https://docs.ceph.com/en/latest/radosgw/multisite/#setting-a-zone
- Rendered PR: https://ceph--64803.org.readthedocs.build/en/64803/radosgw/multisite/#setting-a-zone

`doc/radosgw/pools.rst`:
- Before: https://docs.ceph.com/en/latest/radosgw/pools/#tuning
- Rendered PR: https://ceph--64803.org.readthedocs.build/en/64803/radosgw/pools/#tuning

`doc/rbd/iscsi-target-cli.rst`: scroll down 1 page.
- Before: https://docs.ceph.com/en/latest/rbd/iscsi-target-cli/#configuring-the-iscsi-target-using-the-command-line-interface
- Rendered PR: https://ceph--64803.org.readthedocs.build/en/64803/rbd/iscsi-target-cli/#configuring-the-iscsi-target-using-the-command-line-interface

`doc/start/hardware-recommendations.rst`:
- Before: https://docs.ceph.com/en/latest/start/hardware-recommendations/#data-storage
- Rendered PR: https://ceph--64803.org.readthedocs.build/en/64803/start/hardware-recommendations/#data-storage





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
