### PR TITLE
doc/cephadm: Small improvements in services/tracing.rst

### DIFF
--- a/doc/cephadm/services/tracing.rst
+++ b/doc/cephadm/services/tracing.rst
@@ -8,38 +8,35 @@ Tracing Services
 Jaeger Tracing
 ==============
 
-Ceph uses Jaeger as the tracing backend. in order to use tracing, we need to deploy those services.
+Ceph uses Jaeger as its tracing backend. In order to use tracing, we need to
+deploy those services.
 
-Further details on tracing in ceph:
-
-`Ceph Tracing documentation <https://docs.ceph.com/en/latest/jaegertracing/#jaeger-distributed-tracing/>`_
+For further details on tracing in Ceph, see
+:ref:`Ceph tracing documentation <jaegertracing>`.
 
 Deployment
 ==========
 
-Jaeger services consist of 3 services:
+Jaeger tracing consists of 3 services:
 
-1. Jaeger Agent
+#. Jaeger Agent
+#. Jaeger Collector
+#. Jaeger Query
 
-2. Jaeger Collector
+Jaeger requires a database for the traces. We use ElasticSearch (version 6)
+by default.
 
-3. Jaeger Query
+To deploy Jaeger services when not using your own ElasticSearch (deploys
+all 3 services with a new ElasticSearch container):
 
-Jaeger requires a database for the traces. we use ElasticSearch (version 6) by default.
+.. prompt:: bash #
 
+   ceph orch apply jaeger
 
-To deploy jaeger tracing service, when not using your own ElasticSearch:
+To deploy Jaeger services with an existing ElasticSearch cluster and
+an existing Jaeger query (deploys agents and collectors only):
 
-#. Deploy jaeger services, with a new elasticsearch container:
+.. prompt:: bash #
 
-    .. prompt:: bash #
-
-        ceph orch apply jaeger
-
-
-#. Deploy jaeger services, with existing elasticsearch cluster and existing jaeger query (deploy agents and collectors):
-
-     .. prompt:: bash #
-
-        ceph orch apply jaeger --without-query --es_nodes=ip:port,..
+   ceph orch apply jaeger --without-query --es_nodes=ip:port,..
 

--- a/doc/jaegertracing/index.rst
+++ b/doc/jaegertracing/index.rst
@@ -1,3 +1,5 @@
+.. _jaegertracing:
+
 JAEGER- DISTRIBUTED TRACING
 ===========================
 


### PR DESCRIPTION
Use ref instead of a full URL link and add label for it in `doc/jaegertracing/index.rst`.

Capitalize "Ceph", "Jaeger", "ElasticSearch" consistently.  
Start sentences with capital case consistently.  
Fix a typo.

Wrap lines a bit before column 80.

Use an ordered list instead of hardcoding list numbers in separate paragraphs.

Don't use ordered list for items that do not both fit under the text paragraph introducing the list.  
Rewrite the sentences to be more consistent and hopefully more correct.

Add articles that I believe should be there.

- Before: https://docs.ceph.com/en/latest/cephadm/services/tracing/
- Rendered PR: https://ceph--64808.org.readthedocs.build/en/64808/cephadm/services/tracing/





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
