### PR TITLE
doc/radosgw: Small improvements in s3-notification-compatibility.rst

### DIFF
--- a/doc/radosgw/s3-notification-compatibility.rst
+++ b/doc/radosgw/s3-notification-compatibility.rst
@@ -4,20 +4,24 @@
 S3 Bucket Notifications Compatibility
 =====================================
 
-Ceph's `Bucket Notifications`_ API follows `AWS S3 Bucket Notifications API`_. However, some differences exist, as listed below.
+Ceph's `Bucket Notifications`_ API follows `AWS S3 Bucket Notifications API`_.
+However, some differences exist, as listed below.
 
 
 .. note::
 
-    Compatibility is different depending on which of the above mechanism is used
+   Compatibility is different depending on which of the below mechanisms
+   is used.
 
 Supported Destination
 ---------------------
 
-AWS supports: **SNS**, **SQS** and **Lambda** as possible destinations (AWS internal destinations).
+AWS supports: **SNS**, **SQS** and **Lambda** as possible destinations (AWS
+internal destinations).
 Currently, we support: **HTTP/S**, **Kafka** and **AMQP**.
 
-We are using the **SNS** ARNs to represent the **HTTP/S**, **Kafka** and **AMQP** destinations.
+We are using the **SNS** ARNs to represent the **HTTP/S**, **Kafka** and
+**AMQP** destinations.
 
 Notification Configuration XML
 ------------------------------
@@ -37,13 +41,16 @@ REST API Extension
 
 Ceph's bucket notification API has the following extensions:
 
-- Deletion of a specific notification, or all notifications on a bucket, using the ``DELETE`` verb
+- Deletion of a specific notification, or all notifications on a bucket,
+  using the ``DELETE`` verb
 
- - In S3, all notifications are deleted when the bucket is deleted, or when an empty notification is set on the bucket
+  - In S3, all notifications are deleted when the bucket is deleted, or
+    when an empty notification is set on the bucket.
 
-- Getting the information on a specific notification (when more than one exists on a bucket)
+- Getting the information on a specific notification (when more than one
+  exists on a bucket)
 
-  - In S3, it is only possible to fetch all notifications on a bucket
+  - In S3, it is only possible to fetch all notifications on a bucket.
 
 - In addition to filtering based on prefix/suffix of object keys we support:
 
@@ -53,15 +60,18 @@ Ceph's bucket notification API has the following extensions:
 
   - Filtering based on object tags
 
-- Each one of the additional filters extends the S3 API and using it will require extension of the client SDK (unless you are using plain HTTP).
+- Each one of the additional filters extends the S3 API and using it will
+  require extension of the client SDK (unless you are using plain HTTP).
 
-- Filtering overlapping is allowed, so that same event could be sent as different notification
+- Filtering overlapping is allowed, so that same event could be sent as
+  different notification.
 
 
 Unsupported Fields in the Event Record
 --------------------------------------
 
-The records sent for bucket notification follows the format described in: `Event Message Structure`_.
+The records sent for bucket notification follows the format described in:
+`Event Message Structure`_.
 However, the ``requestParameters.sourceIPAddress`` field will be sent empty.
 
 
@@ -141,32 +151,39 @@ Event Types
 
 .. note::
 
-   The ``s3:ObjectRemoved:DeleteMarkerCreated`` event presents information on the latest version of the object
+   The ``s3:ObjectRemoved:DeleteMarkerCreated`` event presents information
+   on the latest version of the object.
 
 .. note::
 
-   In case of multipart upload, an ``ObjectCreated:CompleteMultipartUpload`` notification will be sent at the end of the process.
+   In case of multipart upload, an ``ObjectCreated:CompleteMultipartUpload``
+   notification will be sent at the end of the process.
 
 .. note::
 
-   The ``s3:ObjectSynced:Create`` event is sent when an object successfully syncs to a zone. It must be explicitly set for each zone.
+   The ``s3:ObjectSynced:Create`` event is sent when an object successfully
+   syncs to a zone. It must be explicitly set for each zone.
 
 Topic Configuration
 -------------------
-In the case of bucket notifications, the topics management API will be derived from `AWS Simple Notification Service API`_.
-Note that most of the API is not applicable to Ceph, and only the following actions are implemented:
+In the case of bucket notifications, the topics management API will be
+derived from `AWS Simple Notification Service API`_.
+Note that most of the API is not applicable to Ceph, and only the following
+actions are implemented:
 
- - ``CreateTopic``
- - ``DeleteTopic``
- - ``ListTopics``
+- ``CreateTopic``
+- ``DeleteTopic``
+- ``ListTopics``
 
 We also have the following extensions to topic configuration:
 
- - In ``GetTopic`` we allow fetching a specific topic, instead of all user topics
- - In ``CreateTopic``
+- In ``GetTopic`` we allow fetching a specific topic, instead of all
+  user topics.
+- In ``CreateTopic``:
 
-  - we allow setting endpoint attributes
-  - we allow setting opaque data that will be sent to the endpoint in the notification
+  - We allow setting endpoint attributes.
+  - We allow setting opaque data that will be sent to the endpoint in
+    the notification.
 
 
 .. _AWS Simple Notification Service API: https://docs.aws.amazon.com/sns/latest/api/API_Operations.html


### PR DESCRIPTION
Attempt a small fix to a grammatical error in a sentence.  
It should also refer to "below" and not "above", probably.

End full sentences in full stops.

Indent an unordered list consistently so that it renders consistently with the same bullets.
Also indent all various blocks at the same columns consistently.

Wrap lines before column 80 while we're at it.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
