### PR TITLE
dmclock: Add crimson specific implementation of RunEvery class

### DIFF
--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -72,7 +72,7 @@ target_link_libraries(crimson-osd
   crimson
   ${FMT_LIB}
   Boost::MPL
-  dmclock::dmclock)
+  dmclock::crimson)
 set_target_properties(crimson-osd PROPERTIES
   POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE})
 install(TARGETS crimson-osd DESTINATION bin)

--- a/src/dmclock/src/CMakeLists.txt
+++ b/src/dmclock/src/CMakeLists.txt
@@ -12,3 +12,13 @@ target_include_directories(dmclock PUBLIC
 target_link_libraries(dmclock
   PUBLIC Boost::boost
   PRIVATE Threads::Threads)
+
+if (WITH_CRIMSON)
+  add_library(dmclock_crimson STATIC ${dmc_srcs})
+  add_library(dmclock::crimson ALIAS dmclock_crimson)
+  target_compile_definitions(dmclock_crimson PRIVATE WITH_CRIMSON)
+  target_compile_options(dmclock_crimson PRIVATE -Wno-write-strings -Wall)
+
+  target_include_directories(dmclock_crimson PRIVATE seastar)
+  target_link_libraries(dmclock_crimson PRIVATE seastar)
+endif()

--- a/src/dmclock/support/src/run_every.cc
+++ b/src/dmclock/support/src/run_every.cc
@@ -19,6 +19,40 @@
 // can define ADD_MOVE_SEMANTICS, although not fully debugged and tested
 
 
+
+#ifdef WITH_CRIMSON
+crimson::RunEvery::RunEvery(std::chrono::milliseconds _wait_period,
+                   std::function<void()> _body)
+  : wait_period(_wait_period), body(std::move(_body))
+{
+  timer.set_callback([this] {
+    on_timer();
+  });
+}
+
+void crimson::RunEvery::start()
+{
+  arm_timer();
+}
+
+crimson::RunEvery::~RunEvery() {
+  timer.cancel();
+}
+
+void crimson::RunEvery::try_update(std::chrono::milliseconds _wait_period) {
+  wait_period = _wait_period;
+}
+
+void crimson::RunEvery::arm_timer() {
+  timer.arm(wait_period);
+}
+
+void crimson::RunEvery::on_timer() {
+  body();
+  arm_timer();  // reschedule again
+}
+
+#else
 namespace chrono = std::chrono;
 
 
@@ -92,3 +126,5 @@ void crimson::RunEvery::run() {
     }
   }
 }
+
+#endif

--- a/src/dmclock/support/src/run_every.h
+++ b/src/dmclock/support/src/run_every.h
@@ -14,7 +14,36 @@
 
 
 #pragma once
+#ifdef WITH_CRIMSON
+// ---------- Crimson/Seastar version ----------
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/loop.hh>
+#include <atomic>
 
+namespace crimson {
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+
+class RunEvery {
+  std::chrono::milliseconds wait_period;
+  std::function<void()> body;
+  seastar::timer<seastar::lowres_clock> timer;
+  void arm_timer();
+  void on_timer();
+public:
+  RunEvery(std::chrono::milliseconds _wait_period,
+           std::function<void()> _body);
+
+  ~RunEvery();
+
+  void try_update(std::chrono::milliseconds _wait_period);
+  void start();
+};
+
+}
+
+#else
 #include <chrono>
 #include <mutex>
 #include <condition_variable>
@@ -79,3 +108,5 @@ namespace crimson {
     void run();
   };
 }
+
+#endif


### PR DESCRIPTION
The class itself use to run a task in background, the current
implemention would not work for crimson.

Fixes: https://tracker.ceph.com/issues/72456
Signed-off-by: Mohit Agrawal <moagrawa@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
