### PR TITLE
doc/rados: Use ref instead of relative external links

### DIFF
--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -4,7 +4,7 @@
  Erasure code
 ==============
 
-By default, Ceph `pools <../pools>`_ are created with the type "replicated". In
+By default, Ceph :ref:`rados_pools` are created with the type "replicated". In
 replicated-type pools, every object is copied to multiple disks. This
 multiple copying is the method of data protection known as "replication".
 
@@ -169,8 +169,8 @@ no two *chunks* are stored in the same rack.
                                  +------+
 
  
-More information can be found in the `erasure-code profiles
-<../erasure-code-profile>`_ documentation.
+More information can be found in the :ref:`erasure-code-profiles`
+documentation.
 
 
 Erasure Coding with Overwrites
@@ -204,7 +204,7 @@ erasure-coded pool as the ``--data-pool`` during image creation:
     rbd create --size 1G --data-pool ec_pool replicated_pool/image_name
 
 For CephFS, an erasure-coded pool can be set as the default data pool during
-file system creation or via `file layouts <../../../cephfs/file-layouts>`_.
+file system creation or via :ref:`file-layouts`.
 
 Erasure-coded pool overhead
 ---------------------------

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -15,8 +15,8 @@ Pools provide:
   
   For example: a typical configuration stores three replicas
   (copies) of each RADOS object (that is: ``size = 3``), but you can configure
-  the number of replicas on a per-pool basis. For `erasure-coded pools
-  <../erasure-code>`_, resilience is defined as the number of coding (aka parity) chunks 
+  the number of replicas on a per-pool basis. For :ref:`erasure-coded pools
+  <ecpool>`, resilience is defined as the number of coding (aka parity) chunks
   (for example, ``m = 2`` in the default erasure code profile).
 
 - **Placement Groups**: The :ref:`autoscaler <pg-autoscaler>` sets the number
@@ -99,12 +99,12 @@ To retrieve even more information, you can execute this command with the ``--for
 Creating a Pool
 ===============
 
-Before creating a pool, consult `Pool, PG and CRUSH Config Reference`_. The
+Before creating a pool, consult :ref:`rados_config_pool_pg_crush_ref`. The
 Ceph central configuration database contains a default setting
 (namely, ``osd_pool_default_pg_num``) that determines the number of PGs assigned
 to a new pool if no specific value has been specified. It is possible to change
 this value from its default. For more on the subject of setting the number of
-PGs per pool, see `setting the number of placement groups`_.
+PGs per pool, see :ref:`setting the number of placement groups`.
 
 .. note:: In Luminous and later releases, each pool must be associated with the
    application that will be using the pool. For more information, see
@@ -163,7 +163,7 @@ following:
 
    The pool's data protection strategy. This can be either ``replicated``
    (like RAID1 and RAID10) ``erasure (a kind
-   of `generalized parity RAID <../erasure-code>`_ strategy like RAID6 but
+   of :ref:`generalized parity RAID <ecpool>` strategy like RAID6 but
    more flexible).  A 
    ``replicated`` pool yields less usable capacity for a given amount of
    raw storage but is suitable for all Ceph components and use cases.
@@ -185,12 +185,12 @@ following:
 
    :Type: String
    :Required: No.
-   :Default: For ``replicated`` pools, it is by default the rule specified by the :confval:`osd_pool_default_crush_rule` configuration option. This rule must exist.  For ``erasure`` pools, it is the ``erasure-code`` rule if the ``default`` `erasure code profile`_ is used or the ``{pool-name}`` rule  if not. This rule will be created implicitly if it doesn't already exist.
+   :Default: For ``replicated`` pools, it is by default the rule specified by the :confval:`osd_pool_default_crush_rule` configuration option. This rule must exist.  For ``erasure`` pools, it is the ``erasure-code`` rule if the ``default`` :ref:`erasure code profile <erasure-code-profiles>` is used or the ``{pool-name}`` rule  if not. This rule will be created implicitly if it doesn't already exist.
 
 .. describe:: [erasure-code-profile=profile]
 
-   For ``erasure`` pools only. Instructs Ceph to use the specified `erasure
-   code profile`_. This profile must be an existing profile as defined via
+   For ``erasure`` pools only. Instructs Ceph to use the specified :ref:`erasure
+   code profile <erasure-code-profiles>`. This profile must be an existing profile as defined via
    the dashboard or invoking ``osd erasure-code-profile set``.  Note that
    changes to the EC profile of a pool after creation do *not* take effect.
    To change the EC profile of an existing pool one must modify the pool to
@@ -198,8 +198,6 @@ following:
 
   :Type: String
   :Required: No.
-
-.. _erasure code profile: ../erasure-code-profile
 
 .. describe:: --autoscale-mode=<on,off,warn>
 
@@ -275,9 +273,7 @@ To remove a pool, you must set the ``mon_allow_pool_delete`` flag to ``true``
 in central configuration, otherwise the Ceph  monitors will refuse to remove
 pools.
 
-For more information, see `Monitor Configuration`_.
-
-.. _Monitor Configuration: ../../configuration/mon-config-ref
+For more information, see :ref:`Monitor Configuration <monitor-config-reference>`.
 
 If there are custom CRUSH rules that are no longer in use or needed, consider
 deleting those rules.
@@ -420,7 +416,7 @@ You may set values for the following keys:
 
 .. describe:: min_size
    
-   :Description: Sets the minimum number of active replicas (or shards) required for PGs to be active and thus for I/O operations to proceed.  For further details, see `Setting the Number of RADOS Object Replicas`_.  For erasure-coded pools, this should be set to a value greater than ``K``. If I/O is allowed with only ``K`` shards available, there will be no redundancy and data will be lost in the event of an additional, permanent OSD failure. For more information, see `Erasure Code <../erasure-code>`_
+   :Description: Sets the minimum number of active replicas (or shards) required for PGs to be active and thus for I/O operations to proceed.  For further details, see `Setting the Number of RADOS Object Replicas`_.  For erasure-coded pools, this should be set to a value greater than ``K``. If I/O is allowed with only ``K`` shards available, there will be no redundancy and data will be lost in the event of an additional, permanent OSD failure. For more information, see :ref:`ecpool`
    :Type: Integer
    :Version: ``0.54`` and above
 
@@ -902,9 +898,7 @@ Here are the break downs of the argument:
    :Type: String
    :Required: Yes.
 
-.. _Pool, PG and CRUSH Config Reference: ../../configuration/pool-pg-config-ref
 .. _Bloom Filter: https://en.wikipedia.org/wiki/Bloom_filter
-.. _setting the number of placement groups: ../placement-groups#set-the-number-of-placement-groups
 .. _Erasure Coding with Overwrites: ../erasure-code#erasure-coding-with-overwrites
 .. _Block Device Commands: ../../../rbd/rados-rbd-cmds/#create-a-block-device-pool
 .. _pgcalc: ../pgcalc

--- a/doc/rados/troubleshooting/troubleshooting-osd.rst
+++ b/doc/rados/troubleshooting/troubleshooting-osd.rst
@@ -11,7 +11,7 @@ is a monitor quorum.
 
 If the monitors don't have a quorum or if there are errors with the monitor
 status, address the monitor issues before proceeding by consulting the material
-in `Troubleshooting Monitors <../troubleshooting-mon>`_.
+in :ref:`rados-troubleshooting-mon`.
 
 Next, check your networks to make sure that they are running properly. Networks
 can have a significant impact on OSD operation and performance. Look for
@@ -421,7 +421,7 @@ the full OSD.
    copy of your data on at least one OSD. Deleting placement group directories
    is a rare and extreme intervention. It is not to be undertaken lightly.
 
-See `Monitor Config Reference`_ for more information.
+See :ref:`monitor-config-reference` for more information.
 
 
 OSDs are Slow/Unresponsive
@@ -812,11 +812,8 @@ being marked ``out`` (regardless of the current value of
 
 
 .. _iostat: https://en.wikipedia.org/wiki/Iostat
-.. _Ceph Logging and Debugging: ../../configuration/ceph-conf#ceph-logging-and-debugging
 .. _Logging and Debugging: ../log-and-debug
-.. _Debugging and Logging: ../debug
 .. _Monitor/OSD Interaction: ../../configuration/mon-osd-interaction
-.. _Monitor Config Reference: ../../configuration/mon-config-ref
 .. _monitoring your OSDs: ../../operations/monitoring-osd-pg
 
 .. _monitoring OSDs: ../../operations/monitoring-osd-pg/#monitoring-osds


### PR DESCRIPTION
Instead of external links use :ref: where dst labels exist already in: 
- `operations/erasure-code.rst`
- `operations/pools.rst` - also fixes 1 broken anchor in the link
- `troubleshooting/troubleshooting-osd.rst`

Use link text generation where it is reasonably close to previous manual link text.
Delete some unused link definitions.

`operations/erasure-code.rst`:
- Before: https://docs.ceph.com/en/latest/rados/operations/erasure-code/
- Rendered PR: https://ceph--64838.org.readthedocs.build/en/64838/rados/operations/pools/

`operations/pools.rst`:
- Before: https://docs.ceph.com/en/latest/rados/operations/pools/
- Rendered PR: https://ceph--64838.org.readthedocs.build/en/64838/rados/operations/pools/

`troubleshooting/troubleshooting-osd.rst`:
- Before: https://docs.ceph.com/en/latest/rados/troubleshooting/troubleshooting-osd/
- Rendered PR: https://ceph--64838.org.readthedocs.build/en/64838/rados/troubleshooting/troubleshooting-osd/




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
