### PR TITLE
replace `tl::expected` with `std::expected` (modified to unstale)

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -12,6 +12,7 @@
  * 
  */
 
+#include <expected>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -387,7 +388,7 @@ int main(int argc, const char **argv)
   // Run a benchmark if specified
   if (run_benchmark) {
     store->mount();
-    tl::expected<std::string, int> res =
+    std::expected<std::string, int> res =
       OSD::run_osd_bench(g_ceph_context, store.get());
     if (!res.has_value()) {
       int ret = res.error();

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -8,6 +8,7 @@
 #endif
 
 #include <charconv>
+#include <expected>
 
 #include "common/fmt_common.h"
 
@@ -39,10 +40,10 @@ inline bool MemoryModel::cmp_against(
 }
 
 
-tl::expected<int64_t, std::string> MemoryModel::get_mapped_heap()
+std::expected<int64_t, std::string> MemoryModel::get_mapped_heap()
 {
   if (!proc_maps.is_open()) {
-    return tl::unexpected("unable to open proc/maps");
+    return std::unexpected("unable to open proc/maps");
   }
   // always rewind before reading
   proc_maps.clear();
@@ -108,10 +109,10 @@ tl::expected<int64_t, std::string> MemoryModel::get_mapped_heap()
 }
 
 
-tl::expected<mem_snap_t, std::string> MemoryModel::full_sample()
+std::expected<mem_snap_t, std::string> MemoryModel::full_sample()
 {
   if (!proc_status.is_open()) {
-    return tl::unexpected("unable to open proc/status");
+    return std::unexpected("unable to open proc/status");
   }
   // always rewind before reading
   proc_status.clear();

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -15,12 +15,12 @@
 #ifndef CEPH_MEMORYMODEL_H
 #define CEPH_MEMORYMODEL_H
 
+#include <expected>
 #include <fstream>
 #include <string>
 #include <string_view>
 #include "include/common_fwd.h"
 #include "include/compat.h"
-#include "include/expected.hpp"
 
 
 class MemoryModel {
@@ -53,7 +53,7 @@ private:
    * \retval the mapped heap size, or an error message if the file had not been opened
    *    when the object was constructed.
    */
-  tl::expected<int64_t, std::string> get_mapped_heap();
+  std::expected<int64_t, std::string> get_mapped_heap();
 
   /**
    * @brief Compare a line against an expected data label
@@ -75,7 +75,7 @@ public:
    *    Note that no error is returned if only /proc/maps is not open (the heap
    *    size will be reported as 0).
    */
-  tl::expected<mem_snap_t, std::string> full_sample();
+  std::expected<mem_snap_t, std::string> full_sample();
 };
 
 #endif

--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -16,10 +16,10 @@
 #define MAPCACHER_H
 
 #include "include/Context.h"
-#include "include/expected.hpp"
 #include "common/sharedptr_registry.hpp"
 
 #include <boost/optional.hpp>
+#include <expected>
 
 #include <map>
 #include <set>
@@ -141,7 +141,7 @@ public:
     K last_key;
     V data;
   };
-  using MaybePosAndData = tl::expected<PosAndData, int>;
+  using MaybePosAndData = std::expected<PosAndData, int>;
 
   MaybePosAndData get_1st_after_key(
       K key  ///< [in] key after which to get next
@@ -157,13 +157,13 @@ public:
       std::pair<K, V> store;
       int r = driver->get_next(key, &store);
       if (r < 0 && r != -ENOENT) {
-        return tl::unexpected(r);
+        return std::unexpected(r);
       } else if (r == 0) {
 	got_store = true;
       }
 
       if (!got_cached && !got_store) {
-        return tl::unexpected(-ENOENT);
+        return std::unexpected(-ENOENT);
       } else if (got_cached && (!got_store || store.first >= cached.first)) {
 	if (cached.second) {
 	  return PosAndData{cached.first, *cached.second};
@@ -176,7 +176,7 @@ public:
       }
     }
     ceph_abort();  // not reachable
-    return tl::unexpected(-EINVAL);
+    return std::unexpected(-EINVAL);
   }
 
 

--- a/src/crimson/common/tmap_helpers.cc
+++ b/src/crimson/common/tmap_helpers.cc
@@ -7,6 +7,7 @@
 #include "include/encoding.h"
 #include "include/rados.h"
 
+#include <expected>
 #include <map>
 
 namespace detail {
@@ -103,29 +104,29 @@ public:
 
 namespace crimson::common {
 
-using do_tmap_up_ret = tl::expected<bufferlist, int>;
+using do_tmap_up_ret = std::expected<bufferlist, int>;
 do_tmap_up_ret do_tmap_up(bufferlist::const_iterator in, bufferlist contents)
 {
   detail::TMapContents tmap;
   auto bliter = contents.cbegin();
   int r = tmap.decode(bliter);
   if (r < 0) {
-    return tl::unexpected(r);
+    return std::unexpected(r);
   }
   r = tmap.update(in);
   if (r < 0) {
-    return tl::unexpected(r);
+    return std::unexpected(r);
   }
   return tmap.encode();
 }
 
-using do_tmap_up_ret = tl::expected<bufferlist, int>;
+using do_tmap_up_ret = std::expected<bufferlist, int>;
 do_tmap_up_ret do_tmap_put(bufferlist::const_iterator in)
 {
   detail::TMapContents tmap;
   int r = tmap.decode(in);
   if (r < 0) {
-    return tl::unexpected(r);
+    return std::unexpected(r);
   }
   return tmap.encode();
 }

--- a/src/crimson/common/tmap_helpers.h
+++ b/src/crimson/common/tmap_helpers.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include "include/expected.hpp"
-
 #include "include/buffer.h"
 #include "include/encoding.h"
+
+#include <expected>
 
 namespace crimson::common {
 
@@ -22,7 +22,7 @@ namespace crimson::common {
  *   -EEXIST for CEPH_OSD_TMAP_CREATE on a key that exists
  *   -ENOENT for CEPH_OSD_TMAP_RM on a key that does not exist 
  */
-using do_tmap_up_ret = tl::expected<bufferlist, int>;
+using do_tmap_up_ret = std::expected<bufferlist, int>;
 do_tmap_up_ret do_tmap_up(bufferlist::const_iterator in, bufferlist contents);
 
 /**
@@ -34,7 +34,7 @@ do_tmap_up_ret do_tmap_up(bufferlist::const_iterator in, bufferlist contents);
  * @return buffer containing validated tmap encoded by in
  *   -EINVAL for decoding errors,
  */
-using do_tmap_up_ret = tl::expected<bufferlist, int>;
+using do_tmap_up_ret = std::expected<bufferlist, int>;
 do_tmap_up_ret do_tmap_put(bufferlist::const_iterator in);
 
 }

--- a/src/crimson/osd/main_config_bootstrap_helpers.h
+++ b/src/crimson/osd/main_config_bootstrap_helpers.h
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <expected>
 #include <iostream>
 #include <fstream>
 #include <random>
@@ -13,7 +14,6 @@
 #include <seastar/core/future.hh>
 
 #include "common/ceph_argparse.h"
-#include "include/expected.hpp"
 #include "include/random.h"
 
 namespace crimson::osd {
@@ -85,7 +85,7 @@ struct early_config_t {
  * therefore be called very early in main().  (See implementation for an
  * explanation).
  */
-tl::expected<early_config_t, int>
+std::expected<early_config_t, int>
 get_early_config(int argc, const char *argv[]);
 
 }

--- a/src/crimson/tools/objectstore/objectstore_tool.cc
+++ b/src/crimson/tools/objectstore/objectstore_tool.cc
@@ -2,13 +2,13 @@
 // vim: ts=8 sw=2 smarttab ft=cpp
 
 #include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <expected>
 #include <fmt/format.h>
 
 #include "common/hobject.h"
 #include "crimson/os/alienstore/alien_store.h"
 #include "crimson/os/futurized_collection.h"
 #include "crimson/os/futurized_store.h"
-#include "include/expected.hpp"
 #include "objectstore_tool.h"
 #include "seastar/core/future.hh"
 #include "seastar/core/smp.hh"
@@ -259,62 +259,62 @@ seastar::future<bool> StoreTool::set_bytes(
 }
 
 // Object attribute operations
-seastar::future<tl::expected<FuturizedStore::Shard::attrs_t, std::string>> StoreTool::get_attrs(
+seastar::future<std::expected<FuturizedStore::Shard::attrs_t, std::string>> StoreTool::get_attrs(
   const coll_t& cid,
   const ghobject_t& oid)
 {
   return seastar::smp::submit_to(
     shard_id,
-    [this, cid, oid]() -> seastar::future<tl::expected<FuturizedStore::Shard::attrs_t, std::string>>
+    [this, cid, oid]() -> seastar::future<std::expected<FuturizedStore::Shard::attrs_t, std::string>>
   {
     auto coll = co_await store->get_sharded_store().open_collection(cid
     ).handle_exception([](std::exception_ptr) {
       return seastar::make_ready_future<FuturizedStore::Shard::CollectionRef>(nullptr);
     });
     if (!coll) {
-      co_return tl::make_unexpected(std::string("Failed to open collection: collection does not exist"));
+      co_return std::unexpected(std::string("Failed to open collection: collection does not exist"));
     }
     using attrs_t = FuturizedStore::Shard::attrs_t;
-    using ret_t = tl::expected<attrs_t, std::string>;
+    using ret_t = std::expected<attrs_t, std::string>;
 
     co_return co_await store->get_sharded_store()
       .get_attrs(coll, oid)   // ertr::future<attrs_t>
       .safe_then(
         [](attrs_t&& a) {
-          return ret_t{tl::in_place, std::move(a)};
+          return ret_t{std::in_place, std::move(a)};
         },
         FuturizedStore::Shard::get_attrs_ertr::all_same_way(
           [](const std::error_code& e) {
-            return ret_t{tl::unexpected<std::string>(e.message())};
+            return ret_t{std::unexpected<std::string>(e.message())};
           })
       );
   });
 }
 
-seastar::future<tl::expected<std::string, std::string>> StoreTool::get_attr(
+seastar::future<std::expected<std::string, std::string>> StoreTool::get_attr(
   const coll_t& cid,
   const ghobject_t& oid,
   const std::string& key)
 {
   return seastar::smp::submit_to(
     shard_id,
-    [this, cid, oid, key]() -> seastar::future<tl::expected<std::string, std::string>>
+    [this, cid, oid, key]() -> seastar::future<std::expected<std::string, std::string>>
   {
     auto coll = co_await store->get_sharded_store().open_collection(cid
     ).handle_exception([](std::exception_ptr) {
       return seastar::make_ready_future<FuturizedStore::Shard::CollectionRef>(nullptr);
     });
     if (!coll) {
-      co_return tl::make_unexpected(std::string("Failed to open collection: collection does not exist"));
+      co_return std::unexpected(std::string("Failed to open collection: collection does not exist"));
     }
-    using return_type = tl::expected<std::string, std::string>;
+    using return_type = std::expected<std::string, std::string>;
     co_return co_await store->get_sharded_store().get_attr(coll, oid, key).safe_then(
       [](auto&& bl) {
-        return return_type{tl::in_place, bl.to_str()};
+        return return_type{std::in_place, bl.to_str()};
       },
       FuturizedStore::Shard::get_attr_errorator::all_same_way(
         [](const std::error_code& e) {
-          return return_type{tl::unexpected<std::string>(e.message())};
+          return return_type{std::unexpected<std::string>(e.message())};
         }
       )
     );

--- a/src/crimson/tools/objectstore/objectstore_tool.h
+++ b/src/crimson/tools/objectstore/objectstore_tool.h
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include <expected>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -9,7 +10,6 @@
 #include "common/hobject.h"
 #include "crimson/os/alienstore/alien_store.h"
 #include "crimson/os/futurized_store.h"
-#include "include/expected.hpp"
 #include "osd/osd_types.h"
 #include "seastar/core/future.hh"
 
@@ -67,10 +67,10 @@ public:
     const std::string& data);
   
   // Object attribute operations
-  seastar::future<tl::expected<FuturizedStore::Shard::attrs_t, std::string>> get_attrs(
+  seastar::future<std::expected<FuturizedStore::Shard::attrs_t, std::string>> get_attrs(
     const coll_t& cid,
     const ghobject_t& oid);
-  seastar::future<tl::expected<std::string, std::string>> get_attr(
+  seastar::future<std::expected<std::string, std::string>> get_attr(
     const coll_t& cid,
     const ghobject_t& oid,
     const std::string& key);

--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -18,6 +18,7 @@
 
 #include <concepts>
 #include <cstddef>
+#include <expected>
 #include <memory>
 #include <optional>
 #include <tuple>
@@ -40,10 +41,6 @@
 #include <boost/uuid/uuid.hpp>
 
 #include <boost/system/error_code.hpp>
-
-// Will be in C++20!
-
-#include "include/expected.hpp"
 
 // Had better be in C++20. Why is this not in Boost?
 
@@ -1688,7 +1685,7 @@ public:
       }, consigned);
   }
 
-  tl::expected<ceph::timespan, boost::system::error_code>
+  std::expected<ceph::timespan, boost::system::error_code>
   check_watch(uint64_t cookie);
 
   using NotifySig =
@@ -1856,7 +1853,7 @@ private:
 	      std::optional<std::chrono::seconds> timeout,
 	      std::uint32_t queue_size);
   void next_notification_(uint64_t cookie, NextNotificationComp c);
-  tl::expected<ceph::timespan, boost::system::error_code>
+  std::expected<ceph::timespan, boost::system::error_code>
   watch_check_(std::uint64_t cookie);
   void notify_ack_(Object o, IOContext _ioc,
 		   uint64_t notify_id,

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -14,6 +14,7 @@
 
 #include <boost/asio/associated_executor.hpp>
 #include <boost/asio/error.hpp>
+#include <expected>
 #include <optional>
 #include <deque>
 #include <queue>
@@ -1609,13 +1610,13 @@ void RADOS::notify_ack_(Object o, IOContext _ioc,
 		       nullptr, ioc->extra_op_flags, std::move(c));
 }
 
-tl::expected<ceph::timespan, bs::error_code> RADOS::check_watch(uint64_t cookie)
+std::expected<ceph::timespan, bs::error_code> RADOS::check_watch(uint64_t cookie)
 {
   auto linger_op = reinterpret_cast<Objecter::LingerOp*>(cookie);
   if (impl->objecter->is_valid_watch(linger_op)) {
     return impl->objecter->linger_check(linger_op);
   } else {
-    return tl::unexpected(bs::error_code(ENOTCONN, bs::generic_category()));
+    return std::unexpected(bs::error_code(ENOTCONN, bs::generic_category()));
   }
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -18,6 +18,7 @@
 #include "acconfig.h"
 
 #include <cctype>
+#include <expected>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -2228,7 +2229,7 @@ int OSD::mkfs(CephContext *cct,
   return ret;
 }
 
-tl::expected<std::string, int>
+std::expected<std::string, int>
 OSD::run_osd_bench(CephContext *cct,
                    ObjectStore *store)
 {
@@ -2249,7 +2250,7 @@ OSD::run_osd_bench(CephContext *cct,
 
   int ret = osd_bench.run_test();
   if (ret != 0) {
-    return tl::unexpected(ret);
+    return std::unexpected(ret);
   }
 
   // Format the result in json format
@@ -2270,7 +2271,7 @@ OSD::run_osd_bench(CephContext *cct,
     f->flush(out);
     result = std::string(out.c_str(), out.length());
   } else {
-    return tl::unexpected(-1);
+    return std::unexpected(-1);
   }
 
   return result;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -42,6 +42,7 @@
 #include "osd/scheduler/OpScheduler.h"
 
 #include <atomic>
+#include <expected>
 #include <map>
 #include <memory>
 #include <string>
@@ -2173,7 +2174,7 @@ private:
 		  int whoami,
 		  std::string osdspec_affinity);
 
-  static tl::expected<std::string, int>
+  static std::expected<std::string, int>
     run_osd_bench(CephContext *cct, ObjectStore *store);
 
   /* remove any non-user xattrs from a std::map of them */

--- a/src/osd/SnapMapReaderI.h
+++ b/src/osd/SnapMapReaderI.h
@@ -6,10 +6,10 @@
  * \file
  * \brief Defines the interface for the snap-mapper used by the scrubber.
  */
+#include <expected>
 #include <set>
 
 #include "common/scrub_types.h"
-#include "include/expected.hpp"
 
 namespace Scrub {
 /*
@@ -35,7 +35,7 @@ struct SnapMapReaderI {
    *  \returns a set of snaps, or an error code
    *  \attn: only OBJ_ DB entries are consulted
    */
-  virtual tl::expected<std::set<snapid_t>, result_t> get_snaps(
+  virtual std::expected<std::set<snapid_t>, result_t> get_snaps(
     const hobject_t& hoid) const = 0;
 
   /**
@@ -45,7 +45,7 @@ struct SnapMapReaderI {
    *  A mismatch between both sets of entries will result in an error.
    *  \returns a set of snaps, or an error code.
    */
-  virtual tl::expected<std::set<snapid_t>, result_t>
+  virtual std::expected<std::set<snapid_t>, result_t>
   get_snaps_check_consistency(const hobject_t& hoid) const = 0;
 
   virtual ~SnapMapReaderI() = default;

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -14,6 +14,7 @@
 
 #include "SnapMapper.h"
 
+#include <expected>
 #include <fmt/printf.h>
 #include <fmt/ranges.h>
 
@@ -371,17 +372,17 @@ int SnapMapper::get_snaps(const hobject_t &oid, object_snaps *out) const
   }
 }
 
-tl::expected<std::set<snapid_t>, Scrub::SnapMapReaderI::result_t>
+std::expected<std::set<snapid_t>, Scrub::SnapMapReaderI::result_t>
 SnapMapper::get_snaps(const hobject_t &oid) const
 {
   auto snaps = get_snaps_common(oid);
   if (snaps) {
     return snaps->snaps;
   }
-  return tl::unexpected(snaps.error());
+  return std::unexpected(snaps.error());
 }
 
-tl::expected<SnapMapper::object_snaps, Scrub::SnapMapReaderI::result_t>
+std::expected<SnapMapper::object_snaps, Scrub::SnapMapReaderI::result_t>
 SnapMapper::get_snaps_common(const hobject_t &oid) const
 {
   ceph_assert(check(oid));
@@ -393,11 +394,11 @@ SnapMapper::get_snaps_common(const hobject_t &oid) const
   int r = backend.get_keys(keys, &got);
   if (r < 0) {
     dout(10) << __func__ << " " << oid << " got err " << r << dendl;
-    return tl::unexpected(result_t{code_t::backend_error, r});
+    return std::unexpected(result_t{code_t::backend_error, r});
   }
   if (got.empty()) {
     dout(10) << __func__ << " " << oid << " got.empty()" << dendl;
-    return tl::unexpected(result_t{code_t::not_found, -ENOENT});
+    return std::unexpected(result_t{code_t::not_found, -ENOENT});
   }
 
   object_snaps out;
@@ -406,7 +407,7 @@ SnapMapper::get_snaps_common(const hobject_t &oid) const
     decode(out, bp);
   } catch (...) {
     dout(1) << __func__ << ": " << oid << " decode failed" << dendl;
-    return tl::unexpected(result_t{code_t::backend_error, -EIO});
+    return std::unexpected(result_t{code_t::backend_error, -EIO});
   }
 
   dout(20) << __func__ << " " << oid << " " << out.snaps << dendl;
@@ -432,7 +433,7 @@ std::set<std::string> SnapMapper::to_raw_keys(
   return keys;
 }
 
-tl::expected<std::set<snapid_t>, result_t>
+std::expected<std::set<snapid_t>, result_t>
 SnapMapper::get_snaps_check_consistency(const hobject_t &hoid) const
 {
   // derive the set of snaps from the 'OBJ_' entry
@@ -455,7 +456,7 @@ SnapMapper::get_snaps_check_consistency(const hobject_t &hoid) const
     // that's a backend error, but for the SNA_ entries. Let's treat it as an
     // internal consistency error (although a backend error would have made
     // sense too).
-    return tl::unexpected(result_t{code_t::inconsistent, r});
+    return std::unexpected(result_t{code_t::inconsistent, r});
   }
 
   std::set<snapid_t> snaps_from_mapping;
@@ -468,7 +469,7 @@ SnapMapper::get_snaps_check_consistency(const hobject_t &hoid) const
 		   "{}: unexpected object ID {} for key{} (expected {})",
 		   __func__, obj, k, hoid)
 	      << dendl;
-      return tl::unexpected(result_t{code_t::inconsistent});
+      return std::unexpected(result_t{code_t::inconsistent});
     }
     snaps_from_mapping.insert(sn);
   }
@@ -478,7 +479,7 @@ SnapMapper::get_snaps_check_consistency(const hobject_t &hoid) const
 		  "{}: hoid:{} -> mapper internal inconsistency ({} vs {})",
 		  __func__, hoid, *obj_snaps, snaps_from_mapping)
 	     << dendl;
-    return tl::unexpected(result_t{code_t::inconsistent});
+    return std::unexpected(result_t{code_t::inconsistent});
   }
   dout(10) << fmt::format(
 		"{}: snaps for {}: {}", __func__, hoid, snaps_from_mapping)

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -16,6 +16,7 @@
 #define SNAPMAPPER_H
 
 #include <cstring>
+#include <expected>
 #include <map>
 #include <set>
 #include <string>
@@ -275,7 +276,7 @@ private:
     );
 
   /// Get snaps (as an 'object_snaps' object) for oid
-  tl::expected<object_snaps, SnapMapReaderI::result_t> get_snaps_common(
+  std::expected<object_snaps, SnapMapReaderI::result_t> get_snaps_common(
     const hobject_t &hoid) const;
 
   /// \returns vector with the first objects with @snap as a snap
@@ -370,7 +371,7 @@ private:
     MapCacher::Transaction<std::string, ceph::buffer::list> *t);
 
   /// Get snaps for oid - alternative interface
-  tl::expected<std::set<snapid_t>, SnapMapReaderI::result_t> get_snaps(
+  std::expected<std::set<snapid_t>, SnapMapReaderI::result_t> get_snaps(
     const hobject_t &hoid) const final;
 
   /**
@@ -379,7 +380,7 @@ private:
    * Returns snaps for hoid as in get_snaps(), but additionally validates the
    * snap->hobject_t mappings ('SNA_' entries).
    */
-  tl::expected<std::set<snapid_t>, SnapMapReaderI::result_t>
+  std::expected<std::set<snapid_t>, SnapMapReaderI::result_t>
   get_snaps_check_consistency(const hobject_t &hoid) const final;
 };
 WRITE_CLASS_ENCODER(SnapMapper::object_snaps)

--- a/src/osd/scrubber/ScrubStore.cc
+++ b/src/osd/scrubber/ScrubStore.cc
@@ -463,10 +463,10 @@ std::vector<bufferlist> Store::get_errors(
 
     // keys not smaller than end_key are not interesting
     if (latest_sh.has_value() && latest_sh->last_key >= end_key) {
-      latest_sh = tl::unexpected(-EINVAL);
+      latest_sh = std::unexpected(-EINVAL);
     }
     if (latest_dp.has_value() && latest_dp->last_key >= end_key) {
-      latest_dp = tl::unexpected(-EINVAL);
+      latest_dp = std::unexpected(-EINVAL);
     }
 
     if (!latest_sh && !latest_dp) {

--- a/src/osd/scrubber/ScrubStore.h
+++ b/src/osd/scrubber/ScrubStore.h
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include <expected>
 #include <string>
 #include <vector>
 
@@ -122,7 +123,7 @@ class Store {
 
   using CacherPosData =
       MapCacher::MapCacher<std::string, ceph::buffer::list>::PosAndData;
-  using ExpCacherPosData = tl::expected<CacherPosData, int>;
+  using ExpCacherPosData = std::expected<CacherPosData, int>;
 
   /// access to the owning Scrubber object, for logging mostly
   PgScrubber& m_scrubber;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -16,6 +16,7 @@
 #include "Striper.h"
 
 #include <algorithm>
+#include <expected>
 #include <sstream>
 
 #include "osd/OSDMap.h"
@@ -765,7 +766,7 @@ void Objecter::_linger_ping(LingerOp *info, bs::error_code ec, ceph::coarse_mono
   }
 }
 
-tl::expected<ceph::timespan,
+std::expected<ceph::timespan,
 	     bs::error_code> Objecter::linger_check(LingerOp *info)
 {
   std::shared_lock l(info->watch_lock);
@@ -779,7 +780,7 @@ tl::expected<ceph::timespan,
 		 << " err " << info->last_error
 		 << " age " << age << dendl;
   if (info->last_error)
-    return tl::unexpected(info->last_error);
+    return std::unexpected(info->last_error);
   // return a safe upper bound (we are truncating to ms)
   return age;
 }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_OBJECTER_H
 #define CEPH_OBJECTER_H
 
+#include <expected>
 #include <list>
 #include <map>
 #include <mutex>
@@ -39,7 +40,6 @@
 #include "include/ceph_assert.h"
 #include "include/ceph_fs.h"
 #include "include/common_fwd.h"
-#include "include/expected.hpp"
 #include "include/types.h"
 #include "include/rados/rados_types.hpp"
 #include "include/function2.hpp"
@@ -3248,7 +3248,7 @@ public:
 			 OpContextVert(onack, poutbl),
 			 objver);
   }
-  tl::expected<ceph::timespan,
+  std::expected<ceph::timespan,
 	       boost::system::error_code> linger_check(LingerOp *info);
   void linger_cancel(LingerOp *info);  // releases a reference
   void _linger_cancel(LingerOp *info);

--- a/src/test/cls_user/test_cls_user.cc
+++ b/src/test/cls_user/test_cls_user.cc
@@ -16,9 +16,9 @@
 #include "test/librados/test_cxx.h"
 #include "gtest/gtest.h"
 
+#include <expected>
 #include <optional>
 #include <system_error>
-#include "include/expected.hpp"
 
 // create/destroy a pool that's shared by all tests in the process
 struct RadosEnv : public ::testing::Environment {
@@ -61,7 +61,7 @@ class ClsAccount : public ::testing::Test {
   }
 
   auto get(const std::string& oid, std::string_view name)
-      -> tl::expected<cls_user_account_resource, int>
+      -> std::expected<cls_user_account_resource, int>
   {
     librados::ObjectReadOperation op;
     cls_user_account_resource resource;
@@ -69,8 +69,8 @@ class ClsAccount : public ::testing::Test {
     cls_user_account_resource_get(op, name, resource, &r2);
 
     int r1 = ioctx.operate(oid, &op, nullptr);
-    if (r1 < 0) return tl::unexpected(r1);
-    if (r2 < 0) return tl::unexpected(r2);
+    if (r1 < 0) return std::unexpected(r1);
+    if (r2 < 0) return std::unexpected(r2);
     return resource;
   }
 
@@ -157,9 +157,9 @@ TEST_F(ClsAccount, get)
   const std::string oid = __PRETTY_FUNCTION__;
   const auto u1 = cls_user_account_resource{.name = "user1", .path = "A"};
   const auto u2 = cls_user_account_resource{.name = "USER1"};
-  EXPECT_EQ(tl::unexpected(-ENOENT), get(oid, u1.name));
+  EXPECT_EQ(std::unexpected(-ENOENT), get(oid, u1.name));
   EXPECT_EQ(-EUSERS, add(oid, u1, true, 0));
-  EXPECT_EQ(tl::unexpected(-ENOENT), get(oid, u1.name));
+  EXPECT_EQ(std::unexpected(-ENOENT), get(oid, u1.name));
   EXPECT_EQ(0, add(oid, u1, true, 1));
   EXPECT_EQ(u1, get(oid, u1.name));
   EXPECT_EQ(0, add(oid, u2, false, 1)); // overwrite with different case

--- a/src/test/osd/test_scrubber_be.cc
+++ b/src/test/osd/test_scrubber_be.cc
@@ -3,6 +3,7 @@
 #include "./scrubber_generators.h"
 #include "./scrubber_test_datasets.h"
 
+#include <expected>
 #include <gtest/gtest.h>
 #include <signal.h>
 #include <stdio.h>
@@ -254,10 +255,10 @@ class TestScrubber : public ScrubBeListener, public Scrub::SnapMapReaderI {
   int get_snaps(const hobject_t& hoid,
 		std::set<snapid_t>* snaps_set) const;
 
-  tl::expected<std::set<snapid_t>, result_t> get_snaps(
+  std::expected<std::set<snapid_t>, result_t> get_snaps(
     const hobject_t& oid) const final;
 
-  tl::expected<std::set<snapid_t>, result_t> get_snaps_check_consistency(
+  std::expected<std::set<snapid_t>, result_t> get_snaps_check_consistency(
     const hobject_t& oid) const final
   {
     /// \todo for now
@@ -317,7 +318,7 @@ int TestScrubber::get_snaps(const hobject_t& hoid,
   return 0;
 }
 
-tl::expected<std::set<snapid_t>, Scrub::SnapMapReaderI::result_t>
+std::expected<std::set<snapid_t>, Scrub::SnapMapReaderI::result_t>
 TestScrubber::get_snaps(const hobject_t& oid) const
 {
   std::set<snapid_t> snapset;
@@ -325,7 +326,7 @@ TestScrubber::get_snaps(const hobject_t& oid) const
   if (r >= 0) {
     return snapset;
   }
-  return tl::make_unexpected(Scrub::SnapMapReaderI::result_t{
+  return std::unexpected(Scrub::SnapMapReaderI::result_t{
     Scrub::SnapMapReaderI::result_t::code_t::not_found,
     r});
 }


### PR DESCRIPTION
Ceph Umbrella will be based on C++ 23. This is a perfect opportunity to replace the Tartan Lama's original implementation of 'expected' (`tl::expected`) with the standard implementation `std::expected`. This PR does the migration work.

The changes in this PR is very straight-forward and only consists of namespace changes.

Closes: https://tracker.ceph.com/issues/72487

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
