### PR TITLE
doc/install: Linkify mention of ceph.conf and use ref for links

### DIFF
--- a/doc/install/clone-source.rst
+++ b/doc/install/clone-source.rst
@@ -119,11 +119,9 @@ will be on the ``main`` branch by default, which is the unstable
 development branch. You may choose other branches too.
 
 - ``main``: The unstable development branch.
-- ``stable-release-name``: The name of the stable, `Active Releases`_. e.g. ``Pacific``
+- ``stable-release-name``: The name of the stable, :ref:`active-releases`. e.g. ``Pacific``
 - ``next``: The release candidate branch.
 
 ::
 
 	git checkout main
-
-.. _Active Releases: https://docs.ceph.com/en/latest/releases/#active-releases

--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -120,7 +120,7 @@ For RPMs::
 
   https://download.ceph.com/rpm-{version}
 
-The major releases of Ceph are summarized at: `Releases`_
+The major releases of Ceph are summarized at: :ref:`Releases <ceph-releases-index>`
 
 .. tip:: For non-US users: There might be a mirror close to you where
          to download Ceph from. For more information see: `Ceph Mirrors`_.
@@ -387,7 +387,6 @@ line to get the short codename.
 
 
 
-.. _Releases: https://docs.ceph.com/en/latest/releases/
 .. _the testing Debian repository: https://download.ceph.com/debian-testing/dists
 .. _the shaman page: https://shaman.ceph.com
 .. _Ceph Mirrors: ../mirrors

--- a/doc/install/index_manual.rst
+++ b/doc/install/index_manual.rst
@@ -9,7 +9,7 @@ Get Software
 ============
 
 There are several methods for getting Ceph software. The easiest and most common
-method is to `get packages`_ by adding repositories for use with package
+method is to :ref:`get packages <packages>` by adding repositories for use with package
 management tools such as the Advanced Package Tool (APT) or Yellowdog Updater,
 Modified (YUM). You may also retrieve pre-compiled packages from the Ceph
 repository. Finally, you can retrieve tarballs or clone the Ceph source code
@@ -66,4 +66,3 @@ sequence.
 .. toctree::
    :maxdepth: 2
 
-.. _get packages: ../get-packages

--- a/doc/install/install-storage-cluster.rst
+++ b/doc/install/install-storage-cluster.rst
@@ -38,7 +38,7 @@ To install Ceph with RPMs, execute the following steps:
      enabled = 1
 
 #. Ensure your YUM ``ceph.repo`` entry includes ``priority=2``. See
-   `Get Packages`_ for details::
+   :ref:`packages` for details::
 
      [ceph]
      name=Ceph packages for $basearch
@@ -91,7 +91,6 @@ executing the following:
    sudo ninja install
 
 If you install Ceph locally, ``ninja`` will place the executables in
-``usr/local/bin``. You may add the Ceph configuration file to the
+``usr/local/bin``. You may add the :ref:`Ceph configuration file <configuring-ceph>` to the
 ``usr/local/bin`` directory to run Ceph from a single directory.
 
-.. _Get Packages: ../get-packages

--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -79,8 +79,8 @@ a number of things:
   a ``client.admin`` user. So you must generate the admin user and keyring,
   and you must also add the ``client.admin`` user to the monitor keyring.
 
-The foregoing requirements do not imply the creation of a Ceph Configuration
-file. However, as a best practice, we recommend creating a Ceph configuration
+The foregoing requirements do not imply the creation of a :ref:`Ceph Configuration
+file <configuring-ceph>`. However, as a best practice, we recommend creating a Ceph configuration
 file and populating it with the ``fsid``, the ``mon initial members`` and the
 ``mon host`` settings.
 
@@ -529,11 +529,10 @@ You should see output that looks something like this::
 	-3	1		host osd-node2
 	1	1			osd.1	up	1
 
-To add (or remove) additional monitors, see `Add/Remove Monitors`_.
+To add (or remove) additional monitors, see :ref:`adding-and-removing-monitors`.
 To add (or remove) additional Ceph OSD Daemons, see `Add/Remove OSDs`_.
 
 
-.. _Add/Remove Monitors: ../../rados/operations/add-or-rm-mons
 .. _Add/Remove OSDs: ../../rados/operations/add-or-rm-osds
 .. _Network Configuration Reference: ../../rados/configuration/network-config-ref
 .. _Monitor Config Reference - Data: ../../rados/configuration/mon-config-ref#data

--- a/doc/install/manual-freebsd-deployment.rst
+++ b/doc/install/manual-freebsd-deployment.rst
@@ -107,7 +107,7 @@ a number of things:
   For example, when you run multiple clusters in a :ref:`multisite configuration <multisite>`,
   the cluster name (e.g., ``us-west``, ``us-east``) identifies the cluster for
   the current CLI session. **Note:** To identify the cluster name on the
-  command line interface, specify the a Ceph configuration file with the
+  command line interface, specify a :ref:`Ceph configuration file <configuring-ceph>` with the
   cluster name (e.g., ``ceph.conf``, ``us-west.conf``, ``us-east.conf``, etc.).
   Also see CLI usage (``ceph --cluster {cluster-name}``).
 
@@ -517,11 +517,10 @@ You should see output that looks something like this::
 	-3	1		host node2
 	1	1			osd.1	up	1
 
-To add (or remove) additional monitors, see `Add/Remove Monitors`_.
+To add (or remove) additional monitors, see :ref:`adding-and-removing-monitors`.
 To add (or remove) additional Ceph OSD Daemons, see `Add/Remove OSDs`_.
 
 
-.. _Add/Remove Monitors: ../../rados/operations/add-or-rm-mons
 .. _Add/Remove OSDs: ../../rados/operations/add-or-rm-osds
 .. _Network Configuration Reference: ../../rados/configuration/network-config-ref
 .. _Monitor Config Reference - Data: ../../rados/configuration/mon-config-ref#data


### PR DESCRIPTION
Linkify first mention of config file to ceph.conf docs in:
- install-storage-cluster.rst
- manual-deployment.rst
- manual-freebsd-deployment.rst

Use ref instead of an external link in:
- clone-source.rst
- get-packages.rst
- index_manual.rst
- install-storage-cluster.rst
- manual-deploymen.rst
- manual-freebsd-deployment.rst

Only where a label already exists at the destination.  
Delete the old link definition if one was used previously.  
That should be about all external links in install/ that can use existing labels for ref.

Fix an instance of "the a" into just "a" that is consistent with other similar mentions in manual-freebsd-deployment.rst.

Links to individual hunks:

`doc/install/clone-source.rst`:
- Before: https://docs.ceph.com/en/latest/install/clone-source/#choose-a-branch
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/clone-source/#choose-a-branch

`doc/install/get-packages.rst`:
- Before: https://docs.ceph.com/en/latest/install/get-packages/#ceph-release-packages
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/get-packages/#ceph-release-packages

`doc/install/index_manual.rst`:
- Before: https://docs.ceph.com/en/latest/install/index_manual/#get-software
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/index_manual/#get-software

`doc/install/install-storage-cluster.rst`:
- Before: https://docs.ceph.com/en/latest/install/install-storage-cluster/#installing-with-rpm
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/install-storage-cluster/#installing-with-rpm
- Before: https://docs.ceph.com/en/latest/install/install-storage-cluster/#installing-a-build
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/install-storage-cluster/#installing-a-build

`doc/install/manual-deployment.rst`:
- Before: https://docs.ceph.com/en/latest/install/manual-deployment/#monitor-bootstrapping
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/manual-deployment/#monitor-bootstrapping
- Before: https://docs.ceph.com/en/latest/install/manual-deployment/#summary
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/manual-deployment/#summary

`doc/install/manual-freebsd-deployment.rst`:
- Before: https://docs.ceph.com/en/latest/install/manual-freebsd-deployment/#monitor-bootstrapping
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/manual-freebsd-deployment/#monitor-bootstrapping
- Before: https://docs.ceph.com/en/latest/install/manual-freebsd-deployment/#summary
- Rendered PR: https://ceph--64848.org.readthedocs.build/en/64848/install/manual-freebsd-deployment/#summary





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
