### PR TITLE
tentacle: osd/scrub: do not limit operator-initiated repairs

### DIFF
--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -426,3 +426,8 @@ bool ScrubJob::is_autorepair_allowed(urgency_t urgency)
 	 urgency == urgency_t::operator_requested ||
 	 urgency == urgency_t::repairing || urgency == urgency_t::must_repair;
 }
+
+bool ScrubJob::is_repairs_count_limited(urgency_t urgency)
+{
+  return urgency < urgency_t::operator_requested;
+}

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -375,6 +375,13 @@ class ScrubJob {
   static bool is_repair_implied(urgency_t urgency);
 
   static bool is_autorepair_allowed(urgency_t urgency);
+
+  /**
+   * should we cancel the repair if the number of damaged objects
+   * exceeds the configured limit ('osd_scrub_auto_repair_num_errors')?
+   * This does not apply to any repair that was operator-initiated.
+   */
+  static bool is_repairs_count_limited(urgency_t urgency);
 };
 }  // namespace Scrub
 


### PR DESCRIPTION
'auto-repair' scrubs are limited to a maximum of 'scrub_auto_repair_num_errors' damaged objects.
However, operator-initiated repairs should not be limited by that number. Alas, a bug in a previous commit
(97de817ad1c253ee1c7c9c9302981ad2435301b9) modified the code in such a way that it applied the
'scrub_auto_repair_num_errors' limit to all repairs, including operator-initiated ones. This commit fixes that.

Backport of https://github.com/ceph/ceph/pull/64849
Backport tracker: https://tracker.ceph.com/issues/72437
Original tracker: https://tracker.ceph.com/issues/72420

(cherry picked from commit 5afc446fdafe3f2e168f9846f324d1d6a71f0f77)

