### PR TITLE
test/standalone/scrub: improve build_pg_dicts() performance

### DIFF
--- a/qa/standalone/scrub/scrub-helpers.sh
+++ b/qa/standalone/scrub/scrub-helpers.sh
@@ -268,7 +268,7 @@ function standard_scrub_cluster() {
     done
 
     if [[ "$poolname" != "nopool" ]]; then
-        create_pool $poolname $pg_num $pg_num
+        create_pool $poolname $pg_num $pg_num --autoscale_mode=off || return 1
         wait_for_clean || return 1
     fi
 


### PR DESCRIPTION
build_pg_dicts() is used to construct a set of dictionaries
(PG to Primary OSD, PG to Acting OSDs, etc.)
from the output of 'ceph pg dump'.  The original code
wasn't very efficient. So much so, that when used in a new
test that creates a large cluster, its run time was
prohibitively long.