### PR TITLE
squid: mgr/dashboard: Fixed incorrect snapshot scheduled date for rbd block in GUI

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -403,7 +403,7 @@ export class RbdListComponent extends ListWithDetails implements OnInit {
         const scheduleStatus = 'scheduled';
         let nextSnapshotDate = +new Date(image.schedule_info.schedule_time);
         const offset = new Date().getTimezoneOffset();
-        nextSnapshotDate = nextSnapshotDate + Math.abs(offset) * 60000;
+        nextSnapshotDate = (nextSnapshotDate + Math.abs(offset) * 60000) / 1000;
         scheduling.push(image.mirror_mode, scheduleStatus, nextSnapshotDate);
         image.mirror_mode = scheduling;
         scheduling = [];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72448

---

backport of https://github.com/ceph/ceph/pull/64689
parent tracker: https://tracker.ceph.com/issues/72288

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh