### PR TITLE
squid: mds/MDSDaemon: unlock `mds_lock` while shutting down Beacon and others

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -899,6 +899,13 @@ void MDSDaemon::suicide()
   // to wait for us to go laggy. Only do this if we're actually in the MDSMap,
   // because otherwise the MDSMonitor will drop our message.
   beacon.set_want_state(*mdsmap, MDSMap::STATE_DNE);
+
+  /* Unlock the mds_lock while waiting for beacon ACK to avoid a
+   * deadlock with the dispatcher thread which may try to acquire
+   * mds_lock, preventing it from receiving the beacon ACK.
+   */
+  mds_lock.unlock();
+
   if (!mdsmap->is_dne_gid(mds_gid_t(monc->get_global_id()))) {
     beacon.send_and_wait(1);
   }
@@ -906,6 +913,8 @@ void MDSDaemon::suicide()
 
   if (mgrc.is_initialized())
     mgrc.shutdown();
+
+  mds_lock.lock();
 
   if (mds_rank) {
     mds_rank->shutdown();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72390

---

backport of https://github.com/ceph/ceph/pull/60326
parent tracker: https://tracker.ceph.com/issues/68760

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh