### PR TITLE
reef: doc/cephfs: edit troubleshooting.rst

### DIFF
--- a/doc/cephfs/troubleshooting.rst
+++ b/doc/cephfs/troubleshooting.rst
@@ -105,13 +105,14 @@ Do the following when restoring your file system:
      ``refuse_client_session`` file-system setting to prevent new sessions from
      connecting to the CephFS.
 
-* **Extend the MDS heartbeat grace period.** This avoids replacing an MDS that
-  appears "stuck" during some operation. Sometimes recovery of an MDS may
-  involve an operation that takes longer than expected (from the programmer's
-  perspective). This is more likely when recovery is already taking longer than
-  normal to complete (indicated by your reading this document). Avoid
-  unnecessary replacement loops by running the following command and extending
-  the heartbeat grace period:
+* **Extend the MDS heartbeat grace period.** Doing this causes the system to
+  avoid replacing an MDS that becomes "stuck" during an operation. Sometimes
+  recovery of an MDS may involve operations that take longer than expected
+  (from the programmer's perspective). This is more likely when recovery has 
+  already taken longer than normal to complete (which, if you're reading this
+  document, is likely the situation you find yourself in). Avoid unnecessary
+  replacement loops by running the following command and extending the
+  heartbeat grace period:
 
    .. prompt:: bash #
 
@@ -125,8 +126,9 @@ Do the following when restoring your file system:
 * **Disable open-file-table prefetch.** Under normal circumstances, the MDS
   prefetches directory contents during recovery as a way of heating up its
   cache. During a long recovery, the cache is probably already hot **and
-  large**. So this behavior is unnecessary and can be undesirable. Disable
-  open-file-table prefetching by running the following command:
+  large**. If the cache is already hot and large, this prefetching is
+  unnecessary and can be undesirable. Disable open-file-table prefetching by
+  running the following command:
 
   .. prompt:: bash #
 
@@ -134,10 +136,11 @@ Do the following when restoring your file system:
 
 * **Turn off clients.** Clients that reconnect to the newly ``up:active`` MDS
   can create new load on the file system just as it is becoming operational.
-  Maintenance is often necessary before allowing clients to connect to the file
-  system and resuming a regular workload. For example, expediting the trimming
-  of journals may be advisable if the recovery took a long time because replay
-  was reading a very large journal.
+  This is often undesirable. Maintenance is often necessary before allowing
+  clients to connect to the file system and before resuming a regular workload.
+  For example, expediting the trimming of journals may be advisable if the
+  recovery took a long time due to the amount of time replay spent in reading a
+  very large journal.
 
   Client sessions can be refused manually, or by using the
   ``refuse_client_session`` tunable as in the following command: 
@@ -149,9 +152,9 @@ Do the following when restoring your file system:
   This command has the effect of preventing clients from establishing new
   sessions with the MDS.
 
-* **Do not tweak max_mds.** Modifying the file system setting variable
-  ``max_mds`` is sometimes thought to be good step during troubleshooting or
-  recovery. But modifying ``max_mds`` might have the effect of further
+* **Do not tweak max_mds.** Modifying the file-system setting variable
+  ``max_mds`` may seem like a good idea during troubleshooting and recovery,
+  but it probably isn't. Modifying ``max_mds`` might have the effect of further
   destabilizing the cluster. If ``max_mds`` must be changed in such
   circumstances, run the command to change ``max_mds`` with the confirmation
   flag (``--yes-i-really-mean-it``).


### PR DESCRIPTION
Edit "Avoiding Recovery Roadblocks" in the "Stuck During Recovery" section of doc/cephfs/troubleshooting.rst.

This commit follows https://github.com/ceph/ceph/pull/64854.


(cherry picked from commit c55eb8ad52bbfd3a9264d2f72abc0694c6183799)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
