### PR TITLE
tentacle: osd/scrub: avoid using moved-from auth_n_errs

### DIFF
--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -905,18 +905,15 @@ void ScrubBackend::inconsistents(const hobject_t& ho,
                                  auth_and_obj_errs_t&& auth_n_errs,
                                  stringstream& errstream)
 {
-  auto& object_errors = auth_n_errs.object_errors;
-  auto& auth_list = auth_n_errs.auth_list;
-
-  this_chunk->cur_inconsistent.insert(object_errors.begin(),
-                                      object_errors.end());  // merge?
+  this_chunk->cur_inconsistent.insert(auth_n_errs.object_errors.begin(),
+                                      auth_n_errs.object_errors.end());
 
   dout(15) << fmt::format(
                 "{}: object errors #: {}  auth list #: {}  cur_missing #: {}  "
                 "cur_incon #: {}",
                 __func__,
-                object_errors.size(),
-                auth_list.size(),
+                auth_n_errs.object_errors.size(),
+                auth_n_errs.auth_list.size(),
                 this_chunk->cur_missing.size(),
                 this_chunk->cur_inconsistent.size())
            << dendl;
@@ -944,8 +941,7 @@ void ScrubBackend::inconsistents(const hobject_t& ho,
 
   if (!this_chunk->cur_inconsistent.empty() ||
       !this_chunk->cur_missing.empty()) {
-
-    this_chunk->authoritative[ho] = auth_list;
+    this_chunk->authoritative[ho] = std::move(auth_n_errs.auth_list);
 
   } else if (!this_chunk->fix_digest && m_is_replicated) {
 


### PR DESCRIPTION
... in ScrubBackend::inconsistents()

Existing code was using a reference to a moved-from `auth_and_obj_errs_t` object, which is undefined behavior.

The change here was tested locally. No noticeable performance degradation was observed, and the code is now more robust.

A backport of https://github.com/ceph/ceph/pull/64859
Original tracker: https://tracker.ceph.com/issues/72426
Backport tracker: https://tracker.ceph.com/issues/72440
(cherry picked from commit 60950a659200eda8fda120899e7f967bdc7e27da)
