### PR TITLE
mon: default chunk size change

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -21,10 +21,15 @@ options:
     stripe for erasure coded pools. Every object of size S
     will be stored as N stripes, with each data chunk
     receiving ``stripe unit`` bytes. Each stripe of ``N *
-    stripe unit`` bytes will be encoded/decoded
-    individually. This option can is overridden by the
-    ``stripe_unit`` setting in an erasure code profile.
-  default: 4_K
+    stripe unit`` bytes will be encoded/decoded individually. 
+    A value of 0 causes the code to select either a 4KB or 16KB
+    stripe_unit depending on whether ``allow_ec_optimizations`` 
+    is enabled.  If enabled, ``stripe unit`` is set to 16KB, otherwise it 
+    is set to 4KB. This option can be overridden by the ``stripe_unit``
+    setting in an erasure code profile.
+  long_desc: A value of 0 causes the code to select either a 4KB or 16KB stripe_unit 
+    depending on whether allow_ec_optimizations is enabled.
+  default: 0
   services:
   - mon
 - name: osd_pool_default_crimson

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7832,6 +7832,17 @@ int OSDMonitor::prepare_pool_stripe_width(const unsigned pool_type,
 	break;
       uint32_t data_chunks = erasure_code->get_data_chunk_count();
       uint32_t stripe_unit = g_conf().get_val<Option::size_t>("osd_pool_erasure_code_stripe_unit");
+
+      if (stripe_unit == 0) {
+        if (((erasure_code->get_supported_optimizations() & 
+              ErasureCodeInterface::FLAG_EC_PLUGIN_OPTIMIZED_SUPPORTED) != 0) &&
+            (cct->_conf.get_val<bool>("osd_pool_default_flag_ec_optimizations"))) {
+            stripe_unit = 16 * 1024;
+        } else {
+          stripe_unit = 4 * 1024;
+        }
+      } 
+    
       auto it = profile.find("stripe_unit");
       if (it != profile.end()) {
 	string err_str;

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -617,7 +617,7 @@ TEST(ErasureCodeLrc, encode_decode)
   profile["layers"] = description_string;
   EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ(4U, lrc.get_data_chunk_count());
-  unsigned int chunk_size = g_conf().get_val<Option::size_t>("osd_pool_erasure_code_stripe_unit");
+  unsigned int chunk_size = 4096;
   unsigned int stripe_width = lrc.get_data_chunk_count() * chunk_size;
   EXPECT_EQ(chunk_size, lrc.get_chunk_size(stripe_width));
   shard_id_set want_to_encode;
@@ -757,7 +757,7 @@ TEST(ErasureCodeLrc, encode_decode_2)
   profile["layers"] = description_string;
   EXPECT_EQ(0, lrc.init(profile, &cerr));
   EXPECT_EQ(4U, lrc.get_data_chunk_count());
-  unsigned int chunk_size = g_conf().get_val<Option::size_t>("osd_pool_erasure_code_stripe_unit");
+  unsigned int chunk_size = 4096;
   unsigned int stripe_width = lrc.get_data_chunk_count() * chunk_size;
   EXPECT_EQ(chunk_size, lrc.get_chunk_size(stripe_width));
   shard_id_set want_to_encode;


### PR DESCRIPTION
Added some code to change the default chunk size for Erasure Coding pools. The chunk size will depend on whether EC optimisation is turned ON or OFF, and also if the plugin supports the EC optimisations.

Tested manually by creating different EC profiles and pools and analysing the chunk size each time.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests