### PR TITLE
tentacle: msg: drain stack before stopping processors to avoid shutdown hang

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -481,6 +481,7 @@ int AsyncMessenger::shutdown()
 {
   ldout(cct,10) << __func__ << " " << get_myaddrs() << dendl;
 
+  stack->drain();
   // done!  clean up.
   for (auto &&p : processors)
     p->stop();
@@ -493,7 +494,7 @@ int AsyncMessenger::shutdown()
   stop_cond.notify_all();
   stopped = true;
   lock.unlock();
-  stack->drain();
+
   return 0;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72213

---

backport of https://github.com/ceph/ceph/pull/63261
parent tracker: https://tracker.ceph.com/issues/71303

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh