### PR TITLE
crimson/.../ephemeral: faster seastore eph dev

### DIFF
--- a/src/crimson/os/seastore/segment_manager/ephemeral.cc
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.cc
@@ -177,12 +177,9 @@ EphemeralSegmentManager::init_ertr::future<> EphemeralSegmentManager::init()
     return crimson::ct_error::invarg::make();
   }
 
-  void* addr = ::mmap(
-    nullptr,
-    config.size,
-    PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
-    -1,
-    0);
+  // memset 0 is not needed: anonymous mapping is zero-filled
+  void* addr = ::mmap(nullptr, config.size, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
   segment_state.resize(config.size / config.segment_size, segment_state_t::EMPTY);
 
@@ -191,7 +188,6 @@ EphemeralSegmentManager::init_ertr::future<> EphemeralSegmentManager::init()
 
   buffer = (char*)addr;
 
-  ::memset(buffer, 0, config.size);
   return init_ertr::now().safe_then([] {
     return seastar::sleep(std::chrono::milliseconds(1));
   });

--- a/src/crimson/os/seastore/segment_manager/ephemeral.cc
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.cc
@@ -4,8 +4,6 @@
 #include <sys/mman.h>
 #include <string.h>
 
-#include "seastar/core/sleep.hh"
-
 #include "crimson/common/log.h"
 
 #include "include/buffer.h"
@@ -93,7 +91,7 @@ segment_off_t EphemeralSegment::get_write_capacity() const
 Segment::close_ertr::future<> EphemeralSegment::close()
 {
   return manager.segment_close(id).safe_then([] {
-    return seastar::sleep(std::chrono::milliseconds(1));
+    return seastar::yield();
   });
 }
 
@@ -123,7 +121,7 @@ Segment::close_ertr::future<> EphemeralSegmentManager::segment_close(segment_id_
 
   segment_state[s_id] = segment_state_t::CLOSED;
   return Segment::close_ertr::now().safe_then([] {
-    return seastar::sleep(std::chrono::milliseconds(1));
+    return seastar::yield();
   });
 }
 
@@ -157,7 +155,7 @@ Segment::write_ertr::future<> EphemeralSegmentManager::segment_write(
 
   bl.begin().copy(bl.length(), buffer + get_offset(addr));
   return Segment::write_ertr::now().safe_then([] {
-    return seastar::sleep(std::chrono::milliseconds(1));
+    return seastar::yield();
   });
 }
 
@@ -189,7 +187,7 @@ EphemeralSegmentManager::init_ertr::future<> EphemeralSegmentManager::init()
   buffer = (char*)addr;
 
   return init_ertr::now().safe_then([] {
-    return seastar::sleep(std::chrono::milliseconds(1));
+    return seastar::yield();
   });
 }
 
@@ -249,7 +247,7 @@ SegmentManager::release_ertr::future<> EphemeralSegmentManager::release(
   ::memset(buffer + get_offset(paddr_t::make_seg_paddr(id, 0)), 0, config.segment_size);
   segment_state[s_id] = segment_state_t::EMPTY;
   return release_ertr::now().safe_then([] {
-    return seastar::sleep(std::chrono::milliseconds(1));
+    return seastar::yield();
   });
 }
 
@@ -288,7 +286,7 @@ SegmentManager::read_ertr::future<> EphemeralSegmentManager::read(
     bl.begin().crc32c(len, 1));
 
   return read_ertr::now().safe_then([] {
-    return seastar::sleep(std::chrono::milliseconds(1));
+    return seastar::yield();
   });
 }
 


### PR DESCRIPTION
- Anonymous mmap is zero-filled on first access by the kernel, so the 1 GB memset(0) performed on every init routine was redundant and has been removed
- Replaced fixed 1ms sleep calls with seastar::yield() to eliminate wall-clock delays while still yielding execution to the scheduler

This patches does not bring as big of a win as #64810, but still provides a meaningful improvement.

#64810 only
```
 1/12 Test #276: unittest-transaction-manager ............   Passed  603.54 sec
 2/12 Test #277: unittest-omap-manager ...................   Passed  973.02 sec
 3/12 Test #278: unittest-btree-lba-manager ..............   Passed   99.77 sec
 4/12 Test #279: unittest-seastore-journal ...............   Passed    4.89 sec
 5/12 Test #280: unittest-seastore-cache .................   Passed    2.59 sec
 6/12 Test #281: unittest-object-data-handler ............   Passed  385.56 sec
 7/12 Test #282: unittest-collection-manager .............   Passed   15.45 sec
 8/12 Test #283: unittest-seastore .......................   Passed  234.76 sec
 9/12 Test #284: unittest-seastore-randomblock-manager ...   Passed    0.58 sec
10/12 Test #285: unittest-seastore-nvmedevice ............   Passed    0.49 sec
11/12 Test #286: unittest-seastore-cbjournal .............   Passed   32.21 sec
12/12 Test #287: unittest-seastore-extent-allocator ......   Passed    0.50 sec
```

This PR on top of #64810
```
 1/12 Test #276: unittest-transaction-manager ............   Passed  495.09 sec (-18%)
 2/12 Test #277: unittest-omap-manager ...................   Passed  939.61 sec (- 3%)
 3/12 Test #278: unittest-btree-lba-manager ..............   Passed   88.33 sec (-12%)
 4/12 Test #279: unittest-seastore-journal ...............   Passed    0.72 sec (-85%)
 5/12 Test #280: unittest-seastore-cache .................   Passed    0.88 sec (-66%)
 6/12 Test #281: unittest-object-data-handler ............   Passed  274.08 sec (-29%)
 7/12 Test #282: unittest-collection-manager .............   Passed    9.09 sec (-41%)
 8/12 Test #283: unittest-seastore .......................   Passed  165.57 sec (-30%)
 9/12 Test #284: unittest-seastore-randomblock-manager ...   Passed    0.56 sec (- 3%)
10/12 Test #285: unittest-seastore-nvmedevice ............   Passed    0.47 sec (- 4%)
11/12 Test #286: unittest-seastore-cbjournal .............   Passed   32.24 sec (+ 0%)
12/12 Test #287: unittest-seastore-extent-allocator ......   Passed    0.50 sec (+ 0%)
```

Fixes: https://tracker.ceph.com/issues/71704

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
