### PR TITLE
crimson/os/seastore: Switch to common return types

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -651,8 +651,7 @@ JournalTrimmerImpl::trim_alloc()
         t,
         target,
         config.max_backref_bytes_per_cycle
-      ).si_then([this, FNAME, &t](auto trim_alloc_to)
-        -> ExtentCallbackInterface::submit_transaction_direct_iertr::future<>
+      ).si_then([this, FNAME, &t](auto trim_alloc_to) -> base_iertr::future<>
       {
         DEBUGT("trim_alloc_to={}", t, trim_alloc_to);
         if (trim_alloc_to != JOURNAL_SEQ_NULL) {

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -327,8 +327,7 @@ public:
   }
 
   /// See Cache::get_next_dirty_extents
-  using get_next_dirty_extents_iertr = base_iertr;
-  using get_next_dirty_extents_ret = get_next_dirty_extents_iertr::future<
+  using get_next_dirty_extents_ret = base_iertr::future<
     std::vector<CachedExtentRef>>;
   virtual get_next_dirty_extents_ret get_next_dirty_extents(
     Transaction &t,     ///< [in] current transaction
@@ -344,9 +343,7 @@ public:
    * handle finding the current instance if it is still alive and
    * otherwise ignore it.
    */
-  using rewrite_extent_iertr = base_iertr;
-  using rewrite_extent_ret = rewrite_extent_iertr::future<>;
-  virtual rewrite_extent_ret rewrite_extent(
+  virtual base_iertr::future<> rewrite_extent(
     Transaction &t,
     CachedExtentRef extent,
     rewrite_gen_t target_generation,
@@ -361,8 +358,7 @@ public:
    * See TransactionManager::get_extents_if_live and
    * LBAManager::get_physical_extent_if_live.
    */
-  using get_extents_if_live_iertr = base_iertr;
-  using get_extents_if_live_ret = get_extents_if_live_iertr::future<
+  using get_extents_if_live_ret = base_iertr::future<
     std::list<CachedExtentRef>>;
   virtual get_extents_if_live_ret get_extents_if_live(
     Transaction &t,
@@ -376,10 +372,7 @@ public:
    *
    * Submits transaction without any space throttling.
    */
-  using submit_transaction_direct_iertr = base_iertr;
-  using submit_transaction_direct_ret =
-    submit_transaction_direct_iertr::future<>;
-  virtual submit_transaction_direct_ret submit_transaction_direct(
+  virtual base_iertr::future<> submit_transaction_direct(
     Transaction &t,
     std::optional<journal_seq_t> seq_to_trim = std::nullopt) = 0;
 

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -37,11 +37,11 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
               c.cache.get_extent_viewable_by_trans(c.trans, backref_root)};
     } else {
       return {false,
-              Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
+              base_iertr::make_ready_future<CachedExtentRef>()};
     }
   } else {
     return {false,
-            Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
+            base_iertr::make_ready_future<CachedExtentRef>()};
   }
 }
 
@@ -237,7 +237,7 @@ BtreeBackrefManager::new_mapping(
 	  });
 	});
     }).si_then([c](auto &&state) {
-      return new_mapping_iertr::make_ready_future<BackrefMapping>(
+      return base_iertr::make_ready_future<BackrefMapping>(
 	BackrefMapping::create(state.ret->get_cursor(c)));
     });
 }
@@ -261,7 +261,7 @@ BtreeBackrefManager::merge_cached_backrefs(
       [this, &t, &limit, &backref_entryrefs_by_seq, max](auto &iter, auto &inserted_to) {
       return trans_intr::repeat(
         [&iter, this, &t, &limit, &backref_entryrefs_by_seq, max, &inserted_to]()
-        -> merge_cached_backrefs_iertr::future<seastar::stop_iteration> {
+        -> base_iertr::future<seastar::stop_iteration> {
         if (iter == backref_entryrefs_by_seq.end()) {
           return seastar::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);
@@ -317,13 +317,12 @@ BtreeBackrefManager::merge_cached_backrefs(
           std::move(inserted_to));
       });
     });
-    return merge_cached_backrefs_iertr::make_ready_future<journal_seq_t>(
+    return base_iertr::make_ready_future<journal_seq_t>(
       std::move(inserted_to));
   });
 }
 
-BtreeBackrefManager::scan_mapped_space_ret
-BtreeBackrefManager::scan_mapped_space(
+base_iertr::future<> BtreeBackrefManager::scan_mapped_space(
   Transaction &t,
   BtreeBackrefManager::scan_mapped_space_func_t &&f)
 {
@@ -483,8 +482,7 @@ BtreeBackrefManager::init_cached_extent_ret BtreeBackrefManager::init_cached_ext
   });
 }
 
-BtreeBackrefManager::rewrite_extent_ret
-BtreeBackrefManager::rewrite_extent(
+base_iertr::future<> BtreeBackrefManager::rewrite_extent(
   Transaction &t,
   CachedExtentRef extent)
 {

--- a/src/crimson/os/seastore/backref/btree_backref_manager.h
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.h
@@ -50,7 +50,7 @@ public:
     Transaction &t,
     paddr_t offset) final;
 
-  scan_mapped_space_ret scan_mapped_space(
+  base_iertr::future<> scan_mapped_space(
     Transaction &t,
     scan_mapped_space_func_t &&f) final;
 
@@ -58,7 +58,7 @@ public:
     Transaction &t,
     CachedExtentRef e) final;
 
-  rewrite_extent_ret rewrite_extent(
+  base_iertr::future<> rewrite_extent(
     Transaction &t,
     CachedExtentRef extent) final;
 

--- a/src/crimson/os/seastore/backref_manager.h
+++ b/src/crimson/os/seastore/backref_manager.h
@@ -26,8 +26,7 @@ public:
    *
    * Future will not resolve until all pins have resolved
    */
-  using get_mappings_iertr = base_iertr;
-  using get_mappings_ret = get_mappings_iertr::future<backref_mapping_list_t>;
+  using get_mappings_ret = base_iertr::future<backref_mapping_list_t>;
   virtual get_mappings_ret get_mappings(
     Transaction &t,
     paddr_t offset,
@@ -50,17 +49,14 @@ public:
    *
    * rewrite extent into passed transaction
    */
-  using rewrite_extent_iertr = base_iertr;
-  using rewrite_extent_ret = rewrite_extent_iertr::future<>;
-  virtual rewrite_extent_ret rewrite_extent(
+  virtual base_iertr::future<> rewrite_extent(
     Transaction &t,
     CachedExtentRef extent) = 0;
 
   /**
    * Insert new paddr_t -> laddr_t mapping
    */
-  using new_mapping_iertr = base_iertr;
-  using new_mapping_ret = new_mapping_iertr::future<BackrefMapping>;
+  using new_mapping_ret = base_iertr::future<BackrefMapping>;
   virtual new_mapping_ret new_mapping(
     Transaction &t,
     paddr_t key,
@@ -74,8 +70,7 @@ public:
    *
    * @return returns whether the extent is alive
    */
-  using init_cached_extent_iertr = base_iertr;
-  using init_cached_extent_ret = init_cached_extent_iertr::future<bool>;
+  using init_cached_extent_ret = base_iertr::future<bool>;
   virtual init_cached_extent_ret init_cached_extent(
     Transaction &t,
     CachedExtentRef e) = 0;
@@ -85,9 +80,8 @@ public:
     paddr_t start,
     paddr_t end) = 0;
 
-  using retrieve_backref_extents_in_range_iertr = base_iertr;
   using retrieve_backref_extents_in_range_ret =
-    retrieve_backref_extents_in_range_iertr::future<std::vector<CachedExtentRef>>;
+    base_iertr::future<std::vector<CachedExtentRef>>;
   virtual retrieve_backref_extents_in_range_ret
   retrieve_backref_extents_in_range(
     Transaction &t,
@@ -102,8 +96,7 @@ public:
   /**
    * merge in-cache paddr_t -> laddr_t mappings to the on-disk backref tree
    */
-  using merge_cached_backrefs_iertr = base_iertr;
-  using merge_cached_backrefs_ret = merge_cached_backrefs_iertr::future<journal_seq_t>;
+  using merge_cached_backrefs_ret = base_iertr::future<journal_seq_t>;
   virtual merge_cached_backrefs_ret merge_cached_backrefs(
     Transaction &t,
     const journal_seq_t &limit,
@@ -130,11 +123,9 @@ public:
    * including backref extents, logical extents and lba extents,
    * visit them with scan_mapped_space_func_t
    */
-  using scan_mapped_space_iertr = base_iertr;
-  using scan_mapped_space_ret = scan_mapped_space_iertr::future<>;
   using scan_mapped_space_func_t = std::function<
     void(paddr_t, paddr_t, extent_len_t, extent_types_t, laddr_t)>;
-  virtual scan_mapped_space_ret scan_mapped_space(
+  virtual base_iertr::future<> scan_mapped_space(
     Transaction &t,
     scan_mapped_space_func_t &&f) = 0;
 

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1035,8 +1035,7 @@ public:
    *
    * Returns if e is live.
    */
-  using init_cached_extent_iertr = base_iertr;
-  using init_cached_extent_ret = init_cached_extent_iertr::future<bool>;
+  using init_cached_extent_ret = base_iertr::future<bool>;
   init_cached_extent_ret init_cached_extent(
     op_context_t c,
     CachedExtentRef e)
@@ -1190,9 +1189,7 @@ public:
    * Rewrites a fresh copy of extent into transaction and updates internal
    * references.
    */
-  using rewrite_extent_iertr = base_iertr;
-  using rewrite_extent_ret = rewrite_extent_iertr::future<>;
-  rewrite_extent_ret rewrite_extent(
+  base_iertr::future<> rewrite_extent(
     op_context_t c,
     CachedExtentRef e) {
     LOG_PREFIX(FixedKVBtree::rewrite_extent);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -49,7 +49,7 @@ Cache::~Cache()
 }
 
 // TODO: this method can probably be removed in the future
-Cache::retire_extent_ret Cache::retire_extent_addr(
+base_iertr::future<> Cache::retire_extent_addr(
   Transaction &t, paddr_t paddr, extent_len_t length)
 {
   LOG_PREFIX(Cache::retire_extent_addr);
@@ -63,7 +63,7 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
     DEBUGT("retire {}~0x{:x} on t -- {}",
            t, paddr, length, *ext);
     t.add_present_to_retired_set(ext);
-    return retire_extent_iertr::now();
+    return base_iertr::now();
   } else if (result == Transaction::get_extent_ret::RETIRED) {
     ERRORT("retire {}~0x{:x} failed, already retired -- {}",
            t, paddr, length, *ext);
@@ -90,7 +90,7 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
     add_extent(ext);
   }
   t.add_absent_to_retired_set(ext);
-  return retire_extent_iertr::now();
+  return base_iertr::now();
 }
 
 void Cache::retire_absent_extent_addr(
@@ -2248,7 +2248,7 @@ Cache::get_root_ret Cache::get_root(Transaction &t)
   if (t.root) {
     TRACET("root already on t -- {}", t, *t.root);
     return t.root->wait_io().then([&t] {
-      return get_root_iertr::make_ready_future<RootBlockRef>(
+      return base_iertr::make_ready_future<RootBlockRef>(
 	t.root);
     });
   } else {
@@ -2256,7 +2256,7 @@ Cache::get_root_ret Cache::get_root(Transaction &t)
     t.root = root;
     t.add_to_read_set(root);
     return root->wait_io().then([root=root] {
-      return get_root_iertr::make_ready_future<RootBlockRef>(
+      return base_iertr::make_ready_future<RootBlockRef>(
 	root);
     });
   }

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
@@ -54,7 +54,7 @@ FlatCollectionManager::get_coll_root(const coll_root_t &coll_root, Transaction &
   ).si_then([](auto maybe_indirect_extent) {
     assert(!maybe_indirect_extent.is_indirect());
     assert(!maybe_indirect_extent.is_clone);
-    return get_root_iertr::make_ready_future<CollectionNodeRef>(
+    return base_iertr::make_ready_future<CollectionNodeRef>(
         std::move(maybe_indirect_extent.extent));
   });
 }

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.h
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.h
@@ -19,8 +19,7 @@ class FlatCollectionManager : public CollectionManager {
     return coll_context_t{tm, t};
   }
 
-  using get_root_iertr = base_iertr;
-  using get_root_ret = get_root_iertr::future<CollectionNodeRef>;
+  using get_root_ret = base_iertr::future<CollectionNodeRef>;
   get_root_ret get_coll_root(const coll_root_t &coll_root, Transaction &t);
 
 public:

--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -77,11 +77,11 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
               c.cache.get_extent_viewable_by_trans(c.trans, lba_root)};
     } else {
       return {false,
-              Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
+              base_iertr::make_ready_future<CachedExtentRef>()};
     }
   } else {
     return {false,
-            Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
+            base_iertr::make_ready_future<CachedExtentRef>()};
   }
 }
 
@@ -151,7 +151,7 @@ BtreeLBAManager::get_mappings(
             ret.emplace_back(LBAMapping::create_direct(std::move(cursor)));
             TRACET("{}~0x{:x} got {}",
                    c.trans, laddr, length, ret.back());
-            return get_mappings_iertr::now();
+            return base_iertr::now();
           }
 	  assert(cursor->val->refcount == EXTENT_DEFAULT_REF_COUNT);
 	  assert(cursor->val->checksum == 0);
@@ -161,7 +161,7 @@ BtreeLBAManager::get_mappings(
 		std::move(direct), std::move(cursor)));
             TRACET("{}~0x{:x} got {}",
                    c.trans, laddr, length, ret.back());
-            return get_mappings_iertr::now();
+            return base_iertr::now();
           });
         });
       });
@@ -818,8 +818,7 @@ BtreeLBAManager::scan_mappings(
     });
 }
 
-BtreeLBAManager::rewrite_extent_ret
-BtreeLBAManager::rewrite_extent(
+base_iertr::future<> BtreeLBAManager::rewrite_extent(
   Transaction &t,
   CachedExtentRef extent)
 {
@@ -841,7 +840,7 @@ BtreeLBAManager::rewrite_extent(
       });
   } else {
     DEBUGT("skip non lba extent -- {}", t, *extent);
-    return rewrite_extent_iertr::now();
+    return base_iertr::now();
   }
 }
 
@@ -1002,7 +1001,7 @@ BtreeLBAManager::complete_indirect_lba_mapping(
   assert(mapping.is_viewable());
   assert(mapping.is_indirect());
   if (mapping.is_complete_indirect()) {
-    return complete_lba_mapping_iertr::make_ready_future<
+    return base_iertr::make_ready_future<
       LBAMapping>(std::move(mapping));
   }
   auto c = get_context(t);

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -263,7 +263,7 @@ public:
     laddr_t end,
     scan_mappings_func_t &&f) final;
 
-  rewrite_extent_ret rewrite_extent(
+  base_iertr::future<> rewrite_extent(
     Transaction &t,
     CachedExtentRef extent) final;
 
@@ -560,14 +560,14 @@ private:
     LBABtree &btree,
     laddr_t laddr);
 
-  using _get_cursors_ret = get_mappings_iertr::future<std::list<LBACursorRef>>;
+  using _get_cursors_ret = base_iertr::future<std::list<LBACursorRef>>;
   _get_cursors_ret get_cursors(
     op_context_t c,
     LBABtree& btree,
     laddr_t offset,
     extent_len_t length);
 
-  using resolve_indirect_cursor_ret = get_mappings_iertr::future<LBACursorRef>;
+  using resolve_indirect_cursor_ret = base_iertr::future<LBACursorRef>;
   resolve_indirect_cursor_ret resolve_indirect_cursor(
     op_context_t c,
     LBABtree& btree,

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -42,8 +42,7 @@ public:
    * For indirect lba mappings, get_mappings will always retrieve the original
    * lba value.
    */
-  using get_mappings_iertr = base_iertr;
-  using get_mappings_ret = get_mappings_iertr::future<lba_mapping_list_t>;
+  using get_mappings_ret = base_iertr::future<lba_mapping_list_t>;
   virtual get_mappings_ret get_mappings(
     Transaction &t,
     laddr_t offset, extent_len_t length) = 0;
@@ -73,8 +72,7 @@ public:
 
 
 #ifdef UNIT_TESTS_BUILT
-  using get_end_mapping_iertr = base_iertr;
-  using get_end_mapping_ret = get_end_mapping_iertr::future<LBAMapping>;
+  using get_end_mapping_ret = base_iertr::future<LBAMapping>;
   virtual get_end_mapping_ret get_end_mapping(Transaction &t) = 0;
 #endif
 
@@ -230,8 +228,7 @@ public:
    *
    * @return returns whether the extent is alive
    */
-  using init_cached_extent_iertr = base_iertr;
-  using init_cached_extent_ret = init_cached_extent_iertr::future<bool>;
+  using init_cached_extent_ret = base_iertr::future<bool>;
   virtual init_cached_extent_ret init_cached_extent(
     Transaction &t,
     CachedExtentRef e) = 0;
@@ -259,9 +256,7 @@ public:
    *
    * rewrite extent into passed transaction
    */
-  using rewrite_extent_iertr = base_iertr;
-  using rewrite_extent_ret = rewrite_extent_iertr::future<>;
-  virtual rewrite_extent_ret rewrite_extent(
+  virtual base_iertr::future<> rewrite_extent(
     Transaction &t,
     CachedExtentRef extent) = 0;
 
@@ -309,9 +304,7 @@ public:
     laddr_t laddr,
     extent_len_t len) = 0;
 
-  using complete_lba_mapping_iertr = get_mappings_iertr;
-  using complete_lba_mapping_ret =
-    complete_lba_mapping_iertr::future<LBAMapping>;
+  using complete_lba_mapping_ret = base_iertr::future<LBAMapping>;
   /*
    * Completes an incomplete indirect mappings
    *

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
@@ -35,8 +35,7 @@ class BtreeOMapManager : public OMapManager {
    *
    * load omap tree root node
    */
-  using get_root_iertr = base_iertr;
-  using get_root_ret = get_root_iertr::future<OMapNodeRef>;
+  using get_root_ret = base_iertr::future<OMapNodeRef>;
   static get_root_ret get_omap_root(
     omap_context_t c,
     const omap_root_t &omap_root);

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
@@ -100,14 +100,12 @@ struct OMapNode : LogicalChildNode {
   using clear_ret = clear_iertr::future<>;
   virtual clear_ret clear(omap_context_t oc) = 0;
 
-  using full_merge_iertr = base_iertr;
-  using full_merge_ret = full_merge_iertr::future<OMapNodeRef>;
+  using full_merge_ret = base_iertr::future<OMapNodeRef>;
   virtual full_merge_ret make_full_merge(
     omap_context_t oc,
     OMapNodeRef right) = 0;
 
-  using make_balanced_iertr = base_iertr;
-  using make_balanced_ret = make_balanced_iertr::future
+  using make_balanced_ret = base_iertr::future
           <std::tuple<OMapNodeRef, OMapNodeRef, std::string>>;
   virtual make_balanced_ret make_balanced(
     omap_context_t oc,

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -436,7 +436,7 @@ OMapInnerNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
         std::move(replacement));
   }).handle_error_interruptible(
     crimson::ct_error::enospc::assert_failure{"unexpected enospc"},
-    full_merge_iertr::pass_further{}
+    base_iertr::pass_further{}
   );
 }
 
@@ -462,7 +462,7 @@ OMapInnerNode::make_balanced(
                                *replacement_left, *replacement_right)));
   }).handle_error_interruptible(
     crimson::ct_error::enospc::assert_failure{"unexpected enospc"},
-    make_balanced_iertr::pass_further{}
+    base_iertr::pass_further{}
   );
 }
 
@@ -909,7 +909,7 @@ OMapLeafNode::make_full_merge(omap_context_t oc, OMapNodeRef right)
         std::move(replacement));
   }).handle_error_interruptible(
     crimson::ct_error::enospc::assert_failure{"unexpected enospc"},
-    full_merge_iertr::pass_further{}
+    base_iertr::pass_further{}
   );
 }
 
@@ -934,7 +934,7 @@ OMapLeafNode::make_balanced(
                  *replacement_left, *replacement_right)));
   }).handle_error_interruptible(
     crimson::ct_error::enospc::assert_failure{"unexpected enospc"},
-    make_balanced_iertr::pass_further{}
+    base_iertr::pass_further{}
   );
 }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -73,8 +73,7 @@ class NodeExtentManager {
   virtual read_iertr::future<NodeExtentRef> read_extent(
       Transaction&, laddr_t) = 0;
 
-  using alloc_iertr = base_iertr;
-  virtual alloc_iertr::future<NodeExtentRef> alloc_extent(
+  virtual base_iertr::future<NodeExtentRef> alloc_extent(
       Transaction&, laddr_t hint, extent_len_t) = 0;
 
   using retire_iertr = base_iertr::extend<
@@ -82,8 +81,7 @@ class NodeExtentManager {
   virtual retire_iertr::future<> retire_extent(
       Transaction&, NodeExtentRef) = 0;
 
-  using getsuper_iertr = base_iertr;
-  virtual getsuper_iertr::future<Super::URef> get_super(
+  virtual base_iertr::future<Super::URef> get_super(
       Transaction&, RootNodeTracker&) = 0;
 
   virtual std::ostream& print(std::ostream& os) const = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -88,7 +88,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     }
   }
 
-  alloc_iertr::future<NodeExtentRef> alloc_extent(
+  base_iertr::future<NodeExtentRef> alloc_extent(
       Transaction& t, laddr_t hint, extent_len_t len) override {
     SUBTRACET(seastore_onode, "allocating {}B with hint {} ...", t, len, hint);
     if constexpr (SYNC) {
@@ -116,7 +116,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     }
   }
 
-  getsuper_iertr::future<Super::URef> get_super(
+  base_iertr::future<Super::URef> get_super(
       Transaction& t, RootNodeTracker& tracker) override {
     SUBTRACET(seastore_onode, "get root ...", t);
     if constexpr (SYNC) {
@@ -146,7 +146,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     return read_iertr::make_ready_future<NodeExtentRef>(extent);
   }
 
-  alloc_iertr::future<NodeExtentRef> alloc_extent_sync(
+  base_iertr::future<NodeExtentRef> alloc_extent_sync(
       Transaction& t, extent_len_t len) {
     assert(len % ALIGNMENT == 0);
     auto r = ceph::buffer::create_aligned(len, ALIGNMENT);
@@ -161,7 +161,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
         "allocated {}B at {} -- {}",
         t, extent->get_length(), extent->get_laddr(), *extent);
     assert(extent->get_length() == len);
-    return alloc_iertr::make_ready_future<NodeExtentRef>(extent);
+    return base_iertr::make_ready_future<NodeExtentRef>(extent);
   }
 
   retire_iertr::future<> retire_extent_sync(
@@ -177,10 +177,10 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     return retire_iertr::now();
   }
 
-  getsuper_iertr::future<Super::URef> get_super_sync(
+  base_iertr::future<Super::URef> get_super_sync(
       Transaction& t, RootNodeTracker& tracker) {
     SUBTRACET(seastore_onode, "got root {}", t, root_laddr);
-    return getsuper_iertr::make_ready_future<Super::URef>(
+    return base_iertr::make_ready_future<Super::URef>(
         Super::URef(new DummySuper(t, tracker, &root_laddr)));
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -127,14 +127,14 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
     });
   }
 
-  alloc_iertr::future<NodeExtentRef> alloc_extent(
+  base_iertr::future<NodeExtentRef> alloc_extent(
       Transaction& t, laddr_t hint, extent_len_t len) override {
     SUBTRACET(seastore_onode, "allocating {}B with hint {} ...", t, len, hint);
     if constexpr (INJECT_EAGAIN) {
       if (trigger_eagain()) {
         SUBDEBUGT(seastore_onode, "allocating {}B: trigger eagain", t, len);
         t.test_set_conflict();
-        return alloc_iertr::make_ready_future<NodeExtentRef>();
+        return base_iertr::make_ready_future<NodeExtentRef>();
       }
     }
     return tm.alloc_non_data_extent<SeastoreNodeExtent>(t, hint, len
@@ -153,7 +153,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       return NodeExtentRef(extent);
     }).handle_error_interruptible(
       crimson::ct_error::enospc::assert_failure{"unexpected enospc"},
-      alloc_iertr::pass_further{}
+      base_iertr::pass_further{}
     );
   }
 
@@ -180,14 +180,14 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
     });
   }
 
-  getsuper_iertr::future<Super::URef> get_super(
+  base_iertr::future<Super::URef> get_super(
       Transaction& t, RootNodeTracker& tracker) override {
     SUBTRACET(seastore_onode, "get root ...", t);
     if constexpr (INJECT_EAGAIN) {
       if (trigger_eagain()) {
         SUBDEBUGT(seastore_onode, "get root: trigger eagain", t);
         t.test_set_conflict();
-        return getsuper_iertr::make_ready_future<Super::URef>();
+        return base_iertr::make_ready_future<Super::URef>();
       }
     }
     return tm.read_onode_root(t).si_then([this, &t, &tracker](auto root_addr) {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -150,7 +150,7 @@ public:
    *
    * Get logical pins overlapping offset~length
    */
-  using get_pins_iertr = LBAManager::get_mappings_iertr;
+  using get_pins_iertr = base_iertr;
   using get_pins_ret = get_pins_iertr::future<lba_mapping_list_t>;
   get_pins_ret get_pins(
     Transaction &t,
@@ -299,7 +299,7 @@ public:
 	return lba_manager->complete_indirect_lba_mapping(
 	  t, std::move(npin));
       } else {
-	return LBAManager::complete_lba_mapping_iertr::make_ready_future<
+	return base_iertr::make_ready_future<
 	  LBAMapping>(std::move(npin));
       }
     }).si_then([&t, this, partial_off, partial_len,
@@ -750,8 +750,7 @@ public:
     return cache->create_transaction(src, name, cache_hint, is_weak);
   }
 
-  using ExtentCallbackInterface::submit_transaction_direct_ret;
-  submit_transaction_direct_ret submit_transaction_direct(
+  base_iertr::future<> submit_transaction_direct(
     Transaction &t,
     std::optional<journal_seq_t> seq_to_trim = std::nullopt) final;
 
@@ -761,8 +760,7 @@ public:
     journal_seq_t seq,
     size_t max_bytes) final;
 
-  using ExtentCallbackInterface::rewrite_extent_ret;
-  rewrite_extent_ret rewrite_extent(
+  base_iertr::future<> rewrite_extent(
     Transaction &t,
     CachedExtentRef extent,
     rewrite_gen_t target_generation,
@@ -1365,7 +1363,7 @@ private:
 	  std::vector<remap_entry_t>(remaps.begin(), remaps.end())
 	).si_then([FNAME, &t](auto ret) {
 	  SUBDEBUGT(seastore_tm, "remapped {} pins", t, ret.size());
-	  return Cache::retire_extent_iertr::make_ready_future<
+	  return base_iertr::make_ready_future<
 	    std::vector<LBAMapping>>(std::move(ret));
 	});
       }).handle_error_interruptible(
@@ -1377,11 +1375,11 @@ private:
     });
   }
 
-  rewrite_extent_ret rewrite_logical_extent(
+  base_iertr::future<> rewrite_logical_extent(
     Transaction& t,
     LogicalChildNodeRef extent);
 
-  submit_transaction_direct_ret do_submit_transaction(
+  base_iertr::future<> do_submit_transaction(
     Transaction &t,
     ExtentPlacementManager::dispatch_result_t dispatch_result,
     std::optional<journal_seq_t> seq_to_trim = std::nullopt);

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -607,7 +607,7 @@ struct btree_lba_manager_test : btree_test_base {
 	    return cache->retire_extent_addr(
 	      t, result.result.addr.get_paddr(), result.result.length);
 	  }
-	  return Cache::retire_extent_iertr::now();
+	  return base_iertr::now();
 	});
       }).unsafe_get();
     if (target->second.refcount == 0) {


### PR DESCRIPTION
~blocked by: https://github.com/ceph/ceph/pull/64812~
Description to be edited.
The idea here would be to drop all method-specific return types and switch to common/generic errorator return types (e.g base_iertr).
This should help with:
* Easier error handling / passing. Which in turn will help to avoid us handling errors multiple times just to silence the compilation time errors (of unhandled error).
* IMO, it would be easier to understand which errors are expected from each method without trying to find the errorator declaration. Some errorator has multiple name forwarding in different files/classes which takes time to find the actual error definition.
  *  Moreover, with coroutines in mind, we would really like to avoid error handling when possible to keep the code easy to read and only let the upper layer (caller) handle the error.
* Lastly, this could potentially pave the way to "named-converters" between errorator types.

See, early wip: 4c949f4c1b20cc4f336b91f4ff0784f864edf387.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
