### PR TITLE
librbd/api: restrict APIs on secondary mirror groups

### DIFF
--- a/src/librbd/api/Group.h
+++ b/src/librbd/api/Group.h
@@ -59,7 +59,7 @@ struct Group {
                            group_snap_info2_t* group_snap);
   static int snap_rollback(librados::IoCtx& group_ioctx,
                            const char *group_name, const char *snap_name,
-                           ProgressContext& pctx);
+                           ProgressContext& pctx, bool restrict_to_primary);
 
   static int group_image_list_by_id(librados::IoCtx& group_ioctx,
                                     const std::string &group_id,

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -3154,7 +3154,7 @@ int Mirror<I>::group_promote(IoCtx& group_ioctx, const char *group_name,
 
       librbd::NoOpProgressContext prog_ctx;
       r = Group<I>::snap_rollback(group_ioctx,
-                                  group_name, snap->name.c_str(), prog_ctx);
+                                  group_name, snap->name.c_str(), prog_ctx, false);
       if (r < 0) {
         lderr(cct) << "failed to rollback to group snapshot: " << snap->id
                    << " :" << cpp_strerror(r) << dendl;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1690,7 +1690,7 @@ namespace librbd {
                group_ioctx.get_id(), group_name, snap_name);
     librbd::NoOpProgressContext prog_ctx;
     int r = librbd::api::Group<>::snap_rollback(group_ioctx, group_name,
-                                                snap_name, prog_ctx);
+                                                snap_name, prog_ctx, true);
     tracepoint(librbd, group_snap_rollback_exit, r);
     return r;
   }
@@ -1704,7 +1704,7 @@ namespace librbd {
                group_ioctx.get_pool_name().c_str(),
                group_ioctx.get_id(), group_name, snap_name);
     int r = librbd::api::Group<>::snap_rollback(group_ioctx, group_name,
-                                                snap_name, prog_ctx);
+                                                snap_name, prog_ctx, true);
     tracepoint(librbd, group_snap_rollback_exit, r);
     return r;
   }
@@ -7984,7 +7984,7 @@ extern "C" int rbd_group_snap_rollback(rados_ioctx_t group_p,
 
   librbd::NoOpProgressContext prog_ctx;
   int r = librbd::api::Group<>::snap_rollback(group_ioctx, group_name,
-                                              snap_name, prog_ctx);
+                                              snap_name, prog_ctx, true);
 
   tracepoint(librbd, group_snap_rollback_exit, r);
 
@@ -8050,7 +8050,7 @@ extern "C" int rbd_group_snap_rollback_with_progress(rados_ioctx_t group_p,
 
   librbd::CProgressContext prog_ctx(cb, cbdata);
   int r = librbd::api::Group<>::snap_rollback(group_ioctx, group_name,
-                                              snap_name, prog_ctx);
+                                              snap_name, prog_ctx, true);
 
   tracepoint(librbd, group_snap_rollback_exit, r);
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
