### PR TITLE
src/rgw: replace tl::expected to std::expected

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -39,6 +39,7 @@
 #include "include/timegm.h"
 
 #include <boost/asio/yield.hpp>
+#include <expected>
 #include <shared_mutex> // for std::shared_lock
 #include <string_view>
 
@@ -6124,7 +6125,7 @@ int RGWBucketPipeSyncStatusManager::remote_info(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-tl::expected<std::unique_ptr<RGWBucketPipeSyncStatusManager>, int>
+std::expected<std::unique_ptr<RGWBucketPipeSyncStatusManager>, int>
 RGWBucketPipeSyncStatusManager::construct(
   const DoutPrefixProvider* dpp,
   rgw::sal::RadosStore* driver,
@@ -6138,7 +6139,7 @@ RGWBucketPipeSyncStatusManager::construct(
 				       dest_bucket)};
   auto r = self->do_init(dpp, ostr);
   if (r < 0) {
-    return tl::unexpected(r);
+    return std::unexpected(r);
   }
   return self;
 }
@@ -6172,7 +6173,7 @@ int RGWBucketPipeSyncStatusManager::init_sync_status(
   return 0;
 }
 
-tl::expected<std::map<int, rgw_bucket_shard_sync_info>, int>
+std::expected<std::map<int, rgw_bucket_shard_sync_info>, int>
 RGWBucketPipeSyncStatusManager::read_sync_status(
   const DoutPrefixProvider *dpp)
 {
@@ -6190,19 +6191,19 @@ RGWBucketPipeSyncStatusManager::read_sync_status(
     if (sz == sources.end()) {
       ldpp_dout(this, 0) << "ERROR: failed to find source zone: "
 			 << *source_zone << dendl;
-      return tl::unexpected(-ENOENT);
+      return std::unexpected(-ENOENT);
     }
   } else {
     ldpp_dout(this, 5) << "No source zone specified, using source zone: "
 		       << sz->sc.source_zone << dendl;
-    return tl::unexpected(-ENOENT);
+    return std::unexpected(-ENOENT);
   }
   uint64_t num_shards, latest_gen;
   auto ret = remote_info(dpp, *sz, nullptr, &latest_gen, &num_shards);
   if (ret < 0) {
     ldpp_dout(this, 5) << "Unable to get remote info: "
 		       << ret << dendl;
-    return tl::unexpected(ret);
+    return std::unexpected(ret);
   }
   auto stack = new RGWCoroutinesStack(driver->ctx(), &cr_mgr);
   std::vector<rgw_bucket_sync_pair_info> pairs(num_shards);
@@ -6222,7 +6223,7 @@ RGWBucketPipeSyncStatusManager::read_sync_status(
   if (ret < 0) {
     ldpp_dout(this, 0) << "ERROR: failed to read sync status for "
 		       << bucket_str{dest_bucket} << dendl;
-    return tl::unexpected(ret);
+    return std::unexpected(ret);
   }
 
   return sync_status;

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -24,6 +24,7 @@
 
 #include "rgw_bucket_sync.h"
 #include "sync_fairness.h"
+#include <expected>
 
 // represents an obligation to sync an entry up a given time
 struct rgw_data_sync_obligation {
@@ -769,7 +770,7 @@ class RGWBucketPipeSyncStatusManager : public DoutPrefixProvider {
 		  uint64_t* oldest_gen, uint64_t* latest_gen,
 		  uint64_t* num_shards);
 public:
-  static tl::expected<std::unique_ptr<RGWBucketPipeSyncStatusManager>, int>
+  static std::expected<std::unique_ptr<RGWBucketPipeSyncStatusManager>, int>
   construct(const DoutPrefixProvider* dpp, rgw::sal::RadosStore* driver,
 	    std::optional<rgw_zone_id> source_zone,
 	    std::optional<rgw_bucket> source_bucket,
@@ -794,7 +795,7 @@ public:
   std::ostream& gen_prefix(std::ostream& out) const override;
 
   int init_sync_status(const DoutPrefixProvider *dpp);
-  tl::expected<std::map<int, rgw_bucket_shard_sync_info>, int> read_sync_status(
+  std::expected<std::map<int, rgw_bucket_shard_sync_info>, int> read_sync_status(
     const DoutPrefixProvider *dpp);
   int run(const DoutPrefixProvider *dpp);
 };

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab ft=cpp
 
 #include <array>
+#include <expected>
 #include <string>
 #include <variant>
 
@@ -330,7 +331,7 @@ auto transform_old_authinfo(const DoutPrefixProvider* dpp,
                             sal::Driver* driver,
                             sal::User* user,
                             std::vector<IAM::Policy>* policies_)
-  -> tl::expected<std::unique_ptr<Identity>, int>
+  -> std::expected<std::unique_ptr<Identity>, int>
 {
   const RGWUserInfo& info = user->get_info();
   const sal::Attrs& attrs = user->get_attrs();
@@ -341,7 +342,7 @@ auto transform_old_authinfo(const DoutPrefixProvider* dpp,
   int r = load_account_and_policies(dpp, y, driver, info, attrs,
                                     account, policies);
   if (r < 0) {
-    return tl::unexpected(r);
+    return std::unexpected(r);
   }
 
   if (policies_) { // return policies to caller if requested

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <expected>
 #include <functional>
 #include <optional>
 #include <ostream>
@@ -10,7 +11,6 @@
 #include <system_error>
 #include <utility>
 
-#include "include/expected.hpp"
 #include "include/function2.hpp"
 
 #include "rgw_common.h"
@@ -119,7 +119,7 @@ auto transform_old_authinfo(const DoutPrefixProvider* dpp,
                             sal::Driver* driver,
                             sal::User* user,
                             std::vector<IAM::Policy>* policies_ = nullptr)
-  -> tl::expected<std::unique_ptr<Identity>, int>;
+  -> std::expected<std::unique_ptr<Identity>, int>;
 
 // Load the user account and all user/group policies. May throw
 // PolicyParseException on malformed policy.

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include <expected>
+
 #include "rgw_common.h"
 #include "rgw_rest_client.h"
 #include "rgw_acl_s3.h"
@@ -371,7 +373,7 @@ static void scope_from_api_name(const DoutPrefixProvider *dpp,
 }
 
 auto RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const RGWAccessKey& key, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y, std::string service)
-  -> tl::expected<int, int>
+  -> std::expected<int, int>
 {
 
   string date_str;
@@ -417,7 +419,7 @@ auto RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const 
   int ret = sign_request(dpp, key, region, s, new_env, new_info, nullptr);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to sign request" << dendl;
-    return tl::unexpected(ret);
+    return std::unexpected(ret);
   }
 
   if (s == "iam") {
@@ -463,7 +465,7 @@ auto RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const 
 
   if (http_status == 0) {
     // no http status, generally means the service is not available
-    return tl::unexpected(-ERR_SERVICE_UNAVAILABLE);
+    return std::unexpected(-ERR_SERVICE_UNAVAILABLE);
   }
 
   response.append((char)0); /* NULL terminate response */

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include "include/expected.hpp"
+#include <expected>
+
 #include "rgw_http_client.h"
 
 class RGWGetDataCB;
@@ -69,7 +70,7 @@ public:
 
   // return the http status of the response or an error code from the transport
   auto forward_request(const DoutPrefixProvider *dpp, const RGWAccessKey& key, const req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y, std::string service="")
-    -> tl::expected<int, int>;
+    -> std::expected<int, int>;
 };
 
 class RGWWriteDrainCB {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include <expected>
+
 #include "rgw_zone.h"
 #include "rgw_rest_conn.h"
 #include "rgw_http_errors.h"
@@ -157,14 +159,14 @@ void RGWRESTConn::populate_params(param_vec_t& params, const rgw_owner* uid, con
 auto RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
                           const req_info& info, size_t max_response,
                           bufferlist *inbl, bufferlist *outbl, optional_yield y)
-  -> tl::expected<int, int>
+  -> std::expected<int, int>
 {
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
     string url;
     int ret = get_url(url);
     if (ret < 0) {
-      return tl::unexpected(ret);
+      return std::unexpected(ret);
     }
     param_vec_t params;
     populate_params(params, &uid, self_zone_group);
@@ -180,20 +182,20 @@ auto RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
       ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
     }
   }
-  return tl::unexpected(-EIO);
+  return std::unexpected(-EIO);
 }
 
 auto RGWRESTConn::forward_iam(const DoutPrefixProvider *dpp, const req_info& info,
                               size_t max_response, bufferlist *inbl,
                               bufferlist *outbl, optional_yield y)
-  -> tl::expected<int, int>
+  -> std::expected<int, int>
 {
   static constexpr int NUM_ENPOINT_IOERROR_RETRIES = 20;
   for (int tries = 0; tries < NUM_ENPOINT_IOERROR_RETRIES; tries++) {
     string url;
     int ret = get_url(url);
     if (ret < 0) {
-      return tl::unexpected(ret);
+      return std::unexpected(ret);
     }
     param_vec_t params;
     std::string service = "iam";
@@ -210,7 +212,7 @@ auto RGWRESTConn::forward_iam(const DoutPrefixProvider *dpp, const req_info& inf
       ldpp_dout(dpp, 20) << __func__  << "(): failed to forward request. retries=" << tries << dendl;
     }
   }
-  return tl::unexpected(-EIO);
+  return std::unexpected(-EIO);
 }
 
 int RGWRESTConn::put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req)

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -10,6 +10,7 @@
 #include "rgw_sal_fwd.h"
 
 #include <atomic>
+#include <expected>
 
 class RGWSI_Zone;
 
@@ -133,13 +134,13 @@ public:
   auto forward(const DoutPrefixProvider *dpp, const rgw_owner& uid,
                const req_info& info, size_t max_response,
                bufferlist *inbl, bufferlist *outbl, optional_yield y)
-    -> tl::expected<int, int>;
+    -> std::expected<int, int>;
 
   /* sync request */
   auto forward_iam(const DoutPrefixProvider *dpp, const req_info& info,
                    size_t max_response, bufferlist *inbl,
                    bufferlist *outbl, optional_yield y)
-    -> tl::expected<int, int>;
+    -> std::expected<int, int>;
 
   /* async requests */
   int put_obj_send_init(const rgw_obj& obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);


### PR DESCRIPTION
Ceph Umbrella will be based on C++ 23. This is a perfect opportunity to replace the Tartan Lama's original implementation of 'expected' (`tl::expected`) with the standard implementation `std::expected`. This PR does the migration work.

The changes in this PR is very straight-forward and only consists of namespace changes. This PR is in continuation of https://github.com/ceph/ceph/pull/64839 but with only RGW changes for easier review.

Closes: https://tracker.ceph.com/issues/72487

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
