### PR TITLE
tentacle: mds: skip charmap handler check for MDS requests

### DIFF
--- a/qa/tasks/cephfs/test_dir_charmap.py
+++ b/qa/tasks/cephfs/test_dir_charmap.py
@@ -320,6 +320,20 @@ class TestCharMapVxattr(CephFSTestCase, CharMapMixin):
             else:
                 self.fail("should fail")
 
+    def test_charmap_to_stray(self):
+        """
+        That internal renames for reintegration works with charmap.
+        """
+
+        self.mount_a.run_shell_payload("mkdir foo/")
+        self.mount_a.setfattr("foo/", "ceph.dir.casesensitive", "0")
+        self.check_cs("foo", casesensitive=False)
+
+        self.mount_a.run_shell_payload("touch foo/a; ln foo/a foo/b; rm foo/a; sync foo")
+        self.fs.flush()
+
+        self.mount_a.run_shell_payload("stat foo/b")
+
 
 class TestCharMapRecovery(CephFSTestCase, CharMapMixin):
     CLIENTS_REQUIRED = 1

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4772,16 +4772,18 @@ bool Server::is_valid_layout(file_layout_t *layout)
 
 bool Server::can_handle_charmap(const MDRequestRef& mdr, CDentry* dn)
 {
-  CDir *dir = dn->get_dir();
-  CInode *diri = dir->get_inode();
-  if (auto* csp = diri->get_charmap()) {
-    dout(20) << __func__ << ": with " << *csp << dendl;
-    auto& client_metadata = mdr->session->info.client_metadata;
-    bool allowed  = client_metadata.features.test(CEPHFS_FEATURE_CHARMAP);
-    if (!allowed) {
-      dout(5) << " client cannot handle charmap" << dendl;
-      respond_to_request(mdr, -EPERM);
-      return false;
+  if (mdr->session) {
+    CDir *dir = dn->get_dir();
+    CInode *diri = dir->get_inode();
+    if (auto* csp = diri->get_charmap()) {
+      dout(20) << __func__ << ": with " << *csp << dendl;
+      auto& client_metadata = mdr->session->info.client_metadata;
+      bool allowed  = client_metadata.features.test(CEPHFS_FEATURE_CHARMAP);
+      if (!allowed) {
+        dout(5) << " client cannot handle charmap" << dendl;
+        respond_to_request(mdr, -EPERM);
+        return false;
+      }
     }
   }
   return true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72514

---

backport of https://github.com/ceph/ceph/pull/64822
parent tracker: https://tracker.ceph.com/issues/72349

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh