### PR TITLE
Add missing includes to many subsystems

### DIFF
--- a/src/auth/AuthMethodList.cc
+++ b/src/auth/AuthMethodList.cc
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include "common/debug.h"
+#include "include/ceph_fs.h" // for CEPH_AUTH_*
 #include "include/str_list.h"
 
 #include "AuthMethodList.h"

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -15,11 +15,19 @@
 #ifndef CEPH_KEYSSERVER_H
 #define CEPH_KEYSSERVER_H
 
+#include <cstdint>
+#include <list>
+#include <map>
+#include <string>
+
 #include "auth/KeyRing.h"
 #include "CephxProtocol.h"
 #include "common/ceph_json.h"
 #include "common/ceph_mutex.h"
+#include "common/Formatter.h"
 #include "include/common_fwd.h"
+#include "include/encoding.h"
+#include "include/types.h" // for version_t
 
 struct KeyServerData {
   version_t version{0};

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -21,6 +21,7 @@
 #include "common/async/context_pool.h"
 #include "common/config.h"
 #include "common/errno.h"
+#include "log/Log.h" // for g_ceph_context->_log
 
 #include "client/Client.h"
 #include "client/fuse_ll.h"
@@ -31,6 +32,7 @@
 
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
+#include "common/debug.h"
 #if defined(__linux__)
 #include "common/linux_version.h"
 #endif

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -14,9 +14,11 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <dirent.h>
 #include <fcntl.h>
 
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "common/config.h"

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -18,6 +18,7 @@
 #include <boost/scoped_ptr.hpp>
 
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "auth/KeyRing.h"

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -42,9 +42,11 @@
 #include "global/signal_handler.h"
 
 #include "include/color.h"
+#include "common/debug.h"
 #include "common/errno.h"
 #include "common/pick_address.h"
 
+#include "log/Log.h"
 #include "perfglue/heap_profiler.h"
 
 #include "include/ceph_assert.h"

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -16,6 +16,8 @@
 #ifndef CEPH_CLIENT_H
 #define CEPH_CLIENT_H
 
+#include <dirent.h>
+
 #include "common/admin_socket.h"
 #include "common/CommandTable.h"
 #include "common/Finisher.h"

--- a/src/client/ClientSnapRealm.h
+++ b/src/client/ClientSnapRealm.h
@@ -4,6 +4,10 @@
 #ifndef CEPH_CLIENT_SNAPREALM_H
 #define CEPH_CLIENT_SNAPREALM_H
 
+#include <iostream>
+#include <set>
+#include <vector>
+
 #include "include/types.h"
 #include "common/snap_types.h"
 #include "include/xlist.h"

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -20,6 +20,7 @@
 
 
 #include "common/config.h"
+#include "common/debug.h"
 #include "SyntheticClient.h"
 #include "osdc/Objecter.h"
 #include "osdc/Filer.h"

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -32,6 +32,7 @@
 #endif
 
 // ceph
+#include "common/debug.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "include/types.h"

--- a/src/cls/2pc_queue/cls_2pc_queue_types.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_types.h
@@ -2,6 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include "common/ceph_time.h" // for ceph::coarse_real_time
+#include "common/Formatter.h"
+#include "include/encoding.h"
 #include "include/types.h"
 
 #include <unordered_map>

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -34,6 +34,7 @@
 #include "include/types.h"
 
 #include "common/ceph_time.h"
+#include "common/Formatter.h"
 
 class JSONObj;
 

--- a/src/cls/journal/cls_journal.cc
+++ b/src/cls/journal/cls_journal.cc
@@ -4,6 +4,7 @@
 #include "include/int_types.h"
 #include "include/buffer.h"
 #include "include/encoding.h"
+#include "include/intarith.h" // for round_up_to()
 #include "common/errno.h"
 #include "objclass/objclass.h"
 #include "cls/journal/cls_journal_types.h"

--- a/src/cls/otp/cls_otp_types.h
+++ b/src/cls/otp/cls_otp_types.h
@@ -11,6 +11,7 @@
 #define CLS_OTP_MAX_REPO_SIZE 100
 
 class JSONObj;
+namespace ceph { class Formatter; }
 
 namespace rados {
   namespace cls {

--- a/src/cls/queue/cls_queue_types.h
+++ b/src/cls/queue/cls_queue_types.h
@@ -5,6 +5,9 @@
 #define CEPH_CLS_QUEUE_TYPES_H
 
 #include <errno.h>
+
+#include "common/Formatter.h"
+#include "include/encoding.h"
 #include "include/types.h"
 
 //Size of head leaving out urgent data

--- a/src/cls/refcount/cls_refcount_client.h
+++ b/src/cls/refcount/cls_refcount_client.h
@@ -4,6 +4,9 @@
 #ifndef CEPH_CLS_REFCOUNT_CLIENT_H
 #define CEPH_CLS_REFCOUNT_CLIENT_H
 
+#include <list>
+#include <string>
+
 #include "include/rados/librados_fwd.hpp"
 #include "include/types.h"
 

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -9,6 +9,7 @@
 #include <list>
 #include <string>
 
+#include "common/Formatter.h"
 #include "include/encoding.h"
 #include "include/types.h"
 

--- a/src/common/CDC.cc
+++ b/src/common/CDC.cc
@@ -1,11 +1,13 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "CDC.h"
+
 #include <random>
 
-#include "CDC.h"
 #include "FastCDC.h"
 #include "FixedCDC.h"
+#include "include/byteorder.h" // for ceph_le64
 
 std::unique_ptr<CDC> CDC::create(
   const std::string& type,

--- a/src/common/CommandTable.h
+++ b/src/common/CommandTable.h
@@ -15,8 +15,16 @@
 #ifndef COMMAND_TABLE_H_
 #define COMMAND_TABLE_H_
 
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "include/buffer_fwd.h"
+#include "include/types.h" // for ceph_tid_t
 #include "messages/MCommand.h"
 #include "messages/MMgrCommand.h"
+#include "msg/Connection.h" // for ConnectionRef
 
 class CommandOp
 {

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "Finisher.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/perf_counters.h"
 #include "include/types.h" // for operator<<(std::vector)
 

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -15,6 +15,12 @@
 #ifndef CEPH_FINISHER_H
 #define CEPH_FINISHER_H
 
+#include <atomic>
+#include <list>
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include "include/Context.h"
 #include "common/Thread.h"
 #include "common/ceph_mutex.h"

--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -7,6 +7,7 @@
 
 #include "common/Formatter.h"
 #include "common/LogEntry.h"
+#include "include/uuid.h"
 #include "log/Entry.h"
 #include "log/SubsystemMap.h"
 

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -25,6 +25,7 @@
 #include "common/ostream_temp.h"
 #include "common/ref.h"
 #include "include/health.h"
+#include "include/uuid.h"
 
 class LogClient;
 class MLog;

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -18,6 +18,7 @@
 
 #include "include/compat.h"
 #include "include/str_list.h"
+#include "include/types.h" // for operator<<(std::list)
 #include "common/BackTrace.h"
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/debug.h"

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <string>
 #include <typeindex>
+#include "include/encoding.h"
 #include <include/types.h>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>

--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -2,8 +2,9 @@
  * Ceph string constants
  */
 #include "ceph_strings.h"
-#include "include/types.h"
 #include "include/ceph_features.h"
+#include "include/ceph_fs.h" // for CEPH_CON_MODE_*
+#include "include/msgr.h" // for CEPH_ENTITY_TYPE_*
 
 const char *ceph_entity_type_name(int type)
 {

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -18,6 +18,7 @@
 #include <fmt/chrono.h>
 #include <fmt/ostream.h>
 
+#include "include/rados.h" // for struct ceph_timespec
 #include "log/LogClock.h"
 #include "config.h"
 #include "strtol.h"

--- a/src/common/scrub_types.h
+++ b/src/common/scrub_types.h
@@ -4,8 +4,14 @@
 #ifndef CEPH_SCRUB_TYPES_H
 #define CEPH_SCRUB_TYPES_H
 
+#include <cstdint>
+#include <map>
+#include <vector>
+
 #include <fmt/ranges.h>
 
+#include "include/buffer.h"
+#include "include/types.h" // for epoch_t
 #include "osd/osd_types.h"
 
 // wrappers around scrub types to offer the necessary bits other than

--- a/src/crimson/osd/scrub/scrub_machine.h
+++ b/src/crimson/osd/scrub/scrub_machine.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <ranges>
 
+#include <boost/optional.hpp>
 #include <boost/statechart/custom_reaction.hpp>
 #include <boost/statechart/deferral.hpp>
 #include <boost/statechart/event.hpp>

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "include/err.h"
 #include "include/encoding.h"
 #include "include/mempool.h"
+#include "include/rados.h" // for CEPH_PG_TYPE_*
 
 namespace ceph {
   class Formatter;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -14,6 +14,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <sstream>
 #include "acconfig.h"
 #ifdef HAVE_BREAKPAD
 #include <breakpad/client/linux/handler/exception_handler.h>
@@ -36,6 +37,7 @@
 #include "global/signal_handler.h"
 #include "include/compat.h"
 #include "include/str_list.h"
+#include "log/Log.h"
 #include "mon/MonClient.h"
 
 #ifndef _WIN32

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -20,12 +20,14 @@
 #include <ostream>
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
 
 #include "include/compact_set.h"
 #include "include/encoding.h"
 #include "include/fs_types.h"
 #include "include/ceph_fs.h"
+#include "include/object.h" // for snapid_t
 #include "include/types.h" // for version_t
 #include "include/utime.h"
 

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -35,6 +35,7 @@ extern "C" {
 #include "statlite.h"
 }
 
+#include <deque>
 #include <string>
 #include <list>
 #include <set>
@@ -47,8 +48,10 @@ extern "C" {
 #include <optional>
 #include <ostream>
 #include <iomanip>
+#include <unordered_map>
 #include <unordered_set>
 
+#include "common/convenience.h" // for ceph::for_each()
 #include "common/Formatter.h"
 
 #include "object.h"

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -14,12 +14,14 @@
 #ifndef CEPH_UTIL_H
 #define CEPH_UTIL_H
 
-#include "common/Formatter.h"
-#include "include/types.h"
-
+#include <cstdint>
 #include <list>
 #include <map>
 #include <string>
+
+#include "common/Formatter.h"
+#include "include/buffer.h"
+#include "include/encoding.h"
 
 std::string bytes2str(uint64_t count);
 

--- a/src/journal/ObjectPlayer.cc
+++ b/src/journal/ObjectPlayer.cc
@@ -4,6 +4,7 @@
 #include "journal/ObjectPlayer.h"
 #include "journal/Utils.h"
 #include "common/Timer.h"
+#include "include/rados.h" // for CEPH_OSD_OP_FLAG_FADVISE_DONTNEED
 #include <limits>
 
 #define dout_subsys ceph_subsys_journaler

--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -5,6 +5,7 @@
 #include "journal/Future.h"
 #include "journal/Utils.h"
 #include "include/ceph_assert.h"
+#include "include/types.h" // for operator<<(std::set)
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/Timer.h"
 #include "common/errno.h"

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -22,6 +22,7 @@
 #include "rocksdb/utilities/table_properties_collectors.h"
 #include "rocksdb/merge_operator.h"
 
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/perf_counters.h"
 #include "common/PriorityCache.h"
 #include "common/strtol.h"
@@ -30,6 +31,7 @@
 #include "include/str_list.h"
 #include "include/stringify.h"
 #include "include/str_map.h"
+#include "include/utime.h"
 #include "KeyValueDB.h"
 #include "RocksDBStore.h"
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -3,6 +3,9 @@
 #ifndef ROCKS_DB_STORE_H
 #define ROCKS_DB_STORE_H
 
+#include <sys/types.h>
+#include <dirent.h>
+
 #include "include/types.h"
 #include "include/buffer_fwd.h"
 #include "KeyValueDB.h"

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -7,6 +7,7 @@
 #include "include/neorados/RADOS.hpp"
 
 #include "common/ceph_context.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/perf_counters.h"

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -14,7 +14,9 @@
 #include "librbd/image_watcher/NotifyLockOwner.h"
 #include "librbd/io/AioCompletion.h"
 #include "include/encoding.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/errno.h"
+#include "common/perf_counters.h"
 #include <boost/bind/bind.hpp>
 
 #include <shared_mutex> // for std::shared_lock

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -4,6 +4,7 @@
 #include "librbd/Journal.h"
 #include "include/rados/librados.hpp"
 #include "common/AsyncOpTracker.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/errno.h"
 #include "common/Timer.h"
 #include "common/WorkQueue.h"

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -14,6 +14,7 @@
 #include "librbd/object_map/DiffRequest.h"
 #include "include/rados/librados.hpp"
 #include "include/interval_set.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/errno.h"
 #include "common/Cond.h"
 #include "common/Throttle.h"

--- a/src/librbd/api/PoolMetadata.cc
+++ b/src/librbd/api/PoolMetadata.cc
@@ -3,6 +3,7 @@
 
 #include "librbd/api/PoolMetadata.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/Cond.h"

--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -3,6 +3,7 @@
 
 #include "librbd/api/Trash.h"
 #include "include/rados/librados.hpp"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/Cond.h"

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -4,6 +4,7 @@
 #include "librbd/cache/ObjectCacherObjectDispatch.h"
 #include "include/neorados/RADOS.hpp"
 #include "common/errno.h"
+#include "common/perf_counters.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Journal.h"
 #include "librbd/Utils.h"

--- a/src/librbd/cache/pwl/ssd/LogEntry.cc
+++ b/src/librbd/cache/pwl/ssd/LogEntry.cc
@@ -4,6 +4,8 @@
 #include "librbd/cache/ImageWriteback.h"
 #include "librbd/cache/pwl/ssd/LogEntry.h"
 
+#include "include/intarith.h" // for round_up_to()
+
 #define dout_subsys ceph_subsys_rbd_pwl
 #undef dout_prefix
 #define dout_prefix *_dout << "librbd::cache::pwl::ssd::WriteLogEntry: " \

--- a/src/librbd/cache/pwl/ssd/Request.cc
+++ b/src/librbd/cache/pwl/ssd/Request.cc
@@ -3,6 +3,10 @@
 
 #include "Request.h"
 
+#include "include/intarith.h" // for round_up_to()
+
+#include <ostream>
+
 #define dout_subsys ceph_subsys_rbd_pwl
 #undef dout_prefix
 #define dout_prefix *_dout << "librbd::cache::pwl::ssd::Request: " << this << " " \

--- a/src/librbd/cache/pwl/ssd/Request.h
+++ b/src/librbd/cache/pwl/ssd/Request.h
@@ -6,6 +6,8 @@
 
 #include "librbd/cache/pwl/Request.h"
 
+#include <iosfwd>
+
 namespace librbd {
 class BlockGuardCell;
 

--- a/src/librbd/cache/pwl/ssd/Types.h
+++ b/src/librbd/cache/pwl/ssd/Types.h
@@ -6,6 +6,7 @@
   
 #include "acconfig.h"
     
+#include "common/Formatter.h"
 #include "librbd/io/Types.h"
 #include "librbd/cache/pwl/Types.h"
 

--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -5,6 +5,7 @@
 #include "include/buffer.h"
 #include "include/Context.h"
 #include "include/ceph_assert.h"
+#include "include/intarith.h" // for round_up_to()
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/deleter.h"
 #include "common/dout.h"

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -16,6 +16,7 @@
 #include "librbd/io/Utils.h"
 #include "librbd/journal/Types.h"
 #include "include/rados/librados.hpp"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/errno.h"
 #include "common/perf_counters.h"
 #include "osdc/Striper.h"

--- a/src/librbd/object_map/SnapshotRemoveRequest.h
+++ b/src/librbd/object_map/SnapshotRemoveRequest.h
@@ -6,6 +6,7 @@
 
 #include "include/int_types.h"
 #include "include/buffer.h"
+#include "include/rados.h" // for CEPH_NOSNAP
 #include "common/bit_vector.hpp"
 #include "librbd/AsyncRequest.h"
 

--- a/src/librbd/object_map/SnapshotRollbackRequest.h
+++ b/src/librbd/object_map/SnapshotRollbackRequest.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_OBJECT_MAP_SNAPSHOT_ROLLBACK_REQUEST_H
 
 #include "include/int_types.h"
+#include "include/rados.h" // for CEPH_NOSNAP
 #include "librbd/object_map/Request.h"
 
 class Context;

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -3,6 +3,7 @@
 
 #include "cls/rbd/cls_rbd_types.h"
 #include "librbd/operation/SnapshotCreateRequest.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/dout.h"
 #include "common/errno.h"
 #include "librbd/ExclusiveLock.h"

--- a/src/mds/Anchor.cc
+++ b/src/mds/Anchor.cc
@@ -17,6 +17,8 @@
 #include "common/Formatter.h"
 #include "include/denc.h"
 
+#include <dirent.h> // for DT_DIR
+
 void Anchor::encode(bufferlist &bl) const
 {
   ENCODE_START(2, 1, bl);

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -15,11 +15,17 @@
 #ifndef CEPH_ANCHOR_H
 #define CEPH_ANCHOR_H
 
+#include <iosfwd>
+#include <set>
 #include <string>
 
 #include "include/types.h"
 #include "mdstypes.h"
 #include "include/buffer.h"
+#include "include/cephfs/types.h" // for mds_rank_t
+#include "include/frag.h"
+#include "include/fs_types.h" // for inodeno_t
+#include "include/int_types.h" // for __u8
 
 /*
  * Anchor represents primary linkage of an inode. When adding inode to an

--- a/src/mds/BatchOp.h
+++ b/src/mds/BatchOp.h
@@ -16,9 +16,11 @@
 #ifndef MDS_BATCHOP_H
 #define MDS_BATCHOP_H
 
-#include "common/ref.h"
+#include <iosfwd>
 
 #include "mdstypes.h"
+#include "common/ref.h"
+#include "include/cephfs/types.h" // for mds_rank_t
 
 class BatchOp {
 public:

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -32,6 +32,8 @@
 #include "mds/mdstypes.h"
 #include "osdc/Objecter.h"
 
+#include "messages/MMDSBeacon.h"
+
 #include <chrono>
 
 #define dout_context g_ceph_context

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_CINODE_H
 #define CEPH_CINODE_H
 
+#include <dirent.h> // for IFTODT()
+
 #include <list>
 #include <map>
 #include <set>
@@ -33,6 +35,7 @@
 #include "include/compact_set.h"
 
 #include "MDSCacheObject.h"
+#include "mdstypes.h" // for old_inode_t
 #include "flock.h"
 #include "inode_backtrace.h" // for inode_backtrace_t
 

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -15,6 +15,7 @@
 #include "Capability.h"
 #include "BatchOp.h"
 #include "CInode.h"
+#include "Mutation.h" // for struct MDLockCache
 #include "SessionMap.h"
 
 #include "common/debug.h"

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -17,8 +17,12 @@
 #define CEPH_CAPABILITY_H
 
 #include "include/buffer_fwd.h"
+#include "include/ceph_fs.h" // for CEPH_CAP_*
 #include "include/counter.h"
 #include "include/mempool.h"
+#include "include/object.h" // for snapid_t
+#include "include/types.h" // for version_t
+#include "include/utime.h"
 #include "include/xlist.h"
 #include "include/elist.h"
 

--- a/src/mds/DamageTable.h
+++ b/src/mds/DamageTable.h
@@ -18,9 +18,16 @@
 
 #include "mdstypes.h"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
+
+#include "include/cephfs/types.h" // for mds_rank_t
+#include "include/frag.h"
+#include "include/fs_types.h" // for inodeno_t
+#include "include/object.h" // for snapid_t
+#include "include/utime.h"
 
 class CDir;
 class CInode;

--- a/src/mds/FSMapUser.cc
+++ b/src/mds/FSMapUser.cc
@@ -1,4 +1,5 @@
 #include "FSMapUser.h"
+#include "common/Formatter.h"
 
 void FSMapUser::encode(ceph::buffer::list& bl, uint64_t features) const
 {

--- a/src/mds/FSMapUser.h
+++ b/src/mds/FSMapUser.h
@@ -15,10 +15,17 @@
 #define CEPH_FSMAPCOMPACT_H
 
 #include <map>
+#include <iosfwd>
 #include <string>
 #include <string_view>
 
 #include "mds/mdstypes.h"
+
+#include "include/encoding.h"
+#include "include/cephfs/types.h" // for fs_cluster_id_t
+#include "include/types.h" // for epoch_t
+
+namespace ceph { class Formatter; }
 
 class FSMapUser {
 public:

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -17,6 +17,7 @@
 #define CEPH_INOTABLE_H
 
 #include "MDSTable.h"
+#include "include/fs_types.h" // for inodeno_t
 #include "include/interval_set.h"
 
 class MDSRank;

--- a/src/mds/JournalPointer.cc
+++ b/src/mds/JournalPointer.cc
@@ -14,6 +14,10 @@
 
 
 #include "mds/JournalPointer.h"
+
+#include <iomanip>
+#include <ostream>
+
 #include "mds/mdstypes.h"
 
 #include "common/debug.h"

--- a/src/mds/JournalPointer.h
+++ b/src/mds/JournalPointer.h
@@ -16,6 +16,12 @@
 #ifndef JOURNAL_POINTER_H
 #define JOURNAL_POINTER_H
 
+#include <iosfwd>
+#include <list>
+#include <string>
+
+#include "common/Formatter.h"
+#include "include/fs_types.h" // for inodeno_t
 #include "include/encoding.h"
 #include "mdstypes.h"
 

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -37,6 +37,7 @@ class MClientCaps;
 class MClientCapRelease;
 class MClientLease;
 class MClientReply;
+class MInodeFileCaps;
 class MDCache;
 class MLock;
 class MDSContext;

--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -18,7 +18,9 @@
 #include "include/elist.h"
 #include "include/interval_set.h"
 #include "include/Context.h"
-#include "mdstypes.h"
+#include "include/fs_types.h" // for inodeno_t
+#include "include/types.h" // for version_t
+#include "mdstypes.h" // for dirfrag_t, metareqid_t
 #include "CInode.h"
 #include "CDentry.h"
 #include "CDir.h"

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -14,8 +14,16 @@
 #ifndef CEPH_MDBALANCER_H
 #define CEPH_MDBALANCER_H
 
-#include "mdstypes.h"
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "mdstypes.h" // for dirfrag_t, mds_load_t
 #include "include/types.h"
+#include "common/ceph_time.h" // for coarse_mono_time()
+#include "include/cephfs/types.h" // for mds_rank_t
 #include "common/Clock.h"
 #include "common/ref.h"
 

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -41,6 +41,7 @@ enum {
   l_mdl_last,
 };
 
+#include "include/fs_types.h" // for inodeno_t
 #include "include/types.h"
 #include "include/Context.h"
 
@@ -53,8 +54,12 @@ enum {
 #include "mdstypes.h"
 #include "LogSegmentRef.h"
 
+#include <atomic>
 #include <list>
 #include <map>
+#include <set>
+#include <string>
+#include <vector>
 
 class Journaler;
 class JournalPointer;

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -8,6 +8,7 @@
 #include "common/config.h"
 
 #include "include/ceph_assert.h"
+#include "include/cephfs/types.h" // for mds_rank_t
 #include "include/mempool.h"
 #include "include/types.h"
 

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <ranges>
 #include <string_view>
+#include <vector>
 
 #include <errno.h>
 

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -27,6 +27,7 @@
 
 #include "include/types.h"
 #include "include/ceph_features.h"
+#include "include/cephfs/types.h" // for mds_gid_t, mds_rank_t, MAX_MDS
 #include "include/health.h"
 #include "include/CompatSet.h"
 #include "include/common_fwd.h"
@@ -35,7 +36,7 @@
 #include "common/ceph_releases.h"
 #include "common/config.h"
 
-#include "mds/mdstypes.h"
+#include "mds/mdstypes.h" // feature_bitset_t
 
 namespace ceph { class Formatter; }
 

--- a/src/mds/MDSPerfMetricTypes.h
+++ b/src/mds/MDSPerfMetricTypes.h
@@ -6,6 +6,8 @@
 
 #include <ostream>
 
+#include "common/Formatter.h"
+#include "include/cephfs/types.h" // for mds_rank_t
 #include "include/denc.h"
 #include "include/utime.h"
 #include "mdstypes.h"

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -25,6 +25,7 @@
 #include "common/cmdparse.h"
 #include "log/Log.h"
 
+#include "messages/MClientRequest.h"
 #include "messages/MClientRequestForward.h"
 #include "messages/MMDSLoadTargets.h"
 #include "messages/MMDSMap.h"
@@ -2551,7 +2552,7 @@ void MDSRankDispatcher::handle_mds_map(
   }
 
   {
-    map<epoch_t,MDSContext::vec >::iterator p = waiting_for_mdsmap.begin();
+    std::map<epoch_t,MDSContext::vec >::iterator p = waiting_for_mdsmap.begin();
     while (p != waiting_for_mdsmap.end() && p->first <= mdsmap->get_epoch()) {
       MDSContext::vec ls;
       ls.swap(p->second);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -21,6 +21,7 @@
 #include "common/admin_socket.h" // for asok_finisher
 #include "common/DecayCounter.h"
 #include "common/LogClient.h"
+#include "common/TrackedOp.h" // for class OpTracker
 
 #include "include/common_fwd.h"
 
@@ -36,9 +37,12 @@
 // benefit of those including this header and using MDSRank::logger
 #include "common/perf_counters.h"
 
+#include <boost/intrusive_ptr.hpp>
+
 class MDSContext;
 class MDSMetaRequest;
 class MMDSMap;
+typedef boost::intrusive_ptr<MDRequestImpl> MDRequestRef;
 
 namespace boost::asio { class io_context; }
 

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -15,7 +15,8 @@
 #ifndef CEPH_MDSTABLE_H
 #define CEPH_MDSTABLE_H
 
-#include "include/buffer_fwd.h"
+#include "include/buffer.h"
+#include "include/object.h" // for object_t
 #include "include/types.h" // for version_t
 #include "include/cephfs/types.h" // for mds_rank_t
 

--- a/src/mds/MDSTableClient.h
+++ b/src/mds/MDSTableClient.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_MDSTABLECLIENT_H
 #define CEPH_MDSTABLECLIENT_H
 
+#include "include/buffer.h"
 #include "include/types.h"
 #include "mds_table_types.h"
 #include "mdstypes.h" // for mds_rank_t
@@ -30,6 +31,8 @@ class MMDSTableRequest;
 class MMDSTableQuery;
 class MDSRank;
 class LogSegment;
+using ceph::bufferlist;
+using ceph::cref_t;
 
 class MDSTableClient {
 public:

--- a/src/mds/MDSTableServer.h
+++ b/src/mds/MDSTableServer.h
@@ -15,10 +15,16 @@
 #ifndef CEPH_MDSTABLESERVER_H
 #define CEPH_MDSTABLESERVER_H
 
+#include <map>
+#include <set>
+
 #include "MDSTable.h"
 #include "mdstypes.h" // for mds_table_pending_t
+#include "mds_table_types.h" // for get_mdstable_name()
 
 #include "messages/MMDSTableRequest.h"
+
+#include "common/ref.h" // for cref_t
 
 class MDSContext;
 

--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -17,6 +17,7 @@
 #include "Mantle.h"
 #include "msg/Messenger.h"
 #include "common/Clock.h"
+#include "common/dout.h"
 #include "CInode.h"
 
 /* Note, by default debug_mds_balancer is 1/5. For debug messages 1<lvl<=5,

--- a/src/mds/Mantle.h
+++ b/src/mds/Mantle.h
@@ -24,6 +24,8 @@
 
 #include "mdstypes.h"
 
+#include "include/cephfs/types.h" // for mds_rank_t
+
 class Mantle {
   public:
     Mantle();

--- a/src/mds/MetricAggregator.h
+++ b/src/mds/MetricAggregator.h
@@ -7,14 +7,16 @@
 #include <map>
 #include <set>
 #include <thread>
+#include <unordered_set>
 
-#include "msg/msg_types.h"
+#include "msg/msg_types.h" // for entity_inst_t
 #include "msg/Dispatcher.h"
 #include "common/ceph_mutex.h"
 #include "common/perf_counters.h"
 #include "include/common_fwd.h"
 
-#include "mgr/MetricTypes.h"
+#include "mgr/Types.h" // for PerformanceCounters
+#include "mgr/MetricTypes.h" // for MetricPayload
 #include "mgr/MDSPerfMetricTypes.h"
 
 #include "mdstypes.h"

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -23,12 +23,16 @@
 #include <unordered_map>
 #include <vector>
 
+#include "common/ref.h" // for cref_t
+#include "include/cephfs/types.h" // for mds_rank_t
+#include "include/Context.h"
 #include "include/interval_set.h"
 #include "include/elist.h"
 #include "include/filepath.h"
 
 #include "Capability.h"
 #include "LogSegmentRef.h"
+#include "mdstypes.h" // for dirfrag_t, metareqid_t
 
 #include "common/StackStringStream.h"
 #include "common/TrackedOp.h"

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -15,7 +15,9 @@
 #ifndef OPEN_FILE_TABLE_H
 #define OPEN_FILE_TABLE_H
 
+#include <cstdint>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -23,7 +25,14 @@
 
 #include "common/config_proxy.h" // for class ConfigProxy
 #include "global/global_context.h" // for g_conf()
+#include "include/buffer_fwd.h"
+#include "include/cephfs/types.h" // for mds_rank_t"
+#include "include/frag.h"
+#include "include/fs_types.h" // for inodeno_t
+#include "include/object.h"
+#include "include/types.h" // for version_t
 
+namespace TOPNSPC::common { class PerfCounters; }
 struct inode_backpointer_t;
 class Context;
 class CDir;
@@ -155,7 +164,7 @@ protected:
   std::map<uint64_t, std::vector<inodeno_t> > logseg_destroyed_inos;
   std::set<inodeno_t> destroyed_inos_set;
 
-  std::unique_ptr<PerfCounters> logger;
+  std::unique_ptr<TOPNSPC::common::PerfCounters> logger;
 
   std::map<uint64_t, std::vector<Context*>> waiting_for_commit;
 };

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -18,6 +18,7 @@
 #include "mds/mdstypes.h"
 #include "common/Finisher.h"
 #include "common/snap_types.h" // for class SnapContext
+#include "include/cephfs/types.h" // for mds_rank_t
 #include "osdc/Journaler.h"
 #include "include/frag.h"
 

--- a/src/mds/QuiesceDb.h
+++ b/src/mds/QuiesceDb.h
@@ -22,6 +22,7 @@
 
 #include "mds/mdstypes.h"
 #include "common/ceph_time.h"
+#include "include/cephfs/types.h" // for mds_gid_t
 
 class Context;
 

--- a/src/mds/QuiesceDbManager.h
+++ b/src/mds/QuiesceDbManager.h
@@ -23,6 +23,9 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "include/cephfs/types.h" // for fs_cluster_id_t
+#include "include/types.h" // for epoch_t
+
 struct QuiesceClusterMembership {
   static const QuiesceInterface::PeerId INVALID_MEMBER;
 

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -19,6 +19,8 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <vector>
 
 #include "include/ceph_assert.h"
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -49,6 +49,7 @@
 #include "messages/MClientReclaim.h"
 #include "messages/MClientReclaimReply.h"
 #include "messages/MLock.h"
+#include "messages/MMDSPeerRequest.h"
 #include "msg/Messenger.h"
 
 #include "osdc/Objecter.h"

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -24,12 +24,15 @@
 #include <string>
 #include <unordered_map>
 
+#include "include/ceph_assert.h"
+#include "include/cephfs/types.h" // for mds_rank_t
 #include "include/Context.h"
 #include "include/xlist.h"
 #include "include/elist.h"
 #include "include/interval_set.h"
-#include "mdstypes.h"
+#include "mdstypes.h" // for metareqid_t, session_info_t
 #include "mds/MDSAuthCaps.h"
+#include "common/ceph_time.h" // for ceph::coarse_mono_{clock,time}
 #include "common/DecayCounter.h"
 
 #include "Mutation.h" // for struct MDRequestImpl

--- a/src/mds/SnapClient.h
+++ b/src/mds/SnapClient.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "MDSTableClient.h"
+#include "mds_table_types.h" // for TABLE_SNAP
 #include "snap.h"
 
 class MDSContext;

--- a/src/mds/SnapRealm.h
+++ b/src/mds/SnapRealm.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_MDS_SNAPREALM_H
 #define CEPH_MDS_SNAPREALM_H
 
+#include <map>
+#include <set>
 #include <string_view>
 
 #include "Capability.h"

--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -15,8 +15,14 @@
 #ifndef CEPH_SNAPSERVER_H
 #define CEPH_SNAPSERVER_H
 
+#include <list>
+#include <map>
+#include <set>
+
 #include "MDSTableServer.h"
 #include "snap.h"
+#include "include/encoding.h"
+#include "include/object.h" // for struct snapid_t
 
 class MDSRank;
 class MRemoveSnaps;

--- a/src/mds/cephfs_features.cc
+++ b/src/mds/cephfs_features.cc
@@ -3,6 +3,7 @@
 
 #include "cephfs_features.h"
 #include "mdstypes.h"
+#include "common/Formatter.h"
 #include "common/StackStringStream.h"
 
 #include <fmt/format.h>

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -3,6 +3,7 @@
 
 #include "mds/flock.h"
 #include "common/debug.h"
+#include "common/Formatter.h"
 #include "mdstypes.h"
 
 #include <iostream>

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -43,6 +43,8 @@
 #include "include/random.h" // for ceph::util::generate_random_number()
 #include "include/stringify.h"
 
+#include "messages/MMDSTableRequest.h"
+
 #include "LogSegment.h"
 
 #include "MDSRank.h"

--- a/src/mds/mds_table_types.h
+++ b/src/mds/mds_table_types.h
@@ -19,6 +19,8 @@
 
 #include <string_view>
 
+#include "include/ceph_assert.h" // for ceph_abort()
+
 enum {
   TABLE_ANCHOR,
   TABLE_SNAP,

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -17,6 +17,8 @@
 #include "include/frag.h"
 #include "include/interval_set.h"
 #include "include/fs_types.h"
+#include "include/types.h" // for ceph_tid_t, version_t
+#include "include/utime.h"
 
 #include "include/ceph_assert.h"
 #include "include/cephfs/dump.h"

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -18,12 +18,15 @@
 #include <iosfwd>
 #include <list>
 #include <map>
+#include <set>
 #include <string>
 #include <string_view>
 
 #include "mdstypes.h"
 #include "common/snap_types.h"
 #include "include/buffer.h"
+#include "include/object.h" // for snapid_t
+#include "include/utime.h"
 
 namespace ceph { class Formatter; }
 

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -33,10 +33,16 @@
  *  
  */
 
+#include <list>
+#include <map>
+#include <ostream>
+#include <string>
 #include <string_view>
+#include <vector>
 
 #include "include/filepath.h"
 #include "mds/mdstypes.h"
+#include "common/Formatter.h"
 #include "include/ceph_features.h"
 #include "mds/cephfs_features.h"
 #include "messages/MMDSOp.h"

--- a/src/messages/MCommand.h
+++ b/src/messages/MCommand.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_MCOMMAND_H
 #define CEPH_MCOMMAND_H
 
+#include <string>
 #include <vector>
 
 #include "msg/Message.h"

--- a/src/messages/MCommandReply.h
+++ b/src/messages/MCommandReply.h
@@ -15,8 +15,10 @@
 #ifndef CEPH_MCOMMANDREPLY_H
 #define CEPH_MCOMMANDREPLY_H
 
+#include <string>
 #include <string_view>
 
+#include "include/types.h" // for errorcode32_t
 #include "msg/Message.h"
 #include "MCommand.h"
 

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -15,7 +15,10 @@
 #ifndef CEPH_MMDSBEACON_H
 #define CEPH_MMDSBEACON_H
 
+#include <map>
+#include <string>
 #include <string_view>
+#include <vector>
 
 #include "msg/Message.h"
 #include "messages/PaxosServiceMessage.h"

--- a/src/messages/MMDSLoadTargets.h
+++ b/src/messages/MMDSLoadTargets.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_MMDSLoadTargets_H
 #define CEPH_MMDSLoadTargets_H
 
+#include <set>
+
 #include "msg/Message.h"
 #include "mds/mdstypes.h"
 #include "messages/PaxosServiceMessage.h"

--- a/src/messages/MMDSOpenIno.h
+++ b/src/messages/MMDSOpenIno.h
@@ -15,6 +15,9 @@
 #ifndef CEPH_MDSOPENINO_H
 #define CEPH_MDSOPENINO_H
 
+#include <ostream>
+#include <vector>
+
 #include "messages/MMDSOp.h"
 #include "mds/inode_backtrace.h" // for inode_backpointer_t
 

--- a/src/messages/MMDSOpenInoReply.h
+++ b/src/messages/MMDSOpenInoReply.h
@@ -15,6 +15,9 @@
 #ifndef CEPH_MDSOPENINOREPLY_H
 #define CEPH_MDSOPENINOREPLY_H
 
+#include <ostream>
+#include <vector>
+
 #include "messages/MMDSOp.h"
 
 class MMDSOpenInoReply final : public MMDSOp {

--- a/src/messages/MMgrCommand.h
+++ b/src/messages/MMgrCommand.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <ostream>
+#include <string>
 #include <vector>
 
 #include "msg/Message.h"

--- a/src/messages/MMgrCommandReply.h
+++ b/src/messages/MMgrCommandReply.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <ostream>
+#include <string>
 #include <string_view>
 
 #include "msg/Message.h"

--- a/src/messages/MMonCommandAck.h
+++ b/src/messages/MMonCommandAck.h
@@ -19,6 +19,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 using ceph::common::cmdmap_from_json;
 using ceph::common::cmd_getval;

--- a/src/messages/MMonUsedPendingKeys.h
+++ b/src/messages/MMonUsedPendingKeys.h
@@ -14,6 +14,11 @@
 
 #pragma once
 
+#include <map>
+
+#include <boost/intrusive_ptr.hpp>
+
+#include "auth/Crypto.h" // for CryptoKey
 #include "messages/PaxosServiceMessage.h"
 
 class MMonUsedPendingKeys final : public PaxosServiceMessage {

--- a/src/messages/MOSDFastDispatchOp.h
+++ b/src/messages/MOSDFastDispatchOp.h
@@ -4,8 +4,9 @@
 #ifndef CEPH_MOSDFASTDISPATCHOP_H
 #define CEPH_MOSDFASTDISPATCHOP_H
 
+#include "include/types.h" // for epoch_t
 #include "msg/Message.h"
-#include "osd/osd_types.h"
+#include "osd/osd_types.h" // for spg_t
 
 class MOSDFastDispatchOp : public Message {
 public:

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -17,9 +17,12 @@
 #define CEPH_MOSDOP_H
 
 #include <atomic>
+#include <cstdint>
+#include <vector>
 
 #include "MOSDFastDispatchOp.h"
 #include "include/ceph_features.h"
+#include "include/ceph_fs.h" // for CEPH_MSG_OSD_OP
 #include "common/hobject.h"
 
 /*

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -16,6 +16,9 @@
 #ifndef CEPH_MOSDOPREPLY_H
 #define CEPH_MOSDOPREPLY_H
 
+#include <ostream>
+#include <vector>
+
 #include "msg/Message.h"
 
 #include "MOSDOp.h"

--- a/src/messages/MPGStats.h
+++ b/src/messages/MPGStats.h
@@ -15,6 +15,9 @@
 #ifndef CEPH_MPGSTATS_H
 #define CEPH_MPGSTATS_H
 
+#include <map>
+
+#include "common/Formatter.h"
 #include "osd/osd_types.h"
 #include "messages/PaxosServiceMessage.h"
 

--- a/src/messages/MPGStatsAck.h
+++ b/src/messages/MPGStatsAck.h
@@ -15,7 +15,9 @@
 #ifndef CEPH_MPGSTATSACK_H
 #define CEPH_MPGSTATSACK_H
 
-#include "osd/osd_types.h"
+#include "include/types.h" // for epoch_t, version_t
+#include "msg/Message.h"
+#include "osd/osd_types.h" // for pg_t
 
 class MPGStatsAck final : public Message {
 public:

--- a/src/messages/MPing.h
+++ b/src/messages/MPing.h
@@ -16,6 +16,7 @@
 #ifndef CEPH_MPING_H
 #define CEPH_MPING_H
 
+#include "include/ceph_fs.h" // for CEPH_MSG_PING
 #include "msg/Message.h"
 
 class MPing final : public Message {

--- a/src/messages/MStatfs.h
+++ b/src/messages/MStatfs.h
@@ -18,6 +18,8 @@
 
 #include <optional>
 #include <sys/statvfs.h>    /* or <sys/statfs.h> */
+
+#include "include/ceph_fs.h" // for CEPH_MSG_STATFS
 #include "messages/PaxosServiceMessage.h"
 
 class MStatfs final : public PaxosServiceMessage {

--- a/src/messages/MTimeCheck.h
+++ b/src/messages/MTimeCheck.h
@@ -15,6 +15,14 @@
 #ifndef CEPH_MTIMECHECK_H
 #define CEPH_MTIMECHECK_H
 
+#include <cstdint>
+#include <map>
+
+#include "include/encoding.h"
+#include "include/utime.h"
+#include "include/types.h" // for version_t
+#include "msg/Message.h"
+
 class MTimeCheck final : public Message {
 public:
   static constexpr int HEAD_VERSION = 1;

--- a/src/messages/MTimeCheck2.h
+++ b/src/messages/MTimeCheck2.h
@@ -14,6 +14,14 @@
 
 #pragma once
 
+#include <cstdint>
+#include <map>
+
+#include "include/encoding.h"
+#include "include/utime.h"
+#include "include/types.h" // for version_t
+#include "msg/Message.h"
+
 class MTimeCheck2 final : public Message {
 public:
   static constexpr int HEAD_VERSION = 1;

--- a/src/messages/MWatchNotify.h
+++ b/src/messages/MWatchNotify.h
@@ -16,6 +16,8 @@
 #ifndef CEPH_MWATCHNOTIFY_H
 #define CEPH_MWATCHNOTIFY_H
 
+#include <ostream>
+
 #include "msg/Message.h"
 
 

--- a/src/messages/PaxosServiceMessage.h
+++ b/src/messages/PaxosServiceMessage.h
@@ -6,7 +6,7 @@
 #include "msg/Message.h"
 #include "mon/Session.h"
 #include "include/encoding.h"
-#include "include/types.h" // for epoch_t
+#include "include/types.h" // for epoch_t, version_t
 
 #include <cstdint>
 #include <string_view>

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -22,6 +22,7 @@
 #include "common/perf_counters_key.h"
 #include "crush/CrushWrapper.h"
 #include "include/stringify.h"
+#include "json_spirit/json_spirit_writer.h"
 
 #include "mon/MonMap.h"
 #include "osd/OSDMap.h"
@@ -29,6 +30,7 @@
 #include "mgr/MgrContext.h"
 #include "mgr/TTLCache.h"
 #include "mgr/mgr_perf_counters.h"
+#include "messages/MMgrReport.h" // for class PerfCounterType
 
 #include "DaemonKey.h"
 #include "DaemonServer.h"

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -26,6 +26,7 @@
 #include "mon/MonCommand.h"
 #include "mon/mon_types.h"
 #include "mon/ConfigMap.h"
+#include "mgr/MDSPerfMetricTypes.h"
 #include "mgr/TTLCache.h"
 
 #include "DaemonState.h"
@@ -33,6 +34,7 @@
 #include "OSDPerfMetricTypes.h"
 
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -39,6 +39,7 @@
 #include "messages/MCommandReply.h"
 #include "messages/MMgrCommand.h"
 #include "messages/MMgrCommandReply.h"
+#include "messages/MMgrReport.h"
 #include "messages/MPGStats.h"
 #include "messages/MOSDScrub2.h"
 #include "messages/MOSDForceRecovery.h"

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -17,6 +17,7 @@
 
 #include "MgrSession.h"
 #include "include/stringify.h"
+#include "include/str_map.h"
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/debug.h"
 #include "common/Formatter.h"

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -21,12 +21,17 @@
 #include <set>
 #include <boost/circular_buffer.hpp>
 
+#include "common/ceph_mutex.h"
+#include "common/perf_counters.h" // for enum perfcounter_type_d
+#include "common/RefCountedObj.h"
 #include "include/str_map.h"
+#include "include/utime.h"
 
 #include "msg/msg_types.h"
 
 // For PerfCounterType
 #include "messages/MMgrReport.h"
+#include "DaemonHealthMetric.h"
 #include "DaemonKey.h"
 
 namespace ceph {

--- a/src/mgr/MDSPerfMetricTypes.h
+++ b/src/mgr/MDSPerfMetricTypes.h
@@ -8,8 +8,10 @@
 #include <vector>
 #include <iosfwd>
 
+#include "include/cephfs/types.h" // for mds_rank_t
 #include "include/denc.h"
 #include "include/stringify.h"
+#include "include/utime.h"
 #include "common/Formatter.h"
 
 #include "mds/mdstypes.h"

--- a/src/mgr/MetricTypes.h
+++ b/src/mgr/MetricTypes.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_MGR_METRIC_TYPES_H
 #define CEPH_MGR_METRIC_TYPES_H
 
+#include <boost/variant/static_visitor.hpp>
 #include <variant>
 #include "include/denc.h"
 #include "include/ceph_features.h"

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -17,6 +17,7 @@
 #include "common/errno.h"
 #include "mon/MonClient.h"
 #include "include/stringify.h"
+#include "include/str_map.h"
 #include "global/global_context.h"
 #include "global/signal_handler.h"
 

--- a/src/mgr/OSDPerfMetricTypes.h
+++ b/src/mgr/OSDPerfMetricTypes.h
@@ -11,7 +11,13 @@
 
 #include "mgr/Types.h"
 
+#include <iosfwd>
+#include <list>
+#include <map>
 #include <regex>
+#include <set>
+#include <string>
+#include <vector>
 
 typedef std::vector<std::string> OSDPerfMetricSubKey; // array of regex match
 typedef std::vector<OSDPerfMetricSubKey> OSDPerfMetricKey;

--- a/src/mgr/Types.h
+++ b/src/mgr/Types.h
@@ -4,6 +4,8 @@
 #ifndef CEPH_MGR_TYPES_H
 #define CEPH_MGR_TYPES_H
 
+#include <vector>
+
 typedef int MetricQueryID;
 
 typedef std::pair<uint64_t,uint64_t> PerformanceCounter;

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <set>
 
+#include "auth/cephx/CephxKeyServer.h"
 #include "global/global_init.h"
 #include "include/ceph_features.h"
 #include "include/types.h"

--- a/src/mon/ConnectionTracker.h
+++ b/src/mon/ConnectionTracker.h
@@ -13,7 +13,15 @@
  */
 
 #pragma once
+
+#include "include/encoding.h"
 #include "include/types.h"
+
+#include <iosfwd>
+#include <map>
+#include <set>
+
+namespace ceph { class Formatter; }
 
 struct ConnectionReport {
   int rank = -1; // mon rank this state belongs to

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -19,6 +19,7 @@
 #include "MonitorDBStore.h"
 #include "messages/MMonElection.h"
 #include "messages/MMonPing.h"
+#include "msg/Messenger.h"
 
 #include "common/config.h"
 #include "include/ceph_assert.h"

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -21,6 +21,8 @@
 #include "osd/OSDMap.h"
 #include "common/strtol.h" // for strict_strtoll()
 
+#include <boost/optional.hpp>
+
 using TOPNSPC::common::cmd_getval;
 
 using std::list;

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -19,6 +19,8 @@
 #include "Monitor.h"
 #include "CommandHandler.h"
 
+#include "include/cephfs/types.h" // for fs_cluster_id_t"
+
 #include <iosfwd>
 #include <memory>
 #include <string>

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -27,6 +27,7 @@
 #include "mon/HealthMonitor.h"
 #include "mon/OSDMonitor.h"
 
+#include "messages/MMonCommand.h"
 #include "messages/MMonHealthChecks.h"
 
 #include "common/Formatter.h"

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -14,6 +14,10 @@
 #ifndef CEPH_HEALTH_MONITOR_H
 #define CEPH_HEALTH_MONITOR_H
 
+#include <map>
+#include <set>
+#include <string>
+
 #include "mon/PaxosService.h"
 
 class HealthMonitor : public PaxosService

--- a/src/mon/KVMonitor.cc
+++ b/src/mon/KVMonitor.cc
@@ -5,6 +5,7 @@
 #include "mon/KVMonitor.h"
 #include "include/stringify.h"
 #include "messages/MKVData.h"
+#include "messages/MMonCommand.h"
 
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -53,6 +53,7 @@
 #include "messages/MMonCommand.h"
 #include "messages/MLog.h"
 #include "messages/MLogAck.h"
+#include "msg/Messenger.h"
 #include "common/Graylog.h"
 #include "common/Journald.h"
 #include "common/errno.h"

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -23,8 +23,10 @@
 #include <vector>
 
 #include "include/types.h"
+#include "Monitor.h"
 #include "PaxosFSMap.h"
 #include "PaxosService.h"
+#include "mds/MDSMap.h"
 #include "msg/Messenger.h"
 #include "messages/MMDSBeacon.h"
 #include "CommandHandler.h"

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -16,6 +16,7 @@
 #include "messages/MMgrBeacon.h"
 #include "messages/MMgrMap.h"
 #include "messages/MMgrDigest.h"
+#include "messages/MMonCommand.h"
 
 #include "include/stringify.h"
 #include "mgr/MgrContext.h"
@@ -23,6 +24,7 @@
 #include "OSDMonitor.h"
 #include "ConfigMonitor.h"
 #include "HealthMonitor.h"
+#include "Monitor.h"
 
 #include "common/TextTable.h"
 #include "include/stringify.h"

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -4,6 +4,7 @@
 #include "MgrStatMonitor.h"
 #include "mon/OSDMonitor.h"
 #include "mon/MgrMonitor.h"
+#include "mon/Monitor.h"
 #include "mon/PGMap.h"
 #include "messages/MGetPoolStats.h"
 #include "messages/MGetPoolStatsReply.h"

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -4,12 +4,16 @@
 #ifndef CEPH_MONCAP_H
 #define CEPH_MONCAP_H
 
+#include <map>
 #include <ostream>
+#include <string>
+#include <vector>
 
 #include "include/common_fwd.h"
 #include "include/types.h"
 #include "common/entity_name.h"
 #include "mds/mdstypes.h"
+#include "msg/msg_types.h" // for entity_addr_t
 
 static const __u8 MON_CAP_R     = (1 << 1);      // read
 static const __u8 MON_CAP_W     = (1 << 2);      // write

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -21,6 +21,7 @@
 
 #include "common/config_fwd.h"
 #include "common/ceph_releases.h"
+#include "include/types.h" // for epoch_t
 #include "include/uuid.h" // for uuid_d
 
 #include "mon/mon_types.h" // for mon_feature_t

--- a/src/mon/MonSub.h
+++ b/src/mon/MonSub.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "common/ceph_time.h"
+#include "include/ceph_fs.h" // for ceph_mon_subscribe_item
 #include "include/types.h"
 
 // mon subscriptions

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -19,9 +19,11 @@
 #ifndef CEPH_MONMAPMONITOR_H
 #define CEPH_MONMAPMONITOR_H
 
-#include <map>
+#include <iosfwd>
 #include <set>
+#include <string>
 
+#include "include/buffer_fwd.h"
 #include "include/types.h"
 #include "msg/Messenger.h"
 

--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -15,6 +15,7 @@
 #include "include/stringify.h"
 #include "NVMeofGwMon.h"
 #include "NVMeofGwMap.h"
+#include "Monitor.h"
 #include "OSDMonitor.h"
 #include "mon/health_check.h"
 

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -14,6 +14,8 @@
 #include <boost/tokenizer.hpp>
 #include "include/stringify.h"
 #include "NVMeofGwMon.h"
+#include "Monitor.h"
+#include "messages/MMonCommand.h"
 #include "messages/MNVMeofGwBeacon.h"
 #include "messages/MNVMeofGwMap.h"
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -22,6 +22,7 @@
 #define CEPH_PGMAP_H
 
 #include "include/buffer.h"
+#include "include/ceph_fs.h" // for ceph_statfs
 #include "common/debug.h" // for cmdmap_t
 #include "common/cmdparse.h"
 #include "common/Formatter.h"

--- a/src/mon/PaxosFSMap.h
+++ b/src/mon/PaxosFSMap.h
@@ -16,6 +16,7 @@
 #define CEPH_PAXOS_FSMAP_H
 
 #include <chrono>
+#include <map>
 
 #include "mds/FSMap.h"
 #include "mds/MDSMap.h"

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -17,6 +17,7 @@
 #include "common/config.h"
 #include "include/stringify.h"
 #include "include/ceph_assert.h"
+#include "messages/PaxosServiceMessage.h"
 #include "mon/MonOpRequest.h"
 
 using std::ostream;

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -37,7 +37,7 @@
 #include "common/tracer.h"
 #include "include/ceph_assert.h" // Because intrusive_ptr clobbers our assert...
 #include "include/buffer.h"
-#include "include/types.h"
+#include "include/utime.h"
 #include "msg/Connection.h"
 #include "msg/MessageRef.h"
 #include "msg_types.h"

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -20,9 +20,11 @@
 #include <atomic>
 #include <pthread.h>
 #include <climits>
+#include <deque>
 #include <list>
 #include <mutex>
 #include <map>
+#include <set>
 #include <functional>
 #include <optional>
 

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -12,6 +12,7 @@
 #include "include/random.h"
 #include "auth/AuthClient.h"
 #include "auth/AuthServer.h"
+#include "auth/AuthSessionHandler.h" // for struct DecryptionError
 
 #define dout_subsys ceph_subsys_ms
 #undef dout_prefix

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -5,6 +5,7 @@
 #define _MSG_ASYNC_PROTOCOL_V2_
 
 #include "Protocol.h"
+#include "AsyncConnection.h"
 #include "crypto_onwire.h"
 #include "compression_meta.h"
 #include "compression_onwire.h"

--- a/src/msg/compressor_registry.cc
+++ b/src/msg/compressor_registry.cc
@@ -3,6 +3,7 @@
 
 #include "compressor_registry.h"
 #include "common/dout.h"
+#include "include/types.h" // for operator<<(std::vector)
 
 using namespace std::literals;
 

--- a/src/msg/compressor_registry.h
+++ b/src/msg/compressor_registry.h
@@ -4,12 +4,16 @@
 #pragma once
 
 #include <map>
+#include <mutex> // for std::scoped_lock
 #include <vector>
 
 #include "compressor/Compressor.h"
 #include "common/ceph_mutex.h"
 #include "common/ceph_context.h"
 #include "common/config_cacher.h"
+#include "common/config_obs.h"
+#include "include/common_fwd.h" // for CephContext
+#include "include/msgr.h" // for CEPH_ENTITY_TYPE_OSD
 
 class CompressorRegistry : public md_config_obs_t {
 public:

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -30,6 +30,7 @@
 #include "include/types.h"
 #include "include/blobhash.h"
 #include "include/encoding.h"
+#include "include/msgr.h" // for CEPH_ENTITY_TYPE_*
 
 #define MAX_PORT_NUMBER 65535
 

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "BitmapAllocator.h"
+#include "include/types.h" // for byte_u_t
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore

--- a/src/os/bluestore/Compression.cc
+++ b/src/os/bluestore/Compression.cc
@@ -14,6 +14,8 @@
 #include "Compression.h"
 #include "BlueStore.h"
 #include "include/intarith.h"
+#include "common/debug.h" // for dout()
+#include "common/Formatter.h"
 #include <limits>
 
 template <typename Char>

--- a/src/os/bluestore/Compression.h
+++ b/src/os/bluestore/Compression.h
@@ -14,6 +14,9 @@
 #ifndef COMPRESSION_H_INCLUDED
 #define COMPRESSION_H_INCLUDED
 
+#include <map>
+#include <vector>
+
 #include "BlueStore.h"
 #include "Writer.h"
 

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_OSD_BLUESTORE_COMMON_H
 #define CEPH_OSD_BLUESTORE_COMMON_H
 
+#include "include/byteorder.h" // for ceph_le64
 #include "include/intarith.h"
 #include "include/ceph_assert.h"
 #include "kv/KeyValueDB.h"

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -22,13 +22,12 @@
 #include <vector>
 #include <array>
 #include "include/mempool.h"
-#include "include/types.h"
 #include "include/interval_set.h"
 #include "include/utime.h"
-#include "common/hobject.h"
 #include "compressor/Compressor.h"
 #include "common/Checksummer.h"
 #include "include/ceph_hash.h"
+#include "include/intarith.h" // for round_up_to()
 
 namespace ceph {
   class Formatter;

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -7,6 +7,9 @@
 #include "common/ceph_context.h"
 #include "include/dlfcn_compat.h"
 
+#include <sys/types.h>
+#include <dirent.h>
+
 #include <map>
 
 #if defined(__FreeBSD__)

--- a/src/osd/DynamicPerfStats.h
+++ b/src/osd/DynamicPerfStats.h
@@ -4,7 +4,13 @@
 #ifndef DYNAMIC_PERF_STATS_H
 #define DYNAMIC_PERF_STATS_H
 
+#include <list>
+#include <map>
+#include <string>
+#include <vector>
+
 #include "include/random.h"
+#include "include/stringify.h"
 #include "messages/MOSDOp.h"
 #include "mgr/OSDPerfMetricTypes.h"
 

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -10,6 +10,7 @@
 
 #include "osd/osd_types.h"
 #include "common/WorkQueue.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/Cond.h"
 
 class OSDMap;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -20,7 +20,7 @@
 #include "include/mempool.h"
 
 // re-include our assert to clobber boost's
-#include "common/admin_finisher.h"
+#include "common/admin_finisher.h" // for asok_finisher
 #include "include/ceph_assert.h" 
 #include "include/common_fwd.h"
 
@@ -49,6 +49,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <vector>
 
 //#define DEBUG_RECOVERY_OIDS   // track std::set of recovering oids explicitly, to find counting bugs
 //#define PG_DEBUG_REFS    // track provenance of pg refs, helpful for finding leaks
@@ -78,6 +79,7 @@ namespace Scrub {
   void put_with_id(PG *pg, uint64_t id);
   typedef TrackedIntPtr<PG> PGRef;
 #else
+#include <boost/intrusive_ptr.hpp>
   typedef boost::intrusive_ptr<PG> PGRef;
 #endif
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -19,6 +19,7 @@
 
 #include <boost/tuple/tuple.hpp>
 #include "include/ceph_assert.h"
+#include "include/types.h" // for client_t
 #include "DynamicPerfStats.h"
 #include "OSD.h"
 #include "PG.h"

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include "common/Clock.h" // for ceph_clock_now()
 #include "include/function2.hpp"
 #include "rgw_acl_s3.h"
 #include "rgw_tag_s3.h"

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -4,6 +4,7 @@
 #include "rgw_gc.h"
 
 #include "rgw_tools.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "include/scope_guard.h"
 #include "include/rados/librados.hpp"
 #include "cls/rgw/cls_rgw_client.h"

--- a/src/rgw/driver/rados/rgw_object_expirer_core.cc
+++ b/src/rgw/driver/rados/rgw_object_expirer_core.cc
@@ -11,6 +11,7 @@
 
 #include "common/armor.h"
 #include "common/ceph_json.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/config.h"
 #include "common/ceph_argparse.h"
 #include "common/Formatter.h"

--- a/src/rgw/radosgw-admin/orphan.cc
+++ b/src/rgw/radosgw-admin/orphan.cc
@@ -8,7 +8,7 @@
 #include "radosgw-admin/orphan.h"
 #include <string>
 
-
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/config.h"
 #include "common/Formatter.h"
 #include "common/errno.h"

--- a/src/rgw/rgw_bucket_encryption.h
+++ b/src/rgw/rgw_bucket_encryption.h
@@ -3,8 +3,10 @@
 
 #pragma once
 #include <include/types.h>
+#include "include/encoding.h"
 
 class XMLObj;
+namespace ceph { class Formatter; }
 
 class ApplyServerSideEncryptionByDefault
 {

--- a/src/rgw/rgw_compression_types.h
+++ b/src/rgw/rgw_compression_types.h
@@ -15,6 +15,15 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "include/encoding.h"
+
+namespace ceph { class Formatter; }
+
 struct compression_block {
   uint64_t old_ofs;
   uint64_t new_ofs;

--- a/src/rgw/rgw_dedup_cluster.cc
+++ b/src/rgw/rgw_dedup_cluster.cc
@@ -21,6 +21,7 @@
 #include "include/rados/buffer.h"
 #include "include/rados/librados.hpp"
 #include "svc_zone.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/config.h"
 #include "common/Cond.h"
 #include "common/debug.h"

--- a/src/rgw/rgw_dedup_epoch.h
+++ b/src/rgw/rgw_dedup_epoch.h
@@ -13,6 +13,8 @@
  */
 
 #pragma once
+
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/dout.h"
 #include "rgw_dedup_utils.h"
 

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -13,6 +13,7 @@
 #include "rgw_common.h"
 #include "rgw_http_client.h"
 #include "common/ceph_mutex.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "global/global_init.h"
 
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -16,6 +16,7 @@
 
 #include "include/scope_guard.h"
 #include "include/function2.hpp"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/Formatter.h"
 #include "common/containers.h"
 #include "common/split.h"

--- a/src/rgw/rgw_object_lock.h
+++ b/src/rgw/rgw_object_lock.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include "include/encoding.h"
 #include "common/ceph_time.h"
 #include "common/iso_8601.h"
 #include "rgw_xml.h"

--- a/src/rgw/rgw_pool_types.h
+++ b/src/rgw/rgw_pool_types.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <fmt/format.h>
 
+#include "include/encoding.h"
 #include "include/types.h"
 #include "common/Formatter.h"
 

--- a/src/rgw/rgw_restore.cc
+++ b/src/rgw/rgw_restore.cc
@@ -16,6 +16,7 @@
 
 #include "include/scope_guard.h"
 #include "include/function2.hpp"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/Formatter.h"
 #include "common/containers.h"
 #include "common/split.h"

--- a/src/rgw/rgw_tag.h
+++ b/src/rgw/rgw_tag.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <include/types.h>
 #include <map>
+
+#include "include/encoding.h"
 
 class RGWObjTags
 {

--- a/src/test/cls_lua/test_cls_lua.cc
+++ b/src/test/cls_lua/test_cls_lua.cc
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <lua.hpp>
+#include "include/encoding.h"
 #include "include/types.h"
 #include "include/rados/librados.hpp"
 #include "gtest/gtest.h"

--- a/src/test/common/test_cdc.cc
+++ b/src/test/common/test_cdc.cc
@@ -6,6 +6,7 @@
 #include <iostream> // for std::cout
 #include <random>
 
+#include "include/intarith.h" // for cbits()
 #include "include/types.h"
 #include "include/buffer.h"
 

--- a/src/test/common/test_time.cc
+++ b/src/test/common/test_time.cc
@@ -15,6 +15,8 @@
 
 #include <ctime>
 
+#include <math.h> // for pow()
+
 #include "common/ceph_time.h"
 #include "include/rados.h"
 #include "gtest/gtest.h"

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -6,6 +6,7 @@
 #include <boost/container/small_vector.hpp>
 
 #include "gtest/gtest.h"
+#include "include/ceph_fs.h" // for CEPH_CRYPTO_AES
 #include "include/types.h"
 #include "auth/Crypto.h"
 #include "common/Clock.h"

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -10,6 +10,7 @@
 #include "include/stringify.h"
 #include "include/types.h"
 #include "global/global_context.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/Cond.h"
 #include "common/ceph_crypto.h"
 #include "test/librados/test_cxx.h"

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -5,6 +5,7 @@
 #include "test/librados_test_stub/TestMemRadosClient.h"
 #include "common/Clock.h"
 #include "include/err.h"
+#include "include/types.h" // for operator<<(std::vector)
 #include <functional>
 #include <shared_mutex> // for std::shared_lock
 #include <boost/algorithm/string/predicate.hpp>

--- a/src/test/librados_test_stub/TestMemRadosClient.h
+++ b/src/test/librados_test_stub/TestMemRadosClient.h
@@ -6,6 +6,8 @@
 
 #include "test/librados_test_stub/TestRadosClient.h"
 #include "include/ceph_assert.h"
+#include "include/rados.h" // for CEPH_RELEASE_*
+
 #include <list>
 #include <string>
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -20,6 +20,7 @@
 #include "include/event_type.h"
 #include "include/err.h"
 #include "include/intarith.h" // for round_up_to()
+#include "include/rados.h" // for EBLOCKLISTED
 #include "common/ceph_mutex.h"
 #include "json_spirit/json_spirit.h"
 #include "test/librados/crimson_utils.h"

--- a/src/test/librbd/test_mock_TrashWatcher.cc
+++ b/src/test/librbd/test_mock_TrashWatcher.cc
@@ -3,6 +3,7 @@
 
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librbd/test_support.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "include/rbd_types.h"
 #include "librbd/TrashWatcher.h"
 #include "gtest/gtest.h"

--- a/src/test/librbd/trash/test_mock_MoveRequest.cc
+++ b/src/test/librbd/trash/test_mock_MoveRequest.cc
@@ -8,6 +8,7 @@
 #include "test/librbd/mock/MockImageState.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "include/rbd/librbd.hpp"
 #include "librbd/Utils.h"
 #include "librbd/trash/MoveRequest.h"

--- a/src/test/objectstore/Allocator_bench.cc
+++ b/src/test/objectstore/Allocator_bench.cc
@@ -8,6 +8,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <gtest/gtest.h>
 
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/Cond.h"
 #include "common/errno.h"
 #include "include/stringify.h"

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -21,6 +21,7 @@
 #include "kv/RocksDBStore.h"
 #include "include/Context.h"
 #include "common/ceph_argparse.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "global/global_init.h"
 #include "common/Cond.h"
 #include "common/errno.h"

--- a/src/test/omap_bench.cc
+++ b/src/test/omap_bench.cc
@@ -15,6 +15,7 @@
 #include "include/Context.h"
 #include "common/ceph_context.h"
 #include "common/ceph_mutex.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/Cond.h"
 #include "include/utime.h"
 #include "common/ceph_argparse.h"

--- a/src/test/osdc/object_cacher_misc.cc
+++ b/src/test/osdc/object_cacher_misc.cc
@@ -10,6 +10,7 @@
 
 #include "common/ceph_argparse.h"
 #include "common/ceph_mutex.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/common_init.h"
 #include "common/config.h"
 #include "common/snap_types.h"

--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -46,6 +46,7 @@
 #include "include/ceph_hash.h"
 #include "include/spinlock.h"
 #include "common/ceph_argparse.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/Cycles.h"
 #include "common/Cond.h"
 #include "common/ceph_mutex.h"

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -14,6 +14,7 @@
  *
  */
 
+#include "common/Clock.h" // for ceph_clock_now()
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
 #include "include/stringify.h"

--- a/src/tools/ceph_dedup/ceph_dedup_daemon.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_daemon.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "common.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "log/Log.h"
 
 #include <shared_mutex> // for std::shared_lock

--- a/src/tools/ceph_dedup/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_tool.cc
@@ -13,6 +13,7 @@
  */
 
 #include "common.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "log/Log.h"
 
 #include <boost/optional.hpp>

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <sys/time.h>
 #include <sys/file.h>
+#include <boost/optional/optional_io.hpp>
 #include <boost/scope_exit.hpp>
 
 #include "common/admin_socket.h"

--- a/src/tools/cephfs_mirror/Watcher.cc
+++ b/src/tools/cephfs_mirror/Watcher.cc
@@ -5,6 +5,7 @@
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/WorkQueue.h"
+#include "include/rados.h" // for EBLOCKLISTED
 #include "include/stringify.h"
 #include "aio_utils.h"
 #include "watcher/RewatchRequest.h"

--- a/src/tools/cephfs_mirror/watcher/RewatchRequest.cc
+++ b/src/tools/cephfs_mirror/watcher/RewatchRequest.cc
@@ -5,6 +5,7 @@
 #include "common/debug.h"
 #include "common/errno.h"
 #include "include/Context.h"
+#include "include/rados.h" // for EBLOCKLISTED
 #include "tools/cephfs_mirror/aio_utils.h"
 #include "RewatchRequest.h"
 

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -24,6 +24,7 @@
  using namespace libradosstriper;
 #endif
 
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/config.h"
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"

--- a/src/tools/radosacl.cc
+++ b/src/tools/radosacl.cc
@@ -18,6 +18,8 @@
 
 #include <iostream> // for std::cerr
 
+#include "include/encoding.h"
+#include "include/int_types.h" // for __u32
 #include "include/types.h"
 #include "include/rados/librados.hpp"
 

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -4,6 +4,7 @@
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
 #include "tools/rbd/Utils.h"
+#include "common/ceph_time.h" // for coarse_mono_time()
 #include "common/errno.h"
 #include "common/strtol.h"
 #include "common/ceph_mutex.h"

--- a/src/tools/rbd/action/Clone.cc
+++ b/src/tools/rbd/action/Clone.cc
@@ -6,6 +6,7 @@
 #include "tools/rbd/Utils.h"
 #include "include/types.h"
 #include "common/errno.h"
+#include "include/rados.h" // for CEPH_NOSNAP
 #include <iostream>
 #include <boost/program_options.hpp>
 

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -4,6 +4,7 @@
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
 #include "tools/rbd/Utils.h"
+#include "include/rados.h" // for CEPH_NOSNAP
 #include "include/types.h"
 #include "include/stringify.h"
 #include "common/errno.h"

--- a/src/tools/rbd/action/Info.cc
+++ b/src/tools/rbd/action/Info.cc
@@ -4,8 +4,9 @@
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
 #include "tools/rbd/Utils.h"
-#include "include/types.h"
+#include "include/rbd_types.h" // for RBD_GROUP_INVALID_POOL
 #include "include/stringify.h"
+#include "include/types.h" // for byte_u_t
 #include "common/errno.h"
 #include "common/Formatter.h"
 #include <iostream>

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -9,6 +9,7 @@
 #include "common/ceph_json.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
+#include "include/rbd_types.h" // for RBD_DIRECTORY
 #include "include/stringify.h"
 #include <fstream>
 #include <sstream>

--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -4,8 +4,9 @@
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
 #include "tools/rbd/Utils.h"
-#include "include/types.h"
+#include "include/rados.h" // for CEPH_NOSNAP
 #include "include/stringify.h"
+#include "include/types.h" // for byte_u_t
 #include "common/errno.h"
 #include "common/Formatter.h"
 #include "common/TextTable.h"

--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -9,6 +9,7 @@
 #include "tools/rbd/Utils.h"
 #include "include/rbd_types.h"
 #include "include/stringify.h"
+#include "include/types.h" // for byte_u_t
 #include "librbd/cache/Types.h"
 #include <iostream>
 #include <boost/program_options.hpp>

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -10,6 +10,7 @@
 #include "common/admin_socket.h"
 #include "common/debug.h"
 #include "common/errno.h"
+#include "include/intarith.h" // for p2roundup()
 #include "journal/Types.h"
 #include "librbd/ImageCtx.h"
 #include "perfglue/heap_profiler.h"

--- a/src/tools/rbd_mirror/Throttler.cc
+++ b/src/tools/rbd_mirror/Throttler.cc
@@ -16,6 +16,7 @@
 #include "common/Formatter.h"
 #include "common/debug.h"
 #include "common/errno.h"
+#include "include/types.h" // for operator<<(std::pair)
 #include "librbd/Utils.h"
 
 #define dout_context g_ceph_context

--- a/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
@@ -4,6 +4,7 @@
 #include "tools/rbd_mirror/image_deleter/TrashMoveRequest.h"
 #include "include/rbd_types.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/WorkQueue.h"

--- a/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "Replayer.h"
+#include "common/Clock.h" // for ceph_clock_now()
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/perf_counters.h"

--- a/src/tools/scratchtoolpp.cc
+++ b/src/tools/scratchtoolpp.cc
@@ -12,7 +12,7 @@
  * 
  */
 
-#include "include/types.h"
+#include "include/rados.h" // for CEPH_OSD_CMPXATTR_OP_EQ
 #include "include/rados/librados.hpp"
 
 using namespace librados;


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490

This is a big PR spanning many subsystems, but all commits are trivial and obvious enough, I think. All those subsystems have buggy include directives that need to be fixed, or else Ceph builds can fail randomly.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
