### PR TITLE
tentacle: monitoring: Add per share metrics to SMB dashboard

### DIFF
--- a/monitoring/ceph-mixin/dashboards_out/smb-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/smb-overview.json
@@ -1,40 +1,41 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
    "annotations": {
       "list": [
          {
             "builtIn": 1,
-            "datasource": "-- Grafana --",
+            "datasource": {
+               "type": "datasource",
+               "uid": "grafana"
+            },
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
             "showIn": 0,
-            "tags": [ ],
+            "tags": [],
             "type": "dashboard"
          }
       ]
    },
    "description": "SMB Overview dashboard shows data across all clusters and hosts associated with the SMB service.",
    "editable": false,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
    "hideControls": false,
    "id": null,
-   "links": [ ],
+   "links": [],
    "panels": [
       {
-         "colors": null,
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "description": "SMB metrics daemon health.",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
+               "links": [],
                "mappings": [
                   {
-                     "id": 0,
                      "options": {
                         "0": {
                            "color": "red",
@@ -52,8 +53,7 @@
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -62,7 +62,8 @@
                   ]
                },
                "unit": "short"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 8,
@@ -71,12 +72,12 @@
             "y": 0
          },
          "id": 2,
-         "links": [ ],
          "options": {
             "colorMode": "background",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -84,12 +85,16 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
                "expr": "sum(smb_metrics_status{instance=~\"$hostname\"})  by (instance)",
                "format": "time_series",
                "instant": false,
@@ -100,24 +105,23 @@
             }
          ],
          "title": "Prometheus SMB metrics status",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
-         "description": "Number of nodes per cluster",
+         "datasource": {
+            "uid": "${datasource}"
+         },
+         "description": "Number of nodes per cluster/s",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -126,7 +130,8 @@
                   ]
                },
                "unit": "none"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 4,
@@ -135,12 +140,12 @@
             "y": 0
          },
          "id": 3,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -148,13 +153,18 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
-               "expr": "count by (netbiosname) (smb_sessions_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"})",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
+               "expr": "sum(count by (netbiosname) (smb_sessions_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -163,25 +173,24 @@
                "refId": "A"
             }
          ],
-         "title": "Nodes per Cluster",
-         "transparent": false,
+         "title": "Nodes",
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
-         "description": "Number of users currently logged in Cluster",
+         "datasource": {
+            "uid": "${datasource}"
+         },
+         "description": "Number of users currently logged in Cluster/s",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -190,7 +199,8 @@
                   ]
                },
                "unit": "none"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 4,
@@ -199,12 +209,12 @@
             "y": 0
          },
          "id": 4,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -212,14 +222,19 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
                "exemplar": false,
-               "expr": "sum by(netbiosname)(smb_sessions_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}) / (count by ( netbiosname)(smb_sessions_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}))",
+               "expr": "sum(sum by(netbiosname)(smb_sessions_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}) / (count by ( netbiosname)(smb_sessions_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"})))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -228,25 +243,24 @@
                "refId": "A"
             }
          ],
-         "title": "Active sessions per Cluster",
-         "transparent": false,
+         "title": "Active sessions",
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
-         "description": "Number of remote machines using a share in cluster",
+         "datasource": {
+            "uid": "${datasource}"
+         },
+         "description": "Number of remote machines using a share in cluster/s",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -255,7 +269,8 @@
                   ]
                },
                "unit": "none"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 4,
@@ -264,12 +279,12 @@
             "y": 4
          },
          "id": 5,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -277,14 +292,19 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
                "exemplar": false,
-               "expr": "sum by(netbiosname)(smb_share_activity * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}) / (count by ( netbiosname)(smb_share_activity * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}))",
+               "expr": "sum(sum by(netbiosname)(smb_share_activity * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}) / (count by ( netbiosname)(smb_share_activity * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"})))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -293,25 +313,24 @@
                "refId": "A"
             }
          ],
-         "title": "Shares activity per Cluster",
-         "transparent": false,
+         "title": "Shares activity",
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
-         "description": "Number of currently active SMB user per cluster",
+         "datasource": {
+            "uid": "${datasource}"
+         },
+         "description": "Number of currently active SMB user per cluster/s",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -320,7 +339,8 @@
                   ]
                },
                "unit": "none"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 4,
@@ -329,12 +349,12 @@
             "y": 4
          },
          "id": 6,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -342,14 +362,19 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
                "exemplar": false,
-               "expr": "sum by(netbiosname)(smb_users_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}) / (count by ( netbiosname)(smb_users_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}))",
+               "expr": "sum(sum by(netbiosname)(smb_users_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"}) / (count by ( netbiosname)(smb_users_total * on (instance) group_left (netbiosname) smb_metrics_status{netbiosname=~\"$SMBcluster\"})))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -358,25 +383,24 @@
                "refId": "A"
             }
          ],
-         "title": "Active users per Cluster",
-         "transparent": false,
+         "title": "Active users",
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "description": "Current total ingress throughput, bytes going in per second",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -385,7 +409,8 @@
                   ]
                },
                "unit": "decbytes"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 5,
@@ -394,12 +419,12 @@
             "y": 8
          },
          "id": 7,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -407,14 +432,19 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
                "exemplar": false,
-               "expr": "sum(rate(smb_smb2_request_inbytes{instance=~\"$hostname\"}[$__rate_interval]))",
+               "expr": "sum(rate(smb_smb2_request_inbytes{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval]))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -424,24 +454,23 @@
             }
          ],
          "title": "Ingress throughtput",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "description": "Current total request time for the sum of all runing operations",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -450,7 +479,8 @@
                   ]
                },
                "unit": "µs"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 5,
@@ -459,12 +489,12 @@
             "y": 8
          },
          "id": 8,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -472,14 +502,19 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
                "exemplar": false,
-               "expr": "sum(rate(smb_smb2_request_duration_microseconds_sum{instance=~\"$hostname\"}[$__rate_interval]))",
+               "expr": "sum(rate(smb_smb2_request_duration_microseconds_sum{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval]))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -489,24 +524,23 @@
             }
          ],
          "title": "Latency",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "description": "Current total egress throughput, bytes going out per second",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -515,7 +549,8 @@
                   ]
                },
                "unit": "decbytes"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 5,
@@ -524,12 +559,12 @@
             "y": 8
          },
          "id": 9,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -537,14 +572,19 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
                "exemplar": false,
-               "expr": "sum(rate(smb_smb2_request_outbytes{instance=~\"$hostname\"}[$__rate_interval]))",
+               "expr": "sum(rate(smb_smb2_request_outbytes{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval]))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -554,24 +594,23 @@
             }
          ],
          "title": "Egress throughtput",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "colors": null,
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "description": "Current total number of operations per second",
          "fieldConfig": {
             "defaults": {
                "decimals": 0,
-               "links": [ ],
-               "mappings": [ ],
+               "links": [],
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
                   "steps": [
                      {
-                        "color": "green",
-                        "value": null
+                        "color": "green"
                      },
                      {
                         "color": "red",
@@ -580,7 +619,8 @@
                   ]
                },
                "unit": "short"
-            }
+            },
+            "overrides": []
          },
          "gridPos": {
             "h": 5,
@@ -589,12 +629,12 @@
             "y": 8
          },
          "id": 10,
-         "links": [ ],
          "options": {
             "colorMode": "none",
             "graphMode": "none",
             "justifyMode": "auto",
             "orientation": "auto",
+            "percentChangeColorMode": "standard",
             "reduceOptions": {
                "calcs": [
                   "lastNotNull"
@@ -602,14 +642,19 @@
                "fields": "",
                "values": false
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
          },
-         "pluginVersion": "9.4.7",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
                "exemplar": false,
-               "expr": "sum(rate(smb_smb2_request_outbytes{instance=~\"$hostname\"}[$__rate_interval]))",
+               "expr": "sum(rate(smb_smb2_request_total{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval]))",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
@@ -619,22 +664,25 @@
             }
          ],
          "title": "I/O",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "fieldConfig": {
             "defaults": {
                "color": {
                   "mode": "palette-classic"
                },
                "custom": {
+                  "axisBorderShow": false,
                   "axisCenteredZero": false,
                   "axisColorMode": "text",
                   "axisLabel": "",
                   "axisPlacement": "auto",
                   "barAlignment": 0,
+                  "barWidthFactor": 0.6,
                   "drawStyle": "line",
                   "fillOpacity": 8,
                   "gradientMode": "none",
@@ -643,6 +691,7 @@
                      "tooltip": false,
                      "viz": false
                   },
+                  "insertNulls": false,
                   "lineInterpolation": "linear",
                   "lineWidth": 1,
                   "pointSize": 5,
@@ -660,13 +709,14 @@
                   }
                },
                "decimals": 2,
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
-                  "steps": [ ]
+                  "steps": []
                },
                "unit": "decbytes"
             },
-            "overrides": [ ]
+            "overrides": []
          },
          "gridPos": {
             "h": 9,
@@ -687,50 +737,61 @@
                "sortDesc": true
             },
             "tooltip": {
+               "hideZeros": false,
                "mode": "single",
                "sort": "none"
             }
          },
-         "pluginVersion": "9.1.3",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
-               "expr": "rate(smb_smb2_request_inbytes{instance=~\"$hostname\"}[$__rate_interval])",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
+               "expr": "rate(smb_smb2_request_inbytes{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval])",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
-               "legendFormat": "Inbytes.{{instance}}.{{operation}}",
+               "legendFormat": "Input - {{operation}}",
                "range": true,
                "refId": "A"
             },
             {
-               "datasource": "${datasource}",
-               "expr": "rate(smb_smb2_request_outbytes{instance=~\"$hostname\"}[$__rate_interval])",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
+               "expr": "rate(smb_smb2_request_outbytes{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval])",
                "format": "time_series",
                "hide": false,
                "instant": false,
                "intervalFactor": 1,
-               "legendFormat": "Outbytes.{{instance}}.{{operation}}",
+               "legendFormat": "Output-  {{operation}}",
                "range": true,
                "refId": "B"
             }
          ],
-         "title": "Throughput",
+         "title": "Throughput per Operation",
          "type": "timeseries"
       },
       {
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "fieldConfig": {
             "defaults": {
                "color": {
                   "mode": "palette-classic"
                },
                "custom": {
+                  "axisBorderShow": false,
                   "axisCenteredZero": false,
                   "axisColorMode": "text",
                   "axisLabel": "",
                   "axisPlacement": "auto",
                   "barAlignment": 0,
+                  "barWidthFactor": 0.6,
                   "drawStyle": "line",
                   "fillOpacity": 8,
                   "gradientMode": "none",
@@ -739,6 +800,7 @@
                      "tooltip": false,
                      "viz": false
                   },
+                  "insertNulls": false,
                   "lineInterpolation": "linear",
                   "lineWidth": 1,
                   "pointSize": 5,
@@ -756,13 +818,14 @@
                   }
                },
                "decimals": 2,
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
-                  "steps": [ ]
+                  "steps": []
                },
                "unit": "none"
             },
-            "overrides": [ ]
+            "overrides": []
          },
          "gridPos": {
             "h": 9,
@@ -783,39 +846,47 @@
                "sortDesc": true
             },
             "tooltip": {
+               "hideZeros": false,
                "mode": "single",
                "sort": "none"
             }
          },
-         "pluginVersion": "9.1.3",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
-               "expr": "rate(smb_smb2_request_total{instance=~\"$hostname\"}[$__rate_interval])",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
+               "expr": "rate(smb_smb2_request_total{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval])",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
-               "legendFormat": "{{instance}}.{{operation}}",
+               "legendFormat": "{{operation}}",
                "range": true,
                "refId": "A"
             }
          ],
-         "title": "I/O",
+         "title": "IO per Operation",
          "type": "timeseries"
       },
       {
-         "datasource": "${datasource}",
+         "datasource": {
+            "uid": "${datasource}"
+         },
          "fieldConfig": {
             "defaults": {
                "color": {
                   "mode": "palette-classic"
                },
                "custom": {
+                  "axisBorderShow": false,
                   "axisCenteredZero": false,
                   "axisColorMode": "text",
                   "axisLabel": "",
                   "axisPlacement": "auto",
                   "barAlignment": 0,
+                  "barWidthFactor": 0.6,
                   "drawStyle": "line",
                   "fillOpacity": 8,
                   "gradientMode": "none",
@@ -824,6 +895,7 @@
                      "tooltip": false,
                      "viz": false
                   },
+                  "insertNulls": false,
                   "lineInterpolation": "linear",
                   "lineWidth": 1,
                   "pointSize": 5,
@@ -841,13 +913,14 @@
                   }
                },
                "decimals": 2,
+               "mappings": [],
                "thresholds": {
                   "mode": "absolute",
-                  "steps": [ ]
+                  "steps": []
                },
                "unit": "µs"
             },
-            "overrides": [ ]
+            "overrides": []
          },
          "gridPos": {
             "h": 9,
@@ -868,31 +941,35 @@
                "sortDesc": true
             },
             "tooltip": {
+               "hideZeros": false,
                "mode": "single",
                "sort": "none"
             }
          },
-         "pluginVersion": "9.1.3",
+         "pluginVersion": "11.6.0",
          "targets": [
             {
-               "datasource": "${datasource}",
-               "expr": "rate(smb_smb2_request_duration_microseconds_sum{instance=~\"$hostname\"}[$__rate_interval])",
+               "datasource": {
+                  "uid": "${datasource}"
+               },
+               "editorMode": "code",
+               "expr": "rate(smb_smb2_request_duration_microseconds_sum{instance=~\"$hostname\", share=~\"$share\", client=~\"$client\"}[$__rate_interval])",
                "format": "time_series",
                "instant": false,
                "intervalFactor": 1,
-               "legendFormat": "{{instance}}.{{operation}}",
+               "legendFormat": "{{operation}}",
                "range": true,
                "refId": "A"
             }
          ],
-         "title": "Latencies",
+         "title": "Latencies per operation",
          "type": "timeseries"
       }
    ],
+   "preload": false,
    "refresh": "30s",
-   "rows": [ ],
-   "schemaVersion": 22,
    "style": "dark",
+   "schemaVersion": 41,
    "tags": [
       "ceph-mixin"
    ],
@@ -903,77 +980,95 @@
                "text": "default",
                "value": "default"
             },
-            "hide": 0,
             "label": "Data Source",
             "name": "datasource",
-            "options": [ ],
+            "options": [],
             "query": "prometheus",
             "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
+            "current": {},
             "datasource": "$datasource",
-            "hide": 0,
             "includeAll": false,
-            "label": null,
-            "multi": false,
             "name": "Cluster",
-            "options": [ ],
+            "options": [],
             "query": "label_values(ceph_health_status, cluster)",
             "refresh": 2,
             "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": "SMB Cluster",
-            "multi": false,
-            "name": "SMBcluster",
-            "options": [ ],
-            "query": "label_values(smb_metrics_status,netbiosname)",
-            "refresh": 1,
-            "regex": null,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         },
-         {
-            "allValue": null,
             "current": {
                "text": "All",
-               "value": "All"
+               "value": "$__all"
             },
             "datasource": "$datasource",
-            "hide": 0,
+            "includeAll": true,
+            "label": "SMB Cluster",
+            "name": "SMBcluster",
+            "options": [],
+            "query": "label_values(smb_metrics_status,netbiosname)",
+            "refresh": 1,
+            "sort": 1,
+            "type": "query"
+         },
+         {
+            "current": {
+               "text": "All",
+               "value": "$__all"
+            },
+            "datasource": "$datasource",
+            "hide": 2,
             "includeAll": true,
             "label": "Hostname",
-            "multi": false,
             "name": "hostname",
-            "options": [ ],
+            "options": [],
             "query": "label_values(smb_metrics_status{netbiosname=~\"$SMBcluster\"},instance)",
             "refresh": 1,
-            "regex": null,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
+         },
+         {
+            "current": {
+               "text": "All",
+               "value": "$__all"
+            },
+            "definition": "label_values(smb_smb2_request_inbytes{netbiosname=~\"$SMBcluster\", instance=~\"$hostname\"},share)",
+            "description": "",
+            "includeAll": true,
+            "label": "Share",
+            "name": "share",
+            "options": [],
+            "query": {
+               "qryType": 1,
+               "query": "label_values(smb_smb2_request_inbytes{netbiosname=~\"$SMBcluster\", instance=~\"$hostname\"},share)",
+               "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
+         },
+         {
+            "current": {
+               "text": "All",
+               "value": "$__all"
+            },
+            "definition": "label_values(smb_smb2_request_inbytes{netbiosname=~\"$SMBcluster\", instance=~\"$hostname\", share=~\"$share\"},client)",
+            "description": "",
+            "includeAll": true,
+            "label": "Client",
+            "name": "client",
+            "options": [],
+            "query": {
+               "qryType": 1,
+               "query": "label_values(smb_smb2_request_inbytes{netbiosname=~\"$SMBcluster\", instance=~\"$hostname\", share=~\"$share\"},client)",
+               "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "type": "query"
          }
       ]
    },
@@ -981,33 +1076,9 @@
       "from": "now-6h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
+   "timepicker": {},
    "timezone": "",
    "title": "SMB Overview",
    "uid": "feem6ehrmi2o0b",
-   "version": 0
+   "version": 1
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72538

---

backport of https://github.com/ceph/ceph/pull/64719
parent tracker: https://tracker.ceph.com/issues/72308

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh