### PR TITLE
cephfs.pyx: handle when UID/GID passed to chown() is -1

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1293,8 +1293,10 @@ cdef class LibCephFS(object):
 
         cdef:
             char* _path = path
-            uid_t _uid = uid
-            gid_t _gid = gid
+            # Avoid "OverflowError: can't convert negative value to uid_t."
+            uid_t _uid = uid if uid >= 0 else -1
+            # Avoid "OverflowError: can't convert negative value to gid_t."
+            gid_t _gid = gid if gid >= 0 else -1
         if follow_symlink:
             with nogil:
                 ret = ceph_chown(self.cluster, _path, _uid, _gid)
@@ -1332,8 +1334,10 @@ cdef class LibCephFS(object):
 
         cdef:
             int _fd = fd
-            uid_t _uid = uid
-            gid_t _gid = gid
+            # Avoid "OverflowError: can't convert negative value to uid_t."
+            uid_t _uid = uid if uid >= 0 else -1
+            # Avoid "OverflowError: can't convert negative value to gid_t."
+            gid_t _gid = gid if gid >= 0 else -1
         with nogil:
             ret = ceph_fchown(self.cluster, _fd, _uid, _gid)
         if ret < 0:

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -569,6 +569,93 @@ def test_fchmod(testdir):
     cephfs.close(fd)
     cephfs.unlink(b'/file-fchmod')
 
+def test_chown(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+
+    uid = 1012
+    gid = 1012
+    cephfs.chown('file1', uid, gid)
+    st = cephfs.stat(b'/file1')
+    assert_equal(st.st_uid, uid)
+    assert_equal(st.st_gid, gid)
+
+def test_chown_change_uid_but_not_gid(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+
+    st1 = cephfs.stat(b'/file1')
+
+    uid = 1012
+    cephfs.chown('file1', uid, -1)
+    st2 = cephfs.stat(b'/file1')
+    assert_equal(st2.st_uid, uid)
+
+    # ensure that gid is unchaged.
+    assert_equal(st1.st_gid, st2.st_gid)
+
+def test_chown_change_gid_but_not_uid(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+
+    st1 = cephfs.stat(b'/file1')
+
+    gid = 1012
+    cephfs.chown('file1', -1, gid)
+    st2 = cephfs.stat(b'/file1')
+    assert_equal(st2.st_gid, gid)
+
+    # ensure that uid is unchaged.
+    assert_equal(st1.st_uid, st2.st_uid)
+
+def test_lchown(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+    cephfs.symlink('file1', 'slink1')
+
+    uid = 1012
+    gid = 1012
+    cephfs.lchown('slink1', uid, gid)
+    st = cephfs.lstat(b'/slink1')
+    assert_equal(st.st_uid, uid)
+    assert_equal(st.st_gid, gid)
+
+def test_lchown_change_uid_but_not_gid(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+    cephfs.symlink('file1', 'slink1')
+
+    st1 = cephfs.lstat(b'slink1')
+
+    uid = 1012
+    cephfs.lchown('slink1', uid, -1)
+    st2 = cephfs.lstat(b'/slink1')
+    assert_equal(st2.st_uid, uid)
+
+    # ensure that gid is unchaged.
+    assert_equal(st1.st_gid, st2.st_gid)
+
+def test_lchown_change_gid_but_not_uid(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+    cephfs.close(fd)
+    cephfs.symlink('file1', 'slink1')
+
+    st1 = cephfs.lstat(b'slink1')
+
+    gid = 1012
+    cephfs.lchown('slink1', -1, gid)
+    st2 = cephfs.lstat(b'/slink1')
+    assert_equal(st2.st_gid, gid)
+
+    # ensure that uid is unchaged.
+    assert_equal(st1.st_uid, st2.st_uid)
+
 def test_fchown(testdir):
     fd = cephfs.open(b'/file-fchown', 'w', 0o655)
     uid = os.getuid()
@@ -585,6 +672,38 @@ def test_fchown(testdir):
     assert_equal(st["gid"], 9999)
     cephfs.close(fd)
     cephfs.unlink(b'/file-fchown')
+
+def test_fchown_change_uid_but_not_gid(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+
+    st1 = cephfs.stat(b'/file1')
+
+    uid = 1012
+    cephfs.fchown(fd, uid, -1)
+    st2 = cephfs.stat(b'/file1')
+    assert_equal(st2.st_uid, uid)
+
+    # ensure that uid is unchanged.
+    assert_equal(st1.st_gid, st2.st_gid)
+
+    cephfs.close(fd)
+
+def test_fchown_change_gid_but_not_uid(testdir):
+    fd = cephfs.open('file1', 'w', 0o755)
+    cephfs.write(fd, b'abcd', 0)
+
+    st1 = cephfs.stat(b'/file1')
+
+    gid = 1012
+    cephfs.chown('file1', -1, gid)
+    st2 = cephfs.stat(b'/file1')
+    assert_equal(st2.st_gid, gid)
+
+    # ensure that gid is unchanged.
+    assert_equal(st1.st_uid, st2.st_uid)
+
+    cephfs.close(fd)
 
 def test_truncate(testdir):
     fd = cephfs.open(b'/file-truncate', 'w', 0o755)


### PR DESCRIPTION
When chown() in libcephfs call receives -1 as the value of UID/GID, it
is implicitly converted from signed integer to unsigned integeer but
CephFS cython instead of doing that errors out during complilation.
Therefore make this conversion explicitly to allow users to pass -1
(which they do to indicate that UID/GID value shouldn't be changed) and
also for sake of uniformity and consistency between between CephFS
cython and libcephfs interface.
    
Fixes: https://tracker.ceph.com/issues/72547
Introduced-by: 65328aca31f2f5038cb602148120b9427370ed4f







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>