### PR TITLE
squid: mgr: avoid explicit dropping of ref

### DIFF
--- a/src/mgr/MgrOpRequest.h
+++ b/src/mgr/MgrOpRequest.h
@@ -49,7 +49,6 @@ protected:
 
 public:
   ~MgrOpRequest() override {
-    request->put();
   }
 
   template<class T>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72564

---

backport of https://github.com/ceph/ceph/pull/62445
parent tracker: https://tracker.ceph.com/issues/70618

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh