### PR TITLE
kv/rocksdb: BinnedLRUCache gets rebalancing feature

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3507,17 +3507,76 @@ options:
   level: advanced
   default: 4
   with_legacy: true
-# 'lru' or 'clock'
 - name: rocksdb_cache_type
   type: str
   level: advanced
   default: binned_lru
   with_legacy: true
+  enum_values:
+  - lru
+  - clock
+  - binned_lru
 - name: rocksdb_block_size
   type: size
   level: advanced
   default: 4_K
   with_legacy: true
+- name: rocksdb_cache_rebalance
+  type: bool
+  level: advanced
+  default: true
+  with_legacy: true
+  flags:
+  - startup
+  desc: Enables rebalancing of BinnedLruCache ('binned_lru').
+  long_desc: The default policy of binned_lru cache is to split available capacity evenly
+    between shards. This works very well when cached items are of similar size.
+    However, from time to time RocksDB puts into cache items that are significantly larger -
+    like 7MB or 1.5MB instead of usual 4200b. This causes huge evictions from affected shard.
+    In worst cases it can happen that 2 or 3 of those large items will not even fit in a shard,
+    causing constant eviction and refetch. Balancing counteracts the problem.
+    Instead of keeping same capacity per shard it tries to obtain same item count per shard.
+  see_also:
+  - rocksdb_cache_rebalance_max_steps
+  - rocksdb_cache_rebalance_capacity
+  - rocksdb_cache_rebalance_items
+- name: rocksdb_cache_rebalance_max_steps
+  type: uint
+  level: advanced
+  default: 10000
+  with_legacy: true
+  flags:
+  - runtime
+  desc: Maximum steps of rebalancing algorithm.
+  long_desc: Each step corresponds to capacity of one item moved from most used shard to
+    the least used shard. Special value "0" request to switch from precise moving capacity
+    to the faster one-shot guessing of what the perfect capacity will be.
+- name: rocksdb_cache_rebalance_capacity
+  type: float
+  level: advanced
+  default: 1.1
+  with_legacy: true
+  flags:
+  - runtime
+  desc: Capacity % overshoot that triggers immediate rebalancing.
+  long_desc: Sometimes very large item is inserted into a shard. This would cause massive
+    evictions from the shard immediately. The role of the setting is to perform rebalance
+    after usage spike caused by item insert and before item(s) eviction that will fix usage.
+  see_also:
+  - rocksdb_cache_rebalance_items
+- name: rocksdb_cache_rebalance_items
+  type: float
+  level: advanced
+  default: 0.9
+  with_legacy: true
+  flags:
+  - runtime
+  desc: Item count % reduction that triggers immediate rebalancing.
+  long_desc: When a specific shard is unlucky to get a stream of slighty larger items.
+    Each larger item will cause eviction of many small ones. The role of the setting is to
+    perform rebalance when count of items in shard goes significantly below expected count.
+  see_also:
+  - rocksdb_cache_rebalance_capacity
 # Enabling this will have 5-10% impact on performance for the stats collection
 - name: rocksdb_perf
   type: bool

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -10,4 +10,5 @@ add_library(kv STATIC ${kv_srcs}
 
 target_link_libraries(kv
   RocksDB::RocksDB
-  heap_profiler)
+  heap_profiler
+  ${FMT_LIB})

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -464,11 +464,12 @@ int RocksDBStore::create_and_open(ostream &out,
 }
 
 std::shared_ptr<rocksdb::Cache> RocksDBStore::create_block_cache(
+    const std::string& name,
     const std::string& cache_type, size_t cache_size, double cache_prio_high) {
   std::shared_ptr<rocksdb::Cache> cache;
   auto shard_bits = cct->_conf->rocksdb_cache_shard_bits;
   if (cache_type == "binned_lru") {
-    cache = rocksdb_cache::NewBinnedLRUCache(cct, cache_size, shard_bits, false, cache_prio_high);
+    cache = rocksdb_cache::NewBinnedLRUCache(cct, name, cache_size, shard_bits, false, cache_prio_high);
   } else if (cache_type == "lru") {
     cache = rocksdb::NewLRUCache(cache_size, shard_bits);
   } else if (cache_type == "clock") {
@@ -554,7 +555,7 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
   uint64_t row_cache_size = cache_size * cct->_conf->rocksdb_cache_row_ratio;
   uint64_t block_cache_size = cache_size - row_cache_size;
 
-  bbt_opts.block_cache = create_block_cache(cct->_conf->rocksdb_cache_type, block_cache_size);
+  bbt_opts.block_cache = create_block_cache(rocksdb::kDefaultColumnFamilyName, cct->_conf->rocksdb_cache_type, block_cache_size);
   if (!bbt_opts.block_cache) {
     return -EINVAL;
   }
@@ -1013,7 +1014,7 @@ int RocksDBStore::apply_block_cache_options(const std::string& column_name,
     column_bbt_opts.no_block_cache = true;
   } else {
     if (require_new_block_cache) {
-      block_cache = create_block_cache(cache_type, cache_size, high_pri_pool_ratio);
+      block_cache = create_block_cache(column_name, cache_type, cache_size, high_pri_pool_ratio);
       if (!block_cache) {
 	dout(5) << __func__ << " failed to create block cache for params: " << block_cache_opt << dendl;
 	return -EINVAL;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -164,7 +164,9 @@ private:
 		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& existing_cfs_shard,
 		      std::vector<rocksdb::ColumnFamilyDescriptor>& missing_cfs,
 		      std::vector<std::pair<size_t, RocksDBStore::ColumnFamily> >& missing_cfs_shard);
-  std::shared_ptr<rocksdb::Cache> create_block_cache(const std::string& cache_type, size_t cache_size, double cache_prio_high = 0.0);
+  std::shared_ptr<rocksdb::Cache> create_block_cache(
+    const std::string& name,
+    const std::string& cache_type, size_t cache_size, double cache_prio_high = 0.0);
   int split_column_family_options(const std::string& opts_str,
 				  std::unordered_map<std::string, std::string>* column_opts_map,
 				  std::string* block_cache_opt);

--- a/src/kv/rocksdb_cache/ShardedCache.cc
+++ b/src/kv/rocksdb_cache/ShardedCache.cc
@@ -20,9 +20,9 @@ namespace rocksdb_cache {
 ShardedCache::ShardedCache(size_t capacity, int num_shard_bits,
                            bool strict_capacity_limit)
     : num_shard_bits_(num_shard_bits),
-      capacity_(capacity),
       strict_capacity_limit_(strict_capacity_limit),
-      last_id_(1) {}
+      last_id_(1),
+      capacity_(capacity) {}
 
 void ShardedCache::SetCapacity(size_t capacity) {
   int num_shards = 1 << num_shard_bits_;

--- a/src/kv/rocksdb_cache/ShardedCache.h
+++ b/src/kv/rocksdb_cache/ShardedCache.h
@@ -186,12 +186,12 @@ class ShardedCache : public rocksdb::Cache, public PriorityCache::PriCache {
   uint64_t bins[PriorityCache::Priority::LAST+1] = {0};
   int64_t cache_bytes[PriorityCache::Priority::LAST+1] = {0};
   double cache_ratio = 0;
-
   int num_shard_bits_;
-  mutable std::mutex capacity_mutex_;
-  size_t capacity_;
   bool strict_capacity_limit_;
   std::atomic<uint64_t> last_id_;
+  protected:
+  mutable std::mutex capacity_mutex_;
+  size_t capacity_;
 };
 
 extern int GetDefaultCacheShardBits(size_t capacity);


### PR DESCRIPTION
BinnedLRUCache is sharded. Each shard is independent and has it own capacity.
By default each shard has exactly the same capacity.
When items are of uniform size, same capacity implies same amount of items
which implies same probability in each shard that the last element in LRU will be used.
But sometimes items are significantly larger. This causes a shard to evict significant amount of tail items,
reducing probability of cache hit in the shard.
At most severe cases only 2-3 large most frequently used items fit in the shard.
    
To combat this, a focus is given to item count per shard.
A rebalancing procedure is responsible to adjust shard capacity in a way
to obtain equal item count per shard.
    
New perf counters:
- rocksdb-cache-x/rebalance; average time spent in rebalance procedure,
                              includes freeing items
- rocksdb-cache-x/rebalance_free: average time for freeing evicted items;
                                  this is executed outside shard locks
    
New configurables:
- rocksdb_cache_rebalance
- rocksdb_cache_rebalance_max_steps
- rocksdb_cache_rebalance_capacity
- rocksdb_cache_rebalance_items

Based on #64819

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
