### PR TITLE
rgw: Replace deprecated Barbican payload endpoint with alternative

### DIFF
--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -929,6 +929,7 @@ static int request_key_from_barbican(const DoutPrefixProvider *dpp,
   }
   concat_url(secret_url, "/v1/secrets/");
   concat_url(secret_url, std::string(key_id));
+  concat_url(secret_url, "/payload");
 
   bufferlist secret_bl;
   RGWHTTPTransceiver secret_req(cct, "GET", secret_url, &secret_bl);


### PR DESCRIPTION
`GET /v1/secrets/{uuid}` with Header `Accept:
application/octet-stream` has been deprecated in favor of `GET /v1/secrets/{uuid}/payload` in OpenStack Barbican.

The old API is still functional, but generates a warning level log message on Barbican for every access.

Deprecation commit from 2015:
https://github.com/openstack/barbican/commit/b4b64be6f259acf4d8677eadbc35d37fab3a6df0


Barbican logs before:

```
Aug 13 11:00:58 devstack-vm-0 devstack@barbican-svc.service[950]: 2025-08-13 11:00:58.508 950 WARNING barbican.api.controllers.secrets [None req-ddc6554a-84cb-45c6-8a6a-fda741f0a1cf be847583f67b45a7b31d61cab0c09dd0 82f4afa1eb5241c69ff91370cc332cd2 - - default default] Decrypted secret 2dcfadb9-47a6-41bf-801d-67eb7bd7d5d8 requested using deprecated API call.
Aug 13 11:00:58 devstack-vm-0 devstack@barbican-svc.service[950]: 2025-08-13 11:00:58.511 950 INFO barbican.api.middleware.context [None req-ddc6554a-84cb-45c6-8a6a-fda741f0a1cf be847583f67b45a7b31d61cab0c09dd0 82f4afa1eb5241c69ff91370cc332cd2 - - default default] Processed request: 200 OK - GET http://10.17.4.101/key-manager/v1/secrets/2dcfadb9-47a6-41bf-801d-67eb7bd7d5d8
Aug 13 11:00:58 devstack-vm-0 devstack@barbican-svc.service[950]: [pid: 950|app: 0|req: 4/8] 10.17.4.1 () {48 vars in 1086 bytes} [Wed Aug 13 11:00:58 2025] GET /key-manager/v1/secrets/2dcfadb9-47a6-41bf-801d-67eb7bd7d5d8 => generated 32 bytes in 30 msecs (HTTP/1.1 200) 6 headers in 233 bytes (1 switches on core 0)
```

After:

```
Aug 13 10:59:07 devstack-vm-0 devstack@barbican-svc.service[949]: 2025-08-13 10:59:07.210 949 INFO barbican.api.middleware.context [None req-897d7b39-6d2f-4bfd-88ef-4b6cc92ce67c be847583f67b45a7b31d61cab0c09dd0 82f4afa1eb5241c69ff91370cc332cd2 - - default default] Processed request: 200 OK - GET http://10.17.4.101/key-manager/v1/secrets/2dcfadb9-47a6-41bf-801d-67eb7bd7d5d8/payload
Aug 13 10:59:07 devstack-vm-0 devstack@barbican-svc.service[949]: [pid: 949|app: 0|req: 4/7] 10.17.4.1 () {48 vars in 1110 bytes} [Wed Aug 13 10:59:07 2025] GET /key-manager/v1/secrets/2dcfadb9-47a6-41bf-801d-67eb7bd7d5d8/payload => generated 32 bytes in 43 msecs (HTTP/1.1 200) 6 headers in 233 bytes (1 switches on core 0)
```

Change is covered by existing Teuthology tests against Barbican

Fixes: https://tracker.ceph.com/issues/68535

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
