### PR TITLE
mgr, mon, osdc: pass complex parameters by rvalue reference

### DIFF
--- a/src/erasure-code/consistency/RadosCommands.cc
+++ b/src/erasure-code/consistency/RadosCommands.cc
@@ -29,8 +29,8 @@ int RadosCommands::get_primary_osd(const std::string& pool_name,
   std::ostringstream oss;
   formatter.get()->flush(oss);
 
-  ceph::bufferlist inbl, outbl;
-  int rc = rados.mon_command(oss.str(), inbl, &outbl, nullptr);
+  ceph::bufferlist outbl;
+  int rc = rados.mon_command(oss.str(), {}, &outbl, nullptr);
   ceph_assert(rc == 0);
 
   JSONParser p;
@@ -60,8 +60,8 @@ bool RadosCommands::get_pool_allow_ec_optimizations(const std::string& pool_name
   std::ostringstream oss;
   formatter.get()->flush(oss);
 
-  ceph::bufferlist inbl, outbl;
-  int rc = rados.mon_command(oss.str(), inbl, &outbl, nullptr);
+  ceph::bufferlist outbl;
+  int rc = rados.mon_command(oss.str(), {}, &outbl, nullptr);
   ceph_assert(rc == 0);
 
   JSONParser p;
@@ -89,8 +89,8 @@ std::string RadosCommands::get_pool_ec_profile_name(const std::string& pool_name
   std::ostringstream oss;
   formatter.get()->flush(oss);
 
-  ceph::bufferlist inbl, outbl;
-  int rc = rados.mon_command(oss.str(), inbl, &outbl, nullptr);
+  ceph::bufferlist outbl;
+  int rc = rados.mon_command(oss.str(), {}, &outbl, nullptr);
   ceph_assert(rc == 0);
 
   JSONParser p;
@@ -123,8 +123,8 @@ ceph::ErasureCodeProfile RadosCommands::get_ec_profile_for_pool(const std::strin
   std::ostringstream oss;
   formatter.get()->flush(oss);
 
-  ceph::bufferlist inbl, outbl;
-  int rc = rados.mon_command(oss.str(), inbl, &outbl, nullptr);
+  ceph::bufferlist outbl;
+  int rc = rados.mon_command(oss.str(), {}, &outbl, nullptr);
   ceph_assert(rc == 0);
 
   // Parse the string output into an ErasureCodeProfile
@@ -170,8 +170,8 @@ void RadosCommands::inject_parity_read_on_primary_osd(const std::string& pool_na
   std::ostringstream oss;
   formatter.get()->flush(oss);
 
-  ceph::bufferlist inbl, outbl;
-  int rc = rados.osd_command(primary_osd, oss.str(), inbl, &outbl, nullptr);
+  ceph::bufferlist outbl;
+  int rc = rados.osd_command(primary_osd, oss.str(), {}, &outbl, nullptr);
   ceph_assert(rc == 0);
 }
 
@@ -192,7 +192,7 @@ void RadosCommands::inject_clear_parity_read_on_primary_osd(const std::string& p
   std::ostringstream oss;
   formatter.get()->flush(oss);
 
-  ceph::bufferlist inbl, outbl;
-  int rc = rados.osd_command(primary_osd, oss.str(), inbl, &outbl, nullptr);
+  ceph::bufferlist outbl;
+  int rc = rados.osd_command(primary_osd, oss.str(), {}, &outbl, nullptr);
   ceph_assert(rc == 0);
 }

--- a/src/include/neorados/RADOS.hpp
+++ b/src/include/neorados/RADOS.hpp
@@ -1736,8 +1736,8 @@ public:
 			  std::string, ceph::buffer::list);
   using CommandComp = boost::asio::any_completion_handler<CommandSig>;
   template<boost::asio::completion_token_for<CommandSig> CompletionToken>
-  auto osd_command(int osd, std::vector<std::string> cmd,
-		   ceph::buffer::list in, CompletionToken&& token) {
+  auto osd_command(int osd, std::vector<std::string>&& cmd,
+		   ceph::buffer::list&& in, CompletionToken&& token) {
     auto consigned = consign(std::forward<CompletionToken>(token));
     return boost::asio::async_initiate<decltype(consigned), CommandSig>(
       [osd, this](auto&& handler, std::vector<std::string> cmd,
@@ -1747,8 +1747,8 @@ public:
       }, consigned, std::move(cmd), std::move(in));
   }
   template<boost::asio::completion_token_for<CommandSig> CompletionToken>
-  auto pg_command(PG pg, std::vector<std::string> cmd,
-		  ceph::buffer::list in, CompletionToken&& token) {
+  auto pg_command(PG pg, std::vector<std::string>&& cmd,
+		  ceph::buffer::list&& in, CompletionToken&& token) {
     auto consigned = consign(std::forward<CompletionToken>(token));
     return boost::asio::async_initiate<decltype(consigned), CommandSig>(
       [this](auto&& handler, PG pg, std::vector<std::string> cmd,
@@ -1759,8 +1759,8 @@ public:
   }
 
   template<boost::asio::completion_token_for<SimpleOpSig> CompletionToken>
-  auto mon_command(std::vector<std::string> command,
-		   ceph::buffer::list bl,
+  auto mon_command(std::vector<std::string>&& command,
+		   ceph::buffer::list&& bl,
 		   std::string* outs, ceph::buffer::list* outbl,
 		   CompletionToken&& token) {
     auto consigned = consign(std::forward<CompletionToken>(token));
@@ -1881,13 +1881,13 @@ private:
 			  Cursor end, std::uint32_t max,
 			  ceph::buffer::list filter,
 			  EnumerateComp c);
-  void osd_command_(int osd, std::vector<std::string> cmd,
-		    ceph::buffer::list in, CommandComp c);
-  void pg_command_(PG pg, std::vector<std::string> cmd,
-		   ceph::buffer::list in, CommandComp c);
+  void osd_command_(int osd, std::vector<std::string>&& cmd,
+		    ceph::buffer::list&& in, CommandComp c);
+  void pg_command_(PG pg, std::vector<std::string>&& cmd,
+		   ceph::buffer::list&& in, CommandComp c);
 
-  void mon_command_(std::vector<std::string> command,
-		    ceph::buffer::list bl,
+  void mon_command_(std::vector<std::string>&& command,
+		    ceph::buffer::list&& bl,
 		    std::string* outs, ceph::buffer::list* outbl,
 		    SimpleOpComp c);
 

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1473,13 +1473,13 @@ inline namespace v14_2_0 {
     int get_min_compatible_client(int8_t* min_compat_client,
                                   int8_t* require_min_compat_client);
 
-    int mon_command(std::string cmd, const bufferlist& inbl,
+    int mon_command(std::string&& cmd, bufferlist&& inbl,
 		    bufferlist *outbl, std::string *outs);
-    int mgr_command(std::string cmd, const bufferlist& inbl,
+    int mgr_command(std::string&& cmd, bufferlist&& inbl,
 		    bufferlist *outbl, std::string *outs);
-    int osd_command(int osdid, std::string cmd, const bufferlist& inbl,
+    int osd_command(int osdid, std::string&& cmd, bufferlist&& inbl,
                     bufferlist *outbl, std::string *outs);
-    int pg_command(const char *pgstr, std::string cmd, const bufferlist& inbl,
+    int pg_command(const char *pgstr, std::string&& cmd, bufferlist&& inbl,
                    bufferlist *outbl, std::string *outs);
 
     int ioctx_create(const char *name, IoCtx &pioctx);

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -2107,10 +2107,7 @@ void librados::IoCtxImpl::application_enable_async(const std::string& app_name,
   }
   cmd << "}";
 
-  std::vector<std::string> cmds;
-  cmds.push_back(cmd.str());
-  bufferlist inbl;
-  client->mon_command_async(cmds, inbl, nullptr, nullptr,
+  client->mon_command_async({cmd.str()}, {}, nullptr, nullptr,
                             make_lambda_context(CB_PoolAsync_Safe(c)));
 }
 
@@ -2174,10 +2171,7 @@ int librados::IoCtxImpl::application_metadata_set(const std::string& app_name,
       << "\"value\":\"" << value << "\""
       << "}";
 
-  std::vector<std::string> cmds;
-  cmds.push_back(cmd.str());
-  bufferlist inbl;
-  int r = client->mon_command(cmds, inbl, nullptr, nullptr);
+  int r = client->mon_command({cmd.str()}, {}, nullptr, nullptr);
   if (r < 0) {
     return r;
   }
@@ -2197,10 +2191,7 @@ int librados::IoCtxImpl::application_metadata_remove(const std::string& app_name
       << "\"key\":\"" << key << "\""
       << "}";
 
-  std::vector<std::string> cmds;
-  cmds.push_back(cmd.str());
-  bufferlist inbl;
-  int r = client->mon_command(cmds, inbl, nullptr, nullptr);
+  int r = client->mon_command({cmd.str()}, {}, nullptr, nullptr);
   if (r < 0) {
     return r;
   }

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -150,25 +150,25 @@ public:
 
   int blocklist_add(const std::string& client_address, uint32_t expire_seconds);
 
-  int mon_command(const std::vector<std::string>& cmd, const bufferlist &inbl,
+  int mon_command(std::vector<std::string> &&cmd, bufferlist &&inbl,
 	          bufferlist *outbl, std::string *outs);
-  void mon_command_async(const std::vector<std::string>& cmd, const bufferlist &inbl,
+  void mon_command_async(std::vector<std::string>&& cmd, bufferlist &&inbl,
                          bufferlist *outbl, std::string *outs, Context *on_finish);
   int mon_command(int rank,
-		  const std::vector<std::string>& cmd, const bufferlist &inbl,
+		  std::vector<std::string>&& cmd, bufferlist &&inbl,
 	          bufferlist *outbl, std::string *outs);
-  int mon_command(std::string name,
-		  const std::vector<std::string>& cmd, const bufferlist &inbl,
+  int mon_command(std::string&& name,
+		  std::vector<std::string>&& cmd, bufferlist &&inbl,
 	          bufferlist *outbl, std::string *outs);
-  int mgr_command(const std::vector<std::string>& cmd, const bufferlist &inbl,
+  int mgr_command(std::vector<std::string>&& cmd, bufferlist &&inbl,
 	          bufferlist *outbl, std::string *outs);
   int mgr_command(
-    const std::string& name,
-    const std::vector<std::string>& cmd, const bufferlist &inbl,
+    std::string&& name,
+    std::vector<std::string>&& cmd, bufferlist &&inbl,
     bufferlist *outbl, std::string *outs);
-  int osd_command(int osd, std::vector<std::string>& cmd, const bufferlist& inbl,
+  int osd_command(int osd, std::vector<std::string>&& cmd, bufferlist&& inbl,
                   bufferlist *poutbl, std::string *prs);
-  int pg_command(pg_t pgid, std::vector<std::string>& cmd, const bufferlist& inbl,
+  int pg_command(pg_t pgid, std::vector<std::string>&& cmd, bufferlist&& inbl,
 	         bufferlist *poutbl, std::string *prs);
 
   void handle_log(MLog *m);

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -900,7 +900,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mon_command)(
   }
 
   inbl.append(inbuf, inbuflen);
-  int ret = client->mon_command(cmdvec, inbl, &outbl, &outstring);
+  int ret = client->mon_command(std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -943,9 +943,9 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mon_command_target)(
   inbl.append(inbuf, inbuflen);
   int ret;
   if (rank >= 0)
-    ret = client->mon_command(rank, cmdvec, inbl, &outbl, &outstring);
+    ret = client->mon_command(rank, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
   else
-    ret = client->mon_command(name, cmdvec, inbl, &outbl, &outstring);
+    ret = client->mon_command(name, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -974,7 +974,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_osd_command)(
   }
 
   inbl.append(inbuf, inbuflen);
-  int ret = client->osd_command(osdid, cmdvec, inbl, &outbl, &outstring);
+  int ret = client->osd_command(osdid, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -1005,7 +1005,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mgr_command)(
   }
 
   inbl.append(inbuf, inbuflen);
-  int ret = client->mgr_command(cmdvec, inbl, &outbl, &outstring);
+  int ret = client->mgr_command(std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -1039,7 +1039,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_mgr_command_target)(
   }
 
   inbl.append(inbuf, inbuflen);
-  int ret = client->mgr_command(name, cmdvec, inbl, &outbl, &outstring);
+  int ret = client->mgr_command(name, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);
@@ -1073,7 +1073,7 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_pg_command)(
   if (!pgid.parse(pgstr))
     return -EINVAL;
 
-  int ret = client->pg_command(pgid, cmdvec, inbl, &outbl, &outstring);
+  int ret = client->pg_command(pgid, std::move(cmdvec), std::move(inbl), &outbl, &outstring);
 
   do_out_buffer(outbl, outbuf, outbuflen);
   do_out_buffer(outstring, outs, outslen);

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2617,33 +2617,27 @@ int librados::Rados::pool_reverse_lookup(int64_t id, std::string *name)
   return client->pool_get_name(id, name, true);
 }
 
-int librados::Rados::mon_command(string cmd, const bufferlist& inbl,
+int librados::Rados::mon_command(std::string&& cmd, bufferlist&& inbl,
 				 bufferlist *outbl, string *outs)
 {
-  vector<string> cmdvec;
-  cmdvec.push_back(cmd);
-  return client->mon_command(cmdvec, inbl, outbl, outs);
+  return client->mon_command({std::move(cmd)}, std::move(inbl), outbl, outs);
 }
 
-int librados::Rados::osd_command(int osdid, std::string cmd, const bufferlist& inbl,
+int librados::Rados::osd_command(int osdid, std::string&& cmd, bufferlist&& inbl,
                                  bufferlist *outbl, std::string *outs)
 {
-  vector<string> cmdvec;
-  cmdvec.push_back(cmd);
-  return client->osd_command(osdid, cmdvec, inbl, outbl, outs);
+  return client->osd_command(osdid, {std::move(cmd)}, std::move(inbl), outbl, outs);
 }
 
-int librados::Rados::mgr_command(std::string cmd, const bufferlist& inbl,
+int librados::Rados::mgr_command(std::string&& cmd, bufferlist&& inbl,
                                  bufferlist *outbl, std::string *outs)
 {
-  vector<string> cmdvec;
-  cmdvec.push_back(cmd);
-  return client->mgr_command(cmdvec, inbl, outbl, outs);
+  return client->mgr_command({std::move(cmd)}, std::move(inbl), outbl, outs);
 }
 
 
 
-int librados::Rados::pg_command(const char *pgstr, std::string cmd, const bufferlist& inbl,
+int librados::Rados::pg_command(const char *pgstr, std::string&& cmd, bufferlist&& inbl,
                                 bufferlist *outbl, std::string *outs)
 {
   vector<string> cmdvec;
@@ -2653,7 +2647,7 @@ int librados::Rados::pg_command(const char *pgstr, std::string cmd, const buffer
   if (!pgid.parse(pgstr))
     return -EINVAL;
 
-  return client->pg_command(pgid, cmdvec, inbl, outbl, outs);
+  return client->pg_command(pgid, std::move(cmdvec), std::move(inbl), outbl, outs);
 }
 
 int librados::Rados::ioctx_create(const char *name, IoCtx &io)

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -244,7 +244,7 @@ int get_config_key(librados::Rados& rados, const std::string& uri,
 
   bufferlist in_bl;
   bufferlist out_bl;
-  int r = rados.mon_command(cmd, in_bl, &out_bl, nullptr);
+  int r = rados.mon_command(std::move(cmd), std::move(in_bl), &out_bl, nullptr);
   if (r < 0) {
     lderr(cct) << "failed to retrieve MON config key " << key << ": "
                << cpp_strerror(r) << dendl;

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -55,10 +55,9 @@ int get_config_key(librados::Rados& rados, const std::string& key,
       "\"key\": \"" + key + "\""
     "}";
 
-  bufferlist in_bl;
   bufferlist out_bl;
 
-  int r = rados.mon_command(cmd, in_bl, &out_bl, nullptr);
+  int r = rados.mon_command(std::move(cmd), {}, &out_bl, nullptr);
   if (r == -EINVAL) {
     return -EOPNOTSUPP;
   } else if (r < 0 && r != -ENOENT) {
@@ -84,10 +83,9 @@ int set_config_key(librados::Rados& rados, const std::string& key,
             "\"val\": \"" + value + "\""
           "}";
   }
-  bufferlist in_bl;
   bufferlist out_bl;
 
-  int r = rados.mon_command(cmd, in_bl, &out_bl, nullptr);
+  int r = rados.mon_command(std::move(cmd), {}, &out_bl, nullptr);
   if (r == -EINVAL) {
     return -EOPNOTSUPP;
   } else if (r < 0) {
@@ -180,10 +178,9 @@ int create_bootstrap_user(CephContext* cct, librados::Rados& rados,
     R"(  "format": "json")" \
     R"(})";
 
-  bufferlist in_bl;
   bufferlist out_bl;
 
-  r = rados.mon_command(cmd, in_bl, &out_bl, nullptr);
+  r = rados.mon_command(std::move(cmd), {}, &out_bl, nullptr);
   if (r == -EINVAL) {
     ldout(cct, 5) << "caps mismatch for existing user" << dendl;
     return -EEXIST;

--- a/src/librbd/api/PoolMetadata.cc
+++ b/src/librbd/api/PoolMetadata.cc
@@ -33,9 +33,8 @@ void update_pool_timestamp(librados::IoCtx& io_ctx) {
     R"(})";
 
   librados::Rados rados(io_ctx);
-  bufferlist in_bl;
   std::string ss;
-  int r = rados.mon_command(cmd, in_bl, nullptr, &ss);
+  int r = rados.mon_command(std::move(cmd), {}, nullptr, &ss);
   if (r < 0) {
     lderr(cct) << "failed to notify clients of pool config update: "
                << cpp_strerror(r) << dendl;

--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -407,12 +407,11 @@ int Trash<I>::purge(IoCtx& io_ctx, time_t expire_ts,
       return -EINVAL;
     }
 
-    librados::bufferlist inbl;
     librados::bufferlist outbl;
     std::string pool_name = io_ctx.get_pool_name();
 
     librados::Rados rados(io_ctx);
-    rados.mon_command(R"({"prefix": "df", "format": "json"})", inbl,
+    rados.mon_command(R"({"prefix": "df", "format": "json"})", {},
                       &outbl, nullptr);
 
     json_spirit::mValue json;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -691,7 +691,7 @@ void MDSRank::set_mdsmap_multimds_snaps_allowed()
   dout(0) << __func__ << ": sending mon command: " << cmd[0] << dendl;
 
   C_MDS_MonCommand *fin = new C_MDS_MonCommand(this, cmd[0]);
-  monc->start_mon_command(cmd, {}, nullptr, &fin->outs, new C_IO_Wrapper(this, fin));
+  monc->start_mon_command(std::move(cmd), {}, nullptr, &fin->outs, new C_IO_Wrapper(this, fin));
 
   already_sent = true;
 }
@@ -3986,7 +3986,7 @@ bool MDSRank::evict_client(int64_t session_id,
     }
   };
 
-  auto apply_blocklist = [this, cmd](std::function<void ()> fn){
+  auto apply_blocklist = [this, &cmd](std::function<void ()> fn){
     ceph_assert(ceph_mutex_is_locked_by_me(mds_lock));
 
     Context *on_blocklist_done = new LambdaContext([this, fn](int r) {
@@ -4006,7 +4006,7 @@ bool MDSRank::evict_client(int64_t session_id,
     });
 
     dout(4) << "Sending mon blocklist command: " << cmd[0] << dendl;
-    monc->start_mon_command(cmd, {}, nullptr, nullptr, on_blocklist_done);
+    monc->start_mon_command(std::move(cmd), {}, nullptr, nullptr, on_blocklist_done);
   };
 
   if (wait) {

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -1578,7 +1578,7 @@ void ActivePyModules::set_device_wear_level(const std::string& devid,
     "}";
 
   Command set_cmd;
-  set_cmd.run(&monc, cmd, json);
+  set_cmd.run(&monc, std::move(cmd), std::move(json));
   set_cmd.wait();
 }
 

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -178,7 +178,7 @@ ceph_send_command(BaseMgrModule *self, PyObject *args, PyObject *kwargs)
     self->py_modules->get_monc().start_mon_command(
         name,
         {cmd_json},
-        inbuf,
+        std::move(inbuf),
         &command_c->outbl,
         &command_c->outs,
         new C_OnFinisher(c, &self->py_modules->cmd_finisher));
@@ -198,7 +198,7 @@ ceph_send_command(BaseMgrModule *self, PyObject *args, PyObject *kwargs)
     self->py_modules->get_objecter().osd_command(
         osd_id,
         {cmd_json},
-        inbuf,
+        std::move(inbuf),
         &tid,
 	[command_c, f = &self->py_modules->cmd_finisher]
 	(boost::system::error_code ec, std::string s, ceph::buffer::list bl) {
@@ -227,7 +227,7 @@ ceph_send_command(BaseMgrModule *self, PyObject *args, PyObject *kwargs)
     self->py_modules->get_objecter().pg_command(
         pgid,
         {cmd_json},
-        inbuf,
+        std::move(inbuf),
         &tid,
 	[command_c, f = &self->py_modules->cmd_finisher]
 	(boost::system::error_code ec, std::string s, ceph::buffer::list bl) {

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2488,7 +2488,7 @@ bool DaemonServer::_handle_command(
 	"}";
       op->mark_start_mon_command();
       auto on_finish = new ReplyOnFinish(cmdctx, op);
-      monc->start_mon_command({cmd}, json, nullptr, nullptr, on_finish);
+      monc->start_mon_command({cmd}, std::move(json), nullptr, nullptr, on_finish);
     }
     return true;
   } else if (prefix == "device rm-life-expectancy") {
@@ -2521,7 +2521,7 @@ bool DaemonServer::_handle_command(
       }
       op->mark_start_mon_command();
       auto on_finish = new ReplyOnFinish(cmdctx, op);
-      monc->start_mon_command({cmd}, json, nullptr, nullptr, on_finish);
+      monc->start_mon_command({std::move(cmd)}, std::move(json), nullptr, nullptr, on_finish);
     } else {
       cmdctx->reply(0, ss);
     }

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -484,7 +484,7 @@ bool MgrClient::handle_mgr_close(ref_t<MMgrClose> m)
   return true;
 }
 
-int MgrClient::start_command(const vector<string>& cmd, const bufferlist& inbl,
+int MgrClient::start_command(vector<string>&& cmd, bufferlist&& inbl,
 			     bufferlist *outbl, string *outs,
 			     Context *onfinish)
 {
@@ -498,8 +498,8 @@ int MgrClient::start_command(const vector<string>& cmd, const bufferlist& inbl,
   }
 
   auto &op = command_table.start_command();
-  op.cmd = cmd;
-  op.inbl = inbl;
+  op.cmd = std::move(cmd);
+  op.inbl = std::move(inbl);
   op.outbl = outbl;
   op.outs = outs;
   op.on_finish = onfinish;
@@ -518,8 +518,8 @@ int MgrClient::start_command(const vector<string>& cmd, const bufferlist& inbl,
 }
 
 int MgrClient::start_tell_command(
-  const string& name,
-  const vector<string>& cmd, const bufferlist& inbl,
+  string&& name,
+  vector<string>&& cmd, bufferlist&& inbl,
   bufferlist *outbl, string *outs,
   Context *onfinish)
 {
@@ -534,9 +534,9 @@ int MgrClient::start_tell_command(
 
   auto &op = command_table.start_command();
   op.tell = true;
-  op.name = name;
-  op.cmd = cmd;
-  op.inbl = inbl;
+  op.name = std::move(name);
+  op.cmd = std::move(cmd);
+  op.inbl = std::move(inbl);
   op.outbl = outbl;
   op.outs = outs;
   op.on_finish = onfinish;

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -147,12 +147,12 @@ public:
   }
 
   int start_command(
-    const std::vector<std::string>& cmd, const ceph::buffer::list& inbl,
+    std::vector<std::string>&& cmd, ceph::buffer::list&& inbl,
     ceph::buffer::list *outbl, std::string *outs,
     Context *onfinish);
   int start_tell_command(
-    const std::string& name,
-    const std::vector<std::string>& cmd, const ceph::buffer::list& inbl,
+    std::string&& name,
+    std::vector<std::string>&& cmd, ceph::buffer::list&& inbl,
     ceph::buffer::list *outbl, std::string *outs,
     Context *onfinish);
 

--- a/src/mgr/MgrContext.h
+++ b/src/mgr/MgrContext.h
@@ -35,9 +35,9 @@ public:
         &outbl, &outs, &cond);
   }
 
-  void run(MonClient *monc, const std::string &command, const ceph::buffer::list &inbl)
+  void run(MonClient *monc, const std::string &command, ceph::buffer::list &&inbl)
   {
-    monc->start_mon_command({command}, inbl,
+    monc->start_mon_command({command}, std::move(inbl),
         &outbl, &outs, &cond);
   }
 

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -576,7 +576,7 @@ private:
     CommandCompletion onfinish;
     std::optional<boost::asio::steady_timer> cancel_timer;
 
-    MonCommand(MonClient& monc, uint64_t t, CommandCompletion onfinish)
+    MonCommand(MonClient& monc, uint64_t t, CommandCompletion&& onfinish)
       : tid(t), onfinish(std::move(onfinish)) {
       auto timeout =
           monc.cct->_conf.get_val<std::chrono::seconds>("rados_mon_op_timeout");
@@ -611,8 +611,8 @@ private:
 
 public:
   template<typename CompletionToken>
-  auto start_mon_command(std::vector<std::string> cmd,
-                         ceph::buffer::list inbl,
+  auto start_mon_command(std::vector<std::string>&& cmd,
+                         ceph::buffer::list&& inbl,
 			 CompletionToken&& token) {
     namespace asio = boost::asio;
     ldout(cct,10) << __func__ << " cmd=" << cmd << dendl;
@@ -642,8 +642,8 @@ public:
   }
 
   template<typename CompletionToken>
-  auto start_mon_command(int mon_rank, std::vector<std::string> cmd,
-			 ceph::buffer::list inbl,
+  auto start_mon_command(int mon_rank, std::vector<std::string>&& cmd,
+			 ceph::buffer::list&& inbl,
 			 CompletionToken&& token) {
     namespace asio = boost::asio;
     namespace sys = boost::system;
@@ -675,9 +675,9 @@ public:
   }
 
   template<typename CompletionToken>
-  auto start_mon_command(std::string mon_name,
-                         std::vector<std::string> cmd,
-			 ceph::buffer::list inbl,
+  auto start_mon_command(std::string&& mon_name,
+                         std::vector<std::string>&& cmd,
+			 ceph::buffer::list&& inbl,
 			 CompletionToken&& token) {
     namespace asio = boost::asio;
     ldout(cct,10) << __func__ << " cmd=" << cmd << dendl;
@@ -731,8 +731,8 @@ public:
     ContextVerter& operator =(ContextVerter&&) = default;
 
     void operator()(boost::system::error_code e,
-		    std::string s,
-		    ceph::bufferlist bl) {
+		    std::string&& s,
+		    ceph::bufferlist&& bl) {
       if (outs)
 	*outs = std::move(s);
       if (outbl)
@@ -742,20 +742,20 @@ public:
     }
   };
 
-  void start_mon_command(std::vector<std::string> cmd, bufferlist inbl,
+  void start_mon_command(std::vector<std::string> cmd, bufferlist&& inbl,
 			 bufferlist *outbl, std::string *outs,
 			 Context *onfinish) {
     start_mon_command(std::move(cmd), std::move(inbl),
 		      ContextVerter(outs, outbl, onfinish));
   }
-  void start_mon_command(int mon_rank, std::vector<std::string> cmd,
-			 bufferlist inbl, bufferlist *outbl, std::string *outs,
+  void start_mon_command(int mon_rank, std::vector<std::string>&& cmd,
+			 bufferlist&& inbl, bufferlist *outbl, std::string *outs,
 			 Context *onfinish) {
     start_mon_command(mon_rank, std::move(cmd), std::move(inbl),
 		      ContextVerter(outs, outbl, onfinish));
   }
-  void start_mon_command(std::string mon_name,  ///< mon name, with mon. prefix
-			 std::vector<std::string> cmd, bufferlist inbl,
+  void start_mon_command(std::string&& mon_name,  ///< mon name, with mon. prefix
+			 std::vector<std::string>&& cmd, bufferlist&& inbl,
 			 bufferlist *outbl, std::string *outs,
 			 Context *onfinish) {
     start_mon_command(std::move(mon_name), std::move(cmd), std::move(inbl),

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3600,8 +3600,8 @@ void Monitor::handle_command(MonOpRequestRef op)
     dout(10) << __func__ << " proxying mgr command (+" << size
 	     << " -> " << mgr_proxy_bytes << ")" << dendl;
     C_MgrProxyCommand *fin = new C_MgrProxyCommand(this, op, size);
-    mgr_client.start_command(m->cmd,
-			     m->get_data(),
+    mgr_client.start_command(std::move(m->cmd),
+			     std::move(m->get_data()),
 			     &fin->outbl,
 			     &fin->outs,
 			     new C_OnFinisher(fin, &finisher));

--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -1868,8 +1868,8 @@ void RADOS::enumerate_objects_(IOContext _ioc, Cursor begin, Cursor end,
     });
 }
 
-void RADOS::osd_command_(int osd, std::vector<std::string> cmd,
-			 ceph::bufferlist in, CommandComp c) {
+void RADOS::osd_command_(int osd, std::vector<std::string>&& cmd,
+			 ceph::bufferlist&& in, CommandComp c) {
   impl->objecter->osd_command(
     osd, std::move(cmd), std::move(in), nullptr,
     [c = std::move(c)]
@@ -1879,8 +1879,8 @@ void RADOS::osd_command_(int osd, std::vector<std::string> cmd,
     });
 }
 
-void RADOS::pg_command_(PG pg, std::vector<std::string> cmd,
-			ceph::bufferlist in, CommandComp c) {
+void RADOS::pg_command_(PG pg, std::vector<std::string>&& cmd,
+			ceph::bufferlist&& in, CommandComp c) {
   impl->objecter->pg_command(
     pg_t{pg.seed, pg.pool}, std::move(cmd), std::move(in), nullptr,
     [c = std::move(c)]
@@ -1950,12 +1950,12 @@ void RADOS::wait_for_latest_osd_map_(SimpleOpComp c) {
   impl->objecter->wait_for_latest_osdmap(std::move(c));
 }
 
-void RADOS::mon_command_(std::vector<std::string> command,
-			 cb::list bl, std::string* outs, cb::list* outbl,
+void RADOS::mon_command_(std::vector<std::string>&& command,
+			 cb::list&& bl, std::string* outs, cb::list* outbl,
 			 SimpleOpComp c) {
 
   impl->monclient.start_mon_command(
-    command, bl,
+    std::move(command), std::move(bl),
     [c = std::move(c), outs, outbl](bs::error_code e,
 				    std::string s, cb::list bl) mutable {
       if (outs)

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -607,7 +607,7 @@ void ECBackend::handle_sub_write_reply(
         get_parent()->whoami()) + "\"] }";
     vector<std::string> vcmd{cmd};
     dout(0) << __func__ << " Error inject - marking OSD down" << dendl;
-    get_parent()->start_mon_command(vcmd, {}, nullptr, nullptr, nullptr);
+    get_parent()->start_mon_command(std::move(vcmd), {}, nullptr, nullptr, nullptr);
   }
 
   if (op->pending_commits == 0) {

--- a/src/osd/ECBackendL.cc
+++ b/src/osd/ECBackendL.cc
@@ -1207,7 +1207,7 @@ void ECBackendL::handle_sub_write_reply(
       "{ \"prefix\": \"osd down\", \"ids\": [\"" + std::to_string( get_parent()->whoami() ) + "\"] }";
     vector<std::string> vcmd{cmd};
     dout(0) << __func__ << " Error inject - marking OSD down" << dendl;
-    get_parent()->start_mon_command(vcmd, {}, nullptr, nullptr, nullptr);
+    get_parent()->start_mon_command(std::move(vcmd), {}, nullptr, nullptr, nullptr);
   }
   rmw_pipeline.check_ops();
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4835,26 +4835,22 @@ int OSD::shutdown()
   return r;
 }
 
-int OSD::mon_cmd_maybe_osd_create(string &cmd)
+int OSD::mon_cmd_maybe_osd_create(string &&cmd)
 {
   bool created = false;
   while (true) {
     dout(10) << __func__ << " cmd: " << cmd << dendl;
-    vector<string> vcmd{cmd};
-    bufferlist inbl;
     C_SaferCond w;
     string outs;
-    monc->start_mon_command(vcmd, inbl, NULL, &outs, &w);
+    monc->start_mon_command({std::move(cmd)}, {}, NULL, &outs, &w);
     int r = w.wait();
     if (r < 0) {
       if (r == -ENOENT && !created) {
 	string newcmd = "{\"prefix\": \"osd create\", \"id\": " + stringify(whoami)
 	  + ", \"uuid\": \"" + stringify(superblock.osd_fsid) + "\"}";
-	vector<string> vnewcmd{newcmd};
-	bufferlist inbl;
 	C_SaferCond w;
 	string outs;
-	monc->start_mon_command(vnewcmd, inbl, NULL, &outs, &w);
+	monc->start_mon_command({std::move(newcmd)}, {}, NULL, &outs, &w);
 	int r = w.wait();
 	if (r < 0) {
 	  derr << __func__ << " fail: osd does not exist and created failed: "
@@ -4904,7 +4900,7 @@ int OSD::update_crush_location()
     string("\"id\": ") + stringify(whoami) + ", " +
     string("\"weight\":") + weight + ", " +
     string("\"args\": [") + stringify(cct->crush_location) + "]}";
-  return mon_cmd_maybe_osd_create(cmd);
+  return mon_cmd_maybe_osd_create(std::move(cmd));
 }
 
 int OSD::update_crush_device_class()
@@ -4930,7 +4926,7 @@ int OSD::update_crush_device_class()
     string("\"class\": \"") + device_class + string("\", ") +
     string("\"ids\": [\"") + stringify(whoami) + string("\"]}");
 
-  r = mon_cmd_maybe_osd_create(cmd);
+  r = mon_cmd_maybe_osd_create(std::move(cmd));
   if (r == -EBUSY) {
     // good, already bound to a device-class
     return 0;
@@ -10386,11 +10382,10 @@ bool OSD::maybe_override_options_for_qos(const std::set<std::string> *changed)
                 "\"who\": \"" + osd + "\", "
                 "\"name\": \"" + key + "\""
               "}";
-            vector<std::string> vcmd{cmd};
 
             dout(1) << __func__ << " Removing Key: " << key
                     << " for " << osd << " from Mon db" << dendl;
-            monc->start_mon_command(vcmd, {}, nullptr, nullptr, nullptr);
+            monc->start_mon_command({std::move(cmd)}, {}, nullptr, nullptr, nullptr);
           }
 
           // Raise a cluster warning indicating that the changes did not
@@ -10500,11 +10495,10 @@ void OSD::mon_cmd_set_config(const std::string &key, const std::string &val)
       "\"name\": \"" + key + "\", "
       "\"value\": \"" + val + "\""
     "}";
-  vector<std::string> vcmd{cmd};
 
   auto on_finish = new MonCmdSetConfigOnFinish(this, cct, key, val);
   dout(10) << __func__ << " Set " << key << " = " << val << dendl;
-  monc->start_mon_command(vcmd, {}, nullptr, nullptr, on_finish);
+  monc->start_mon_command({std::move(cmd)}, {}, nullptr, nullptr, on_finish);
 }
 
 op_queue_type_t OSD::osd_op_queue_type() const

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2188,7 +2188,7 @@ private:
   }
 
 private:
-  int mon_cmd_maybe_osd_create(std::string &cmd);
+  int mon_cmd_maybe_osd_create(std::string &&cmd);
   int update_crush_device_class();
   int update_crush_location();
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -293,7 +293,7 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
      virtual void send_message_osd_cluster(
        Message *m, const ConnectionRef& con) = 0;
      virtual void start_mon_command(
-       const std::vector<std::string>& cmd, const bufferlist& inbl,
+       std::vector<std::string>&& cmd, bufferlist&& inbl,
        bufferlist *outbl, std::string *outs,
        Context *onfinish) = 0;
      virtual ConnectionRef get_con_osd_cluster(int peer, epoch_t from_epoch) = 0;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -633,10 +633,10 @@ public:
     osd->send_message_osd_cluster(m, con);
   }
   void start_mon_command(
-    const std::vector<std::string>& cmd, const bufferlist& inbl,
+    std::vector<std::string>&& cmd, bufferlist&& inbl,
     bufferlist *outbl, std::string *outs,
     Context *onfinish) override {
-    osd->monc->start_mon_command(cmd, inbl, outbl, outs, onfinish);
+    osd->monc->start_mon_command(std::move(cmd), std::move(inbl), outbl, outs, onfinish);
   }
   ConnectionRef get_con_osd_cluster(int peer, epoch_t from_epoch) override;
   entity_name_t get_cluster_msgr_name() override {

--- a/src/rgw/driver/rados/rgw_dedup.cc
+++ b/src/rgw/driver/rados/rgw_dedup.cc
@@ -277,7 +277,6 @@ namespace rgw::dedup {
     // temporary solution until we find a way to disable the health warn on replica1
     std::string replica_count(std::to_string(2));
 #endif
-    librados::bufferlist inbl;
     std::string output;
     std::string command = R"(
     {
@@ -290,7 +289,7 @@ namespace rgw::dedup {
     })";
 
     auto rados_handle = store->getRados()->get_rados_handle();
-    int ret = rados_handle->mon_command(command, inbl, nullptr, &output);
+    int ret = rados_handle->mon_command(std::move(command), {}, nullptr, &output);
     if (output.length()) {
       if (output != "pool 'rgw_dedup_pool' already exists") {
         ldpp_dout(dpp, 10) << __func__ << "::" << output << dendl;

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -54,13 +54,12 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
 
     if (mostly_omap) {
       // set pg_autoscale_bias
-      bufferlist inbl;
       float bias = g_conf().get_val<double>("rgw_rados_pool_autoscale_bias");
       int r = rados->mon_command(
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" +
 	pool.name + "\", \"var\": \"pg_autoscale_bias\", \"val\": \"" +
 	stringify(bias) + "\"}",
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
       if (r < 0) {
 	ldpp_dout(dpp, 10) << __func__ << " warning: failed to set pg_autoscale_bias on "
 		 << pool.name << dendl;
@@ -71,7 +70,7 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" +
 	pool.name + "\", \"var\": \"recovery_priority\": \"" +
 	stringify(p) + "\"}",
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
       if (r < 0) {
 	ldpp_dout(dpp, 10) << __func__ << " warning: failed to set recovery_priority on "
 		 << pool.name << dendl;
@@ -79,11 +78,10 @@ int rgw_init_ioctx(const DoutPrefixProvider *dpp,
     }
     if (bulk) {
       // set bulk
-      bufferlist inbl;
       int r = rados->mon_command(
         "{\"prefix\": \"osd pool set\", \"pool\": \"" +
         pool.name + "\", \"var\": \"bulk\", \"val\": \"true\"}",
-        inbl, NULL, NULL);
+        {}, NULL, NULL);
       if (r < 0) {
         ldpp_dout(dpp, 10) << __func__ << " warning: failed to set 'bulk' on "
                  << pool.name << dendl;
@@ -355,8 +353,7 @@ int rgw_clog_warn(librados::Rados* h, const string& msg)
       "\"logtext\": [\"" + msg + "\"]"
     "}";
 
-  bufferlist inbl;
-  return h->mon_command(cmd, inbl, nullptr, nullptr);
+  return h->mon_command(std::move(cmd), {}, nullptr, nullptr);
 }
 
 int rgw_list_pool(const DoutPrefixProvider *dpp,

--- a/src/rgw/services/svc_config_key_rados.cc
+++ b/src/rgw/services/svc_config_key_rados.cc
@@ -41,8 +41,7 @@ int RGWSI_ConfigKey_RADOS::get(const string& key, bool secure,
       "\"key\": \"" + key + "\""
     "}";
 
-  bufferlist inbl;
-  int ret = rados->mon_command(cmd, inbl, result, nullptr);
+  int ret = rados->mon_command(std::move(cmd), {}, result, nullptr);
   if (ret < 0) {
     return ret;
   }

--- a/src/test/cls_hello/test_cls_hello.cc
+++ b/src/test/cls_hello/test_cls_hello.cc
@@ -81,10 +81,9 @@ TEST(ClsHello, RecordHello) {
 
 static std::string _get_required_osd_release(Rados& cluster)
 {
-  bufferlist inbl;
   std::string cmd = std::string("{\"prefix\": \"osd dump\",\"format\":\"json\"}");
   bufferlist outbl;
-  int r = cluster.mon_command(cmd, inbl, &outbl, NULL);
+  int r = cluster.mon_command(std::move(cmd), {}, &outbl, NULL);
   ceph_assert(r >= 0);
   std::string outstr(outbl.c_str(), outbl.length());
   json_spirit::Value v;

--- a/src/test/lazy-omap-stats/lazy_omap_stats_test.cc
+++ b/src/test/lazy-omap-stats/lazy_omap_stats_test.cc
@@ -83,9 +83,8 @@ void LazyOmapStatsTest::init(const int argc, const char** argv)
       "size": )" + to_string(conf.replica_count) +
                    R"(
     })";
-  librados::bufferlist inbl;
   string output;
-  ret = rados.mon_command(command, inbl, nullptr, &output);
+  ret = rados.mon_command(std::move(command), {}, nullptr, &output);
   if (output.length()) cout << output << endl;
   if (ret < 0) {
     ret = -ret;
@@ -196,7 +195,7 @@ void LazyOmapStatsTest::scrub()
   sleep(5);
 
   string command = R"({"prefix": "osd deep-scrub", "who": "all"})";
-  auto output = get_output(command);
+  auto output = get_output(std::move(command));
   cout << output << endl;
 
   cout << "Waiting for deep-scrub to complete..." << endl;
@@ -231,17 +230,17 @@ const int LazyOmapStatsTest::find_matches(string& output, boost::regex& reg) con
   return x;
 }
 
-const string LazyOmapStatsTest::get_output(const string command,
+const string LazyOmapStatsTest::get_output(std::string&& command,
                                            const bool silent,
                                            const CommandTarget target)
 {
-  librados::bufferlist inbl, outbl;
+  librados::bufferlist outbl;
   string output;
   int ret = 0;
   if (target == CommandTarget::TARGET_MON) {
-    ret = rados.mon_command(command, inbl, &outbl, &output);
+    ret = rados.mon_command(std::move(command), {}, &outbl, &output);
   } else {
-    ret = rados.mgr_command(command, inbl, &outbl, &output);
+    ret = rados.mgr_command(std::move(command), {}, &outbl, &output);
   }
   if (output.length() && !silent) {
     cout << output << endl;
@@ -261,7 +260,7 @@ void LazyOmapStatsTest::get_pool_id(const string& pool)
 
   string command = R"({"prefix": "osd pool ls", "detail": "detail", "format": "json"})";
   librados::bufferlist inbl, outbl;
-  auto output = get_output(command, false, CommandTarget::TARGET_MON);
+  auto output = get_output(std::move(command), false, CommandTarget::TARGET_MON);
   JSONParser parser;
   parser.parse(output.c_str(), output.size());
   for (const auto& pool : parser.get_array_elements()) {
@@ -284,7 +283,7 @@ void LazyOmapStatsTest::get_pool_id(const string& pool)
 map<string, string> LazyOmapStatsTest::get_scrub_stamps() {
   map<string, string> stamps;
   string command = R"({"prefix": "pg dump", "format": "json"})";
-  auto output = get_output(command);
+  auto output = get_output(std::move(command));
   JSONParser parser;
   parser.parse(output.c_str(), output.size());
   auto* obj = parser.find_obj("pg_map")->find_obj("pg_stats");
@@ -453,7 +452,7 @@ void LazyOmapStatsTest::check_pg_dump_summary()
   cout << R"(Checking "pg dump summary" output)" << endl;
 
   string command = R"({"prefix": "pg dump", "dumpcontents": ["summary"]})";
-  string dump_output = get_output(command);
+  string dump_output = get_output(std::move(command));
   cout << dump_output << endl;
 
   boost::regex reg(
@@ -483,7 +482,7 @@ void LazyOmapStatsTest::check_pg_dump_pgs()
   cout << R"(Checking "pg dump pgs" output)" << endl;
 
   string command = R"({"prefix": "pg dump", "dumpcontents": ["pgs"]})";
-  string dump_output = get_output(command);
+  string dump_output = get_output(std::move(command));
   cout << dump_output << endl;
 
   boost::regex reg(R"(^(PG_STAT\s.*))"
@@ -509,7 +508,7 @@ void LazyOmapStatsTest::check_pg_dump_pools()
   cout << R"(Checking "pg dump pools" output)" << endl;
 
   string command = R"({"prefix": "pg dump", "dumpcontents": ["pools"]})";
-  string dump_output = get_output(command);
+  string dump_output = get_output(std::move(command));
   cout << dump_output << endl;
 
   boost::regex reg(R"(^(POOLID\s.*))"
@@ -539,7 +538,7 @@ void LazyOmapStatsTest::check_pg_ls()
   cout << R"(Checking "pg ls" output)" << endl;
 
   string command = R"({"prefix": "pg ls"})";
-  string dump_output = get_output(command);
+  string dump_output = get_output(std::move(command));
   cout << dump_output << endl;
 
   boost::regex reg(R"(^(PG\s.*))"
@@ -572,7 +571,7 @@ void LazyOmapStatsTest::wait_for_active_clean()
   string command = R"({"prefix": "pg dump"})";
   int num_not_clean;
   do {
-    string dump_output = get_output(command, true);
+    string dump_output = get_output(std::move(command), true);
     if (index == -1) {
       boost::regex ireg(
           "\n"

--- a/src/test/lazy-omap-stats/lazy_omap_stats_test.h
+++ b/src/test/lazy-omap-stats/lazy_omap_stats_test.h
@@ -73,7 +73,7 @@ class LazyOmapStatsTest
   void check_pg_dump_pools();
   void check_pg_ls();
   const std::string get_output(
-      const std::string command = R"({"prefix": "pg dump"})",
+      std::string&& command = R"({"prefix": "pg dump"})",
       const bool silent = false,
       const CommandTarget target = CommandTarget::TARGET_MGR);
   void get_pool_id(const std::string& pool);

--- a/src/test/librados/aio_cxx.cc
+++ b/src/test/librados/aio_cxx.cc
@@ -101,11 +101,10 @@ TEST(LibRadosAio, PoolQuotaPP) {
   ASSERT_EQ(0, test_data.m_cluster.ioctx_create(p.c_str(), ioctx));
   ioctx.application_enable("rados", true);
 
-  bufferlist inbl;
   ASSERT_EQ(0, test_data.m_cluster.mon_command(
       "{\"prefix\": \"osd pool set-quota\", \"pool\": \"" + p +
       "\", \"field\": \"max_bytes\", \"val\": \"4096\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
 
   bufferlist bl;
   bufferptr z(4096);
@@ -2391,7 +2390,6 @@ TEST(LibRadosAio, PoolEIOFlag) {
 
     if (i == max / 2) {
       t = new std::thread([&] {
-        bufferlist empty;
         cout << "sending pool EIO time: " << ceph_clock_now() << std::endl;
         ASSERT_EQ(0, test_data.m_cluster.mon_command(
           fmt::format(R"({{
@@ -2400,7 +2398,7 @@ TEST(LibRadosAio, PoolEIOFlag) {
             "var": "eio",
             "val": "true"
             }})", test_data.m_pool_name),
-       empty, nullptr, nullptr));
+          {}, nullptr, nullptr));
 
         {
           std::scoped_lock lk(my_lock);

--- a/src/test/librados/misc_cxx.cc
+++ b/src/test/librados/misc_cxx.cc
@@ -549,7 +549,7 @@ TEST_F(LibRadosTwoPoolsECPP, CopyFrom) {
 
 TEST_F(LibRadosMiscPP, CopyScrubPP) {
   SKIP_IF_CRIMSON();
-  bufferlist inbl, bl, x;
+  bufferlist bl, x;
   for (int i=0; i<100; ++i)
     x.append("barrrrrrrrrrrrrrrrrrrrrrrrrr");
   bl.append(buffer::create(g_conf()->osd_copyfrom_max_chunk * 3));
@@ -590,7 +590,7 @@ TEST_F(LibRadosMiscPP, CopyScrubPP) {
       ss << "{\"prefix\": \"pg deep-scrub\", \"pgid\": \""
 	 << ioctx.get_id() << "." << i
 	 << "\"}";
-      cluster.mon_command(ss.str(), inbl, NULL, NULL);
+      cluster.mon_command(ss.str(), {}, NULL, NULL);
     }
 
     // give it a few seconds to go.  this is sloppy but is usually enough time
@@ -630,7 +630,7 @@ TEST_F(LibRadosMiscPP, CopyScrubPP) {
       ss << "{\"prefix\": \"pg deep-scrub\", \"pgid\": \""
 	 << ioctx.get_id() << "." << i
 	 << "\"}";
-      cluster.mon_command(ss.str(), inbl, NULL, NULL);
+      cluster.mon_command(ss.str(), {}, NULL, NULL);
     }
 
     // give it a few seconds to go.  this is sloppy but is usually enough time
@@ -822,10 +822,10 @@ TEST_F(LibRadosMiscPP, CmpExtPP) {
 }
 
 TEST_F(LibRadosMiscPP, Applications) {
-  bufferlist inbl, outbl;
+  bufferlist outbl;
   string outs;
   ASSERT_EQ(0, cluster.mon_command("{\"prefix\": \"osd dump\"}",
-				   inbl, &outbl, &outs));
+				   {}, &outbl, &outs));
   ASSERT_LT(0u, outbl.length());
   ASSERT_LE(0u, outs.length());
   if (!std::regex_search(outbl.to_str(),

--- a/src/test/librados/service_cxx.cc
+++ b/src/test/librados/service_cxx.cc
@@ -88,9 +88,9 @@ TEST(LibRadosServicePP, Close) {
       ASSERT_EQ(0, cluster.conf_read_file(NULL));
       cluster.conf_parse_env(NULL);
       ASSERT_EQ(0, cluster.connect());
-      bufferlist inbl, outbl;
+      bufferlist outbl;
       ASSERT_EQ(0, cluster.mon_command("{\"prefix\": \"service dump\"}",
-				       inbl, &outbl, NULL));
+				       {}, &outbl, NULL));
       string s = outbl.to_str();
       cluster.shutdown();
 

--- a/src/test/librados/snapshots_stats_cxx.cc
+++ b/src/test/librados/snapshots_stats_cxx.cc
@@ -30,15 +30,14 @@ protected:
         "\"value\": \"off\""
       "}";
     std::cout << "Setting pg_autoscaler to 'off'" << std::endl;
-    bufferlist inbl;
     bufferlist outbl;
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     // disable scrubs for the test
     cmd = "{\"prefix\": \"osd set\",\"key\":\"noscrub\"}";
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
     cmd = "{\"prefix\": \"osd set\",\"key\":\"nodeep-scrub\"}";
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     RadosTestPP::SetUp();
   }
@@ -53,15 +52,14 @@ protected:
         "\"value\": \"on\""
       "}";
     std::cout << "Setting pg_autoscaler to 'on'" << std::endl;
-    bufferlist inbl;
     bufferlist outbl;
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     // re-enable scrubs
     cmd = "{\"prefix\": \"osd unset\",\"key\":\"noscrub\"}";
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
     cmd = string("{\"prefix\": \"osd unset\",\"key\":\"nodeep-scrub\"}");
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     RadosTestPP::TearDown();
   }
@@ -82,15 +80,14 @@ protected:
         "\"value\": \"off\""
       "}";
     std::cout << "Setting pg_autoscaler to 'off'" << std::endl;
-    bufferlist inbl;
     bufferlist outbl;
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     // disable scrubs for the test
     cmd = string("{\"prefix\": \"osd set\",\"key\":\"noscrub\"}");
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
     cmd = string("{\"prefix\": \"osd set\",\"key\":\"nodeep-scrub\"}");
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     RadosTestECPP::SetUp();
   }
@@ -105,15 +102,14 @@ protected:
         "\"value\": \"on\""
       "}";
     std::cout << "Setting pg_autoscaler to 'on'" << std::endl;
-    bufferlist inbl;
     bufferlist outbl;
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     // re-enable scrubs
     cmd = string("{\"prefix\": \"osd unset\",\"key\":\"noscrub\"}");
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
     cmd = string("{\"prefix\": \"osd unset\",\"key\":\"nodeep-scrub\"}");
-    ASSERT_EQ(0, s_cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, s_cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
 
     RadosTestECPP::TearDown();
   }
@@ -207,9 +203,8 @@ TEST_F(LibRadosSnapshotStatsSelfManagedPP, SnaptrimStatsPP) {
   int tries = 0;
   do {
     string cmd = string("{\"prefix\": \"pg dump\",\"format\":\"json\"}");
-    bufferlist inbl;
     bufferlist outbl;
-    ASSERT_EQ(0, cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
     string outstr(outbl.c_str(), outbl.length());
     json_spirit::Value v;
     ASSERT_NE(0, json_spirit::read(outstr, v)) << "unable to parse json." << '\n' << outstr;
@@ -289,9 +284,8 @@ TEST_F(LibRadosSnapshotStatsSelfManagedECPP, SnaptrimStatsECPP) {
   int tries = 0;
   do {
     string cmd = string("{\"prefix\": \"pg dump\",\"format\":\"json\"}");
-    bufferlist inbl;
     bufferlist outbl;
-    ASSERT_EQ(0, cluster.mon_command(cmd, inbl, &outbl, NULL));
+    ASSERT_EQ(0, cluster.mon_command(std::move(cmd), {},  &outbl, NULL));
     string outstr(outbl.c_str(), outbl.length());
     json_spirit::Value v;
     ASSERT_NE(0, json_spirit::read(outstr, v)) << "unable to parse json." << '\n' << outstr;

--- a/src/test/librados/test_cxx.cc
+++ b/src/test/librados/test_cxx.cc
@@ -53,9 +53,8 @@ int destroy_rule_pp(Rados &cluster,
                        const std::string &rule,
                        std::ostream &oss)
 {
-  bufferlist inbl;
   int ret = cluster.mon_command("{\"prefix\": \"osd crush rule rm\", \"name\":\"" +
-                                rule + "\"}", inbl, NULL, NULL);
+                                rule + "\"}", {}, NULL, NULL);
   if (ret)
     oss << "mon_command: osd crush rule rm " + rule + " failed with error " << ret << std::endl;
   return ret;
@@ -64,9 +63,8 @@ int destroy_rule_pp(Rados &cluster,
 int destroy_ec_profile_pp(Rados &cluster, const std::string& pool_name,
 			  std::ostream &oss)
 {
-  bufferlist inbl;
   int ret = cluster.mon_command("{\"prefix\": \"osd erasure-code-profile rm\", \"name\": \"testprofile-" + pool_name + "\"}",
-                                inbl, NULL, NULL);
+                                {}, NULL, NULL);
   if (ret)
     oss << "mon_command: osd erasure-code-profile rm testprofile-" << pool_name << " failed with error " << ret << std::endl;
   return ret;
@@ -96,10 +94,9 @@ std::string create_one_ec_pool_pp(const std::string &pool_name, Rados &cluster)
     return oss.str();
   }
 
-  bufferlist inbl;
   ret = cluster.mon_command(
     "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile-" + pool_name + "\", \"profile\": [ \"k=2\", \"m=1\", \"crush-failure-domain=osd\"]}",
-    inbl, NULL, NULL);
+    {}, NULL, NULL);
   if (ret) {
     cluster.shutdown();
     oss << "mon_command erasure-code-profile set name:testprofile-" << pool_name << " failed with error " << ret;
@@ -108,9 +105,8 @@ std::string create_one_ec_pool_pp(const std::string &pool_name, Rados &cluster)
     
   ret = cluster.mon_command(
     "{\"prefix\": \"osd pool create\", \"pool\": \"" + pool_name + "\", \"pool_type\":\"erasure\", \"pg_num\":8, \"pgp_num\":8, \"erasure_code_profile\":\"testprofile-" + pool_name + "\"}",
-    inbl, NULL, NULL);
+    {}, NULL, NULL);
   if (ret) {
-    bufferlist inbl;
     destroy_ec_profile_pp(cluster, pool_name, oss);
     cluster.shutdown();
     oss << "mon_command osd pool create pool:" << pool_name << " pool_type:erasure failed with error " << ret;
@@ -124,10 +120,9 @@ std::string create_one_ec_pool_pp(const std::string &pool_name, Rados &cluster)
 std::string set_allow_ec_overwrites_pp(const std::string &pool_name, Rados &cluster, bool allow)
 {
   std::ostringstream oss;
-  bufferlist inbl;
   int ret = cluster.mon_command(
     "{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name + "\", \"var\": \"allow_ec_overwrites\", \"val\": \"" + (allow ? "true" : "false") + "\"}",
-    inbl, NULL, NULL);
+    {}, NULL, NULL);
   if (ret) {
     cluster.shutdown();
     oss << "mon_command osd pool set pool:" << pool_name << " pool_type:erasure allow_ec_overwrites true failed with error " << ret;

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -87,19 +87,18 @@ void RadosTestParamPPNS::TearDownTestCase()
 {
   if (cache_pool_name.length()) {
     // tear down tiers
-    bufferlist inbl;
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
       "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
       "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd pool delete\", \"pool\": \"" + cache_pool_name +
       "\", \"pool2\": \"" + cache_pool_name + "\", \"yes_i_really_really_mean_it\": true}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     cache_pool_name = "";
   }
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, s_cluster));
@@ -111,24 +110,23 @@ void RadosTestParamPPNS::SetUp()
       cache_pool_name.empty()) {
     auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
     cache_pool_name = get_temp_pool_name();
-    bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
       "\", \"pg_num\": 4}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
       "\", \"tierpool\": \"" + cache_pool_name +
       "\", \"force_nonempty\": \"--force-nonempty\" }",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
       "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
       "\", \"mode\": \"writeback\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     cluster.wait_for_latest_osdmap();
   }
 
@@ -287,19 +285,18 @@ void RadosTestParamPP::TearDownTestCase()
 {
   if (cache_pool_name.length()) {
     // tear down tiers
-    bufferlist inbl;
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
       "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
       "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd pool delete\", \"pool\": \"" + cache_pool_name +
       "\", \"pool2\": \"" + cache_pool_name + "\", \"yes_i_really_really_mean_it\": true}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     cache_pool_name = "";
   }
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, s_cluster));
@@ -311,24 +308,23 @@ void RadosTestParamPP::SetUp()
       cache_pool_name.empty()) {
     auto pool_prefix = fmt::format("{}_", ::testing::UnitTest::GetInstance()->current_test_case()->name());
     cache_pool_name = get_temp_pool_name();
-    bufferlist inbl;
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd pool create\", \"pool\": \"" + cache_pool_name +
       "\", \"pg_num\": 4}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
       "\", \"tierpool\": \"" + cache_pool_name +
       "\", \"force_nonempty\": \"--force-nonempty\" }",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
       "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
       "\", \"mode\": \"writeback\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     cluster.wait_for_latest_osdmap();
   }
 

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -39,7 +39,6 @@ typedef RadosTestECPP LibRadosTierECPP;
 
 void flush_evict_all(librados::Rados& cluster, librados::IoCtx& cache_ioctx)
 {
-  bufferlist inbl;
   cache_ioctx.set_namespace(all_nspaces);
   for (NObjectIterator it = cache_ioctx.nobjects_begin();
        it != cache_ioctx.nobjects_end(); ++it) {
@@ -72,10 +71,9 @@ void flush_evict_all(librados::Rados& cluster, librados::IoCtx& cache_ioctx)
 
 static string _get_required_osd_release(Rados& cluster)
 {
-  bufferlist inbl;
   string cmd = string("{\"prefix\": \"osd dump\",\"format\":\"json\"}");
   bufferlist outbl;
-  int r = cluster.mon_command(cmd, inbl, &outbl, NULL);
+  int r = cluster.mon_command(std::move(cmd), {}, &outbl, NULL);
   ceph_assert(r >= 0);
   string outstr(outbl.c_str(), outbl.length());
   json_spirit::Value v;
@@ -236,16 +234,15 @@ protected:
     // flush + evict cache
     flush_evict_all(cluster, cache_ioctx);
 
-    bufferlist inbl;
     // tear down tiers
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
       "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
       "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+      {}, NULL, NULL));
 
     // wait for maps to settle before next test
     cluster.wait_for_latest_osdmap();
@@ -360,16 +357,15 @@ TEST_F(LibRadosTwoPoolsPP, Overlay) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -414,20 +410,19 @@ TEST_F(LibRadosTwoPoolsPP, Promote) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -522,20 +517,19 @@ TEST_F(LibRadosTwoPoolsPP, PromoteSnap) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -634,20 +628,19 @@ TEST_F(LibRadosTwoPoolsPP, PromoteSnapScrub) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -687,7 +680,7 @@ TEST_F(LibRadosTwoPoolsPP, PromoteSnapScrub) {
 	ss << "{\"prefix\": \"pg scrub\", \"pgid\": \""
 	   << cache_ioctx.get_id() << "." << i
 	   << "\"}";
-	int r = cluster.mon_command(ss.str(), inbl, NULL, NULL);
+	int r = cluster.mon_command(ss.str(), {}, NULL, NULL);
 	if (r == -ENOENT ||  // in case mgr osdmap is stale
 	    r == -EAGAIN) {
 	  sleep(5);
@@ -735,20 +728,19 @@ TEST_F(LibRadosTwoPoolsPP, PromoteSnapTrimRace) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -782,20 +774,19 @@ TEST_F(LibRadosTwoPoolsPP, Whiteout) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -869,20 +860,19 @@ TEST_F(LibRadosTwoPoolsPP, Whiteout) {
 TEST_F(LibRadosTwoPoolsPP, WhiteoutDeleteCreate) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -924,20 +914,19 @@ TEST_F(LibRadosTwoPoolsPP, Evict) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -1127,20 +1116,19 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -1325,20 +1313,19 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnap2) {
     ASSERT_EQ(0, ioctx.operate("foo", &op));
   }
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -1444,20 +1431,19 @@ TEST_F(LibRadosTwoPoolsPP, ListSnap){
   }
 
   // Configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // Wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -1561,20 +1547,19 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnapRollbackReadRace) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -1645,20 +1630,19 @@ TEST_F(LibRadosTwoPoolsPP, EvictSnapRollbackReadRace) {
 TEST_F(LibRadosTwoPoolsPP, TryFlush) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -1790,20 +1774,19 @@ TEST_F(LibRadosTwoPoolsPP, TryFlush) {
 TEST_F(LibRadosTwoPoolsPP, Flush) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -1987,20 +1970,19 @@ TEST_F(LibRadosTwoPoolsPP, Flush) {
 TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2146,7 +2128,7 @@ TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2174,7 +2156,7 @@ TEST_F(LibRadosTwoPoolsPP, FlushSnap) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // cleanup
   ioctx.selfmanaged_snap_remove(my_snaps[0]);
@@ -2194,19 +2176,18 @@ TEST_F(LibRadosTierPP, FlushWriteRaces) {
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2287,11 +2268,11 @@ TEST_F(LibRadosTierPP, FlushWriteRaces) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -2303,20 +2284,19 @@ TEST_F(LibRadosTierPP, FlushWriteRaces) {
 TEST_F(LibRadosTwoPoolsPP, FlushTryFlushRaces) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2501,20 +2481,19 @@ void flush_read_race_cb(completion_t cb, void *arg)
 TEST_F(LibRadosTwoPoolsPP, TryFlushReadRace) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2597,21 +2576,20 @@ string set_pool_str(string pool, string var, int val)
 TEST_F(LibRadosTwoPoolsPP, HitSetRead) {
   SKIP_IF_CRIMSON();
   // make it a tier
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // enable hitset tracking for this pool
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", 2),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", 600),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type",
 						"explicit_object"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2660,12 +2638,11 @@ TEST_F(LibRadosTwoPoolsPP, HitSetRead) {
 
 static int _get_pg_num(Rados& cluster, string pool_name)
 {
-  bufferlist inbl;
   string cmd = string("{\"prefix\": \"osd pool get\",\"pool\":\"")
     + pool_name
     + string("\",\"var\": \"pg_num\",\"format\": \"json\"}");
   bufferlist outbl;
-  int r = cluster.mon_command(cmd, inbl, &outbl, NULL);
+  int r = cluster.mon_command(std::move(cmd), {}, &outbl, NULL);
   ceph_assert(r >= 0);
   string outstr(outbl.c_str(), outbl.length());
   json_spirit::Value v;
@@ -2738,21 +2715,20 @@ TEST_F(LibRadosTwoPoolsPP, HitSetWrite) {
   ceph_assert(num_pg > 0);
 
   // make it a tier
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // enable hitset tracking for this pool
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", 8),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", 600),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type",
 						"explicit_hash"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2797,22 +2773,21 @@ TEST_F(LibRadosTwoPoolsPP, HitSetTrim) {
   unsigned period = 3;
 
   // make it a tier
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // enable hitset tracking for this pool
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", count),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", period),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_fpp", ".01"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2872,40 +2847,39 @@ TEST_F(LibRadosTwoPoolsPP, PromoteOn2ndRead) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // enable hitset tracking for this pool
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_count", 2),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_period", 600),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "min_read_recency_for_promote", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_grade_decay_rate", 20),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_search_last_n", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -2975,11 +2949,11 @@ TEST_F(LibRadosTwoPoolsPP, PromoteOn2ndRead) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -2997,20 +2971,19 @@ TEST_F(LibRadosTwoPoolsPP, ProxyRead) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"readproxy\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -3034,11 +3007,11 @@ TEST_F(LibRadosTwoPoolsPP, ProxyRead) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -3077,20 +3050,19 @@ TEST_F(LibRadosTwoPoolsPP, CachePin) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -3141,19 +3113,19 @@ TEST_F(LibRadosTwoPoolsPP, CachePin) {
   // enable agent
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_count", 2),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_period", 600),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "min_read_recency_for_promote", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "target_max_objects", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   sleep(10);
 
@@ -3186,11 +3158,11 @@ TEST_F(LibRadosTwoPoolsPP, CachePin) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -3565,10 +3537,9 @@ TEST_F(LibRadosTwoPoolsPP, ManifestDedupRefRead) {
     GTEST_SKIP() << "cluster is not yet nautilus, skipping test";
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	    set_pool_str(pool_name, "fingerprint_algorithm", "sha1"),
-	    inbl, NULL, NULL));
+	    {}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
   string tgt_oid;
 
@@ -3630,10 +3601,9 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapRefcount) {
     return;
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // create object
@@ -3938,10 +3908,9 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapRefcount2) {
     return;
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // create object
@@ -4325,10 +4294,9 @@ TEST_F(LibRadosTwoPoolsPP, ManifestCheckRefcountWhenModification) {
     GTEST_SKIP() << "cluster is not yet octopus, skipping test";
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // create object
@@ -4983,13 +4951,12 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapSizeMismatch) {
   // scrub
   {
     for (int tries = 0; tries < 5; ++tries) {
-      bufferlist inbl;
       ostringstream ss;
       ss << "{\"prefix\": \"pg deep-scrub\", \"pgid\": \""
         << cache_ioctx.get_id() << "."
         << std::hex << hash
         << "\"}";
-      int r = cluster.mon_command(ss.str(), inbl, NULL, NULL);
+      int r = cluster.mon_command(ss.str(), {}, NULL, NULL);
       if (r == -ENOENT ||  
          r == -EAGAIN) {
        sleep(5);
@@ -5018,19 +4985,18 @@ TEST_F(LibRadosTwoPoolsPP, DedupFlushRead) {
     GTEST_SKIP() << "cluster is not yet octopus, skipping test";
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_tier", pool_name),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_chunk_algorithm", "fastcdc"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 1024),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -5102,7 +5068,7 @@ TEST_F(LibRadosTwoPoolsPP, DedupFlushRead) {
 
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 512),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // make a dirty chunks
@@ -5150,7 +5116,7 @@ TEST_F(LibRadosTwoPoolsPP, DedupFlushRead) {
 
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 16384),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // make a dirty chunks
@@ -5198,7 +5164,7 @@ TEST_F(LibRadosTwoPoolsPP, DedupFlushRead) {
   // less than object size
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 1024),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // make a dirty chunks
@@ -5274,19 +5240,18 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushSnap) {
     return;
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_tier", pool_name),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_chunk_algorithm", "fastcdc"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 1024),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -5458,19 +5423,18 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushDupCount) {
     return;
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_tier", pool_name),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_chunk_algorithm", "fastcdc"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 1024),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
 
   // create object
   bufferlist gbl;
@@ -5676,24 +5640,22 @@ TEST_F(LibRadosTwoPoolsPP, TierFlushDuringFlush) {
     return;
   }
 
-  bufferlist inbl;
-
   // create a new pool 
   std::string temp_pool_name = get_temp_pool_name() + "-test-flush";
   ASSERT_EQ(0, cluster.pool_create(temp_pool_name.c_str()));
 
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_tier", temp_pool_name),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_chunk_algorithm", "fastcdc"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 1024),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
 
   // create object
   bufferlist gbl;
@@ -5757,10 +5719,9 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapHasChunk) {
     return;
   }
 
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
 	set_pool_str(pool_name, "fingerprint_algorithm", "sha1"),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // create object
@@ -6291,16 +6252,15 @@ protected:
     // flush + evict cache
     flush_evict_all(cluster, cache_ioctx);
 
-    bufferlist inbl;
     // tear down tiers
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
       "\"}",
-      inbl, NULL, NULL));
+      {}, NULL, NULL));
     ASSERT_EQ(0, cluster.mon_command(
       "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
       "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
     // wait for maps to settle before next test
     cluster.wait_for_latest_osdmap();
@@ -6394,16 +6354,15 @@ TEST_F(LibRadosTwoPoolsECPP, Overlay) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -6448,20 +6407,19 @@ TEST_F(LibRadosTwoPoolsECPP, Promote) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -6556,20 +6514,19 @@ TEST_F(LibRadosTwoPoolsECPP, PromoteSnap) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -6602,7 +6559,7 @@ TEST_F(LibRadosTwoPoolsECPP, PromoteSnap) {
 	 << cache_ioctx.get_id() << "."
 	 << hash
 	 << "\"}";
-      int r = cluster.mon_command(ss.str(), inbl, NULL, NULL);
+      int r = cluster.mon_command(ss.str(), {}, NULL, NULL);
       if (r == -EAGAIN ||
 	  r == -ENOENT) {  // in case mgr osdmap is a bit stale
 	sleep(5);
@@ -6689,20 +6646,19 @@ TEST_F(LibRadosTwoPoolsECPP, PromoteSnapTrimRace) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -6736,20 +6692,19 @@ TEST_F(LibRadosTwoPoolsECPP, Whiteout) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -6832,20 +6787,19 @@ TEST_F(LibRadosTwoPoolsECPP, Evict) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7035,20 +6989,19 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7212,20 +7165,19 @@ TEST_F(LibRadosTwoPoolsECPP, EvictSnap) {
 TEST_F(LibRadosTwoPoolsECPP, TryFlush) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7357,20 +7309,19 @@ TEST_F(LibRadosTwoPoolsECPP, TryFlush) {
 TEST_F(LibRadosTwoPoolsECPP, FailedFlush) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7495,20 +7446,19 @@ TEST_F(LibRadosTwoPoolsECPP, FailedFlush) {
 TEST_F(LibRadosTwoPoolsECPP, Flush) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7692,20 +7642,19 @@ TEST_F(LibRadosTwoPoolsECPP, Flush) {
 TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7851,7 +7800,7 @@ TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7879,7 +7828,7 @@ TEST_F(LibRadosTwoPoolsECPP, FlushSnap) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   cluster.wait_for_latest_osdmap();
 
   // cleanup
@@ -7900,19 +7849,18 @@ TEST_F(LibRadosTierECPP, FlushWriteRaces) {
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -7993,11 +7941,11 @@ TEST_F(LibRadosTierECPP, FlushWriteRaces) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -8009,20 +7957,19 @@ TEST_F(LibRadosTierECPP, FlushWriteRaces) {
 TEST_F(LibRadosTwoPoolsECPP, FlushTryFlushRaces) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8176,20 +8123,19 @@ TEST_F(LibRadosTwoPoolsECPP, FlushTryFlushRaces) {
 TEST_F(LibRadosTwoPoolsECPP, TryFlushReadRace) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8248,35 +8194,34 @@ TEST_F(LibRadosTierECPP, CallForcesPromote) {
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), ioctx));
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // set things up such that the op would normally be proxied
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "hit_set_count", 2),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "hit_set_period", 600),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "hit_set_type",
 			   "explicit_object"),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "min_read_recency_for_promote",
 			   "4"),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8339,11 +8284,11 @@ TEST_F(LibRadosTierECPP, CallForcesPromote) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -8376,21 +8321,20 @@ TEST_F(LibRadosTierECPP, HitSetNone) {
 TEST_F(LibRadosTwoPoolsECPP, HitSetRead) {
   SKIP_IF_CRIMSON();
   // make it a tier
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // enable hitset tracking for this pool
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", 2),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", 600),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type",
 						"explicit_object"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8444,14 +8388,13 @@ TEST_F(LibRadosTierECPP, HitSetWrite) {
   ceph_assert(num_pg > 0);
 
   // enable hitset tracking for this pool
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_count", 8),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_period", 600),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(pool_name, "hit_set_type",
 						"explicit_hash"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8519,22 +8462,21 @@ TEST_F(LibRadosTwoPoolsECPP, HitSetTrim) {
   unsigned period = 3;
 
   // make it a tier
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // enable hitset tracking for this pool
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_count", count),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_period", period),
-						inbl, NULL, NULL));
+						{}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(set_pool_str(cache_pool_name, "hit_set_fpp", ".01"),
-				   inbl, NULL, NULL));
+				   {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8599,40 +8541,39 @@ TEST_F(LibRadosTwoPoolsECPP, PromoteOn2ndRead) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // enable hitset tracking for this pool
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_count", 2),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_period", 600),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "min_read_recency_for_promote", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_grade_decay_rate", 20),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_search_last_n", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8702,11 +8643,11 @@ TEST_F(LibRadosTwoPoolsECPP, PromoteOn2ndRead) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -8724,20 +8665,19 @@ TEST_F(LibRadosTwoPoolsECPP, ProxyRead) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"readproxy\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8761,11 +8701,11 @@ TEST_F(LibRadosTwoPoolsECPP, ProxyRead) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -8804,20 +8744,19 @@ TEST_F(LibRadosTwoPoolsECPP, CachePin) {
   }
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8868,19 +8807,19 @@ TEST_F(LibRadosTwoPoolsECPP, CachePin) {
   // enable agent
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_count", 2),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_period", 600),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "min_read_recency_for_promote", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "target_max_objects", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   sleep(10);
 
@@ -8913,11 +8852,11 @@ TEST_F(LibRadosTwoPoolsECPP, CachePin) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" + pool_name +
     "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -8941,12 +8880,11 @@ TEST_F(LibRadosTwoPoolsECPP, SetRedirectRead) {
   }
 
   // configure tier
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -8970,7 +8908,7 @@ TEST_F(LibRadosTwoPoolsECPP, SetRedirectRead) {
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();
@@ -9111,10 +9049,9 @@ TEST_F(LibRadosTwoPoolsECPP, TrySetDedupTier) {
   SKIP_IF_CRIMSON();
   // note: require >= mimic
   
-  bufferlist inbl;
   ASSERT_EQ(-EOPNOTSUPP, cluster.mon_command(
 	set_pool_str(pool_name, "dedup_tier", cache_pool_name),
-	inbl, NULL, NULL));
+	{}, NULL, NULL));
 }
 
 TEST_F(LibRadosTwoPoolsPP, PropagateBaseTierError) {
@@ -9128,33 +9065,32 @@ TEST_F(LibRadosTwoPoolsPP, PropagateBaseTierError) {
   ASSERT_EQ(0, ioctx.operate("propagate-base-tier-error", &op1));
 
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_type", "bloom"),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_count", 1),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "hit_set_period", 600),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "target_max_objects", 250),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -9173,36 +9109,35 @@ TEST_F(LibRadosTwoPoolsPP, PropagateBaseTierError) {
 TEST_F(LibRadosTwoPoolsPP, HelloWriteReturn) {
   SKIP_IF_CRIMSON();
   // configure cache
-  bufferlist inbl;
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier add\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name +
     "\", \"force_nonempty\": \"--force-nonempty\" }",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" + pool_name +
     "\", \"overlaypool\": \"" + cache_pool_name + "\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" + cache_pool_name +
     "\", \"mode\": \"writeback\"}",
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // set things up such that the op would normally be proxied
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "hit_set_count", 2),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "hit_set_period", 600),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "hit_set_type",
 			   "explicit_object"),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
 	      set_pool_str(cache_pool_name, "min_read_recency_for_promote",
 			   "10000"),
-	      inbl, NULL, NULL));
+	      {}, NULL, NULL));
 
   // wait for maps to settle
   cluster.wait_for_latest_osdmap();
@@ -9247,18 +9182,16 @@ TEST_F(LibRadosTwoPoolsPP, TierFlushDuringUnsetDedupTier) {
     return;
   }
 
-  bufferlist inbl;
-
   // set dedup parameters without dedup_tier
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "fingerprint_algorithm", "sha1"),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "dedup_chunk_algorithm", "fastcdc"),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
   ASSERT_EQ(0, cluster.mon_command(
     set_pool_str(cache_pool_name, "dedup_cdc_chunk_size", 1024),
-    inbl, NULL, NULL));
+    {}, NULL, NULL));
 
   // create object
   bufferlist gbl;

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -1159,13 +1159,11 @@ int Rados::ioctx_create2(int64_t pool_id, IoCtx &io)
   return 0;
 }
 
-int Rados::mon_command(std::string cmd, const bufferlist& inbl,
+int Rados::mon_command(std::string&& cmd, bufferlist&& inbl,
                        bufferlist *outbl, std::string *outs) {
   TestRadosClient *impl = reinterpret_cast<TestRadosClient*>(client);
 
-  std::vector<std::string> cmds;
-  cmds.push_back(cmd);
-  return impl->mon_command(cmds, inbl, outbl, outs);
+  return impl->mon_command({std::move(cmd)}, std::move(inbl), outbl, outs);
 }
 
 int Rados::service_daemon_register(const std::string& service,

--- a/src/test/librados_test_stub/NeoradosTestStub.cc
+++ b/src/test/librados_test_stub/NeoradosTestStub.cc
@@ -626,11 +626,11 @@ void RADOS::execute_(Object o, IOContext ioc, WriteOp op,
   ceph_assert(r == 0);
 }
 
-void RADOS::mon_command_(std::vector<std::string> command,
-			 bufferlist bl,
+void RADOS::mon_command_(std::vector<std::string>&& command,
+			 bufferlist&& bl,
 			 std::string* outs, bufferlist* outbl,
 			 Op::Completion c) {
-  auto r = impl->test_rados_client->mon_command(command, bl, outbl, outs);
+  auto r = impl->test_rados_client->mon_command(std::move(command), std::move(bl), outbl, outs);
   asio::post(get_executor(),
 	     asio::append(std::move(c),
 			  (r < 0 ? bs::error_code(-r, osd_category()) :

--- a/src/test/multi_stress_watch.cc
+++ b/src/test/multi_stress_watch.cc
@@ -100,11 +100,10 @@ void
 test_erasure(Rados &cluster, const std::string &pool_name, const std::string &obj_name)
 {
   string outs;
-  bufferlist inbl;
   int ret;
   ret = cluster.mon_command(
     "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile\", \"profile\": [ \"k=2\", \"m=1\", \"crush-failure-domain=osd\"]}",
-    inbl, NULL, &outs);
+    {}, NULL, &outs);
   if (ret < 0) {
     std::cerr << "mon_command erasure-code-profile set failed with " << ret << std::endl;
     exit(1);
@@ -114,7 +113,7 @@ test_erasure(Rados &cluster, const std::string &pool_name, const std::string &ob
   outs.clear();
   ret = cluster.mon_command(
     "{\"prefix\": \"osd pool create\", \"pool\": \"" + pool_name + "\", \"pool_type\":\"erasure\", \"pg_num\":12, \"pgp_num\":12, \"erasure_code_profile\":\"testprofile\"}",
-    inbl, NULL, &outs);
+    {}, NULL, &outs);
   if (ret < 0) {
     std::cerr << outs << std::endl;
     std::cerr << "mon_command create pool failed with " << ret << std::endl;

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -269,11 +269,10 @@ public:
 	return r;
       }
     }
-    bufferlist inbl;
     r = rados.mon_command(
       "{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
       "\", \"var\": \"write_fadvise_dontneed\", \"val\": \"" + (write_fadvise_dontneed ? "true" : "false") + "\"}",
-      inbl, NULL, NULL);
+      {}, NULL, NULL);
     if (r < 0) {
       rados.shutdown();
       return r;
@@ -282,7 +281,7 @@ public:
       r = rados.mon_command(
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
 	"\", \"var\": \"fingerprint_algorithm\", \"val\": \"" + "sha256" + "\"}",
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
       if (r < 0) {
 	rados.shutdown();
 	return r;
@@ -290,7 +289,7 @@ public:
       r = rados.mon_command(
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
 	"\", \"var\": \"dedup_tier\", \"val\": \"" + low_tier_pool_name + "\"}",
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
       if (r < 0) {
 	rados.shutdown();
 	return r;
@@ -298,7 +297,7 @@ public:
       r = rados.mon_command(
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
 	"\", \"var\": \"dedup_chunk_algorithm\", \"val\": \"" + chunk_algo  + "\"}",
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
       if (r < 0) {
 	rados.shutdown();
 	return r;
@@ -306,7 +305,7 @@ public:
       r = rados.mon_command(
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
 	"\", \"var\": \"dedup_cdc_chunk_size\", \"val\": \"" + chunk_size + "\"}",
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
       if (r < 0) {
 	rados.shutdown();
 	return r;

--- a/src/test/osd/ceph_test_osd_stale_read.cc
+++ b/src/test/osd/ceph_test_osd_stale_read.cc
@@ -27,14 +27,13 @@ using namespace librados;
 int get_primary_osd(Rados& rados, const string& pool_name,
 		    const string& oid, int *pprimary)
 {
-  bufferlist inbl;
   string cmd = string("{\"prefix\": \"osd map\",\"pool\":\"")
     + pool_name
     + string("\",\"object\": \"")
     + oid
     + string("\",\"format\": \"json\"}");
   bufferlist outbl;
-  if (int r = rados.mon_command(cmd, inbl, &outbl, nullptr);
+  if (int r = rados.mon_command(std::move(cmd), {}, &outbl, nullptr);
       r < 0) {
     return r;
   }
@@ -60,19 +59,19 @@ int get_primary_osd(Rados& rados, const string& pool_name,
 
 int fence_osd(Rados& rados, int osd)
 {
-  bufferlist inbl, outbl;
+  bufferlist outbl;
   string cmd("{\"prefix\": \"injectargs\",\"injected_args\":["
 	     "\"--ms-blackhole-osd\", "
 	     "\"--ms-blackhole-mon\"]}");
-  return rados.osd_command(osd, cmd, inbl, &outbl, NULL);
+  return rados.osd_command(osd, std::move(cmd), {}, &outbl, NULL);
 }
 
 int mark_down_osd(Rados& rados, int osd)
 {
-  bufferlist inbl, outbl;
+  bufferlist outbl;
   string cmd("{\"prefix\": \"osd down\",\"ids\":[\"" +
 	     stringify(osd) + "\"]}");
-  return rados.mon_command(cmd, inbl, &outbl, NULL);
+  return rados.mon_command(std::move(cmd), {}, &outbl, NULL);
 }
 
 TEST(OSD, StaleRead) {

--- a/src/test/rbd_mirror/test_ClusterWatcher.cc
+++ b/src/test/rbd_mirror/test_ClusterWatcher.cc
@@ -112,14 +112,13 @@ public:
         "\\\"key\\\": \\\"" + peer.key + "\\\""
       "}";
 
-    bufferlist in_bl;
     ASSERT_EQ(0, m_cluster->mon_command(
       "{"
         "\"prefix\": \"config-key set\","
         "\"key\": \"" RBD_MIRROR_PEER_CONFIG_KEY_PREFIX + stringify(pool_id) +
           "/" + peer.uuid + "\","
         "\"val\": \"" + json + "\"" +
-      "}", in_bl, nullptr, nullptr));
+      "}", {}, nullptr, nullptr));
   }
 
   void check_peers() {

--- a/src/tools/ceph_dedup/ceph_dedup_tool.cc
+++ b/src/tools/ceph_dedup/ceph_dedup_tool.cc
@@ -981,31 +981,30 @@ int make_dedup_object(const po::variables_map &opts)
       snap = true;
     }
 
-    bufferlist inbl;
     ret = rados.mon_command(
 	make_pool_str(pool_name, "fingerprint_algorithm", fp_algo),
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
     if (ret < 0) {
       std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;
     }
     ret = rados.mon_command(
 	make_pool_str(pool_name, "dedup_tier", chunk_pool_name),
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
     if (ret < 0) {
       std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;
     }
     ret = rados.mon_command(
 	make_pool_str(pool_name, "dedup_chunk_algorithm", "fastcdc"),
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
     if (ret < 0) {
       std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;
     }
     ret = rados.mon_command(
 	make_pool_str(pool_name, "dedup_cdc_chunk_size", chunk_size),
-	inbl, NULL, NULL);
+	{}, NULL, NULL);
     if (ret < 0) {
       std::cerr << " operate fail : " << cpp_strerror(ret) << std::endl;
       return ret;

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -244,10 +244,9 @@ int PeerReplayer::init() {
       "\"key\": \"" + key + "\""
     "}";
 
-  bufferlist in_bl;
   bufferlist out_bl;
 
-  int r = m_local_cluster->mon_command(cmd, in_bl, &out_bl, nullptr);
+  int r = m_local_cluster->mon_command(std::move(cmd), {}, &out_bl, nullptr);
   dout(5) << ": mon command r=" << r << dendl;
   if (r < 0 && r != -ENOENT) {
     return r;

--- a/src/tools/rbd/MirrorDaemonServiceInfo.cc
+++ b/src/tools/rbd/MirrorDaemonServiceInfo.cc
@@ -98,10 +98,9 @@ MirrorServices MirrorDaemonServiceInfo::get_mirror_services() const {
 int MirrorDaemonServiceInfo::get_mirror_service_dump() {
   librados::Rados rados(m_io_ctx);
   std::string cmd = R"({"prefix": "service dump", "format": "json"})";
-  bufferlist in_bl;
   bufferlist out_bl;
 
-  int r = rados.mon_command(cmd, in_bl, &out_bl, nullptr);
+  int r = rados.mon_command(std::move(cmd), {}, &out_bl, nullptr);
   if (r < 0) {
     std::cerr << "rbd: failed to query services: " << cpp_strerror(r)
               << std::endl;
@@ -178,10 +177,9 @@ int MirrorDaemonServiceInfo::get_mirror_service_dump() {
 int MirrorDaemonServiceInfo::get_mirror_service_status() {
   librados::Rados rados(m_io_ctx);
   std::string cmd = R"({"prefix": "service status", "format": "json"})";
-  bufferlist in_bl;
   bufferlist out_bl;
 
-  int r = rados.mon_command(cmd, in_bl, &out_bl, nullptr);
+  int r = rados.mon_command(std::move(cmd), {}, &out_bl, nullptr);
   if (r < 0) {
     std::cerr << "rbd: failed to query service status: " << cpp_strerror(r)
               << std::endl;

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -1194,10 +1194,9 @@ int mgr_command(librados::Rados& rados, const std::string& cmd,
       "prefix": ")" + cmd + R"(", )" + mgr_command_args_to_str(args) + R"(
     })";
 
-  bufferlist in_bl;
   bufferlist out_bl;
   std::string outs;
-  int r = rados.mgr_command(command, in_bl, &out_bl, &outs);
+  int r = rados.mgr_command(std::move(command), {}, &out_bl, &outs);
   if (r < 0) {
     (*err_os) << "rbd: " << cmd << " failed: " << cpp_strerror(r);
     if (!outs.empty()) {

--- a/src/tools/rbd/action/Config.cc
+++ b/src/tools/rbd/action/Config.cc
@@ -126,10 +126,9 @@ int config_global_list(
       "\"prefix\": \"config dump\", "
       "\"format\": \"json\" "
     "}";
-  bufferlist in_bl;
   bufferlist out_bl;
   std::string ss;
-  int r = rados.mon_command(cmd, in_bl, &out_bl, &ss);
+  int r = rados.mon_command(std::move(cmd), {}, &out_bl, &ss);
   if (r < 0) {
     std::cerr << "rbd: error reading config: " << ss << std::endl;
     return r;
@@ -273,9 +272,8 @@ int execute_global_set(const po::variables_map &vm,
       "\"name\": \"" + key + "\", "
       "\"value\": \"" + stringify(json_stream_escaper(value)) + "\""
     "}";
-  bufferlist in_bl;
   std::string ss;
-  r = rados.mon_command(cmd, in_bl, nullptr, &ss);
+  r = rados.mon_command(std::move(cmd), {}, nullptr, &ss);
   if (r < 0) {
     std::cerr << "rbd: error setting " << key << ": " << ss << std::endl;
     return r;
@@ -318,9 +316,8 @@ int execute_global_remove(
       "\"who\": \"" + stringify(json_stream_escaper(config_entity)) + "\", "
       "\"name\": \"" + key + "\""
     "}";
-  bufferlist in_bl;
   std::string ss;
-  r = rados.mon_command(cmd, in_bl, nullptr, &ss);
+  r = rados.mon_command(std::move(cmd), {}, nullptr, &ss);
   if (r < 0) {
     std::cerr << "rbd: error removing " << key << ": " << ss << std::endl;
     return r;

--- a/src/tools/rbd/action/Perf.cc
+++ b/src/tools/rbd/action/Perf.cc
@@ -120,10 +120,9 @@ int query_iostats(librados::Rados& rados, const std::string& pool_spec,
       "format": "json"
     }")";
 
-  bufferlist in_bl;
   bufferlist out_bl;
   std::string outs;
-  int r = rados.mgr_command(cmd, in_bl, &out_bl, &outs);
+  int r = rados.mgr_command(std::move(cmd), {}, &out_bl, &outs);
   if (r == -EOPNOTSUPP) {
     err_os << "rbd: 'rbd_support' mgr module is not enabled."
            << std::endl << std::endl

--- a/src/tools/rbd_mirror/ClusterWatcher.cc
+++ b/src/tools/rbd_mirror/ClusterWatcher.cc
@@ -205,9 +205,8 @@ int ClusterWatcher::resolve_peer_site_config_keys(int64_t pool_id,
         "/" + peer->uuid + "\""
     "}";
 
-  bufferlist in_bl;
   bufferlist out_bl;
-  int r = m_cluster->mon_command(cmd, in_bl, &out_bl, nullptr);
+  int r = m_cluster->mon_command(std::move(cmd), {}, &out_bl, nullptr);
   if (r == -ENOENT || out_bl.length() == 0) {
     return 0;
   } else if (r < 0) {


### PR DESCRIPTION
A non-trivial type is always passed by reference, even if the parameter is declared as a value; in that case, the compiler must allocate stack space and move the value there, and then really passes a reference to this stack allocation.  This only adds overhead for no reason.

A side effect of this API change is that all callers that accidently created temporary copies are now revealed by throwing a compiler error.  This commit fixes all callers and reduces a good amount of useless overhead by wrapping those parameters in std::move() instead of copying temporaries.

More temporaries are avoided by emplacing the std::string&& into the std::vector.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
