### PR TITLE
Add .clang-format configuration file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,219 @@
+---
+
+# Documentation on clang-format options here:
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+Language: Cpp
+Standard: c++20
+
+# Google style is a good starting point; modifiers attempt to match style
+# guide here: https://github.com/ceph/ceph/blob/main/CodingStyle
+BasedOnStyle: Google
+IndentWidth: 2
+TabWidth: 8
+UseTab: Always
+MaxEmptyLinesToKeep: 2
+ContinuationIndentWidth: 4
+
+# The intended impact here is to allow up to 96 characters, but break at 80 if
+# 96 is exceeded.
+ColumnLimit: 80
+
+# The "Penalty" concept in clang-format is not well
+# documented, see here for more: https://stackoverflow.com/questions/26635370
+#
+# Note that the penalties are not numbers of characters, they act more like
+# decision weights.
+PenaltyExcessCharacter: 50
+PenaltyBreakAssignment: 50
+PenaltyBreakBeforeFirstCallParameter: 50
+PenaltyBreakOpenParenthesis: 50
+
+# Brace wrapping to match style guide
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterCaseLabel: false
+    AfterClass: false
+    AfterControlStatement: Never
+    AfterEnum: false
+    AfterFunction: true
+    AfterNamespace: false
+    AfterStruct: false
+    BeforeCatch: false
+    BeforeElse: false
+    BeforeLambdaBody: false
+    SplitEmptyFunction: false
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: false
+
+# Access modifiers indent/outdent specified relative to body, use -2 to
+# align to braces.  Also do not indent case blocks. Finally, an emply line
+# should always precede "private:" or "public:" or "protected:"
+AccessModifierOffset: -2
+IndentCaseLabels: false
+EmptyLineBeforeAccessModifier: Always
+
+
+#Always break after an open bracket, if the parameters don’t fit on a single line
+AlignAfterOpenBracket: AlwaysBreak
+
+# Newline escapes should be aligned and located at the leftmost alignment
+AlignEscapedNewlines: Left
+
+# Align after operands across continuation into multiple lines for binary and
+# ternary.
+AlignOperands: Align
+
+# Do not align trailing comments across multiple lines. Note that this only applies
+# to the single-line comment style using "//". Block inlines are always left alone.
+AlignTrailingComments: false
+
+# If the function declaration doesn’t fit on a line, allow putting all parameters of a
+# function declaration onto the next line even if BinPackParameters is OnePerLine
+AllowAllParametersOfDeclarationOnNextLine: false
+
+# Do not allow short enums on a single line.
+AllowShortEnumsOnASingleLine: false
+
+# Only merge functions defined inside a class. Implies empty
+AllowShortFunctionsOnASingleLine: Inline
+
+# Never put short ifs on the same line.
+AllowShortIfStatementsOnASingleLine: false
+
+# If true, "while (true) continue;" can be put on a single line
+AllowShortLoopsOnASingleLine: false
+
+# Always break after the return type of function definitions.
+AlwaysBreakAfterReturnType: AllDefinitions
+
+# Always break after template declaration.
+AlwaysBreakTemplateDeclarations: Yes
+
+# If false, a function declaration’s or function definition’s parameters
+# will either all be on the same line or will have one line each.
+BinPackArguments: true
+BinPackParameters: BinPack
+
+# The break should always be after the binary and ternary operands.
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+
+# Break constructor initializers before the colon and after the commas.
+# Constructor()
+#     : initializer1(),
+#       initializer2()
+BreakConstructorInitializers: BeforeColon
+
+# Pad the braced list with spaces inside the braces.
+Cpp11BracedListStyle: false
+
+# Where to put the & and the * in the case of pointers/references.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Keep empty lines at end of file.
+KeepEmptyLinesAtEOF: false
+
+# Keep empty lines at start of a block.
+KeepEmptyLinesAtTheStartOfBlocks: true
+
+# Align lambda body relative to the lambda signature.
+LambdaBodyIndentation: Signature
+
+# No indent in namespaces.
+NamespaceIndentation: None
+
+# No way to specify C vs C++ style comment for namespace closure, so just
+# leave them alone.
+FixNamespaceComments: false
+
+# 1 space before trailing comments
+SpacesBeforeTrailingComments: 1
+
+# Colon spacing should always be '"key" : "value"'
+BitFieldColonSpacing: Both
+
+# Do not break up strings into multi-line strings. This becomes a problem when
+# multi-line strings with no spaces are broken, which upsets the Tup code checker.
+BreakStringLiterals: false
+
+# C-tor should always break before the : and again before the {} in cases where
+# otherwise the c-tor could theoretically be one-lined. In the case where the
+# initializer list is short enough to fit on one line after the wrap, do not break
+# into individual lines.
+# Note NextLineOnly requires clang-format >= 15
+PackConstructorInitializers: NextLineOnly
+
+# includes are sorted based on the other suboptions below
+SortIncludes:    true
+# Merge multiple #include blocks together and sort as one. Then split into groups based on
+# category priority.
+IncludeBlocks: Regroup
+# Regular expressions denoting the different #include categories used for ordering #includes.
+IncludeCategories:
+  - Regex:      'debug.h'
+    Priority:   4
+  - Regex:      '\"\./[^/]+\"'
+    Priority:   1
+  - Regex:      '\"[^/]+\"'
+    Priority:   8
+  - Regex:	'boost'
+    Priority:   5
+  - Regex:      '<.*\.h'
+    Priority:   2
+  - Regex:      '<'
+    Priority:   3
+  - Regex:      '.*'
+    Priority:   6
+
+# use "template <>" instead of "template<>"
+SpaceAfterTemplateKeyword: true
+
+# Always pad assignments with a space, like "variable = 2;".
+SpaceBeforeAssignmentOperators: true
+
+# Turn off comment reflow entirely
+# TODO: This was done to prevent undoing good formatting of doxygen @brief @param
+#       etc multi-line comments (similar to this comment). Investigate comment
+#       pragmas to leave these alone?
+ReflowComments: false
+
+# There should always be an empty line between method definiton blocks.
+SeparateDefinitionBlocks: Always
+
+# The penalty for each line break introduced inside a comment.
+PenaltyBreakComment: 0
+
+# How many spaces are allowed at the start of a line comment. To disable the maximum
+# set it to -1, apart from that the maximum takes precedence over the minimum
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+
+---
+
+Language: Proto
+
+# Google style is a good starting point;
+BasedOnStyle: Google
+IndentWidth: 2
+
+# The intended impact here is to allow up to 96 characters, but break at 80 if
+# 96 is exceeded.  The "Penalty" concept in clang-format is not well
+# documented, see here for more: https://stackoverflow.com/questions/26635370
+ColumnLimit: 80
+PenaltyExcessCharacter: 50
+
+# Turn off comment reflow entirely
+# TODO: This was done to prevent undoing user-defined formatting of multi-line
+#       comments.
+ReflowComments: false
+
+---
+Language: Json
+
+# Google style is a good starting point
+BasedOnStyle: Google
+IndentWidth: 2
+MaxEmptyLinesToKeep: 2


### PR DESCRIPTION
```markdown
# Pull Request: Add Clang-Format Configuration for Consistent Coding Standards

This pull request introduces a `.clang-format` configuration file to establish a consistent coding 
standard across the project. The configuration is based on the settings from [this Gist](https://gist.github.com/ronen-fr/504e7ed29785fcf645610a66c5b5c031) and serves as a 
starting point for discussion on adopting a unified formatting approach.

## Purpose
The goal is to initiate a conversation about the benefits of a standardized coding style and 
how best to implement it. The proposed configuration includes several settings that may spark 
discussion, including:

1. **Include Sorting and Grouping**: The configuration enables include sorting (`SortIncludes: true`). This organizes include statements but may be debated for its necessity or impact on readability.
3. **Bin Packing**: With `BinPackParameters: true`, function parameters exceeding the line length are packed into fewer lines for compactness. However, this may lead to more line changes when parameters are modified. Alternatives include splitting each parameter to its own line for clarity.
4. **Short Declarations**: The configuration allows short declarations (e.g., simple variables or functions) on a single line. We should discuss whether this improves readability or if stricter rules are preferred.
5. **Pointer Alignment**: The placement of `*` and `&` (e.g., next to the type, variable, or in the middle) is configured. This is a stylistic choice that may require team consensus.

## Using `git-clang-format`
To integrate the `.clang-format` configuration with your workflow, you can use `git-clang-format` to apply formatting changes to only the modified lines in your Git commits, ensuring minimal disruption to the codebase. Here's how to use it:

1. **Install Clang-Format**: Ensure `clang-format` is installed on your system. You can download it as part of LLVM or install it via a package manager (e.g., `apt install clang-format` on Ubuntu or `brew install clang-format` on macOS).
2. **Run `git-clang-format`**:
   - To format only the changes in your current working directory (staged or unstaged), run:
     ```bash
     git clang-format
     ```
     This applies the `.clang-format` configuration to the modified lines in your working tree and stages the formatting changes.
   - To format changes in a specific commit (e.g., the most recent commit), run:
     ```bash
     git clang-format HEAD^ HEAD
     ```
     This formats the changes introduced in the specified commit range.
   - To format changes in your entire branch compared to a base branch (e.g., `main`), run:
     ```bash
     git clang-format main
     ```
3. **Review Changes**: After running `git-clang-format`, review the formatted changes using `git diff` or `git status`. The tool modifies only the lines you’ve changed, preserving the rest of the codebase.
4. **Commit Changes**: Once satisfied, commit the formatting changes along with your code changes:
     ```bash
     git commit -m "Apply clang-format to modified lines"
     ```

**Note**: Ensure the `.clang-format` file is in the repository’s root directory or specify its path with the `--style=file:<path>` option if it’s located elsewhere.

## Next Steps
Please review the configuration and share feedback on the proposed settings. Additionally, discuss how `git-clang-format` can be integrated into our workflow to maintain consistent formatting. This is an opportunity to align on a coding standard that balances readability, maintainability, and team preferences.
```
Fixes: https://tracker.ceph.com/issues/72587




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
