### PR TITLE
tentacle: qa/workunits/rados/test.sh: add timeout mechanism and more info to workloads with parallel tests

### DIFF
--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -1,14 +1,39 @@
 #!/usr/bin/env bash
 set -ex
 
+# ./test.sh                       # Default: parallel mode, 30-min timeout
+# ./test.sh --serial              # Serial mode, 30-min timeout
+# ./test.sh --crimson             # Crimson mode, 30-min timeout
+# ./test.sh --timeout 3600        # Parallel mode, 60-min timeout
+# ./test.sh --serial --timeout 60 # Serial mode, 1-min timeout
+# ./test.sh --crimson --timeout 0 # Crimson mode, no timeout
+
+# First argument must be either --serial or --crimson or nothing
 parallel=1
-[ "$1" = "--serial" ] && parallel=0
-
-# let crimson run in serial mode
 crimson=0
-[ "$1" = "--crimson" ] && parallel=0 && crimson=1
+if [ "$1" = "--serial" ]; then
+    parallel=0
+    shift # Remove the first argument from the list so timeout can be processed next
+elif [ "$1" = "--crimson" ]; then
+    parallel=0
+    crimson=1
+    shift
+fi
 
-color=""
+# After processing the first arg, check for --timeout
+timeout=1800  # 30 minutes default value
+if [ "$1" = "--timeout" ]; then
+    shift
+    if [ -n "$1" ] && [[ "$1" =~ ^[0-9]+$ ]]; then
+        timeout=$1
+        shift # Remove the timeout value from the list so color can be processed next
+    else
+        echo "Invalid or missing timeout value after --timeout. Must be a number."
+        exit 1
+    fi
+fi
+
+color="" # Default color setting for gtest in terminal (-t)
 [ -t 1 ] && color="--gtest_color=yes"
 
 function cleanup() {
@@ -77,12 +102,35 @@ ret=0
 if [ $parallel -eq 1 ]; then
 for t in "${!pids[@]}"
 do
-  pid=${pids[$t]}
-  if ! wait $pid
-  then
-    echo "error in $t ($pid)"
-    ret=1
-  fi
+    # Set timeout values
+    max_wait=$timeout
+    waited=0
+    check_interval=10
+    pid=${pids[$t]}
+    echo "Checking Test $t (PID $pid)..."
+    # Check in a loop with timeout
+    # kill -0 checks if the process is running
+    # and 2 >/dev/null suppresses error messages if the process is not found
+    while kill -0 $pid 2>/dev/null; do
+        sleep $check_interval
+        waited=$((waited + check_interval))
+        echo "Waiting for test $t (PID $pid)... waited $waited seconds"
+        if [ $waited -ge $max_wait ]; then
+        # Process timed out
+        echo "ERROR: Test $t ($pid) - TIMED OUT after $max_wait seconds"
+        kill -9 $pid 2>/dev/null || true
+        ret=1
+        break
+        fi
+    done
+    # Only wait after process has ended naturally or been killed
+    # We only call wait after determining that the process is no longer running
+    # So this won't hang indefinitely like https://tracker.ceph.com/issues/70772
+    wait $pid 2>/dev/null || {
+        echo "ERROR: Test $t (PID $pid) failed with non-zero exit status"
+        echo "Check the logs for failures in $t"
+        ret=1
+    }
 done
 fi
 

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -1,12 +1,47 @@
 #!/usr/bin/env bash
 set -ex
+# This script runs the RADOS API tests in parallel or serial mode, with optional --timeout for each test.
+# It can also be run in a vstart environment for local testing.
 
-# ./test.sh                               # Default: parallel mode, 30-min timeout
-# ./test.sh --serial                      # Serial mode, 30-min timeout
-# ./test.sh --crimson                     # Crimson mode, 30-min timeout
-# ./test.sh --timeout 3600                # Parallel mode, 60-min timeout
-# ./test.sh --serial --timeout 60         # Serial mode, 1-min timeout
-# ./test.sh --crimson --timeout 0         # Crimson mode, no timeout
+# Define test arrays for better organization
+RADOS_TESTS=(
+    api_aio api_aio_pp
+    api_io api_io_pp
+    api_asio api_list
+    api_lock api_lock_pp
+    api_misc api_misc_pp
+    api_tier_pp
+    api_pool
+    api_snapshots api_snapshots_pp
+    api_stat api_stat_pp
+    api_watch_notify api_watch_notify_pp
+    api_cmd api_cmd_pp
+    api_service api_service_pp
+    api_c_write_operations
+    api_c_read_operations
+    list_parallel
+    open_pools_parallel
+    delete_pools_parallel
+)
+
+NEORADOS_TESTS=(
+    cls cmd handler_error io ec_io list ec_list misc pool
+    read_operations snapshots watch_notify write_operations
+)
+
+# Note on argument ordering: This script processes arguments sequentially,
+# so the order matters. Arguments must be provided in this specific sequence:
+# 1. --serial OR --crimson (optional)
+# 2. --timeout VALUE (optional) (for each test)
+# 3. --vstart (optional)
+#
+# For example:
+# ./test.sh                               # Default: parallel mode, 90-min timeout for each test
+# ./test.sh --serial                      # Serial mode, 90-min timeout for each test
+# ./test.sh --crimson                     # Crimson mode, 90-min timeout for each test
+# ./test.sh --timeout 3600                # Parallel mode, 60-min timeout for each test
+# ./test.sh --serial --timeout 60         # Serial mode, 1-min timeout for each test
+# ./test.sh --crimson --timeout 0         # Crimson mode, no timeout for each test
 # ../qa/workunits/rados/test.sh --vstart  # Run tests locally from `ceph/build` dir
 
 # First argument must be either --serial or --crimson or nothing
@@ -22,10 +57,11 @@ elif [ "$1" = "--crimson" ]; then
 fi
 
 # After processing the first arg, check for --timeout
-timeout=1800  # 30 minutes default value
+timeout=5400  # 90 minutes default value
 if [ "$1" = "--timeout" ]; then
     shift
     if [ -n "$1" ] && [[ "$1" =~ ^[0-9]+$ ]]; then
+        echo "Setting timeout to $1 seconds for each test"
         timeout=$1
         shift # Remove the timeout value from the list so color can be processed next
     else
@@ -38,7 +74,10 @@ color="" # Default color setting for gtest in terminal (-t)
 [ -t 1 ] && color="--gtest_color=yes"
 
 vstart=0
-[ "$1" = "--vstart" ] && vstart=1
+if [ "$1" = "--vstart" ]; then
+    vstart=1
+    shift
+fi
 
 function cleanup() {
     pkill -P $$ || true
@@ -49,35 +88,17 @@ GTEST_OUTPUT_DIR=${TESTDIR:-$(mktemp -d)}/archive/unit_test_xml_report
 mkdir -p $GTEST_OUTPUT_DIR
 
 declare -A pids
+declare -A test_type
+ret=0
 
-
-# If in vstart mode, compile all test targets
+# If in vstart mode, compile all test targets and start a vstart cluster.
 if [ $vstart -eq 1 ]; then
-    for f in \
-        api_aio api_aio_pp \
-	api_io api_io_pp \
-	api_asio api_list \
-	api_lock api_lock_pp \
-	api_misc api_misc_pp \
-	api_tier_pp \
-	api_pool \
-	api_snapshots api_snapshots_pp \
-	api_stat api_stat_pp \
-	api_watch_notify api_watch_notify_pp \
-	api_cmd api_cmd_pp \
-	api_service api_service_pp \
-	api_c_write_operations \
-	api_c_read_operations \
-	list_parallel \
-	open_pools_parallel \
-	delete_pools_parallel
+    for f in "${RADOS_TESTS[@]}";
     do
         ninja -j$(nproc) ceph_test_rados_$f
     done
 
-    for f in \
-        cls cmd handler_error io ec_io list ec_list misc pool read_operations snapshots \
-        watch_notify write_operations
+    for f in "${NEORADOS_TESTS[@]}";
     do
         ninja -j$(nproc) ceph_test_neorados_$f
     done
@@ -87,41 +108,32 @@ if [ $vstart -eq 1 ]; then
     ../src/vstart.sh --debug --new -x --localhost --bluestore
 fi
 
-# Running all tests
-for f in \
-    api_aio api_aio_pp \
-    api_io api_io_pp \
-    api_asio api_list \
-    api_lock api_lock_pp \
-    api_misc api_misc_pp \
-    api_pool \
-    api_snapshots api_snapshots_pp \
-    api_stat api_stat_pp \
-    api_watch_notify api_watch_notify_pp \
-    api_cmd api_cmd_pp \
-    api_service api_service_pp \
-    api_c_write_operations \
-    api_c_read_operations \
-    list_parallel \
-    open_pools_parallel \
-    delete_pools_parallel
+# Running all tests in ceph_test_rados
+for f in "${RADOS_TESTS[@]}"
 do
     executable="ceph_test_rados_$f"
     if [ $vstart -eq 1 ]; then
         executable="./bin/$executable"
     fi
     if [ $parallel -eq 1 ]; then
-	r=`printf '%25s' $f`
-	ff=`echo $f | awk '{print $1}'`
-	bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
-	pid=$!
-	echo "test $f on pid $pid"
-	pids[$f]=$pid
+        r=`printf '%25s' $f`
+        ff=`echo $f | awk '{print $1}'`
+        bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
+        pid=$!
+        echo "test $f on pid $pid"
+	    pids[$f]=$pid
+        test_type["$f"]="rados" # Store test type for later use in parallel mode
     else
-	$executable
+        # If running in serial mode, run the test directly
+        if ! timeout $timeout $executable; then
+            echo "ERROR: Test $f timed out after $timeout seconds"
+            echo "Check the logs for failures in $f"
+            ret=1
+        fi
     fi
 done
 
+# Running all tests in ceph_test_neorados
 for f in \
     cls cmd handler_error io ec_io list ec_list misc pool read_operations snapshots \
     watch_notify write_operations
@@ -131,28 +143,33 @@ do
         executable="./bin/$executable"
     fi
     if [ $parallel -eq 1 ]; then
-	r=`printf '%25s' $f`
-	ff=`echo $f | awk '{print $1}'`
-	bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/neorados_$f.xml $color 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
-	pid=$!
-	echo "test $f on pid $pid"
-	pids[$f]=$pid
+        r=`printf '%25s' $f`
+        ff=`echo $f | awk '{print $1}'`
+        bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/neorados_$f.xml $color 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
+        pid=$!
+        echo "test $f on pid $pid"
+        pids[$f]=$pid
+        test_type["$f"]="neorados" # Store test type for later use in parallel mode
     else
-	if [ $crimson -eq 1 ]; then
-		if [ $f = "ec_io" ] || [ $f = "ec_list" ]; then
-			echo "Skipping EC with Crimson"
-			continue
-		fi
-	fi
-	$executable
+        if [ $crimson -eq 1 ]; then
+            if [ $f = "ec_io" ] || [ $f = "ec_list" ]; then
+                echo "Skipping EC with Crimson"
+                continue
+            fi
+        fi
+        # If running in serial mode, run the test directly
+        if ! timeout $timeout $executable; then
+            echo "ERROR: Test $f timed out after $timeout seconds"
+            echo "Check the logs for failures in $f"
+            ret=1
+        fi
     fi
 done
 
-ret=0
 if [ $parallel -eq 1 ]; then
 for t in "${!pids[@]}"
 do
-    # Set timeout values
+    # Set timeout value for each test
     max_wait=$timeout
     waited=0
     check_interval=10
@@ -166,17 +183,16 @@ do
         waited=$((waited + check_interval))
         echo "Waiting for test $t (PID $pid)... waited $waited seconds"
         if [ $waited -ge $max_wait ]; then
-        # Process timed out
-        echo "ERROR: Test $t ($pid) - TIMED OUT after $max_wait seconds"
-
-        # Create fallback XML file
-        xml_path="$GTEST_OUTPUT_DIR/$t.xml"
-        if [[ $t == neorados_* ]]; then
-            xml_path="$GTEST_OUTPUT_DIR/neorados_$t.xml"
-        fi
-
-        echo "Creating fallback XML report at $xml_path"
-        cat > "$xml_path" << EOF
+            # Process timed out
+            echo "ERROR: Test $t ($pid) - TIMED OUT after $max_wait seconds"
+            # Create fallback XML file
+            if [ "${test_type[$t]}" = "neorados" ]; then
+                xml_path="$GTEST_OUTPUT_DIR/neorados_$t.xml"
+            else
+                xml_path="$GTEST_OUTPUT_DIR/$t.xml"
+            fi
+            echo "Creating fallback XML report at $xml_path"
+            cat > "$xml_path" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="1" failures="1" disabled="0" errors="0" time="${max_wait}.000" timestamp="$(date -Iseconds)" name="AllTests">
   <testsuite name="Timeout" tests="1" failures="1" disabled="0" errors="0" time="${max_wait}.000">
@@ -190,9 +206,9 @@ do
   </testsuite>
 </testsuites>
 EOF
-        kill -9 $pid 2>/dev/null || true
-        ret=1
-        break
+            kill -9 $pid 2>/dev/null || true
+            ret=1
+            break
         fi
     done
     # Only wait after process has ended naturally or been killed

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -118,6 +118,28 @@ do
         if [ $waited -ge $max_wait ]; then
         # Process timed out
         echo "ERROR: Test $t ($pid) - TIMED OUT after $max_wait seconds"
+
+        # Create fallback XML file
+        xml_path="$GTEST_OUTPUT_DIR/$t.xml"
+        if [[ $t == neorados_* ]]; then
+            xml_path="$GTEST_OUTPUT_DIR/neorados_$t.xml"
+        fi
+
+        echo "Creating fallback XML report at $xml_path"
+        cat > "$xml_path" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="1" disabled="0" errors="0" time="${max_wait}.000" timestamp="$(date -Iseconds)" name="AllTests">
+  <testsuite name="Timeout" tests="1" failures="1" disabled="0" errors="0" time="${max_wait}.000">
+    <testcase name="UnknownTestCase" status="timeout" time="${max_wait}.000" classname="${t}">
+      <failure message="Test suite timed out after ${max_wait} seconds" type="timeout">
+        The test suite ${t} (PID ${pid}) exceeded the maximum allowed execution time of ${max_wait} seconds.
+        Unable to determine which specific test case was running when the timeout occurred.
+        Please check the logs for more details, this may indicate a hang, deadlock, or extremely slow performance.
+      </failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+EOF
         kill -9 $pid 2>/dev/null || true
         ret=1
         break

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -ex
 
-# ./test.sh                       # Default: parallel mode, 30-min timeout
-# ./test.sh --serial              # Serial mode, 30-min timeout
-# ./test.sh --crimson             # Crimson mode, 30-min timeout
-# ./test.sh --timeout 3600        # Parallel mode, 60-min timeout
-# ./test.sh --serial --timeout 60 # Serial mode, 1-min timeout
-# ./test.sh --crimson --timeout 0 # Crimson mode, no timeout
+# ./test.sh                               # Default: parallel mode, 30-min timeout
+# ./test.sh --serial                      # Serial mode, 30-min timeout
+# ./test.sh --crimson                     # Crimson mode, 30-min timeout
+# ./test.sh --timeout 3600                # Parallel mode, 60-min timeout
+# ./test.sh --serial --timeout 60         # Serial mode, 1-min timeout
+# ./test.sh --crimson --timeout 0         # Crimson mode, no timeout
+# ../qa/workunits/rados/test.sh --vstart  # Run tests locally from `ceph/build` dir
 
 # First argument must be either --serial or --crimson or nothing
 parallel=1
@@ -36,6 +37,9 @@ fi
 color="" # Default color setting for gtest in terminal (-t)
 [ -t 1 ] && color="--gtest_color=yes"
 
+vstart=0
+[ "$1" = "--vstart" ] && vstart=1
+
 function cleanup() {
     pkill -P $$ || true
 }
@@ -46,6 +50,44 @@ mkdir -p $GTEST_OUTPUT_DIR
 
 declare -A pids
 
+
+# If in vstart mode, compile all test targets
+if [ $vstart -eq 1 ]; then
+    for f in \
+        api_aio api_aio_pp \
+	api_io api_io_pp \
+	api_asio api_list \
+	api_lock api_lock_pp \
+	api_misc api_misc_pp \
+	api_tier_pp \
+	api_pool \
+	api_snapshots api_snapshots_pp \
+	api_stat api_stat_pp \
+	api_watch_notify api_watch_notify_pp \
+	api_cmd api_cmd_pp \
+	api_service api_service_pp \
+	api_c_write_operations \
+	api_c_read_operations \
+	list_parallel \
+	open_pools_parallel \
+	delete_pools_parallel
+    do
+        ninja -j$(nproc) ceph_test_rados_$f
+    done
+
+    for f in \
+        cls cmd handler_error io ec_io list ec_list misc pool read_operations snapshots \
+        watch_notify write_operations
+    do
+        ninja -j$(nproc) ceph_test_neorados_$f
+    done
+
+    echo "Setting up a test cluster..."
+    ninja -j$(nproc) vstart
+    ../src/vstart.sh --debug --new -x --localhost --bluestore
+fi
+
+# Running all tests
 for f in \
     api_aio api_aio_pp \
     api_io api_io_pp \
@@ -64,15 +106,19 @@ for f in \
     open_pools_parallel \
     delete_pools_parallel
 do
+    executable="ceph_test_rados_$f"
+    if [ $vstart -eq 1 ]; then
+        executable="./bin/$executable"
+    fi
     if [ $parallel -eq 1 ]; then
 	r=`printf '%25s' $f`
 	ff=`echo $f | awk '{print $1}'`
-	bash -o pipefail -exc "ceph_test_rados_$f --gtest_output=xml:$GTEST_OUTPUT_DIR/$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
+	bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
 	pid=$!
 	echo "test $f on pid $pid"
 	pids[$f]=$pid
     else
-	ceph_test_rados_$f
+	$executable
     fi
 done
 
@@ -80,10 +126,14 @@ for f in \
     cls cmd handler_error io ec_io list ec_list misc pool read_operations snapshots \
     watch_notify write_operations
 do
+    executable="ceph_test_neorados_$f"
+    if [ $vstart -eq 1 ]; then
+        executable="./bin/$executable"
+    fi
     if [ $parallel -eq 1 ]; then
 	r=`printf '%25s' $f`
 	ff=`echo $f | awk '{print $1}'`
-	bash -o pipefail -exc "ceph_test_neorados_$f --gtest_output=xml:$GTEST_OUTPUT_DIR/neorados_$f.xml $color 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
+	bash -o pipefail -exc "$executable --gtest_output=xml:$GTEST_OUTPUT_DIR/neorados_$f.xml $color 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
 	pid=$!
 	echo "test $f on pid $pid"
 	pids[$f]=$pid
@@ -94,7 +144,7 @@ do
 			continue
 		fi
 	fi
-	ceph_test_neorados_$f
+	$executable
     fi
 done
 
@@ -154,6 +204,11 @@ EOF
         ret=1
     }
 done
+fi
+
+if [ $vstart -eq 1 ]; then
+    echo "Shutting down test cluster..."
+    ../src/stop.sh
 fi
 
 exit $ret

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -83,7 +83,7 @@ do
     if [ $parallel -eq 1 ]; then
 	r=`printf '%25s' $f`
 	ff=`echo $f | awk '{print $1}'`
-	bash -o pipefail -exc "ceph_test_neorados_$f $color 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
+	bash -o pipefail -exc "ceph_test_neorados_$f --gtest_output=xml:$GTEST_OUTPUT_DIR/neorados_$f.xml $color 2>&1 | tee ceph_test_neorados_$ff.log | sed \"s/^/$r: /\"" &
 	pid=$!
 	echo "test $f on pid $pid"
 	pids[$f]=$pid


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72597

backport of https://github.com/ceph/ceph/pull/64219
parent tracker: https://tracker.ceph.com/issues/70772


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
