### PR TITLE
tentacle: Optimize the libcephfs proxy to reduce the overhead

### DIFF
--- a/src/libcephfs_proxy/libcephfs_proxy.c
+++ b/src/libcephfs_proxy/libcephfs_proxy.c
@@ -33,7 +33,8 @@ static bool client_stop(proxy_link_t *link)
 
 static int32_t proxy_negotiation_check(proxy_link_negotiate_t *neg)
 {
-	proxy_log(LOG_INFO, 0, "Features enabled: %08x", neg->v1.enabled);
+	proxy_log(LOG_INFO, 0, "Features enabled: %08x, protocol: %u",
+		  neg->v1.enabled, neg->v2.protocol);
 
 	return 0;
 }
@@ -75,7 +76,7 @@ static int32_t proxy_global_connect(void)
 		}
 
 		proxy_link_negotiate_init(&global_cmount.neg, 0, PROXY_FEAT_ALL,
-					  0, 0);
+					  0, 0, PROXY_LINK_PROTOCOL_VERSION);
 
 		err = proxy_link_handshake_client(&global_cmount.link, err,
 						  &global_cmount.neg,
@@ -181,7 +182,8 @@ __public int ceph_create(struct ceph_mount_info **cmount, const char *const id)
 	sd = err;
 
 	proxy_link_negotiate_init(&ceph_mount->neg, 0, PROXY_FEAT_ALL, 0,
-				  PROXY_FEAT_ASYNC_IO);
+				  PROXY_FEAT_ASYNC_IO,
+				  PROXY_LINK_PROTOCOL_VERSION);
 
 	err = proxy_link_handshake_client(&ceph_mount->link, sd,
 					  &ceph_mount->neg,

--- a/src/libcephfs_proxy/libcephfs_proxy.c
+++ b/src/libcephfs_proxy/libcephfs_proxy.c
@@ -86,7 +86,9 @@ static int32_t proxy_global_connect(void)
 		}
 
 		proxy_link_negotiate_init(&global_cmount.neg, 0, PROXY_FEAT_ALL,
-					  0, 0, PROXY_LINK_PROTOCOL_VERSION);
+					  0,
+					  PROXY_FEAT_EMBEDDED_PERMS,
+					  PROXY_LINK_PROTOCOL_VERSION);
 
 		err = proxy_link_handshake_client(&global_cmount.link, err,
 						  &global_cmount.neg,
@@ -217,7 +219,8 @@ __public int ceph_create(struct ceph_mount_info **cmount, const char *const id)
 	sd = err;
 
 	proxy_link_negotiate_init(&ceph_mount->neg, 0, PROXY_FEAT_ALL, 0,
-				  PROXY_FEAT_ASYNC_IO,
+				  PROXY_FEAT_ASYNC_IO |
+				  PROXY_FEAT_EMBEDDED_PERMS,
 				  PROXY_LINK_PROTOCOL_VERSION);
 
 	err = proxy_link_handshake_client(&ceph_mount->link, sd,

--- a/src/libcephfs_proxy/libcephfs_proxy.c
+++ b/src/libcephfs_proxy/libcephfs_proxy.c
@@ -114,7 +114,7 @@ static int32_t proxy_check(struct ceph_mount_info *cmount, int32_t err,
 	({                                                          \
 		int32_t __err = -ENOTCONN;                          \
 		if (proxy_link_is_connected(&(_cmount)->link)) {    \
-			(_req).cmount = (_cmount)->cmount;          \
+			(_req).v0.cmount = (_cmount)->cmount;       \
 			__err = CEPH_RUN(_cmount, _op, _req, _ans); \
 		}                                                   \
 		__err;                                              \
@@ -124,7 +124,7 @@ __public int ceph_chdir(struct ceph_mount_info *cmount, const char *path)
 {
 	CEPH_REQ(ceph_chdir, req, 1, ans, 0);
 
-	CEPH_STR_ADD(req, path, path);
+	CEPH_STR_ADD(req, v0.path, path);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_CHDIR, req, ans);
 }
@@ -134,9 +134,9 @@ __public int ceph_conf_get(struct ceph_mount_info *cmount, const char *option,
 {
 	CEPH_REQ(ceph_conf_get, req, 1, ans, 1);
 
-	req.size = len;
+	req.v0.size = len;
 
-	CEPH_STR_ADD(req, option, option);
+	CEPH_STR_ADD(req, v0.option, option);
 	CEPH_BUFF_ADD(ans, buf, len);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_CONF_GET, req, ans);
@@ -147,7 +147,7 @@ __public int ceph_conf_read_file(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_conf_read_file, req, 1, ans, 0);
 
-	CEPH_STR_ADD(req, path, path_list);
+	CEPH_STR_ADD(req, v0.path, path_list);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_CONF_READ_FILE, req, ans);
 }
@@ -157,8 +157,8 @@ __public int ceph_conf_set(struct ceph_mount_info *cmount, const char *option,
 {
 	CEPH_REQ(ceph_conf_set, req, 2, ans, 0);
 
-	CEPH_STR_ADD(req, option, option);
-	CEPH_STR_ADD(req, value, value);
+	CEPH_STR_ADD(req, v0.option, option);
+	CEPH_STR_ADD(req, v0.value, value);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_CONF_SET, req, ans);
 }
@@ -198,14 +198,14 @@ __public int ceph_create(struct ceph_mount_info **cmount, const char *const id)
 		}
 	}
 
-	CEPH_STR_ADD(req, id, id);
+	CEPH_STR_ADD(req, v0.id, id);
 
 	err = CEPH_CALL(sd, LIBCEPHFSD_OP_CREATE, req, ans);
 	if ((err < 0) || ((err = ans.header.result) < 0)) {
 		goto failed_link;
 	}
 
-	ceph_mount->cmount = ans.cmount;
+	ceph_mount->cmount = ans.v0.cmount;
 
 	*cmount = ceph_mount;
 
@@ -251,7 +251,7 @@ __public int ceph_ll_close(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_ll_close, req, 0, ans, 0);
 
-	req.fh = ptr_value(filehandle);
+	req.v0.fh = ptr_value(filehandle);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_CLOSE, req, ans);
 }
@@ -265,20 +265,20 @@ __public int ceph_ll_create(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_create, req, 1, ans, 1);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.parent = ptr_value(parent);
-	req.mode = mode;
-	req.oflags = oflags;
-	req.want = want;
-	req.flags = lflags;
+	req.v0.userperm = ptr_value(perms);
+	req.v0.parent = ptr_value(parent);
+	req.v0.mode = mode;
+	req.v0.oflags = oflags;
+	req.v0.want = want;
+	req.v0.flags = lflags;
 
-	CEPH_STR_ADD(req, name, name);
+	CEPH_STR_ADD(req, v0.name, name);
 	CEPH_BUFF_ADD(ans, stx, sizeof(*stx));
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_CREATE, req, ans);
 	if (err >= 0) {
-		*outp = value_ptr(ans.inode);
-		*fhp = value_ptr(ans.fh);
+		*outp = value_ptr(ans.v0.inode);
+		*fhp = value_ptr(ans.v0.fh);
 	}
 
 	return err;
@@ -289,10 +289,10 @@ __public int ceph_ll_fallocate(struct ceph_mount_info *cmount, struct Fh *fh,
 {
 	CEPH_REQ(ceph_ll_fallocate, req, 0, ans, 0);
 
-	req.fh = ptr_value(fh);
-	req.mode = mode;
-	req.offset = offset;
-	req.length = length;
+	req.v0.fh = ptr_value(fh);
+	req.v0.mode = mode;
+	req.v0.offset = offset;
+	req.v0.length = length;
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_FALLOCATE, req, ans);
 }
@@ -302,8 +302,8 @@ __public int ceph_ll_fsync(struct ceph_mount_info *cmount, struct Fh *fh,
 {
 	CEPH_REQ(ceph_ll_fsync, req, 0, ans, 0);
 
-	req.fh = ptr_value(fh);
-	req.dataonly = syncdataonly;
+	req.v0.fh = ptr_value(fh);
+	req.v0.dataonly = syncdataonly;
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_FSYNC, req, ans);
 }
@@ -314,10 +314,10 @@ __public int ceph_ll_getattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_getattr, req, 0, ans, 1);
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.want = want;
-	req.flags = flags;
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.want = want;
+	req.v0.flags = flags;
 
 	CEPH_BUFF_ADD(ans, stx, sizeof(*stx));
 
@@ -330,10 +330,10 @@ __public int ceph_ll_getxattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_getxattr, req, 1, ans, 1);
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.size = size;
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.size = size;
+	CEPH_STR_ADD(req, v0.name, name);
 
 	CEPH_BUFF_ADD(ans, value, size);
 
@@ -346,10 +346,10 @@ __public int ceph_ll_link(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_link, req, 1, ans, 0);
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.parent = ptr_value(newparent);
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.parent = ptr_value(newparent);
+	CEPH_STR_ADD(req, v0.name, name);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_LINK, req, ans);
 }
@@ -361,15 +361,15 @@ __public int ceph_ll_listxattr(struct ceph_mount_info *cmount, struct Inode *in,
 	CEPH_REQ(ceph_ll_listxattr, req, 0, ans, 1);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.size = buf_size;
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.size = buf_size;
 
 	CEPH_BUFF_ADD(ans, list, buf_size);
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_LISTXATTR, req, ans);
 	if (err >= 0) {
-		*list_size = ans.size;
+		*list_size = ans.v0.size;
 	}
 
 	return err;
@@ -383,17 +383,17 @@ __public int ceph_ll_lookup(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_lookup, req, 1, ans, 1);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.parent = ptr_value(parent);
-	req.want = want;
-	req.flags = flags;
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.parent = ptr_value(parent);
+	req.v0.want = want;
+	req.v0.flags = flags;
+	CEPH_STR_ADD(req, v0.name, name);
 
 	CEPH_BUFF_ADD(ans, stx, sizeof(*stx));
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_LOOKUP, req, ans);
 	if (err >= 0) {
-		*out = value_ptr(ans.inode);
+		*out = value_ptr(ans.v0.inode);
 	}
 
 	return err;
@@ -405,11 +405,11 @@ __public int ceph_ll_lookup_inode(struct ceph_mount_info *cmount,
 	CEPH_REQ(ceph_ll_lookup_inode, req, 0, ans, 0);
 	int32_t err;
 
-	req.ino = ino;
+	req.v0.ino = ino;
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_LOOKUP_INODE, req, ans);
 	if (err >= 0) {
-		*inode = value_ptr(ans.inode);
+		*inode = value_ptr(ans.v0.inode);
 	}
 
 	return err;
@@ -422,7 +422,7 @@ __public int ceph_ll_lookup_root(struct ceph_mount_info *cmount, Inode **parent)
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_LOOKUP_ROOT, req, ans);
 	if (err >= 0) {
-		*parent = value_ptr(ans.inode);
+		*parent = value_ptr(ans.v0.inode);
 	}
 
 	return err;
@@ -434,13 +434,13 @@ __public off_t ceph_ll_lseek(struct ceph_mount_info *cmount,
 	CEPH_REQ(ceph_ll_lseek, req, 0, ans, 0);
 	int32_t err;
 
-	req.fh = ptr_value(filehandle);
-	req.offset = offset;
-	req.whence = whence;
+	req.v0.fh = ptr_value(filehandle);
+	req.v0.offset = offset;
+	req.v0.whence = whence;
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_LSEEK, req, ans);
 	if (err >= 0) {
-		return ans.offset;
+		return ans.v0.offset;
 	}
 
 	return err;
@@ -454,18 +454,18 @@ __public int ceph_ll_mkdir(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_mkdir, req, 1, ans, 1);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.parent = ptr_value(parent);
-	req.mode = mode;
-	req.want = want;
-	req.flags = flags;
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.parent = ptr_value(parent);
+	req.v0.mode = mode;
+	req.v0.want = want;
+	req.v0.flags = flags;
+	CEPH_STR_ADD(req, v0.name, name);
 
 	CEPH_BUFF_ADD(ans, stx, sizeof(*stx));
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_MKDIR, req, ans);
 	if (err >= 0) {
-		*out = value_ptr(ans.inode);
+		*out = value_ptr(ans.v0.inode);
 	}
 
 	return err;
@@ -479,19 +479,19 @@ __public int ceph_ll_mknod(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_mknod, req, 1, ans, 1);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.parent = ptr_value(parent);
-	req.mode = mode;
-	req.rdev = rdev;
-	req.want = want;
-	req.flags = flags;
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.parent = ptr_value(parent);
+	req.v0.mode = mode;
+	req.v0.rdev = rdev;
+	req.v0.want = want;
+	req.v0.flags = flags;
+	CEPH_STR_ADD(req, v0.name, name);
 
 	CEPH_BUFF_ADD(ans, stx, sizeof(*stx));
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_MKNOD, req, ans);
 	if (err >= 0) {
-		*out = value_ptr(ans.inode);
+		*out = value_ptr(ans.v0.inode);
 	}
 
 	return err;
@@ -503,13 +503,13 @@ __public int ceph_ll_open(struct ceph_mount_info *cmount, struct Inode *in,
 	CEPH_REQ(ceph_ll_open, req, 0, ans, 0);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.flags = flags;
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.flags = flags;
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_OPEN, req, ans);
 	if (err >= 0) {
-		*fh = value_ptr(ans.fh);
+		*fh = value_ptr(ans.v0.fh);
 	}
 
 	return err;
@@ -522,12 +522,12 @@ __public int ceph_ll_opendir(struct ceph_mount_info *cmount, struct Inode *in,
 	CEPH_REQ(ceph_ll_opendir, req, 0, ans, 0);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_OPENDIR, req, ans);
 	if (err >= 0) {
-		*dirpp = value_ptr(ans.dir);
+		*dirpp = value_ptr(ans.v0.dir);
 	}
 
 	return err;
@@ -537,7 +537,7 @@ __public int ceph_ll_put(struct ceph_mount_info *cmount, struct Inode *in)
 {
 	CEPH_REQ(ceph_ll_put, req, 0, ans, 0);
 
-	req.inode = ptr_value(in);
+	req.v0.inode = ptr_value(in);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_PUT, req, ans);
 }
@@ -547,9 +547,9 @@ __public int ceph_ll_read(struct ceph_mount_info *cmount, struct Fh *filehandle,
 {
 	CEPH_REQ(ceph_ll_read, req, 0, ans, 1);
 
-	req.fh = ptr_value(filehandle);
-	req.offset = off;
-	req.len = len;
+	req.v0.fh = ptr_value(filehandle);
+	req.v0.offset = off;
+	req.v0.len = len;
 
 	CEPH_BUFF_ADD(ans, buf, len);
 
@@ -561,9 +561,9 @@ __public int ceph_ll_readlink(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_readlink, req, 0, ans, 1);
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.size = bufsize;
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.size = bufsize;
 
 	CEPH_BUFF_ADD(ans, buf, bufsize);
 
@@ -575,7 +575,7 @@ __public int ceph_ll_releasedir(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_ll_releasedir, req, 0, ans, 0);
 
-	req.dir = ptr_value(dir);
+	req.v0.dir = ptr_value(dir);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_RELEASEDIR, req, ans);
 }
@@ -586,9 +586,9 @@ __public int ceph_ll_removexattr(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_ll_removexattr, req, 1, ans, 0);
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	CEPH_STR_ADD(req, v0.name, name);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_REMOVEXATTR, req, ans);
 }
@@ -600,11 +600,11 @@ __public int ceph_ll_rename(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_ll_rename, req, 2, ans, 0);
 
-	req.userperm = ptr_value(perms);
-	req.old_parent = ptr_value(parent);
-	req.new_parent = ptr_value(newparent);
-	CEPH_STR_ADD(req, old_name, name);
-	CEPH_STR_ADD(req, new_name, newname);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.old_parent = ptr_value(parent);
+	req.v0.new_parent = ptr_value(newparent);
+	CEPH_STR_ADD(req, v0.old_name, name);
+	CEPH_STR_ADD(req, v0.new_name, newname);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_RENAME, req, ans);
 }
@@ -614,7 +614,7 @@ __public void ceph_rewinddir(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_rewinddir, req, 0, ans, 0);
 
-	req.dir = ptr_value(dirp);
+	req.v0.dir = ptr_value(dirp);
 
 	CEPH_PROCESS(cmount, LIBCEPHFSD_OP_REWINDDIR, req, ans);
 }
@@ -624,9 +624,9 @@ __public int ceph_ll_rmdir(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_rmdir, req, 1, ans, 0);
 
-	req.userperm = ptr_value(perms);
-	req.parent = ptr_value(in);
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.parent = ptr_value(in);
+	CEPH_STR_ADD(req, v0.name, name);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_RMDIR, req, ans);
 }
@@ -637,9 +637,9 @@ __public int ceph_ll_setattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_setattr, req, 1, ans, 0);
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.mask = mask;
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.mask = mask;
 	CEPH_BUFF_ADD(req, stx, sizeof(*stx));
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_SETATTR, req, ans);
@@ -651,11 +651,11 @@ __public int ceph_ll_setxattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_setxattr, req, 2, ans, 0);
 
-	req.userperm = ptr_value(perms);
-	req.inode = ptr_value(in);
-	req.size = size;
-	req.flags = flags;
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.inode = ptr_value(in);
+	req.v0.size = size;
+	req.v0.flags = flags;
+	CEPH_STR_ADD(req, v0.name, name);
 	CEPH_BUFF_ADD(req, value, size);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_SETXATTR, req, ans);
@@ -666,7 +666,7 @@ __public int ceph_ll_statfs(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_statfs, req, 0, ans, 1);
 
-	req.inode = ptr_value(in);
+	req.v0.inode = ptr_value(in);
 
 	CEPH_BUFF_ADD(ans, stbuf, sizeof(*stbuf));
 
@@ -681,18 +681,18 @@ __public int ceph_ll_symlink(struct ceph_mount_info *cmount, Inode *in,
 	CEPH_REQ(ceph_ll_symlink, req, 2, ans, 1);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.parent = ptr_value(in);
-	req.want = want;
-	req.flags = flags;
-	CEPH_STR_ADD(req, name, name);
-	CEPH_STR_ADD(req, target, value);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.parent = ptr_value(in);
+	req.v0.want = want;
+	req.v0.flags = flags;
+	CEPH_STR_ADD(req, v0.name, name);
+	CEPH_STR_ADD(req, v0.target, value);
 
 	CEPH_BUFF_ADD(req, stx, sizeof(*stx));
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_SYMLINK, req, ans);
 	if (err >= 0) {
-		*out = value_ptr(ans.inode);
+		*out = value_ptr(ans.v0.inode);
 	}
 
 	return err;
@@ -703,9 +703,9 @@ __public int ceph_ll_unlink(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_unlink, req, 1, ans, 0);
 
-	req.userperm = ptr_value(perms);
-	req.parent = ptr_value(in);
-	CEPH_STR_ADD(req, name, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.parent = ptr_value(in);
+	CEPH_STR_ADD(req, v0.name, name);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_UNLINK, req, ans);
 }
@@ -717,16 +717,16 @@ __public int ceph_ll_walk(struct ceph_mount_info *cmount, const char *name,
 	CEPH_REQ(ceph_ll_walk, req, 1, ans, 1);
 	int32_t err;
 
-	req.userperm = ptr_value(perms);
-	req.want = want;
-	req.flags = flags;
-	CEPH_STR_ADD(req, path, name);
+	req.v0.userperm = ptr_value(perms);
+	req.v0.want = want;
+	req.v0.flags = flags;
+	CEPH_STR_ADD(req, v0.path, name);
 
 	CEPH_BUFF_ADD(ans, stx, sizeof(*stx));
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_WALK, req, ans);
 	if (err >= 0) {
-		*i = value_ptr(ans.inode);
+		*i = value_ptr(ans.v0.inode);
 	}
 
 	return err;
@@ -738,9 +738,9 @@ __public int ceph_ll_write(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_ll_write, req, 1, ans, 0);
 
-	req.fh = ptr_value(filehandle);
-	req.offset = off;
-	req.len = len;
+	req.v0.fh = ptr_value(filehandle);
+	req.v0.offset = off;
+	req.v0.len = len;
 	CEPH_BUFF_ADD(req, data, len);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_WRITE, req, ans);
@@ -750,7 +750,7 @@ __public int ceph_mount(struct ceph_mount_info *cmount, const char *root)
 {
 	CEPH_REQ(ceph_mount, req, 1, ans, 0);
 
-	CEPH_STR_ADD(req, root, root);
+	CEPH_STR_ADD(req, v0.root, root);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_MOUNT, req, ans);
 }
@@ -771,7 +771,7 @@ __public int ceph_readdir_r(struct ceph_mount_info *cmount,
 
 	CEPH_REQ(ceph_readdir, req, 0, ans, 1);
 
-	req.dir = ptr_value(dirp);
+	req.v0.dir = ptr_value(dirp);
 
 	CEPH_BUFF_ADD(ans, de, sizeof(struct dirent));
 
@@ -779,7 +779,7 @@ __public int ceph_readdir_r(struct ceph_mount_info *cmount,
 	if (err < 0) {
 		return err;
 	}
-	if (ans.eod) {
+	if (ans.v0.eod) {
 		return 0;
 	}
 
@@ -815,7 +815,7 @@ __public int ceph_select_filesystem(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_select_filesystem, req, 1, ans, 0);
 
-	CEPH_STR_ADD(req, fs, fs_name);
+	CEPH_STR_ADD(req, v0.fs, fs_name);
 
 	return CEPH_PROCESS(cmount, LIBCEPHFSD_OP_SELECT_FILESYSTEM, req, ans);
 }
@@ -831,7 +831,7 @@ __public void ceph_userperm_destroy(UserPerm *perms)
 {
 	CEPH_REQ(ceph_userperm_destroy, req, 0, ans, 0);
 
-	req.userperm = ptr_value(perms);
+	req.v0.userperm = ptr_value(perms);
 
 	CEPH_RUN(&global_cmount, LIBCEPHFSD_OP_USERPERM_DESTROY, req, ans);
 }
@@ -842,9 +842,9 @@ __public UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids,
 	CEPH_REQ(ceph_userperm_new, req, 1, ans, 0);
 	int32_t err;
 
-	req.uid = uid;
-	req.gid = gid;
-	req.groups = ngids;
+	req.v0.uid = uid;
+	req.v0.gid = gid;
+	req.v0.groups = ngids;
 	CEPH_BUFF_ADD(req, gidlist, sizeof(gid_t) * ngids);
 
 	err = proxy_global_connect();
@@ -853,7 +853,7 @@ __public UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids,
 			       ans);
 	}
 	if (err >= 0) {
-		return value_ptr(ans.userperm);
+		return value_ptr(ans.v0.userperm);
 	}
 
 	errno = -err;
@@ -886,9 +886,9 @@ __public const char *ceph_version(int *major, int *minor, int *patch)
 			return "Unknown";
 		}
 
-		cached_major = ans.major;
-		cached_minor = ans.minor;
-		cached_patch = ans.patch;
+		cached_major = ans.v0.major;
+		cached_minor = ans.v0.minor;
+		cached_patch = ans.v0.patch;
 	}
 
 	*major = cached_major;
@@ -909,7 +909,7 @@ __public UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount)
 		return NULL;
 	}
 
-	return value_ptr(ans.userperm);
+	return value_ptr(ans.v0.userperm);
 }
 
 __public int64_t ceph_ll_nonblocking_readv_writev(
@@ -923,20 +923,20 @@ __public int64_t ceph_ll_nonblocking_readv_writev(
 		return -EOPNOTSUPP;
 	}
 
-	req.info = ptr_checksum(&cmount->async.random, io_info);
-	req.fh = (uintptr_t)io_info->fh;
-	req.off = io_info->off;
-	req.size = 0;
-	req.write = io_info->write;
-	req.fsync = io_info->fsync;
-	req.syncdataonly = io_info->syncdataonly;
+	req.v0.info = ptr_checksum(&cmount->async.random, io_info);
+	req.v0.fh = (uintptr_t)io_info->fh;
+	req.v0.off = io_info->off;
+	req.v0.size = 0;
+	req.v0.write = io_info->write;
+	req.v0.fsync = io_info->fsync;
+	req.v0.syncdataonly = io_info->syncdataonly;
 
 	for (i = 0; i < io_info->iovcnt; i++) {
 		if (io_info->write) {
 			CEPH_BUFF_ADD(req, io_info->iov[i].iov_base,
 				      io_info->iov[i].iov_len);
 		}
-		req.size += io_info->iov[i].iov_len;
+		req.v0.size += io_info->iov[i].iov_len;
 	}
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_NONBLOCKING_RW, req, ans);
@@ -944,5 +944,5 @@ __public int64_t ceph_ll_nonblocking_readv_writev(
 		return err;
 	}
 
-	return ans.res;
+	return ans.v0.res;
 }

--- a/src/libcephfs_proxy/libcephfs_proxy.c
+++ b/src/libcephfs_proxy/libcephfs_proxy.c
@@ -267,7 +267,7 @@ __public int ceph_ll_create(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_create, req, 1, ans, 1);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.parent = ptr_value(parent);
 	req.v0.mode = mode;
 	req.v0.oflags = oflags;
@@ -316,7 +316,7 @@ __public int ceph_ll_getattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_getattr, req, 0, ans, 1);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.want = want;
 	req.v0.flags = flags;
@@ -332,7 +332,7 @@ __public int ceph_ll_getxattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_getxattr, req, 1, ans, 1);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.size = size;
 	CEPH_STR_ADD(req, v0.name, name);
@@ -348,7 +348,7 @@ __public int ceph_ll_link(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_link, req, 1, ans, 0);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.parent = ptr_value(newparent);
 	CEPH_STR_ADD(req, v0.name, name);
@@ -363,7 +363,7 @@ __public int ceph_ll_listxattr(struct ceph_mount_info *cmount, struct Inode *in,
 	CEPH_REQ(ceph_ll_listxattr, req, 0, ans, 1);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.size = buf_size;
 
@@ -385,7 +385,7 @@ __public int ceph_ll_lookup(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_lookup, req, 1, ans, 1);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.parent = ptr_value(parent);
 	req.v0.want = want;
 	req.v0.flags = flags;
@@ -456,7 +456,7 @@ __public int ceph_ll_mkdir(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_mkdir, req, 1, ans, 1);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.parent = ptr_value(parent);
 	req.v0.mode = mode;
 	req.v0.want = want;
@@ -481,7 +481,7 @@ __public int ceph_ll_mknod(struct ceph_mount_info *cmount, Inode *parent,
 	CEPH_REQ(ceph_ll_mknod, req, 1, ans, 1);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.parent = ptr_value(parent);
 	req.v0.mode = mode;
 	req.v0.rdev = rdev;
@@ -505,7 +505,7 @@ __public int ceph_ll_open(struct ceph_mount_info *cmount, struct Inode *in,
 	CEPH_REQ(ceph_ll_open, req, 0, ans, 0);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.flags = flags;
 
@@ -524,7 +524,7 @@ __public int ceph_ll_opendir(struct ceph_mount_info *cmount, struct Inode *in,
 	CEPH_REQ(ceph_ll_opendir, req, 0, ans, 0);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 
 	err = CEPH_PROCESS(cmount, LIBCEPHFSD_OP_LL_OPENDIR, req, ans);
@@ -563,7 +563,7 @@ __public int ceph_ll_readlink(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_readlink, req, 0, ans, 1);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.size = bufsize;
 
@@ -588,7 +588,7 @@ __public int ceph_ll_removexattr(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_ll_removexattr, req, 1, ans, 0);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	CEPH_STR_ADD(req, v0.name, name);
 
@@ -602,7 +602,7 @@ __public int ceph_ll_rename(struct ceph_mount_info *cmount,
 {
 	CEPH_REQ(ceph_ll_rename, req, 2, ans, 0);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.old_parent = ptr_value(parent);
 	req.v0.new_parent = ptr_value(newparent);
 	CEPH_STR_ADD(req, v0.old_name, name);
@@ -626,7 +626,7 @@ __public int ceph_ll_rmdir(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_rmdir, req, 1, ans, 0);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.parent = ptr_value(in);
 	CEPH_STR_ADD(req, v0.name, name);
 
@@ -639,7 +639,7 @@ __public int ceph_ll_setattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_setattr, req, 1, ans, 0);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.mask = mask;
 	CEPH_BUFF_ADD(req, stx, sizeof(*stx));
@@ -653,7 +653,7 @@ __public int ceph_ll_setxattr(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_setxattr, req, 2, ans, 0);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.inode = ptr_value(in);
 	req.v0.size = size;
 	req.v0.flags = flags;
@@ -683,7 +683,7 @@ __public int ceph_ll_symlink(struct ceph_mount_info *cmount, Inode *in,
 	CEPH_REQ(ceph_ll_symlink, req, 2, ans, 1);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.parent = ptr_value(in);
 	req.v0.want = want;
 	req.v0.flags = flags;
@@ -705,7 +705,7 @@ __public int ceph_ll_unlink(struct ceph_mount_info *cmount, struct Inode *in,
 {
 	CEPH_REQ(ceph_ll_unlink, req, 1, ans, 0);
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.parent = ptr_value(in);
 	CEPH_STR_ADD(req, v0.name, name);
 
@@ -719,7 +719,7 @@ __public int ceph_ll_walk(struct ceph_mount_info *cmount, const char *name,
 	CEPH_REQ(ceph_ll_walk, req, 1, ans, 1);
 	int32_t err;
 
-	req.v0.userperm = ptr_value(perms);
+	req.v0.userperm.ptr = ptr_value(perms);
 	req.v0.want = want;
 	req.v0.flags = flags;
 	CEPH_STR_ADD(req, v0.path, name);

--- a/src/libcephfs_proxy/libcephfsd.c
+++ b/src/libcephfs_proxy/libcephfsd.c
@@ -91,11 +91,11 @@ static int32_t libcephfsd_version(proxy_client_t *client, proxy_req_t *req,
 	text = ceph_version(&major, &minor, &patch);
 	TRACE("ceph_version(%d, %d, %d) -> %s", major, minor, patch, text);
 
-	ans.major = major;
-	ans.minor = minor;
-	ans.patch = patch;
+	ans.v0.major = major;
+	ans.v0.minor = minor;
+	ans.v0.patch = patch;
 
-	CEPH_STR_ADD(ans, text, text);
+	CEPH_STR_ADD(ans, v0.text, text);
 
 	return CEPH_RET(client->sd, 0, ans);
 }
@@ -107,15 +107,16 @@ static int32_t libcephfsd_userperm_new(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *userperm;
 	int32_t err;
 
-	userperm = ceph_userperm_new(req->userperm_new.uid,
-				     req->userperm_new.gid,
-				     req->userperm_new.groups, (gid_t *)data);
+	userperm = ceph_userperm_new(req->userperm_new.v0.uid,
+				     req->userperm_new.v0.gid,
+				     req->userperm_new.v0.groups,
+				     (gid_t *)data);
 	TRACE("ceph_userperm_new(%u, %u, %u) -> %p", req->userperm_new.uid,
 	      req->userperm_new.gid, req->userperm_new.groups, userperm);
 
 	err = -ENOMEM;
 	if (userperm != NULL) {
-		ans.userperm = ptr_checksum(&global_random, userperm);
+		ans.v0.userperm = ptr_checksum(&global_random, userperm);
 		err = 0;
 	}
 
@@ -130,7 +131,7 @@ static int32_t libcephfsd_userperm_destroy(proxy_client_t *client,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&global_random, req->userperm_destroy.userperm,
+	err = ptr_check(&global_random, req->userperm_destroy.v0.userperm,
 			(void **)&perms);
 
 	if (err >= 0) {
@@ -149,13 +150,13 @@ static int32_t libcephfsd_create(proxy_client_t *client, proxy_req_t *req,
 	const char *id;
 	int32_t err;
 
-	id = CEPH_STR_GET(req->create, id, data);
+	id = CEPH_STR_GET(req->create, v0.id, data);
 
 	err = proxy_mount_create(&mount, id);
 	TRACE("ceph_create(%p, '%s') -> %d", mount, id, err);
 
 	if (err >= 0) {
-		ans.cmount = ptr_checksum(&client->random, mount);
+		ans.v0.cmount = ptr_checksum(&client->random, mount);
 	}
 
 	return CEPH_COMPLETE(client, err, ans);
@@ -168,7 +169,8 @@ static int32_t libcephfsd_release(proxy_client_t *client, proxy_req_t *req,
 	proxy_mount_t *mount;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->release.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->release.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
 		err = proxy_mount_release(mount);
 		TRACE("ceph_release(%p) -> %d", mount, err);
@@ -186,10 +188,10 @@ static int32_t libcephfsd_conf_read_file(proxy_client_t *client,
 	const char *path;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->conf_read_file.cmount,
+	err = ptr_check(&client->random, req->conf_read_file.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		path = CEPH_STR_GET(req->conf_read_file, path, data);
+		path = CEPH_STR_GET(req->conf_read_file, v0.path, data);
 
 		err = proxy_mount_config(mount, path);
 		TRACE("ceph_conf_read_file(%p, '%s') ->%d", mount, path, err);
@@ -210,19 +212,21 @@ static int32_t libcephfsd_conf_get(proxy_client_t *client, proxy_req_t *req,
 
 	buffer = client->buffer;
 	size = client->buffer_size;
-	if (req->conf_get.size < size) {
-		size = req->conf_get.size;
+	if (req->conf_get.v0.size < size) {
+		size = req->conf_get.v0.size;
 	}
-	err = ptr_check(&client->random, req->conf_get.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->conf_get.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		option = CEPH_STR_GET(req->conf_get, option, data);
+		option = CEPH_STR_GET(req->conf_get, v0.option, data);
 
 		err = proxy_mount_get(mount, option, buffer, size);
 		TRACE("ceph_conf_get(%p, '%s', '%s') -> %d", mount, option,
 		      (char *)buffer, err);
 
 		if (err >= 0) {
-			CEPH_DATA_ADD(ans, value, buffer, strlen(buffer) + 1);
+			CEPH_DATA_ADD(ans, v0.value, buffer,
+				      strlen(buffer) + 1);
 		}
 	}
 
@@ -237,11 +241,12 @@ static int32_t libcephfsd_conf_set(proxy_client_t *client, proxy_req_t *req,
 	const char *option, *value;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->conf_set.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->conf_set.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		option = CEPH_STR_GET(req->conf_set, option, data);
-		value = CEPH_STR_GET(req->conf_set, value,
-				     (const char *)(data) + req->conf_set.option);
+		option = CEPH_STR_GET(req->conf_set, v0.option, data);
+		value = CEPH_STR_GET(req->conf_set, v0.value,
+				     (const char *)(data) + req->conf_set.v0.option);
 
 		err = proxy_mount_set(mount, option, value);
 		TRACE("ceph_conf_set(%p, '%s', '%s') -> %d", mount, option,
@@ -258,7 +263,7 @@ static int32_t libcephfsd_init(proxy_client_t *client, proxy_req_t *req,
 	proxy_mount_t *mount;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->init.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->init.v0.cmount, (void **)&mount);
 	if (err >= 0) {
 		err = proxy_mount_init(mount);
 		TRACE("ceph_init(%p) -> %d", mount, err);
@@ -276,10 +281,10 @@ static int32_t libcephfsd_select_filesystem(proxy_client_t *client,
 	const char *fs;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->select_filesystem.cmount,
+	err = ptr_check(&client->random, req->select_filesystem.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		fs = CEPH_STR_GET(req->select_filesystem, fs, data);
+		fs = CEPH_STR_GET(req->select_filesystem, v0.fs, data);
 
 		err = proxy_mount_select(mount, fs);
 		TRACE("ceph_select_filesystem(%p, '%s') -> %d", mount, fs, err);
@@ -296,9 +301,9 @@ static int32_t libcephfsd_mount(proxy_client_t *client, proxy_req_t *req,
 	const char *root;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->mount.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->mount.v0.cmount, (void **)&mount);
 	if (err >= 0) {
-		root = CEPH_STR_GET(req->mount, root, data);
+		root = CEPH_STR_GET(req->mount, v0.root, data);
 
 		err = proxy_mount_mount(mount, root);
 		TRACE("ceph_mount(%p, '%s') -> %d", mount, root, err);
@@ -314,7 +319,8 @@ static int32_t libcephfsd_unmount(proxy_client_t *client, proxy_req_t *req,
 	proxy_mount_t *mount;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->unmount.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->unmount.v0.cmount,
+			(void **)&mount);
 
 	if (err >= 0) {
 		err = proxy_mount_unmount(mount);
@@ -333,10 +339,10 @@ static int32_t libcephfsd_ll_statfs(proxy_client_t *client, proxy_req_t *req,
 	struct Inode *inode;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_statfs.cmount,
+	err = ptr_check(&client->random, req->ll_statfs.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_statfs.inode,
+		err = ptr_check(&client->random, req->ll_statfs.v0.inode,
 				(void **)&inode);
 	}
 
@@ -362,20 +368,20 @@ static int32_t libcephfsd_ll_lookup(proxy_client_t *client, proxy_req_t *req,
 	uint32_t want, flags;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_lookup.cmount,
+	err = ptr_check(&client->random, req->ll_lookup.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_lookup.parent,
+		err = ptr_check(&client->random, req->ll_lookup.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_lookup.userperm,
+		err = ptr_check(&global_random, req->ll_lookup.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		want = req->ll_lookup.want;
-		flags = req->ll_lookup.flags;
-		name = CEPH_STR_GET(req->ll_lookup, name, data);
+		want = req->ll_lookup.v0.want;
+		flags = req->ll_lookup.v0.flags;
+		name = CEPH_STR_GET(req->ll_lookup, v0.name, data);
 
 		CEPH_BUFF_ADD(ans, &stx, sizeof(stx));
 
@@ -397,7 +403,7 @@ static int32_t libcephfsd_ll_lookup(proxy_client_t *client, proxy_req_t *req,
 		      mount, parent, name, out, want, flags, perms, err);
 
 		if (err >= 0) {
-			ans.inode = ptr_checksum(&client->random, out);
+			ans.v0.inode = ptr_checksum(&client->random, out);
 		}
 	}
 
@@ -414,17 +420,17 @@ static int32_t libcephfsd_ll_lookup_inode(proxy_client_t *client,
 	struct inodeno_t ino;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_lookup_inode.cmount,
+	err = ptr_check(&client->random, req->ll_lookup_inode.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		ino = req->ll_lookup_inode.ino;
+		ino = req->ll_lookup_inode.v0.ino;
 
 		err = ceph_ll_lookup_inode(proxy_cmount(mount), ino, &inode);
 		TRACE("ceph_ll_lookup_inode(%p, %lu, %p) -> %d", mount, ino.val,
 		      inode, err);
 
 		if (err >= 0) {
-			ans.inode = ptr_checksum(&client->random, inode);
+			ans.v0.inode = ptr_checksum(&client->random, inode);
 		}
 	}
 
@@ -439,7 +445,7 @@ static int32_t libcephfsd_ll_lookup_root(proxy_client_t *client,
 	proxy_mount_t *mount;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_lookup_root.cmount,
+	err = ptr_check(&client->random, req->ll_lookup_root.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
 		/* The libcephfs view of the root of the mount could be
@@ -451,7 +457,8 @@ static int32_t libcephfsd_ll_lookup_root(proxy_client_t *client,
 		      err);
 
 		if (err >= 0) {
-			ans.inode = ptr_checksum(&client->random, mount->root);
+			ans.v0.inode = ptr_checksum(&client->random,
+						    mount->root);
 		}
 	}
 
@@ -466,9 +473,10 @@ static int32_t libcephfsd_ll_put(proxy_client_t *client, proxy_req_t *req,
 	struct Inode *inode;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_put.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_put.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_put.inode,
+		err = ptr_check(&client->random, req->ll_put.v0.inode,
 				(void **)&inode);
 	}
 
@@ -492,15 +500,16 @@ static int32_t libcephfsd_ll_walk(proxy_client_t *client, proxy_req_t *req,
 	uint32_t want, flags;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_walk.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_walk.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_walk.userperm,
+		err = ptr_check(&global_random, req->ll_walk.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		want = req->ll_walk.want;
-		flags = req->ll_walk.flags;
-		path = CEPH_STR_GET(req->ll_walk, path, data);
+		want = req->ll_walk.v0.want;
+		flags = req->ll_walk.v0.flags;
+		path = CEPH_STR_GET(req->ll_walk, v0.path, data);
 
 		CEPH_BUFF_ADD(ans, &stx, sizeof(stx));
 
@@ -510,7 +519,7 @@ static int32_t libcephfsd_ll_walk(proxy_client_t *client, proxy_req_t *req,
 		      path, inode, want, flags, perms, err);
 
 		if (err >= 0) {
-			ans.inode = ptr_checksum(&client->random, inode);
+			ans.v0.inode = ptr_checksum(&client->random, inode);
 		}
 	}
 
@@ -528,9 +537,9 @@ static int32_t libcephfsd_chdir(proxy_client_t *client, proxy_req_t *req,
 	char *realpath;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->chdir.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->chdir.v0.cmount, (void **)&mount);
 	if (err >= 0) {
-		path = CEPH_STR_GET(req->chdir, path, data);
+		path = CEPH_STR_GET(req->chdir, v0.path, data);
 
 		/* Since the libcephfs mount may be shared, we can't really
 		 * change the current directory to avoid interferences with
@@ -565,13 +574,14 @@ static int32_t libcephfsd_getcwd(proxy_client_t *client, proxy_req_t *req,
 	const char *path;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->getcwd.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->getcwd.v0.cmount,
+			(void **)&mount);
 
 	if (err >= 0) {
 		/* We just return the cached name from the last chdir(). */
 		path = mount->cwd_path;
 		TRACE("ceph_getcwd(%p) -> '%s'", mount, path);
-		CEPH_STR_ADD(ans, path, path);
+		CEPH_STR_ADD(ans, v0.path, path);
 		err = 0;
 	}
 
@@ -587,9 +597,10 @@ static int32_t libcephfsd_readdir(proxy_client_t *client, proxy_req_t *req,
 	struct ceph_dir_result *dirp;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->readdir.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->readdir.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->readdir.dir,
+		err = ptr_check(&client->random, req->readdir.v0.dir,
 				(void **)&dirp);
 	}
 
@@ -597,9 +608,9 @@ static int32_t libcephfsd_readdir(proxy_client_t *client, proxy_req_t *req,
 		err = ceph_readdir_r(proxy_cmount(mount), dirp, &de);
 		TRACE("ceph_readdir_r(%p, %p, %p) -> %d", mount, dirp, &de,
 		      err);
-		ans.eod = true;
+		ans.v0.eod = true;
 		if (err > 0) {
-			ans.eod = false;
+			ans.v0.eod = false;
 			CEPH_BUFF_ADD(ans, &de,
 				      offset_of(struct dirent, d_name) +
 					      strlen(de.d_name) + 1);
@@ -617,10 +628,10 @@ static int32_t libcephfsd_rewinddir(proxy_client_t *client, proxy_req_t *req,
 	struct ceph_dir_result *dirp;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->rewinddir.cmount,
+	err = ptr_check(&client->random, req->rewinddir.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->rewinddir.dir,
+		err = ptr_check(&client->random, req->rewinddir.v0.dir,
 				(void **)&dirp);
 	}
 
@@ -642,17 +653,18 @@ static int32_t libcephfsd_ll_open(proxy_client_t *client, proxy_req_t *req,
 	struct Fh *fh;
 	int32_t flags, err;
 
-	err = ptr_check(&client->random, req->ll_open.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_open.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_open.inode,
+		err = ptr_check(&client->random, req->ll_open.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_open.userperm,
+		err = ptr_check(&global_random, req->ll_open.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		flags = req->ll_open.flags;
+		flags = req->ll_open.v0.flags;
 
 		err = ceph_ll_open(proxy_cmount(mount), inode, flags, &fh,
 				   perms);
@@ -660,7 +672,7 @@ static int32_t libcephfsd_ll_open(proxy_client_t *client, proxy_req_t *req,
 		      flags, fh, perms, err);
 
 		if (err >= 0) {
-			ans.fh = ptr_checksum(&client->random, fh);
+			ans.v0.fh = ptr_checksum(&client->random, fh);
 		}
 	}
 
@@ -681,22 +693,22 @@ static int32_t libcephfsd_ll_create(proxy_client_t *client, proxy_req_t *req,
 	uint32_t want, flags;
 	int32_t oflags, err;
 
-	err = ptr_check(&client->random, req->ll_create.cmount,
+	err = ptr_check(&client->random, req->ll_create.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_create.parent,
+		err = ptr_check(&client->random, req->ll_create.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_create.userperm,
+		err = ptr_check(&global_random, req->ll_create.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		mode = req->ll_create.mode;
-		oflags = req->ll_create.oflags;
-		want = req->ll_create.want;
-		flags = req->ll_create.flags;
-		name = CEPH_STR_GET(req->ll_create, name, data);
+		mode = req->ll_create.v0.mode;
+		oflags = req->ll_create.v0.oflags;
+		want = req->ll_create.v0.want;
+		flags = req->ll_create.v0.flags;
+		name = CEPH_STR_GET(req->ll_create, v0.name, data);
 
 		CEPH_BUFF_ADD(ans, &stx, sizeof(stx));
 
@@ -709,8 +721,8 @@ static int32_t libcephfsd_ll_create(proxy_client_t *client, proxy_req_t *req,
 		      perms, err);
 
 		if (err >= 0) {
-			ans.fh = ptr_checksum(&client->random, fh);
-			ans.inode = ptr_checksum(&client->random, inode);
+			ans.v0.fh = ptr_checksum(&client->random, fh);
+			ans.v0.inode = ptr_checksum(&client->random, inode);
 		}
 	}
 
@@ -731,21 +743,22 @@ static int32_t libcephfsd_ll_mknod(proxy_client_t *client, proxy_req_t *req,
 	uint32_t want, flags;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_mknod.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_mknod.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_mknod.parent,
+		err = ptr_check(&client->random, req->ll_mknod.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_mknod.userperm,
+		err = ptr_check(&global_random, req->ll_mknod.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		mode = req->ll_mknod.mode;
-		rdev = req->ll_mknod.rdev;
-		want = req->ll_mknod.want;
-		flags = req->ll_mknod.flags;
-		name = CEPH_STR_GET(req->ll_mknod, name, data);
+		mode = req->ll_mknod.v0.mode;
+		rdev = req->ll_mknod.v0.rdev;
+		want = req->ll_mknod.v0.want;
+		flags = req->ll_mknod.v0.flags;
+		name = CEPH_STR_GET(req->ll_mknod, v0.name, data);
 
 		CEPH_BUFF_ADD(ans, &stx, sizeof(stx));
 
@@ -757,7 +770,7 @@ static int32_t libcephfsd_ll_mknod(proxy_client_t *client, proxy_req_t *req,
 		      perms, err);
 
 		if (err >= 0) {
-			ans.inode = ptr_checksum(&client->random, inode);
+			ans.v0.inode = ptr_checksum(&client->random, inode);
 		}
 	}
 
@@ -772,9 +785,10 @@ static int32_t libcephfsd_ll_close(proxy_client_t *client, proxy_req_t *req,
 	struct Fh *fh;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_close.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_close.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_close.fh,
+		err = ptr_check(&client->random, req->ll_close.v0.fh,
 				(void **)&fh);
 	}
 
@@ -796,24 +810,24 @@ static int32_t libcephfsd_ll_rename(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_rename.cmount,
+	err = ptr_check(&client->random, req->ll_rename.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_rename.old_parent,
+		err = ptr_check(&client->random, req->ll_rename.v0.old_parent,
 				(void **)&old_parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_rename.new_parent,
+		err = ptr_check(&client->random, req->ll_rename.v0.new_parent,
 				(void **)&new_parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_rename.userperm,
+		err = ptr_check(&global_random, req->ll_rename.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		old_name = CEPH_STR_GET(req->ll_rename, old_name, data);
-		new_name = CEPH_STR_GET(req->ll_rename, new_name,
-					(const char *)data + req->ll_rename.old_name);
+		old_name = CEPH_STR_GET(req->ll_rename, v0.old_name, data);
+		new_name = CEPH_STR_GET(req->ll_rename, v0.new_name,
+					(const char *)data + req->ll_rename.v0.old_name);
 
 		err = ceph_ll_rename(proxy_cmount(mount), old_parent, old_name,
 				     new_parent, new_name, perms);
@@ -833,14 +847,15 @@ static int32_t libcephfsd_ll_lseek(proxy_client_t *client, proxy_req_t *req,
 	off_t offset, pos;
 	int32_t whence, err;
 
-	err = ptr_check(&client->random, req->ll_lseek.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_lseek.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_lseek.fh,
+		err = ptr_check(&client->random, req->ll_lseek.v0.fh,
 				(void **)&fh);
 	}
 	if (err >= 0) {
-		offset = req->ll_lseek.offset;
-		whence = req->ll_lseek.whence;
+		offset = req->ll_lseek.v0.offset;
+		whence = req->ll_lseek.v0.whence;
 
 		pos = ceph_ll_lseek(proxy_cmount(mount), fh, offset, whence);
 		err = -errno;
@@ -848,7 +863,7 @@ static int32_t libcephfsd_ll_lseek(proxy_client_t *client, proxy_req_t *req,
 		      offset, whence, pos, -err);
 
 		if (pos >= 0) {
-			ans.offset = pos;
+			ans.v0.offset = pos;
 			err = 0;
 		}
 	}
@@ -870,13 +885,15 @@ static int32_t libcephfsd_ll_read(proxy_client_t *client, proxy_req_t *req,
 
 	buffer = client->buffer;
 
-	err = ptr_check(&client->random, req->ll_read.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_read.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_read.fh, (void **)&fh);
+		err = ptr_check(&client->random, req->ll_read.v0.fh,
+				(void **)&fh);
 	}
 	if (err >= 0) {
-		offset = req->ll_read.offset;
-		len = req->ll_read.len;
+		offset = req->ll_read.v0.offset;
+		len = req->ll_read.v0.len;
 
 		size = client->buffer_size;
 		if (len > size) {
@@ -916,14 +933,15 @@ static int32_t libcephfsd_ll_write(proxy_client_t *client, proxy_req_t *req,
 	int64_t offset;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_write.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_write.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_write.fh,
+		err = ptr_check(&client->random, req->ll_write.v0.fh,
 				(void **)&fh);
 	}
 	if (err >= 0) {
-		offset = req->ll_write.offset;
-		len = req->ll_write.len;
+		offset = req->ll_write.v0.offset;
+		len = req->ll_write.v0.len;
 
 		err = ceph_ll_write(proxy_cmount(mount), fh, offset, len, data);
 		TRACE("ceph_ll_write(%p, %p, %ld, %lu) -> %d", mount, fh,
@@ -943,21 +961,22 @@ static int32_t libcephfsd_ll_link(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_link.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_link.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_link.inode,
+		err = ptr_check(&client->random, req->ll_link.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_link.parent,
+		err = ptr_check(&client->random, req->ll_link.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_link.userperm,
+		err = ptr_check(&global_random, req->ll_link.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		name = CEPH_STR_GET(req->ll_link, name, data);
+		name = CEPH_STR_GET(req->ll_link, v0.name, data);
 
 		err = ceph_ll_link(proxy_cmount(mount), inode, parent, name,
 				   perms);
@@ -978,18 +997,18 @@ static int32_t libcephfsd_ll_unlink(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_unlink.cmount,
+	err = ptr_check(&client->random, req->ll_unlink.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_unlink.parent,
+		err = ptr_check(&client->random, req->ll_unlink.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_unlink.userperm,
+		err = ptr_check(&global_random, req->ll_unlink.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		name = CEPH_STR_GET(req->ll_unlink, name, data);
+		name = CEPH_STR_GET(req->ll_unlink, v0.name, data);
 
 		err = ceph_ll_unlink(proxy_cmount(mount), parent, name, perms);
 		TRACE("ceph_ll_unlink(%p, %p, '%s', %p) -> %d", mount, parent,
@@ -1010,19 +1029,19 @@ static int32_t libcephfsd_ll_getattr(proxy_client_t *client, proxy_req_t *req,
 	uint32_t want, flags;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_getattr.cmount,
+	err = ptr_check(&client->random, req->ll_getattr.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_getattr.inode,
+		err = ptr_check(&client->random, req->ll_getattr.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_getattr.userperm,
+		err = ptr_check(&global_random, req->ll_getattr.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		want = req->ll_getattr.want;
-		flags = req->ll_getattr.flags;
+		want = req->ll_getattr.v0.want;
+		flags = req->ll_getattr.v0.flags;
 
 		CEPH_BUFF_ADD(ans, &stx, sizeof(stx));
 
@@ -1044,18 +1063,18 @@ static int32_t libcephfsd_ll_setattr(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *perms;
 	int32_t mask, err;
 
-	err = ptr_check(&client->random, req->ll_setattr.cmount,
+	err = ptr_check(&client->random, req->ll_setattr.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_setattr.inode,
+		err = ptr_check(&client->random, req->ll_setattr.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_setattr.userperm,
+		err = ptr_check(&global_random, req->ll_setattr.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		mask = req->ll_setattr.mask;
+		mask = req->ll_setattr.v0.mask;
 
 		err = ceph_ll_setattr(proxy_cmount(mount), inode, (void *)data,
 				      mask, perms);
@@ -1076,16 +1095,16 @@ static int32_t libcephfsd_ll_fallocate(proxy_client_t *client, proxy_req_t *req,
 	mode_t mode;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_fallocate.cmount,
+	err = ptr_check(&client->random, req->ll_fallocate.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_fallocate.fh,
+		err = ptr_check(&client->random, req->ll_fallocate.v0.fh,
 				(void **)&fh);
 	}
 	if (err >= 0) {
-		mode = req->ll_fallocate.mode;
-		offset = req->ll_fallocate.offset;
-		len = req->ll_fallocate.length;
+		mode = req->ll_fallocate.v0.mode;
+		offset = req->ll_fallocate.v0.offset;
+		len = req->ll_fallocate.v0.length;
 
 		err = ceph_ll_fallocate(proxy_cmount(mount), fh, mode, offset,
 					len);
@@ -1104,13 +1123,14 @@ static int32_t libcephfsd_ll_fsync(proxy_client_t *client, proxy_req_t *req,
 	struct Fh *fh;
 	int32_t dataonly, err;
 
-	err = ptr_check(&client->random, req->ll_fsync.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_fsync.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_fsync.fh,
+		err = ptr_check(&client->random, req->ll_fsync.v0.fh,
 				(void **)&fh);
 	}
 	if (err >= 0) {
-		dataonly = req->ll_fsync.dataonly;
+		dataonly = req->ll_fsync.v0.dataonly;
 
 		err = ceph_ll_fsync(proxy_cmount(mount), fh, dataonly);
 		TRACE("ceph_ll_fsync(%p, %p, %d) -> %d", mount, fh, dataonly,
@@ -1130,18 +1150,18 @@ static int32_t libcephfsd_ll_listxattr(proxy_client_t *client, proxy_req_t *req,
 	size_t size;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_listxattr.cmount,
+	err = ptr_check(&client->random, req->ll_listxattr.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_listxattr.inode,
+		err = ptr_check(&client->random, req->ll_listxattr.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_listxattr.userperm,
+		err = ptr_check(&global_random, req->ll_listxattr.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		size = req->ll_listxattr.size;
+		size = req->ll_listxattr.v0.size;
 		if (size > client->buffer_size) {
 			size = client->buffer_size;
 		}
@@ -1151,7 +1171,7 @@ static int32_t libcephfsd_ll_listxattr(proxy_client_t *client, proxy_req_t *req,
 		      size, perms, err);
 
 		if (err >= 0) {
-			ans.size = size;
+			ans.v0.size = size;
 			CEPH_BUFF_ADD(ans, client->buffer, size);
 		}
 	}
@@ -1170,19 +1190,19 @@ static int32_t libcephfsd_ll_getxattr(proxy_client_t *client, proxy_req_t *req,
 	size_t size;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_getxattr.cmount,
+	err = ptr_check(&client->random, req->ll_getxattr.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_getxattr.inode,
+		err = ptr_check(&client->random, req->ll_getxattr.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_getxattr.userperm,
+		err = ptr_check(&global_random, req->ll_getxattr.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		size = req->ll_getxattr.size;
-		name = CEPH_STR_GET(req->ll_getxattr, name, data);
+		size = req->ll_getxattr.v0.size;
+		name = CEPH_STR_GET(req->ll_getxattr, v0.name, data);
 
 		if (size > client->buffer_size) {
 			size = client->buffer_size;
@@ -1211,21 +1231,21 @@ static int32_t libcephfsd_ll_setxattr(proxy_client_t *client, proxy_req_t *req,
 	size_t size;
 	int32_t flags, err;
 
-	err = ptr_check(&client->random, req->ll_setxattr.cmount,
+	err = ptr_check(&client->random, req->ll_setxattr.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_setxattr.inode,
+		err = ptr_check(&client->random, req->ll_setxattr.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_setxattr.userperm,
+		err = ptr_check(&global_random, req->ll_setxattr.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		name = CEPH_STR_GET(req->ll_setxattr, name, data);
-		value = (const char *)data + req->ll_setxattr.name;
-		size = req->ll_setxattr.size;
-		flags = req->ll_setxattr.flags;
+		name = CEPH_STR_GET(req->ll_setxattr, v0.name, data);
+		value = (const char *)data + req->ll_setxattr.v0.name;
+		size = req->ll_setxattr.v0.size;
+		flags = req->ll_setxattr.v0.flags;
 
 		err = ceph_ll_setxattr(proxy_cmount(mount), inode, name, value,
 				       size, flags, perms);
@@ -1247,18 +1267,18 @@ static int32_t libcephfsd_ll_removexattr(proxy_client_t *client,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_removexattr.cmount,
+	err = ptr_check(&client->random, req->ll_removexattr.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_removexattr.inode,
+		err = ptr_check(&client->random, req->ll_removexattr.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_removexattr.userperm,
+		err = ptr_check(&global_random, req->ll_removexattr.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		name = CEPH_STR_GET(req->ll_removexattr, name, data);
+		name = CEPH_STR_GET(req->ll_removexattr, v0.name, data);
 
 		err = ceph_ll_removexattr(proxy_cmount(mount), inode, name,
 					  perms);
@@ -1279,18 +1299,18 @@ static int32_t libcephfsd_ll_readlink(proxy_client_t *client, proxy_req_t *req,
 	size_t size;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_readlink.cmount,
+	err = ptr_check(&client->random, req->ll_readlink.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_readlink.inode,
+		err = ptr_check(&client->random, req->ll_readlink.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_readlink.userperm,
+		err = ptr_check(&global_random, req->ll_readlink.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		size = req->ll_readlink.size;
+		size = req->ll_readlink.v0.size;
 
 		if (size > client->buffer_size) {
 			size = client->buffer_size;
@@ -1316,22 +1336,22 @@ static int32_t libcephfsd_ll_symlink(proxy_client_t *client, proxy_req_t *req,
 	uint32_t want, flags;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_symlink.cmount,
+	err = ptr_check(&client->random, req->ll_symlink.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_symlink.parent,
+		err = ptr_check(&client->random, req->ll_symlink.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_symlink.userperm,
+		err = ptr_check(&global_random, req->ll_symlink.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		name = CEPH_STR_GET(req->ll_symlink, name, data);
-		value = CEPH_STR_GET(req->ll_symlink, target,
-				     (const char *)data + req->ll_symlink.name);
-		want = req->ll_symlink.want;
-		flags = req->ll_symlink.flags;
+		name = CEPH_STR_GET(req->ll_symlink, v0.name, data);
+		value = CEPH_STR_GET(req->ll_symlink, v0.target,
+				     (const char *)data + req->ll_symlink.v0.name);
+		want = req->ll_symlink.v0.want;
+		flags = req->ll_symlink.v0.flags;
 
 		CEPH_BUFF_ADD(ans, &stx, sizeof(stx));
 
@@ -1343,7 +1363,7 @@ static int32_t libcephfsd_ll_symlink(proxy_client_t *client, proxy_req_t *req,
 		      err);
 
 		if (err >= 0) {
-			ans.inode = ptr_checksum(&client->random, inode);
+			ans.v0.inode = ptr_checksum(&client->random, inode);
 		}
 	}
 
@@ -1360,14 +1380,14 @@ static int32_t libcephfsd_ll_opendir(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_opendir.cmount,
+	err = ptr_check(&client->random, req->ll_opendir.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_opendir.inode,
+		err = ptr_check(&client->random, req->ll_opendir.v0.inode,
 				(void **)&inode);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_opendir.userperm,
+		err = ptr_check(&global_random, req->ll_opendir.v0.userperm,
 				(void **)&perms);
 	}
 
@@ -1377,7 +1397,7 @@ static int32_t libcephfsd_ll_opendir(proxy_client_t *client, proxy_req_t *req,
 		      dirp, perms, err);
 
 		if (err >= 0) {
-			ans.dir = ptr_checksum(&client->random, dirp);
+			ans.v0.dir = ptr_checksum(&client->random, dirp);
 		}
 	}
 
@@ -1397,20 +1417,20 @@ static int32_t libcephfsd_ll_mkdir(proxy_client_t *client, proxy_req_t *req,
 	uint32_t want, flags;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_mkdir.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_mkdir.v0.cmount, (void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_mkdir.parent,
+		err = ptr_check(&client->random, req->ll_mkdir.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_mkdir.userperm,
+		err = ptr_check(&global_random, req->ll_mkdir.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		mode = req->ll_mkdir.mode;
-		want = req->ll_mkdir.want;
-		flags = req->ll_mkdir.flags;
-		name = CEPH_STR_GET(req->ll_mkdir, name, data);
+		mode = req->ll_mkdir.v0.mode;
+		want = req->ll_mkdir.v0.want;
+		flags = req->ll_mkdir.v0.flags;
+		name = CEPH_STR_GET(req->ll_mkdir, v0.name, data);
 
 		CEPH_BUFF_ADD(ans, &stx, sizeof(stx));
 
@@ -1421,7 +1441,7 @@ static int32_t libcephfsd_ll_mkdir(proxy_client_t *client, proxy_req_t *req,
 		      err);
 
 		if (err >= 0) {
-			ans.inode = ptr_checksum(&client->random, inode);
+			ans.v0.inode = ptr_checksum(&client->random, inode);
 		}
 	}
 
@@ -1438,17 +1458,18 @@ static int32_t libcephfsd_ll_rmdir(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_rmdir.cmount, (void **)&mount);
+	err = ptr_check(&client->random, req->ll_rmdir.v0.cmount,
+			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_rmdir.parent,
+		err = ptr_check(&client->random, req->ll_rmdir.v0.parent,
 				(void **)&parent);
 	}
 	if (err >= 0) {
-		err = ptr_check(&global_random, req->ll_rmdir.userperm,
+		err = ptr_check(&global_random, req->ll_rmdir.v0.userperm,
 				(void **)&perms);
 	}
 	if (err >= 0) {
-		name = CEPH_STR_GET(req->ll_rmdir, name, data);
+		name = CEPH_STR_GET(req->ll_rmdir, v0.name, data);
 
 		err = ceph_ll_rmdir(proxy_cmount(mount), parent, name, perms);
 		TRACE("ceph_ll_rmdir(%p, %p, '%s', %p) -> %d", mount, parent,
@@ -1467,10 +1488,10 @@ static int32_t libcephfsd_ll_releasedir(proxy_client_t *client,
 	struct ceph_dir_result *dirp;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->ll_releasedir.cmount,
+	err = ptr_check(&client->random, req->ll_releasedir.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
-		err = ptr_check(&client->random, req->ll_releasedir.dir,
+		err = ptr_check(&client->random, req->ll_releasedir.v0.dir,
 				(void **)&dirp);
 	}
 
@@ -1490,13 +1511,13 @@ static int32_t libcephfsd_mount_perms(proxy_client_t *client, proxy_req_t *req,
 	UserPerm *perms;
 	int32_t err;
 
-	err = ptr_check(&client->random, req->mount_perms.cmount,
+	err = ptr_check(&client->random, req->mount_perms.v0.cmount,
 			(void **)&mount);
 	if (err >= 0) {
 		perms = ceph_mount_perms(proxy_cmount(mount));
 		TRACE("ceph_mount_perms(%p) -> %p", mount, perms);
 
-		ans.userperm = ptr_checksum(&global_random, perms);
+		ans.v0.userperm = ptr_checksum(&global_random, perms);
 	}
 
 	return CEPH_COMPLETE(client, err, ans);
@@ -1512,11 +1533,11 @@ static void libcephfsd_ll_nonblocking_rw_cbk(struct ceph_ll_io_info *cb_info)
 	async_io = container_of(cb_info, proxy_async_io_t, io_info);
 	async = async_io->async;
 
-	cbk.info = (uintptr_t)cb_info->priv;
-	cbk.res = cb_info->result;
+	cbk.v0.info = (uintptr_t)cb_info->priv;
+	cbk.v0.res = cb_info->result;
 
-	if ((cbk.res >= 0) && !cb_info->write) {
-		CEPH_BUFF_ADD(cbk, cb_info->iov->iov_base, cbk.res);
+	if ((cbk.v0.res >= 0) && !cb_info->write) {
+		CEPH_BUFF_ADD(cbk, cb_info->iov->iov_base, cbk.v0.res);
 	}
 
 	err = CEPH_CALL_CBK(async->fd, LIBCEPHFSD_CBK_LL_NONBLOCKING_RW, cbk);
@@ -1548,7 +1569,7 @@ static int32_t libcephfsd_ll_nonblocking_rw(proxy_client_t *client,
 		return -EOPNOTSUPP;
 	}
 
-	err = ptr_check(&client->random, req->ll_nonblocking_rw.cmount,
+	err = ptr_check(&client->random, req->ll_nonblocking_rw.v0.cmount,
 			(void **)&mount);
 	if (err < 0) {
 		goto done;
@@ -1563,15 +1584,15 @@ static int32_t libcephfsd_ll_nonblocking_rw(proxy_client_t *client,
 
 	memset(io_info, 0, sizeof(struct ceph_ll_io_info));
 	io_info->callback = libcephfsd_ll_nonblocking_rw_cbk;
-	io_info->priv = (void *)(uintptr_t)req->ll_nonblocking_rw.info;
+	io_info->priv = (void *)(uintptr_t)req->ll_nonblocking_rw.v0.info;
 	io_info->iov = &async_io->iov;
 	io_info->iovcnt = 1;
-	io_info->off = req->ll_nonblocking_rw.off;
-	io_info->write = req->ll_nonblocking_rw.write;
-	io_info->fsync = req->ll_nonblocking_rw.fsync;
-	io_info->syncdataonly = req->ll_nonblocking_rw.syncdataonly;
+	io_info->off = req->ll_nonblocking_rw.v0.off;
+	io_info->write = req->ll_nonblocking_rw.v0.write;
+	io_info->fsync = req->ll_nonblocking_rw.v0.fsync;
+	io_info->syncdataonly = req->ll_nonblocking_rw.v0.syncdataonly;
 
-	err = ptr_check(&client->random, req->ll_nonblocking_rw.fh,
+	err = ptr_check(&client->random, req->ll_nonblocking_rw.v0.fh,
 			(void **)&io_info->fh);
 	if (err < 0) {
 		goto done;
@@ -1581,7 +1602,7 @@ static int32_t libcephfsd_ll_nonblocking_rw(proxy_client_t *client,
 		async_io->iov.iov_len = data_size;
 		async_io->iov.iov_base = (void *)data;
 	} else {
-		async_io->iov.iov_len = req->ll_nonblocking_rw.size;
+		async_io->iov.iov_len = req->ll_nonblocking_rw.v0.size;
 		async_io->iov.iov_base = proxy_malloc(async_io->iov.iov_len);
 		if (async_io->iov.iov_base == NULL) {
 			proxy_free(async_io);
@@ -1595,7 +1616,7 @@ static int32_t libcephfsd_ll_nonblocking_rw(proxy_client_t *client,
 	res = ceph_ll_nonblocking_readv_writev(proxy_cmount(mount), io_info);
 	TRACE("ceph_ll_nonblocking_readv_writev(%p) -> %ld", mount, res);
 
-	ans.res = res;
+	ans.v0.res = res;
 	if (res < 0) {
 		if (!io_info->write) {
 			proxy_free(async_io->iov.iov_base);

--- a/src/libcephfs_proxy/libcephfsd.c
+++ b/src/libcephfs_proxy/libcephfsd.c
@@ -1736,7 +1736,8 @@ static void serve_binary(proxy_client_t *client)
 
 static int32_t server_negotiation_check(proxy_link_negotiate_t *neg)
 {
-	proxy_log(LOG_INFO, 0, "Features enabled: %08x", neg->v1.enabled);
+	proxy_log(LOG_INFO, 0, "Features enabled: %08x, protocol: %u",
+		  neg->v1.enabled, neg->v2.protocol);
 
 	return 0;
 }
@@ -1748,7 +1749,8 @@ static void serve_connection(proxy_worker_t *worker)
 
 	client = container_of(worker, proxy_client_t, worker);
 
-	proxy_link_negotiate_init(&client->neg, 0, PROXY_FEAT_ALL, 0, 0);
+	proxy_link_negotiate_init(&client->neg, 0, PROXY_FEAT_ALL, 0, 0,
+				  PROXY_LINK_PROTOCOL_VERSION);
 
 	err = proxy_link_handshake_server(client->link, client->sd,
 					  &client->neg,

--- a/src/libcephfs_proxy/proxy.h
+++ b/src/libcephfs_proxy/proxy.h
@@ -20,6 +20,8 @@
 #define PROXY_SOCKET "/run/libcephfsd.sock"
 #define PROXY_SOCKET_ENV "LIBCEPHFSD_SOCKET"
 
+#define field_size(_type, _field) sizeof(((_type *)0)->_field)
+
 #define offset_of(_type, _field) ((uintptr_t) & ((_type *)0)->_field)
 
 #define container_of(_ptr, _type, _field) \
@@ -29,11 +31,15 @@ enum {
 	/* Support for ceph_ll_nonblocking_readv_writev */
 	PROXY_FEAT_ASYNC_IO = 0x00000001,
 
+	/* Support for embedding the user credentials inside the request itself
+	 * instead of using ceph_userperm_new/ceph_userperm_destroy */
+	PROXY_FEAT_EMBEDDED_PERMS = 0x00000002,
+
 	/* Mask of all features requiring the asynchronous callback handling. */
 	PROXY_FEAT_ASYNC_CBK = 0x00000001,
 
 	/* Mask of all supported/known features. */
-	PROXY_FEAT_ALL = 0x00000001
+	PROXY_FEAT_ALL = 0x00000003
 };
 
 struct _list;

--- a/src/libcephfs_proxy/proxy_async.c
+++ b/src/libcephfs_proxy/proxy_async.c
@@ -40,7 +40,7 @@ static int32_t libcephfsd_cbk_nonblocking_rw(proxy_async_t *async,
 			}
 
 			memcpy(iov->iov_base, data, iov->iov_len);
-			data += iov->iov_len;
+			data = (char*)data + iov->iov_len;
 			size -= iov->iov_len;
 			iov++;
 			count--;

--- a/src/libcephfs_proxy/proxy_async.c
+++ b/src/libcephfs_proxy/proxy_async.c
@@ -18,13 +18,13 @@ static int32_t libcephfsd_cbk_nonblocking_rw(proxy_async_t *async,
 	const struct iovec *iov;
 	int32_t err, count;
 
-	err = ptr_check(&async->random, cbk->ll_nonblocking_rw.info,
+	err = ptr_check(&async->random, cbk->ll_nonblocking_rw.v0.info,
 			(void **)&info);
 	if (err < 0) {
 		return err;
 	}
 
-	info->result = cbk->ll_nonblocking_rw.res;
+	info->result = cbk->ll_nonblocking_rw.v0.res;
 
 	if (!info->write) {
 		iov = info->iov;

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -17,9 +17,10 @@
 
 /* Known versions for communication protocol. */
 #define PROXY_PROTOCOL_V0 0
+#define PROXY_PROTOCOL_V1 1
 
 /* The maximum supported protocol version. */
-#define PROXY_LINK_PROTOCOL_VERSION PROXY_PROTOCOL_V0
+#define PROXY_LINK_PROTOCOL_VERSION PROXY_PROTOCOL_V1
 
 /* Version 0 structure will be used to handle legacy clients that don't support
  * negotiation. */

--- a/src/libcephfs_proxy/proxy_link.h
+++ b/src/libcephfs_proxy/proxy_link.h
@@ -13,7 +13,13 @@
  * starting with "NEG_VERSION" and do the appropriate changes in each place. */
 
 /* NEG_VERSION: Update this value to the latest implemented version. */
-#define PROXY_LINK_NEGOTIATE_VERSION 1
+#define PROXY_LINK_NEGOTIATE_VERSION 2
+
+/* Known versions for communication protocol. */
+#define PROXY_PROTOCOL_V0 0
+
+/* The maximum supported protocol version. */
+#define PROXY_LINK_PROTOCOL_VERSION PROXY_PROTOCOL_V0
 
 /* Version 0 structure will be used to handle legacy clients that don't support
  * negotiation. */
@@ -38,11 +44,16 @@ typedef struct _proxy_link_negotiate_v1 {
 	uint32_t enabled;
 } proxy_link_negotiate_v1_t;
 
+typedef struct _proxy_link_negotiate_v2 {
+	uint32_t protocol;
+} proxy_link_negotiate_v2_t;
+
 /* NEG_VERSION: Add typedefs for new negotiate extensions above this comment. */
 
 struct _proxy_link_negotiate {
 	proxy_link_negotiate_v0_t v0;
 	proxy_link_negotiate_v1_t v1;
+	proxy_link_negotiate_v2_t v2;
 
 	/* NEG_VERSION: Add newly defined typedefs above this comment. */
 };
@@ -85,13 +96,17 @@ static inline void proxy_link_negotiate_init(proxy_link_negotiate_t *neg,
 					     uint32_t min_version,
 					     uint32_t supported,
 					     uint32_t required,
-					     uint32_t enabled)
+					     uint32_t enabled,
+					     uint32_t protocol)
 {
 	proxy_link_negotiate_init_v0(neg, PROXY_LINK_NEGOTIATE_VERSION,
 				     min_version);
+
 	neg->v1.supported = supported;
 	neg->v1.required = required;
 	neg->v1.enabled = enabled;
+
+	neg->v2.protocol = protocol;
 }
 
 static inline bool proxy_link_is_connected(proxy_link_t *link)

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -161,161 +161,486 @@ enum {
 
 /* Declaration of types used to transder requests and answers. */
 
-CEPH_TYPE(ceph_version, REQ(),
-	  ANS(int32_t major; int32_t minor; int32_t patch; int16_t text;));
+CEPH_TYPE(ceph_version,
+	REQ(
+	),
+	ANS(
+		int32_t major;
+		int32_t minor;
+		int32_t patch;
+		int16_t text;
+	)
+);
 
-CEPH_TYPE(ceph_userperm_new, REQ(uint32_t uid; uint32_t gid; uint32_t groups;),
-	  ANS(uint64_t userperm;));
+CEPH_TYPE(ceph_userperm_new,
+	REQ(
+		uint32_t uid;
+		uint32_t gid;
+		uint32_t groups;
+	),
+	ANS(
+		uint64_t userperm;
+	)
+);
 
-CEPH_TYPE(ceph_userperm_destroy, REQ(uint64_t userperm;), ANS());
+CEPH_TYPE(ceph_userperm_destroy,
+	REQ(
+		uint64_t userperm;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_create, REQ(int16_t id;), ANS_CMOUNT());
+CEPH_TYPE(ceph_create,
+	REQ(
+		int16_t id;
+	),
+	ANS_CMOUNT(
+	)
+);
 
-CEPH_TYPE(ceph_release, REQ_CMOUNT(), ANS());
+CEPH_TYPE(ceph_release,
+	REQ_CMOUNT(
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_conf_read_file, REQ_CMOUNT(uint16_t path;), ANS());
+CEPH_TYPE(ceph_conf_read_file,
+	REQ_CMOUNT(
+		uint16_t path;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_conf_get, REQ_CMOUNT(uint32_t size; uint16_t option;),
-	  ANS(uint16_t value;));
+CEPH_TYPE(ceph_conf_get,
+	REQ_CMOUNT(
+		uint32_t size;
+		uint16_t option;
+	),
+	ANS(
+		uint16_t value;
+	)
+);
 
-CEPH_TYPE(ceph_conf_set, REQ_CMOUNT(uint16_t option; uint16_t value;), ANS());
+CEPH_TYPE(ceph_conf_set,
+	REQ_CMOUNT(
+		uint16_t option;
+		uint16_t value;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_init, REQ_CMOUNT(), ANS());
+CEPH_TYPE(ceph_init,
+	REQ_CMOUNT(
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_select_filesystem, REQ_CMOUNT(uint16_t fs;), ANS());
+CEPH_TYPE(ceph_select_filesystem,
+	REQ_CMOUNT(
+		uint16_t fs;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_mount, REQ_CMOUNT(uint16_t root;), ANS());
+CEPH_TYPE(ceph_mount,
+	REQ_CMOUNT(
+		uint16_t root;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_unmount, REQ_CMOUNT(), ANS());
+CEPH_TYPE(ceph_unmount,
+	REQ_CMOUNT(
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_ll_statfs, REQ_CMOUNT(uint64_t inode;), ANS());
+CEPH_TYPE(ceph_ll_statfs,
+	REQ_CMOUNT(
+		uint64_t inode;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_lookup,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t parent; uint32_t want;
-		     uint32_t flags; uint16_t name;),
-	  ANS(uint64_t inode;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t parent;
+		uint32_t want;
+		uint32_t flags;
+		uint16_t name;
+	),
+	ANS(
+		uint64_t inode;
+	)
+);
 
-CEPH_TYPE(ceph_ll_lookup_inode, REQ_CMOUNT(struct inodeno_t ino;),
-	  ANS(uint64_t inode;));
+CEPH_TYPE(ceph_ll_lookup_inode,
+	REQ_CMOUNT(
+		struct inodeno_t ino;
+	),
+	ANS(
+		uint64_t inode;
+	)
+);
 
-CEPH_TYPE(ceph_ll_lookup_root, REQ_CMOUNT(), ANS(uint64_t inode;));
+CEPH_TYPE(ceph_ll_lookup_root,
+	REQ_CMOUNT(
+	),
+	ANS(
+		uint64_t inode;
+	)
+);
 
-CEPH_TYPE(ceph_ll_put, REQ_CMOUNT(uint64_t inode;), ANS());
+CEPH_TYPE(ceph_ll_put,
+	REQ_CMOUNT(
+		uint64_t inode;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_walk,
-	  REQ_CMOUNT(uint64_t userperm; uint32_t want; uint32_t flags;
-		     uint16_t path;),
-	  ANS(uint64_t inode;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint32_t want;
+		uint32_t flags;
+		uint16_t path;
+	),
+	ANS(
+		uint64_t inode;
+	)
+);
 
-CEPH_TYPE(ceph_chdir, REQ_CMOUNT(uint16_t path;), ANS());
+CEPH_TYPE(ceph_chdir,
+	REQ_CMOUNT(
+		uint16_t path;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_getcwd, REQ_CMOUNT(), ANS(uint16_t path;));
+CEPH_TYPE(ceph_getcwd,
+	REQ_CMOUNT(
+	),
+	ANS(
+		uint16_t path;
+	)
+);
 
-CEPH_TYPE(ceph_readdir, REQ_CMOUNT(uint64_t dir;), ANS(bool eod;));
+CEPH_TYPE(ceph_readdir,
+	REQ_CMOUNT(
+		uint64_t dir;
+	),
+	ANS(
+		bool eod;
+	)
+);
 
-CEPH_TYPE(ceph_rewinddir, REQ_CMOUNT(uint64_t dir;), ANS());
+CEPH_TYPE(ceph_rewinddir,
+	REQ_CMOUNT(
+		uint64_t dir;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_open,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; int32_t flags;),
-	  ANS(uint64_t fh;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		int32_t flags;
+	),
+	ANS(
+		uint64_t fh;
+	)
+);
 
 CEPH_TYPE(ceph_ll_create,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t parent; mode_t mode;
-		     int32_t oflags; uint32_t want; uint32_t flags;
-		     uint16_t name;),
-	  ANS(uint64_t inode; uint64_t fh;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t parent;
+		mode_t mode;
+		int32_t oflags;
+		uint32_t want;
+		uint32_t flags;
+		uint16_t name;
+	),
+	ANS(
+		uint64_t inode;
+		uint64_t fh;
+	)
+);
 
 CEPH_TYPE(ceph_ll_mknod,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t parent; mode_t mode;
-		     dev_t rdev; uint32_t want; uint32_t flags; uint16_t name;),
-	  ANS(uint64_t inode;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t parent;
+		mode_t mode;
+		dev_t rdev;
+		uint32_t want;
+		uint32_t flags;
+		uint16_t name;
+	),
+	ANS(
+		uint64_t inode;
+	)
+);
 
-CEPH_TYPE(ceph_ll_close, REQ_CMOUNT(uint64_t fh;), ANS());
+CEPH_TYPE(ceph_ll_close,
+	REQ_CMOUNT(
+		uint64_t fh;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_rename,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t old_parent;
-		     uint64_t new_parent; uint16_t old_name;
-		     uint16_t new_name;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t old_parent;
+		uint64_t new_parent;
+		uint16_t old_name;
+		uint16_t new_name;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_ll_lseek, REQ_CMOUNT(uint64_t fh; off_t offset; int32_t whence;),
-	  ANS(off_t offset;));
+CEPH_TYPE(ceph_ll_lseek,
+	REQ_CMOUNT(
+		uint64_t fh;
+		off_t offset;
+		int32_t whence;
+	),
+	ANS(
+		off_t offset;
+	)
+);
 
-CEPH_TYPE(ceph_ll_read, REQ_CMOUNT(uint64_t fh; int64_t offset; uint64_t len;),
-	  ANS());
+CEPH_TYPE(ceph_ll_read,
+	REQ_CMOUNT(
+		uint64_t fh;
+		int64_t offset;
+		uint64_t len;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_ll_write, REQ_CMOUNT(uint64_t fh; int64_t offset; uint64_t len;),
-	  ANS());
+CEPH_TYPE(ceph_ll_write,
+	REQ_CMOUNT(
+		uint64_t fh;
+		int64_t offset;
+		uint64_t len;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_link,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; uint64_t parent;
-		     uint16_t name;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		uint64_t parent;
+		uint16_t name;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_unlink,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t parent; uint16_t name;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t parent;
+		uint16_t name;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_getattr,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; uint32_t want;
-		     uint32_t flags;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		uint32_t want;
+		uint32_t flags;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_setattr,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; int32_t mask;), ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		int32_t mask;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_fallocate,
-	  REQ_CMOUNT(uint64_t fh; int64_t offset; int64_t length;
-		     int32_t mode;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t fh;
+		int64_t offset;
+		int64_t length;
+		int32_t mode;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_ll_fsync, REQ_CMOUNT(uint64_t fh; int32_t dataonly;), ANS());
+CEPH_TYPE(ceph_ll_fsync,
+	REQ_CMOUNT(
+		uint64_t fh;
+		int32_t dataonly;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_listxattr,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; size_t size;),
-	  ANS(size_t size;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		size_t size;
+	),
+	ANS(
+		size_t size;
+	)
+);
 
 CEPH_TYPE(ceph_ll_getxattr,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; size_t size;
-		     uint16_t name;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		size_t size;
+		uint16_t name;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_setxattr,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; size_t size;
-		     int32_t flags; uint16_t name;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		size_t size;
+		int32_t flags;
+		uint16_t name;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_removexattr,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; uint16_t name;), ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		uint16_t name;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_readlink,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t inode; size_t size;), ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+		size_t size;
+	),
+	ANS(
+	)
+);
 
 CEPH_TYPE(ceph_ll_symlink,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t parent; uint32_t want;
-		     uint32_t flags; uint16_t name; uint16_t target;),
-	  ANS(uint64_t inode;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t parent;
+		uint32_t want;
+		uint32_t flags;
+		uint16_t name;
+		uint16_t target;
+	),
+	ANS(
+		uint64_t inode;
+	)
+);
 
-CEPH_TYPE(ceph_ll_opendir, REQ_CMOUNT(uint64_t userperm; uint64_t inode;),
-	  ANS(uint64_t dir;));
+CEPH_TYPE(ceph_ll_opendir,
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t inode;
+	),
+	ANS(
+		uint64_t dir;
+	)
+);
 
 CEPH_TYPE(ceph_ll_mkdir,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t parent; mode_t mode;
-		     uint32_t want; uint32_t flags; uint16_t name;),
-	  ANS(uint64_t inode;));
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t parent;
+		mode_t mode;
+		uint32_t want;
+		uint32_t flags;
+		uint16_t name;
+	),
+	ANS(
+		uint64_t inode;
+	)
+);
 
 CEPH_TYPE(ceph_ll_rmdir,
-	  REQ_CMOUNT(uint64_t userperm; uint64_t parent; uint16_t name;),
-	  ANS());
+	REQ_CMOUNT(
+		uint64_t userperm;
+		uint64_t parent;
+		uint16_t name;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_ll_releasedir, REQ_CMOUNT(uint64_t dir;), ANS());
+CEPH_TYPE(ceph_ll_releasedir,
+	REQ_CMOUNT(
+		uint64_t dir;
+	),
+	ANS(
+	)
+);
 
-CEPH_TYPE(ceph_mount_perms, REQ_CMOUNT(), ANS(uint64_t userperm;));
+CEPH_TYPE(ceph_mount_perms,
+	REQ_CMOUNT(
+	),
+	ANS(
+		uint64_t userperm;
+	)
+);
 
 CEPH_TYPE(ceph_ll_nonblocking_readv_writev,
-	  REQ_CMOUNT(uint64_t info; uint64_t fh; int64_t off; uint64_t size;
-		     bool write; bool fsync; bool syncdataonly;),
-	  ANS(int64_t res;));
+	REQ_CMOUNT(
+		uint64_t info;
+		uint64_t fh;
+		int64_t off;
+		uint64_t size;
+		bool write;
+		bool fsync;
+		bool syncdataonly;
+	),
+	ANS(
+		int64_t res;
+	)
+);
 
 typedef union _proxy_req {
 	proxy_link_req_t header;
@@ -371,7 +696,11 @@ typedef union _proxy_req {
 } proxy_req_t;
 
 CEPH_TYPE_CBK(ceph_ll_nonblocking_readv_writev,
-	      CBK(uint64_t info; int64_t res;));
+	CBK(
+		uint64_t info;
+		int64_t res;
+	)
+);
 
 typedef union _proxy_cbk {
 	proxy_link_req_t header;

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -127,544 +127,738 @@ enum {
 	LIBCEPHFSD_CBK_TOTAL_OPS
 };
 
-#define PROTO_REQ(_fields...) proxy_link_req_t header; _fields
-#define PROTO_ANS(_fields...) proxy_link_ans_t header; _fields
-#define PROTO_CBK(_fields...) proxy_link_req_t header; _fields
+#define PROTO_REQ(_fields...) _fields
+#define PROTO_ANS(_fields...) _fields
+#define PROTO_CBK(_fields...) _fields
+
+#define PROTO_VER(_name, _fields...) struct { _fields } _name
 
 #define PROTO_TYPE(_name, _fields...) typedef struct { _fields } _name
 
 #define PROTO_CALL(_name, _req, _ans) \
-	PROTO_TYPE(proxy_##_name##_req_t, _req);  \
-	PROTO_TYPE(proxy_##_name##_ans_t, _ans)
+	PROTO_TYPE(proxy_##_name##_req_t, proxy_link_req_t header; _req); \
+	PROTO_TYPE(proxy_##_name##_ans_t, proxy_link_ans_t header; _ans)
 
 #define PROTO_NOTIFY(_name, _cbk) \
-	PROTO_TYPE(proxy_##_name##_cbk_t, _cbk)
+	PROTO_TYPE(proxy_##_name##_cbk_t, proxy_link_req_t header; _cbk)
 
 /* Declaration of types used to transfer requests and answers. */
 
 PROTO_CALL(ceph_version,
 	PROTO_REQ(
+		PROTO_VER(v0,
+		);
 	),
 	PROTO_ANS(
-		int32_t major;
-		int32_t minor;
-		int32_t patch;
-		int16_t text;
+		PROTO_VER(v0,
+			int32_t major;
+			int32_t minor;
+			int32_t patch;
+			int16_t text;
+		);
 	)
 );
 
 PROTO_CALL(ceph_userperm_new,
 	PROTO_REQ(
-		uint32_t uid;
-		uint32_t gid;
-		uint32_t groups;
+		PROTO_VER(v0,
+			uint32_t uid;
+			uint32_t gid;
+			uint32_t groups;
+		);
 	),
 	PROTO_ANS(
-		uint64_t userperm;
+		PROTO_VER(v0,
+			uint64_t userperm;
+		);
 	)
 );
 
 PROTO_CALL(ceph_userperm_destroy,
 	PROTO_REQ(
-		uint64_t userperm;
+		PROTO_VER(v0,
+			uint64_t userperm;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_create,
 	PROTO_REQ(
-		int16_t id;
+		PROTO_VER(v0,
+			int16_t id;
+		);
 	),
 	PROTO_ANS(
-		uint64_t cmount;
+		PROTO_VER(v0,
+			uint64_t cmount;
+		);
 	)
 );
 
 PROTO_CALL(ceph_release,
 	PROTO_REQ(
-		uint64_t cmount;
+		PROTO_VER(v0,
+			uint64_t cmount;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_conf_read_file,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint16_t path;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint16_t path;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_conf_get,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint32_t size;
-		uint16_t option;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint32_t size;
+			uint16_t option;
+		);
 	),
 	PROTO_ANS(
-		uint16_t value;
+		PROTO_VER(v0,
+			uint16_t value;
+		);
 	)
 );
 
 PROTO_CALL(ceph_conf_set,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint16_t option;
-		uint16_t value;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint16_t option;
+			uint16_t value;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_init,
 	PROTO_REQ(
-		uint64_t cmount;
+		PROTO_VER(v0,
+			uint64_t cmount;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_select_filesystem,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint16_t fs;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint16_t fs;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_mount,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint16_t root;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint16_t root;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_unmount,
 	PROTO_REQ(
-		uint64_t cmount;
+		PROTO_VER(v0,
+			uint64_t cmount;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_statfs,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t inode;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_lookup,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t parent;
-		uint32_t want;
-		uint32_t flags;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t parent;
+			uint32_t want;
+			uint32_t flags;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t inode;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_lookup_inode,
 	PROTO_REQ(
-		uint64_t cmount;
-		struct inodeno_t ino;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			struct inodeno_t ino;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t inode;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_lookup_root,
 	PROTO_REQ(
-		uint64_t cmount;
+		PROTO_VER(v0,
+			uint64_t cmount;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t inode;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_put,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t inode;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_walk,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint32_t want;
-		uint32_t flags;
-		uint16_t path;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint32_t want;
+			uint32_t flags;
+			uint16_t path;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t inode;
+		);
 	)
 );
 
 PROTO_CALL(ceph_chdir,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint16_t path;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint16_t path;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_getcwd,
 	PROTO_REQ(
-		uint64_t cmount;
+		PROTO_VER(v0,
+			uint64_t cmount;
+		);
 	),
 	PROTO_ANS(
-		uint16_t path;
+		PROTO_VER(v0,
+			uint16_t path;
+		);
 	)
 );
 
 PROTO_CALL(ceph_readdir,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t dir;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t dir;
+		);
 	),
 	PROTO_ANS(
-		bool eod;
+		PROTO_VER(v0,
+			bool eod;
+		);
 	)
 );
 
 PROTO_CALL(ceph_rewinddir,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t dir;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t dir;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_open,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		int32_t flags;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			int32_t flags;
+		);
 	),
 	PROTO_ANS(
-		uint64_t fh;
+		PROTO_VER(v0,
+			uint64_t fh;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_create,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t parent;
-		mode_t mode;
-		int32_t oflags;
-		uint32_t want;
-		uint32_t flags;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t parent;
+			mode_t mode;
+			int32_t oflags;
+			uint32_t want;
+			uint32_t flags;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
-		uint64_t fh;
+		PROTO_VER(v0,
+			uint64_t inode;
+			uint64_t fh;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_mknod,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t parent;
-		mode_t mode;
-		dev_t rdev;
-		uint32_t want;
-		uint32_t flags;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t parent;
+			mode_t mode;
+			dev_t rdev;
+			uint32_t want;
+			uint32_t flags;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t inode;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_close,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t fh;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t fh;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_rename,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t old_parent;
-		uint64_t new_parent;
-		uint16_t old_name;
-		uint16_t new_name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t old_parent;
+			uint64_t new_parent;
+			uint16_t old_name;
+			uint16_t new_name;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_lseek,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t fh;
-		off_t offset;
-		int32_t whence;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t fh;
+			off_t offset;
+			int32_t whence;
+		);
 	),
 	PROTO_ANS(
-		off_t offset;
+		PROTO_VER(v0,
+			off_t offset;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_read,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t fh;
-		int64_t offset;
-		uint64_t len;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t fh;
+			int64_t offset;
+			uint64_t len;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_write,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t fh;
-		int64_t offset;
-		uint64_t len;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t fh;
+			int64_t offset;
+			uint64_t len;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_link,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		uint64_t parent;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			uint64_t parent;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_unlink,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t parent;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t parent;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_getattr,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		uint32_t want;
-		uint32_t flags;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			uint32_t want;
+			uint32_t flags;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_setattr,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		int32_t mask;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			int32_t mask;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_fallocate,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t fh;
-		int64_t offset;
-		int64_t length;
-		int32_t mode;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t fh;
+			int64_t offset;
+			int64_t length;
+			int32_t mode;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_fsync,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t fh;
-		int32_t dataonly;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t fh;
+			int32_t dataonly;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_listxattr,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		size_t size;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			size_t size;
+		);
 	),
 	PROTO_ANS(
-		size_t size;
+		PROTO_VER(v0,
+			size_t size;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_getxattr,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		size_t size;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			size_t size;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_setxattr,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		size_t size;
-		int32_t flags;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			size_t size;
+			int32_t flags;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_removexattr,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_readlink,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
-		size_t size;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+			size_t size;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_symlink,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t parent;
-		uint32_t want;
-		uint32_t flags;
-		uint16_t name;
-		uint16_t target;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t parent;
+			uint32_t want;
+			uint32_t flags;
+			uint16_t name;
+			uint16_t target;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t inode;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_opendir,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t inode;
+		);
 	),
 	PROTO_ANS(
-		uint64_t dir;
+		PROTO_VER(v0,
+			uint64_t dir;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_mkdir,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t parent;
-		mode_t mode;
-		uint32_t want;
-		uint32_t flags;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t parent;
+			mode_t mode;
+			uint32_t want;
+			uint32_t flags;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
-		uint64_t inode;
+		PROTO_VER(v0,
+			uint64_t inode;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_rmdir,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t userperm;
-		uint64_t parent;
-		uint16_t name;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t userperm;
+			uint64_t parent;
+			uint16_t name;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_releasedir,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t dir;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t dir;
+		);
 	),
 	PROTO_ANS(
+		PROTO_VER(v0,
+		);
 	)
 );
 
 PROTO_CALL(ceph_mount_perms,
 	PROTO_REQ(
-		uint64_t cmount;
+		PROTO_VER(v0,
+			uint64_t cmount;
+		);
 	),
 	PROTO_ANS(
-		uint64_t userperm;
+		PROTO_VER(v0,
+			uint64_t userperm;
+		);
 	)
 );
 
 PROTO_CALL(ceph_ll_nonblocking_readv_writev,
 	PROTO_REQ(
-		uint64_t cmount;
-		uint64_t info;
-		uint64_t fh;
-		int64_t off;
-		uint64_t size;
-		bool write;
-		bool fsync;
-		bool syncdataonly;
+		PROTO_VER(v0,
+			uint64_t cmount;
+			uint64_t info;
+			uint64_t fh;
+			int64_t off;
+			uint64_t size;
+			bool write;
+			bool fsync;
+			bool syncdataonly;
+		);
 	),
 	PROTO_ANS(
-		int64_t res;
+		PROTO_VER(v0,
+			int64_t res;
+		);
 	)
 );
 
@@ -723,8 +917,10 @@ typedef union _proxy_req {
 
 PROTO_NOTIFY(ceph_ll_nonblocking_readv_writev,
 	PROTO_CBK(
-		uint64_t info;
-		int64_t res;
+		PROTO_VER(v0,
+			uint64_t info;
+			int64_t res;
+		);
 	)
 );
 

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -150,9 +150,7 @@ enum {
 
 #define FIELDS(_fields...) _fields
 #define REQ(_fields...) FIELDS(proxy_link_req_t header; _fields)
-#define REQ_CMOUNT(_fields...) REQ(uint64_t cmount; _fields)
 #define ANS(_fields...) FIELDS(proxy_link_ans_t header; _fields)
-#define ANS_CMOUNT(_fields...) ANS(uint64_t cmount; _fields)
 #define CBK(_fields...) FIELDS(proxy_link_req_t header; _fields)
 
 #define CEPH_TYPE(_name, _req, _ans) \
@@ -195,19 +193,22 @@ CEPH_TYPE(ceph_create,
 	REQ(
 		int16_t id;
 	),
-	ANS_CMOUNT(
+	ANS(
+		uint64_t cmount;
 	)
 );
 
 CEPH_TYPE(ceph_release,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 	),
 	ANS(
 	)
 );
 
 CEPH_TYPE(ceph_conf_read_file,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint16_t path;
 	),
 	ANS(
@@ -215,7 +216,8 @@ CEPH_TYPE(ceph_conf_read_file,
 );
 
 CEPH_TYPE(ceph_conf_get,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint32_t size;
 		uint16_t option;
 	),
@@ -225,7 +227,8 @@ CEPH_TYPE(ceph_conf_get,
 );
 
 CEPH_TYPE(ceph_conf_set,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint16_t option;
 		uint16_t value;
 	),
@@ -234,14 +237,16 @@ CEPH_TYPE(ceph_conf_set,
 );
 
 CEPH_TYPE(ceph_init,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 	),
 	ANS(
 	)
 );
 
 CEPH_TYPE(ceph_select_filesystem,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint16_t fs;
 	),
 	ANS(
@@ -249,7 +254,8 @@ CEPH_TYPE(ceph_select_filesystem,
 );
 
 CEPH_TYPE(ceph_mount,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint16_t root;
 	),
 	ANS(
@@ -257,14 +263,16 @@ CEPH_TYPE(ceph_mount,
 );
 
 CEPH_TYPE(ceph_unmount,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 	),
 	ANS(
 	)
 );
 
 CEPH_TYPE(ceph_ll_statfs,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t inode;
 	),
 	ANS(
@@ -272,7 +280,8 @@ CEPH_TYPE(ceph_ll_statfs,
 );
 
 CEPH_TYPE(ceph_ll_lookup,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		uint32_t want;
@@ -285,7 +294,8 @@ CEPH_TYPE(ceph_ll_lookup,
 );
 
 CEPH_TYPE(ceph_ll_lookup_inode,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		struct inodeno_t ino;
 	),
 	ANS(
@@ -294,7 +304,8 @@ CEPH_TYPE(ceph_ll_lookup_inode,
 );
 
 CEPH_TYPE(ceph_ll_lookup_root,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 	),
 	ANS(
 		uint64_t inode;
@@ -302,7 +313,8 @@ CEPH_TYPE(ceph_ll_lookup_root,
 );
 
 CEPH_TYPE(ceph_ll_put,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t inode;
 	),
 	ANS(
@@ -310,7 +322,8 @@ CEPH_TYPE(ceph_ll_put,
 );
 
 CEPH_TYPE(ceph_ll_walk,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint32_t want;
 		uint32_t flags;
@@ -322,7 +335,8 @@ CEPH_TYPE(ceph_ll_walk,
 );
 
 CEPH_TYPE(ceph_chdir,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint16_t path;
 	),
 	ANS(
@@ -330,7 +344,8 @@ CEPH_TYPE(ceph_chdir,
 );
 
 CEPH_TYPE(ceph_getcwd,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 	),
 	ANS(
 		uint16_t path;
@@ -338,7 +353,8 @@ CEPH_TYPE(ceph_getcwd,
 );
 
 CEPH_TYPE(ceph_readdir,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t dir;
 	),
 	ANS(
@@ -347,7 +363,8 @@ CEPH_TYPE(ceph_readdir,
 );
 
 CEPH_TYPE(ceph_rewinddir,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t dir;
 	),
 	ANS(
@@ -355,7 +372,8 @@ CEPH_TYPE(ceph_rewinddir,
 );
 
 CEPH_TYPE(ceph_ll_open,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		int32_t flags;
@@ -366,7 +384,8 @@ CEPH_TYPE(ceph_ll_open,
 );
 
 CEPH_TYPE(ceph_ll_create,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		mode_t mode;
@@ -382,7 +401,8 @@ CEPH_TYPE(ceph_ll_create,
 );
 
 CEPH_TYPE(ceph_ll_mknod,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		mode_t mode;
@@ -397,7 +417,8 @@ CEPH_TYPE(ceph_ll_mknod,
 );
 
 CEPH_TYPE(ceph_ll_close,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t fh;
 	),
 	ANS(
@@ -405,7 +426,8 @@ CEPH_TYPE(ceph_ll_close,
 );
 
 CEPH_TYPE(ceph_ll_rename,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t old_parent;
 		uint64_t new_parent;
@@ -417,7 +439,8 @@ CEPH_TYPE(ceph_ll_rename,
 );
 
 CEPH_TYPE(ceph_ll_lseek,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t fh;
 		off_t offset;
 		int32_t whence;
@@ -428,7 +451,8 @@ CEPH_TYPE(ceph_ll_lseek,
 );
 
 CEPH_TYPE(ceph_ll_read,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t fh;
 		int64_t offset;
 		uint64_t len;
@@ -438,7 +462,8 @@ CEPH_TYPE(ceph_ll_read,
 );
 
 CEPH_TYPE(ceph_ll_write,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t fh;
 		int64_t offset;
 		uint64_t len;
@@ -448,7 +473,8 @@ CEPH_TYPE(ceph_ll_write,
 );
 
 CEPH_TYPE(ceph_ll_link,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		uint64_t parent;
@@ -459,7 +485,8 @@ CEPH_TYPE(ceph_ll_link,
 );
 
 CEPH_TYPE(ceph_ll_unlink,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		uint16_t name;
@@ -469,7 +496,8 @@ CEPH_TYPE(ceph_ll_unlink,
 );
 
 CEPH_TYPE(ceph_ll_getattr,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		uint32_t want;
@@ -480,7 +508,8 @@ CEPH_TYPE(ceph_ll_getattr,
 );
 
 CEPH_TYPE(ceph_ll_setattr,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		int32_t mask;
@@ -490,7 +519,8 @@ CEPH_TYPE(ceph_ll_setattr,
 );
 
 CEPH_TYPE(ceph_ll_fallocate,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t fh;
 		int64_t offset;
 		int64_t length;
@@ -501,7 +531,8 @@ CEPH_TYPE(ceph_ll_fallocate,
 );
 
 CEPH_TYPE(ceph_ll_fsync,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t fh;
 		int32_t dataonly;
 	),
@@ -510,7 +541,8 @@ CEPH_TYPE(ceph_ll_fsync,
 );
 
 CEPH_TYPE(ceph_ll_listxattr,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		size_t size;
@@ -521,7 +553,8 @@ CEPH_TYPE(ceph_ll_listxattr,
 );
 
 CEPH_TYPE(ceph_ll_getxattr,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		size_t size;
@@ -532,7 +565,8 @@ CEPH_TYPE(ceph_ll_getxattr,
 );
 
 CEPH_TYPE(ceph_ll_setxattr,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		size_t size;
@@ -544,7 +578,8 @@ CEPH_TYPE(ceph_ll_setxattr,
 );
 
 CEPH_TYPE(ceph_ll_removexattr,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		uint16_t name;
@@ -554,7 +589,8 @@ CEPH_TYPE(ceph_ll_removexattr,
 );
 
 CEPH_TYPE(ceph_ll_readlink,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		size_t size;
@@ -564,7 +600,8 @@ CEPH_TYPE(ceph_ll_readlink,
 );
 
 CEPH_TYPE(ceph_ll_symlink,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		uint32_t want;
@@ -578,7 +615,8 @@ CEPH_TYPE(ceph_ll_symlink,
 );
 
 CEPH_TYPE(ceph_ll_opendir,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 	),
@@ -588,7 +626,8 @@ CEPH_TYPE(ceph_ll_opendir,
 );
 
 CEPH_TYPE(ceph_ll_mkdir,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		mode_t mode;
@@ -602,7 +641,8 @@ CEPH_TYPE(ceph_ll_mkdir,
 );
 
 CEPH_TYPE(ceph_ll_rmdir,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		uint16_t name;
@@ -612,7 +652,8 @@ CEPH_TYPE(ceph_ll_rmdir,
 );
 
 CEPH_TYPE(ceph_ll_releasedir,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t dir;
 	),
 	ANS(
@@ -620,7 +661,8 @@ CEPH_TYPE(ceph_ll_releasedir,
 );
 
 CEPH_TYPE(ceph_mount_perms,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 	),
 	ANS(
 		uint64_t userperm;
@@ -628,7 +670,8 @@ CEPH_TYPE(ceph_mount_perms,
 );
 
 CEPH_TYPE(ceph_ll_nonblocking_readv_writev,
-	REQ_CMOUNT(
+	REQ(
+		uint64_t cmount;
 		uint64_t info;
 		uint64_t fh;
 		int64_t off;

--- a/src/libcephfs_proxy/proxy_requests.h
+++ b/src/libcephfs_proxy/proxy_requests.h
@@ -127,42 +127,25 @@ enum {
 	LIBCEPHFSD_CBK_TOTAL_OPS
 };
 
-#define CEPH_TYPE_REQ(_name, _fields...)                           \
-	struct _proxy_##_name##_req;                               \
-	typedef struct _proxy_##_name##_req proxy_##_name##_req_t; \
-	struct _proxy_##_name##_req {                              \
-		_fields                                            \
-	}
+#define PROTO_REQ(_fields...) proxy_link_req_t header; _fields
+#define PROTO_ANS(_fields...) proxy_link_ans_t header; _fields
+#define PROTO_CBK(_fields...) proxy_link_req_t header; _fields
 
-#define CEPH_TYPE_ANS(_name, _fields...)                           \
-	struct _proxy_##_name##_ans;                               \
-	typedef struct _proxy_##_name##_ans proxy_##_name##_ans_t; \
-	struct _proxy_##_name##_ans {                              \
-		_fields                                            \
-	}
+#define PROTO_TYPE(_name, _fields...) typedef struct { _fields } _name
 
-#define CEPH_TYPE_CBK(_name, _fields...)                           \
-	struct _proxy_##_name##_cbk;                               \
-	typedef struct _proxy_##_name##_cbk proxy_##_name##_cbk_t; \
-	struct _proxy_##_name##_cbk {                              \
-		_fields                                            \
-	}
+#define PROTO_CALL(_name, _req, _ans) \
+	PROTO_TYPE(proxy_##_name##_req_t, _req);  \
+	PROTO_TYPE(proxy_##_name##_ans_t, _ans)
 
-#define FIELDS(_fields...) _fields
-#define REQ(_fields...) FIELDS(proxy_link_req_t header; _fields)
-#define ANS(_fields...) FIELDS(proxy_link_ans_t header; _fields)
-#define CBK(_fields...) FIELDS(proxy_link_req_t header; _fields)
+#define PROTO_NOTIFY(_name, _cbk) \
+	PROTO_TYPE(proxy_##_name##_cbk_t, _cbk)
 
-#define CEPH_TYPE(_name, _req, _ans) \
-	CEPH_TYPE_REQ(_name, _req);  \
-	CEPH_TYPE_ANS(_name, _ans)
+/* Declaration of types used to transfer requests and answers. */
 
-/* Declaration of types used to transder requests and answers. */
-
-CEPH_TYPE(ceph_version,
-	REQ(
+PROTO_CALL(ceph_version,
+	PROTO_REQ(
 	),
-	ANS(
+	PROTO_ANS(
 		int32_t major;
 		int32_t minor;
 		int32_t patch;
@@ -170,117 +153,117 @@ CEPH_TYPE(ceph_version,
 	)
 );
 
-CEPH_TYPE(ceph_userperm_new,
-	REQ(
+PROTO_CALL(ceph_userperm_new,
+	PROTO_REQ(
 		uint32_t uid;
 		uint32_t gid;
 		uint32_t groups;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t userperm;
 	)
 );
 
-CEPH_TYPE(ceph_userperm_destroy,
-	REQ(
+PROTO_CALL(ceph_userperm_destroy,
+	PROTO_REQ(
 		uint64_t userperm;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_create,
-	REQ(
+PROTO_CALL(ceph_create,
+	PROTO_REQ(
 		int16_t id;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t cmount;
 	)
 );
 
-CEPH_TYPE(ceph_release,
-	REQ(
+PROTO_CALL(ceph_release,
+	PROTO_REQ(
 		uint64_t cmount;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_conf_read_file,
-	REQ(
+PROTO_CALL(ceph_conf_read_file,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint16_t path;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_conf_get,
-	REQ(
+PROTO_CALL(ceph_conf_get,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint32_t size;
 		uint16_t option;
 	),
-	ANS(
+	PROTO_ANS(
 		uint16_t value;
 	)
 );
 
-CEPH_TYPE(ceph_conf_set,
-	REQ(
+PROTO_CALL(ceph_conf_set,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint16_t option;
 		uint16_t value;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_init,
-	REQ(
+PROTO_CALL(ceph_init,
+	PROTO_REQ(
 		uint64_t cmount;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_select_filesystem,
-	REQ(
+PROTO_CALL(ceph_select_filesystem,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint16_t fs;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_mount,
-	REQ(
+PROTO_CALL(ceph_mount,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint16_t root;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_unmount,
-	REQ(
+PROTO_CALL(ceph_unmount,
+	PROTO_REQ(
 		uint64_t cmount;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_statfs,
-	REQ(
+PROTO_CALL(ceph_ll_statfs,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t inode;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_lookup,
-	REQ(
+PROTO_CALL(ceph_ll_lookup,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
@@ -288,103 +271,103 @@ CEPH_TYPE(ceph_ll_lookup,
 		uint32_t flags;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 	)
 );
 
-CEPH_TYPE(ceph_ll_lookup_inode,
-	REQ(
+PROTO_CALL(ceph_ll_lookup_inode,
+	PROTO_REQ(
 		uint64_t cmount;
 		struct inodeno_t ino;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 	)
 );
 
-CEPH_TYPE(ceph_ll_lookup_root,
-	REQ(
+PROTO_CALL(ceph_ll_lookup_root,
+	PROTO_REQ(
 		uint64_t cmount;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 	)
 );
 
-CEPH_TYPE(ceph_ll_put,
-	REQ(
+PROTO_CALL(ceph_ll_put,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t inode;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_walk,
-	REQ(
+PROTO_CALL(ceph_ll_walk,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint32_t want;
 		uint32_t flags;
 		uint16_t path;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 	)
 );
 
-CEPH_TYPE(ceph_chdir,
-	REQ(
+PROTO_CALL(ceph_chdir,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint16_t path;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_getcwd,
-	REQ(
+PROTO_CALL(ceph_getcwd,
+	PROTO_REQ(
 		uint64_t cmount;
 	),
-	ANS(
+	PROTO_ANS(
 		uint16_t path;
 	)
 );
 
-CEPH_TYPE(ceph_readdir,
-	REQ(
+PROTO_CALL(ceph_readdir,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t dir;
 	),
-	ANS(
+	PROTO_ANS(
 		bool eod;
 	)
 );
 
-CEPH_TYPE(ceph_rewinddir,
-	REQ(
+PROTO_CALL(ceph_rewinddir,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t dir;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_open,
-	REQ(
+PROTO_CALL(ceph_ll_open,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		int32_t flags;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t fh;
 	)
 );
 
-CEPH_TYPE(ceph_ll_create,
-	REQ(
+PROTO_CALL(ceph_ll_create,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
@@ -394,14 +377,14 @@ CEPH_TYPE(ceph_ll_create,
 		uint32_t flags;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 		uint64_t fh;
 	)
 );
 
-CEPH_TYPE(ceph_ll_mknod,
-	REQ(
+PROTO_CALL(ceph_ll_mknod,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
@@ -411,22 +394,22 @@ CEPH_TYPE(ceph_ll_mknod,
 		uint32_t flags;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 	)
 );
 
-CEPH_TYPE(ceph_ll_close,
-	REQ(
+PROTO_CALL(ceph_ll_close,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t fh;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_rename,
-	REQ(
+PROTO_CALL(ceph_ll_rename,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t old_parent;
@@ -434,138 +417,138 @@ CEPH_TYPE(ceph_ll_rename,
 		uint16_t old_name;
 		uint16_t new_name;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_lseek,
-	REQ(
+PROTO_CALL(ceph_ll_lseek,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t fh;
 		off_t offset;
 		int32_t whence;
 	),
-	ANS(
+	PROTO_ANS(
 		off_t offset;
 	)
 );
 
-CEPH_TYPE(ceph_ll_read,
-	REQ(
+PROTO_CALL(ceph_ll_read,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t fh;
 		int64_t offset;
 		uint64_t len;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_write,
-	REQ(
+PROTO_CALL(ceph_ll_write,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t fh;
 		int64_t offset;
 		uint64_t len;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_link,
-	REQ(
+PROTO_CALL(ceph_ll_link,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		uint64_t parent;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_unlink,
-	REQ(
+PROTO_CALL(ceph_ll_unlink,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_getattr,
-	REQ(
+PROTO_CALL(ceph_ll_getattr,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		uint32_t want;
 		uint32_t flags;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_setattr,
-	REQ(
+PROTO_CALL(ceph_ll_setattr,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		int32_t mask;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_fallocate,
-	REQ(
+PROTO_CALL(ceph_ll_fallocate,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t fh;
 		int64_t offset;
 		int64_t length;
 		int32_t mode;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_fsync,
-	REQ(
+PROTO_CALL(ceph_ll_fsync,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t fh;
 		int32_t dataonly;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_listxattr,
-	REQ(
+PROTO_CALL(ceph_ll_listxattr,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		size_t size;
 	),
-	ANS(
+	PROTO_ANS(
 		size_t size;
 	)
 );
 
-CEPH_TYPE(ceph_ll_getxattr,
-	REQ(
+PROTO_CALL(ceph_ll_getxattr,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		size_t size;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_setxattr,
-	REQ(
+PROTO_CALL(ceph_ll_setxattr,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
@@ -573,34 +556,34 @@ CEPH_TYPE(ceph_ll_setxattr,
 		int32_t flags;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_removexattr,
-	REQ(
+PROTO_CALL(ceph_ll_removexattr,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_readlink,
-	REQ(
+PROTO_CALL(ceph_ll_readlink,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 		size_t size;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_symlink,
-	REQ(
+PROTO_CALL(ceph_ll_symlink,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
@@ -609,24 +592,24 @@ CEPH_TYPE(ceph_ll_symlink,
 		uint16_t name;
 		uint16_t target;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 	)
 );
 
-CEPH_TYPE(ceph_ll_opendir,
-	REQ(
+PROTO_CALL(ceph_ll_opendir,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t inode;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t dir;
 	)
 );
 
-CEPH_TYPE(ceph_ll_mkdir,
-	REQ(
+PROTO_CALL(ceph_ll_mkdir,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
@@ -635,42 +618,42 @@ CEPH_TYPE(ceph_ll_mkdir,
 		uint32_t flags;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t inode;
 	)
 );
 
-CEPH_TYPE(ceph_ll_rmdir,
-	REQ(
+PROTO_CALL(ceph_ll_rmdir,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t userperm;
 		uint64_t parent;
 		uint16_t name;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_ll_releasedir,
-	REQ(
+PROTO_CALL(ceph_ll_releasedir,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t dir;
 	),
-	ANS(
+	PROTO_ANS(
 	)
 );
 
-CEPH_TYPE(ceph_mount_perms,
-	REQ(
+PROTO_CALL(ceph_mount_perms,
+	PROTO_REQ(
 		uint64_t cmount;
 	),
-	ANS(
+	PROTO_ANS(
 		uint64_t userperm;
 	)
 );
 
-CEPH_TYPE(ceph_ll_nonblocking_readv_writev,
-	REQ(
+PROTO_CALL(ceph_ll_nonblocking_readv_writev,
+	PROTO_REQ(
 		uint64_t cmount;
 		uint64_t info;
 		uint64_t fh;
@@ -680,7 +663,7 @@ CEPH_TYPE(ceph_ll_nonblocking_readv_writev,
 		bool fsync;
 		bool syncdataonly;
 	),
-	ANS(
+	PROTO_ANS(
 		int64_t res;
 	)
 );
@@ -738,8 +721,8 @@ typedef union _proxy_req {
 	proxy_ceph_ll_nonblocking_readv_writev_req_t ll_nonblocking_rw;
 } proxy_req_t;
 
-CEPH_TYPE_CBK(ceph_ll_nonblocking_readv_writev,
-	CBK(
+PROTO_NOTIFY(ceph_ll_nonblocking_readv_writev,
+	PROTO_CBK(
 		uint64_t info;
 		int64_t res;
 	)


### PR DESCRIPTION
Backport of #62658 and #64716 

<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
