### PR TITLE
qa: Improve teuthology test failure reason when daemon crashes

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -776,6 +776,7 @@ def cluster(ctx, config):
     ctx.ceph[cluster_name] = argparse.Namespace()
     ctx.ceph[cluster_name].conf = conf
     ctx.ceph[cluster_name].mons = mons
+    ctx.ceph[cluster_name].assert_trackers = []
 
     default_keyring = '/etc/ceph/{cluster}.keyring'.format(cluster=cluster_name)
     keyring_path = config.get('keyring_path', default_keyring)
@@ -1401,6 +1402,66 @@ def run_daemon(ctx, config, type_):
     :param config: Configuration
     :param type_: Role type
     """
+    class AssertTracker(StringIO):
+        MAX_BT_LINES = 100
+        DISPLAY_BT_LINES = 7
+
+        def __init__(self, cluster_name, type_, id_, logger):
+            super().__init__()
+            self.role = cluster_name + '.' + type_
+            self.id_ = id_
+            self.bt_lines = []
+            self.assertion = None
+            self.backtrace = None
+            self.in_bt = False
+            self.logger = logger
+            self.failure_time = None
+
+        def write(self, line):
+            if "FAILED ceph_assert" in line or "__ceph_assert_fail" in line:
+                self.assertion = line.strip()
+            if line.startswith(" ceph version"):
+                # The start of a backtrace!
+                self.bt_lines = [line]
+                self.in_bt = True
+                self.failure_time = time.time()
+            elif line.startswith(" NOTE: a copy of the executable") or \
+                 line.strip().endswith("clone()") or \
+                 "clone()+0x" in line:
+                # The backtrace terminated
+                if len(self.bt_lines):
+                    if self.assertion is not None:
+                        self.bt_lines.insert(0, self.assertion)
+                        self.assertion = None
+                    # Limit number of lines of backtrace in the failure reason
+                    self.backtrace = ("".join(self.bt_lines[:self.DISPLAY_BT_LINES])).strip()
+                else:
+                    self.logger.warning("Saw end of backtrace but not start")
+                self.in_bt = False
+            elif self.in_bt:
+                # We're in a backtrace, push the line onto the list
+                if len(self.bt_lines) > self.MAX_BT_LINES:
+                    self.logger.warning("Failed to capture backtrace")
+                    self.bt_lines = ["Failed to capture backtrace", self.assertion]
+                    self.in_bt = False
+                else:
+                    # Backtrace filtering - skip lines for libraries, but include
+                    # libraries with ceph or rados in their path or name
+                    if "ceph" in line or "rados" in line or not re.match(r" [0-9]+: /.*", line):
+                        # Truncate long lines
+                        line = re.sub(r"([0-9]+: .{80}).*(\+0x[0-9a-fA-F]*\) \[0x[0-9a-fA-F]*\])", r"\1 ... \2", line)
+                        self.bt_lines.append(line)
+
+        def get_exception(self):
+            if self.backtrace is not None:
+                return Exception(self.backtrace)
+            if self.assertion is not None:
+                return Exception(self.assertion)
+            return None
+
+        def match_role_and_id(self, role, id_):
+            return self.role == role and self.id_ == id_
+
     cluster_name = config['cluster']
     log.info('Starting %s daemons in cluster %s...', type_, cluster_name)
     testdir = teuthology.get_testdir(ctx)
@@ -1501,13 +1562,17 @@ def run_daemon(ctx, config, type_):
                 maybe_redirect_stderr(config, type_, run_cmd, log_path)
             if create_log_cmd:
                 remote.sh(create_log_cmd)
+
             # always register mgr; don't necessarily start
+            asserttracker = AssertTracker(cluster_name, type_, id_, log.getChild(role))
+            ctx.ceph[cluster_name].assert_trackers.append(asserttracker)
             ctx.daemons.register_daemon(
                 remote, type_, id_,
                 cluster=cluster_name,
                 args=run_cmd,
                 logger=log.getChild(role),
                 stdin=run.PIPE,
+                stderr=asserttracker,
                 wait=False
             )
             if type_ != 'mgr' or not config.get('skip_mgr_daemons', False):

--- a/qa/tasks/daemonwatchdog.py
+++ b/qa/tasks/daemonwatchdog.py
@@ -1,6 +1,7 @@
 import logging
 import signal
 import time
+import traceback
 
 from gevent import sleep
 from gevent.greenlet import Greenlet
@@ -15,7 +16,7 @@ class BarkError(Exception):
     """
 
     def __init__(self, bark_reason):
-        self.message = f"The WatchDog barked due to {bark_reason}"
+        self.message = f"Watchdog timeout: {bark_reason}"
         super().__init__(self.message)
 
 class DaemonWatchdog(Greenlet):
@@ -61,6 +62,7 @@ class DaemonWatchdog(Greenlet):
         self.stopping = Event()
         self.thrashers = ctx.ceph[config["cluster"]].thrashers
         self.watched_processes = ctx.ceph[config["cluster"]].watched_processes
+        self.assert_trackers = ctx.ceph[config["cluster"]].assert_trackers
 
     def _run(self):
         try:
@@ -113,7 +115,7 @@ class DaemonWatchdog(Greenlet):
         daemon_timeout = int(self.config.get('daemon_timeout', 300))
         daemon_restart = self.config.get('daemon_restart', False)
         daemon_failure_time = {}
-        bark_reason: str = ""
+        bark_reason = []
         while not self.stopping.is_set():
             bark = False
             now = time.time()
@@ -131,39 +133,92 @@ class DaemonWatchdog(Greenlet):
             daemon_failures.extend(filter(lambda daemon: daemon.finished(), rgws))
             daemon_failures.extend(filter(lambda daemon: daemon.finished(), mgrs))
 
-            for daemon in daemon_failures:
-                name = daemon.role + '.' + daemon.id_
-                dt = daemon_failure_time.setdefault(name, (daemon, now))
-                assert dt[0] is daemon
-                delta = now-dt[1]
-                self.log("daemon {name} is failed for ~{t:.0f}s".format(name=name, t=delta))
-                if delta > daemon_timeout:
-                    bark = True
-                    bark_reason = f"Daemon {name} has failed"
-                if daemon_restart == 'normal' and daemon.proc.exitstatus == 0:
-                    self.log(f"attempting to restart daemon {name}")
-                    daemon.restart()
+            def shorten_failure_list(failures, reason):
+                if len(failures) > 1:
+                    # Remove common prefixes from failure list
+                    last=""
+                    failures2 = []
+                    for f in failures:
+                        p = last.split(".")
+                        n = f.split(".")
+                        if p[0] != n[0] or len(p) == 1 or len(n) == 1:
+                            failures2.append(f)
+                        elif p[1] != n[1] or len(n) == 2:
+                            failures2.append(".".join(n[1:]))
+                        else:
+                            failures2.append(".".join(n[2:]))
+                        last = f
+                    failure_list = ",".join(failures2)
+                    bark_reason.append(f"Multiple daemons {failure_list} have {reason}")
+                elif len(failures) == 1:
+                    bark_reason.append(f"Daemon {failures[0]} has {reason}")
 
-            # If a daemon is no longer failed, remove it from tracking:
-            for name in list(daemon_failure_time.keys()):
-                if name not in [d.role + '.' + d.id_ for d in daemon_failures]:
-                    self.log("daemon {name} has been restored".format(name=name))
-                    del daemon_failure_time[name]
+            try:
+                earliest = None
+                failures = []
+                for daemon in daemon_failures:
+                    name = daemon.role + '.' + daemon.id_
+                    dt = daemon_failure_time.setdefault(name, (daemon, now))
+                    assert dt[0] is daemon
+                    delta = now-dt[1]
+                    self.log("daemon {name} is failed for ~{t:.0f}s".format(name=name, t=delta))
+                    if delta > daemon_timeout:
+                        bark = True
+                        failures.append(f"{name}")
+                        for at in self.assert_trackers:
+                            if at.match_role_and_id(daemon.role, daemon.id_):
+                                exception = at.get_exception()
+                                if exception is not None:
+                                    if earliest is None or at.failure_time < earliest.failure_time:
+                                        earliest = at
 
-            for thrasher in self.thrashers:
-                if thrasher.exception is not None:
-                    self.log("{name} failed".format(name=thrasher.name))
-                    bark_reason = f"Thrasher {name} threw exception {thrasher.exception}"
-                    bark = True
+                    if daemon_restart == 'normal' and daemon.proc.exitstatus == 0:
+                        self.log(f"attempting to restart daemon {name}")
+                        daemon.restart()
 
-            for proc in self.watched_processes:
-                if proc.exception is not None:
-                    self.log("Remote process %s failed" % proc.id)
-                    bark_reason = f"Remote process {proc.id} threw exception {proc.exception}"
-                    bark = True
+                shorten_failure_list(failures, "timed out")
+
+                # If a daemon is no longer failed, remove it from tracking:
+                for name in list(daemon_failure_time.keys()):
+                    if name not in [d.role + '.' + d.id_ for d in daemon_failures]:
+                        self.log("daemon {name} has been restored".format(name=name))
+                        del daemon_failure_time[name]
+
+                for thrasher in self.thrashers:
+                    if thrasher.exception is not None:
+                        self.log("{name} failed".format(name=thrasher.name))
+                        bark_reason.append(f"Thrasher {name} threw exception {thrasher.exception}")
+                        bark = True
+
+                for proc in self.watched_processes:
+                    if proc.exception is not None:
+                        self.log("Remote process %s failed" % proc.id)
+                        bark_reason.append(f"Remote process {proc.id} threw exception {proc.exception}")
+                        bark = True
+
+                # If a thrasher or watched process failed then check for the earliest daemon failure
+                failures = []
+                if bark and earliest is None:
+                    for at in self.assert_trackers:
+                        exception = at.get_exception()
+                        if exception is not None:
+                            failures.append(f"{at.role}.{at.id_}")
+                            if earliest is None or at.failure_time < earliest.failure_time:
+                                earliest = at
+
+                shorten_failure_list(failures, "crashed")
+
+                # Only report details about one daemon failure
+                if earliest is not None:
+                    bark_reason.append(f"First crash: Daemon {earliest.role}.{earliest.id_} at {time.ctime(earliest.failure_time)}")
+                    bark_reason.append(f"{earliest.get_exception()}")
+
+            except:
+                bark = True
+                bark_reason.append(f"Watchdog bug {traceback.format_exc()}")
 
             if bark:
-                self.bark(bark_reason)
+                self.bark("\n".join(bark_reason))
                 return
 
             sleep(5)

--- a/qa/tasks/watched_process.py
+++ b/qa/tasks/watched_process.py
@@ -4,12 +4,12 @@ WatchedProcess process base class.
 This can be applied to an object that we want the DaemonWatchdog to monitor
 for failure, and bark when it sees an error
 """
+from logging import Logger
 
-from abc import ABCMeta, abstractmethod
-from typing import Optional
+from abc import ABCMeta
+from typing import Optional, Any
 
 from gevent.greenlet import Greenlet
-
 
 class WatchedProcess(Greenlet, metaclass=ABCMeta):
     """
@@ -18,19 +18,23 @@ class WatchedProcess(Greenlet, metaclass=ABCMeta):
     The abstract base class for a process that the DaemonWatchdog can monitor
     for errors. It is based on the ThrasherGreenlet class in qa/tasks/thrasher.py
     """
-    def __init__(self) -> None:
+    def __init__(self, ctx: dict[Any, Any], log: Logger, process: str, cluster: str, sub_processes: dict[str, Any]) -> None:
+        self._log = log
         self._exception: Optional[BaseException] = None
+        self._sub_processes = sub_processes
+        self._name: str = f"{process}-{cluster}"
+        ctx.ceph[cluster].watched_processes.append(self)
 
     @property
     def exception(self) -> Optional[BaseException]:
         return self._exception
 
     @property
-    @abstractmethod
     def id(self) -> str:
         """
         Return a string identifier for this process
         """
+        return self._name
 
     def set_exception(self, e: Exception) -> None:
         """
@@ -38,8 +42,21 @@ class WatchedProcess(Greenlet, metaclass=ABCMeta):
         """
         self._exception = e
 
-    @abstractmethod
+    def try_set_exception(self, e: Exception) -> None:
+        """
+        Set the exception for this process unless there is a previous exception
+        """
+        if (self._exception is None):
+            self._exception = e
+
     def stop(self) -> None:
         """
         Stop the remote process running
         """
+        debug: str = f"Stopping {self._name}"
+        if self._exception:
+            debug += f" due to exception {self._exception}"
+        self.log.debug(debug)
+        for test_id, proc in self._sub_processes.items():
+            self.log.info("Stopping instance %s", test_id)
+            proc.stdin.close()


### PR DESCRIPTION
Improvement to the daemon watchdog that monitors daemons and fails the test if a daemon has stopped responding to provide better information about the daemons that have stopped responding, including an assert string and a condensed backtrace if a daemon has crashed.

https://pulpito.ceph.com/billscales-2025-08-15_13:42:55-rados:thrash-erasure-code-optimizations-main-distro-default-smithi/ is an example of a failed test with these changes. Prior to pull request 64889 this would have been reported as a dead job (and taken 8 hours to fail). With pull request 64889 it would have been reported as a watchdog timeout and failed a lot quicker.

The formatting of the job failure needs tweaking to preserve whitespace and newlines - this requires a tweak to the CSS files for pulpito and pulpito-ng. Separate PRs will deliver these changes.

Here is what it looks like with a modified CSS with some annotations to show the various techniques used to condense the failure reason (the first attempt at this PR produced a 30 line failure reason which is far too much detail). There is an unnecessary blank line at the start of the failure reason - this is also removed with the pulpito change

<img width="1265" height="649" alt="teuthologycrash" src="https://github.com/user-attachments/assets/2817b1f8-0819-4390-994a-73830936a77e" />

The objective of the change is to provide enough information in the failure reason for daemon crashes to be able to search for duplicates in the tracker.
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
