### PR TITLE
tentacle: smb: add remote control server

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -57,7 +57,7 @@ Create Cluster
 
    ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>] [--clustering=<clustering>] [--password-filter=<password_filter>] [--password-filter-out=<password_filter_out>]
 
-Create a new logical cluster, identified by the cluster id value. The cluster
+Create a new logical cluster, identified by the cluster ID value. The cluster
 create command must specify the authentication mode the cluster will use. This
 may either be one of:
 
@@ -278,7 +278,7 @@ password_filter
 ``resource_name`` arguments can take the following forms:
 
 - ``ceph.smb.cluster``: show all cluster resources
-- ``ceph.smb.cluster.<cluster_id>``: show specific cluster with given cluster id
+- ``ceph.smb.cluster.<cluster_id>``: show specific cluster with given cluster ID
 - ``ceph.smb.share``: show all share resources
 - ``ceph.smb.share.<cluster_id>``: show all share resources part of the given
   cluster
@@ -453,7 +453,7 @@ custom_ports
     ``smb``, ``smbmetrics``, ``ctdb``, and ``remote-control``. If a service
     name is not present in the mapping the default port will be used.
     For example, ``{"smb": 4455, "smbmetrics": 9009}`` will change the
-    ports used by smb for client access and the metrics exporter, but
+    ports used by SMB for client access and the metrics exporter, but
     not change the port used by the CTDB clustering daemon.
     Note - not all SMB clients are able to use alternate port numbers.
 bind_addrs
@@ -765,7 +765,7 @@ auth
     password
         Required string. The AD user's password
 linked_to_cluster:
-    Optional. A string containing a cluster id. If set, the resource may only
+    Optional. A string containing a cluster ID. If set, the resource may only
     be used with the linked cluster and will automatically be removed when the
     linked cluster is removed.
 
@@ -808,7 +808,7 @@ values
         name
             The name of the group
 linked_to_cluster:
-    Optional. A string containing a cluster id. If set, the resource may only
+    Optional. A string containing a cluster ID. If set, the resource may only
     be used with the linked cluster and will automatically be removed when the
     linked cluster is removed.
 
@@ -848,7 +848,7 @@ credential_type
 value:
     A string containing the TLS certificate or key value in PEM encoding.
 linked_to_cluster:
-    Optional. A string containing a cluster id. If set, the resource may only
+    Optional. A string containing a cluster ID. If set, the resource may only
     be used with the linked cluster and will automatically be removed when the
     linked cluster is removed.
 

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -450,8 +450,8 @@ custom_dns
 custom_ports
     Optional. A mapping of service names to port numbers that will override the
     default ports used for those services. The service names are:
-    ``smb``, ``smbmetrics``, and ``ctdb``. If a service name is not
-    present in the mapping the default port will be used.
+    ``smb``, ``smbmetrics``, ``ctdb``, and ``remote-control``. If a service
+    name is not present in the mapping the default port will be used.
     For example, ``{"smb": 4455, "smbmetrics": 9009}`` will change the
     ports used by smb for client access and the metrics exporter, but
     not change the port used by the CTDB clustering daemon.
@@ -506,6 +506,32 @@ public_addrs
         host. Run ``cephadm list-networks`` for an example of these mappings.
         If destination is not supplied the network is automatically determined
         using the address value supplied and taken as the destination.
+remote_control
+    Optional object. This object configures an SMB cluster to deploy an extra
+    ``remote control`` service. This service provides a gRPC server that
+    can be used to enumerate connected clients and disconnect clients from
+    shares. This service uses mTLS for authentication. By default, this service
+    uses port 54445. The port can be configured using the ``custom_ports``
+    parameter in the cluster resource. If the service is enabled and any of the
+    ``cert``, ``key``, or ``ca_cert`` fields are not populated mTLS will be
+    disabled and the service will operate in a read-only mode. Running the
+    service with mTLS disabled is not recommended.
+    Fields:
+
+    enabled
+        Optional boolean. If explicitly set to ``true`` or ``false`` this
+        field will enable or disable the remote control service. If left
+        unset the TLS fields will be checked - if the TLS fields are filled
+        automatically enable the service.
+    cert
+        Optional object. The fields are described in :ref:`tls source
+        fields<tls-source-fields>`
+    key
+        Optional object. The fields are described in :ref:`tls source
+        fields<tls-source-fields>`
+    ca_cert
+        Optional object. The fields are described in :ref:`tls source
+        fields<tls-source-fields>`
 custom_smb_global_options
     Optional mapping. Specify key-value pairs that will be directly added to
     the global ``smb.conf`` options (or equivalent) of a Samba server.  Do
@@ -560,6 +586,16 @@ source_type
 ref
     String. Required for ``source_type: resource``. Must refer to the ID of a
     ``ceph.smb.join.auth`` resource
+
+.. _tls-source-fields:
+
+A TLS source object supports the following fields:
+
+source_type
+    Optional. Must be ``resource`` if specified.
+ref
+    String. Required for ``source_type: resource``. Must refer to the ID of a
+    ``ceph.smb.tls.credential`` resource
 
 .. note::
    The ``source_type`` ``empty`` is generally only for debugging and testing
@@ -790,6 +826,52 @@ Example:
         - name: steves
           password: F00Bar123
         groups: []
+
+
+TLS Credential Resource
+------------------------
+
+TLS credential resources store copies of TLS files such as Certificates, Keys,
+or CA Certificates.
+A TLS credential resource supports the following fields:
+
+resource_type
+    A literal string ``ceph.smb.tls.credential``
+tls_credential_id
+    A short string identifying the TLS credential resource
+intent
+    One of ``present`` or ``removed``. If not provided, ``present`` is assumed.
+    If ``removed`` all following fields are optional
+credential_type
+    Required string.  The value may be one of ``cert``, ``key``, or ``ca-cert``.
+    This value indicates what type of TLS credential the value field holds.
+value:
+    A string containing the TLS certificate or key value in PEM encoding.
+linked_to_cluster:
+    Optional. A string containing a cluster id. If set, the resource may only
+    be used with the linked cluster and will automatically be removed when the
+    linked cluster is removed.
+
+Example:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.tls.credential
+    tls_credential_id: mycert1
+    credential_type: cert
+    # NOTE: The value below is truncated to make the documentation more
+    # consise. A real embedded certificate is expected to be valid and
+    # will be longer than this example.
+    value: |
+      -----BEGIN CERTIFICATE-----
+      MIIFDjCCA/agAwIBAgISBtFQfoXc4RmyVabbv28RClKdMA0GCSqGSIb3DQEBCwUA
+      MDMxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQwwCgYDVQQD
+      EwNSMTAwHhcNMjUwNTE5MTAyNzUyWhcNMjUwODE3MTAyNzUxWjASMRAwDgYDVQQD
+      EwdjZXBoLmlvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx6fif6PQ
+      LOTdnO8d1JHcF7D+oB/mQlplFz4vwq/GB6Y4oWK3uCQ4PPz/qyvE4wyvc5EPhjfg
+      d8XNc4ajEBcSUoRj3UwWwiA4oht0SyoJIfwVGp/kF5jxHhVCLdoaaqAxv7nAghWM
+      6Dg=
+      -----END CERTIFICATE-----
 
 
 A Declarative Configuration Example

--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -48,12 +48,14 @@ logger = logging.getLogger()
 _SCC = '/usr/bin/samba-container'
 _NODES_SUBCMD = [_SCC, 'ctdb-list-nodes']
 _MUTEX_SUBCMD = [_SCC, 'ctdb-rados-mutex']  # requires rados uri
+_ETC_SAMBA_TLS = '/etc/samba/tls'
 
 
 class Features(enum.Enum):
     DOMAIN = 'domain'
     CLUSTERED = 'clustered'
     CEPHFS_PROXY = 'cephfs-proxy'
+    REMOTE_CONTROL = 'remote-control'
 
     @classmethod
     def valid(cls, value: str) -> bool:
@@ -105,6 +107,7 @@ class Ports(enum.Enum):
     SMB = 445
     SMBMETRICS = 9922
     CTDB = 4379
+    REMOTE_CONTROL = 54445
 
     def customized(self, service_ports: Dict[str, int]) -> int:
         """Return a custom port value if it is present in service_ports or the
@@ -114,6 +117,53 @@ class Ports(enum.Enum):
         if port:
             return int(port)
         return int(self.value)
+
+
+@dataclasses.dataclass(frozen=True)
+class TLSFiles:
+    cert: str = ''
+    key: str = ''
+    ca_cert: str = ''
+
+    def __bool__(self) -> bool:
+        return bool(self.cert or self.key or self.ca_cert)
+
+    def _interior_path(self, value: str) -> str:
+        if not value:
+            return value
+        return f'{_ETC_SAMBA_TLS}/{value}'
+
+    @property
+    def cert_interior_path(self) -> str:
+        return self._interior_path(self.cert)
+
+    @property
+    def key_interior_path(self) -> str:
+        return self._interior_path(self.key)
+
+    @property
+    def ca_cert_interior_path(self) -> str:
+        return self._interior_path(self.ca_cert)
+
+    @classmethod
+    def match(cls, files: Iterable[str], service: str) -> 'TLSFiles':
+        kwargs: Dict[str, str] = {}
+        for filename in files:
+            if not filename.startswith(f'{service}.'):
+                continue
+            if filename.endswith('.ca.crt'):
+                kwargs['ca_cert'] = filename
+            elif filename.endswith('.crt'):
+                kwargs['cert'] = filename
+            elif filename.endswith('.key'):
+                kwargs['key'] = filename
+        return cls(**kwargs)
+
+
+@dataclasses.dataclass(frozen=True)
+class RemoteControlConfig:
+    port: int
+    tls_files: TLSFiles
 
 
 @dataclasses.dataclass(frozen=True)
@@ -145,6 +195,7 @@ class Config:
     )
     bind_to: List[BindInterface] = dataclasses.field(default_factory=list)
     proxy_image: str = ''
+    remote_control: Optional[RemoteControlConfig] = None
 
     def config_uris(self) -> List[str]:
         uris = [self.source_config]
@@ -275,6 +326,9 @@ class SMBDContainer(SambaContainerCommon):
             if self.cfg.metrics_port:
                 metrics_port = self.cfg.metrics_port
                 cargs.extend(self._publish(metrics_port, metrics_port))
+            if self.cfg.remote_control:
+                rc_port = self.cfg.remote_control.port
+                cargs.extend(self._publish(rc_port, rc_port))
         cargs.extend(_container_dns_args(self.cfg))
         return cargs
 
@@ -337,6 +391,38 @@ class SMBMetricsContainer(ContainerCommon):
         if self.cfg.bind_to:
             args.append(f'--address={self.cfg.bind_to[0].address}')
         return args
+
+
+class RemoteControlContainer(SambaContainerCommon):
+    def name(self) -> str:
+        return 'remotectl'
+
+    def args(self) -> List[str]:
+        args = super().args()
+        assert self.cfg.remote_control, 'remote_control is not configured'
+        args.append('serve')
+        args.append('--grpc')
+        address = self.cfg.bind_to[0].address if self.cfg.bind_to else '*'
+        port = self.cfg.remote_control.port
+        args.append(f'--address={address}:{port}')
+        if not self.cfg.remote_control.tls_files:
+            args.append('--insecure')
+        else:
+            cert_path = self.cfg.remote_control.tls_files.cert_interior_path
+            key_path = self.cfg.remote_control.tls_files.key_interior_path
+            ca_cert = self.cfg.remote_control.tls_files.ca_cert_interior_path
+            assert cert_path
+            assert key_path
+            args.append(f'--tls-cert={cert_path}')
+            args.append(f'--tls-key={key_path}')
+            if ca_cert:
+                args.append(f'--tls-ca-cert={ca_cert}')
+        return args
+
+    def container_args(self) -> List[str]:
+        return super().container_args() + [
+            '--entrypoint=samba-remote-control'
+        ]
 
 
 class CephFSProxyContainer(ContainerCommon):
@@ -462,6 +548,7 @@ class SMB(ContainerDaemonForm):
         self._identity = ident
         self._instance_cfg: Optional[Config] = None
         self._files: Dict[str, str] = {}
+        self._tls_files: Dict[str, str] = {}
         self._raw_configs: Dict[str, Any] = context_getters.fetch_configs(ctx)
         self._config_keyring = context_getters.get_config_and_keyring(ctx)
         self._cached_layout: Optional[ContainerLayout] = None
@@ -542,16 +629,29 @@ class SMB(ContainerDaemonForm):
             # cache the cephadm networks->devices mapping for later
             self._network_mapper.load()
 
+        self._organize_files(files)
+
+        if Features.REMOTE_CONTROL.value in instance_features:
+            remote_control_cfg = RemoteControlConfig(
+                port=Ports.REMOTE_CONTROL.customized(service_ports),
+                tls_files=TLSFiles.match(self._tls_files, 'remote_control'),
+            )
+        else:
+            remote_control_cfg = None
+
         rank, rank_gen = self._rank_info
         self._instance_cfg = Config(
+            # core configuration
             identity=self._identity,
             instance_id=instance_id,
             source_config=source_config,
             join_sources=join_sources,
             user_sources=user_sources,
             custom_dns=custom_dns,
+            # major features
             domain_member=Features.DOMAIN.value in instance_features,
             clustered=Features.CLUSTERED.value in instance_features,
+            # config details
             smb_port=Ports.SMB.customized(service_ports),
             ctdb_port=Ports.CTDB.customized(service_ports),
             ceph_config_entity=ceph_config_entity,
@@ -565,10 +665,13 @@ class SMB(ContainerDaemonForm):
             cluster_public_addrs=_public_addrs,
             proxy_image=proxy_image,
             bind_to=self._network_mapper.bind_interfaces(bind_networks),
+            remote_control=remote_control_cfg,
         )
-        self._files = files
         logger.debug('SMB Instance Config: %s', self._instance_cfg)
         logger.debug('Configured files: %s', self._files)
+        logger.debug(
+            'Configured TLS/SSL files: %s', list(self._tls_files.keys())
+        )
 
     @property
     def _cfg(self) -> Config:
@@ -622,6 +725,8 @@ class SMB(ContainerDaemonForm):
             ctrs.append(
                 CephFSProxyContainer(self._cfg, self._cfg.proxy_image)
             )
+        if self._cfg.remote_control:
+            ctrs.append(RemoteControlContainer(self._cfg))
 
         if self._cfg.clustered:
             init_ctrs += [
@@ -756,6 +861,9 @@ class SMB(ContainerDaemonForm):
         mounts[run_samba] = '/run:z'  # TODO: make this a shared tmpfs
         mounts[config] = '/etc/ceph/ceph.conf:z'
         mounts[keyring] = '/etc/ceph/keyring:z'
+        if self._tls_files:
+            tls_dir = str(data_dir / 'tls')
+            mounts[tls_dir] = f'{_ETC_SAMBA_TLS}:z'
         if self._cfg.clustered:
             ctdb_persistent = str(data_dir / 'ctdb/persistent')
             ctdb_run = str(data_dir / 'ctdb/run')  # TODO: tmpfs too!
@@ -802,6 +910,15 @@ class SMB(ContainerDaemonForm):
                 for addr in addrs:
                     endpoints.append(EndPoint(addr, self._cfg.metrics_port))
 
+    def _organize_files(self, files: Dict[str, str]) -> None:
+        # this separation is similar to how ceph services are set up
+        # regarding certs and keys
+        for key, value in files.items():
+            if key.endswith(('.crt', '.key')):
+                self._tls_files[key] = value
+            else:
+                self._files[key] = value
+
     def prepare_data_dir(self, data_dir: str, uid: int, gid: int) -> None:
         self.validate()
         ddir = pathlib.Path(data_dir)
@@ -811,6 +928,10 @@ class SMB(ContainerDaemonForm):
         file_utils.makedirs(ddir / 'run', uid, gid, 0o770)
         if self._files:
             file_utils.populate_files(data_dir, self._files, uid, gid)
+        if self._tls_files:
+            tls_dir = ddir / 'tls'
+            file_utils.makedirs(tls_dir, uid, gid, 0o700)
+            file_utils.populate_files(tls_dir, self._tls_files, uid, gid)
         if self._cfg.clustered:
             file_utils.makedirs(ddir / 'ctdb/persistent', uid, gid, 0o770)
             file_utils.makedirs(ddir / 'ctdb/run', uid, gid, 0o770)

--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -17,6 +17,8 @@ from typing import (
     Tuple,
 )
 
+import ceph.smb.constants
+
 from .. import context_getters
 from .. import daemon_form
 from .. import data_utils
@@ -104,19 +106,34 @@ class BindInterface(NamedTuple):
 
 
 class Ports(enum.Enum):
-    SMB = 445
-    SMBMETRICS = 9922
-    CTDB = 4379
-    REMOTE_CONTROL = 54445
+    SMB = ceph.smb.constants.SMB_PORT
+    SMBMETRICS = ceph.smb.constants.SMBMETRICS_PORT
+    CTDB = ceph.smb.constants.CTDB_PORT
+    REMOTE_CONTROL = ceph.smb.constants.REMOTE_CONTROL_PORT
 
     def customized(self, service_ports: Dict[str, int]) -> int:
         """Return a custom port value if it is present in service_ports or the
         default port value if it is not present.
         """
-        port = service_ports.get(self.name.lower())
+        port = service_ports.get(str(self))
         if port:
             return int(port)
         return int(self.value)
+
+    def __str__(self) -> str:
+        # NOTE: mypy is getting the key type below wrong. using reveal_type:
+        # >>> reveal_type(self.SMB)
+        # > note: Revealed type is "builtins.int"
+        # >>> reveal_type(self)
+        # > note: Revealed type is "cephadmlib.daemons.smb.Ports"
+        # maybe newer versions would not hit this issue?
+        names: Dict[Any, str] = {
+            self.SMB: ceph.smb.constants.SMB,
+            self.SMBMETRICS: ceph.smb.constants.SMBMETRICS,
+            self.CTDB: ceph.smb.constants.CTDB,
+            self.REMOTE_CONTROL: ceph.smb.constants.REMOTE_CONTROL,
+        }
+        return names[self]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/cephadm/cephadmlib/file_utils.py
+++ b/src/cephadm/cephadmlib/file_utils.py
@@ -54,7 +54,7 @@ def write_new(
 
 
 def populate_files(
-    config_dir: str, config_files: Dict, uid: int, gid: int
+    config_dir: Union[str, Path], config_files: Dict, uid: int, gid: int
 ) -> None:
     """create config files for different services"""
     for fname in config_files:

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -158,6 +158,23 @@ class SMBService(CephService):
         config_blobs['service_ports'] = smb_spec.service_ports()
         if smb_spec.bind_addrs:
             config_blobs['bind_networks'] = smb_spec.bind_networks()
+        if 'remote-control' in smb_spec.features:
+            files = config_blobs.setdefault('files', {})
+            _add_cfg(
+                files,
+                'remote_control.ssl.crt',
+                smb_spec.remote_control_ssl_cert,
+            )
+            _add_cfg(
+                files,
+                'remote_control.ssl.key',
+                smb_spec.remote_control_ssl_key,
+            )
+            _add_cfg(
+                files,
+                'remote_control.ca.crt',
+                smb_spec.remote_control_ca_cert,
+            )
 
         logger.debug('smb generate_config: %r', config_blobs)
         self._configure_cluster_meta(smb_spec, daemon_spec)

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -20,6 +20,11 @@ from ..schedule import DaemonPlacement
 logger = logging.getLogger(__name__)
 
 
+def _add_cfg(cfg_dict: Dict[str, Any], key: str, value: Any) -> None:
+    if value:
+        cfg_dict[key] = value
+
+
 @register_cephadm_service
 class SMBService(CephService):
     TYPE = 'smb'
@@ -130,19 +135,13 @@ class SMBService(CephService):
         config_blobs['cluster_id'] = smb_spec.cluster_id
         config_blobs['features'] = smb_spec.features
         config_blobs['config_uri'] = smb_spec.config_uri
-        if smb_spec.join_sources:
-            config_blobs['join_sources'] = smb_spec.join_sources
-        if smb_spec.user_sources:
-            config_blobs['user_sources'] = smb_spec.user_sources
-        if smb_spec.custom_dns:
-            config_blobs['custom_dns'] = smb_spec.custom_dns
-        if smb_spec.cluster_meta_uri:
-            config_blobs['cluster_meta_uri'] = smb_spec.cluster_meta_uri
-        if smb_spec.cluster_lock_uri:
-            config_blobs['cluster_lock_uri'] = smb_spec.cluster_lock_uri
+        _add_cfg(config_blobs, 'join_sources', smb_spec.join_sources)
+        _add_cfg(config_blobs, 'user_sources', smb_spec.user_sources)
+        _add_cfg(config_blobs, 'custom_dns', smb_spec.custom_dns)
+        _add_cfg(config_blobs, 'cluster_meta_uri', smb_spec.cluster_meta_uri)
+        _add_cfg(config_blobs, 'cluster_lock_uri', smb_spec.cluster_lock_uri)
         cluster_public_addrs = smb_spec.strict_cluster_ip_specs()
-        if cluster_public_addrs:
-            config_blobs['cluster_public_addrs'] = cluster_public_addrs
+        _add_cfg(config_blobs, 'cluster_public_addrs', cluster_public_addrs)
         ceph_users = smb_spec.include_ceph_users or []
         config_blobs.update(
             self._ceph_config_and_keyring_for(

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3897,7 +3897,12 @@ class TestSMB:
                 'keyring': '[client.smb.config.tango.briskly]\nkey = None\n',
                 'config_auth_entity': 'client.smb.config.tango.briskly',
                 'metrics_image': 'quay.io/samba.org/samba-metrics:ceph20-centos-amd64',
-                'service_ports': {'smb': 445, 'smbmetrics': 9922, 'ctdb': 4379},
+                'service_ports': {
+                    'smb': 445,
+                    'smbmetrics': 9922,
+                    'ctdb': 4379,
+                    'remote-control': 54445,
+                },
             },
         }
         with with_host(cephadm_module, 'hostx'):
@@ -3972,7 +3977,12 @@ class TestSMB:
                 ),
                 'config_auth_entity': 'client.smb.config.tango.briskly',
                 'metrics_image': 'quay.io/samba.org/samba-metrics:ceph20-centos-amd64',
-                'service_ports': {'smb': 445, 'smbmetrics': 9922, 'ctdb': 4379},
+                'service_ports': {
+                    'smb': 445,
+                    'smbmetrics': 9922,
+                    'ctdb': 4379,
+                    'remote-control': 54445,
+                },
             },
         }
         with with_host(cephadm_module, 'hostx'):

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -59,10 +59,16 @@ class AuthMode(_StrEnum):
     ACTIVE_DIRECTORY = 'active-directory'
 
 
+class SourceReferenceType(_StrEnum):
+    RESOURCE = 'resource'
+
+
+# NOTE: Use SourceReferenceType for new source objects
 class JoinSourceType(_StrEnum):
     RESOURCE = 'resource'
 
 
+# NOTE: Use SourceReferenceType for new source objects
 class UserGroupSourceType(_StrEnum):
     RESOURCE = 'resource'
     EMPTY = 'empty'

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -129,3 +129,11 @@ class InputPasswordFilter(_StrEnum):
         # but we want a InputPasswordFilter to be a strict subset of the
         # password filter enum.
         return PasswordFilter(self.value)
+
+
+class TLSCredentialType(_StrEnum):
+    """Specify the type of a TLS credential."""
+
+    CERT = 'cert'
+    KEY = 'key'
+    CA_CERT = 'ca-cert'

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -79,6 +79,7 @@ class ConfigNS(_StrEnum):
     SHARES = 'shares'
     USERS_AND_GROUPS = 'users_and_groups'
     JOIN_AUTHS = 'join_auths'
+    TLS_CREDENTIALS = 'tls_creds'
 
 
 class LoginCategory(_StrEnum):

--- a/src/pybind/mgr/smb/external.py
+++ b/src/pybind/mgr/smb/external.py
@@ -49,6 +49,18 @@ def spec_backup_key(cluster_id: str) -> EntryKey:
     return (cluster_id, 'spec.smb')
 
 
+def tls_credential_key(
+    cluster_id: str, tls_credential_id: str, cred_type: str
+) -> EntryKey:
+    """Return key identifying a TLS credential in an external store."""
+    suffix = {
+        'cert': 'ssl.crt',
+        'key': 'ssl.key',
+        'ca-cert': 'ca.crt',
+    }[cred_type]
+    return (cluster_id, f'{tls_credential_id}.{suffix}')
+
+
 # Enumerate keys in a store
 
 

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -625,35 +625,6 @@ class ClusterConfigHandler:
             _cephx_data_entity(cluster_id),
         )
 
-    def generate_smb_service_spec(self, cluster_id: str) -> SMBSpec:
-        """Demo function that generates a smb service spec on demand."""
-        cluster = self._cluster_entry(cluster_id).get_cluster()
-        # if the user manually puts custom configurations (aka "override"
-        # configs) in the store, use that in favor of the generated config.
-        # this is mainly intended for development/test
-        config_entries = [
-            self.public_store[external.config_key(cluster_id)],
-            self.public_store[external.config_key(cluster_id, override=True)],
-        ]
-        join_source_entries = [
-            self.priv_store[(cluster_id, key)]
-            for key in external.stored_join_source_keys(
-                self.priv_store, cluster_id
-            )
-        ]
-        user_source_entries = [
-            self.priv_store[(cluster_id, key)]
-            for key in external.stored_usergroup_source_keys(
-                self.priv_store, cluster_id
-            )
-        ]
-        return _generate_smb_service_spec(
-            cluster,
-            config_entries=config_entries,
-            join_source_entries=join_source_entries,
-            user_source_entries=user_source_entries,
-        )
-
 
 def order_resources(
     resource_objs: Iterable[SMBResource],

--- a/src/pybind/mgr/smb/internal.py
+++ b/src/pybind/mgr/smb/internal.py
@@ -206,6 +206,23 @@ class UsersAndGroupsEntry(CommonResourceEntry):
         return self.get_resource_type(resources.UsersAndGroups)
 
 
+class TLSCredentialEntry(CommonResourceEntry):
+    """TLSCredentialEntry resource getter/setter for the smb internal data
+    store(s).
+    """
+
+    namespace = ConfigNS.TLS_CREDENTIALS
+    _for_resource = resources.TLSCredential
+
+    @classmethod
+    def to_key(cls, resource: SMBResource) -> ResourceKey:
+        assert isinstance(resource, cls._for_resource)
+        return ResourceIDKey(resource.tls_credential_id)
+
+    def get_tls_credential(self) -> resources.TLSCredential:
+        return self.get_resource_type(resources.TLSCredential)
+
+
 def _map_resource_entry(
     resource: Union[SMBResource, Type[SMBResource]]
 ) -> Type[ResourceEntry]:
@@ -217,6 +234,7 @@ def _map_resource_entry(
         resources.RemovedShare: ShareEntry,
         resources.JoinAuth: JoinAuthEntry,
         resources.UsersAndGroups: UsersAndGroupsEntry,
+        resources.TLSCredential: TLSCredentialEntry,
     }
     try:
         return _map[rcls]

--- a/src/pybind/mgr/smb/mon_store.py
+++ b/src/pybind/mgr/smb/mon_store.py
@@ -146,6 +146,14 @@ class MonKeyStoreEntry:
         """Get the deserialized store entry value."""
         return json.loads(self._store._get_val(self._key))
 
+    def set_data(self, data: str) -> None:
+        """Set the store entry value to the given data."""
+        self._store._set_val(self._key, data)
+
+    def get_data(self) -> str:
+        """Get the stored data value."""
+        return self._store._get_val(self._key)
+
     def remove(self) -> bool:
         """Remove the current entry from the store."""
         return self._store.remove(self.full_key)

--- a/src/pybind/mgr/smb/mon_store.py
+++ b/src/pybind/mgr/smb/mon_store.py
@@ -168,7 +168,7 @@ class MonKeyStoreEntry:
         # The rados:mon-config-key pseudo scheme is made up for the
         # purposes of communicating a key using the URI syntax with
         # other components, particularly the sambacc library.
-        return f'rados:mon-config-key:{self._store_key}'
+        return f'{self._store.SCHEME}:{self._store_key}'
 
     @property
     def full_key(self) -> EntryKey:
@@ -191,6 +191,7 @@ class MonKeyConfigStore:
     """
 
     PREFIX = 'smb/config/'
+    SCHEME = 'rados:mon-config-key'
 
     def __init__(self, mc: MonCommandIssuer):
         self._mc = mc
@@ -282,3 +283,17 @@ class MonKeyConfigStore:
         if ret != 0:
             raise KeyError(f'config-key rm {key!r} failed [{ret}]: {err}')
         return json_data
+
+    def lookup_uri(self, uri: str) -> MonKeyStoreEntry:
+        _scheme = f'{self.SCHEME}:'
+        if not uri.startswith(_scheme):
+            raise ValueError(f'invalid uri: {uri}')
+        slen = len(_scheme)
+        path = uri[slen:]
+        if not path.startswith(self.PREFIX):
+            raise ValueError(f'invalid path: {path!r} from {uri}')
+        plen = len(self.PREFIX)
+        subpath = path[plen:]
+        key = tuple(subpath.split('/', 1))
+        assert len(key) == 2
+        return self[key]

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -62,17 +62,10 @@ class ResourceKey(Protocol):
         ...  # pragma: no cover
 
 
-class ConfigEntry(Protocol):
-    """A protocol for describing a configuration object that can be kept within
-    a configuration store. Has the ability to identify itself either by a
-    relative key or by a global URI value.
+class BaseEntry(Protocol):
+    """Base protocol class for Entry objects. Entry objects are stored
+    peristently and can by identified by an internal key or URI.
     """
-
-    def get(self) -> Simplified:
-        ...  # pragma: no cover
-
-    def set(self, obj: Simplified) -> None:
-        ...  # pragma: no cover
 
     def remove(self) -> bool:
         ...  # pragma: no cover
@@ -86,6 +79,29 @@ class ConfigEntry(Protocol):
 
     @property
     def full_key(self) -> EntryKey:
+        ...  # pragma: no cover
+
+
+class ConfigEntry(BaseEntry, Protocol):
+    """A protocol for describing a configuration object that can be kept within
+    a configuration store. Has the ability to identify itself either by a
+    relative key or by a global URI value.
+    """
+
+    def get(self) -> Simplified:
+        ...  # pragma: no cover
+
+    def set(self, obj: Simplified) -> None:
+        ...  # pragma: no cover
+
+
+class RawConfigEntry(BaseEntry, Protocol):
+    """Like a ConfigEntry but for opaque data blobs."""
+
+    def get_data(self) -> str:
+        ...  # pragma: no cover
+
+    def set_data(self, obj: Simplified) -> None:
         ...  # pragma: no cover
 
 

--- a/src/pybind/mgr/smb/resourcelib.py
+++ b/src/pybind/mgr/smb/resourcelib.py
@@ -223,6 +223,11 @@ class Field:
     default: Any = _unset
     quiet: bool = False  # customization value
     keep_none: bool = False  # customization value
+    # wrapper_type can be used to customize the output type of a scalar value.
+    # Typically this is used to assist YAML serialization.
+    # IMPORTANT: make sure the type produces valid YAML and JSON, ideally as
+    # subclass as a native type.
+    wrapper_type: Optional[Callable] = None
 
     def optional(self) -> bool:
         """Return true if the type of the field is Optional."""
@@ -462,11 +467,15 @@ class Resource:
             }
             return
 
+        if fld.wrapper_type:
+            _out = fld.wrapper_type
+        else:
+            _out = lambda v: v  # noqa: E731
         if isinstance(value, str):
-            data[fld.name] = str(value)
+            data[fld.name] = _out(str(value))
             return
         if isinstance(value, (int, float)):
-            data[fld.name] = value
+            data[fld.name] = _out(value)
             return
         raise ResourceTypeError(f'unexpected type for field {fld.name}')
 

--- a/src/pybind/mgr/smb/resourcelib.py
+++ b/src/pybind/mgr/smb/resourcelib.py
@@ -507,6 +507,11 @@ class Resource:
         _customize = getattr(resource_cls, '_customize_resource', None)
         if _customize is not None:
             resource = _customize(resource)
+            if not resource:
+                raise ValueError(
+                    '_customize_resource must return a valid resource object,'
+                    f' not {resource!r}'
+                )
         return resource
 
 

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -530,6 +530,8 @@ class Cluster(_RBase):
     # bind_addrs are used to restrict what IP addresses instances of this
     # cluster will use
     bind_addrs: Optional[List[ClusterBindIP]] = None
+    # configure a remote control sidecar server.
+    remote_control: Optional[RemoteControl] = None
 
     def validate(self) -> None:
         if not self.cluster_id:
@@ -575,6 +577,15 @@ class Cluster(_RBase):
     @property
     def clustering_mode(self) -> SMBClustering:
         return self.clustering if self.clustering else SMBClustering.DEFAULT
+
+    @property
+    def remote_control_is_enabled(self) -> bool:
+        """Return true if a remote control service should be enabled for this
+        cluster.
+        """
+        if not self.remote_control:
+            return False
+        return self.remote_control.is_enabled
 
     def is_clustered(self) -> bool:
         """Return true if smbd instance should use (CTDB) clustering."""

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -31,6 +31,8 @@ from .utils import checked
 
 ConversionOp = Tuple[PasswordFilter, PasswordFilter]
 
+_MASKED = '*' * 16
+
 
 def _get_intent(data: Simplified) -> Intent:
     """Helper function that returns the intent value from a data dict."""
@@ -644,7 +646,7 @@ def _password_convert(pvalue: str, operation: ConversionOp) -> str:
     if operation == (PasswordFilter.NONE, PasswordFilter.BASE64):
         pvalue = base64.b64encode(pvalue.encode("utf8")).decode("utf8")
     elif operation == (PasswordFilter.NONE, PasswordFilter.HIDDEN):
-        pvalue = "*" * 16
+        pvalue = _MASKED
     elif operation == (PasswordFilter.BASE64, PasswordFilter.NONE):
         pvalue = base64.b64decode(pvalue.encode("utf8")).decode("utf8")
     else:

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -25,6 +25,7 @@ from .enums import (
     LoginCategory,
     PasswordFilter,
     SMBClustering,
+    SourceReferenceType,
     TLSCredentialType,
     UserGroupSourceType,
 )
@@ -463,6 +464,27 @@ class ClusterBindIP(_RBase):
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.address.quiet = True
         rc.network.quiet = True
+        return rc
+
+
+@resourcelib.component()
+class TLSSource(_RBase):
+    """Represents TLS Certificates and Keys used to configure SMB related
+    resources.
+    """
+
+    source_type: SourceReferenceType = SourceReferenceType.RESOURCE
+    ref: str = ''
+
+    def validate(self) -> None:
+        if not self.ref:
+            raise ValueError('reference value must be specified')
+        else:
+            validation.check_id(self.ref)
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.ref.quiet = True
         return rc
 
 

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -488,6 +488,28 @@ class TLSSource(_RBase):
         return rc
 
 
+@resourcelib.component()
+class RemoteControl(_RBase):
+    # enabled can be set to explicitly toggle the remote control server
+    enabled: Optional[bool] = None
+    # cert specifies the ssl/tls certificate to use
+    cert: Optional[TLSSource] = None
+    # cert specifies the ssl/tls server key to use
+    key: Optional[TLSSource] = None
+    # ca_cert specifies the ssl/tls ca cert for mTLS auth
+    ca_cert: Optional[TLSSource] = None
+
+    def validate(self) -> None:
+        if bool(self.cert) ^ bool(self.key):
+            raise ValueError('cert and key values must be provided together')
+
+    @property
+    def is_enabled(self) -> bool:
+        if self.enabled is not None:
+            return self.enabled
+        return bool(self.cert and self.key)
+
+
 @resourcelib.resource('ceph.smb.cluster')
 class Cluster(_RBase):
     """Represents a cluster (instance) that is / should be present."""

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -506,6 +506,20 @@ class MirrorUsersAndGroups(Mirror):
         return filtered
 
 
+class MirrorTLSCredentials(Mirror):
+    """Mirroring configuration for objects in the tls_credentials namespace."""
+
+    def __init__(self, store: ConfigStore) -> None:
+        super().__init__('tls_credentials', store)
+
+    def filter_object(self, obj: Simplified) -> Simplified:
+        """Filter tls_credential for sqlite3 store."""
+        filtered = copy.deepcopy(obj)
+        if filtered.get('credential_type') and filtered.get('value'):
+            filtered.pop('value', None)
+        return filtered
+
+
 def _tables(
     *,
     specialize: bool = True,
@@ -526,6 +540,7 @@ def _tables(
         srt,
         SimpleTable('join_auths', 'join_auths'),
         SimpleTable('users_and_groups', 'users_and_groups'),
+        SimpleTable('tls_creds', 'tls_creds'),
     ]
 
 
@@ -539,6 +554,10 @@ def _mirror_join_auths(opts: Optional[Dict[str, str]] = None) -> bool:
 
 def _mirror_users_and_groups(opts: Optional[Dict[str, str]] = None) -> bool:
     return (opts or {}).get('mirror_users_and_groups') != 'no'
+
+
+def _mirror_tls_credentials(opts: Optional[Dict[str, str]] = None) -> bool:
+    return (opts or {}).get('mirror_tls_credentials') != 'no'
 
 
 def mgr_sqlite3_db(
@@ -566,6 +585,8 @@ def mgr_sqlite3_db_with_mirroring(
         mirrors.append(MirrorJoinAuths(mirror_store))
     if _mirror_users_and_groups(opts):
         mirrors.append(MirrorUsersAndGroups(mirror_store))
+    if _mirror_tls_credentials(opts):
+        mirrors.append(MirrorTLSCredentials(mirror_store))
     return SqliteMirroringStore(mgr, tables, mirrors)
 
 

--- a/src/pybind/mgr/smb/tests/test_resources.py
+++ b/src/pybind/mgr/smb/tests/test_resources.py
@@ -750,6 +750,59 @@ login_control:
     assert share.login_control[3].access == enums.LoginAccess.NONE
 
 
+def test_tls_credential():
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.tls.credential
+tls_credential_id: tc1
+credential_type: cert
+value: |
+  -----BEGIN CERTIFICATE-----
+  MIIGFjCCA/6gAwIBAgIUZLL4QTx5ESBYQYS761DcZ7S1c24wDQYJKoZIhvcNAQEN
+  BQAwgYgxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJNQTEPMA0GA1UEBwwGTG93ZWxs
+  MR8wHQYDVQQKDBZCaXJjaCBTdHJlZXQgQ29tcHV0aW5nMRYwFAYDVQQDDA1Kb2hu
+  IE11bGxpZ2FuMSIwIAYJKoZIhvcNAQkBFhNqb2hubUBhc3luY2hyb25vLnVzMB4X
+  DTI1MDYzMDE5MzAwM1oXDTI2MDcyNDE5MzAwM1owbjELMAkGA1UEBhMCVVMxCzAJ
+  BgNVBAgMAk1BMQ8wDQYDVQQHDAZMb3dlbGwxHzAdBgNVBAoMFkJpcmNoIFN0cmVl
+  dCBDb21wdXRpbmcxIDAeBgNVBAMMF0ROUzpjZXBoMC5jeC5mZG9wZW4ubmV0MIIC
+  IjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApZYqA73a8ojX7QsCJHiXh0J2
+  KKEqDU6k0Yjoie9raYCP/aaiJpffSjhKl1rYuIqjBUG5D0tdT3sRw3m96Nw6gkhM
+  5J8r02muQpJqmzPmfAn75IVjRkJ9OsHyS1Mf9GADTfv3pMBkwqqrGb8NxWQXeS4s
+  PLPBv8SI4ozFNwwlEvZ0kesI4Qf0VRZ1ieSzAArjDWWFX8kURMt6UzN8opnxGvzT
+  cfY4J0iKCYBK6Vqmf/OrMg3IjDojKaQqBlMPAQURyiYeF1hfDrcqGQC6S4Iz5mDt
+  ZsMywFQFlEhkWkhJdMMkY4bqvn01BKXl3WY0HY5pPslRWWfj4aQeBb8DFH+rFeTf
+  I/S02ECE/SKc+O7JJa23HtzJspiaK/MV6XQUDDWYdFQEfLhQb3y3RuYJ7C0WZDMc
+  EmJHuB1D0/RS5xWiukTyRbOFf0Dbzn07PPUycE5BaCJ/ekwpMBvYQ6uCZq19CRAE
+  v5j7oyC1+rjOCKpTBPGCFWbODJmf5LrfcZLX/VtR+vu3a28OKmbxvdQ3uzLPwjFx
+  szzsJRn4URyI5hxl3K0w5Yptd/mvdnSeQTnX9TmMFE/G+EdlGxZtc695mOvWX6gK
+  ezwSqwtxVAZ18x/we6NZUkeuaC4+Xec8HoowHYmfRUH1P69ZXAuKKSIZizuvDYIF
+  tfcDeDY6s0wp3SKQ1bUCAwEAAaOBkDCBjTAJBgNVHRMEAjAAMEAGA1UdEQQ5MDeC
+  E2NlcGgwLmN4LmZkb3Blbi5uZXSCGnJjLnNtYi5jZXBoMC5jeC5mZG9wZW4ubmV0
+  hwTAqEzIMB0GA1UdDgQWBBR9bOCw+6pMkeS1HnAuCFhmoM7NPzAfBgNVHSMEGDAW
+  gBRsCQk9OUjWypZgtyH+5LxzZ4eBJDANBgkqhkiG9w0BAQ0FAAOCAgEAF6u76+6C
+  JkQEqBSYU09JQT8JDWX3AUZDXoCIpv2F1UD26ueAIaYD1dkpKDFg0UOOBwC7TiR9
+  uf210HtY5ic++Bm5xavhRk65FGwypv65SqjfehqTiRU+b0my0LG2OaAVrUcKWdbn
+  ZvwiBr1I7Wyn0MV1Ko7sqZh0j7Y4kPXCa2D8QG1inr9YBQQpid7CUwNeS5eYAVbP
+  gI4zTYKKvJMYPr4lTqsweCDOpctC7fwVb43XGTRVhVXQdOux9n5emROx/Ok0d2xX
+  mi5rlUfMxlrWjs7KK336x8z31i3w+1xc1ESaF0eP1byikvpbYBN1dEYahilMaSVl
+  3IpDYCwCFMU+ZZUZdqVyQQL+lTxqsc2orzzFgfv594hkEdYNlJ/z/f1b8idYk3g1
+  WTrixgd+KYcHoCCS8pHFVs8lankBqQGMckZmIyzfP7RxY43j6XTV+4791O4o0waZ
+  I5AwhUmgJj7G2Mp1jacMlHtZPqC0iDlci5fh6KpzVjPzrqA2sIN+9yJAlX8teJnC
+  adKnxoY+AbqwLLTHfGx/W0W8jUxmea0eYufgUqxoQv5qdREafcuchGM36bKukVYb
+  L3pqleYyvguwxxcc2MJvXjgAiZ5EsNJ2TCr4Mt0mZP406BhEQxfvpBSdRXTiHGJ/
+  KNDwOknnnEhdXshW5M8G8ZhkahG8YABHTBw=
+  -----END CERTIFICATE-----
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+    tcred = loaded[0]
+    assert isinstance(tcred, smb.resources.TLSCredential)
+    assert tcred.tls_credential_id == 'tc1'
+    assert tcred.credential_type == enums.TLSCredentialType.CERT
+
+
 @pytest.mark.parametrize(
     "params",
     [

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -828,3 +828,104 @@ def test_apply_password_filter_in_out(tmodule):
     assert len(out['values']['users']) == 2
     assert out['values']['users'][0]['password'] == 'abracadabra'
     assert out['values']['users'][1]['password'] == 'xyzzy'
+
+
+cert1 = """
+-----BEGIN CERTIFICATE-----
+MIIGFjCCA/6gAwIBAgIUZLL4QTx5ESBYQYS761DcZ7S1c24wDQYJKoZIhvcNAQEN
+BQAwgYgxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJNQTEPMA0GA1UEBwwGTG93ZWxs
+MR8wHQYDVQQKDBZCaXJjaCBTdHJlZXQgQ29tcHV0aW5nMRYwFAYDVQQDDA1Kb2hu
+IE11bGxpZ2FuMSIwIAYJKoZIhvcNAQkBFhNqb2hubUBhc3luY2hyb25vLnVzMB4X
+DTI1MDYzMDE5MzAwM1oXDTI2MDcyNDE5MzAwM1owbjELMAkGA1UEBhMCVVMxCzAJ
+BgNVBAgMAk1BMQ8wDQYDVQQHDAZMb3dlbGwxHzAdBgNVBAoMFkJpcmNoIFN0cmVl
+dCBDb21wdXRpbmcxIDAeBgNVBAMMF0ROUzpjZXBoMC5jeC5mZG9wZW4ubmV0MIIC
+IjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApZYqA73a8ojX7QsCJHiXh0J2
+KKEqDU6k0Yjoie9raYCP/aaiJpffSjhKl1rYuIqjBUG5D0tdT3sRw3m96Nw6gkhM
+5J8r02muQpJqmzPmfAn75IVjRkJ9OsHyS1Mf9GADTfv3pMBkwqqrGb8NxWQXeS4s
+PLPBv8SI4ozFNwwlEvZ0kesI4Qf0VRZ1ieSzAArjDWWFX8kURMt6UzN8opnxGvzT
+cfY4J0iKCYBK6Vqmf/OrMg3IjDojKaQqBlMPAQURyiYeF1hfDrcqGQC6S4Iz5mDt
+ZsMywFQFlEhkWkhJdMMkY4bqvn01BKXl3WY0HY5pPslRWWfj4aQeBb8DFH+rFeTf
+I/S02ECE/SKc+O7JJa23HtzJspiaK/MV6XQUDDWYdFQEfLhQb3y3RuYJ7C0WZDMc
+EmJHuB1D0/RS5xWiukTyRbOFf0Dbzn07PPUycE5BaCJ/ekwpMBvYQ6uCZq19CRAE
+v5j7oyC1+rjOCKpTBPGCFWbODJmf5LrfcZLX/VtR+vu3a28OKmbxvdQ3uzLPwjFx
+szzsJRn4URyI5hxl3K0w5Yptd/mvdnSeQTnX9TmMFE/G+EdlGxZtc695mOvWX6gK
+ezwSqwtxVAZ18x/we6NZUkeuaC4+Xec8HoowHYmfRUH1P69ZXAuKKSIZizuvDYIF
+tfcDeDY6s0wp3SKQ1bUCAwEAAaOBkDCBjTAJBgNVHRMEAjAAMEAGA1UdEQQ5MDeC
+E2NlcGgwLmN4LmZkb3Blbi5uZXSCGnJjLnNtYi5jZXBoMC5jeC5mZG9wZW4ubmV0
+hwTAqEzIMB0GA1UdDgQWBBR9bOCw+6pMkeS1HnAuCFhmoM7NPzAfBgNVHSMEGDAW
+gBRsCQk9OUjWypZgtyH+5LxzZ4eBJDANBgkqhkiG9w0BAQ0FAAOCAgEAF6u76+6C
+JkQEqBSYU09JQT8JDWX3AUZDXoCIpv2F1UD26ueAIaYD1dkpKDFg0UOOBwC7TiR9
+uf210HtY5ic++Bm5xavhRk65FGwypv65SqjfehqTiRU+b0my0LG2OaAVrUcKWdbn
+ZvwiBr1I7Wyn0MV1Ko7sqZh0j7Y4kPXCa2D8QG1inr9YBQQpid7CUwNeS5eYAVbP
+gI4zTYKKvJMYPr4lTqsweCDOpctC7fwVb43XGTRVhVXQdOux9n5emROx/Ok0d2xX
+mi5rlUfMxlrWjs7KK336x8z31i3w+1xc1ESaF0eP1byikvpbYBN1dEYahilMaSVl
+3IpDYCwCFMU+ZZUZdqVyQQL+lTxqsc2orzzFgfv594hkEdYNlJ/z/f1b8idYk3g1
+WTrixgd+KYcHoCCS8pHFVs8lankBqQGMckZmIyzfP7RxY43j6XTV+4791O4o0waZ
+I5AwhUmgJj7G2Mp1jacMlHtZPqC0iDlci5fh6KpzVjPzrqA2sIN+9yJAlX8teJnC
+adKnxoY+AbqwLLTHfGx/W0W8jUxmea0eYufgUqxoQv5qdREafcuchGM36bKukVYb
+L3pqleYyvguwxxcc2MJvXjgAiZ5EsNJ2TCr4Mt0mZP406BhEQxfvpBSdRXTiHGJ/
+KNDwOknnnEhdXshW5M8G8ZhkahG8YABHTBw=
+-----END CERTIFICATE-----
+"""
+
+
+def test_tls_credential(tmodule):
+    _example_cfg_1(tmodule)
+
+    txt = json.dumps(
+        {
+            'resource_type': 'ceph.smb.tls.credential',
+            'tls_credential_id': 'tc1',
+            'intent': 'present',
+            'credential_type': 'cert',
+            'value': cert1,
+        }
+    )
+
+    rg = tmodule.apply_resources(txt)
+    assert rg.success, rg.to_simplified()
+    ts = rg.to_simplified()
+    assert len(ts['results']) == 1
+    r = ts['results'][0]['resource']
+    assert r['resource_type'] == 'ceph.smb.tls.credential'
+    out = tmodule.show()
+    res = out.get('resources')
+    assert res
+    assert len(res) == 5
+    clusters = [r for r in res if r['resource_type'] == 'ceph.smb.cluster']
+    assert len(clusters) == 1
+    shares = [r for r in res if r['resource_type'] == 'ceph.smb.share']
+    assert len(shares) == 2
+    jauths = [r for r in res if r['resource_type'] == 'ceph.smb.join.auth']
+    assert len(jauths) == 1
+    tcs = [r for r in res if r['resource_type'] == 'ceph.smb.tls.credential']
+    assert len(tcs) == 1
+    assert tcs[0]['credential_type'] == 'cert'
+    assert tcs[0]['value'] == cert1
+
+
+def test_tls_credential_yaml_show(tmodule):
+    _example_cfg_1(tmodule)
+
+    txt = json.dumps(
+        {
+            'resource_type': 'ceph.smb.tls.credential',
+            'tls_credential_id': 'tc1',
+            'intent': 'present',
+            'credential_type': 'cert',
+            'value': cert1,
+        }
+    )
+
+    rg = tmodule.apply_resources(txt)
+    assert rg.success, rg.to_simplified()
+    ts = rg.to_simplified()
+    assert len(ts['results']) == 1
+    r = ts['results'][0]['resource']
+    assert r['resource_type'] == 'ceph.smb.tls.credential'
+    res, body, status = tmodule.show.command(
+        ['ceph.smb.tls.credential'], format='yaml'
+    )
+    assert res == 0
+    body = body.strip()
+    assert 'value: |' in body

--- a/src/pybind/mgr/smb/tests/test_validation.py
+++ b/src/pybind/mgr/smb/tests/test_validation.py
@@ -144,8 +144,17 @@ def test_check_access_name(value, ok, err_match):
         ({'smb': 4455, 'sbmetrics': 9009}, 'invalid service names'),
         (
             {'smb': 4455, 'smbmetrics': 9999, 'ctdb': 9999},
-            'must not be repeated',
+            'must be unique',
         ),
+        # can't use 445 it's the default smb port!
+        (
+            {'smbmetrics': 445},
+            'must be unique',
+        ),
+        # its valid to swap stuff around (don't do this please)
+        ({'smbmetrics': 4379, 'ctdb': 9922}, None),
+        # remote-control is a valid service name to modify
+        ({'remote-control': 65432}, None),
     ],
 )
 def test_check_custom_ports(value, err_match):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -3287,8 +3287,8 @@ class SMBClusterBindIPSpec:
 
 class SMBSpec(ServiceSpec):
     service_type = 'smb'
-    _valid_features = {'domain', 'clustered', 'cephfs-proxy'}
-    _valid_service_names = {'smb', 'smbmetrics', 'ctdb'}
+    _valid_features = {'domain', 'clustered', 'cephfs-proxy', 'remote-control'}
+    _valid_service_names = {'smb', 'smbmetrics', 'ctdb', 'remote-control'}
     _default_cluster_meta_obj = 'cluster.meta.json'
     _default_cluster_lock_obj = 'cluster.meta.lock'
 
@@ -3348,6 +3348,10 @@ class SMBSpec(ServiceSpec):
         # not listed the default port will be used.
         custom_ports: Optional[Dict[str, int]] = None,
         bind_addrs: Optional[List[SMBClusterBindIPSpec]] = None,
+        # === remote control server ===
+        remote_control_ssl_cert: Optional[str] = None,
+        remote_control_ssl_key: Optional[str] = None,
+        remote_control_ca_cert: Optional[str] = None,
         # --- genearal tweaks ---
         extra_container_args: Optional[GeneralArgList] = None,
         extra_entrypoint_args: Optional[GeneralArgList] = None,
@@ -3382,6 +3386,9 @@ class SMBSpec(ServiceSpec):
         )
         self.custom_ports = custom_ports
         self.bind_addrs = SMBClusterBindIPSpec.convert_list(bind_addrs)
+        self.remote_control_ssl_cert = remote_control_ssl_cert
+        self.remote_control_ssl_key = remote_control_ssl_key
+        self.remote_control_ca_cert = remote_control_ca_cert
         self.validate()
 
     def validate(self) -> None:
@@ -3434,6 +3441,7 @@ class SMBSpec(ServiceSpec):
             'smb': 445,
             'smbmetrics': 9922,
             'ctdb': 4379,
+            'remote-control': 54445,
         }
 
     def service_ports(self) -> Dict[str, int]:

--- a/src/python-common/ceph/smb/constants.py
+++ b/src/python-common/ceph/smb/constants.py
@@ -1,0 +1,49 @@
+# Shared constant values that apply across all ceph components that manage
+# smb services (mgr module, cephadm mgr module, cephadm binary, etc)
+
+
+# Generic/common names
+SMB = 'smb'
+CTDB = 'ctdb'
+
+
+# Feature names
+CEPHFS_PROXY = 'cephfs-proxy'
+CLUSTERED = 'clustered'
+DOMAIN = 'domain'
+REMOTE_CONTROL = 'remote-control'
+SMBMETRICS = 'smbmetrics'
+
+
+# Features are optional components that can be deployed in a suite of smb
+# related containers. It may run as a separate sidecar or side-effect the
+# configuration of another component.
+FEATURES = {
+    CEPHFS_PROXY,
+    CLUSTERED,
+    DOMAIN,
+    REMOTE_CONTROL,
+}
+
+# Services are components that listen on a "public" network port, to expose
+# network services to remote clients.
+SERVICES = {
+    CTDB,
+    REMOTE_CONTROL,
+    SMB,
+    SMBMETRICS,
+}
+
+
+# Default port values
+SMB_PORT = 445
+SMBMETRICS_PORT = 9922
+CTDB_PORT = 4379
+REMOTE_CONTROL_PORT = 54445
+
+DEFAULT_PORTS = {
+    SMB: SMB_PORT,
+    SMBMETRICS: SMBMETRICS_PORT,
+    CTDB: CTDB_PORT,
+    REMOTE_CONTROL: REMOTE_CONTROL_PORT,
+}


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/64372 and https://github.com/ceph/ceph/pull/65069

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
