### PR TITLE
smb: fix custom ports feature with remote-control sidecar

### DIFF
--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -17,6 +17,8 @@ from typing import (
     Tuple,
 )
 
+import ceph.smb.constants
+
 from .. import context_getters
 from .. import daemon_form
 from .. import data_utils
@@ -104,19 +106,34 @@ class BindInterface(NamedTuple):
 
 
 class Ports(enum.Enum):
-    SMB = 445
-    SMBMETRICS = 9922
-    CTDB = 4379
-    REMOTE_CONTROL = 54445
+    SMB = ceph.smb.constants.SMB_PORT
+    SMBMETRICS = ceph.smb.constants.SMBMETRICS_PORT
+    CTDB = ceph.smb.constants.CTDB_PORT
+    REMOTE_CONTROL = ceph.smb.constants.REMOTE_CONTROL_PORT
 
     def customized(self, service_ports: Dict[str, int]) -> int:
         """Return a custom port value if it is present in service_ports or the
         default port value if it is not present.
         """
-        port = service_ports.get(self.name.lower())
+        port = service_ports.get(str(self))
         if port:
             return int(port)
         return int(self.value)
+
+    def __str__(self) -> str:
+        # NOTE: mypy is getting the key type below wrong. using reveal_type:
+        # >>> reveal_type(self.SMB)
+        # > note: Revealed type is "builtins.int"
+        # >>> reveal_type(self)
+        # > note: Revealed type is "cephadmlib.daemons.smb.Ports"
+        # maybe newer versions would not hit this issue?
+        names: Dict[Any, str] = {
+            self.SMB: ceph.smb.constants.SMB,
+            self.SMBMETRICS: ceph.smb.constants.SMBMETRICS,
+            self.CTDB: ceph.smb.constants.CTDB,
+            self.REMOTE_CONTROL: ceph.smb.constants.REMOTE_CONTROL,
+        }
+        return names[self]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/pybind/mgr/smb/tests/test_validation.py
+++ b/src/pybind/mgr/smb/tests/test_validation.py
@@ -144,8 +144,17 @@ def test_check_access_name(value, ok, err_match):
         ({'smb': 4455, 'sbmetrics': 9009}, 'invalid service names'),
         (
             {'smb': 4455, 'smbmetrics': 9999, 'ctdb': 9999},
-            'must not be repeated',
+            'must be unique',
         ),
+        # can't use 445 it's the default smb port!
+        (
+            {'smbmetrics': 445},
+            'must be unique',
+        ),
+        # its valid to swap stuff around (don't do this please)
+        ({'smbmetrics': 4379, 'ctdb': 9922}, None),
+        # remote-control is a valid service name to modify
+        ({'remote-control': 65432}, None),
     ],
 )
 def test_check_custom_ports(value, err_match):

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -35,6 +35,7 @@ from ceph.deployment.utils import unwrap_ipv6, valid_addr, verify_non_negative_i
 from ceph.deployment.utils import verify_positive_int, verify_non_negative_number
 from ceph.deployment.utils import verify_boolean, verify_enum
 from ceph.utils import is_hex
+from ceph.smb import constants as smbconst
 
 ServiceSpecT = TypeVar('ServiceSpecT', bound='ServiceSpec')
 FuncT = TypeVar('FuncT', bound=Callable)
@@ -3315,8 +3316,8 @@ class SMBClusterBindIPSpec:
 
 class SMBSpec(ServiceSpec):
     service_type = 'smb'
-    _valid_features = {'domain', 'clustered', 'cephfs-proxy', 'remote-control'}
-    _valid_service_names = {'smb', 'smbmetrics', 'ctdb', 'remote-control'}
+    _valid_features = smbconst.FEATURES
+    _valid_service_names = smbconst.SERVICES
     _default_cluster_meta_obj = 'cluster.meta.json'
     _default_cluster_lock_obj = 'cluster.meta.lock'
 
@@ -3430,23 +3431,24 @@ class SMBSpec(ServiceSpec):
                 raise ValueError(
                     f'invalid feature flags: {", ".join(invalid)}'
                 )
-        if 'clustered' in self.features and not self.cluster_meta_uri:
+        _clustered = smbconst.CLUSTERED
+        if _clustered in self.features and not self.cluster_meta_uri:
             # derive a cluster meta uri from config uri by default (if possible)
             self.cluster_meta_uri = self._derive_cluster_uri(
                 self.config_uri,
                 self._default_cluster_meta_obj,
             )
-        if 'clustered' not in self.features and self.cluster_meta_uri:
+        if _clustered not in self.features and self.cluster_meta_uri:
             raise ValueError(
                 'cluster meta uri unsupported when "clustered" feature not set'
             )
-        if 'clustered' in self.features and not self.cluster_lock_uri:
+        if _clustered in self.features and not self.cluster_lock_uri:
             # derive a cluster meta uri from config uri by default (if possible)
             self.cluster_lock_uri = self._derive_cluster_uri(
                 self.config_uri,
                 self._default_cluster_lock_obj,
             )
-        if 'clustered' not in self.features and self.cluster_lock_uri:
+        if _clustered not in self.features and self.cluster_lock_uri:
             raise ValueError(
                 'cluster lock uri unsupported when "clustered" feature not set'
             )
@@ -3465,12 +3467,7 @@ class SMBSpec(ServiceSpec):
         return uri
 
     def _default_ports(self) -> Dict[str, int]:
-        return {
-            'smb': 445,
-            'smbmetrics': 9922,
-            'ctdb': 4379,
-            'remote-control': 54445,
-        }
+        return dict(smbconst.DEFAULT_PORTS)
 
     def service_ports(self) -> Dict[str, int]:
         ports = self._default_ports()
@@ -3479,13 +3476,13 @@ class SMBSpec(ServiceSpec):
         return ports
 
     def metrics_exporter_port(self) -> int:
-        return self.service_ports()['smbmetrics']
+        return self.service_ports()[smbconst.SMBMETRICS]
 
     def get_port_start(self) -> List[int]:
         _ports = self.service_ports()
-        ports = [_ports['smb'], _ports['smbmetrics']]
-        if 'clustered' in self.features:
-            ports.append(_ports['ctdb'])
+        ports = [_ports[smbconst.SMB], _ports[smbconst.SMBMETRICS]]
+        if smbconst.CLUSTERED in self.features:
+            ports.append(_ports[smbconst.CTDB])
         return ports
 
     def strict_cluster_ip_specs(self) -> List[Dict[str, Any]]:

--- a/src/python-common/ceph/smb/constants.py
+++ b/src/python-common/ceph/smb/constants.py
@@ -1,0 +1,49 @@
+# Shared constant values that apply across all ceph components that manage
+# smb services (mgr module, cephadm mgr module, cephadm binary, etc)
+
+
+# Generic/common names
+SMB = 'smb'
+CTDB = 'ctdb'
+
+
+# Feature names
+CEPHFS_PROXY = 'cephfs-proxy'
+CLUSTERED = 'clustered'
+DOMAIN = 'domain'
+REMOTE_CONTROL = 'remote-control'
+SMBMETRICS = 'smbmetrics'
+
+
+# Features are optional components that can be deployed in a suite of smb
+# related containers. It may run as a separate sidecar or side-effect the
+# configuration of another component.
+FEATURES = {
+    CEPHFS_PROXY,
+    CLUSTERED,
+    DOMAIN,
+    REMOTE_CONTROL,
+}
+
+# Services are components that listen on a "public" network port, to expose
+# network services to remote clients.
+SERVICES = {
+    CTDB,
+    REMOTE_CONTROL,
+    SMB,
+    SMBMETRICS,
+}
+
+
+# Default port values
+SMB_PORT = 445
+SMBMETRICS_PORT = 9922
+CTDB_PORT = 4379
+REMOTE_CONTROL_PORT = 54445
+
+DEFAULT_PORTS = {
+    SMB: SMB_PORT,
+    SMBMETRICS: SMBMETRICS_PORT,
+    CTDB: CTDB_PORT,
+    REMOTE_CONTROL: REMOTE_CONTROL_PORT,
+}


### PR DESCRIPTION
Fixes a mistake in 09da84fe1879 when we added a new service/port for the remote-control and fixes a mistake in 4180cddc1a08 where the port name is based on lowercasing the enum name (as that value will have an underscore instead of dash as generated by the mgr).

Take the opportunity to use common constants for some of these smb related things by creating a new directory under python-common/ceph, specifically so these common things can be used by the mgr code, cephadm code, and/or other parts of python-common.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Manually tested only

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
