### PR TITLE
crimson/os/seastore/rbm: fix NVMeBlockDevice::stat_device()

### DIFF
--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
@@ -253,48 +253,24 @@ public:
     uint64_t offset, size_t len, void *buffer_ptr);
 
   stat_device_ret stat_device() final {
-    return seastar::file_stat(device_path, seastar::follow_symlink::yes
+    auto stat = co_await seastar::file_stat(device_path, seastar::follow_symlink::yes
     ).handle_exception([](auto e) -> stat_device_ret {
       return crimson::ct_error::input_output_error::make();
-    }).then([this](auto stat) {
-      return seastar::open_file_dma(
-	device_path,
-	seastar::open_flags::rw | seastar::open_flags::dsync
-      ).then([this, stat](auto file) mutable {
-	return seastar::do_with(
-	  file, stat,
-	  [this](auto &file, auto &stat) mutable 
-	{
-	  return file.size().then([this, &stat, &file](auto size) mutable {
-	    stat.size = size;
-	    return identify_namespace(file
-	    ).safe_then([&stat] (auto id_namespace_data) mutable {
-	      // LBA format provides LBA size which is power of 2. LBA is the
-	      // minimum size of read and write.
-	      stat.block_size = (1 << id_namespace_data.lbaf[0].lbads);
-	      if (stat.block_size < RBM_SUPERBLOCK_SIZE) {
-		stat.block_size = RBM_SUPERBLOCK_SIZE;
-	      } 
-	      return read_ertr::now();
-	    }).handle_error(crimson::ct_error::input_output_error::handle(
-	      [&stat]() mutable {
-	      if (stat.block_size < RBM_SUPERBLOCK_SIZE) {
-                stat.block_size = RBM_SUPERBLOCK_SIZE;
-              }
-	      return read_ertr::now();
-	    }), crimson::ct_error::pass_further_all{});
-	  }).safe_then([&file, &stat]() mutable {
-	    return file.close(
-	    ).then([&stat] {
-	      return stat_device_ret(
-		read_ertr::ready_future_marker{},
-		stat
-	      );
-	    });
-	  });
-	});
-      });
     });
+    auto file = co_await seastar::open_file_dma(
+      device_path,
+      seastar::open_flags::rw | seastar::open_flags::dsync);
+    auto size = co_await file.size();
+    stat.size = size;
+    auto id_namespace_data = co_await identify_namespace(file);
+    // LBA format provides LBA size which is power of 2. LBA is the
+    // minimum size of read and write.
+    stat.block_size = (1 << id_namespace_data.lbaf[0].lbads);
+    if (stat.block_size < RBM_SUPERBLOCK_SIZE) {
+      stat.block_size = RBM_SUPERBLOCK_SIZE;
+    }
+    co_await file.close();
+    co_return stat;
   }
 
   std::string get_device_path() const final {

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
@@ -262,39 +262,33 @@ public:
 	seastar::open_flags::rw | seastar::open_flags::dsync
       ).then([this, stat](auto file) mutable {
 	return seastar::do_with(
-	  file,
-	  [this, stat](auto &file) mutable 
+	  file, stat,
+	  [this](auto &file, auto &stat) mutable 
 	{
-	  return file.size().then([this, stat, &file](auto size) mutable {
+	  return file.size().then([this, &stat, &file](auto size) mutable {
 	    stat.size = size;
 	    return identify_namespace(file
-	    ).safe_then([stat] (auto id_namespace_data) mutable {
+	    ).safe_then([&stat] (auto id_namespace_data) mutable {
 	      // LBA format provides LBA size which is power of 2. LBA is the
 	      // minimum size of read and write.
 	      stat.block_size = (1 << id_namespace_data.lbaf[0].lbads);
 	      if (stat.block_size < RBM_SUPERBLOCK_SIZE) {
 		stat.block_size = RBM_SUPERBLOCK_SIZE;
 	      } 
-	      return stat_device_ret(
-		read_ertr::ready_future_marker{},
-		stat
-	      );
+	      return read_ertr::now();
 	    }).handle_error(crimson::ct_error::input_output_error::handle(
-	      [stat]() mutable {
+	      [&stat]() mutable {
 	      if (stat.block_size < RBM_SUPERBLOCK_SIZE) {
                 stat.block_size = RBM_SUPERBLOCK_SIZE;
               }
+	      return read_ertr::now();
+	    }), crimson::ct_error::pass_further_all{});
+	  }).safe_then([&file, &stat]() mutable {
+	    return file.close(
+	    ).then([&stat] {
 	      return stat_device_ret(
 		read_ertr::ready_future_marker{},
 		stat
-	      );
-	    }), crimson::ct_error::pass_further_all{});
-	  }).safe_then([&file](auto st) mutable {
-	    return file.close(
-	    ).then([st] {
-	      return stat_device_ret(
-		read_ertr::ready_future_marker{},
-		st
 	      );
 	    });
 	  });


### PR DESCRIPTION
Variant of: https://github.com/ceph/ceph/pull/64807


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
