### PR TITLE
mgr/dashboard: expose image summary API

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/_base_controller.py
+++ b/src/pybind/mgr/dashboard/controllers/_base_controller.py
@@ -1,3 +1,4 @@
+import datetime
 import inspect
 import json
 import logging
@@ -279,9 +280,15 @@ class BaseController:
                                                              if version else 'application/xml')
                 return ret.encode('utf8')
             if json_response:
+                # convert datetime obj so json can serialize properly
+                def json_default(obj):
+                    if isinstance(obj, datetime.datetime):
+                        return obj.isoformat().replace("+00:00", "Z")
+                    return str(obj)
+
                 cherrypy.response.headers['Content-Type'] = (version.to_mime_type(subtype='json')
                                                              if version else 'application/json')
-                ret = json.dumps(ret).encode('utf8')
+                ret = json.dumps(ret, default=json_default).encode('utf8')
             return ret
         return inner
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -1558,6 +1558,38 @@ paths:
       summary: Display Rbd Mirroring Summary
       tags:
       - RbdMirroringSummary
+  /api/block/mirroring/{pool_name}/{image_name}/summary:
+    get:
+      parameters:
+      - in: path
+        name: pool_name
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: image_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - RbdMirroringSummary
   /api/block/pool/{pool_name}/namespace:
     get:
       parameters:


### PR DESCRIPTION
Introduce a new API for getting per image summary
```
╰─$ curl -kX GET "https://localhost:4200/api/block/mirroring/rbd/test/summary" \
-H "Accept: application/vnd.ceph.api.v1.0+json" \
-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   637  100   637    0     0  14597      0 --:--:-- --:--:-- --:--:-- 14813
{
  "name": "test2",
  "id": "10d618ea1a58",
  "info": {
    "global_id": "f25678be-64a2-481f-b96c-9bcc566dcbfe",
    "state": 1,
    "primary": true
  },
  "remote_statuses": [
    {
      "state": "Replaying",
      "description": {
        "bytes_per_second": 0.0,
        "bytes_per_snapshot": 0.0,
        "last_snapshot_bytes": 0,
        "last_snapshot_sync_seconds": 0,
        "local_snapshot_timestamp": 1755579780,
        "remote_snapshot_timestamp": 1755579780,
        "replay_state": "idle"
      },
      "last_update": "2025-08-19T05:03:17Z",
      "up": true,
      "mirror_uuid": "4d734616-5a38-4399-b743-86bcd8c1ab8f"
    }
  ],
  "state": 6,
  "description": "local image is primary",
  "last_update": "2025-08-19T05:03:10Z",
  "up": true
}
```
Also update the existing API to add the image syncing status. The
/summary API's `image_ready` will also have the `remote_status` which is
a list of dict to show the status of all the remote clusters (one image
can be mirrored to more than one cluster)

```
"image_ready": [
            {
                "pool_name": "rbd",
                "name": "test2",
                "state_color": "info",
                "state": "Stopped",
                "mirror_mode": "snapshot",
                "description": "local image is primary",
                "remote_status": [
                    {
                        "state": "Replaying",
                        "description": {
                            "bytes_per_second": 0.0,
                            "bytes_per_snapshot": 0.0,
                            "last_snapshot_bytes": 0,
                            "last_snapshot_sync_seconds": 0,
                            "local_snapshot_timestamp": 1755579780,
                            "remote_snapshot_timestamp": 1755579780,
                            "replay_state": "idle"
                        },
                        "last_update": "2025-08-19T05:03:47Z",
                        "up": true,
                        "mirror_uuid": "4d734616-5a38-4399-b743-86bcd8c1ab8f"
                    }
                ]
            }
        ]

```
Fixes: https://tracker.ceph.com/issues/72520





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
