### PR TITLE
tentacle: pybind/rados: Add list_lockers() and break_lock() to Rados Python interface

### DIFF
--- a/src/pybind/rados/c_rados.pxd
+++ b/src/pybind/rados/c_rados.pxd
@@ -239,6 +239,13 @@ cdef extern from "rados/librados.h" nogil:
                           const char * cookie, const char * tag, const char * desc,
                           timeval * duration, uint8_t flags)
     int rados_unlock(rados_ioctx_t io, const char * o, const char * name, const char * cookie)
+    int rados_break_lock(rados_ioctx_t io, const char *o, const char *name,
+                         const char *client, const char *cookie)
+    ssize_t rados_list_lockers(rados_ioctx_t io, const char *o, const char *name,
+                               int *exclusive, char *tag, size_t *tag_len,
+                               char *clients, size_t *clients_len,
+                               char *cookies, size_t *cookies_len,
+                               char *addrs, size_t *addrs_len)
 
     rados_write_op_t rados_create_write_op()
     void rados_release_write_op(rados_write_op_t write_op)

--- a/src/pybind/rados/mock_rados.pxi
+++ b/src/pybind/rados/mock_rados.pxi
@@ -331,6 +331,14 @@ cdef nogil:
         pass
     int rados_unlock(rados_ioctx_t io, const char * o, const char * name, const char * cookie):
         pass
+    int rados_break_lock(rados_ioctx_t io, const char *o, const char *name,
+                         const char *client, const char *cookie):
+        pass
+    ssize_t rados_list_lockers(rados_ioctx_t io, const char *o, const char *name,
+                               int *exclusive, char *tag, size_t *tag_len,
+                               char *clients, size_t *clients_len, char *cookies,
+                               size_t *cookies_len, char *addrs, size_t *addrs_len):
+        pass
 
     rados_write_op_t rados_create_write_op():
         pass

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from assertions import assert_equal as eq, assert_raises
 from rados import (Rados, Error, RadosStateError, Object, ObjectExists,
-                   ObjectNotFound, ObjectBusy, NotConnected,
+                   ObjectNotFound, ObjectBusy, NotConnected, InvalidArgumentError,
                    LIBRADOS_ALL_NSPACES, WriteOpCtx, ReadOpCtx, LIBRADOS_CREATE_EXCLUSIVE,
                    LIBRADOS_CMPXATTR_OP_EQ, LIBRADOS_CMPXATTR_OP_GT, LIBRADOS_CMPXATTR_OP_LT, OSError,
                    LIBRADOS_SNAP_HEAD, LIBRADOS_OPERATION_BALANCE_READS, LIBRADOS_OPERATION_SKIPRWLOCKS, MonitorLog, MAX_ERRNO, NoData, ExtendMismatch)
@@ -1057,23 +1057,75 @@ class TestIoctx(object):
     def test_lock(self):
         self.ioctx.lock_exclusive("foo", "lock", "locker", "desc_lock",
                                   10000, 0)
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "")
+        eq(lockers_info["exclusive"], True)
+        eq(len(lockers_info["lockers"]), 1)
         assert_raises(ObjectExists,
                       self.ioctx.lock_exclusive,
                       "foo", "lock", "locker", "desc_lock", 10000, 0)
         self.ioctx.unlock("foo", "lock", "locker")
         assert_raises(ObjectNotFound, self.ioctx.unlock, "foo", "lock", "locker")
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "")
+        eq(lockers_info["exclusive"], True)
+        eq(len(lockers_info["lockers"]), 0)
 
         self.ioctx.lock_shared("foo", "lock", "locker1", "tag", "desc_lock",
                                10000, 0)
         self.ioctx.lock_shared("foo", "lock", "locker2", "tag", "desc_lock",
                                10000, 0)
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "tag")
+        eq(lockers_info["exclusive"], False)
+        eq(len(lockers_info["lockers"]), 2)
         assert_raises(ObjectBusy,
                       self.ioctx.lock_exclusive,
                       "foo", "lock", "locker3", "desc_lock", 10000, 0)
         self.ioctx.unlock("foo", "lock", "locker1")
         self.ioctx.unlock("foo", "lock", "locker2")
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "tag")
+        eq(lockers_info["exclusive"], False)
+        eq(len(lockers_info["lockers"]), 0)
         assert_raises(ObjectNotFound, self.ioctx.unlock, "foo", "lock", "locker1")
         assert_raises(ObjectNotFound, self.ioctx.unlock, "foo", "lock", "locker2")
+        self.ioctx.lock_shared("foo", "lock", "locker3", "tag", "desc_lock",
+                               10000, 0)
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "tag")
+        eq(lockers_info["exclusive"], False)
+        eq(len(lockers_info["lockers"]), 1)
+        lock_client = lockers_info["lockers"][0][0]
+        assert_raises(ObjectNotFound,
+                      self.ioctx.break_lock, "bar", "lock",
+                      lock_client, "locker3")
+        assert_raises(ObjectNotFound,
+                      self.ioctx.break_lock, "foo", "wrong",
+                      lock_client, "locker3")
+        assert_raises(InvalidArgumentError,
+                      self.ioctx.break_lock, "foo", "lock",
+                      "wrong_client", "locker3")
+        assert_raises(ObjectNotFound,
+                      self.ioctx.break_lock, "foo", "lock",
+                      lock_client, "wrong cookie")
+        self.ioctx.lock_shared("foo", "lock", "locker4", "tag", "desc_lock",
+                               10000, 0)
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "tag")
+        eq(lockers_info["exclusive"], False)
+        eq(len(lockers_info["lockers"]), 2)
+        self.ioctx.break_lock("foo", "lock", lock_client, "locker3")
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "tag")
+        eq(lockers_info["exclusive"], False)
+        eq(len(lockers_info["lockers"]), 1)
+        assert_raises(ObjectNotFound, self.ioctx.unlock, "foo", "lock", "locker3")
+        self.ioctx.unlock("foo", "lock", "locker4")
+        lockers_info = self.ioctx.list_lockers("foo", "lock")
+        eq(lockers_info["tag"], "tag")
+        eq(lockers_info["exclusive"], False)
+        eq(len(lockers_info["lockers"]), 0)
 
     def test_execute(self):
         self.ioctx.write("foo", b"") # ensure object exists


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72610

---

backport of https://github.com/ceph/ceph/pull/65022
parent tracker: https://tracker.ceph.com/issues/72544