### PR TITLE
ceph-objectstore-tool: update `clear-snapset` command doc

### DIFF
--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -153,8 +153,6 @@ function create_scenario() {
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clone_overlap || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj11)"
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clones || return 1
-    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj12)"
-    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset head || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj13)"
     ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset snaps || return 1
     JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj14)"

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -3598,6 +3598,9 @@ void usage(po::options_description &desc)
     cerr << "ceph-objectstore-tool ... <object> set-size" << std::endl;
     cerr << "ceph-objectstore-tool ... <object> clear-data-digest" << std::endl;
     cerr << "ceph-objectstore-tool ... <object> remove-clone-metadata <cloneid>" << std::endl;
+    cerr << "ceph-objectstore-tool ... <object> clear-snapset "
+            "[(corrupt|seq|snaps|clones|clone_size|clone_overlap|size)]"
+         << std::endl;
     cerr << std::endl;
     cerr << "<object> can be a JSON object description as displayed" << std::endl;
     cerr << "by --op list." << std::endl;
@@ -3608,6 +3611,19 @@ void usage(po::options_description &desc)
     cerr << std::endl;
     cerr << "The optional [file] argument will read stdin or write stdout" << std::endl;
     cerr << "if not specified or if '-' specified." << std::endl;
+    cerr << std::endl;
+    cerr << "clear-snapset options:" << std::endl;
+    cerr << "  clear-snapset               : by default, clear clones, "
+            "clone_size and clone_overlap"
+         << std::endl;
+    cerr << "  clear-snapset corrupt       : clear entire snapset" << std::endl;
+    cerr << "  clear-snapset seq           : clear snapset.seq" << std::endl;
+    cerr << "  clear-snapset clone_size    : clear clone_size" << std::endl;
+    cerr << "  clear-snapset clone_overlap : clear clone_overlap" << std::endl;
+    cerr << "  clear-snapset clones        : clear clones" << std::endl;
+    cerr << "  clear-snapset snaps         : clear clone_snaps" << std::endl;
+    cerr << "  clear-snapset size          : break all clone sizes by adding 1"
+         << std::endl;
 }
 
 bool ends_with(const string& check, const string& ending)
@@ -4690,9 +4706,22 @@ int main(int argc, char **argv)
         ret = clear_data_digest(fs.get(), coll, ghobj);
         goto out;
       } else if (objcmd == "clear-snapset") {
-        // UNDOCUMENTED: For testing zap SnapSet
-        // IGNORE extra args since not in usage anyway
-	if (!ghobj.hobj.has_snapset()) {
+        if (vm.count("arg1") == 0) {
+          usage(desc);
+          ret = 1;
+          goto out;
+        }
+
+        if (vm.count("arg2") != 0) {
+          if (arg2 != "corrupt" && arg2 != "seq" && arg2 != "snaps" &&
+              arg2 != "clones" && arg2 != "clone_size" &&
+              arg2 != "clone_overlap" && arg2 != "size") {
+            usage(desc);
+            ret = 1;
+            goto out;
+          }
+        }
+        if (!ghobj.hobj.has_snapset()) {
 	  cerr << "'" << objcmd << "' requires a head or snapdir object" << std::endl;
 	  ret = 1;
 	  goto out;


### PR DESCRIPTION
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2251015
Closes: https://tracker.ceph.com/issues/78807

The `ceph-objectstore-tool --help` is now updated to the following:
```
Allowed options:                                                   
  --help                      produce help message
  --type arg                  Arg is one of [bluestore (default), memstore]

....

Positional syntax:                                                                                                                     
                                                                                                                                       
ceph-objectstore-tool ... <object> (get|set)-bytes [file]                                                                                                                                             
....                                                           
ceph-objectstore-tool ... <object> clear-snapset [(corrupt|seq|snaps|clones|clone_size|clone_overlap|size)]  <--- Newly added option

<object> can be a JSON object description as displayed                                                                                 
by --op list.                                                                                                                          
<object> can be an object name which will be looked up in all                                                                          
the OSD's PGs.                                                     
<object> can be the empty string ('') which with a provided pgid 
specifies the pgmeta object                                                                                                            
                                                                                                                                       
The optional [file] argument will read stdin or write stdout                                                                           
if not specified or if '-' specified.                                                                                                  
                                                                                                                                       
clear-snapset options:      <---- Newly added section                                       
  clear-snapset               : by default, clear clones, clone_size and clone_overlap
  clear-snapset corrupt       : clear entire snapset                                                                                   
  clear-snapset seq           : clear snapset.seq                                                                                      
  clear-snapset clone_size    : clear clone_size                   
  clear-snapset clone_overlap : clear clone_overlap                                                                                    
  clear-snapset clones        : clear clones                                                                                           
  clear-snapset snaps         : clear clone_snaps                                                                                      
  clear-snapset size          : break all clone sizes by adding 1

```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
