### PR TITLE
mgr/dashboard : Optimized /host API to minimum resp

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -289,10 +289,27 @@ class Host(RESTController):
         if str_to_bool(facts):
             if orch.available():
                 if not orch.get_missing_features(['get_facts']):
+                    all_facts = orch.hosts.get_facts()
                     hosts_facts = []
+                    facts_map = {facts.get('hostname'): facts for facts in all_facts}
                     for host in hosts:
-                        facts = orch.hosts.get_facts(host['hostname'])[0]
-                        hosts_facts.append(facts)
+                        hostname = host['hostname']
+                        facts = facts_map.get(hostname, {})
+                        host_facts = {
+                            'hostname': facts.get('hostname', hostname),
+                            'addr': facts.get('addr', ''),
+                            'cpu_cores': facts.get('cpu_cores', 0),
+                            'cpu_count': facts.get('cpu_count', 0),
+                            'model': facts.get('model', ''),
+                            'memory_total_kb': facts.get('memory_total_kb', 0),
+                            'nic_count': facts.get('nic_count', 0),
+                            'hdd_count': facts.get('hdd_count', 0),
+                            'flash_count': facts.get('flash_count', 0),
+                            'hdd_capacity_bytes': facts.get('hdd_capacity_bytes', 0),
+                            'flash_capacity_bytes': facts.get('flash_capacity_bytes', 0)
+                        }
+                        hosts_facts.append(host_facts)
+
                     return merge_list_of_dicts_by_key(hosts, hosts_facts, 'hostname')
 
                 raise DashboardException(

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -105,6 +105,14 @@ class HostControllerTest(ControllerTestCase):
                 'ceph': True,
                 'orchestrator': False
             },
+            'addr': '',
+            'cpu_cores': 0,
+            'model': '',
+            'nic_count': 0,
+            'hdd_count': 0,
+            'flash_count': 0,
+            'hdd_capacity_bytes': 0,
+            'flash_capacity_bytes': 0,
             'cpu_count': 1,
             'memory_total_kb': 1024,
             'services': [],
@@ -115,6 +123,14 @@ class HostControllerTest(ControllerTestCase):
                 'ceph': False,
                 'orchestrator': True
             },
+            'addr': '',
+            'cpu_cores': 0,
+            'model': '',
+            'nic_count': 0,
+            'hdd_count': 0,
+            'flash_count': 0,
+            'hdd_capacity_bytes': 0,
+            'flash_capacity_bytes': 0,
             'cpu_count': 2,
             'memory_total_kb': 1024,
             'services': [],
@@ -124,10 +140,12 @@ class HostControllerTest(ControllerTestCase):
         with patch_orch(True, hosts=hosts_without_facts) as fake_client:
             mock_get_hosts.return_value = hosts_without_facts
 
-            def get_facts_mock(hostname: str):
-                if hostname == 'host-0':
-                    return [hosts_facts[0]]
-                return [hosts_facts[1]]
+            def get_facts_mock(*args, **_kwargs):
+                if args:
+                    hostname = args[0]
+                    return [hosts_facts[0]] if hostname == 'host-0' else [hosts_facts[1]]
+                return hosts_facts
+
             fake_client.hosts.get_facts.side_effect = get_facts_mock
             # test with ?facts=true
             self._get('{}?facts=true'.format(self.URL_HOST), version=APIVersion(1, 3))


### PR DESCRIPTION
fixes : https://tracker.ceph.com/issues/72608

Before removing unwanted API resp.

<img width="1144" height="416" alt="image" src="https://github.com/user-attachments/assets/7ac9a0fe-769a-489e-a815-df5d3509bd45" />

after removing unwanted API resp.
<img width="1144" height="416" alt="image" src="https://github.com/user-attachments/assets/0bd69f1f-80b6-407f-98eb-5b6271db89ea" />



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
