### PR TITLE
mds: Return ceph.dir.subvolume vxattr

### DIFF
--- a/qa/tasks/cephfs/test_subvolume.py
+++ b/qa/tasks/cephfs/test_subvolume.py
@@ -213,6 +213,28 @@ class TestSubvolume(CephFSTestCase):
         # cleanup
         self.mount_a.run_shell(['rm', '-rf', 'group/subvol3'])
 
+
+    def test_subvolume_vxattr_retrieval(self):
+        """
+        To verify that the ceph.dir.subvolume vxattr can be acquired using getfattr
+        """
+        # create subvolume dir
+        subvol_dir:str = 'group/subvol5'
+        self.mount_a.run_shell(['mkdir', subvol_dir])
+        mkdir_fattr = self.mount_a.getfattr(subvol_dir, 'ceph.dir.subvolume')
+        self.assertEqual('0', mkdir_fattr)
+
+        self.mount_a.setfattr(subvol_dir, 'ceph.dir.subvolume', '1')
+        new_fattr:str = self.mount_a.getfattr(subvol_dir, 'ceph.dir.subvolume')
+        self.assertEqual('1', new_fattr)
+
+        # clear subvolume flag
+        self.mount_a.removexattr(subvol_dir, 'ceph.dir.subvolume')
+
+        # cleanup
+        self.mount_a.run_shell(['rm', '-rf', subvol_dir])
+
+
 class TestSubvolumeReplicated(CephFSTestCase):
     CLIENTS_REQUIRED = 1
     MDSS_REQUIRED = 2

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7284,6 +7284,9 @@ void Server::handle_client_getvxattr(const MDRequestRef& mdr)
       // since we only handle ceph vxattrs here
       r = -ENODATA; // no such attribute
     }
+  } else if (xattr_name == "ceph.dir.subvolume"sv) {
+    const auto* srnode = cur->get_projected_srnode();
+    *css << (srnode && srnode->is_subvolume() ? "1"sv : "0"sv);
   } else {
     // otherwise respond as invalid request
     // since we only handle ceph vxattrs here

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -505,21 +505,22 @@ private:
 
   static bool is_ceph_dir_vxattr(std::string_view xattr_name) {
     return xattr_name == "ceph.dir.layout" ||
-	    xattr_name == "ceph.dir.layout.json" ||
-	    xattr_name == "ceph.dir.layout.object_size" ||
-	    xattr_name == "ceph.dir.layout.stripe_unit" ||
-	    xattr_name == "ceph.dir.layout.stripe_count" ||
-	    xattr_name == "ceph.dir.layout.pool" ||
-	    xattr_name == "ceph.dir.layout.pool_name" ||
-	    xattr_name == "ceph.dir.layout.pool_id" ||
-	    xattr_name == "ceph.dir.layout.pool_namespace" ||
-	    xattr_name == "ceph.dir.pin" ||
-	    xattr_name == "ceph.dir.pin.random" ||
-	    xattr_name == "ceph.dir.pin.distributed" ||
-            xattr_name == "ceph.dir.charmap"sv ||
-            xattr_name == "ceph.dir.normalization"sv ||
-            xattr_name == "ceph.dir.encoding"sv ||
-            xattr_name == "ceph.dir.casesensitive"sv;
+	   xattr_name == "ceph.dir.layout.json" ||
+	   xattr_name == "ceph.dir.layout.object_size" ||
+	   xattr_name == "ceph.dir.layout.stripe_unit" ||
+	   xattr_name == "ceph.dir.layout.stripe_count" ||
+	   xattr_name == "ceph.dir.layout.pool" ||
+	   xattr_name == "ceph.dir.layout.pool_name" ||
+	   xattr_name == "ceph.dir.layout.pool_id" ||
+	   xattr_name == "ceph.dir.layout.pool_namespace" ||
+	   xattr_name == "ceph.dir.pin" ||
+	   xattr_name == "ceph.dir.pin.random" ||
+	   xattr_name == "ceph.dir.pin.distributed" ||
+	   xattr_name == "ceph.dir.charmap"sv ||
+	   xattr_name == "ceph.dir.normalization"sv ||
+	   xattr_name == "ceph.dir.encoding"sv ||
+	   xattr_name == "ceph.dir.casesensitive"sv ||
+	   xattr_name == "ceph.dir.subvolume"sv;
   }
 
   static bool is_ceph_file_vxattr(std::string_view xattr_name) {


### PR DESCRIPTION
This introduces handling for the "ceph.dir.subvolume" virtual xattr on directories.
- Returns ASCII "1" when the directory is a subvolume root, "0" otherwise.
- Uses srnode->is_subvolume() for the determination.
- Returns -ENOTDIR for non-directory targets.
- Uses a lightweight rdlock on the directory’s snaplock to guard the read-only check.
- If the rdlock cannot be acquired immediately, returns -EBUSY to avoid blocking; callers can retry.
- Caches success of rd-only checks within the request via mdr->more()->rdonly_checks to prevent re-acquiring locks in the same op.
- Drops the rdlock once the check is complete.

QA:
- Extend CephFS subvolume tests to validate vxattr retrieval and behavior around setting/removal.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
