### PR TITLE
reef: doc/cephfs: edit troubleshooting.rst

### DIFF
--- a/doc/cephfs/troubleshooting.rst
+++ b/doc/cephfs/troubleshooting.rst
@@ -455,36 +455,53 @@ To disable debug logging, run a command of the following form:
 In-memory Log Dump
 ==================
 
-In-memory logs can be dumped by setting ``mds_extraordinary_events_dump_interval``
-during a lower level debugging (log level < 10). ``mds_extraordinary_events_dump_interval``
-is the interval in seconds for dumping the recent in-memory logs when there is an Extra-Ordinary event.
+In-memory logs can be dumped by setting
+``mds_extraordinary_events_dump_interval`` when
+the log level is set to less than ``10``.
+``mds_extraordinary_events_dump_interval`` is the interval in seconds for
+dumping the recent in-memory logs when there is an extraordinary event.
 
-The Extra-Ordinary events are classified as:
+Extraordinary events include the following:
 
 * Client Eviction
 * Missed Beacon ACK from the monitors
 * Missed Internal Heartbeats
 
-In-memory Log Dump is disabled by default to prevent log file bloat in a production environment.
-The below commands consecutively enables it::
+In-memory log dump is disabled by default. This prevents production
+environments from experiencing log file bloat by default.
 
-  $ ceph config set mds debug_mds <log_level>/<gather_level>
-  $ ceph config set mds mds_extraordinary_events_dump_interval <seconds>
+Run the following two commands in order to enable in-memory log dumping: 
 
-The ``log_level`` should be < 10 and ``gather_level`` should be >= 10 to enable in-memory log dump.
-When it is enabled, the MDS checks for the extra-ordinary events every
-``mds_extraordinary_events_dump_interval`` seconds and if any of them occurs, MDS dumps the
-in-memory logs containing the relevant event details in ceph-mds log.
+#. 
+   .. prompt:: bash $
 
-.. note:: For higher log levels (log_level >= 10) there is no reason to dump the In-memory Logs and a
-          lower gather level (gather_level < 10) is insufficient to gather In-memory Logs. Thus a
-          log level >=10 or a gather level < 10 in debug_mds would prevent enabling the In-memory Log Dump.
-          In such cases, when there is a failure it's required to reset the value of
-          mds_extraordinary_events_dump_interval to 0 before enabling using the above commands.
+      ceph config set mds debug_mds <log_level>/<gather_level>
+   Set ``log_level`` to a value of less than ``10``. Set ``gather_level`` to a
+   value greater than ``10``. When those two values have been set,  in-memory
+   log dump is enabled.
+#. 
+   .. prompt:: bash #
 
-The In-memory Log Dump can be disabled using::
+      ceph config set mds mds_extraordinary_events_dump_interval <seconds>
+   When in-memory log dumping is enabled, the MDS checks for
+   extraordinary events every ``mds_extraordinary_events_dump_interval``
+   seconds. If any extraordinary event occurs, the MDS dumps the in-memory logs
+   that contain relevant event details to the Ceph MDS log.
 
-  $ ceph config set mds mds_extraordinary_events_dump_interval 0
+.. note:: When higher log levels are set (``log_level`` greater than or equal
+   to ``10``) there is no reason to dump the in-memory logs. A lower gather
+   level (``gather_level`` less than ``10``) is insufficient to gather in-
+   memory logs. This means that a log level of greater than or equal to ``10``
+   or a gather level of less than ``10`` in ``debug_mds`` prevents enabling
+   in-memory-log dumping. In such cases, if there is a failure, you must reset
+   the value of ``mds_extraordinary_events_dump_interval`` to ``0`` before
+   enabling the use of the above commands.
+
+Disable in-memory log dumping by running the following command:
+
+.. prompt:: bash #
+
+   ceph config set mds mds_extraordinary_events_dump_interval 0
 
 Filesystems Become Inaccessible After an Upgrade
 ================================================


### PR DESCRIPTION
Edit the section "In-memory log dumps" in
doc/cephfs/troubleshooting.rst.


(cherry picked from commit bc1aa66f356981ed977ac96e7d235f4f9c43547b)

fixup



(cherry picked from commit 3d8a6759c45a91c27d8698c0d0033638d06279f7)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>

