### PR TITLE
rpm: default to gcc-toolset-13, not just for crimson

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -239,24 +239,16 @@ BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
 BuildRequires:	git
 BuildRequires:	grpc-devel
-%if 0%{?fedora} || 0%{?suse_version} > 1500 || 0%{?rhel} == 9 || 0%{?openEuler}
-BuildRequires:	gcc-c++ >= 11
-%endif
-%if 0%{?suse_version} == 1500
-BuildRequires: gcc11-c++
-%endif
-%if 0%{?gts_version} > 0
-%if 0%{?gts_version} == 13
 # Before 13.3, an lto bug resulted in a segfault in SafeTimer and perhaps
 # elsewhere. Require the fixed version so we can reenable lto. See
 # ceph bug https://tracker.ceph.com/issues/63867
 # and
 # gcc bug https://bugzilla.redhat.com/show_bug.cgi?id=2241339
 # for details.
-BuildRequires:	gcc-toolset-%{gts_version}-gcc-c++ >= 13.3
+%if 0%{?gts_version} == 0
+BuildRequires:	gcc-c++ >= 13.3
 %else
-BuildRequires:	gcc-toolset-%{gts_version}-gcc-c++
-%endif
+BuildRequires:	gcc-toolset-%{gts_version}-gcc-c++ >= 13.3
 BuildRequires:	gcc-toolset-%{gts_version}-runtime
 BuildRequires:	gcc-toolset-%{gts_version}-libatomic-devel
 %endif

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -150,14 +150,8 @@
 %{!?python3_pkgversion: %global python3_pkgversion 3}
 %{!?python3_version_nodots: %global python3_version_nodots 3}
 %{!?python3_version: %global python3_version 3}
-%if 0%{with crimson}
 %if 0%{?rhel} < 10
 %{!?gts_version: %global gts_version 13}
-%endif
-%else
-%if 0%{?rhel} == 8
-%{!?gts_version: %global gts_version 11}
-%endif
 %endif
 
 # Disable lto on systems that do not support symver attribute

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -195,10 +195,6 @@
 %if 0%{?enable_devtoolset13:1}
 %enable_devtoolset13
 %endif
-%else
-%if 0%{?enable_devtoolset11:1}
-%enable_devtoolset11
-%endif
 %endif
 %endif
 
@@ -267,11 +263,7 @@ BuildRequires:	gcc-toolset-%{gts_version}-gcc-c++ >= 13.3
 %else
 BuildRequires:	gcc-toolset-%{gts_version}-gcc-c++
 %endif
-%if 0%{?gts_version} >= 12
 BuildRequires:	gcc-toolset-%{gts_version}-runtime
-%else
-BuildRequires:	gcc-toolset-%{gts_version}-build
-%endif
 BuildRequires:	gcc-toolset-%{gts_version}-libatomic-devel
 %endif
 %if 0%{?fedora} || 0%{?rhel} == 9 || 0%{?openEuler}
@@ -399,12 +391,7 @@ BuildRequires:  libasan
 BuildRequires:  protobuf-devel
 BuildRequires:  protobuf-compiler
 %if 0%{?gts_version} > 0
-%if 0%{?gts_version} >= 12
 BuildRequires:  gcc-toolset-%{gts_version}-gcc-plugin-annobin
-%else
-BuildRequires:  gcc-toolset-%{gts_version}-annobin
-BuildRequires:  gcc-toolset-%{gts_version}-annobin-plugin-gcc
-%endif
 BuildRequires:  gcc-toolset-%{gts_version}-libubsan-devel
 BuildRequires:  gcc-toolset-%{gts_version}-libasan-devel
 %endif

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -154,12 +154,6 @@
 %{!?gts_version: %global gts_version 13}
 %endif
 
-# Disable lto on systems that do not support symver attribute
-# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48200 for details
-%if (0%{?rhel} && 0%{?rhel} < 9) || ( 0%{?suse_version} && 0%{?suse_version} <= 1500 )
-%define _lto_cflags %{nil}
-%endif
-
 %if ! 0%{?suse_version}
 # use multi-threaded xz compression: xz level 7 using ncpus threads
 %global _source_payload w7T%{_smp_build_ncpus}.xzdio


### PR DESCRIPTION
followup to https://github.com/ceph/ceph/pull/58881 which only covered crimson:

* el9 builds set gts_version to 13 for all flavors
* remove checks for gts_version < 13 now that we don't use 11
* require gcc >= 13.3 for non-gts builds too (el10 and later)

Fixes: https://tracker.ceph.com/issues/72643

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
