### PR TITLE
crimson/os/seastore: OP_CLONERANGE2 support ---- another approach

### DIFF
--- a/qa/suites/crimson-rados/thrash_simple/thrashers/simple.yaml
+++ b/qa/suites/crimson-rados/thrash_simple/thrashers/simple.yaml
@@ -25,7 +25,6 @@ tasks:
     sighup_delay: 0
     min_in: 3
     noscrub_toggle_delay: 0
-    chance_down: 0
     chance_thrash_pg_upmap: 0
     reweight_osd: 0
     thrash_primary_affinity: false

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -105,6 +105,8 @@ public:
     LBAMapping pos,
     LBAMapping mapping,
     laddr_t laddr,
+    extent_len_t offset,
+    extent_len_t len,
     bool updateref) final;
 
 #ifdef UNIT_TESTS_BUILT

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -117,15 +117,19 @@ public:
   using clone_mapping_iertr = alloc_extent_iertr;
   using clone_mapping_ret = clone_mapping_iertr::future<clone_mapping_ret_t>;
   /*
-   * Clones "mapping" at the position "pos" with new laddr "laddr", if updateref
-   * is true, update the refcount of the mapping "mapping"
+   * Clones (part of) "mapping" at the position "pos" with the new lba key "laddr".
    */
   virtual clone_mapping_ret clone_mapping(
     Transaction &t,
-    LBAMapping pos,
-    LBAMapping mapping,
-    laddr_t laddr,
-    bool updateref) = 0;
+    LBAMapping pos,		// the destined position
+    LBAMapping mapping,		// the mapping to be cloned
+    laddr_t laddr,		// the new lba key of the cloned mapping
+    extent_len_t offset,	// the offset of the part to be cloned,
+				// relative to the start of the mapping.
+    extent_len_t len,		// the length of the part to be cloned
+    bool updateref		// whether to update the refcount of the
+				// direct mapping
+  ) = 0;
 
   virtual alloc_extent_ret reserve_region(
     Transaction &t,

--- a/src/crimson/os/seastore/lba_mapping.h
+++ b/src/crimson/os/seastore/lba_mapping.h
@@ -148,6 +148,10 @@ public:
     return direct_cursor->get_laddr();
   }
 
+  laddr_t get_end() const {
+    return (get_key() + get_length()).checked_to_laddr();
+  }
+
    // An lba pin may be indirect, see comments in lba/btree_lba_manager.h
   laddr_t get_intermediate_key() const {
     assert(is_indirect());

--- a/src/crimson/os/seastore/lba_mapping.h
+++ b/src/crimson/os/seastore/lba_mapping.h
@@ -111,6 +111,7 @@ public:
   bool is_zero_reserved() const {
     return !is_indirect() && get_val().is_zero();
   }
+  // true if the mapping corresponds to real data
   bool is_real() const {
     return !is_indirect() && !get_val().is_zero();
   }

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -331,6 +331,8 @@ public:
   using clone_ret = clone_iertr::future<>;
   clone_ret clone(context_t ctx);
 
+  clone_ret copy_on_write(context_t ctx);
+
 private:
   /// Updates region [_offset, _offset + bl.length) to bl
   write_ret overwrite(

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -323,6 +323,10 @@ public:
   clear_ret clear(context_t ctx);
 
   /// Clone data of an Onode
+  /// Note that the clone always assume that ctx.onode
+  /// is a snap onode, so, for OP_CLONE, the caller of
+  /// this method should swap the layout of the onode
+  /// and the dest_onode first.
   using clone_iertr = base_iertr;
   using clone_ret = clone_iertr::future<>;
   clone_ret clone(context_t ctx);
@@ -336,6 +340,21 @@ private:
     extent_len_t len,
     std::optional<bufferlist> &&bl,
     LBAMapping first_mapping);
+
+  /**
+   * do_clone
+   *
+   * Clone lba mappings from object_data to d_object_data.
+   * object_data must belong to ctx.onode, and d_object_data must belong to ctx.d_onode
+   * This implementation is asymmetric and optimizes for (but does not require) the case
+   * that source is not further mutated.
+   */
+  clone_ret do_clone(
+    context_t ctx,
+    object_data_t &object_data,
+    object_data_t &d_object_data,
+    LBAMapping first_mapping,
+    bool updateref);
 
   /// Ensures object_data reserved region is prepared
   write_iertr::future<std::optional<LBAMapping>>

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -79,6 +79,15 @@ private:
   mutable std::optional<ceph::bufferptr> ptr = std::nullopt;
 };
 
+struct clone_range_t {
+  LBAMapping first_src_mapping;
+  laddr_t src_base = L_ADDR_NULL;
+  laddr_t dest_base = L_ADDR_NULL;
+  extent_len_t offset = 0;
+  extent_len_t len = 0;
+};
+std::ostream& operator<<(std::ostream &out, const clone_range_t &);
+
 struct overwrite_range_t {
   objaddr_t unaligned_len = 0;
   laddr_offset_t unaligned_begin;
@@ -86,6 +95,7 @@ struct overwrite_range_t {
   laddr_t aligned_begin = L_ADDR_NULL;
   laddr_t aligned_end = L_ADDR_NULL;
   objaddr_t aligned_len = 0;
+  std::optional<clone_range_t> clonerange_info;
   overwrite_range_t(
     objaddr_t unaligned_len,
     laddr_offset_t unaligned_begin,
@@ -99,6 +109,22 @@ struct overwrite_range_t {
       aligned_len(
 	aligned_end.template get_byte_distance<
 	  extent_len_t>(aligned_begin))
+  {}
+  overwrite_range_t(
+    objaddr_t unaligned_len,
+    laddr_offset_t unaligned_begin,
+    laddr_offset_t unaligned_end,
+    extent_len_t block_size,
+    clone_range_t &&clonerange_info)
+    : unaligned_len(unaligned_len),
+      unaligned_begin(unaligned_begin),
+      unaligned_end(unaligned_end),
+      aligned_begin(unaligned_begin.get_aligned_laddr(block_size)),
+      aligned_end(unaligned_end.get_roundup_laddr(block_size)),
+      aligned_len(
+	aligned_end.template get_byte_distance<
+	  extent_len_t>(aligned_begin)),
+      clonerange_info(std::move(clonerange_info))
   {}
 
   bool is_empty() const {
@@ -165,10 +191,38 @@ struct overwrite_range_t {
 };
 std::ostream& operator<<(std::ostream &, const overwrite_range_t &);
 
+// |<-headbl->|<-head_padding->|<--------bl------->|<-tail_padding->|<-tailbl->|
+// |----------4KB--------------|-------------------|----------4KB--------------|
+//            |------------------overwrite_range--------------------|
 struct data_t {
   std::optional<bufferlist> headbl;
+  std::optional<bufferlist> head_padding;
   std::optional<bufferlist> bl;
   std::optional<bufferlist> tailbl;
+  std::optional<bufferlist> tail_padding;
+  data_t() = default;
+  data_t(std::optional<bufferlist> &&_bl) : bl(std::move(_bl)) {}
+  void merge_head(extent_len_t block_size) {
+    assert(head_padding.has_value());
+    if (headbl) {
+      headbl->append(*head_padding);
+    } else {
+      headbl = bufferlist{};
+      headbl->append_zero(block_size - head_padding->length());
+      headbl->append(*head_padding);
+    }
+    head_padding.reset();
+  }
+  void merge_tail(extent_len_t block_size) {
+    assert(tail_padding.has_value());
+    if (tailbl) {
+      tail_padding->append(*tailbl);
+    } else {
+      tail_padding->append_zero(block_size - tail_padding->length());
+    }
+    tailbl = std::move(tail_padding);
+    tail_padding.reset();
+  }
 };
 std::ostream& operator<<(std::ostream &out, const data_t &data);
 
@@ -331,7 +385,18 @@ public:
   using clone_ret = clone_iertr::future<>;
   clone_ret clone(context_t ctx);
 
+  /// Clone the object so that the later modification
+  /// won't be seen by other objects sharing the same
+  /// direct lba mappings.
   clone_ret copy_on_write(context_t ctx);
+
+  /// Clone the specified range from the src object
+  /// to the dest object
+  clone_ret clone_range(
+    context_t ctx,
+    extent_len_t srcoff,
+    extent_len_t len,
+    extent_len_t destoff);
 
 private:
   /// Updates region [_offset, _offset + bl.length) to bl
@@ -380,7 +445,8 @@ private:
   enum op_type_t : uint8_t {
     OVERWRITE,
     ZERO,
-    TRIM
+    TRIM,
+    OP_CLONERANGE
   };
   enum edge_handle_policy_t : uint8_t {
     DELTA_BASED_PUNCH,
@@ -569,6 +635,13 @@ private:
     overwrite_range_t &overwrite_range,
     data_t &data,
     LBAMapping edge_mapping);
+
+  read_iertr::future<> read_edge_for_clone_range(
+    context_t ctx,
+    object_data_t &object_data,
+    extent_len_t offset,
+    extent_len_t len,
+    data_t &data);
 
 private:
   /**

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -93,6 +93,9 @@ public:
   virtual const onode_layout_t &get_layout() const = 0;
   virtual ~Onode() = default;
 
+  const hobject_t &get_hobj() const {
+    return hobj;
+  }
   bool is_head() const {
     return hobj.is_head();
   }

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -93,6 +93,15 @@ public:
   virtual const onode_layout_t &get_layout() const = 0;
   virtual ~Onode() = default;
 
+  bool is_head() const {
+    return hobj.is_head();
+  }
+  bool is_snap() const {
+    return hobj.is_snap();
+  }
+  bool need_cow() const {
+    return get_layout().need_cow;
+  }
   virtual void update_onode_size(Transaction&, uint32_t) = 0;
   virtual void update_omap_root(Transaction&, omap_root_t&) = 0;
   virtual void update_log_root(Transaction&, omap_root_t&) = 0;

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -40,6 +40,14 @@ struct onode_layout_t {
 
   char oi[MAX_OI_LENGTH] = {0};
   char ss[MAX_SS_LENGTH] = {0};
+  /**
+    * needs_cow
+    *
+    * If true, all lba mappings for onode must be cloned
+    * to a new range prior to mutation. See ObjectDataHandler::copy_on_write,
+    * do_clone, do_clonerange
+    */
+  bool need_cow = false;
 
   onode_layout_t() : omap_root(omap_type_t::OMAP), log_root(omap_type_t::LOG),
     xattr_root(omap_type_t::XATTR) {}
@@ -94,6 +102,8 @@ public:
   virtual void update_snapset(Transaction&, ceph::bufferlist&) = 0;
   virtual void clear_object_info(Transaction&) = 0;
   virtual void clear_snapset(Transaction&) = 0;
+  virtual void set_need_cow(Transaction&) = 0;
+  virtual void unset_need_cow(Transaction&) = 0;
 
   laddr_t get_metadata_hint(uint64_t block_size) const {
     assert(default_metadata_offset);

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -104,6 +104,7 @@ public:
   virtual void clear_snapset(Transaction&) = 0;
   virtual void set_need_cow(Transaction&) = 0;
   virtual void unset_need_cow(Transaction&) = 0;
+  virtual void swap_layout(Transaction&, Onode&) = 0;
 
   laddr_t get_metadata_hint(uint64_t block_size) const {
     assert(default_metadata_offset);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -20,6 +20,18 @@ void FLTreeOnode::Recorder::apply_value_delta(
     ceph::decode(op, bliter);
     auto &mlayout = *reinterpret_cast<onode_layout_t*>(value.get_write());
     switch (op) {
+    case delta_op_t::UNSET_NEED_COW:
+      DEBUG("setting need_cow");
+      bliter.copy(
+	sizeof(mlayout.need_cow),
+	(char *)&mlayout.need_cow);
+      break;
+    case delta_op_t::SET_NEED_COW:
+      DEBUG("setting need_cow");
+      bliter.copy(
+	sizeof(mlayout.need_cow),
+	(char *)&mlayout.need_cow);
+      break;
     case delta_op_t::UPDATE_ONODE_SIZE:
       DEBUG("update onode size");
       bliter.copy(sizeof(mlayout.size), (char *)&mlayout.size);
@@ -80,6 +92,18 @@ void FLTreeOnode::Recorder::encode_update(
   auto &encoded = get_encoded(payload_mut);
   ceph::encode(op, encoded);
   switch(op) {
+  case delta_op_t::UNSET_NEED_COW:
+    DEBUG("setting need_cow");
+    encoded.append(
+      (const char *)&layout.need_cow,
+      sizeof(layout.need_cow));
+    break;
+  case delta_op_t::SET_NEED_COW:
+    DEBUG("setting need_cow");
+    encoded.append(
+      (const char *)&layout.need_cow,
+      sizeof(layout.need_cow));
+    break;
   case delta_op_t::UPDATE_ONODE_SIZE:
     DEBUG("update onode size");
     encoded.append(

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1957,21 +1957,49 @@ SeaStore::Shard::_clone(
   {
     auto &object_size = onode.get_layout().size;
     d_onode.update_onode_size(*ctx.transaction, object_size);
-    return objHandler.clone(
-      ObjectDataHandler::context_t{
-	*transaction_manager,
-	*ctx.transaction,
-	onode,
-	&d_onode});
+    if (onode.is_head()) { // OP_CLONE
+      assert(onode.is_head());
+      assert(d_onode.is_snap());
+      /* The most common usage of OP_CLONE is during a write operation.
+       * The osd will submit a transaction cloning HEAD to clone and
+       * then mutating HEAD.  ObjectDataHandler::do_clone optimizes for
+       * the case where the *source* is not further mutated, so here we
+       * reverse the two onodes so that HEAD will be the target.
+       */
+      onode.swap_layout(*ctx.transaction, d_onode);
+      return objHandler.clone(
+	ObjectDataHandler::context_t{
+	  *transaction_manager,
+	  *ctx.transaction,
+	  d_onode,
+	  &onode});
+    } else { // OP_ROLLBACK
+      assert(d_onode.is_head());
+      return objHandler.clone(
+	ObjectDataHandler::context_t{
+	  *transaction_manager,
+	  *ctx.transaction,
+	  onode,
+	  &d_onode});
+    }
   }).si_then([&ctx, &onode, &d_onode, this] {
     return omaptree_clone(
-      *ctx.transaction, omap_type_t::XATTR, onode, d_onode);
+      *ctx.transaction,
+      omap_type_t::XATTR,
+      onode.is_head() ? d_onode : onode,
+      onode.is_head() ? onode : d_onode);
   }).si_then([&ctx, &onode, &d_onode, this] {
     return omaptree_clone(
-      *ctx.transaction, omap_type_t::OMAP, onode, d_onode);
+      *ctx.transaction,
+      omap_type_t::OMAP,
+      onode.is_head() ? d_onode : onode,
+      onode.is_head() ? onode : d_onode);
   }).si_then([&ctx, &onode, &d_onode, this] {
     return omaptree_clone(
-      *ctx.transaction, omap_type_t::LOG, onode, d_onode);
+      *ctx.transaction,
+      omap_type_t::LOG,
+      onode.is_head() ? d_onode : onode,
+      onode.is_head() ? onode : d_onode);
   });
 }
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1891,12 +1891,18 @@ SeaStore::Shard::_remove(
       ObjectDataHandler(max_object_size),
       [&onode, this, &ctx](auto &objhandler)
     {
-      return objhandler.clear(
-        ObjectDataHandler::context_t{
-          *transaction_manager,
-          *ctx.transaction,
-          *onode,
-        });
+      auto fut = ObjectDataHandler::clone_iertr::now();
+      auto objctx = ObjectDataHandler::context_t{
+	  *transaction_manager,
+	  *ctx.transaction,
+	  *onode,
+	};
+      if (onode->need_cow()) {
+	fut = objhandler.copy_on_write(objctx);
+      }
+      return fut.si_then([&objhandler, objctx] {
+	return objhandler.clear(objctx);
+      });
     });
   }).si_then([this, &ctx, &onode] {
     return onode_manager->erase_onode(*ctx.transaction, onode);
@@ -1934,14 +1940,18 @@ SeaStore::Shard::_write(
     std::move(_bl),
     ObjectDataHandler(max_object_size),
     [=, this, &ctx, &onode](auto &bl, auto &objhandler) {
-      return objhandler.write(
-        ObjectDataHandler::context_t{
-          *transaction_manager,
-          *ctx.transaction,
-          onode,
-        },
-        offset,
-        bl);
+      auto fut = ObjectDataHandler::clone_iertr::now();
+      auto objctx = ObjectDataHandler::context_t{
+	  *transaction_manager,
+	  *ctx.transaction,
+	  onode,
+	};
+      if (onode.need_cow()) {
+	fut = objhandler.copy_on_write(objctx);
+      }
+      return fut.si_then([&objhandler, objctx, offset, &bl] {
+	return objhandler.write(objctx, offset, bl);
+      });
     });
 }
 
@@ -2023,14 +2033,18 @@ SeaStore::Shard::_zero(
   return seastar::do_with(
     ObjectDataHandler(max_object_size),
     [=, this, &ctx, &onode](auto &objhandler) {
-      return objhandler.zero(
-        ObjectDataHandler::context_t{
-          *transaction_manager,
-          *ctx.transaction,
-          onode,
-        },
-        offset,
-        len);
+    auto fut = ObjectDataHandler::clone_iertr::now();
+    auto objctx = ObjectDataHandler::context_t{
+	*transaction_manager,
+	*ctx.transaction,
+	onode,
+      };
+    if (onode.need_cow()) {
+      fut = objhandler.copy_on_write(objctx);
+    }
+    return fut.si_then([&objhandler, objctx, offset, len] {
+      return objhandler.zero(objctx, offset, len);
+    });
   });
 }
 
@@ -2079,13 +2093,18 @@ SeaStore::Shard::_truncate(
   return seastar::do_with(
     ObjectDataHandler(max_object_size),
     [=, this, &ctx, &onode](auto &objhandler) {
-    return objhandler.truncate(
-      ObjectDataHandler::context_t{
-        *transaction_manager,
-        *ctx.transaction,
-        onode
-      },
-      size);
+    auto fut = ObjectDataHandler::clone_iertr::now();
+    auto objctx = ObjectDataHandler::context_t{
+	*transaction_manager,
+	*ctx.transaction,
+	onode,
+      };
+    if (onode.need_cow()) {
+      fut = objhandler.copy_on_write(objctx);
+    }
+    return fut.si_then([&objhandler, objctx, size] {
+      return objhandler.truncate(objctx, size);
+    });
   });
 }
 

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -352,6 +352,13 @@ public:
       internal_context_t &ctx,
       OnodeRef &onode,
       OnodeRef &d_onode);
+    tm_ret _clone_range(
+      internal_context_t &ctx,
+      OnodeRef &src_onode,
+      OnodeRef &dst_onode,
+      extent_len_t srcoff,
+      extent_len_t length,
+      extent_len_t dstoff);
     tm_ret _zero(
       internal_context_t &ctx,
       Onode &onode,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1824,6 +1824,9 @@ public:
     reserved_data_len = 0;
   }
 };
+constexpr object_data_t get_null_object_data() {
+  return object_data_t{L_ADDR_NULL, 0};
+}
 
 struct __attribute__((packed)) object_data_le_t {
   laddr_le_t reserved_data_base = laddr_le_t(L_ADDR_NULL);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -584,6 +584,8 @@ public:
     LBAMapping pos,
     LBAMapping mapping,
     laddr_t hint,
+    extent_len_t offset,
+    extent_len_t len,
     bool updateref) {
     LOG_PREFIX(TransactionManager::clone_pin);
     SUBDEBUGT(seastore_tm, "{} clone to hint {} ... pos={}, updateref={}",
@@ -591,17 +593,20 @@ public:
     return seastar::do_with(
       std::move(pos),
       std::move(mapping),
-      [FNAME, this, &t, hint, updateref](auto &pos, auto &mapping) {
+      [offset, len, FNAME, this, &t, hint, updateref](auto &pos, auto &mapping) {
       return pos.refresh(
       ).si_then([&pos, &mapping](auto m) {
 	pos = std::move(m);
 	return mapping.refresh();
-      }).si_then([FNAME, this, &pos, &t, hint, updateref](auto mapping) {
+      }).si_then([offset, len, FNAME, this, &pos,
+		  &t, hint, updateref](auto mapping) {
 	return lba_manager->clone_mapping(
 	  t,
 	  std::move(pos),
 	  std::move(mapping),
 	  hint,
+	  offset,
+	  len,
 	  updateref
 	).si_then([FNAME, &t](auto ret) {
 	  SUBDEBUGT(seastore_tm, "cloned as {}", t, ret.cloned_mapping);
@@ -664,9 +669,11 @@ public:
 	if (mapping.is_real()) {
 	  ret = true;
 	}
+	auto len = mapping.get_length();
 	return clone_pin(
 	  t, std::move(pos), std::move(mapping),
-	  (base + offset).checked_to_laddr(), updateref
+	  (base + offset).checked_to_laddr(),
+	  0, len, updateref
 	).si_then([&offset, &pos, &mapping](auto ret) {
 	  offset += ret.cloned_mapping.get_length();
 	  return ret.cloned_mapping.next(

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -616,79 +616,69 @@ public:
     });
   }
 
+  struct clone_range_ret_t {
+    bool shared_direct_mapping = false;
+    LBAMapping next_mapping;
+  };
   // clone the mappings in range base~len, returns true if there exists
   // direct mappings that are cloned.
   using clone_iertr = base_iertr;
-  using clone_ret = clone_iertr::future<bool>;
+  using clone_ret = clone_iertr::future<clone_range_ret_t>;
   clone_ret clone_range(
     Transaction &t,
-    laddr_t base,
+    laddr_t src_base,
+    laddr_t dst_base,
+    extent_len_t offset,
     extent_len_t len,
     LBAMapping pos,
     LBAMapping mapping,
     bool updateref)
   {
     LOG_PREFIX(TransactionManager::clone_range);
-    SUBDEBUGT(seastore_tm, "object_data={}~{} mapping={} updateref={}",
-      t, base, len, mapping, updateref);
-    return seastar::do_with(
-      std::move(pos),
-      std::move(mapping),
-      (extent_len_t)0,
-      false,
-      [&t, this, updateref, base, len]
-      (auto &pos, auto &mapping, auto &offset, auto &ret) {
-      return trans_intr::repeat(
-	[&t, this, &pos, &mapping, &offset, updateref, base, len, &ret]()
-	-> clone_iertr::future<seastar::stop_iteration> {
-	if (offset >= len) {
-	  return clone_iertr::make_ready_future<
-	    seastar::stop_iteration>(seastar::stop_iteration::yes);
-	}
-	if (!mapping.is_indirect() && mapping.is_zero_reserved()) {
-	  return reserve_region(
-	    t,
-	    std::move(pos),
-	    (base + offset).checked_to_laddr(),
-	    mapping.get_length()
-	  ).si_then([base, &offset](auto r) {
-	    assert((base + offset).checked_to_laddr() == r.get_key());
-	    offset += r.get_length();
-	    return r.next();
-	  }).si_then([&pos, &mapping](auto r) {
-	    pos = std::move(r);
-	    return mapping.next();
-	  }).si_then([&mapping](auto p) {
-	    mapping = std::move(p);
-	    return seastar::stop_iteration::no;
-	  }).handle_error_interruptible(
-	    clone_iertr::pass_further{},
-	    crimson::ct_error::assert_all{"unexpected error"}
-	  );
-	}
-	if (mapping.is_real()) {
-	  ret = true;
-	}
-	auto len = mapping.get_length();
-	return clone_pin(
-	  t, std::move(pos), std::move(mapping),
-	  (base + offset).checked_to_laddr(),
-	  0, len, updateref
-	).si_then([&offset, &pos, &mapping](auto ret) {
-	  offset += ret.cloned_mapping.get_length();
-	  return ret.cloned_mapping.next(
-	  ).si_then([&pos, ret=std::move(ret)](auto p) mutable {
-	    pos = std::move(p);
-	    return ret.orig_mapping.next();
-	  }).si_then([&mapping](auto p) {
-	    mapping = std::move(p);
-	    return seastar::stop_iteration::no;
-	  });
-	});
-      }).si_then([&ret] {
-	return ret;
-      });
-    });
+    SUBDEBUGT(seastore_tm,
+      "src_base={}, dst_base={}, {}~{}, mapping={}, pos={}, updateref={}",
+      t, src_base, dst_base, offset, len, mapping, pos, updateref);
+    pos = co_await pos.refresh();
+    mapping = co_await mapping.refresh();
+    auto left = len;
+    bool shared_direct = false;
+    auto cloned_to = offset;
+    while (left != 0) {
+      auto src_offset = src_base.template get_byte_distance<
+	extent_len_t>(mapping.get_key());
+      ceph_assert(cloned_to >= src_offset);
+      extent_len_t clone_offset = cloned_to - src_offset;
+      extent_len_t clone_len = mapping.get_length() - clone_offset;
+      clone_len = std::min(clone_len, left);
+      left -= clone_len;
+      if (!mapping.is_indirect() && mapping.get_val().is_zero()) {
+	auto r = co_await reserve_region(
+	  t,
+	  std::move(pos),
+	  (dst_base + cloned_to).checked_to_laddr(),
+	  clone_len
+	).handle_error_interruptible(
+	  clone_iertr::pass_further{},
+	  crimson::ct_error::assert_all{"unexpected error"}
+	);
+	assert((dst_base + cloned_to).checked_to_laddr() == r.get_key());
+	cloned_to += clone_len;
+	pos = co_await r.next();
+	mapping = co_await mapping.next();
+	continue;
+      }
+      if (mapping.is_real()) {
+	shared_direct = true;
+      }
+      auto ret = co_await clone_pin(
+	t, std::move(pos), std::move(mapping),
+	(dst_base + cloned_to).checked_to_laddr(),
+	clone_offset, clone_len, updateref);
+      cloned_to += clone_len;
+      pos = co_await ret.cloned_mapping.next();
+      mapping = co_await ret.orig_mapping.next();
+    }
+    co_return clone_range_ret_t{shared_direct, std::move(pos)};
   }
 
   /* alloc_extents

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -153,5 +153,5 @@ ghobject_t OSDMeta::final_pool_info_oid(int64_t pool)
 
 ghobject_t OSDMeta::superblock_oid()
 {
-  return ghobject_t(hobject_t(sobject_t(object_t("osd_superblock"), 0)));
+  return ghobject_t(hobject_t(sobject_t(object_t("osd_superblock"), CEPH_NOSNAP)));
 }

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -36,6 +36,16 @@ public:
   bool is_alive() const final {
     return true;
   }
+  void swap_layout(Transaction &t, Onode& other) final {
+    static_cast<TestOnode&>(other).with_mutable_layout(
+      t,
+      [this](auto &o_mlayout) {
+      std::swap(layout.object_data, o_mlayout.object_data);
+      std::swap(layout.omap_root, o_mlayout.omap_root);
+      std::swap(layout.log_root, o_mlayout.log_root);
+      std::swap(layout.xattr_root, o_mlayout.xattr_root);
+    });
+  }
   laddr_t get_hint() const final {return L_ADDR_MIN; }
   ~TestOnode() final = default;
 

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -39,6 +39,18 @@ public:
   laddr_t get_hint() const final {return L_ADDR_MIN; }
   ~TestOnode() final = default;
 
+  void set_need_cow(Transaction &t) final {
+    with_mutable_layout(t, [](onode_layout_t &mlayout) {
+      mlayout.need_cow = true;
+    });
+  }
+
+  void unset_need_cow(Transaction &t) final {
+    with_mutable_layout(t, [](onode_layout_t &mlayout) {
+      mlayout.need_cow = false;
+    });
+  }
+
   void update_onode_size(Transaction &t, uint32_t size) final {
     with_mutable_layout(t, [size](onode_layout_t &mlayout) {
       mlayout.size = size;

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -226,6 +226,63 @@ struct seastore_test_t :
 	std::move(t)).get();
     }
 
+    void clone_range(
+      SeaStoreShard &sharded_seastore,
+      const object_state_t &s_obj,
+      extent_len_t srcoff,
+      extent_len_t length,
+      extent_len_t dstoff) {
+      CTransaction t;
+      clone_range(sharded_seastore, t, s_obj, srcoff, length, dstoff);
+      sharded_seastore.do_transaction(coll, std::move(t)).get();
+    }
+
+    void clone_range(
+      SeaStoreShard &sharded_seastore,
+      CTransaction &t,
+      const object_state_t &s_obj,
+      extent_len_t srcoff,
+      extent_len_t length,
+      extent_len_t dstoff) {
+      bufferlist to_check;
+      if (s_obj.contents.length() >= srcoff) {
+	to_check.substr_of(
+	  s_obj.contents,
+	  srcoff,
+	  std::min((uint64_t)length,
+		   (uint64_t)s_obj.contents.length() - srcoff));
+      }
+      auto ret = sharded_seastore.read(
+	coll,
+	s_obj.oid,
+	srcoff,
+	length).unsafe_get();
+      EXPECT_EQ(ret.length(), to_check.length());
+      EXPECT_EQ(ret, to_check);
+
+      bufferlist new_contents;
+      if (srcoff > 0 && contents.length()) {
+	new_contents.substr_of(
+	  contents,
+	  0,
+	  std::min<size_t>(srcoff, contents.length())
+	);
+      }
+      new_contents.append_zero(srcoff - new_contents.length());
+      new_contents.append(ret);
+
+      auto tail_offset = srcoff + ret.length();
+      if (contents.length() > tail_offset) {
+	bufferlist tail;
+	tail.substr_of(
+	  contents,
+	  tail_offset,
+	  contents.length() - tail_offset);
+	new_contents.append(tail);
+      }
+      contents.swap(new_contents);
+      t.clone_range(cid, s_obj.oid, oid, srcoff, length, dstoff);
+    }
     void write(
       SeaStoreShard &sharded_seastore,
       CTransaction &t,
@@ -1279,6 +1336,58 @@ TEST_P(seastore_test_t, sparse_read)
       off += miter.second;
     }
     test_obj.remove(*sharded_seastore);
+  });
+}
+
+TEST_P(seastore_test_t, clone_range)
+{
+  run_async([this] {
+    auto &test_obj1 = get_object(make_oid(0));
+    test_obj1.write(*sharded_seastore, 0, 4096 * 1024, 'c');
+    auto test_obj2 = test_obj1.get_clone(10);
+    test_obj2.write(*sharded_seastore, 65536, 65536, 'b');
+    test_obj2.write(*sharded_seastore, 1 << 18, 1 << 16, 'd');
+
+    auto test_obj3 = test_obj1.get_clone(20);
+    test_obj3.clone_range(*sharded_seastore, test_obj1, 98304, 4096, 98304);
+    std::cout << "seastore_test_t.clone_range 1 clone_range" << std::endl;
+    test_obj3.read(*sharded_seastore, 0, 131072);
+
+    test_obj3.clone_range(*sharded_seastore, test_obj1, 1 << 18, 4096, 1 << 18);
+    std::cout << "seastore_test_t.clone_range 2 clone_range" << std::endl;
+    test_obj3.read(*sharded_seastore, 0, (1 << 18) + (1 << 16));
+
+    test_obj3.clone_range(
+      *sharded_seastore,
+      test_obj1,
+      (1 << 18) + (1 << 16) - 4096,
+      4096,
+      (1 << 18) + (1 << 16) - 4096);
+    std::cout << "seastore_test_t.clone_range 3 clone_range" << std::endl;
+    test_obj3.read(*sharded_seastore, 0, (1 << 18) + (1 << 16));
+
+    auto test_obj4 = test_obj1.get_clone(30);
+    test_obj4.clone_range(*sharded_seastore, test_obj2, 98304, 4096, 98304);
+    std::cout << "seastore_test_t.clone_range 4 clone_range" << std::endl;
+    test_obj4.read(*sharded_seastore, 0, 131072);
+
+    test_obj4.clone_range(*sharded_seastore, test_obj2, 1 << 18, 4096, 1 << 18);
+    std::cout << "seastore_test_t.clone_range 5 clone_range" << std::endl;
+    test_obj4.read(*sharded_seastore, 0, (1 << 18) + (1 << 16));
+
+    test_obj4.clone_range(
+      *sharded_seastore,
+      test_obj2,
+      (1 << 18) + (1 << 16) - 4096,
+      4096,
+      (1 << 18) + (1 << 16) - 4096);
+    std::cout << "seastore_test_t.clone_range 6 clone_range" << std::endl;
+    test_obj4.read(*sharded_seastore, 0, (1 << 18) + (1 << 16));
+
+    auto test_obj5 =test_obj1.get_clone(40);
+    test_obj5.clone_range(*sharded_seastore, test_obj1, 2048, (1 << 18), 2048);
+    std::cout << "seastore_test_t.clone_range 7 clone_range" << std::endl;
+    test_obj5.read(*sharded_seastore, 0, (1 << 18) + 2048);
   });
 }
 

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -708,11 +708,14 @@ struct transaction_manager_test_t :
     laddr_t offset) {
     auto key = mapping.get_key();
     auto pin = with_trans_intr(*(t.t), [&](auto &trans) {
+      auto len = mapping.get_length();
       return tm->clone_pin(
 	trans,
 	std::move(pos),
 	std::move(mapping),
 	offset,
+	0,
+	len,
 	true);
     }).unsafe_get().cloned_mapping;
     EXPECT_EQ(offset, pin.get_key());


### PR DESCRIPTION
This is another approach in implementing `OP_CLONERANGE2` support in SeaStore than #57735 .

Before this PR, we have implemented the support for `OP_CLONE` and `OP_CLONERANGE2` in a way which requires maintaining strict symmetric indirect lba mapping relations at any time. This means we have to create two sets of indirect lba mappings when dealing with `OP_CLONE` and move the direct mapping out when dealing with `OP_CLONERANGE2`, which makes the mechanism of `clone` and `clone_range` very complex, error prone and inefficient in terms of performance.

This PR takes another approach, which also ensures that modifications to any clone won't affect other clones that are sharing data with it, but doesn't require strict symmetric indirect lba mapping relations at any time, only at the time when those modifications actually happens.

Specifically, when dealing with `OP_CLONE` and `OP_CLONERANGE2`, this PR record a boolean value, `needs_cow`, in the onode layout, and set it to `true` if there's any direct lba mapping that's shared with other clones. When doing modifications to object data, we do another clone if the onode's `needs_cow` is true. With this approach, we only need to create one set of indirect lba mappings when dealing with `OP_CLONE` and `OP_CLONERANGE2`, and no direct lba mapping move is needed.

Basically, this PR's approach is to implement a `COW` mechinary of SeaStore itself and makes the mechanism behind `OP_CLONE` and `OP_CLONERANGE2` processing much simpler and more performant.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
