### PR TITLE
libcephfs: convert ceph errno to host-based errno

### DIFF
--- a/qa/workunits/libcephfs/test.sh
+++ b/qa/workunits/libcephfs/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
 ceph_test_libcephfs
 ceph_test_libcephfs_access

--- a/src/include/platform_errno.h
+++ b/src/include/platform_errno.h
@@ -1,0 +1,33 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+/* XXX: This definitions are placed here so that it's easy to import them into
+ * CephFS python bindings. Otherwise, entire src/include/types.h would needed to
+ * be imported, which is unneccessary and also complicated.
+ */
+
+#pragma once
+
+#if defined(__sun) || defined(_AIX) || defined(__APPLE__) || \
+    defined(__FreeBSD__) || defined(_WIN32)
+extern "C" {
+__s32  ceph_to_hostos_errno(__s32 e);
+__s32  hostos_to_ceph_errno(__s32 e);
+}
+#else
+#define  ceph_to_hostos_errno(e) (e)
+#define  hostos_to_ceph_errno(e) (e)
+#endif
+
+

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -17,6 +17,7 @@
 // this is needed for ceph_fs to compile in userland
 #include "int_types.h"
 #include "byteorder.h"
+#include "platform_errno.h"
 
 #include "uuid.h"
 
@@ -514,17 +515,6 @@ struct shard_id_t {
 };
 WRITE_CLASS_ENCODER(shard_id_t)
 std::ostream &operator<<(std::ostream &lhs, const shard_id_t &rhs);
-
-#if defined(__sun) || defined(_AIX) || defined(__APPLE__) || \
-    defined(__FreeBSD__) || defined(_WIN32)
-extern "C" {
-__s32  ceph_to_hostos_errno(__s32 e);
-__s32  hostos_to_ceph_errno(__s32 e);
-}
-#else
-#define  ceph_to_hostos_errno(e) (e)
-#define  hostos_to_ceph_errno(e) (e)
-#endif
 
 struct errorcode32_t {
   using code_t = __s32;

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -62,47 +62,47 @@ CEPH_SETATTR_BTIME = 0x200
 
 CEPH_NOSNAP = -2
 
-# errno definitions
-cdef enum:
-    EBLOCKLISTED = 108
-    EPERM = 1
-    ESTALE = 116
-    ENOSPC = 28
-    ETIMEDOUT = 110
-    EIO = 5
-    ENOTCONN = 107
-    EEXIST = 17
-    EINTR = 4
-    EINVAL = 22
-    EBADF = 9
-    EROFS = 30
-    EAGAIN = 11
-    EACCES = 13
-    ELOOP = 40
-    EISDIR = 21
-    ENOENT = 2
-    ENOTDIR = 20
-    ENAMETOOLONG = 36
-    EBUSY = 16
-    EDQUOT = 122
-    EFBIG = 27
-    ERANGE = 34
-    ENXIO = 6
-    ECANCELED = 125
-    ENODATA = 61
-    EOPNOTSUPP = 95
-    EXDEV = 18
-    ENOMEM = 12
-    ENOTRECOVERABLE = 131
-    ENOSYS = 38
-    EWOULDBLOCK = EAGAIN
-    ENOTEMPTY = 39
-    EDEADLK = 35
-    EDEADLOCK = EDEADLK
-    EDOM = 33
-    EMLINK = 31
-    ETIME = 62
-    EOLDSNAPC = 85
+# XXX: errno definitions, hard-coded numbers here are errnos defined by Linux
+# that are used for the Ceph on-the-wire status codes.
+EBLOCKLISTED = ceph_to_hostos_errno(108)
+EPERM = ceph_to_hostos_errno(1)
+ESTALE = ceph_to_hostos_errno(116)
+ENOSPC = ceph_to_hostos_errno(28)
+ETIMEDOUT = ceph_to_hostos_errno(110)
+EIO = ceph_to_hostos_errno(5)
+ENOTCONN = ceph_to_hostos_errno(107)
+EEXIST = ceph_to_hostos_errno(17)
+EINTR = ceph_to_hostos_errno(4)
+EINVAL = ceph_to_hostos_errno(22)
+EBADF = ceph_to_hostos_errno(9)
+EROFS = ceph_to_hostos_errno(30)
+EAGAIN = ceph_to_hostos_errno(11)
+EWOULDBLOCK = EAGAIN
+EACCES = ceph_to_hostos_errno(13)
+ELOOP = ceph_to_hostos_errno(40)
+EISDIR = ceph_to_hostos_errno(21)
+ENOENT = ceph_to_hostos_errno(2)
+ENOTDIR = ceph_to_hostos_errno(20)
+ENAMETOOLONG = ceph_to_hostos_errno(36)
+EBUSY = ceph_to_hostos_errno(16)
+EDQUOT = ceph_to_hostos_errno(122)
+EFBIG = ceph_to_hostos_errno(27)
+ERANGE = ceph_to_hostos_errno(34)
+ENXIO = ceph_to_hostos_errno(6)
+ECANCELED = ceph_to_hostos_errno(125)
+ENODATA = ceph_to_hostos_errno(61)
+EOPNOTSUPP = ceph_to_hostos_errno(95)
+EXDEV = ceph_to_hostos_errno(18)
+ENOMEM = ceph_to_hostos_errno(12)
+ENOTRECOVERABLE = ceph_to_hostos_errno(131)
+ENOSYS = ceph_to_hostos_errno(38)
+ENOTEMPTY = ceph_to_hostos_errno(39)
+EDEADLK = ceph_to_hostos_errno(35)
+EDEADLOCK = EDEADLK
+EDOM = ceph_to_hostos_errno(33)
+EMLINK = ceph_to_hostos_errno(31)
+ETIME = ceph_to_hostos_errno(62)
+EOLDSNAPC = ceph_to_hostos_errno(85)
 
 cdef extern from "Python.h":
     # These are in cpython/string.pxd, but use "object" types instead of
@@ -512,7 +512,7 @@ cdef class LibCephFS(object):
         with nogil:
             ret = ceph_create_from_rados(&self.cluster, rados_inst.cluster)
         if ret != 0:
-            raise Error("libcephfs_initialize failed with error code: %d" % ret)
+            raise Error(f"libcephfs_initialize failed with error code: {ret}")
         self.state = "configuring"
 
     NO_CONF_FILE = -1
@@ -541,7 +541,7 @@ cdef class LibCephFS(object):
         with nogil:
             ret = ceph_create(&self.cluster, <const char*>_auth_id)
         if ret != 0:
-            raise Error("libcephfs_initialize failed with error code: %d" % ret)
+            raise Error(f"libcephfs_initialize failed with error code: {ret}")
 
         self.state = "configuring"
         if conffile in (self.NO_CONF_FILE, None):

--- a/src/pybind/cephfs/types.pxd
+++ b/src/pybind/cephfs/types.pxd
@@ -55,3 +55,7 @@ ELSE:
             unsigned short int d_reclen
             unsigned char d_type
             char d_name[256]
+
+cdef extern from "../include/platform_errno.h":
+    ctypedef signed int int32_t;
+    int32_t ceph_to_hostos_errno(int32_t e)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/72401






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>