### PR TITLE
build (new arch support) :  Upgrade some PyPI dependency versions to enable better installation on riscv64

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -3,9 +3,9 @@ Sphinx < 7
 sphinx-ditaa@git+https://github.com/ceph/sphinx-ditaa.git@py3
 funcparserlib@git+https://github.com/vlasovskikh/funcparserlib.git
 breathe >= 4.20.0,!=4.33
-cryptography
+cryptography==45.0.4
 Jinja2
-pyyaml >= 5.1.2
+pyyaml == 6.0.2
 Cython
 pcpp
 prettytable

--- a/monitoring/ceph-mixin/requirements-alerts.txt
+++ b/monitoring/ceph-mixin/requirements-alerts.txt
@@ -1,2 +1,2 @@
-pyyaml==6.0.1
+pyyaml==6.0.2
 bs4

--- a/monitoring/ceph-mixin/requirements-lint.txt
+++ b/monitoring/ceph-mixin/requirements-lint.txt
@@ -2,7 +2,7 @@ attrs==21.2.0
 behave==1.2.6
 py==1.10.0
 pyparsing==2.4.7
-PyYAML==6.0.1
+PyYAML==6.0.2
 types-PyYAML==6.0.0
 typing-extensions==3.10.0.2
 termcolor==1.1.0

--- a/monitoring/ceph-mixin/tests_dashboards/requirements.txt
+++ b/monitoring/ceph-mixin/tests_dashboards/requirements.txt
@@ -2,7 +2,7 @@ attrs==21.2.0
 behave==1.2.6
 py==1.10.0
 pyparsing==2.4.7
-PyYAML==6.0.1
+PyYAML==6.0.2
 types-PyYAML==6.0.0
 typing-extensions==3.10.0.2
 termcolor==1.1.0

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -7,11 +7,11 @@ Routes
 -e ../../../python-common
 prettytable
 pytest==7.0.1
-pyyaml
+pyyaml==6.0.2
 natsort
 setuptools
 jsonpatch
-grpcio
-grpcio-tools
+grpcio==1.76.0
+grpcio-tools==1.76.0
 jmespath
 xmltodict

--- a/src/pybind/mgr/diskprediction_local/requirements.txt
+++ b/src/pybind/mgr/diskprediction_local/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.15.1
-scipy==1.1.0
+scipy==1.15.2
 scikit-learn==0.19.2

--- a/src/pybind/mgr/requirements-required.txt
+++ b/src/pybind/mgr/requirements-required.txt
@@ -1,7 +1,7 @@
 -e ../../python-common
 asyncmock
 cherrypy
-cryptography
+cryptography==45.0.4
 jsonpatch
 Jinja2
 pecan
@@ -9,9 +9,9 @@ prettytable<3.4.0
 pyfakefs
 pyOpenSSL
 pytest-cov==2.7.1
-pyyaml
+pyyaml==6.0.2
 requests-mock
-scipy
+scipy==1.15.2
 werkzeug
 natsort
 bcrypt

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -3,6 +3,6 @@ mock; python_version < '3.3'
 mypy; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'
-pyyaml
+pyyaml==6.0.2
 typing-extensions; python_version < '3.8'
 types-PyYAML

--- a/src/script/config-diff/requirements.txt
+++ b/src/script/config-diff/requirements.txt
@@ -1,2 +1,2 @@
 GitPython==3.1.44
-PyYAML==6.0.1
+PyYAML==6.0.2


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>


---
---
---


This PR has been reorganized and now simply upgrades the Python dependencies used by Ceph to make it easier to run `install-deps.sh` on `Fedora 41`+`riscv64`.

Since a certain number of projects still lack riscv64 support, if we want to add riscv64 support to Ceph, we need to do some additional work.

Let me re-introduce how to set up Ceph's dependencies in a `Fedora 41`+`riscv64` environment. This mainly consists of two parts: RPM packages and PyPI packages.

For RPM packages, thanks to Fedora's good riscv64 support, only two packages are missing: `golang-github-prometheus` and `libpmem-devel` (and `libpmemobj-devel` ,which together include the `nvml` project). I've completed the RPM packaging for these two packages in advance and stored the files [here](https://github.com/ffgan/ceph-riscv/releases/tag/0.0.1). If you're interested in the RPM build process, feel free to @ me - I'm happy to answer any questions. In the future, I'll try to contact the package maintainers to ask about adding riscv64 support for these two packages. But for now at least, we need to manually download and install the RPM packages. Since this operation is only temporary and will become unnecessary once official riscv64 support is obtained, I haven't included this operation in the current PR. This means that in the case of `Fedora 41`+`riscv64`, we need to manually resolve these two dependency issues before running `install-deps.sh`.

For PyPI packages, I'd like to divide this into two parts.

The first part consists of packages that already support riscv64. This part isn't reflected in this PR because when we use the latest versions of certain packages, these packages have already gained riscv64 support, so we don't need to worry about them. For example, packages like `rpds-py` and `coverage`.

The second part consists of packages that don't yet support riscv64, which is exactly what this PR introduces. These packages are supported by RISE's `wheel_builder` project - see details [here](https://riseproject.dev/2025/05/14/easy-installation-of-binary-python-packages-on-riscv64-devices/). To use packages from wheel_builder, we need to add an additional PyPI source: https://gitlab.com/api/v4/projects/56254198/packages/pypi/simple. Similarly, since this operation is temporary and will no longer be needed as upstream fully supports riscv64 over time, I haven't included the source configuration operation in this PR either.

After completing the setup for these two parts, we can easily build Ceph's dependency environment on `Fedora 41`+`riscv64`. For specific setup steps, you can refer to my [CI](https://github.com/ffgan/ceph-riscv/blob/fedora/.github/workflows/allow_install_deps.yaml).

So obviously, if upstream projects fully support riscv64 in the future, we'll need to open another PR similar to this one, which would also simply upgrade the dependency versions. Therefore, I believe the current PR should work well and won't introduce any temporary code.

I ran a simple test in my own fork, and the results show everything went smoothly. You can refer to this [link](https://github.com/ffgan/ceph-riscv/actions/runs/21315100067/job/61358914421).

(wheel_builder's support is still not quite complete, which causes some packages to need to be built from source, resulting in somewhat lengthy build times. I'm currently trying to resolve this issue. This issue won't affect the current PR.)

If you have any questions about the above content, feel free to @ me directly - I'm happy to answer any questions.



---
**Other Info**
Co-authored-by: Jincheng Ni <nijincheng@iscas.ac.cn>
Co-authored-by: kotvaer <lanran408@gmail.com>