### PR TITLE
tentacle: cephadm/cephadmlib: Eliminate false warnings about old sysctl conf files

### DIFF
--- a/src/cephadm/cephadmlib/sysctl.py
+++ b/src/cephadm/cephadmlib/sysctl.py
@@ -40,7 +40,7 @@ def install_sysctl(
     conf = Path(ctx.sysctl_dir).joinpath(f'90-ceph-{fsid}-{daemon_type}.conf')
 
     for conf_file in Path(ctx.sysctl_dir).glob('90-ceph-*.conf'):
-        if conf_file.name == f'90-ceph-{fsid}-{daemon_type}.conf':
+        if conf_file.name.startswith(f'90-ceph-{fsid}-'):
             continue
         logger.warning(
             f'Found a sysctl config file for a cluster with a different FSID '


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72668

---

backport of https://github.com/ceph/ceph/pull/65147
parent tracker: https://tracker.ceph.com/issues/72657

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh