### PR TITLE
tentacle: mds: dump export_ephemeral_random_pin as double

### DIFF
--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -1174,7 +1174,7 @@ void inode_t<Allocator>::dump(ceph::Formatter *f) const
   f->dump_unsigned("time_warp_seq", time_warp_seq);
   f->dump_unsigned("change_attr", change_attr);
   f->dump_int("export_pin", export_pin);
-  f->dump_int("export_ephemeral_random_pin", export_ephemeral_random_pin);
+  f->dump_float("export_ephemeral_random_pin", export_ephemeral_random_pin);
   f->dump_bool("export_ephemeral_distributed_pin", get_ephemeral_distributed_pin());
   f->dump_bool("quiesce_block", get_quiesce_block());
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72153

---

backport of https://github.com/ceph/ceph/pull/64325
parent tracker: https://tracker.ceph.com/issues/71944

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh