### PR TITLE
crimson/os/seastore: correct possible mergeable size for ool extents

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -1068,7 +1068,7 @@ RandomBlockOolWriter::do_write(
 
     // TODO : allocate a consecutive address based on a transaction
     if (writes.size() != 0 &&
-        writes.back().offset + writes.back().bp.length() == paddr) {
+	writes.back().offset + writes.back().get_mergeable_length() == paddr) {
       // We can write both the currrent extent and the previous one at once
       // if the extents are located in a row
       if (writes.back().mergeable_bps.size() == 0) {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -195,6 +195,17 @@ private:
     ceph::bufferptr bp;
     RandomBlockManager* rbm;
     std::list<ceph::bufferptr> mergeable_bps;
+
+    extent_len_t get_mergeable_length() const {
+      if (mergeable_bps.size() == 0) {
+	return bp.length();
+      }
+      extent_len_t len = 0;
+      for (auto &p : mergeable_bps) {
+	len += p.length();
+      }
+      return len;
+    }
   };
   alloc_write_iertr::future<> do_write(
     Transaction& t,


### PR DESCRIPTION
Current implementation only checks a previous ool extent before writing a ool extent. This can miss merge opportunities for extents that are sequential but precede the last OOL extent.

This commit fixes this by reporting a correct mergeable size.

Depending on SSDs in my testbed, this can improve sequential write performance up to by 5%.

Before:
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11114586112 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11114651648 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11114717184 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11114782720 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11114848256 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11114913792 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11114979328 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115044864 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115110400 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115175936 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115241472 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115307008 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115372544 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115438080 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115503616 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115569152 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115634688 len 65536
DEBUG 2025-08-21 14:54:39,759 [shard 0:main] seastore_tm - block: write offset 11115700224 len 65536
....


After:
seastore_tm - block: write offset 11062157312 len 4194304


Signed-off-by: Myoungwon Oh <ohmyoungwon@gmail.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
