### PR TITLE
mgr/dashboard: Dashboard nfs export editor rejects ipv6 addresses

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
@@ -41,7 +41,7 @@
                        name="addresses"
                        id="addresses"
                        formControlName="addresses"
-                       placeholder="192.168.0.10, 192.168.1.0/8"
+                       placeholder="e.g. 192.168.0.10, 192.168.1.0/8"
                        [invalid]="!item.controls['addresses'].valid && (item.controls['addresses'].dirty)">
               </cds-text-label>
               <ng-template #addressesError>
@@ -49,8 +49,8 @@
                   <span *ngIf="showError(index, 'addresses', formDir, 'required')"
                         i18n>This field is required.</span>
 
-                  <span *ngIf="showError(index, 'addresses', formDir, 'pattern')">
-                    <ng-container i18n>Must contain one or more comma-separated values</ng-container>
+                  <span *ngIf="showError(index, 'addresses', formDir, 'invalidAddress')">
+                    <ng-container i18n>Must contain one or more comma-separated valid addresses.</ng-container>
                     <br>
                     <ng-container i18n>For example:</ng-container> 192.168.0.10, 192.168.1.0/8
                   </span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
@@ -68,4 +68,46 @@ describe('NfsFormClientComponent', () => {
     component.removeClient(0);
     expect(component.form.getValue('clients')).toEqual([]);
   });
+
+  describe(`test 'isValidClientAddress'`, () => {
+    it('should return false for empty value', () => {
+      expect(component.isValidClientAddress('')).toBeFalsy();
+      expect(component.isValidClientAddress(null)).toBeFalsy();
+    });
+
+    it('should return false for valid single IPv4 address', () => {
+      expect(component.isValidClientAddress('192.168.1.1')).toBeFalsy();
+    });
+
+    it('should return false for valid IPv6 address', () => {
+      expect(component.isValidClientAddress('2001:db8::1')).toBeFalsy();
+    });
+
+    it('should return false for valid FQDN', () => {
+      expect(component.isValidClientAddress('nfs.example.com')).toBeFalsy();
+    });
+
+    it('should return false for valid IP CIDR range', () => {
+      expect(component.isValidClientAddress('192.168.0.0/24')).toBeFalsy();
+      expect(component.isValidClientAddress('2001:db8::/64')).toBeFalsy();
+    });
+
+    it('should return false for multiple valid addresses separated by comma', () => {
+      const input = '192.168.1.1, 2001:db8::1, nfs.example.com, 10.0.0.0/8';
+      expect(component.isValidClientAddress(input)).toBeFalsy();
+    });
+
+    it('should return true for invalid single address', () => {
+      expect(component.isValidClientAddress('invalid-address')).toBeTruthy();
+    });
+
+    it('should return true for mixed valid and invalid addresses', () => {
+      const input = '192.168.1.1, invalid-address';
+      expect(component.isValidClientAddress(input)).toBeTruthy();
+    });
+
+    it('should return true for URLs with protocols', () => {
+      expect(component.isValidClientAddress('http://nfs.example.com')).toBeTruthy();
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -696,7 +696,9 @@ export class CdValidators {
       return null;
     }
 
-    const urls = value.includes(',') ? value.split(',') : [value];
+    const urls = value.includes(',')
+      ? value.split(',').map((v: string) => v.trim())
+      : [value.trim()];
 
     const invalidUrls = urls.filter(
       (url: string) =>


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/72660



https://github.com/user-attachments/assets/90e8af37-8a2c-4657-9a7c-aae034f7a488






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
