### PR TITLE
mon: add config option to change availability score update interval 

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -175,6 +175,14 @@
   five seconds and the feature is enabled by default. A new config option ``enable_availability_tracking``
   can be used to turn off the feature if required. Another command is added to clear the 
   availability status for a specific pool, ``ceph osd pool clear-availability-status <pool-name>``. 
+  users to view the availability score for each pool in a cluster. A pool is considered 
+  unavailable if any PG in the pool is not in active state or if there are unfound 
+  objects. Otherwise the pool is considered available. The score is updated every 
+  one second by default. This interval can be changed using the new config option
+  ``pool_availability_update_interval.``. The feature is on by default. A new config option 
+  ``enable_availability_tracking`` can be used to turn off the feature if required. 
+  Another command is added to clear the availability status for a specific pool, 
+  ``ceph osd pool clear-availability-status <pool-name>``. 
   This feature is in tech preview. 
   Related trackers:
    - https://tracker.ceph.com/issues/67777

--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -628,6 +628,7 @@ Miscellaneous
 .. confval:: mon_memory_target
 .. confval:: mon_memory_autotune
 .. confval:: enable_availability_tracking
+.. confval:: pool_availability_update_interval
 
 NVMe-oF Monitor Client
 ======================

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -781,10 +781,19 @@ the Mean Time Between Failures (MTBF) and Mean Time To Recover (MTTR)
 for each pool. The availability score is then calculated by finding 
 the ratio of MTBF to the total time.  
 
-The score is updated every five seconds. This interval is currently 
-not configurable. Any intermittent changes to the pools that 
-occur between this duration but are reset before we recheck the pool 
-status will not be captured by this feature. 
+The score is updated every one second. Transient changes to pools that 
+occur and are reverted between successive updates will not be captured. 
+It is possible to configure this interval with a command of the following 
+form: 
+
+.. prompt:: bash $
+
+   ceph config set mon pool_availability_update_interval 2
+
+This will set the update interval to two seconds. Please note that 
+it is not possible to set this interval less than the config value set
+for ``paxos_propose_interval``. 
+
 
 This feature is on by default. To turn the feature off, e.g. - for an expected 
 downtime, the ``enable_availability_tracking`` config option can be set to ``false``. 

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1420,3 +1420,13 @@ options:
   default: 30
   services:
   - mon
+- name: pool_availability_update_interval
+  type: float
+  level: advanced
+  desc: Update data availability score at this interval. By default the interval 
+    is same as paxos_propose_interval configuration.  
+  default: 1
+  services :
+  - mon
+  flags:
+  - runtime

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -64,6 +64,7 @@ std::vector<std::string> MgrStatMonitor::get_tracked_keys() const noexcept
 {
   return {
     "enable_availability_tracking",
+    "pool_availability_update_interval",
   };
 }
 
@@ -92,6 +93,16 @@ void MgrStatMonitor::handle_conf_change(
                << now << dendl;
     }
     enable_availability_tracking = newval;
+  }
+
+  if (changed.count("pool_availability_update_interval")) {
+      std::scoped_lock l(lock);
+      dout(10) << __func__ << " pool_availability_update_interval config changed from " 
+             << pool_availability_update_interval << " to " 
+             << g_conf().get_val<double>("pool_availability_update_interval")
+             << dendl;
+      
+      pool_availability_update_interval = g_conf().get_val<double>("pool_availability_update_interval"); 
   }
 }
 

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -57,8 +57,10 @@ public:
   void calc_pool_availability();
   bool enable_availability_tracking = g_conf().get_val<bool>("enable_availability_tracking"); ///< tracking availability score feature 
   double pool_availability_update_interval = g_conf().get_val<double>("pool_availability_update_interval");
+  utime_t pool_availability_last_updated = ceph_clock_now(); 
 
   void clear_pool_availability(int64_t poolid);
+  bool should_calc_pool_availability();
 
   void check_sub(Subscription *sub);
   void check_subs();

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -56,7 +56,8 @@ public:
 
   void calc_pool_availability();
   bool enable_availability_tracking = g_conf().get_val<bool>("enable_availability_tracking"); ///< tracking availability score feature 
-  
+  double pool_availability_update_interval = g_conf().get_val<double>("pool_availability_update_interval");
+
   void clear_pool_availability(int64_t poolid);
 
   void check_sub(Subscription *sub);


### PR DESCRIPTION
This commit adds the dynamic config option to change the interval at which the data availability score is updated.

Fixes: https://tracker.ceph.com/issues/72619

## Implementation details 

`calc_pool_availability` is responsible for updating the availability score. This is invoked inside `MgrStatMonitor::update_from_paxos`. 

`MgrStatMonitor::update_from_paxos` is called at the end of each paxos update. This essentially means frequency of availablity score update is currently tied to paxos update frequency. Looking at `PaxosService::should_propose` it seems like `paxos_propose_interval` config option determines how often paxos updates happen. 

There are two ways I can implement the ability to give users the flexibility to change frequency of how often the score is calculated: 

1. Decouple the two, score update freq & paxos update frequency 
2. Not decouple the above two

|  | Decouple  | Not Decouple |
| --- | --- | --- |
| Flexibility of configuration | Any value can be configured  | Values equal to or greater than `paxos_propose_interval` can be configured  |
| Implementation Effort | Considerable, exact effort needs to be determined | Straightforward  |

I decided to go with not decoupling. The only “downside” here is that users can not configure values less than  `paxos_propose_interval`. I think this should be fine as PG map updates will only be available at an interval greater than or equal to `paxos_propose_interval`. Without new PG map, the availability score we will be calculating will be stale. So it makes sense that users should not be allowed to configure availability score update frequency lesser than `paxos_propose_interval`.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [X] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
