### PR TITLE
OSDMap::calc_pg_maps: fix balancing for some (important) corner cases

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5716,13 +5716,13 @@ int OSDMap::calc_pg_upmaps(
   ldout(cct, 10) << " osd_weight_total " << osd_weight_total << dendl;
   ldout(cct, 10) << " pgs_per_weight " << pgs_per_weight << dendl;
 
-  float stddev = 0;
+  float bal_score = 0; // how balanced the pgs are. 0 is perfect.
   map<int,float> osd_deviation;       // osd, deviation(pgs)
   multimap<float,int> deviation_osd;  // deviation(pgs), osd
   float cur_max_deviation = calc_deviations(cct, pgs_by_osd, osd_weight, pgs_per_weight,
-				      	    osd_deviation, deviation_osd, stddev);
+				      	    osd_deviation, deviation_osd, bal_score);
 
-  ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+  ldout(cct, 10) << " bal_score " << bal_score << " max_deviation " << cur_max_deviation << dendl;
   if (cur_max_deviation <= max_deviation) {
     ldout(cct, 10) << __func__ << " distribution is almost perfect"
                    << dendl;
@@ -5947,17 +5947,17 @@ int OSDMap::calc_pg_upmaps(
 
     // test change, apply if change is good
     ceph_assert(to_unmap.size() || to_upmap.size());
-    float new_stddev = 0;
+    float new_bal_score = 0;
     map<int,float> temp_osd_deviation;
     multimap<float,int> temp_deviation_osd;
     float cur_max_deviation = calc_deviations(cct, temp_pgs_by_osd, osd_weight,
     					      pgs_per_weight, temp_osd_deviation,
-					      temp_deviation_osd, new_stddev);
-    ldout(cct, 10) << " stddev " << stddev << " -> " << new_stddev << dendl;
+					      temp_deviation_osd, new_bal_score);
+    ldout(cct, 10) << " bal_score " << bal_score << " -> " << new_bal_score << dendl;
     // accept change if it doesn't make things worse
-    if (new_stddev > stddev) {
+    if (new_bal_score > bal_score) {
       if (!aggressive) {
-        ldout(cct, 10) << " break because stddev is not decreasing"
+        ldout(cct, 10) << " break because bal_score is not decreasing"
                        << " and aggressive mode is not enabled"
                        << dendl;
         break;
@@ -5984,8 +5984,8 @@ int OSDMap::calc_pg_upmaps(
     }
 
     // ready to go
-    ceph_assert(new_stddev <= stddev);
-    stddev = new_stddev;
+    ceph_assert(new_bal_score <= bal_score);
+    bal_score = new_bal_score;
     pgs_by_osd = temp_pgs_by_osd;
     osd_deviation = temp_osd_deviation;
     deviation_osd = temp_deviation_osd;
@@ -5994,7 +5994,7 @@ int OSDMap::calc_pg_upmaps(
 
     num_changed += pack_upmap_results(cct, to_unmap, to_upmap, tmp_osd_map, pending_inc);
 
-    ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+    ldout(cct, 10) << " bal_score " << bal_score << " max_deviation " << cur_max_deviation << dendl;
     if (cur_max_deviation <= max_deviation) {
       ldout(cct, 10) << __func__ << " Optimization plan is almost perfect"
                      << dendl;
@@ -6129,32 +6129,33 @@ float OSDMap::calc_deviations (
   float pgs_per_weight,
   map<int,float>& osd_deviation,
   multimap<float,int>& deviation_osd,
-  float& stddev)  // return current max deviation
+  float& bal_score)  // return current max deviation
 {
   //
-  // This function calculates the 2 maps osd_deviation and deviation_osd which 
+  // This function calculates the map's osd_deviation and deviation_osd, which
   // hold the deviation between the current number of PGs which map to an OSD 
-  // and the optimal number. Ot also calculates the stddev of the deviations and
+  // and the optimal number. It also calculates a bal_score of the deviations and
   // returns the current max deviation. 
-  // NOTE - the calculation is not exactly stddev it is actually sttdev^2 but as
-  //        long as it is monotonic with stddev (and it is), it is sufficient for
-  //        the balancer code.
   //
   float cur_max_deviation = 0.0;
-  stddev = 0.0;
+  bal_score = 0.0;
   for (auto& [oid, opgs] : pgs_by_osd) {
     // make sure osd is still there (belongs to this crush-tree)
     ceph_assert(osd_weight.count(oid));
-    float target = osd_weight.at(oid) * pgs_per_weight;
-    float deviation = (float)opgs.size() - target;
+    float weight = osd_weight.at(oid);
+    float pgs = (float)opgs.size();
+    float target = weight * pgs_per_weight;
+    float deviation = pgs - target;
     ldout(cct, 20) << " osd." << oid
-                   << "\tpgs " << opgs.size()
+                   << "\tweight " << weight
+                   << "\tpgs " << pgs
                    << "\ttarget " << target
                    << "\tdeviation " << deviation
                    << dendl;
     osd_deviation[oid] = deviation;
     deviation_osd.insert(make_pair(deviation, oid));
-    stddev += deviation * deviation;
+    bal_score += (pgs / target - 1.0) *
+                 (pgs / target - 1.0) * weight;
     if (fabsf(deviation) > cur_max_deviation)
       cur_max_deviation = fabsf(deviation);
   }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5722,7 +5722,7 @@ int OSDMap::calc_pg_upmaps(
   float cur_max_deviation = calc_deviations(cct, pgs_by_osd, osd_weight, pgs_per_weight,
 				      	    osd_deviation, deviation_osd, stddev);
 
-  ldout(cct, 20) << " stdev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+  ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
   if (cur_max_deviation <= max_deviation) {
     ldout(cct, 10) << __func__ << " distribution is almost perfect"
                    << dendl;
@@ -5954,7 +5954,8 @@ int OSDMap::calc_pg_upmaps(
     					      pgs_per_weight, temp_osd_deviation,
 					      temp_deviation_osd, new_stddev);
     ldout(cct, 10) << " stddev " << stddev << " -> " << new_stddev << dendl;
-    if (new_stddev >= stddev) {
+    // accept change if it doesn't make things worse
+    if (new_stddev > stddev) {
       if (!aggressive) {
         ldout(cct, 10) << " break because stddev is not decreasing"
                        << " and aggressive mode is not enabled"
@@ -5983,7 +5984,7 @@ int OSDMap::calc_pg_upmaps(
     }
 
     // ready to go
-    ceph_assert(new_stddev < stddev);
+    ceph_assert(new_stddev <= stddev);
     stddev = new_stddev;
     pgs_by_osd = temp_pgs_by_osd;
     osd_deviation = temp_osd_deviation;
@@ -5993,7 +5994,7 @@ int OSDMap::calc_pg_upmaps(
 
     num_changed += pack_upmap_results(cct, to_unmap, to_upmap, tmp_osd_map, pending_inc);
 
-    ldout(cct, 20) << " stdev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+    ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
     if (cur_max_deviation <= max_deviation) {
       ldout(cct, 10) << __func__ << " Optimization plan is almost perfect"
                      << dendl;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5803,7 +5803,7 @@ int OSDMap::calc_pg_upmaps(
   float cur_max_deviation = calc_deviations(cct, pgs_by_osd, osd_weight, pgs_per_weight,
 				      	    osd_deviation, deviation_osd, stddev);
 
-  ldout(cct, 20) << " stdev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+  ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
   if (cur_max_deviation <= max_deviation) {
     ldout(cct, 10) << __func__ << " distribution is almost perfect"
                    << dendl;
@@ -6039,7 +6039,8 @@ int OSDMap::calc_pg_upmaps(
     					      pgs_per_weight, temp_osd_deviation,
 					      temp_deviation_osd, new_stddev);
     ldout(cct, 10) << " stddev " << stddev << " -> " << new_stddev << dendl;
-    if (new_stddev >= stddev) {
+    // accept change if it doesn't make things worse
+    if (new_stddev > stddev) {
       if (!aggressive) {
         ldout(cct, 10) << " break because stddev is not decreasing"
                        << " and aggressive mode is not enabled"
@@ -6068,7 +6069,7 @@ int OSDMap::calc_pg_upmaps(
     }
 
     // ready to go
-    ceph_assert(new_stddev < stddev);
+    ceph_assert(new_stddev <= stddev);
     stddev = new_stddev;
     pgs_by_osd = temp_pgs_by_osd;
     osd_deviation = temp_osd_deviation;
@@ -6078,7 +6079,7 @@ int OSDMap::calc_pg_upmaps(
 
     num_changed += pack_upmap_results(cct, to_unmap, to_upmap, tmp_osd_map, pending_inc);
 
-    ldout(cct, 20) << " stdev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+    ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
     if (cur_max_deviation <= max_deviation) {
       ldout(cct, 10) << __func__ << " Optimization plan is almost perfect"
                      << dendl;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5797,7 +5797,7 @@ int OSDMap::calc_pg_upmaps(
   ldout(cct, 10) << " osd_weight_total " << osd_weight_total << dendl;
   ldout(cct, 10) << " pgs_per_weight " << pgs_per_weight << dendl;
 
-  float bal_score = 0; // how balanced the pgs are. 0 is perfect.
+  double bal_score = 0; // how balanced the pgs are. 0 is perfect.
   map<int,float> osd_deviation;       // osd, deviation(pgs)
   multimap<float,int> deviation_osd;  // deviation(pgs), osd
   float cur_max_deviation = calc_deviations(cct, pgs_by_osd, osd_weight, pgs_per_weight,
@@ -6032,14 +6032,17 @@ int OSDMap::calc_pg_upmaps(
 
     // test change, apply if change is good
     ceph_assert(to_unmap.size() || to_upmap.size());
-    float new_bal_score = 0;
+    double new_bal_score = 0;
     map<int,float> temp_osd_deviation;
     multimap<float,int> temp_deviation_osd;
     float cur_max_deviation = calc_deviations(cct, temp_pgs_by_osd, osd_weight,
     					      pgs_per_weight, temp_osd_deviation,
 					      temp_deviation_osd, new_bal_score);
-    ldout(cct, 10) << " bal_score " << bal_score << " -> " << new_bal_score << dendl;
-    // accept change if it doesn't make things worse
+    // log the delta too: the totals are printed with the stream's default
+    // precision, so a small but real improvement is invisible in them
+    ldout(cct, 10) << " bal_score " << bal_score << " -> " << new_bal_score
+                   << " (delta " << new_bal_score - bal_score << ")" << dendl;
+    // reject the change if it makes things worse
     if (new_bal_score > bal_score) {
       if (!aggressive) {
         ldout(cct, 10) << " break because bal_score is not decreasing"
@@ -6221,13 +6224,19 @@ float OSDMap::calc_deviations (
   float pgs_per_weight,
   map<int,float>& osd_deviation,
   multimap<float,int>& deviation_osd,
-  float& bal_score)  // return current max deviation
+  double& bal_score)  // return current max deviation
 {
   //
   // This function calculates the map's osd_deviation and deviation_osd, which
-  // hold the deviation between the current number of PGs which map to an OSD 
+  // hold the deviation between the current number of PGs which map to an OSD
   // and the optimal number. It also calculates a bal_score of the deviations and
-  // returns the current max deviation. 
+  // returns the current max deviation.
+  //
+  // NOTE - bal_score is accumulated in double. A single PG moving between two
+  //        OSDs changes one term of a sum taken over every OSD in the crush
+  //        tree; in float that delta can fall below the ULP of the total, so
+  //        two genuinely different mappings compare equal and the balancer
+  //        stalls.
   //
   float cur_max_deviation = 0.0;
   bal_score = 0.0;
@@ -6238,6 +6247,7 @@ float OSDMap::calc_deviations (
     float pgs = (float)opgs.size();
     float target = weight * pgs_per_weight;
     float deviation = pgs - target;
+    ceph_assert(target > 0);
     ldout(cct, 20) << " osd." << oid
                    << "\tweight " << weight
                    << "\tpgs " << pgs
@@ -6246,8 +6256,10 @@ float OSDMap::calc_deviations (
                    << dendl;
     osd_deviation[oid] = deviation;
     deviation_osd.insert(make_pair(deviation, oid));
-    bal_score += (pgs / target - 1.0) *
-                 (pgs / target - 1.0) * weight;
+    // (pgs / target - 1) is the relative deviation, computed from the already
+    // known absolute deviation to avoid cancellation when pgs is close to target
+    double rel_deviation = (double)deviation / target;
+    bal_score += rel_deviation * rel_deviation * weight;
     if (fabsf(deviation) > cur_max_deviation)
       cur_max_deviation = fabsf(deviation);
   }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5797,13 +5797,13 @@ int OSDMap::calc_pg_upmaps(
   ldout(cct, 10) << " osd_weight_total " << osd_weight_total << dendl;
   ldout(cct, 10) << " pgs_per_weight " << pgs_per_weight << dendl;
 
-  float stddev = 0;
+  float bal_score = 0; // how balanced the pgs are. 0 is perfect.
   map<int,float> osd_deviation;       // osd, deviation(pgs)
   multimap<float,int> deviation_osd;  // deviation(pgs), osd
   float cur_max_deviation = calc_deviations(cct, pgs_by_osd, osd_weight, pgs_per_weight,
-				      	    osd_deviation, deviation_osd, stddev);
+				      	    osd_deviation, deviation_osd, bal_score);
 
-  ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+  ldout(cct, 10) << " bal_score " << bal_score << " max_deviation " << cur_max_deviation << dendl;
   if (cur_max_deviation <= max_deviation) {
     ldout(cct, 10) << __func__ << " distribution is almost perfect"
                    << dendl;
@@ -6032,17 +6032,17 @@ int OSDMap::calc_pg_upmaps(
 
     // test change, apply if change is good
     ceph_assert(to_unmap.size() || to_upmap.size());
-    float new_stddev = 0;
+    float new_bal_score = 0;
     map<int,float> temp_osd_deviation;
     multimap<float,int> temp_deviation_osd;
     float cur_max_deviation = calc_deviations(cct, temp_pgs_by_osd, osd_weight,
     					      pgs_per_weight, temp_osd_deviation,
-					      temp_deviation_osd, new_stddev);
-    ldout(cct, 10) << " stddev " << stddev << " -> " << new_stddev << dendl;
+					      temp_deviation_osd, new_bal_score);
+    ldout(cct, 10) << " bal_score " << bal_score << " -> " << new_bal_score << dendl;
     // accept change if it doesn't make things worse
-    if (new_stddev > stddev) {
+    if (new_bal_score > bal_score) {
       if (!aggressive) {
-        ldout(cct, 10) << " break because stddev is not decreasing"
+        ldout(cct, 10) << " break because bal_score is not decreasing"
                        << " and aggressive mode is not enabled"
                        << dendl;
         break;
@@ -6069,8 +6069,8 @@ int OSDMap::calc_pg_upmaps(
     }
 
     // ready to go
-    ceph_assert(new_stddev <= stddev);
-    stddev = new_stddev;
+    ceph_assert(new_bal_score <= bal_score);
+    bal_score = new_bal_score;
     pgs_by_osd = temp_pgs_by_osd;
     osd_deviation = temp_osd_deviation;
     deviation_osd = temp_deviation_osd;
@@ -6079,7 +6079,7 @@ int OSDMap::calc_pg_upmaps(
 
     num_changed += pack_upmap_results(cct, to_unmap, to_upmap, tmp_osd_map, pending_inc);
 
-    ldout(cct, 10) << " stddev " << stddev << " max_deviation " << cur_max_deviation << dendl;
+    ldout(cct, 10) << " bal_score " << bal_score << " max_deviation " << cur_max_deviation << dendl;
     if (cur_max_deviation <= max_deviation) {
       ldout(cct, 10) << __func__ << " Optimization plan is almost perfect"
                      << dendl;
@@ -6221,32 +6221,33 @@ float OSDMap::calc_deviations (
   float pgs_per_weight,
   map<int,float>& osd_deviation,
   multimap<float,int>& deviation_osd,
-  float& stddev)  // return current max deviation
+  float& bal_score)  // return current max deviation
 {
   //
-  // This function calculates the 2 maps osd_deviation and deviation_osd which 
+  // This function calculates the map's osd_deviation and deviation_osd, which
   // hold the deviation between the current number of PGs which map to an OSD 
-  // and the optimal number. Ot also calculates the stddev of the deviations and
+  // and the optimal number. It also calculates a bal_score of the deviations and
   // returns the current max deviation. 
-  // NOTE - the calculation is not exactly stddev it is actually sttdev^2 but as
-  //        long as it is monotonic with stddev (and it is), it is sufficient for
-  //        the balancer code.
   //
   float cur_max_deviation = 0.0;
-  stddev = 0.0;
+  bal_score = 0.0;
   for (auto& [oid, opgs] : pgs_by_osd) {
     // make sure osd is still there (belongs to this crush-tree)
     ceph_assert(osd_weight.count(oid));
-    float target = osd_weight.at(oid) * pgs_per_weight;
-    float deviation = (float)opgs.size() - target;
+    float weight = osd_weight.at(oid);
+    float pgs = (float)opgs.size();
+    float target = weight * pgs_per_weight;
+    float deviation = pgs - target;
     ldout(cct, 20) << " osd." << oid
-                   << "\tpgs " << opgs.size()
+                   << "\tweight " << weight
+                   << "\tpgs " << pgs
                    << "\ttarget " << target
                    << "\tdeviation " << deviation
                    << dendl;
     osd_deviation[oid] = deviation;
     deviation_osd.insert(make_pair(deviation, oid));
-    stddev += deviation * deviation;
+    bal_score += (pgs / target - 1.0) *
+                 (pgs / target - 1.0) * weight;
     if (fabsf(deviation) > cur_max_deviation)
       cur_max_deviation = fabsf(deviation);
   }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1599,7 +1599,7 @@ private: // Bunch of internal functions used only by calc_pg_upmaps (result of c
     float pgs_per_weight,
     std::map<int,float>& osd_deviation,
     std::multimap<float,int>& deviation_osd,
-    float& stddev
+    double& bal_score
   );  // return current max deviation
 
   void fill_overfull_underfull (


### PR DESCRIPTION
This PR fixes upmap balancing for two existing balancer problems: stall out due to stddev not decreasing, and undervaluing the deviation of small OSDs.

https://tracker.ceph.com/issues/78314

### Accept changes that don't decrease stddev

In some cases the balancer can stall out, unable to find any
changes that will help overfull or underfull OSDs get closer
to their target num PGs.

Here's an example from the wild. These changes are not
accepted because the overall stddev is not decreasing:

```
  will try dropping existing remapping pair 264 -> 137 which remapped 24.f9d into overfull osd.137
  existing pg_upmap_items [766,799,264,137] remapped 24.f9d into overfull osd.137, new_pg_upmap_items now [766,799]
  stddev 138085.453125 -> 138085.453125
```
```
  will try dropping existing remapping pair 496 -> 637 which remapped 24.5ca out from underfull osd.496
  existing pg_upmap_items [729,790,496,637] remapped 24.5ca out from underfull osd.496, new_pg_upmap_items now [729,790]
  stddev 138085.453125 -> 138085.453125
```
Those changes will now be accepted, which is good because those
OSDs will improve, even though the sum of squared deviations does
not.

Also fix some debug outputs.

### Improved OSDMap balancing "score"

Currently we score how balanced we are using a sum of the absolute
deviations, treating small and large OSDs equally. This strongly
under values relatively small PGs, which we really need to be
accurately balancing with priority to avoid them getting overfull.

Consider this scenario:

* `osd.0 weight 100.0 pgs 100 target 100 -> deviation 0`
* `osd.1 weight 1.0   pgs 2   target 1   -> deviation 1`

The tiny OSD osd.1 is 2x overfull -- we should prioritize moving
one of its PGs to osd.0, which would only go 1% overfull. The
new values would become:

* `osd.0 weight 100.0 pgs 101 target 100 -> deviation 1`
* `osd.1 weight 1.0   pgs 1   target 1   -> deviation 0`

With the "stddev" calculation, we have these before/after scores:

* `stddev = 0*0 + 1*1 = 1`
* `new_stddev = 1*1 + 0*0 = 1`

(Until recently, that change would be rejected because it does not
decrease the stddev).

To improve things, we calculate a bal_score which incorporates the
relative deviation and OSD weights.

Here's the new scores for the example change above:

* `bal_score = (100/100 - 1)^2 * 100 + (2/1 - 1)^2 * 1 = 2`
* `new_bal_score = (101/100 - 1)^2 * 100 + (1/1 - 1)^2 * 1 = 0.01`

With this new approach the change is highly favourable, as it
should be.







## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests
