### PR TITLE
crimson, os: prevent using ObjectStore instance deployed by wrong flavour of OSD

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -89,6 +89,19 @@ options:
   flags:
   - startup
 
+- name: crimson_osd_objectstore
+  type: str
+  level: advanced
+  desc: Back end for new OSDs (like alienstore-bluestore or seastore)
+  default: alienstore-bluestore
+  enum_values:
+  - alienstore-bluestore
+  - alienstore-memstore
+  - seastore
+  - cyanstore
+  flags:
+  - create
+
 # Bluestore options:
 
 - name: crimson_bluestore_num_threads

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3827,7 +3827,6 @@ options:
   default: bluestore
   enum_values:
   - bluestore
-  - filestore
   - memstore
   - seastore
   - cyanstore

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3828,8 +3828,6 @@ options:
   enum_values:
   - bluestore
   - memstore
-  - seastore
-  - cyanstore
   flags:
   - create
   with_legacy: true

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -71,6 +71,9 @@ if(WITH_LTTNG)
 endif()
 
 # For crimson-alienstore WITH_CRIMSON is not defined
+target_compile_definitions(crimson-alienstore
+  PRIVATE OBJSTORE_NAME_PREFIX="alienstore-")
+
 target_link_libraries(crimson-alienstore
   PRIVATE
     seastar

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -235,7 +235,7 @@ int main(int argc, const char* argv[])
 
           DEBUG("creating object store");
           auto store = crimson::os::FuturizedStore::create(
-            local_conf().get_val<std::string>("osd_objectstore"),
+            local_conf().get_val<std::string>("crimson_osd_objectstore"),
             local_conf().get_val<std::string>("osd_data"),
             local_conf().get_config_values());
           INFO("passed objectstore is {}", local_conf().get_val<std::string>("osd_objectstore"));

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -73,6 +73,12 @@
 #define tracepoint(...)
 #endif
 
+#ifdef OBJSTORE_NAME_PREFIX
+#define BLUESTORE_FLAVOR_NAME OBJSTORE_NAME_PREFIX "bluestore"
+#else
+#define BLUESTORE_FLAVOR_NAME "bluestore"
+#endif
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 
@@ -7831,8 +7837,8 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
       return r;
     }
 
-    if (type != "bluestore") {
-      derr << __func__ << " expected bluestore, but type is " << type << dendl;
+    if (type != BLUESTORE_FLAVOR_NAME) {
+      derr << __func__ << " expected " BLUESTORE_FLAVOR_NAME ", but type is " << type << dendl;
       return -EIO;
     }
   }
@@ -8600,12 +8606,12 @@ int BlueStore::mkfs()
     string type;
     r = read_meta("type", &type);
     if (r == 0) {
-      if (type != "bluestore") {
-	derr << __func__ << " expected bluestore, but type is " << type << dendl;
+      if (type != BLUESTORE_FLAVOR_NAME) {
+	derr << __func__ << " expected " BLUESTORE_FLAVOR_NAME ", but type is " << type << dendl;
 	return -EIO;
       }
     } else {
-      r = write_meta("type", "bluestore");
+      r = write_meta("type", BLUESTORE_FLAVOR_NAME);
       if (r < 0)
         return r;
     }
@@ -9300,8 +9306,8 @@ int BlueStore::_mount_readonly()
       return r;
      }
 
-     if (type != "bluestore") {
-       derr << __func__ << " expected bluestore, but type is " << type << dendl;
+     if (type != BLUESTORE_FLAVOR_NAME) {
+       derr << __func__ << " expected " BLUESTORE_FLAVOR_NAME ", but type is " << type << dendl;
        return -EIO;
      }
    }

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -214,7 +214,11 @@ int MemStore::mkfs()
   if (r < 0)
     return r;
 
+#ifdef OBJSTORE_NAME_PREFIX
+  r = write_meta("type", OBJSTORE_NAME_PREFIX "memstore");
+#else
   r = write_meta("type", "memstore");
+#endif
   if (r < 0)
     return r;
 

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -170,8 +170,10 @@ gssapi_authx=0
 cache=""
 if [ `uname` = FreeBSD ]; then
     objectstore="memstore"
+    crimson_objectstore="alienstore-memstore"
 else
     objectstore="bluestore"
+    crimson_objectstore="alienstore-bluestore"
 fi
 ceph_osd=ceph-osd
 rgw_frontend="beast"
@@ -559,15 +561,17 @@ case $1 in
         ;;
     --memstore)
         objectstore="memstore"
+        crimson_objectstore="alienstore-memstore"
         ;;
     --cyanstore)
         objectstore="cyanstore"
         ;;
     --seastore)
-        objectstore="seastore"
+        crimson_objectstore="seastore"
         ;;
     -b | --bluestore)
         objectstore="bluestore"
+        crimson_objectstore="alienstore-bluestore"
         ;;
     --hitset)
         hitset="$hitset $2 $3"
@@ -926,7 +930,7 @@ EOF
         fi
     fi
 
-    if [ "$objectstore" == "seastore" ]; then
+    if [ "$crimson_objectstore" == "seastore" ]; then
       if [[ ${seastore_size+x} ]]; then
         SEASTORE_OPTS="
         seastore device size = $seastore_size"
@@ -1026,6 +1030,7 @@ $DAEMONOPTS
         
 $BLUESTORE_OPTS
 
+        crimson osd objectstore = $crimson_objectstore
         osd objectstore = $objectstore
 $SEASTORE_OPTS
 $COSDSHORT


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
