### PR TITLE
crimson: further improvements to store-bench

### DIFF
--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -14,6 +14,7 @@
 #include "common/config.h"
 #include "crimson/admin/admin_socket.h"
 #include "crimson/common/log.h"
+#include "crimson/common/metrics_helpers.h"
 #include "crimson/common/perf_counters_collection.h"
 #include "crimson/osd/exceptions.h"
 #include "crimson/osd/osd.h"
@@ -342,81 +343,16 @@ public:
     fref->open_object_section("metrics");
     fref->open_array_section("metrics");
     co_await crimson::invoke_on_all_seq([f = fref.get(), &prefix] {
-      for (const auto& [full_name, metric_family]: seastar::scollectd::get_value_map()) {
-        if (!prefix.empty() && full_name.compare(0, prefix.size(), prefix) != 0) {
-          continue;
-        }
-        for (const auto& [labels, metric] : metric_family) {
-          if (metric && metric->is_enabled()) {
-	    f->open_object_section(""); // enclosed by array
-            DumpMetricsHook::dump_metric_value(f, full_name, *metric, labels.labels());
-	    f->close_section();
-          }
-        }
-      }
+      crimson::metrics::dump_metric_value_map(
+	seastar::scollectd::get_value_map(),
+	f,
+	[prefix](const auto &full_name) {
+	  return prefix.empty() || full_name.compare(0, prefix.size(), prefix) != 0;
+	});
     });
     fref->close_section();
     fref->close_section();
     co_return std::move(fref);
-  }
-private:
-  using registered_metric = seastar::metrics::impl::registered_metric;
-  using data_type = seastar::metrics::impl::data_type;
-
-  static void dump_metric_value(Formatter* f,
-                                string_view full_name,
-                                const registered_metric& metric,
-                                const seastar::metrics::impl::labels_type& labels)
-  {
-    f->open_object_section(full_name);
-    for (const auto& [key, value] : labels) {
-      f->dump_string(key, value);
-    }
-    auto value_name = "value";
-    switch (auto v = metric(); v.type()) {
-    case data_type::GAUGE:
-      f->dump_float(value_name, v.d());
-      break;
-    case data_type::REAL_COUNTER:
-      f->dump_float(value_name, v.d());
-      break;
-    case data_type::COUNTER:
-      double val;
-      try {
-	val = v.ui();
-      } catch (std::range_error&) {
-	// seastar's cpu steal time may be negative
-	val = 0;
-      }
-      f->dump_unsigned(value_name, val);
-      break;
-    case data_type::HISTOGRAM: {
-      f->open_object_section(value_name);
-      auto&& h = v.get_histogram();
-      f->dump_float("sum", h.sample_sum);
-      f->dump_unsigned("count", h.sample_count);
-      f->open_array_section("buckets");
-      for (auto i : h.buckets) {
-        f->open_object_section("bucket");
-        f->dump_float("le", i.upper_bound);
-        f->dump_unsigned("count", i.count);
-        f->close_section(); // "bucket"
-      }
-      {
-        f->open_object_section("bucket");
-        f->dump_string("le", "+Inf");
-        f->dump_unsigned("count", h.sample_count);
-        f->close_section();
-      }
-      f->close_section(); // "buckets"
-      f->close_section(); // value_name
-    }
-      break;
-    default:
-      std::abort();
-      break;
-    }
-    f->close_section(); // full_name
   }
 };
 template std::unique_ptr<AdminSocketHook> make_asok_hook<DumpMetricsHook>();

--- a/src/crimson/common/metrics_helpers.h
+++ b/src/crimson/common/metrics_helpers.h
@@ -1,0 +1,98 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+#include <string>
+
+#include <seastar/core/scollectd_api.hh>
+
+#include "common/Formatter.h"
+
+namespace crimson {
+namespace metrics {
+
+using registered_metric = seastar::metrics::impl::registered_metric;
+using data_type = seastar::metrics::impl::data_type;
+using value_map = seastar::metrics::impl::value_map;
+
+void dump_metric_value(
+  Formatter* f,
+  std::string_view full_name,
+  const registered_metric& metric,
+  const seastar::metrics::impl::labels_type& labels)
+{
+  f->open_object_section(full_name);
+  for (const auto& [key, value] : labels) {
+    f->dump_string(key, value);
+  }
+  auto value_name = "value";
+  switch (auto v = metric(); v.type()) {
+  case data_type::GAUGE:
+    f->dump_float(value_name, v.d());
+    break;
+  case data_type::REAL_COUNTER:
+    f->dump_float(value_name, v.d());
+    break;
+  case data_type::COUNTER:
+    double val;
+    try {
+      val = v.ui();
+    } catch (std::range_error&) {
+      // seastar's cpu steal time may be negative
+      val = 0;
+    }
+    f->dump_unsigned(value_name, val);
+    break;
+  case data_type::HISTOGRAM: {
+    f->open_object_section(value_name);
+    auto&& h = v.get_histogram();
+    f->dump_float("sum", h.sample_sum);
+    f->dump_unsigned("count", h.sample_count);
+    f->open_array_section("buckets");
+    for (auto i : h.buckets) {
+      f->open_object_section("bucket");
+      f->dump_float("le", i.upper_bound);
+      f->dump_unsigned("count", i.count);
+      f->close_section(); // "bucket"
+    }
+    {
+      f->open_object_section("bucket");
+      f->dump_string("le", "+Inf");
+      f->dump_unsigned("count", h.sample_count);
+      f->close_section();
+    }
+    f->close_section(); // "buckets"
+    f->close_section(); // value_name
+  }
+    break;
+  default:
+    std::abort();
+    break;
+  }
+  f->close_section(); // full_name
+}
+
+template <typename F>
+void dump_metric_value_map(
+  const value_map &vmap,
+  Formatter *f,
+  F &&filter)
+{
+  assert(f);
+  for (const auto& [full_name, metric_family]: seastar::scollectd::get_value_map()) {
+    if (!std::invoke(filter, full_name)) {
+      continue;
+    }
+    for (const auto& [labels, metric] : metric_family) {
+      if (metric && metric->is_enabled()) {
+	f->open_object_section(""); // enclosed by array
+	dump_metric_value(
+	  f, full_name, *metric, labels.labels());
+	f->close_section();
+      }
+    }
+  }
+}
+
+}
+}

--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -61,24 +61,25 @@ SET_SUBSYS(osd);
  * num_operations by 1 Each delete increases the number of operations by 1
  */
 struct results_t {
-  int num_operations = 0;
-  std::chrono::duration<double> tot_latency_sec = 0s;
+  uint64_t ios_completed = 0;
+  std::chrono::duration<double> total_latency = 0s;
   std::chrono::duration<double> duration = 0s;
 
   results_t &operator += (const results_t &other_result) {
-    num_operations += other_result.num_operations;
-    tot_latency_sec += other_result.tot_latency_sec;
+    ios_completed += other_result.ios_completed;
+    total_latency += other_result.total_latency;
     return *this;
   }
 
   void dump(ceph::Formatter *f) const {
     f->open_object_section("results_t");
-    f->dump_int("number of operations done", num_operations);
+    f->dump_int("ios_completed", ios_completed);
     f->dump_float(
-        "the total latency aka time for these operations",
-        tot_latency_sec.count());
-    f->dump_float("the time the workload took to run is ",
-                  duration.count());
+      "total_latency_s",
+      total_latency.count());
+    f->dump_float(
+      "total_duration_s",
+      duration.count());
     f->close_section();
   }
 };
@@ -309,7 +310,7 @@ seastar::future<> PGLogWorkload::run(
    * takes to add and remove each key
    */
   auto add_remove_entry = [&]() -> seastar::future<results_t> {
-    int num_ops = 0;
+    uint64_t num_ops = 0;
     std::chrono::duration<double> tot_latency =
         std::chrono::duration<double>(0.0);
     auto start = ceph::mono_clock::now();

--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -26,6 +26,7 @@
 
 #include <random>
 #include <vector>
+#include <experimental/random>
 
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
@@ -572,6 +573,198 @@ seastar::future<results_t> RGWIndexWorkload::run(
     common.get_duration(), common.num_concurrent_io, rgw_actual_test);
 };
 
+
+/**
+ * RandomWriteWorkload 
+ *
+ * Performs a simple random write workload.
+ */
+class RandomWriteWorkload : public StoreBenchWorkload {
+  uint64_t prefill_size = 128<<10;
+  uint64_t io_size = 4<<10;
+  uint64_t size_per_shard = 64<<20;
+  uint64_t size_per_obj = 4<<20;
+  uint64_t colls_per_shard = 16;
+  uint64_t io_concurrency_per_shard = 16;
+  uint64_t get_obj_per_shard() const {
+    return size_per_shard / size_per_obj;
+  }
+  uint64_t get_obj_per_coll() const {
+    return get_obj_per_shard() / colls_per_shard;
+  }
+public:
+  po::options_description get_options() final {
+    po::options_description ret{"RandomWriteWorkload"};
+    ret.add_options()
+      ("prefill-size", po::value<uint64_t>(&prefill_size),
+       "IO size to use when prefilling objets")
+      ("io-size", po::value<uint64_t>(&io_size),
+       "IO size")
+      ("size-per-shard", po::value<uint64_t>(&size_per_shard),
+       "Total size per shard")
+      ("size-per-obj", po::value<uint64_t>(&size_per_obj),
+       "Object Size")
+      ("colls-per-shard", po::value<uint64_t>(&colls_per_shard),
+       "Collections per shard")
+      ("io-concurrency-per-shard", po::value<uint64_t>(&io_concurrency_per_shard),
+       "IO Concurrency Per Shard")
+      ;
+    return ret;
+  }
+  seastar::future<results_t> run(
+    const common_options_t &common,
+    crimson::os::FuturizedStore &global_store) final;
+  ~RandomWriteWorkload() final {}
+};
+
+seastar::future<bufferptr> generate_random_bp(uint64_t size)
+{
+  bufferptr bp(ceph::buffer::create_page_aligned(size));
+  auto f = co_await seastar::open_file_dma(
+    "/dev/urandom", seastar::open_flags::ro);
+  static constexpr uint64_t STRIDE = 256<<10;
+  for (uint64_t off = 0; off < size; off += STRIDE) {
+    co_await f.dma_read(off, bp.c_str() + off, STRIDE);
+  }
+  co_return bp;
+}
+
+
+seastar::future<results_t> RandomWriteWorkload::run(
+  const common_options_t &common,
+  crimson::os::FuturizedStore &global_store)
+{
+  LOG_PREFIX(random_write);
+  auto &local_store = global_store.get_sharded_store();
+
+  auto random_buffer = co_await generate_random_bp(16<<20);
+  auto get_random_buffer = [&random_buffer](uint64_t size) {
+    assert((size % CEPH_PAGE_SIZE) == 0);
+    bufferptr bp(
+      random_buffer,
+      std::experimental::randint<uint64_t>(
+        0,
+        (random_buffer.length() - size) / CEPH_PAGE_SIZE) *
+      CEPH_PAGE_SIZE,
+      size);
+    assert(bp.is_page_aligned());
+    bufferlist bl;
+    bl.append(bp);
+    return bl;
+  };
+
+  auto create_hobj = [](uint64_t obj_id) {
+    return ghobject_t(
+      shard_id_t::NO_SHARD,
+      0,     // pool id
+      obj_id, // hash, normally rjenkins of name, but let's just set it to id
+      "",    // namespace, empty here
+      "",    // name, empty here
+      0,     // snapshot
+      ghobject_t::NO_GEN);
+  };
+
+  std::vector<
+    std::pair<coll_t, crimson::os::CollectionRef>
+    > coll_refs;
+  for (uint64_t collidx = 0; collidx < colls_per_shard; ++collidx) {
+   coll_t cid(
+     spg_t(pg_t(0, (seastar::this_shard_id() * colls_per_shard) + collidx))
+   );
+   auto ref = co_await local_store.create_new_collection(
+     cid);
+   coll_refs.emplace_back(std::make_pair(cid, std::move(ref)));
+  }
+  auto get_coll_id = [&](uint64_t obj_id) {
+    return coll_refs[obj_id % get_obj_per_coll()].first;
+  };
+  auto get_coll_ref = [&](uint64_t obj_id) {
+    return coll_refs[obj_id % get_obj_per_coll()].second;
+  };
+
+  unsigned running = 0;
+  std::optional<seastar::promise<>> complete;
+
+  static constexpr unsigned io_concurrency_per_shard = 16;
+  seastar::semaphore sem{io_concurrency_per_shard};
+  results_t results;
+  auto submit_transaction = [&](
+    crimson::os::CollectionRef &col_ref,
+    ceph::os::Transaction &&t) -> seastar::future<> {
+    ++running;
+    co_await sem.wait(1);
+    std::ignore = local_store.do_transaction(
+      col_ref,
+      std::move(t)
+    ).finally([&, start = ceph::mono_clock::now()] {
+      --running;
+      if (running == 0 && complete) {
+        complete->set_value();
+      }
+      sem.signal(1);
+      results.ios_completed++;
+      results.total_latency += ceph::mono_clock::now() - start;
+    });
+  };
+
+  for (uint64_t obj_id = 0; obj_id < get_obj_per_shard(); ++obj_id) {
+    auto hobj = create_hobj(obj_id);
+    auto coll_id = get_coll_id(obj_id);
+    auto coll_ref = get_coll_ref(obj_id);
+    
+    {
+      ceph::os::Transaction t;
+      t.create(coll_id, hobj);
+      co_await submit_transaction(coll_ref, std::move(t));
+    }
+    for (uint64_t off = 0; off < size_per_obj; off += prefill_size) {
+      ceph::os::Transaction t;
+      t.write(coll_id, hobj, off, prefill_size, get_random_buffer(prefill_size));
+      co_await submit_transaction(coll_ref, std::move(t));
+    }
+    INFO("wrote obj {} of {}", obj_id, get_obj_per_shard());
+  }
+
+  INFO("finished populating");
+
+  auto start = ceph::mono_clock::now();
+  uint64_t writes_started = 0;
+  while (ceph::mono_clock::now() - start < common.get_duration()) {
+    auto obj_id = std::experimental::randint<uint64_t>(0, get_obj_per_shard() - 1);
+    auto hobj = create_hobj(obj_id);
+    auto coll_id = get_coll_id(obj_id);
+    auto coll_ref = get_coll_ref(obj_id);
+
+    auto offset = std::experimental::randint<uint64_t>(
+      0,
+      (size_per_obj / io_size) - 1) * io_size;
+    
+    ceph::os::Transaction t;
+    t.write(
+      coll_id,
+      hobj,
+      offset,
+      io_size,
+      get_random_buffer(io_size));
+    co_await submit_transaction(coll_ref, std::move(t));
+    ++writes_started;
+  }
+
+  INFO("writes_started {}", writes_started);
+  for (auto &[id, ref]: coll_refs) {
+    INFO("flushing {}", id);
+    co_await local_store.flush(ref);
+  }
+
+  if (running > 0) {
+    complete = seastar::promise<>();
+    co_await complete->get_future();
+  }
+
+  results.duration = ceph::mono_clock::now() - start;
+  co_return results;
+}
+
 int main(int argc, char **argv) {
   LOG_PREFIX(main);
   po::options_description desc{"Allowed options"};
@@ -607,6 +800,7 @@ int main(int argc, char **argv) {
     
   workloads.emplace("pg_log", std::make_unique<PGLogWorkload>());
   workloads.emplace("rgw_index", std::make_unique<RGWIndexWorkload>());
+  workloads.emplace("random_write", std::make_unique<RandomWriteWorkload>());
   
   desc.add(common_options.get_options());
   for (auto &[name, workload] : workloads) {

--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -88,6 +88,7 @@ private:
   unsigned duration = 0;
 public:
   unsigned num_concurrent_io = 16;
+  bool dump_metrics = false;
   std::chrono::duration<uint64_t> get_duration() const {
     return std::chrono::seconds(duration);
   }
@@ -100,6 +101,8 @@ public:
       ("duration", po::value<unsigned>(&duration)->required(),
        "how long in seconds the actual testing loop runs "
        "for")
+      ("dump-metrics", po::bool_switch(&dump_metrics),
+       "Dump JSON formatted metrics to stdout")
       ;
     return ret;
   }
@@ -750,6 +753,14 @@ int main(int argc, char **argv) {
             f.dump_string("shard", std::to_string(i));
             f.close_section();
           }
+          f.close_section();
+        }
+        if (common_options.dump_metrics) {
+          f.open_array_section("metrics_values");
+          crimson::metrics::dump_metric_value_map(
+            seastar::scollectd::get_value_map(),
+            &f,
+            [](const auto &) { return true; });
           f.close_section();
         }
         f.close_section();


### PR DESCRIPTION
* adds random write workload
* adds option to dump metrics
* general cleanups

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
