### PR TITLE
tentacle: mgr/dashboard: rgw_crypt_kmip_addr in SSE-KMS kmip address input field validation updated

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-config-modal/rgw-config-modal.component.ts
@@ -25,8 +25,6 @@ import { KmipConfig, VaultConfig } from '~/app/shared/models/rgw-encryption-conf
   styleUrls: ['./rgw-config-modal.component.scss']
 })
 export class RgwConfigModalComponent implements OnInit {
-  readonly vaultAddress = /^((https?:\/\/)|(www.))(?:([a-zA-Z]+)|(\d+\.\d+.\d+.\d+)):\d{4}$/;
-
   kmsProviders: string[];
 
   configForm: CdFormGroup;
@@ -133,18 +131,7 @@ export class RgwConfigModalComponent implements OnInit {
 
   createForm() {
     this.configForm = this.formBuilder.group({
-      addr: [
-        null,
-        [
-          Validators.required,
-          CdValidators.custom('vaultPattern', (value: string) => {
-            if (_.isEmpty(value)) {
-              return false;
-            }
-            return !this.vaultAddress.test(value);
-          })
-        ]
-      ],
+      addr: [null, [CdValidators.urlWithProtocolOption(false), Validators.required]],
       kms_provider: ['vault', Validators.required],
       encryptionType: ['kms', Validators.required],
       auth: [

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -689,7 +689,20 @@ export class CdValidators {
    * Validator function to validate endpoints, allowing FQDN, IPv4, and IPv6 addresses with ports.
    * Accepts multiple endpoints separated by commas.
    */
+
   static url(control: AbstractControl): ValidationErrors | null {
+    return CdValidators.urlInternal(control, true);
+  }
+
+  static urlWithProtocolOption(require_protocol: boolean) {
+    return (control: AbstractControl): ValidationErrors | null =>
+      CdValidators.urlInternal(control, require_protocol);
+  }
+
+  private static urlInternal(
+    control: AbstractControl,
+    require_protocol: boolean
+  ): ValidationErrors | null {
     const value = control.value;
 
     if (_.isEmpty(value)) {
@@ -701,7 +714,7 @@ export class CdValidators {
     const invalidUrls = urls.filter(
       (url: string) =>
         !validator.isURL(url, {
-          require_protocol: true,
+          require_protocol: require_protocol,
           allow_underscores: true,
           require_tld: false
         }) && !validator.isIP(url)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72716

---

backport of https://github.com/ceph/ceph/pull/64827
parent tracker: https://tracker.ceph.com/issues/72408

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh