### PR TITLE
tentacle: mgr/dashboard : Optimized /host API to minimum resp

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -289,10 +289,27 @@ class Host(RESTController):
         if str_to_bool(facts):
             if orch.available():
                 if not orch.get_missing_features(['get_facts']):
+                    all_facts = orch.hosts.get_facts()
                     hosts_facts = []
+                    facts_map = {facts.get('hostname'): facts for facts in all_facts}
                     for host in hosts:
-                        facts = orch.hosts.get_facts(host['hostname'])[0]
-                        hosts_facts.append(facts)
+                        hostname = host['hostname']
+                        facts = facts_map.get(hostname, {})
+                        host_facts = {
+                            'hostname': facts.get('hostname', hostname),
+                            'addr': facts.get('addr', ''),
+                            'cpu_cores': facts.get('cpu_cores', 0),
+                            'cpu_count': facts.get('cpu_count', 0),
+                            'model': facts.get('model', ''),
+                            'memory_total_kb': facts.get('memory_total_kb', 0),
+                            'nic_count': facts.get('nic_count', 0),
+                            'hdd_count': facts.get('hdd_count', 0),
+                            'flash_count': facts.get('flash_count', 0),
+                            'hdd_capacity_bytes': facts.get('hdd_capacity_bytes', 0),
+                            'flash_capacity_bytes': facts.get('flash_capacity_bytes', 0)
+                        }
+                        hosts_facts.append(host_facts)
+
                     return merge_list_of_dicts_by_key(hosts, hosts_facts, 'hostname')
 
                 raise DashboardException(

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -105,6 +105,14 @@ class HostControllerTest(ControllerTestCase):
                 'ceph': True,
                 'orchestrator': False
             },
+            'addr': '',
+            'cpu_cores': 0,
+            'model': '',
+            'nic_count': 0,
+            'hdd_count': 0,
+            'flash_count': 0,
+            'hdd_capacity_bytes': 0,
+            'flash_capacity_bytes': 0,
             'cpu_count': 1,
             'memory_total_kb': 1024,
             'services': [],
@@ -115,6 +123,14 @@ class HostControllerTest(ControllerTestCase):
                 'ceph': False,
                 'orchestrator': True
             },
+            'addr': '',
+            'cpu_cores': 0,
+            'model': '',
+            'nic_count': 0,
+            'hdd_count': 0,
+            'flash_count': 0,
+            'hdd_capacity_bytes': 0,
+            'flash_capacity_bytes': 0,
             'cpu_count': 2,
             'memory_total_kb': 1024,
             'services': [],
@@ -124,10 +140,12 @@ class HostControllerTest(ControllerTestCase):
         with patch_orch(True, hosts=hosts_without_facts) as fake_client:
             mock_get_hosts.return_value = hosts_without_facts
 
-            def get_facts_mock(hostname: str):
-                if hostname == 'host-0':
-                    return [hosts_facts[0]]
-                return [hosts_facts[1]]
+            def get_facts_mock(*args, **_kwargs):
+                if args:
+                    hostname = args[0]
+                    return [hosts_facts[0]] if hostname == 'host-0' else [hosts_facts[1]]
+                return hosts_facts
+
             fake_client.hosts.get_facts.side_effect = get_facts_mock
             # test with ?facts=true
             self._get('{}?facts=true'.format(self.URL_HOST), version=APIVersion(1, 3))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72711

---

backport of https://github.com/ceph/ceph/pull/65102
parent tracker: https://tracker.ceph.com/issues/72608

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh