### PR TITLE
src: replace push_back(T{}) with emplace_back() 

### DIFF
--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -76,7 +76,7 @@ struct EntityAuth {
   }
   static std::list<EntityAuth> generate_test_instances() {
     std::list<EntityAuth> ls;
-    ls.push_back(EntityAuth{});
+    ls.emplace_back();
     return ls;
   }
 };
@@ -122,10 +122,10 @@ struct AuthCapsInfo {
   }
   static std::list<AuthCapsInfo> generate_test_instances() {
     std::list<AuthCapsInfo> ls;
-    ls.push_back(AuthCapsInfo{});
-    ls.push_back(AuthCapsInfo{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().allow_all = true;
-    ls.push_back(AuthCapsInfo{});
+    ls.emplace_back();
     ls.back().caps.append("foo");
     ls.back().caps.append("bar");
     return ls;
@@ -190,8 +190,8 @@ struct AuthTicket {
   }
   static std::list<AuthTicket> generate_test_instances() {
     std::list<AuthTicket> ls;
-    ls.push_back(AuthTicket{});
-    ls.push_back(AuthTicket{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().name.set_id("client.123");
     ls.back().global_id = 123;
     ls.back().init_timestamps(utime_t(123, 456), 7);
@@ -290,8 +290,8 @@ struct ExpiringCryptoKey {
   }
   static std::list<ExpiringCryptoKey> generate_test_instances() {
     std::list<ExpiringCryptoKey> ls;
-    ls.push_back(ExpiringCryptoKey{});
-    ls.push_back(ExpiringCryptoKey{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().key.set_secret(
       CEPH_CRYPTO_AES, bufferptr("1234567890123456", 16), utime_t(123, 456));
     return ls;
@@ -365,8 +365,8 @@ struct RotatingSecrets {
   }
   static std::list<RotatingSecrets> generate_test_instances() {
     std::list<RotatingSecrets> ls;
-    ls.push_back(RotatingSecrets{});
-    ls.push_back(RotatingSecrets{});
+    ls.emplace_back();
+    ls.emplace_back();
     ExpiringCryptoKey eck{};
     ls.back().add(eck);
     return ls;

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -80,8 +80,8 @@ struct KeyServerData {
   }
   static std::list<KeyServerData> generate_test_instances() {
     std::list<KeyServerData> ls;
-    ls.push_back(KeyServerData{});
-    ls.push_back(KeyServerData{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().version = 1;
     return ls;
   }
@@ -180,11 +180,11 @@ struct KeyServerData {
     }
     static std::list<Incremental> generate_test_instances() {
       std::list<Incremental> ls;
-      ls.push_back(Incremental{});
+      ls.emplace_back();
       ls.back().op = AUTH_INC_DEL;
-      ls.push_back(Incremental{});
+      ls.emplace_back();
       ls.back().op = AUTH_INC_ADD;
-      ls.push_back(Incremental{});
+      ls.emplace_back();
       ls.back().op = AUTH_INC_SET_ROTATING;
       return ls;
     }

--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -60,7 +60,7 @@ struct CephXServerChallenge {
   }
   static std::list<CephXServerChallenge> generate_test_instances() {
     std::list<CephXServerChallenge> ls;
-    ls.push_back(CephXServerChallenge{});
+    ls.emplace_back();
     ls.back().server_challenge = 1;
     return ls;
   }
@@ -86,7 +86,7 @@ struct CephXRequestHeader {
   }
   static std::list<CephXRequestHeader> generate_test_instances() {
     std::list<CephXRequestHeader> ls;
-    ls.push_back(CephXRequestHeader{});
+    ls.emplace_back();
     ls.back().request_type = 1;
     return ls;
   }
@@ -113,7 +113,7 @@ struct CephXResponseHeader {
   }
   static std::list<CephXResponseHeader> generate_test_instances() {
     std::list<CephXResponseHeader> ls;
-    ls.push_back(CephXResponseHeader{});
+    ls.emplace_back();
     ls.back().request_type = 1;
     ls.back().status = 0;
     return ls;
@@ -150,7 +150,7 @@ struct CephXTicketBlob {
 
   static std::list<CephXTicketBlob> generate_test_instances() {
     std::list<CephXTicketBlob> ls;
-    ls.push_back(CephXTicketBlob{});
+    ls.emplace_back();
     ls.back().secret_id = 123;
     ls.back().blob.append(std::string_view("this is a blob"));
     return ls;
@@ -204,10 +204,10 @@ struct CephXAuthenticate {
   }
   static std::list<CephXAuthenticate> generate_test_instances() {
     std::list<CephXAuthenticate> ls;
-    ls.push_back(CephXAuthenticate{});
+    ls.emplace_back();
     ls.back().client_challenge = 0;
     ls.back().key = 0;
-    ls.push_back(CephXAuthenticate{});
+    ls.emplace_back();
     ls.back().client_challenge = 1;
     ls.back().key = 2;
     ls.back().old_ticket.secret_id = 3;
@@ -237,7 +237,7 @@ struct CephXChallengeBlob {
   }
   static std::list<CephXChallengeBlob> generate_test_instances() {
     std::list<CephXChallengeBlob> ls;
-    ls.push_back(CephXChallengeBlob{});
+    ls.emplace_back();
     ls.back().server_challenge = 123;
     ls.back().client_challenge = 456;
     return ls;
@@ -299,7 +299,7 @@ struct CephXServiceTicketRequest {
 
   static std::list<CephXServiceTicketRequest> generate_test_instances() {
     std::list<CephXServiceTicketRequest> ls;
-    ls.push_back(CephXServiceTicketRequest{});
+    ls.emplace_back();
     ls.back().keys = 123;
     return ls;
   }
@@ -342,9 +342,9 @@ struct CephXAuthorizeReply {
   }
   static std::list<CephXAuthorizeReply> generate_test_instances() {
     std::list<CephXAuthorizeReply> ls;
-    ls.push_back(CephXAuthorizeReply{});
+    ls.emplace_back();
     ls.back().nonce_plus_one = 0;
-    ls.push_back(CephXAuthorizeReply{});
+    ls.emplace_back();
     ls.back().nonce_plus_one = 123;
     ls.back().connection_secret = "secret";
     return ls;
@@ -457,8 +457,8 @@ struct CephXServiceTicket {
   }
   static std::list<CephXServiceTicket> generate_test_instances() {
     std::list<CephXServiceTicket> ls;
-    ls.push_back(CephXServiceTicket{});
-    ls.push_back(CephXServiceTicket{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().session_key.set_secret(
       CEPH_CRYPTO_AES, bufferptr("1234567890123456", 16), utime_t(123, 456));
     ls.back().validity = utime_t(123, 456);
@@ -492,8 +492,8 @@ struct CephXServiceTicketInfo {
   }
   static std::list<CephXServiceTicketInfo> generate_test_instances() {
     std::list<CephXServiceTicketInfo> ls;
-    ls.push_back(CephXServiceTicketInfo{});
-    ls.push_back(CephXServiceTicketInfo{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().ticket.global_id = 1234;
     ls.back().ticket.init_timestamps(utime_t(123, 456), utime_t(123, 456));
     ls.back().session_key.set_secret(
@@ -522,7 +522,7 @@ struct CephXAuthorizeChallenge : public AuthAuthorizerChallenge {
   }
   static std::list<CephXAuthorizeChallenge> generate_test_instances() {
     std::list<CephXAuthorizeChallenge> ls;
-    ls.push_back(CephXAuthorizeChallenge{});
+    ls.emplace_back();
     ls.back().server_challenge = 1234;
     return ls;
   }
@@ -558,8 +558,8 @@ struct CephXAuthorize {
   }
   static std::list<CephXAuthorize> generate_test_instances() {
     std::list<CephXAuthorize> ls;
-    ls.push_back(CephXAuthorize{});
-    ls.push_back(CephXAuthorize{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().nonce = 1234;
     ls.back().have_challenge = true;
     ls.back().server_challenge_plus_one = 1234;

--- a/src/cls/2pc_queue/cls_2pc_queue_ops.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_ops.h
@@ -32,9 +32,9 @@ struct cls_2pc_queue_reserve_op {
 
   static std::list<cls_2pc_queue_reserve_op> generate_test_instances() {
     std::list<cls_2pc_queue_reserve_op> ls;
-    ls.push_back(cls_2pc_queue_reserve_op{});
+    ls.emplace_back();
     ls.back().size = 0;
-    ls.push_back(cls_2pc_queue_reserve_op{});
+    ls.emplace_back();
     ls.back().size = 123;
     ls.back().entries = 456;
     return ls;
@@ -63,7 +63,7 @@ struct cls_2pc_queue_reserve_ret {
 
   static std::list<cls_2pc_queue_reserve_ret> generate_test_instances() {
     std::list<cls_2pc_queue_reserve_ret> ls;
-    ls.push_back(cls_2pc_queue_reserve_ret{});
+    ls.emplace_back();
     ls.back().id = 123;
     return ls;
   }
@@ -95,7 +95,7 @@ struct cls_2pc_queue_commit_op {
 
   static std::list<cls_2pc_queue_commit_op> generate_test_instances() {
     std::list<cls_2pc_queue_commit_op> ls;
-    ls.push_back(cls_2pc_queue_commit_op{});
+    ls.emplace_back();
     ls.back().id = 123;
     ls.back().bl_data_vec.push_back(ceph::buffer::list());
     ls.back().bl_data_vec.back().append("foo");
@@ -125,7 +125,7 @@ struct cls_2pc_queue_abort_op {
   }
   static std::list<cls_2pc_queue_abort_op> generate_test_instances() {
     std::list<cls_2pc_queue_abort_op> ls;
-    ls.push_back(cls_2pc_queue_abort_op{});
+    ls.emplace_back();
     ls.back().id = 1;
     return ls;
   }
@@ -152,8 +152,8 @@ struct cls_2pc_queue_expire_op {
   }
   static std::list<cls_2pc_queue_expire_op> generate_test_instances() {
     std::list<cls_2pc_queue_expire_op> ls;
-    ls.push_back(cls_2pc_queue_expire_op{});
-    ls.push_back(cls_2pc_queue_expire_op{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().stale_time = ceph::coarse_real_time::min();
     return ls;
   }
@@ -187,8 +187,8 @@ struct cls_2pc_queue_reservations_ret {
 
   static std::list<cls_2pc_queue_reservations_ret> generate_test_instances() {
     std::list<cls_2pc_queue_reservations_ret> ls;
-    ls.push_back(cls_2pc_queue_reservations_ret{});
-    ls.push_back(cls_2pc_queue_reservations_ret{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().reservations[1] = cls_2pc_reservation();
     ls.back().reservations[2] = cls_2pc_reservation();
     return ls;

--- a/src/cls/2pc_queue/cls_2pc_queue_types.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_types.h
@@ -44,9 +44,9 @@ struct cls_2pc_reservation
 
   static std::list<cls_2pc_reservation> generate_test_instances() {
     std::list<cls_2pc_reservation> ls;
-    ls.push_back(cls_2pc_reservation{});
+    ls.emplace_back();
     ls.back().size = 0;
-    ls.push_back(cls_2pc_reservation{});
+    ls.emplace_back();
     ls.back().size = 123;
     ls.back().timestamp = ceph::coarse_real_clock::zero();
     return ls;
@@ -102,8 +102,8 @@ struct cls_2pc_urgent_data
 
   static std::list<cls_2pc_urgent_data> generate_test_instances() {
     std::list<cls_2pc_urgent_data> ls;
-    ls.push_back(cls_2pc_urgent_data{});
-    ls.push_back(cls_2pc_urgent_data{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().reserved_size = 123;
     ls.back().last_id = 456;
     ls.back().reservations.emplace(789, cls_2pc_reservation(1, ceph::coarse_real_clock::zero(), 2));

--- a/src/cls/cas/cls_cas_internal.h
+++ b/src/cls/cas/cls_cas_internal.h
@@ -95,7 +95,7 @@ struct chunk_refs_t {
   }
   static std::list<chunk_refs_t> generate_test_instances() {
     std::list<chunk_refs_t> ls;
-    ls.push_back(chunk_refs_t{});
+    ls.emplace_back();
     return ls;
   }
 };
@@ -149,8 +149,8 @@ struct chunk_refs_by_object_t : public chunk_refs_t::refs_t {
   }
   static std::list<chunk_refs_by_object_t> generate_test_instances() {
     std::list<chunk_refs_by_object_t> ls;
-    ls.push_back(chunk_refs_by_object_t{});
-    ls.push_back(chunk_refs_by_object_t{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().by_object.insert(hobject_t(sobject_t("foo", CEPH_NOSNAP)));
     ls.back().by_object.insert(hobject_t(sobject_t("bar", CEPH_NOSNAP)));
     return ls;
@@ -398,8 +398,8 @@ struct chunk_refs_count_t : public chunk_refs_t::refs_t {
   }
   static std::list<chunk_refs_count_t> generate_test_instances() {
     std::list<chunk_refs_count_t> o;
-    o.push_back(chunk_refs_count_t{});
-    o.push_back(chunk_refs_count_t{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().total = 123;
     return o;
   }

--- a/src/cls/cas/cls_cas_ops.h
+++ b/src/cls/cas/cls_cas_ops.h
@@ -41,7 +41,7 @@ struct cls_cas_chunk_create_or_get_ref_op {
   }
   static std::list<cls_cas_chunk_create_or_get_ref_op> generate_test_instances() {
     std::list<cls_cas_chunk_create_or_get_ref_op> ls;
-    ls.push_back(cls_cas_chunk_create_or_get_ref_op{});
+    ls.emplace_back();
     return ls;
   }
 };
@@ -69,7 +69,7 @@ struct cls_cas_chunk_get_ref_op {
   }
   static std::list<cls_cas_chunk_get_ref_op> generate_test_instances() {
     std::list<cls_cas_chunk_get_ref_op> ls;
-    ls.push_back(cls_cas_chunk_get_ref_op{});
+    ls.emplace_back();
     return ls;
   }
 };
@@ -98,7 +98,7 @@ struct cls_cas_chunk_put_ref_op {
   }
   static std::list<cls_cas_chunk_put_ref_op> generate_test_instances() {
     std::list<cls_cas_chunk_put_ref_op> ls;
-    ls.push_back(cls_cas_chunk_put_ref_op{});
+    ls.emplace_back();
     return ls;
   }
 };

--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -59,8 +59,8 @@ struct entry_header {
   }
   static std::list<entry_header> generate_test_instances() {
     std::list<entry_header> ls;
-    ls.push_back(entry_header{});
-    ls.push_back(entry_header{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().mtime = ceph::real_clock::now();
     return ls;
   }

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -79,8 +79,8 @@ struct create_meta
   }
   static std::list<create_meta> generate_test_instances() {
     std::list<create_meta> o;
-    o.push_back(create_meta{});
-    o.push_back(create_meta{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().id = "id";
     objv v1;
     v1.instance = "inst1";
@@ -116,8 +116,8 @@ struct get_meta
   }
   static std::list<get_meta> generate_test_instances() {
     std::list<get_meta> o;
-    o.push_back(get_meta{});
-    o.push_back(get_meta{});
+    o.emplace_back();
+    o.emplace_back();
     objv v1;
     v1.instance = "inst1";
     v1.ver = 1;
@@ -155,8 +155,8 @@ struct get_meta_reply
   }
   static std::list<get_meta_reply> generate_test_instances() {
     std::list<get_meta_reply> o;
-    o.push_back(get_meta_reply{});
-    o.push_back(get_meta_reply{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().info = fifo::info();
     o.back().part_header_size = 1024;
     o.back().part_entry_overhead = 1024;

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -121,8 +121,8 @@ struct data_params {
   }
   static std::list<data_params> generate_test_instances() {
     std::list<data_params> o;
-    o.push_back(data_params{});
-    o.push_back(data_params{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().max_part_size = 1;
     o.back().max_entry_size = 2;
     o.back().full_size_threshold = 3;
@@ -443,8 +443,8 @@ struct info {
   }
   static std::list<info> generate_test_instances() {
     std::list<info> o;
-    o.push_back(info{});
-    o.push_back(info{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().id = "myid";
     o.back().version = objv();
     o.back().oid_prefix = "myprefix";

--- a/src/cls/journal/cls_journal_types.cc
+++ b/src/cls/journal/cls_journal_types.cc
@@ -35,7 +35,7 @@ void ObjectPosition::dump(Formatter *f) const {
 
 std::list<ObjectPosition> ObjectPosition::generate_test_instances() {
   std::list<ObjectPosition> o;
-  o.push_back(ObjectPosition{});
+  o.emplace_back();
   o.push_back(ObjectPosition(1, 2, 3));
   return o;
 }
@@ -64,7 +64,7 @@ void ObjectSetPosition::dump(Formatter *f) const {
 
 std::list<ObjectSetPosition> ObjectSetPosition::generate_test_instances() {
   std::list<ObjectSetPosition> o;
-  o.push_back(ObjectSetPosition{});
+  o.emplace_back();
   o.push_back(ObjectSetPosition({{0, 1, 120}, {121, 2, 121}}));
   return o;
 }
@@ -142,7 +142,7 @@ void Tag::dump(Formatter *f) const {
 
 std::list<Tag> Tag::generate_test_instances() {
   std::list<Tag> o;
-  o.push_back(Tag{});
+  o.emplace_back();
 
   bufferlist data;
   data.append(std::string(128, '1'));

--- a/src/cls/lock/cls_lock_ops.cc
+++ b/src/cls/lock/cls_lock_ops.cc
@@ -51,7 +51,7 @@ list<cls_lock_lock_op> cls_lock_lock_op::generate_test_instances()
   i.duration = utime_t(5, 0);
   i.flags = LOCK_FLAG_MAY_RENEW;
   o.push_back(std::move(i));
-  o.push_back(cls_lock_lock_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -68,7 +68,7 @@ list<cls_lock_unlock_op> cls_lock_unlock_op::generate_test_instances()
   i.name = "name";
   i.cookie = "cookie";
   o.push_back(std::move(i));
-  o.push_back(cls_lock_unlock_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -87,7 +87,7 @@ list<cls_lock_break_op> cls_lock_break_op::generate_test_instances()
   i.cookie = "cookie";
   i.locker =  entity_name_t::CLIENT(1);
   o.push_back(std::move(i));
-  o.push_back(cls_lock_break_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -102,7 +102,7 @@ list<cls_lock_get_info_op> cls_lock_get_info_op::generate_test_instances()
   cls_lock_get_info_op i;
   i.name = "name";
   o.push_back(std::move(i));
-  o.push_back(cls_lock_get_info_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -154,7 +154,7 @@ list<cls_lock_get_info_reply> cls_lock_get_info_reply::generate_test_instances()
   i.lockers[id2] = locker_info_t(utime_t(20, 0), addr2, "description2");
 
   o.push_back(std::move(i));
-  o.push_back(cls_lock_get_info_reply{});
+  o.emplace_back();
   return o;
 }
 
@@ -179,7 +179,7 @@ list<cls_lock_list_locks_reply> cls_lock_list_locks_reply::generate_test_instanc
   i.locks.push_back("lock3");
 
   o.push_back(std::move(i));
-  o.push_back(cls_lock_list_locks_reply{});
+  o.emplace_back();
   return o;
 }
 
@@ -200,7 +200,7 @@ list<cls_lock_assert_op> cls_lock_assert_op::generate_test_instances()
   i.cookie = "cookie";
   i.tag = "tag";
   o.push_back(std::move(i));
-  o.push_back(cls_lock_assert_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -223,7 +223,7 @@ list<cls_lock_set_cookie_op> cls_lock_set_cookie_op::generate_test_instances()
   i.tag = "tag";
   i.new_cookie = "new cookie";
   o.push_back(std::move(i));
-  o.push_back(cls_lock_set_cookie_op{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/cls/lock/cls_lock_types.cc
+++ b/src/cls/lock/cls_lock_types.cc
@@ -36,7 +36,7 @@ std::list<locker_id_t> locker_id_t::generate_test_instances()
   locker_id_t i;
   generate_lock_id(i, 1, "cookie");
   o.push_back(std::move(i));
-  o.push_back(locker_id_t{});
+  o.emplace_back();
   return o;
 }
 
@@ -67,7 +67,7 @@ std::list<locker_info_t> locker_info_t::generate_test_instances()
   generate_test_addr(i.addr, 1, 2);
   i.description = "description";
   o.push_back(std::move(i));
-  o.push_back(locker_info_t{});
+  o.emplace_back();
   return o;
 }
 
@@ -99,6 +99,6 @@ std::list<lock_info_t> lock_info_t::generate_test_instances()
   i.lock_type = ClsLockType::EXCLUSIVE;
   i.tag = "tag";
   o.push_back(std::move(i));
-  o.push_back(lock_info_t{});
+  o.emplace_back();
   return o;
 }

--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -45,8 +45,8 @@ struct add_op {
     std::list<add_op> l;
     l.emplace_back();
     l.emplace_back();
-    l.back().entries.push_back(entry{});
-    l.back().entries.push_back(entry{});
+    l.back().entries.emplace_back();
+    l.back().entries.emplace_back();
     l.back().entries.back().section = "section";
     l.back().entries.back().name = "name";
     l.back().entries.back().timestamp = ceph::real_time{1s + 2ns};
@@ -137,8 +137,8 @@ struct list_ret {
     std::list<list_ret> ls;
     ls.emplace_back();
     ls.emplace_back();
-    ls.back().entries.push_back(entry{});
-    ls.back().entries.push_back(entry{});
+    ls.back().entries.emplace_back();
+    ls.back().entries.emplace_back();
     ls.back().entries.back().section = "section";
     ls.back().entries.back().name = "name";
     ls.back().entries.back().timestamp = ceph::real_time{1s + 2ns};

--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -71,8 +71,8 @@ struct entry {
 
   static std::list<cls::log::entry> generate_test_instances() {
     std::list<cls::log::entry> l;
-    l.push_back(cls::log::entry{});
-    l.push_back(cls::log::entry{});
+    l.emplace_back();
+    l.emplace_back();
     l.back().id = "test_id";
     l.back().section = "test_section";
     l.back().name = "test_name";
@@ -109,8 +109,8 @@ struct header {
   }
   static std::list<header> generate_test_instances() {
     std::list<header> o;
-    o.push_back(header{});
-    o.push_back(header{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().max_marker = "test_marker";
     o.back().max_time = ceph::real_clock::zero();
     return o;

--- a/src/cls/queue/cls_queue_ops.h
+++ b/src/cls/queue/cls_queue_ops.h
@@ -38,8 +38,8 @@ struct cls_queue_init_op {
 
   static std::list<cls_queue_init_op> generate_test_instances() {
     std::list<cls_queue_init_op> o;
-    o.push_back(cls_queue_init_op{});
-    o.push_back(cls_queue_init_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().queue_size = 1024;
     o.back().max_urgent_data_size = 1024;
     o.back().bl_urgent_data.append(std::string_view("data"));
@@ -71,8 +71,8 @@ struct cls_queue_enqueue_op {
 
   static std::list<cls_queue_enqueue_op> generate_test_instances() {
     std::list<cls_queue_enqueue_op> o;
-    o.push_back(cls_queue_enqueue_op{});
-    o.push_back(cls_queue_enqueue_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().bl_data_vec.push_back(ceph::buffer::list());
     o.back().bl_data_vec.back().append(std::string_view("data"));
     return o;
@@ -112,8 +112,8 @@ struct cls_queue_list_op {
 
   static std::list<cls_queue_list_op> generate_test_instances() {
     std::list<cls_queue_list_op> o;
-    o.push_back(cls_queue_list_op{});
-    o.push_back(cls_queue_list_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().max = 123;
     o.back().start_marker = "foo";
     return o;
@@ -152,7 +152,7 @@ struct cls_queue_list_ret {
 
   static std::list<cls_queue_list_ret> generate_test_instances() {
     std::list<cls_queue_list_ret> o;
-    o.push_back(cls_queue_list_ret{});
+    o.emplace_back();
     o.back().is_truncated = true;
     o.back().next_marker = "foo";
     o.back().entries.push_back(cls_queue_entry());
@@ -186,8 +186,8 @@ struct cls_queue_remove_op {
   }
   static std::list<cls_queue_remove_op> generate_test_instances() {
     std::list<cls_queue_remove_op> o;
-    o.push_back(cls_queue_remove_op{});
-    o.push_back(cls_queue_remove_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().end_marker = "foo";
     return o;
   }
@@ -216,7 +216,7 @@ struct cls_queue_get_capacity_ret {
   }
   static std::list<cls_queue_get_capacity_ret> generate_test_instances() {
     std::list<cls_queue_get_capacity_ret> o;
-    o.push_back(cls_queue_get_capacity_ret{});
+    o.emplace_back();
     o.back().queue_capacity = 123;
     return o;
   }

--- a/src/cls/queue/cls_queue_types.h
+++ b/src/cls/queue/cls_queue_types.h
@@ -41,8 +41,8 @@ struct cls_queue_entry
   }
   static std::list<cls_queue_entry> generate_test_instances() {
     std::list<cls_queue_entry> o;
-    o.push_back(cls_queue_entry{});
-    o.push_back(cls_queue_entry{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().data.append(std::string_view("data"));
     o.back().marker = "marker";
     return o;
@@ -99,8 +99,8 @@ struct cls_queue_marker
   }
   static std::list<cls_queue_marker> generate_test_instances() {
     std::list<cls_queue_marker> o;
-    o.push_back(cls_queue_marker{});
-    o.push_back(cls_queue_marker{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().offset = 1024;
     o.back().gen = 0;
     return o;
@@ -150,8 +150,8 @@ struct cls_queue_head
   }
   static std::list<cls_queue_head> generate_test_instances() {
     std::list<cls_queue_head> o;
-    o.push_back(cls_queue_head{});
-    o.push_back(cls_queue_head{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().max_head_size = 1024;
     o.back().front.offset = 1024;
     o.back().front.gen = 0;

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -234,11 +234,11 @@ struct cls_rbd_snap {
     // otherwise check-generated.sh would fail due to the disprepancies between
     // the original dump and re-encoded dump
     o.push_back(cls_rbd_snap{1, "snap", 123456,
-                             RBD_PROTECTION_STATUS_PROTECTED, cls_rbd_parent{}, 31, {},
+                             RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
                              cls::rbd::UserSnapshotNamespace{}, 543, {}});
     o.push_back(cls_rbd_snap{1, "snap", 123456,
-                             RBD_PROTECTION_STATUS_PROTECTED, cls_rbd_parent{}, 31, utime_t{},
-                             cls::rbd::UserSnapshotNamespace{}, 543, std::optional<uint64_t>{0}});
+                             RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
+                             cls::rbd::UserSnapshotNamespace{}, 543, {0}});
     o.push_back(cls_rbd_snap{1, "snap", 123456,
                              RBD_PROTECTION_STATUS_PROTECTED, {}, 31, {},
                              cls::rbd::UserSnapshotNamespace{}, 543, {123}});

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -95,7 +95,7 @@ struct cls_rbd_parent {
 
   static std::list<cls_rbd_parent> generate_test_instances() {
     std::list<cls_rbd_parent> o;
-    o.push_back(cls_rbd_parent{});
+    o.emplace_back();
     o.push_back(cls_rbd_parent{{1, "", "image id", 234}, {}});
     o.push_back(cls_rbd_parent{{1, "", "image id", 234}, {123}});
     o.push_back(cls_rbd_parent{{1, "ns", "image id", 234}, {123}});

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -539,7 +539,7 @@ void ParentImageSpec::dump(Formatter *f) const {
 
 std::list<ParentImageSpec> ParentImageSpec::generate_test_instances() {
   std::list<ParentImageSpec> o;
-  o.push_back(ParentImageSpec{});
+  o.emplace_back();
   o.push_back(ParentImageSpec{1, "", "foo", 3});
   o.push_back(ParentImageSpec{1, "ns", "foo", 3});
   return o;

--- a/src/cls/refcount/cls_refcount_ops.cc
+++ b/src/cls/refcount/cls_refcount_ops.cc
@@ -16,8 +16,8 @@ void cls_refcount_get_op::dump(ceph::Formatter *f) const
 list<cls_refcount_get_op> cls_refcount_get_op::generate_test_instances()
 {
   list<cls_refcount_get_op> ls;
-  ls.push_back(cls_refcount_get_op{});
-  ls.push_back(cls_refcount_get_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().tag = "foo";
   ls.back().implicit_ref = true;
   return ls;
@@ -33,8 +33,8 @@ void cls_refcount_put_op::dump(ceph::Formatter *f) const
 list<cls_refcount_put_op> cls_refcount_put_op::generate_test_instances()
 {
   list<cls_refcount_put_op> ls;
-  ls.push_back(cls_refcount_put_op{});
-  ls.push_back(cls_refcount_put_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().tag = "foo";
   ls.back().implicit_ref = true;
   return ls;
@@ -50,8 +50,8 @@ void cls_refcount_set_op::dump(ceph::Formatter *f) const
 list<cls_refcount_set_op> cls_refcount_set_op::generate_test_instances()
 {
   list<cls_refcount_set_op> ls;
-  ls.push_back(cls_refcount_set_op{});
-  ls.push_back(cls_refcount_set_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().refs.push_back("foo");
   ls.back().refs.push_back("bar");
   return ls;
@@ -66,8 +66,8 @@ void cls_refcount_read_op::dump(ceph::Formatter *f) const
 list<cls_refcount_read_op> cls_refcount_read_op::generate_test_instances()
 {
   list<cls_refcount_read_op> ls;
-  ls.push_back(cls_refcount_read_op{});
-  ls.push_back(cls_refcount_read_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 
@@ -83,8 +83,8 @@ void cls_refcount_read_ret::dump(ceph::Formatter *f) const
 list<cls_refcount_read_ret> cls_refcount_read_ret::generate_test_instances()
 {
   list<cls_refcount_read_ret> ls;
-  ls.push_back(cls_refcount_read_ret{});
-  ls.push_back(cls_refcount_read_ret{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().refs.push_back("foo");
   ls.back().refs.push_back("bar");
   return ls;
@@ -110,7 +110,7 @@ void obj_refcount::dump(ceph::Formatter *f) const
 list<obj_refcount> obj_refcount::generate_test_instances()
 {
   list<obj_refcount> ls;
-  ls.push_back(obj_refcount{});
+  ls.emplace_back();
   ls.back().refs.emplace("foo",true);
   ls.back().retired_refs.emplace("bar");
   return ls;

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -20,8 +20,8 @@ void rgw_cls_tag_timeout_op::dump(Formatter *f) const
 list<rgw_cls_tag_timeout_op> rgw_cls_tag_timeout_op::generate_test_instances()
 {
   list<rgw_cls_tag_timeout_op> ls;
-  ls.push_back(rgw_cls_tag_timeout_op{});
-  ls.push_back(rgw_cls_tag_timeout_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().tag_timeout = 23323;
   return ls;
 }
@@ -37,8 +37,8 @@ void cls_rgw_gc_set_entry_op::dump(Formatter *f) const
 list<cls_rgw_gc_set_entry_op> cls_rgw_gc_set_entry_op::generate_test_instances()
 {
   list<cls_rgw_gc_set_entry_op> ls;
-  ls.push_back(cls_rgw_gc_set_entry_op{});
-  ls.push_back(cls_rgw_gc_set_entry_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().expiration_secs = 123;
   return ls;
 }
@@ -52,8 +52,8 @@ void cls_rgw_gc_defer_entry_op::dump(Formatter *f) const
 list<cls_rgw_gc_defer_entry_op> cls_rgw_gc_defer_entry_op::generate_test_instances()
 {
   list<cls_rgw_gc_defer_entry_op> ls;
-  ls.push_back(cls_rgw_gc_defer_entry_op{});
-  ls.push_back(cls_rgw_gc_defer_entry_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().expiration_secs = 123;
   ls.back().tag = "footag";
   return ls;
@@ -69,8 +69,8 @@ void cls_rgw_gc_list_op::dump(Formatter *f) const
 list<cls_rgw_gc_list_op> cls_rgw_gc_list_op::generate_test_instances()
 {
   list<cls_rgw_gc_list_op> ls;
-  ls.push_back(cls_rgw_gc_list_op{});
-  ls.push_back(cls_rgw_gc_list_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().marker = "mymarker";
   ls.back().max = 2312;
   return ls;
@@ -86,8 +86,8 @@ void cls_rgw_gc_list_ret::dump(Formatter *f) const
 list<cls_rgw_gc_list_ret> cls_rgw_gc_list_ret::generate_test_instances()
 {
   list<cls_rgw_gc_list_ret> ls;
-  ls.push_back(cls_rgw_gc_list_ret{});
-  ls.push_back(cls_rgw_gc_list_ret{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().entries.push_back(cls_rgw_gc_obj_info());
   ls.back().truncated = true;
   return ls;
@@ -101,8 +101,8 @@ void cls_rgw_gc_remove_op::dump(Formatter *f) const
 list<cls_rgw_gc_remove_op> cls_rgw_gc_remove_op::generate_test_instances()
 {
   list<cls_rgw_gc_remove_op> ls;
-  ls.push_back(cls_rgw_gc_remove_op{});
-  ls.push_back(cls_rgw_gc_remove_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().tags.push_back("tag1");
   ls.back().tags.push_back("tag2");
   return ls;
@@ -117,7 +117,7 @@ list<cls_rgw_lc_get_entry_ret> cls_rgw_lc_get_entry_ret::generate_test_instances
 {
   list<cls_rgw_lc_get_entry_ret> ls;
   cls_rgw_lc_entry entry("bucket1", 6000, 0);
-  ls.push_back(cls_rgw_lc_get_entry_ret{});
+  ls.emplace_back();
   ls.back().entry = entry;
   return ls;
 }
@@ -131,7 +131,7 @@ list<rgw_cls_obj_prepare_op> rgw_cls_obj_prepare_op::generate_test_instances()
   op.tag = "tag";
   op.locator = "locator";
   o.push_back(std::move(op));
-  o.push_back(rgw_cls_obj_prepare_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -159,7 +159,7 @@ list<rgw_cls_obj_complete_op> rgw_cls_obj_complete_op::generate_test_instances()
   op.meta = *iter;
 
   o.push_back(std::move(op));
-  o.push_back(rgw_cls_obj_complete_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -197,7 +197,7 @@ list<rgw_cls_link_olh_op> rgw_cls_link_olh_op::generate_test_instances()
 
   o.push_back(std::move(op));
 
-  o.push_back(rgw_cls_link_olh_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -228,7 +228,7 @@ list<rgw_cls_unlink_instance_op> rgw_cls_unlink_instance_op::generate_test_insta
 
   o.push_back(std::move(op));
 
-  o.push_back(rgw_cls_unlink_instance_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -251,7 +251,7 @@ list<rgw_cls_read_olh_log_op> rgw_cls_read_olh_log_op::generate_test_instances()
   op.olh_tag = "olh_tag";
 
   o.push_back(std::move(op));
-  o.push_back(rgw_cls_read_olh_log_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -272,7 +272,7 @@ list<rgw_cls_read_olh_log_ret> rgw_cls_read_olh_log_ret::generate_test_instances
   r.log[1].push_back(*iter);
 
   o.push_back(std::move(r));
-  o.push_back(rgw_cls_read_olh_log_ret{});
+  o.emplace_back();
   return o;
 }
 
@@ -291,7 +291,7 @@ list<rgw_cls_trim_olh_log_op> rgw_cls_trim_olh_log_op::generate_test_instances()
   op.olh_tag = "olh_tag";
 
   o.push_back(std::move(op));
-  o.push_back(rgw_cls_trim_olh_log_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -310,7 +310,7 @@ list<rgw_cls_bucket_clear_olh_op> rgw_cls_bucket_clear_olh_op::generate_test_ins
   op.olh_tag = "olh_tag";
 
   o.push_back(std::move(op));
-  o.push_back(rgw_cls_bucket_clear_olh_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -328,7 +328,7 @@ list<rgw_cls_list_op> rgw_cls_list_op::generate_test_instances()
   op.num_entries = 100;
   op.filter_prefix = "filter_prefix";
   o.push_back(std::move(op));
-  o.push_back(rgw_cls_list_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -349,7 +349,7 @@ list<rgw_cls_list_ret> rgw_cls_list_ret::generate_test_instances()
     o.push_back(std::move(ret));
   }
 
-  o.push_back(rgw_cls_list_ret{});
+  o.emplace_back();
   return o;
 }
 
@@ -371,7 +371,7 @@ list<rgw_cls_check_index_ret> rgw_cls_check_index_ret::generate_test_instances()
   r.calculated_header = h.front();
   o.push_back(std::move(r));
 
-  o.push_back(rgw_cls_check_index_ret{});
+  o.emplace_back();
   return o;
 }
 
@@ -396,7 +396,7 @@ list<rgw_cls_bucket_update_stats_op> rgw_cls_bucket_update_stats_op::generate_te
   dec_s.total_size_rounded = 4096;
   dec_s.num_entries = 1;
   o.push_back(std::move(r));
-  o.push_back(rgw_cls_bucket_update_stats_op{});
+  o.emplace_back();
   return o;
 }
 
@@ -424,8 +424,8 @@ void cls_rgw_bi_log_list_op::dump(Formatter *f) const
 list<cls_rgw_bi_log_list_op> cls_rgw_bi_log_list_op::generate_test_instances()
 {
   list<cls_rgw_bi_log_list_op> ls;
-  ls.push_back(cls_rgw_bi_log_list_op{});
-  ls.push_back(cls_rgw_bi_log_list_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().marker = "mark";
   ls.back().max = 123;
   return ls;
@@ -440,8 +440,8 @@ void cls_rgw_bi_log_trim_op::dump(Formatter *f) const
 list<cls_rgw_bi_log_trim_op> cls_rgw_bi_log_trim_op::generate_test_instances()
 {
   list<cls_rgw_bi_log_trim_op> ls;
-  ls.push_back(cls_rgw_bi_log_trim_op{});
-  ls.push_back(cls_rgw_bi_log_trim_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().start_marker = "foo";
   ls.back().end_marker = "bar";
   return ls;
@@ -456,8 +456,8 @@ void cls_rgw_bi_log_list_ret::dump(Formatter *f) const
 list<cls_rgw_bi_log_list_ret> cls_rgw_bi_log_list_ret::generate_test_instances()
 {
   list<cls_rgw_bi_log_list_ret> ls;
-  ls.push_back(cls_rgw_bi_log_list_ret{});
-  ls.push_back(cls_rgw_bi_log_list_ret{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().entries.push_back(rgw_bi_log_entry());
   ls.back().truncated = true;
   return ls;
@@ -466,9 +466,9 @@ list<cls_rgw_bi_log_list_ret> cls_rgw_bi_log_list_ret::generate_test_instances()
 std::list<cls_rgw_mp_upload_part_info_update_op> cls_rgw_mp_upload_part_info_update_op::generate_test_instances()
 {
   std::list<cls_rgw_mp_upload_part_info_update_op> ls;
-  ls.push_back(cls_rgw_mp_upload_part_info_update_op{});
+  ls.emplace_back();
   ls.back().part_key = "part1";
-  ls.push_back(cls_rgw_mp_upload_part_info_update_op{});
+  ls.emplace_back();
   ls.back().part_key = "part2";
   return ls;
 }
@@ -483,8 +483,8 @@ void cls_rgw_mp_upload_part_info_update_op::dump(Formatter* f) const
 list<cls_rgw_reshard_add_op> cls_rgw_reshard_add_op::generate_test_instances()
 {
   list<cls_rgw_reshard_add_op> ls;
-  ls.push_back(cls_rgw_reshard_add_op{});
-  ls.push_back(cls_rgw_reshard_add_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   list<cls_rgw_reshard_entry> l = cls_rgw_reshard_entry::generate_test_instances();
   auto iter = l.begin();
   ls.back().entry = *iter;
@@ -499,8 +499,8 @@ void cls_rgw_reshard_add_op::dump(Formatter *f) const
 list<cls_rgw_reshard_list_op> cls_rgw_reshard_list_op::generate_test_instances()
 {
   list<cls_rgw_reshard_list_op> ls;
-  ls.push_back(cls_rgw_reshard_list_op{});
-  ls.push_back(cls_rgw_reshard_list_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().max = 1000;
   ls.back().marker = "foo";
   return ls;
@@ -515,8 +515,8 @@ void cls_rgw_reshard_list_op::dump(Formatter *f) const
 list<cls_rgw_reshard_list_ret> cls_rgw_reshard_list_ret::generate_test_instances()
 {
   list<cls_rgw_reshard_list_ret> ls;
-  ls.push_back(cls_rgw_reshard_list_ret{});
-  ls.push_back(cls_rgw_reshard_list_ret{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().entries.push_back(cls_rgw_reshard_entry());
   ls.back().is_truncated = true;
   return ls;
@@ -531,8 +531,8 @@ void cls_rgw_reshard_list_ret::dump(Formatter *f) const
 list<cls_rgw_reshard_get_op> cls_rgw_reshard_get_op::generate_test_instances()
 {
   list<cls_rgw_reshard_get_op> ls;
-  ls.push_back(cls_rgw_reshard_get_op{});
-  ls.push_back(cls_rgw_reshard_get_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 
@@ -544,8 +544,8 @@ void cls_rgw_reshard_get_op::dump(Formatter *f) const
 list<cls_rgw_reshard_get_ret> cls_rgw_reshard_get_ret::generate_test_instances()
 {
   list<cls_rgw_reshard_get_ret> ls;
-  ls.push_back(cls_rgw_reshard_get_ret{});
-  ls.push_back(cls_rgw_reshard_get_ret{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 
@@ -557,8 +557,8 @@ void cls_rgw_reshard_get_ret::dump(Formatter *f) const
 list<cls_rgw_reshard_remove_op> cls_rgw_reshard_remove_op::generate_test_instances()
 {
   list<cls_rgw_reshard_remove_op> ls;
-  ls.push_back(cls_rgw_reshard_remove_op{});
-  ls.push_back(cls_rgw_reshard_remove_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().bucket_name = "foo";
   ls.back().bucket_id = "bucket_id";
   return ls;
@@ -574,8 +574,8 @@ void cls_rgw_reshard_remove_op::dump(Formatter *f) const
 list<cls_rgw_set_bucket_resharding_op> cls_rgw_set_bucket_resharding_op::generate_test_instances()
 {
   list<cls_rgw_set_bucket_resharding_op> ls;
-  ls.push_back(cls_rgw_set_bucket_resharding_op{});
-  ls.push_back(cls_rgw_set_bucket_resharding_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 
@@ -587,8 +587,8 @@ void cls_rgw_set_bucket_resharding_op::dump(Formatter *f) const
 list<cls_rgw_clear_bucket_resharding_op> cls_rgw_clear_bucket_resharding_op::generate_test_instances()
 {
   list<cls_rgw_clear_bucket_resharding_op> ls;
-  ls.push_back(cls_rgw_clear_bucket_resharding_op{});
-  ls.push_back(cls_rgw_clear_bucket_resharding_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 
@@ -599,8 +599,8 @@ void cls_rgw_clear_bucket_resharding_op::dump(Formatter *f) const
 list<cls_rgw_guard_bucket_resharding_op> cls_rgw_guard_bucket_resharding_op::generate_test_instances()
 {
   list<cls_rgw_guard_bucket_resharding_op> ls;
-  ls.push_back(cls_rgw_guard_bucket_resharding_op{});
-  ls.push_back(cls_rgw_guard_bucket_resharding_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 
@@ -613,8 +613,8 @@ void cls_rgw_guard_bucket_resharding_op::dump(Formatter *f) const
 list<cls_rgw_get_bucket_resharding_op> cls_rgw_get_bucket_resharding_op::generate_test_instances()
 {
   list<cls_rgw_get_bucket_resharding_op> ls;
-  ls.push_back(cls_rgw_get_bucket_resharding_op{});
-  ls.push_back(cls_rgw_get_bucket_resharding_op{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -536,7 +536,7 @@ struct rgw_cls_obj_remove_op {
 
   static std::list<rgw_cls_obj_remove_op> generate_test_instances() {
     std::list<rgw_cls_obj_remove_op> o;
-    o.push_back(rgw_cls_obj_remove_op{});
+    o.emplace_back();
     o.back().keep_attr_prefixes.push_back("keep_attr_prefixes1");
     o.back().keep_attr_prefixes.push_back("keep_attr_prefixes2");
     o.back().keep_attr_prefixes.push_back("keep_attr_prefixes3");
@@ -566,7 +566,7 @@ struct rgw_cls_obj_store_pg_ver_op {
 
   static std::list<rgw_cls_obj_store_pg_ver_op> generate_test_instances() {
     std::list<rgw_cls_obj_store_pg_ver_op> o;
-    o.push_back(rgw_cls_obj_store_pg_ver_op{});
+    o.emplace_back();
     o.back().attr = "attr";
     return o;
   }
@@ -600,7 +600,7 @@ struct rgw_cls_obj_check_attrs_prefix {
 
   static std::list<rgw_cls_obj_check_attrs_prefix> generate_test_instances() {
     std::list<rgw_cls_obj_check_attrs_prefix> o;
-    o.push_back(rgw_cls_obj_check_attrs_prefix{});
+    o.emplace_back();
     o.back().check_prefix = "prefix";
     o.back().fail_if_exist = true;
     return o;
@@ -666,7 +666,7 @@ struct rgw_cls_usage_log_add_op {
 
   static std::list<rgw_cls_usage_log_add_op> generate_test_instances() {
     std::list<rgw_cls_usage_log_add_op> o;
-    o.push_back(rgw_cls_usage_log_add_op{});
+    o.emplace_back();
     return o;
   }
 };
@@ -701,8 +701,8 @@ struct rgw_cls_bi_get_op {
 
   static std::list<rgw_cls_bi_get_op> generate_test_instances() {
     std::list<rgw_cls_bi_get_op> o;
-    o.push_back(rgw_cls_bi_get_op{});
-    o.push_back(rgw_cls_bi_get_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().key.name = "key";
     o.back().key.instance = "instance";
     o.back().type = BIIndexType::Plain;
@@ -734,7 +734,7 @@ struct rgw_cls_bi_get_ret {
 
   static std::list<rgw_cls_bi_get_ret> generate_test_instances() {
     std::list<rgw_cls_bi_get_ret> o;
-    o.push_back(rgw_cls_bi_get_ret{});
+    o.emplace_back();
     o.back().entry.idx = "entry";
     return o;
   }
@@ -764,8 +764,8 @@ struct rgw_cls_bi_put_op {
 
   static std::list<rgw_cls_bi_put_op> generate_test_instances() {
     std::list<rgw_cls_bi_put_op> o;
-    o.push_back(rgw_cls_bi_put_op{});
-    o.push_back(rgw_cls_bi_put_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().entry.idx = "entry";
     return o;
   }
@@ -794,8 +794,8 @@ struct rgw_cls_bi_put_entries_op {
 
   static std::list<rgw_cls_bi_put_entries_op> generate_test_instances() {
     std::list<rgw_cls_bi_put_entries_op> o;
-    o.push_back(rgw_cls_bi_put_entries_op{});
-    o.push_back(rgw_cls_bi_put_entries_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().entries.push_back({.idx = "entry"});
     o.back().check_existing = true;
     return o;
@@ -840,8 +840,8 @@ struct rgw_cls_bi_list_op {
 
   static std::list<rgw_cls_bi_list_op> generate_test_instances() {
     std::list<rgw_cls_bi_list_op> o;
-    o.push_back(rgw_cls_bi_list_op{});
-    o.push_back(rgw_cls_bi_list_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().max = 100;
     o.back().name_filter = "name_filter";
     o.back().marker = "marker";
@@ -878,8 +878,8 @@ struct rgw_cls_bi_list_ret {
 
   static std::list<rgw_cls_bi_list_ret> generate_test_instances() {
     std::list<rgw_cls_bi_list_ret> o;
-    o.push_back(rgw_cls_bi_list_ret{});
-    o.push_back(rgw_cls_bi_list_ret{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().entries.push_back(rgw_cls_bi_entry());
     o.back().entries.push_back(rgw_cls_bi_entry());
     o.back().entries.back().idx = "entry";
@@ -933,7 +933,7 @@ struct rgw_cls_usage_log_read_op {
 
   static std::list<rgw_cls_usage_log_read_op> generate_test_instances() {
     std::list<rgw_cls_usage_log_read_op> o;
-    o.push_back(rgw_cls_usage_log_read_op{});
+    o.emplace_back();
     o.back().start_epoch = 1;
     o.back().end_epoch = 2;
     o.back().owner = "owner";
@@ -974,11 +974,11 @@ struct rgw_cls_usage_log_read_ret {
 
   static std::list<rgw_cls_usage_log_read_ret> generate_test_instances() {
     std::list<rgw_cls_usage_log_read_ret> o;
-    o.push_back(rgw_cls_usage_log_read_ret{});
+    o.emplace_back();
     o.back().next_iter = "123";
     o.back().truncated = true;
     o.back().usage.clear();
-    o.push_back(rgw_cls_usage_log_read_ret{});
+    o.emplace_back();
     o.back().usage[rgw_user_bucket("user1", "bucket1")] = rgw_usage_log_entry();
     o.back().usage[rgw_user_bucket("user2", "bucket2")] = rgw_usage_log_entry();
     o.back().truncated = true;
@@ -1400,8 +1400,8 @@ struct cls_rgw_lc_set_entry_op {
 
   static std::list<cls_rgw_lc_set_entry_op> generate_test_instances() {
     std::list<cls_rgw_lc_set_entry_op> ls;
-    ls.push_back(cls_rgw_lc_set_entry_op{});
-    ls.push_back(cls_rgw_lc_set_entry_op{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().entry.bucket = "foo";
     ls.back().entry.start_time = 123;
     ls.back().entry.status = 456;

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -64,8 +64,8 @@ void rgw_zone_set::dump(Formatter *f) const
 list<rgw_zone_set> rgw_zone_set::generate_test_instances()
 {
   list<rgw_zone_set> o;
-  o.push_back(rgw_zone_set{});
-  o.push_back(rgw_zone_set{});
+  o.emplace_back();
+  o.emplace_back();
   std::optional<string> loc_key = "loc_key";
   o.back().insert("zone1", loc_key);
   o.back().insert("zone2", loc_key);
@@ -151,7 +151,7 @@ list<rgw_bucket_pending_info> rgw_bucket_pending_info::generate_test_instances()
   i.state = CLS_RGW_STATE_COMPLETE;
   i.op = CLS_RGW_OP_DEL;
   o.push_back(std::move(i));
-  o.push_back(rgw_bucket_pending_info{});
+  o.emplace_back();
   return o;
 }
 
@@ -189,7 +189,7 @@ list<rgw_bucket_dir_entry_meta> rgw_bucket_dir_entry_meta::generate_test_instanc
   m.owner_display_name = "display name";
   m.content_type = "content/type";
   o.push_back(std::move(m));
-  o.push_back(rgw_bucket_dir_entry_meta{});
+  o.emplace_back();
   return o;
 }
 
@@ -245,7 +245,7 @@ list<rgw_bucket_dir_entry> rgw_bucket_dir_entry::generate_test_instances()
 
     o.push_back(std::move(e));
   }
-  o.push_back(rgw_bucket_dir_entry{});
+  o.emplace_back();
   return o;
 }
 
@@ -263,8 +263,8 @@ void rgw_bucket_entry_ver::decode_json(JSONObj *obj) {
 list<rgw_bucket_entry_ver> rgw_bucket_entry_ver::generate_test_instances()
 {
   list<rgw_bucket_entry_ver> ls;
-  ls.push_back(rgw_bucket_entry_ver{});
-  ls.push_back(rgw_bucket_entry_ver{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().pool = 123;
   ls.back().epoch = 12322;
   return ls;
@@ -463,7 +463,7 @@ list<rgw_cls_bi_entry> rgw_cls_bi_entry::generate_test_instances()
   m.idx = "idx";
   encode(entry, m.data);
   o.push_back(std::move(m));
-  o.push_back(rgw_cls_bi_entry{});
+  o.emplace_back();
   return o;
 }
 
@@ -501,7 +501,7 @@ list<rgw_bucket_olh_entry> rgw_bucket_olh_entry::generate_test_instances()
   entry.exists = true;
   entry.pending_removal = true;
   o.push_back(std::move(entry));
-  o.push_back(rgw_bucket_olh_entry{});
+  o.emplace_back();
   return o;
 }
 
@@ -522,7 +522,7 @@ list<rgw_bucket_deleted_entry> rgw_bucket_deleted_entry::generate_test_instances
   entry.key.name = "key.name";
   entry.key.instance = "key.instance";
   o.push_back(std::move(entry));
-  o.push_back(rgw_bucket_deleted_entry{});
+  o.emplace_back();
   return o;
 }
 
@@ -537,7 +537,7 @@ list<rgw_bucket_olh_log_entry> rgw_bucket_olh_log_entry::generate_test_instances
   entry.key.instance = "key.instance";
   entry.delete_marker = true;
   o.push_back(std::move(entry));
-  o.push_back(rgw_bucket_olh_log_entry{});
+  o.emplace_back();
   return o;
 }
 
@@ -650,8 +650,8 @@ void rgw_bi_log_entry::dump(Formatter *f) const
 list<rgw_bi_log_entry> rgw_bi_log_entry::generate_test_instances()
 {
   list<rgw_bi_log_entry> ls;
-  ls.push_back(rgw_bi_log_entry{});
-  ls.push_back(rgw_bi_log_entry{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().id = "midf";
   ls.back().object = "obj";
   ls.back().timestamp = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
@@ -671,7 +671,7 @@ list<rgw_bucket_category_stats> rgw_bucket_category_stats::generate_test_instanc
   s.num_entries = 2;
   s.actual_size = 1024;
   o.push_back(std::move(s));
-  o.push_back(rgw_bucket_category_stats{});
+  o.emplace_back();
   return o;
 }
 
@@ -699,7 +699,7 @@ list<rgw_bucket_dir_header> rgw_bucket_dir_header::generate_test_instances()
     o.push_back(std::move(h));
   }
 
-  o.push_back(rgw_bucket_dir_header{});
+  o.emplace_back();
   return o;
 }
 
@@ -742,7 +742,7 @@ list<rgw_bucket_dir> rgw_bucket_dir::generate_test_instances()
     o.push_back(std::move(d));
   }
 
-  o.push_back(rgw_bucket_dir{});
+  o.emplace_back();
   return o;
 }
 
@@ -769,7 +769,7 @@ list<rgw_s3select_usage_data> rgw_s3select_usage_data::generate_test_instances()
   s.bytes_processed = 1024;
   s.bytes_returned = 512;
   o.push_back(std::move(s));
-  o.push_back(rgw_s3select_usage_data{});
+  o.emplace_back();
   return o;
 }
 
@@ -788,7 +788,7 @@ list<rgw_usage_data> rgw_usage_data::generate_test_instances()
   s.ops = 2;
   s.successful_ops = 1;
   o.push_back(std::move(s));
-  o.push_back(rgw_usage_data{});
+  o.emplace_back();
   return o;
 }
 
@@ -811,7 +811,7 @@ list<rgw_usage_log_info> rgw_usage_log_info::generate_test_instances()
   rgw_usage_log_entry r(owner, payer, bucket);
   s.entries.push_back(r);
   o.push_back(std::move(s));
-  o.push_back(rgw_usage_log_info{});
+  o.emplace_back();
   return o;
 }
 
@@ -827,7 +827,7 @@ list<rgw_user_bucket> rgw_user_bucket::generate_test_instances()
   s.user = "user";
   s.bucket = "bucket";
   o.push_back(std::move(s));
-  o.push_back(rgw_user_bucket{});
+  o.emplace_back();
   return o;
 }
 
@@ -889,7 +889,7 @@ list<rgw_usage_log_entry> rgw_usage_log_entry::generate_test_instances()
   entry.usage_map["get_obj"] = usage_data;
   entry.s3select_usage = s3select_usage_data;
   o.push_back(std::move(entry));
-  o.push_back(rgw_usage_log_entry{});
+  o.emplace_back();
   return o;
 }
 
@@ -931,8 +931,8 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
 list<cls_rgw_reshard_entry> cls_rgw_reshard_entry::generate_test_instances()
 {
   list<cls_rgw_reshard_entry> ls;
-  ls.push_back(cls_rgw_reshard_entry{});
-  ls.push_back(cls_rgw_reshard_entry{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().time = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
   ls.back().tenant = "tenant";
   ls.back().bucket_name = "bucket1""";
@@ -950,8 +950,8 @@ void cls_rgw_bucket_instance_entry::dump(Formatter *f) const
 list<cls_rgw_bucket_instance_entry> cls_rgw_bucket_instance_entry::generate_test_instances()
 {
   list<cls_rgw_bucket_instance_entry> ls;
-  ls.push_back(cls_rgw_bucket_instance_entry{});
-  ls.push_back(cls_rgw_bucket_instance_entry{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().reshard_status = RESHARD_STATUS::IN_PROGRESS;
   return ls;
 }
@@ -971,7 +971,7 @@ list<cls_rgw_lc_entry> cls_rgw_lc_entry::generate_test_instances()
   s.start_time = 10;
   s.status = 1;
   o.push_back(std::move(s));
-  o.push_back(cls_rgw_lc_entry{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1179,8 +1179,8 @@ struct cls_rgw_obj {
   }
   static std::list<cls_rgw_obj> generate_test_instances() {
     std::list<cls_rgw_obj> ls;
-    ls.push_back(cls_rgw_obj{});
-    ls.push_back(cls_rgw_obj{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().pool = "mypool";
     ls.back().key.name = "myoid";
     ls.back().loc = "mykey";
@@ -1233,7 +1233,7 @@ struct cls_rgw_obj_chain {
   }
   static std::list<cls_rgw_obj_chain> generate_test_instances() {
     std::list<cls_rgw_obj_chain> ls;
-    ls.push_back(cls_rgw_obj_chain{});
+    ls.emplace_back();
     return ls;
   }
 
@@ -1286,8 +1286,8 @@ struct cls_rgw_gc_obj_info
   }
   static std::list<cls_rgw_gc_obj_info> generate_test_instances() {
     std::list<cls_rgw_gc_obj_info> ls;
-    ls.push_back(cls_rgw_gc_obj_info{});
-    ls.push_back(cls_rgw_gc_obj_info{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().tag = "footag";
     ceph_timespec ts{ceph_le32(21), ceph_le32(32)};
     ls.back().time = ceph::real_clock::from_ceph_timespec(ts);

--- a/src/cls/rgw_gc/cls_rgw_gc_ops.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_ops.h
@@ -32,7 +32,7 @@ struct cls_rgw_gc_queue_init_op {
 
   static std::list<cls_rgw_gc_queue_init_op> generate_test_instances() {
     std::list<cls_rgw_gc_queue_init_op> o;
-    o.push_back(cls_rgw_gc_queue_init_op{});
+    o.emplace_back();
     o.back().size = 1024;
     o.back().num_deferred_entries = 512;
     return o;

--- a/src/cls/rgw_gc/cls_rgw_gc_types.h
+++ b/src/cls/rgw_gc/cls_rgw_gc_types.h
@@ -42,8 +42,8 @@ struct cls_rgw_gc_urgent_data
   }
   static std::list<cls_rgw_gc_urgent_data> generate_test_instances() {
     std::list<cls_rgw_gc_urgent_data> o;
-    o.push_back(cls_rgw_gc_urgent_data{});
-    o.push_back(cls_rgw_gc_urgent_data{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().num_urgent_data_entries = 1024;
     o.back().num_head_urgent_entries = 512;
     o.back().num_xattr_urgent_entries = 512;

--- a/src/cls/timeindex/cls_timeindex_ops.h
+++ b/src/cls/timeindex/cls_timeindex_ops.h
@@ -66,8 +66,8 @@ struct cls_timeindex_list_op {
 
   static std::list<cls_timeindex_list_op> generate_test_instances() {
     std::list<cls_timeindex_list_op> o;
-    o.push_back(cls_timeindex_list_op{});
-    o.push_back(cls_timeindex_list_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().from_time = utime_t(1, 2);
     o.back().marker = "marker";
     o.back().to_time = utime_t(3, 4);
@@ -108,8 +108,8 @@ struct cls_timeindex_list_ret {
 
   static std::list<cls_timeindex_list_ret> generate_test_instances() {
     std::list<cls_timeindex_list_ret> o;
-    o.push_back(cls_timeindex_list_ret{});
-    o.push_back(cls_timeindex_list_ret{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().entries.push_back(cls_timeindex_entry());
     o.back().entries.back().key_ts = utime_t(1, 2);
     o.back().entries.back().key_ext = "key_ext";

--- a/src/cls/timeindex/cls_timeindex_types.cc
+++ b/src/cls/timeindex/cls_timeindex_types.cc
@@ -18,6 +18,6 @@ std::list<cls_timeindex_entry> cls_timeindex_entry::generate_test_instances()
   bl.append("bar");
   i.value = bl;
   o.push_back(std::move(i));
-  o.push_back(cls_timeindex_entry{});
+  o.emplace_back();
   return o;
 }

--- a/src/cls/user/cls_user_ops.cc
+++ b/src/cls/user/cls_user_ops.cc
@@ -19,7 +19,7 @@ void cls_user_set_buckets_op::dump(Formatter *f) const
 list<cls_user_set_buckets_op> cls_user_set_buckets_op::generate_test_instances()
 {
   list<cls_user_set_buckets_op> ls;
-  ls.push_back(cls_user_set_buckets_op{});
+  ls.emplace_back();
   cls_user_set_buckets_op op;
   for (int i = 0; i < 3; i++) {
     cls_user_bucket_entry e;
@@ -40,7 +40,7 @@ void cls_user_remove_bucket_op::dump(Formatter *f) const
 list<cls_user_remove_bucket_op> cls_user_remove_bucket_op::generate_test_instances()
 {
   list<cls_user_remove_bucket_op> ls;
-  ls.push_back(cls_user_remove_bucket_op{});
+  ls.emplace_back();
   cls_user_remove_bucket_op op;
   cls_user_gen_test_bucket(&op.bucket, 0);
   ls.push_back(std::move(op));
@@ -56,7 +56,7 @@ void cls_user_list_buckets_op::dump(Formatter *f) const
 list<cls_user_list_buckets_op> cls_user_list_buckets_op::generate_test_instances()
 {
   list<cls_user_list_buckets_op> ls;
-  ls.push_back(cls_user_list_buckets_op{});
+  ls.emplace_back();
   cls_user_list_buckets_op op;;
   op.marker = "marker";
   op.max_entries = 1000;
@@ -74,7 +74,7 @@ void cls_user_list_buckets_ret::dump(Formatter *f) const
 list<cls_user_list_buckets_ret> cls_user_list_buckets_ret::generate_test_instances()
 {
   list<cls_user_list_buckets_ret> ls;
-  ls.push_back(cls_user_list_buckets_ret{});
+  ls.emplace_back();
   cls_user_list_buckets_ret ret;;
   for (int i = 0; i < 3; i++) {
     cls_user_bucket_entry e;
@@ -95,7 +95,7 @@ void cls_user_get_header_op::dump(Formatter *f) const
 list<cls_user_get_header_op> cls_user_get_header_op::generate_test_instances()
 {
   list<cls_user_get_header_op> ls;
-  ls.push_back(cls_user_get_header_op{});
+  ls.emplace_back();
   return ls;
 }
 
@@ -107,7 +107,7 @@ void cls_user_get_header_ret::dump(Formatter *f) const
 list<cls_user_get_header_ret> cls_user_get_header_ret::generate_test_instances()
 {
   list<cls_user_get_header_ret> ls;
-  ls.push_back(cls_user_get_header_ret{});
+  ls.emplace_back();
   cls_user_get_header_ret ret;
   cls_user_gen_test_header(&ret.header);
   ls.push_back(std::move(ret));
@@ -122,7 +122,7 @@ void cls_user_complete_stats_sync_op::dump(Formatter *f) const
 list<cls_user_complete_stats_sync_op> cls_user_complete_stats_sync_op::generate_test_instances()
 {
   list<cls_user_complete_stats_sync_op> ls;
-  ls.push_back(cls_user_complete_stats_sync_op{});
+  ls.emplace_back();
   cls_user_complete_stats_sync_op op;
   op.time = utime_t(12345, 0).to_real_time();
   ls.push_back(std::move(op));
@@ -140,7 +140,7 @@ void cls_user_account_resource_add_op::dump(Formatter *f) const
 std::list<cls_user_account_resource_add_op> cls_user_account_resource_add_op::generate_test_instances()
 {
   std::list<cls_user_account_resource_add_op> ls;
-  ls.push_back(cls_user_account_resource_add_op{});
+  ls.emplace_back();
   cls_user_account_resource_add_op op;
   cls_user_gen_test_resource(op.entry);
   ls.push_back(std::move(op));
@@ -155,7 +155,7 @@ void cls_user_account_resource_get_op::dump(Formatter *f) const
 std::list<cls_user_account_resource_get_op> cls_user_account_resource_get_op::generate_test_instances()
 {
   std::list<cls_user_account_resource_get_op> ls;
-  ls.push_back(cls_user_account_resource_get_op{});
+  ls.emplace_back();
   cls_user_account_resource_get_op op;
   op.name = "name";
   ls.push_back(std::move(op));
@@ -170,7 +170,7 @@ void cls_user_account_resource_get_ret::dump(Formatter *f) const
 std::list<cls_user_account_resource_get_ret> cls_user_account_resource_get_ret::generate_test_instances()
 {
   std::list<cls_user_account_resource_get_ret> ls;
-  ls.push_back(cls_user_account_resource_get_ret{});
+  ls.emplace_back();
   cls_user_account_resource_get_ret ret;
   cls_user_gen_test_resource(ret.entry);
   ls.push_back(std::move(ret));
@@ -185,7 +185,7 @@ void cls_user_account_resource_rm_op::dump(Formatter *f) const
 std::list<cls_user_account_resource_rm_op> cls_user_account_resource_rm_op::generate_test_instances()
 {
   std::list<cls_user_account_resource_rm_op> ls;
-  ls.push_back(cls_user_account_resource_rm_op{});
+  ls.emplace_back();
   cls_user_account_resource_rm_op op;
   op.name = "name";
   ls.push_back(std::move(op));
@@ -202,7 +202,7 @@ void cls_user_account_resource_list_op::dump(Formatter *f) const
 std::list<cls_user_account_resource_list_op> cls_user_account_resource_list_op::generate_test_instances()
 {
   std::list<cls_user_account_resource_list_op> ls;
-  ls.push_back(cls_user_account_resource_list_op{});
+  ls.emplace_back();
   cls_user_account_resource_list_op op;
   op.marker = "marker";
   op.path_prefix = "path";
@@ -221,7 +221,7 @@ void cls_user_account_resource_list_ret::dump(Formatter *f) const
 std::list<cls_user_account_resource_list_ret> cls_user_account_resource_list_ret::generate_test_instances()
 {
   std::list<cls_user_account_resource_list_ret> ls;
-  ls.push_back(cls_user_account_resource_list_ret{});
+  ls.emplace_back();
   cls_user_account_resource_list_ret ret;
   cls_user_gen_test_resource(ret.entries.emplace_back());
   ret.truncated = true;

--- a/src/cls/user/cls_user_types.cc
+++ b/src/cls/user/cls_user_types.cc
@@ -33,7 +33,7 @@ void cls_user_bucket::dump(Formatter *f) const
 list<cls_user_bucket> cls_user_bucket::generate_test_instances()
 {
   list<cls_user_bucket> ls;
-  ls.push_back(cls_user_bucket{});
+  ls.emplace_back();
   cls_user_bucket b;
   cls_user_gen_test_bucket(&b, 0);
   ls.push_back(std::move(b));
@@ -63,7 +63,7 @@ void cls_user_gen_test_bucket_entry(cls_user_bucket_entry *entry, int i)
 list<cls_user_bucket_entry> cls_user_bucket_entry::generate_test_instances()
 {
   list<cls_user_bucket_entry> ls;
-  ls.push_back(cls_user_bucket_entry{});
+  ls.emplace_back();
   cls_user_bucket_entry entry;
   cls_user_gen_test_bucket_entry(&entry, 0);
   ls.push_back(std::move(entry));
@@ -87,7 +87,7 @@ void cls_user_stats::dump(Formatter *f) const
 list<cls_user_stats> cls_user_stats::generate_test_instances()
 {
   list<cls_user_stats> ls;
-  ls.push_back(cls_user_stats{});
+  ls.emplace_back();
   cls_user_stats s;
   cls_user_gen_test_stats(&s);
   ls.push_back(std::move(s));
@@ -111,7 +111,7 @@ void cls_user_header::dump(Formatter *f) const
 list<cls_user_header> cls_user_header::generate_test_instances()
 {
   list<cls_user_header> ls;
-  ls.push_back(cls_user_header{});
+  ls.emplace_back();
   cls_user_header h;
   cls_user_gen_test_header(&h);
   ls.push_back(std::move(h));
@@ -127,7 +127,7 @@ void cls_user_account_header::dump(ceph::Formatter* f) const
 std::list<cls_user_account_header> cls_user_account_header::generate_test_instances()
 {
   std::list<cls_user_account_header> ls;
-  ls.push_back(cls_user_account_header{});
+  ls.emplace_back();
   return ls;
 }
 
@@ -147,7 +147,7 @@ void cls_user_gen_test_resource(cls_user_account_resource& r)
 std::list<cls_user_account_resource> cls_user_account_resource::generate_test_instances()
 {
   std::list<cls_user_account_resource> ls;
-  ls.push_back(cls_user_account_resource{});
+  ls.emplace_back();
   cls_user_account_resource p;
   cls_user_gen_test_resource(p);
   ls.push_back(std::move(p));

--- a/src/cls/version/cls_version_ops.h
+++ b/src/cls/version/cls_version_ops.h
@@ -30,8 +30,8 @@ struct cls_version_set_op {
 
   static std::list<cls_version_set_op> generate_test_instances() {
     std::list<cls_version_set_op> o;
-    o.push_back(cls_version_set_op{});
-    o.push_back(cls_version_set_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().objv.ver = 123;
     o.back().objv.tag = "foo";
     return o;
@@ -66,8 +66,8 @@ struct cls_version_inc_op {
 
   static std::list<cls_version_inc_op> generate_test_instances() {
     std::list<cls_version_inc_op> o;
-    o.push_back(cls_version_inc_op{});
-    o.push_back(cls_version_inc_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().objv.ver = 123;
     o.back().objv.tag = "foo";
     o.back().conds.push_back(obj_version_cond());
@@ -106,8 +106,8 @@ struct cls_version_check_op {
 
   static std::list<cls_version_check_op> generate_test_instances() {
     std::list<cls_version_check_op> o;
-    o.push_back(cls_version_check_op{});
-    o.push_back(cls_version_check_op{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().objv.ver = 123;
     o.back().objv.tag = "foo";
     o.back().conds.push_back(obj_version_cond());
@@ -142,8 +142,8 @@ struct cls_version_read_ret {
 
   static std::list<cls_version_read_ret> generate_test_instances() {
     std::list<cls_version_read_ret> o;
-    o.push_back(cls_version_read_ret{});
-    o.push_back(cls_version_read_ret{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().objv.ver = 123;
     o.back().objv.tag = "foo";
     return o;

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -114,8 +114,8 @@ struct obj_version_cond {
 
   static std::list<obj_version_cond> generate_test_instances() {
     std::list<obj_version_cond> o;
-    o.push_back(obj_version_cond{});
-    o.push_back(obj_version_cond{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().ver.ver = 1;
     o.back().ver.tag = "foo";
     o.back().cond = VER_COND_EQ;

--- a/src/common/CompatSet.cc
+++ b/src/common/CompatSet.cc
@@ -83,8 +83,8 @@ void CompatSet::dump(ceph::Formatter *f) const {
 
 std::list<CompatSet> CompatSet::generate_test_instances() {
   std::list<CompatSet> o;
-  o.push_back(CompatSet{});
-  o.push_back(CompatSet{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().compat.insert(Feature(1, "one"));
   o.back().compat.insert(Feature(2, "two"));
   o.back().ro_compat.insert(Feature(4, "four"));

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -32,7 +32,7 @@ void LogEntryKey::dump(Formatter *f) const
 list<LogEntryKey> LogEntryKey::generate_test_instances()
 {
   list<LogEntryKey> o;
-  o.push_back(LogEntryKey{});
+  o.emplace_back();
   o.push_back(LogEntryKey(entity_name_t::CLIENT(1234), utime_t(1,2), 34));
   return o;
 }
@@ -274,7 +274,7 @@ void LogEntry::dump(Formatter *f) const
 list<LogEntry> LogEntry::generate_test_instances()
 {
   list<LogEntry> o;
-  o.push_back(LogEntry{});
+  o.emplace_back();
   return o;
 }
 
@@ -359,7 +359,7 @@ void LogSummary::dump(Formatter *f) const
 list<LogSummary> LogSummary::generate_test_instances()
 {
   list<LogSummary> o;
-  o.push_back(LogSummary{});
+  o.emplace_back();
   // more!
   return o;
 }

--- a/src/common/SloppyCRCMap.cc
+++ b/src/common/SloppyCRCMap.cc
@@ -174,7 +174,7 @@ void SloppyCRCMap::dump(ceph::Formatter *f) const
 list<SloppyCRCMap> SloppyCRCMap::generate_test_instances()
 {
   list<SloppyCRCMap> ls;
-  ls.push_back(SloppyCRCMap{});
+  ls.emplace_back();
   ls.push_back(SloppyCRCMap(2));
   bufferlist bl;
   bl.append("some data");

--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -619,7 +619,7 @@ template <uint8_t _b>
 auto BitVector<_b>::generate_test_instances() -> std::list<BitVector> {
   std::list<BitVector> o;
 
-  o.push_back(BitVector{});
+  o.emplace_back();
 
   BitVector b;
   const uint64_t radix = 1 << b.BIT_COUNT;

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -858,16 +858,16 @@ public:
   }
   static std::list<JSONFormattable> generate_test_instances() {
     std::list<JSONFormattable> o;
-    o.push_back(JSONFormattable{});
-    o.push_back(JSONFormattable{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().set_type(FMT_VALUE);
     o.back().value.str = "foo";
     o.back().value.quoted = true;
-    o.push_back(JSONFormattable{});
+    o.emplace_back();
     o.back().set_type(FMT_VALUE);
     o.back().value.str = "foo";
     o.back().value.quoted = false;
-    o.push_back(JSONFormattable{});
+    o.emplace_back();
     o.back().set_type(FMT_ARRAY);
     o.back().arr.push_back(JSONFormattable());
     o.back().arr.back().set_type(FMT_VALUE);
@@ -877,7 +877,7 @@ public:
     o.back().arr.back().set_type(FMT_VALUE);
     o.back().arr.back().value.str = "bar";
     o.back().arr.back().value.quoted = true;
-    o.push_back(JSONFormattable{});
+    o.emplace_back();
     o.back().set_type(FMT_OBJ);
     o.back().obj["foo"] = JSONFormattable();
     o.back().obj["foo"].set_type(FMT_VALUE);

--- a/src/common/entity_name.cc
+++ b/src/common/entity_name.cc
@@ -52,11 +52,11 @@ void EntityName::dump(ceph::Formatter *f) const {
 
 std::list<EntityName> EntityName::generate_test_instances() {
   std::list<EntityName> ls;
-  ls.push_back(EntityName{});
-  ls.push_back(EntityName{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().set_type(CEPH_ENTITY_TYPE_OSD);
   ls.back().set_id("0");
-  ls.push_back(EntityName{});
+  ls.emplace_back();
   ls.back().set_type(CEPH_ENTITY_TYPE_MDS);
   ls.back().set_id("a");
   return ls;

--- a/src/common/frag.cc
+++ b/src/common/frag.cc
@@ -47,7 +47,7 @@ void frag_t::dump(ceph::Formatter *f) const {
 
 std::list<frag_t> frag_t::generate_test_instances() {
   std::list<frag_t> ls;
-  ls.push_back(frag_t{});
+  ls.emplace_back();
   ls.push_back(frag_t(10, 2));
   ls.push_back(frag_t(11, 3));
   return ls;
@@ -189,8 +189,8 @@ void fragtree_t::dump(ceph::Formatter *f) const {
 
 std::list<fragtree_t> fragtree_t::generate_test_instances() {
   std::list<fragtree_t> ls;
-  ls.push_back(fragtree_t{});
-  ls.push_back(fragtree_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   return ls;
 }
 

--- a/src/common/fs_types.cc
+++ b/src/common/fs_types.cc
@@ -146,8 +146,8 @@ void file_layout_t::decode_json(JSONObj *obj){
 std::list<file_layout_t> file_layout_t::generate_test_instances()
 {
   std::list<file_layout_t> o;
-  o.push_back(file_layout_t{});
-  o.push_back(file_layout_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().stripe_unit = 4096;
   o.back().stripe_count = 16;
   o.back().object_size = 1048576;

--- a/src/common/histogram.cc
+++ b/src/common/histogram.cc
@@ -42,8 +42,8 @@ void pow2_hist_t::decode(ceph::buffer::list::const_iterator& p)
 std::list<pow2_hist_t> pow2_hist_t::generate_test_instances()
 {
   std::list<pow2_hist_t> ls;
-  ls.push_back(pow2_hist_t{});
-  ls.push_back(pow2_hist_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().h.push_back(1);
   ls.back().h.push_back(3);
   ls.back().h.push_back(0);

--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -197,8 +197,8 @@ void hobject_t::dump(Formatter *f) const
 list<hobject_t> hobject_t::generate_test_instances()
 {
   list<hobject_t> o;
-  o.push_back(hobject_t{});
-  o.push_back(hobject_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().max = true;
   o.push_back(hobject_t(object_t("oname"), string(), 1, 234, -1, ""));
   o.push_back(hobject_t(object_t("oname2"), string("okey"), CEPH_NOSNAP,
@@ -500,8 +500,8 @@ void ghobject_t::dump(Formatter *f) const
 list<ghobject_t> ghobject_t::generate_test_instances()
 {
   list<ghobject_t> o;
-  o.push_back(ghobject_t{});
-  o.push_back(ghobject_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().hobj.max = true;
   o.push_back(ghobject_t(hobject_t(object_t("oname"), string(), 1, 234, -1, "")));
 

--- a/src/common/snap_types.cc
+++ b/src/common/snap_types.cc
@@ -45,7 +45,7 @@ void SnapRealmInfo::dump(ceph::Formatter *f) const
 std::list<SnapRealmInfo> SnapRealmInfo::generate_test_instances()
 {
   std::list<SnapRealmInfo> o;
-  o.push_back(SnapRealmInfo{});
+  o.emplace_back();
   o.push_back(SnapRealmInfo(1, 10, 10, 0));
   o.push_back(SnapRealmInfo(1, 10, 10, 0));
   o.back().my_snaps.push_back(10);
@@ -88,7 +88,7 @@ void SnapRealmInfoNew::dump(ceph::Formatter *f) const
 std::list<SnapRealmInfoNew> SnapRealmInfoNew::generate_test_instances()
 {
   std::list<SnapRealmInfoNew> o;
-  o.push_back(SnapRealmInfoNew{});
+  o.emplace_back();
   o.push_back(SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 0), utime_t(), 0));
   o.push_back(SnapRealmInfoNew(SnapRealmInfo(1, 10, 10, 0), utime_t(), 1));
   o.back().info.my_snaps.push_back(10);
@@ -145,7 +145,7 @@ void SnapContext::dump(ceph::Formatter *f) const
 std::list<SnapContext> SnapContext::generate_test_instances()
 {
   std::list<SnapContext> o;
-  o.push_back(SnapContext{});
+  o.emplace_back();
   std::vector<snapid_t> v;
   o.push_back(SnapContext(10, v));
   v.push_back(18);

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -214,7 +214,7 @@ struct vinodeno_t {
   void dump(ceph::Formatter *f) const;
   static std::list<vinodeno_t> generate_test_instances() {
     std::list<vinodeno_t> ls;
-    ls.push_back(vinodeno_t{});
+    ls.emplace_back();
     ls.push_back(vinodeno_t(1, 2));
     return ls;
   }
@@ -1134,8 +1134,8 @@ template<template<typename> class Allocator>
 auto inode_t<Allocator>::generate_test_instances() -> std::list<inode_t>
 {
   std::list<inode_t> ls;
-  ls.push_back(inode_t<Allocator>{});
-  ls.push_back(inode_t<Allocator>{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().ino = 1;
   // i am lazy.
   return ls;

--- a/src/include/filepath.cc
+++ b/src/include/filepath.cc
@@ -118,7 +118,7 @@ void filepath::dump(ceph::Formatter *f) const {
 
 std::list<filepath> filepath::generate_test_instances() {
   std::list<filepath> o;
-  o.push_back(filepath{});
+  o.emplace_back();
   o.push_back(filepath("/usr/bin", 0));
   o.push_back(filepath("/usr/sbin", 1));
   o.push_back(filepath("var/log", 1));

--- a/src/include/object.cc
+++ b/src/include/object.cc
@@ -33,7 +33,7 @@ void object_t::dump(ceph::Formatter *f) const {
 
 std::list<object_t> object_t::generate_test_instances() {
   std::list<object_t> o;
-  o.push_back(object_t{});
+  o.emplace_back();
   o.push_back(object_t{"myobject"});
   return o;
 }
@@ -64,7 +64,7 @@ void sobject_t::dump(ceph::Formatter *f) const {
 
 std::list<sobject_t> sobject_t::generate_test_instances() {
   std::list<sobject_t> o;
-  o.push_back(sobject_t{});
+  o.emplace_back();
   o.push_back(sobject_t{object_t("myobject"), 123});
   return o;
 }

--- a/src/include/types.cc
+++ b/src/include/types.cc
@@ -54,7 +54,7 @@ void client_t::dump(ceph::Formatter *f) const {
 
 std::list<client_t> client_t::generate_test_instances() {
   std::list<client_t> ls;
-  ls.push_back(client_t{});
+  ls.emplace_back();
   ls.push_back(client_t(1));
   ls.push_back(client_t(123));
   return ls;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -610,10 +610,10 @@ struct sha_digest_t {
   }
   static std::list<sha_digest_t> generate_test_instances() {
     std::list<sha_digest_t> ls;
-    ls.push_back(sha_digest_t{});
-    ls.push_back(sha_digest_t{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().v[0] = 1;
-    ls.push_back(sha_digest_t{});
+    ls.emplace_back();
     ls.back().v[0] = 2;
     return ls;
   }

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -65,8 +65,8 @@ struct ceph_data_stats
 
   static std::list<ceph_data_stats> generate_test_instances() {
     std::list<ceph_data_stats> ls;
-    ls.push_back(ceph_data_stats{});
-    ls.push_back(ceph_data_stats{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().byte_total = 1024*1024;
     ls.back().byte_used = 512*1024;
     ls.back().byte_avail = 512*1024;

--- a/src/mds/Anchor.cc
+++ b/src/mds/Anchor.cc
@@ -53,8 +53,8 @@ void Anchor::dump(Formatter *f) const
 std::list<Anchor> Anchor::generate_test_instances()
 {
   std::list<Anchor> ls;
-  ls.push_back(Anchor{});
-  ls.push_back(Anchor{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().ino = 1;
   ls.back().dirino = 2;
   ls.back().d_name = "hello";

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -145,8 +145,8 @@ void Capability::revoke_info::dump(ceph::Formatter *f) const
 std::list<Capability::revoke_info> Capability::revoke_info::generate_test_instances()
 {
   std::list<Capability::revoke_info> ls;
-  ls.push_back(revoke_info{});
-  ls.push_back(revoke_info{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().before = 1;
   ls.back().seq = 2;
   ls.back().last_issue = 3;

--- a/src/mds/inode_backtrace.cc
+++ b/src/mds/inode_backtrace.cc
@@ -43,8 +43,8 @@ void inode_backpointer_t::dump(ceph::Formatter *f) const
 std::list<inode_backpointer_t> inode_backpointer_t::generate_test_instances()
 {
   std::list<inode_backpointer_t> ls;
-  ls.push_back(inode_backpointer_t{});
-  ls.push_back(inode_backpointer_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().dirino = 1;
   ls.back().dname = "foo";
   ls.back().version = 123;
@@ -110,8 +110,8 @@ void inode_backtrace_t::dump(ceph::Formatter *f) const
 std::list<inode_backtrace_t> inode_backtrace_t::generate_test_instances()
 {
   std::list<inode_backtrace_t> ls;
-  ls.push_back(inode_backtrace_t{});
-  ls.push_back(inode_backtrace_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().ino = 1;
   ls.back().ancestors.push_back(inode_backpointer_t());
   ls.back().ancestors.back().dirino = 123;

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -87,8 +87,8 @@ void frag_info_t::decode_json(JSONObj *obj){
 std::list<frag_info_t> frag_info_t::generate_test_instances()
 {
   std::list<frag_info_t> ls;
-  ls.push_back(frag_info_t{});
-  ls.push_back(frag_info_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().version = 1;
   ls.back().mtime = utime_t(2, 3);
   ls.back().nfiles = 4;
@@ -170,8 +170,8 @@ void nest_info_t::decode_json(JSONObj *obj){
 std::list<nest_info_t> nest_info_t::generate_test_instances()
 {
   std::list<nest_info_t> ls;
-  ls.push_back(nest_info_t{});
-  ls.push_back(nest_info_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().version = 1;
   ls.back().rbytes = 2;
   ls.back().rfiles = 3;
@@ -216,8 +216,8 @@ void  quota_info_t::decode_json(JSONObj *obj){
 std::list<quota_info_t> quota_info_t::generate_test_instances()
 {
   std::list<quota_info_t> ls;
-  ls.push_back(quota_info_t{});
-  ls.push_back(quota_info_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().max_bytes = 16;
   ls.back().max_files = 16;
   return ls;
@@ -272,8 +272,8 @@ void client_writeable_range_t::byte_range_t::decode_json(JSONObj *obj){
 std::list<client_writeable_range_t> client_writeable_range_t::generate_test_instances()
 {
   std::list<client_writeable_range_t> ls;
-  ls.push_back(client_writeable_range_t{});
-  ls.push_back(client_writeable_range_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().range.first = 123;
   ls.back().range.last = 456;
   ls.back().follows = 12;
@@ -320,8 +320,8 @@ void inline_data_t::dump(Formatter *f) const
 std::list<inline_data_t> inline_data_t::generate_test_instances()
 {
   std::list<inline_data_t> ls;
-  ls.push_back(inline_data_t{});
-  ls.push_back(inline_data_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   bufferlist bl;
   bl.append("inline data");
   ls.back().set_data(bl);
@@ -404,8 +404,8 @@ void fnode_t::decode_json(JSONObj *obj){
 std::list<fnode_t> fnode_t::generate_test_instances()
 {
   std::list<fnode_t> ls;
-  ls.push_back(fnode_t{});
-  ls.push_back(fnode_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().version = 1;
   ls.back().snap_purged_thru = 2;
   list<frag_info_t> fls = frag_info_t::generate_test_instances();
@@ -742,8 +742,8 @@ void session_info_t::dump(Formatter *f) const
 std::list<session_info_t> session_info_t::generate_test_instances()
 {
   std::list<session_info_t>ls;
-  ls.push_back(session_info_t{});
-  ls.push_back(session_info_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().inst = entity_inst_t(entity_name_t::MDS(12), entity_addr_t());
   ls.back().completed_requests.insert(make_pair(234, inodeno_t(111222)));
   ls.back().completed_requests.insert(make_pair(237, inodeno_t(222333)));
@@ -805,11 +805,11 @@ void string_snap_t::dump(Formatter *f) const
 std::list<string_snap_t> string_snap_t::generate_test_instances()
 {
   std::list<string_snap_t> ls;
-  ls.push_back(string_snap_t{});
-  ls.push_back(string_snap_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().name = "foo";
   ls.back().snapid = 123;
-  ls.push_back(string_snap_t{});
+  ls.emplace_back();
   ls.back().name = "bar";
   ls.back().snapid = 456;
   return ls;
@@ -861,13 +861,13 @@ void MDSCacheObjectInfo::print(std::ostream& out) const {
 std::list<MDSCacheObjectInfo> MDSCacheObjectInfo::generate_test_instances()
 {
   std::list<MDSCacheObjectInfo> ls;
-  ls.push_back(MDSCacheObjectInfo{});
-  ls.push_back(MDSCacheObjectInfo{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().ino = 1;
   ls.back().dirfrag = dirfrag_t(2, 3);
   ls.back().dname = "fooname";
   ls.back().snapid = CEPH_NOSNAP;
-  ls.push_back(MDSCacheObjectInfo{});
+  ls.emplace_back();
   ls.back().ino = 121;
   ls.back().dirfrag = dirfrag_t(222, 0);
   ls.back().dname = "bar foo";
@@ -906,8 +906,8 @@ void mds_table_pending_t::dump(Formatter *f) const
 std::list<mds_table_pending_t> mds_table_pending_t::generate_test_instances()
 {
   std::list<mds_table_pending_t> ls;
-  ls.push_back(mds_table_pending_t{});
-  ls.push_back(mds_table_pending_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().reqid = 234;
   ls.back().mds = 2;
   ls.back().tid = 35434;
@@ -925,7 +925,7 @@ void metareqid_t::print(std::ostream& out) const {
 
 std::list<metareqid_t> metareqid_t::generate_test_instances() {
   std::list<metareqid_t> ls;
-  ls.push_back(metareqid_t{});
+  ls.emplace_back();
   ls.push_back(metareqid_t(entity_name_t::CLIENT(123), 456));
   return ls;
 }
@@ -947,7 +947,7 @@ void dirfrag_t::dump(ceph::Formatter *f) const {
 
 std::list<dirfrag_t> dirfrag_t::generate_test_instances() {
   std::list<dirfrag_t> ls;
-  ls.push_back(dirfrag_t{});
+  ls.emplace_back();
   ls.push_back(dirfrag_t(1, frag_t()));
   ls.push_back(dirfrag_t(2, frag_t(3)));
   return ls;
@@ -1139,7 +1139,7 @@ void cap_reconnect_t::dump(Formatter *f) const
 std::list<cap_reconnect_t> cap_reconnect_t::generate_test_instances()
 {
   std::list<cap_reconnect_t> ls;
-  ls.push_back(cap_reconnect_t{});
+  ls.emplace_back();
   ls.back().path = "/test/path";
   ls.back().capinfo.cap_id = 1;
   return ls;
@@ -1180,7 +1180,7 @@ void snaprealm_reconnect_t::dump(Formatter *f) const
 std::list<snaprealm_reconnect_t> snaprealm_reconnect_t::generate_test_instances()
 {
   std::list<snaprealm_reconnect_t> ls;
-  ls.push_back(snaprealm_reconnect_t{});
+  ls.emplace_back();
   ls.back().realm.ino = 0x10000000001ULL;
   ls.back().realm.seq = 2;
   ls.back().realm.parent = 1;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -206,8 +206,8 @@ template<template<typename> class Allocator>
 auto old_inode_t<Allocator>::generate_test_instances() -> std::list<old_inode_t<Allocator>>
 {
   std::list<old_inode_t<Allocator>> ls;
-  ls.push_back(old_inode_t<Allocator>{});
-  ls.push_back(old_inode_t<Allocator>{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().first = 2;
   std::list<inode_t<Allocator>> ils = inode_t<Allocator>::generate_test_instances();
   ls.back().inode = ils.back();

--- a/src/mds/snap.cc
+++ b/src/mds/snap.cc
@@ -67,8 +67,8 @@ void SnapInfo::dump(Formatter *f) const
 std::list<SnapInfo> SnapInfo::generate_test_instances()
 {
   std::list<SnapInfo> ls;
-  ls.push_back(SnapInfo{});
-  ls.push_back(SnapInfo{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().snapid = 1;
   ls.back().ino = 2;
   ls.back().stamp = utime_t(3, 4);
@@ -126,8 +126,8 @@ void snaplink_t::dump(Formatter *f) const
 std::list<snaplink_t> snaplink_t::generate_test_instances()
 {
   std::list<snaplink_t> ls;
-  ls.push_back(snaplink_t{});
-  ls.push_back(snaplink_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().ino = 2;
   ls.back().first = 123;
   return ls;
@@ -226,8 +226,8 @@ void sr_t::dump(Formatter *f) const
 std::list<sr_t> sr_t::generate_test_instances()
 {
   std::list<sr_t> ls;
-  ls.push_back(sr_t{});
-  ls.push_back(sr_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().seq = 1;
   ls.back().created = 2;
   ls.back().last_created = 3;

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -326,8 +326,8 @@ public:
   }
   static std::list<openc_response_t> generate_test_instances() {
     std::list<openc_response_t> ls;
-    ls.push_back(openc_response_t{});
-    ls.push_back(openc_response_t{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().created_ino = 1;
     ls.back().delegated_inos.insert(1, 10);
     return ls;

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -67,8 +67,8 @@ struct SnapPayload {
   }
   static std::list<SnapPayload> generate_test_instances() {
     std::list<SnapPayload> o;
-    o.push_back(SnapPayload{});
-    o.push_back(SnapPayload{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().metadata["key1"] = "val1";
     o.back().metadata["key2"] = "val2";
     return o;
@@ -124,8 +124,8 @@ public:
 
     static std::list<Release> generate_test_instances() {
       std::list<Release> ls;
-      ls.push_back(Release{});
-      ls.push_back(Release{});
+      ls.emplace_back();
+      ls.emplace_back();
       ls.back().item.dname_len = 4;
       ls.back().dname = "test";
       return ls;

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -224,8 +224,8 @@ struct MDSHealth
 
   static std::list<MDSHealth> generate_test_instances() {
     std::list<MDSHealth> ls;
-    ls.push_back(MDSHealth{});
-    ls.push_back(MDSHealth{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().metrics.push_back(MDSHealthMetric(MDS_HEALTH_TRIM, HEALTH_WARN,
              "MDS is behind on trimming"));
     return ls;

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -72,7 +72,7 @@ public:
     }
     static std::list<inode_strong> generate_test_instances() {
       std::list<inode_strong> ls;
-      ls.push_back(inode_strong{});
+      ls.emplace_back();
       ls.push_back(inode_strong(1, 2, 3, 4, 5));
       return ls;
     }
@@ -96,7 +96,7 @@ public:
     }
     static std::list<dirfrag_strong> generate_test_instances() {
       std::list<dirfrag_strong> ls;
-      ls.push_back(dirfrag_strong{});
+      ls.emplace_back();
       ls.push_back(dirfrag_strong(1, 2));
       return ls;
     }
@@ -143,7 +143,7 @@ public:
     }
     static std::list<dn_strong> generate_test_instances() {
       std::list<dn_strong> ls;
-      ls.push_back(dn_strong{});
+      ls.emplace_back();
       ls.push_back(dn_strong(1, "alternate_name", 2, 3, 4, 5, 6));
       return ls;
     }
@@ -201,7 +201,7 @@ public:
     }
     static std::list<dn_strong_new> generate_test_instances() {
       std::list<dn_strong_new> ls;
-      ls.push_back(dn_strong_new{});
+      ls.emplace_back();
       ls.push_back(dn_strong_new(1, "alternate_name", 2, 3, 4, 5, 6, 7));
       return ls;
     }

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -87,8 +87,8 @@ public:
   static std::list<PerfCounterType> generate_test_instances()
   {
     std::list<PerfCounterType> ls;
-    ls.push_back(PerfCounterType{});
-    ls.push_back(PerfCounterType{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().path = "mycounter";
     ls.back().description = "mycounter description";
     ls.back().nick = "mycounter nick";

--- a/src/mgr/MDSPerfMetricTypes.h
+++ b/src/mgr/MDSPerfMetricTypes.h
@@ -399,8 +399,8 @@ struct MDSPerfMetricReport {
   }
   static std::list<MDSPerfMetricReport> generate_test_instances() {
     std::list<MDSPerfMetricReport> o;
-    o.push_back(MDSPerfMetricReport{});
-    o.push_back(MDSPerfMetricReport{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().reports.emplace(MDSPerfMetricQuery(), MDSPerfMetrics());
     o.back().rank_metrics_delayed.insert(1);
     return o;

--- a/src/mgr/MetricTypes.h
+++ b/src/mgr/MetricTypes.h
@@ -244,7 +244,7 @@ struct MDSConfigPayload {
   }
   static std::list<MDSConfigPayload> generate_test_instances() {
     std::list<MDSConfigPayload> ls;
-    ls.push_back(MDSConfigPayload{});
+    ls.emplace_back();
     return ls;
   }
 };

--- a/src/mgr/MgrCap.cc
+++ b/src/mgr/MgrCap.cc
@@ -387,24 +387,24 @@ void MgrCap::dump(ceph::Formatter *f) const {
 
 std::list<MgrCap> MgrCap::generate_test_instances() {
   std::list<MgrCap> ls;
-  ls.push_back(MgrCap{});
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().parse("allow *");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("allow rwx");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("allow service foo x");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("allow command bar x");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("allow service foo r, allow command bar x");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("allow command bar with k1=v1 x");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("allow command bar with k1=v1 k2=v2 x");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("allow module bar with k1=v1 k2=v2 x");
-  ls.push_back(MgrCap{});
+  ls.emplace_back();
   ls.back().parse("profile rbd pool=rbd");
   return ls;
 }

--- a/src/mgr/OSDPerfMetricTypes.h
+++ b/src/mgr/OSDPerfMetricTypes.h
@@ -426,8 +426,8 @@ struct OSDPerfMetricReport {
 
   static std::list<OSDPerfMetricReport> generate_test_instances() {
     std::list<OSDPerfMetricReport> o;
-    o.push_back(OSDPerfMetricReport{});
-    o.push_back(OSDPerfMetricReport{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().performance_counter_descriptors.push_back(
         PerformanceCounterDescriptor(PerformanceCounterType::OPS));
     o.back().performance_counter_descriptors.push_back(

--- a/src/mgr/ServiceMap.cc
+++ b/src/mgr/ServiceMap.cc
@@ -61,8 +61,8 @@ void ServiceMap::Daemon::dump(Formatter *f) const
 auto ServiceMap::Daemon::generate_test_instances() -> std::list<Daemon>
 {
   std::list<Daemon> ls;
-  ls.push_back(Daemon{});
-  ls.push_back(Daemon{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().gid = 222;
   ls.back().metadata["this"] = "that";
   ls.back().task_status["task1"] = "running";
@@ -199,8 +199,8 @@ void ServiceMap::Service::dump(Formatter *f) const
 auto ServiceMap::Service::generate_test_instances() -> std::list<Service>
 {
   std::list<Service> ls;
-  ls.push_back(Service{});
-  ls.push_back(Service{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().daemons["one"].gid = 1;
   ls.back().daemons["two"].gid = 2;
   return ls;
@@ -240,8 +240,8 @@ void ServiceMap::dump(Formatter *f) const
 std::list<ServiceMap> ServiceMap::generate_test_instances()
 {
   std::list<ServiceMap> ls;
-  ls.push_back(ServiceMap{});
-  ls.push_back(ServiceMap{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().epoch = 123;
   ls.back().services["rgw"].daemons["one"].gid = 123;
   ls.back().services["rgw"].daemons["two"].gid = 344;

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -84,11 +84,11 @@ public:
     }
     static std::list<Incremental> generate_test_instances() {
       std::list<Incremental> ls;
-      ls.push_back(Incremental{});
-      ls.push_back(Incremental{});
+      ls.emplace_back();
+      ls.emplace_back();
       ls.back().inc_type = GLOBAL_ID;
       ls.back().max_global_id = 1234;
-      ls.push_back(Incremental{});
+      ls.emplace_back();
       ls.back().inc_type = AUTH_DATA;
       ls.back().auth_type = 12;
       ls.back().auth_data.append("foo");

--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -504,8 +504,8 @@ void ConnectionReport::dump(ceph::Formatter *f) const
 std::list<ConnectionReport> ConnectionReport::generate_test_instances()
 {
   std::list<ConnectionReport> o;
-  o.push_back(ConnectionReport{});
-  o.push_back(ConnectionReport{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().rank = 1;
   o.back().epoch = 2;
   o.back().epoch_version = 3;
@@ -533,8 +533,8 @@ void ConnectionTracker::dump(ceph::Formatter *f) const
 std::list<ConnectionTracker> ConnectionTracker::generate_test_instances()
 {
   std::list<ConnectionTracker> o;
-  o.push_back(ConnectionTracker{});
-  o.push_back(ConnectionTracker{});
+  o.emplace_back();
+  o.emplace_back();
   ConnectionTracker& e = o.back();
   e.rank = 2;
   e.epoch = 3;

--- a/src/mon/CreatingPGs.h
+++ b/src/mon/CreatingPGs.h
@@ -85,9 +85,9 @@ struct creating_pgs_t {
     }
     static std::list<pg_create_info> generate_test_instances() {
       std::list<pg_create_info> o;
-      o.push_back(pg_create_info{});
+      o.emplace_back();
       o.back().create_epoch = 10;
-      o.push_back(pg_create_info{});
+      o.emplace_back();
       o.back().create_epoch = 1;
       o.back().create_stamp = utime_t(2, 3);
       o.back().up = {1, 2, 3};

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -110,8 +110,8 @@ public:
     static std::list<ModuleOption> generate_test_instances()
     {
       std::list<ModuleOption> ls;
-      ls.push_back(ModuleOption{});
-      ls.push_back(ModuleOption{});
+      ls.emplace_back();
+      ls.emplace_back();
       ls.back().name = "name";
       ls.back().type = Option::TYPE_STR;
       ls.back().level = Option::LEVEL_ADVANCED;
@@ -180,8 +180,8 @@ public:
     static std::list<ModuleInfo> generate_test_instances()
     {
       std::list<ModuleInfo> ls;
-      ls.push_back(ModuleInfo{});
-      ls.push_back(ModuleInfo{});
+      ls.emplace_back();
+      ls.emplace_back();
       ls.back().name = "name";
       ls.back().can_run = true;
       ls.back().error_string = "error_string";
@@ -642,7 +642,7 @@ public:
   static std::list<MgrMap> generate_test_instances()
   {
     std::list<MgrMap> l;
-    l.push_back(MgrMap{});
+    l.emplace_back();
     return l;
   }
 

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -532,20 +532,20 @@ void MonCap::dump(Formatter *f) const
 list<MonCap> MonCap::generate_test_instances()
 {
   list<MonCap> ls;
-  ls.push_back(MonCap{});
-  ls.push_back(MonCap{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().parse("allow *");
-  ls.push_back(MonCap{});
+  ls.emplace_back();
   ls.back().parse("allow rwx");
-  ls.push_back(MonCap{});
+  ls.emplace_back();
   ls.back().parse("allow service foo x");
-  ls.push_back(MonCap{});
+  ls.emplace_back();
   ls.back().parse("allow command bar x");
-  ls.push_back(MonCap{});
+  ls.emplace_back();
   ls.back().parse("allow service foo r, allow command bar x");
-  ls.push_back(MonCap{});
+  ls.emplace_back();
   ls.back().parse("allow command bar with k1=v1 x");
-  ls.push_back(MonCap{});
+  ls.emplace_back();
   ls.back().parse("allow command bar with k1=v1 k2=v2 x");
   return ls;
 }

--- a/src/mon/MonCommand.h
+++ b/src/mon/MonCommand.h
@@ -64,8 +64,8 @@ struct MonCommand {
 
   static std::list<MonCommand> generate_test_instances() {
     std::list<MonCommand> ls;
-    ls.push_back(MonCommand{});
-    ls.push_back(MonCommand{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().cmdstring = "foo";
     ls.back().helpstring = "bar";
     ls.back().module = "baz";

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -123,8 +123,8 @@ void mon_info_t::dump(ceph::Formatter *f) const
 list<mon_info_t> mon_info_t::generate_test_instances()
 {
   list<mon_info_t> ls;
-  ls.push_back(mon_info_t{});
-  ls.push_back(mon_info_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().name = "noname";
   ls.back().public_addrs.parse("v1:1.2.3.4:567/890");
   ls.back().priority = 1;
@@ -328,8 +328,8 @@ void MonMap::decode(ceph::buffer::list::const_iterator& p)
 list<MonMap> MonMap::generate_test_instances()
 {
   list<MonMap> o;
-  o.push_back(MonMap{});
-  o.push_back(MonMap{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().epoch = 1;
   o.back().last_changed = utime_t(123, 456);
   o.back().created = utime_t(789, 101112);

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -121,7 +121,7 @@ class MonitorDBStore
 
     static std::list<Op> generate_test_instances() {
       std::list<Op> ls;
-      ls.push_back(Op{});
+      ls.emplace_back();
       // we get coverage here from the Transaction instances
       return ls;
     }
@@ -209,8 +209,8 @@ class MonitorDBStore
 
     static std::list<Transaction> generate_test_instances() {
       std::list<Transaction> ls;
-      ls.push_back(Transaction{});
-      ls.push_back(Transaction{});
+      ls.emplace_back();
+      ls.emplace_back();
       ceph::buffer::list bl;
       bl.append("value");
       ls.back().put("prefix", "key", bl);

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -197,7 +197,7 @@ void PGMapDigest::dump(ceph::Formatter *f) const
 list<PGMapDigest> PGMapDigest::generate_test_instances()
 {
   list<PGMapDigest> ls;
-  ls.push_back(PGMapDigest{});
+  ls.emplace_back();
   return ls;
 }
 
@@ -1118,15 +1118,15 @@ void PGMap::Incremental::dump(ceph::Formatter *f) const
 list<PGMap::Incremental> PGMap::Incremental::generate_test_instances()
 {
   list<PGMap::Incremental> o;
-  o.push_back(Incremental{});
-  o.push_back(Incremental{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().version = 1;
   o.back().stamp = utime_t(123,345);
-  o.push_back(Incremental{});
+  o.emplace_back();
   o.back().version = 2;
   o.back().pg_stat_updates[pg_t(1,2)] = pg_stat_t();
   o.back().osd_stat_updates[5] = osd_stat_t();
-  o.push_back(Incremental{});
+  o.emplace_back();
   o.back().version = 3;
   o.back().osdmap_epoch = 1;
   o.back().pg_scan = 2;
@@ -2264,7 +2264,7 @@ void PGMap::clear_delta()
 list<PGMap> PGMap::generate_test_instances()
 {
   list<PGMap> o;
-  o.push_back(PGMap{});
+  o.emplace_back();
   list<Incremental> inc = Incremental::generate_test_instances();
   inc.pop_front();
   while (!inc.empty()) {

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -84,8 +84,8 @@ public:
     }
     static std::list<pg_count> generate_test_instances() {
       std::list<pg_count> o;
-      o.push_back(pg_count{});
-      o.push_back(pg_count{});
+      o.emplace_back();
+      o.emplace_back();
       o.back().acting = 1;
       o.back().up_not_acting = 2;
       o.back().primary = 3;

--- a/src/mon/health_check.h
+++ b/src/mon/health_check.h
@@ -60,9 +60,9 @@ struct health_check_t {
 
   static std::list<health_check_t> generate_test_instances() {
     std::list<health_check_t> ls;
-    ls.push_back(health_check_t{});
+    ls.emplace_back();
     ls.back().severity = HEALTH_WARN;
-    ls.push_back(health_check_t{});
+    ls.emplace_back();
     ls.back().severity = HEALTH_ERR;
     ls.back().summary = "summarization";
     ls.back().detail = {"one", "two", "three"};
@@ -102,8 +102,8 @@ struct health_mute_t {
 
   static std::list<health_mute_t> generate_test_instances() {
     std::list<health_mute_t> ls;
-    ls.push_back(health_mute_t{});
-    ls.push_back(health_mute_t{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().code = "OSD_DOWN";
     ls.back().ttl = utime_t(1, 2);
     ls.back().sticky = true;
@@ -132,8 +132,8 @@ struct health_check_map_t {
   static std::list<health_check_map_t> generate_test_instances() {
     std::list<health_check_map_t> ls;
 
-    ls.push_back(health_check_map_t{});
-    ls.push_back(health_check_map_t{});
+    ls.emplace_back();
+    ls.emplace_back();
     {
       auto& d = ls.back().add("FOO", HEALTH_WARN, "foo", 2);
       d.detail.push_back("a");

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -120,8 +120,8 @@ struct FeatureMap {
 
   static std::list<FeatureMap> generate_test_instances() {
     std::list<FeatureMap> ls;
-    ls.push_back(FeatureMap{});
-    ls.push_back(FeatureMap{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_UID);
     ls.back().add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_NOSRCADDR);
     ls.back().add(CEPH_ENTITY_TYPE_OSD, CEPH_FEATURE_PGID64);
@@ -179,8 +179,8 @@ struct MonitorDBStoreStats {
 
   static std::list<MonitorDBStoreStats> generate_test_instances() {
     std::list<MonitorDBStoreStats> ls;
-    ls.push_back(MonitorDBStoreStats{});
-    ls.push_back(MonitorDBStoreStats{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().bytes_total = 1024*1024;
     ls.back().bytes_sst = 512*1024;
     ls.back().bytes_log = 256*1024;
@@ -212,8 +212,8 @@ struct DataStats {
   }
   static std::list<DataStats> generate_test_instances() {
     std::list<DataStats> ls;
-    ls.push_back(DataStats{});
-    ls.push_back(DataStats{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().fs_stats.byte_total = 1024*1024;
     ls.back().fs_stats.byte_used = 512*1024;
     ls.back().fs_stats.byte_avail = 256*1024;
@@ -295,8 +295,8 @@ struct ScrubResult {
   }
   static std::list<ScrubResult> generate_test_instances() {
     std::list<ScrubResult> ls;
-    ls.push_back(ScrubResult{});
-    ls.push_back(ScrubResult{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().prefix_crc["foo"] = 123;
     ls.back().prefix_keys["bar"] = 456;
     return ls;
@@ -508,10 +508,10 @@ public:
 
   static std::list<mon_feature_t> generate_test_instances() {
     std::list<mon_feature_t> ls;
-    ls.push_back(mon_feature_t{});
-    ls.push_back(mon_feature_t{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().features = 1;
-    ls.push_back(mon_feature_t{});
+    ls.emplace_back();
     ls.back().features = 2;
     return ls;
   }
@@ -739,8 +739,8 @@ struct ProgressEvent {
   }
   static std::list<ProgressEvent> generate_test_instances() {
     std::list<ProgressEvent> o;
-    o.push_back(ProgressEvent{});
-    o.push_back(ProgressEvent{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().message = "test message";
     o.back().progress = 0.5;
     o.back().add_to_ceph_s = true;
@@ -801,11 +801,11 @@ struct PoolAvailability {
 
   static std::list<PoolAvailability> generate_test_instances() {
     std::list<PoolAvailability> o;
-    o.push_back(PoolAvailability{});
+    o.emplace_back();
     o.back().started_at = utime_t(123, 456);
     o.back().last_uptime = utime_t(123, 456);
     o.back().last_downtime = utime_t(123, 456);
-    o.push_back(PoolAvailability{});
+    o.emplace_back();
     o.back().pool_name = "foo";
     o.back().started_at = utime_t(123, 456);
     o.back().uptime = 100;

--- a/src/os/SequencerPosition.h
+++ b/src/os/SequencerPosition.h
@@ -43,7 +43,7 @@ struct SequencerPosition {
   }
   static std::list<SequencerPosition> generate_test_instances() {
     std::list<SequencerPosition> o;
-    o.push_back(SequencerPosition{});
+    o.emplace_back();
     o.push_back(SequencerPosition(1, 2, 3));
     o.push_back(SequencerPosition(4, 5, 6));
     return o;

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -534,7 +534,7 @@ list<Transaction> Transaction::generate_test_instances()
 {
   list<Transaction> o;
 
-  o.push_back(Transaction{});
+  o.emplace_back();
 
   Transaction t;
   t.nop();

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -28,8 +28,8 @@ void bluefs_extent_t::dump(Formatter *f) const
 list<bluefs_extent_t> bluefs_extent_t::generate_test_instances()
 {
   list<bluefs_extent_t> ls;
-  ls.push_back(bluefs_extent_t{});
-  ls.push_back(bluefs_extent_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().offset = 1;
   ls.back().length = 2;
   ls.back().bdev = 1;
@@ -168,8 +168,8 @@ void bluefs_layout_t::dump(Formatter *f) const
 list<bluefs_layout_t> bluefs_layout_t::generate_test_instances()
 {
   list<bluefs_layout_t> ls;
-  ls.push_back(bluefs_layout_t{});
-  ls.push_back(bluefs_layout_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().shared_bdev = 1;
   ls.back().dedicated_db = true;
   ls.back().dedicated_wal = true;
@@ -224,8 +224,8 @@ void bluefs_super_t::dump(Formatter *f) const
 list<bluefs_super_t> bluefs_super_t::generate_test_instances()
 {
   list<bluefs_super_t> ls;
-  ls.push_back(bluefs_super_t{});
-  ls.push_back(bluefs_super_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().seq = 1;
   ls.back().block_size = 4096;
   return ls;
@@ -313,8 +313,8 @@ void bluefs_fnode_t::dump(Formatter *f) const
 list<bluefs_fnode_t> bluefs_fnode_t::generate_test_instances()
 {
   list<bluefs_fnode_t> ls;
-  ls.push_back(bluefs_fnode_t{});
-  ls.push_back(bluefs_fnode_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().ino = 123;
   ls.back().size = 1048576;
   ls.back().mtime = utime_t(123,45);
@@ -419,8 +419,8 @@ void bluefs_transaction_t::dump(Formatter *f) const
 list<bluefs_transaction_t> bluefs_transaction_t::generate_test_instances()
 {
   list<bluefs_transaction_t> ls;
-  ls.push_back(bluefs_transaction_t{});
-  ls.push_back(bluefs_transaction_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().op_init();
   ls.back().op_dir_create("dir");
   ls.back().op_dir_create("dir2");

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -72,8 +72,8 @@ void bluestore_bdev_label_t::dump(Formatter *f) const
 list<bluestore_bdev_label_t> bluestore_bdev_label_t::generate_test_instances()
 {
   list<bluestore_bdev_label_t> o;
-  o.push_back(bluestore_bdev_label_t{});
-  o.push_back(bluestore_bdev_label_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().size = 123;
   o.back().btime = utime_t(4, 5);
   o.back().description = "fakey";
@@ -379,8 +379,8 @@ void bluestore_extent_ref_map_t::dump(Formatter *f) const
 list<bluestore_extent_ref_map_t> bluestore_extent_ref_map_t::generate_test_instances()
 {
   list<bluestore_extent_ref_map_t> o;
-  o.push_back(bluestore_extent_ref_map_t{});
-  o.push_back(bluestore_extent_ref_map_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().get(10, 10);
   o.back().get(18, 22);
   o.back().get(20, 20);
@@ -749,7 +749,7 @@ ostream& operator<<(ostream& out, const bluestore_pextent_t& o) {
 list<bluestore_pextent_t> bluestore_pextent_t::generate_test_instances()
 {
   list<bluestore_pextent_t> ls;
-  ls.push_back(bluestore_pextent_t{});
+  ls.emplace_back();
   ls.push_back(bluestore_pextent_t(1, 2));
   return ls;
 }
@@ -834,11 +834,11 @@ void bluestore_blob_t::dump(Formatter *f) const
 list<bluestore_blob_t> bluestore_blob_t::generate_test_instances()
 {
   list<bluestore_blob_t> ls;
-  ls.push_back(bluestore_blob_t{});
+  ls.emplace_back();
   ls.push_back(bluestore_blob_t(0));
-  ls.push_back(bluestore_blob_t{});
+  ls.emplace_back();
   ls.back().allocated_test(bluestore_pextent_t(111, 222));
-  ls.push_back(bluestore_blob_t{});
+  ls.emplace_back();
   ls.back().init_csum(Checksummer::CSUM_XXHASH32, 16, 65536);
   ls.back().csum_data = ceph::buffer::claim_malloc(4, strdup("abcd"));
   ls.back().add_unused(0, 3);
@@ -1397,8 +1397,8 @@ void bluestore_onode_t::shard_info::dump(Formatter *f) const
 auto bluestore_onode_t::shard_info::generate_test_instances() -> list<shard_info>
 {
   list<shard_info> o;
-  o.push_back(shard_info{});
-  o.push_back(shard_info{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().offset = 123;
   o.back().bytes = 456;
   return o;
@@ -1501,8 +1501,8 @@ void bluestore_deferred_op_t::dump(Formatter *f) const
 list<bluestore_deferred_op_t> bluestore_deferred_op_t::generate_test_instances()
 {
   list<bluestore_deferred_op_t> o;
-  o.push_back(bluestore_deferred_op_t{});
-  o.push_back(bluestore_deferred_op_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().op = OP_WRITE;
   o.back().extents.push_back(bluestore_pextent_t(1, 2));
   o.back().extents.push_back(bluestore_pextent_t(100, 5));
@@ -1555,7 +1555,7 @@ void bluestore_compression_header_t::dump(Formatter *f) const
 list<bluestore_compression_header_t> bluestore_compression_header_t::generate_test_instances()
 {
   list<bluestore_compression_header_t> o;
-  o.push_back(bluestore_compression_header_t{});
+  o.emplace_back();
   o.push_back(bluestore_compression_header_t(1));
   o.back().length = 1234;
   return o;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -165,7 +165,7 @@ struct bluestore_extent_ref_map_t {
     }
     static std::list<record_t> generate_test_instances() {
       std::list<record_t> o;
-      o.push_back(record_t{});
+      o.emplace_back();
       o.push_back(record_t(123, 456));
       return o;
     }

--- a/src/osd/HitSet.cc
+++ b/src/osd/HitSet.cc
@@ -97,7 +97,7 @@ void HitSet::dump(Formatter *f) const
 list<HitSet> HitSet::generate_test_instances()
 {
   list<HitSet> o;
-  o.push_back(HitSet{});
+  o.emplace_back();
   o.push_back(HitSet(new BloomHitSet(10, .1, 1)));
   o.back().insert(hobject_t());
   o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
@@ -200,7 +200,7 @@ list<HitSet::Params> HitSet::Params::generate_test_instances()
   for (auto& i : kind::Params::generate_test_instances()) \
     o.push_back(Params(&i)); \
 }
-  o.push_back(Params{});
+  o.emplace_back();
   o.push_back(Params(new BloomHitSet::Params));
   loop_hitset_params(BloomHitSet);
   o.push_back(Params(new ExplicitHashHitSet::Params));

--- a/src/osd/HitSet.h
+++ b/src/osd/HitSet.h
@@ -192,7 +192,7 @@ public:
     }
     static std::list<Params> generate_test_instances() {
       std::list<Params> o;
-      o.push_back(Params{});
+      o.emplace_back();
       return o;
     }
   };
@@ -240,8 +240,8 @@ public:
   void dump(ceph::Formatter *f) const override;
   static std::list<ExplicitHashHitSet> generate_test_instances() {
     std::list<ExplicitHashHitSet> o;
-    o.push_back(ExplicitHashHitSet{});
-    o.push_back(ExplicitHashHitSet{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().insert(hobject_t());
     o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
     o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
@@ -267,7 +267,7 @@ public:
     }
     static std::list<Params> generate_test_instances() {
       std::list<Params> o;
-      o.push_back(Params{});
+      o.emplace_back();
       return o;
     }
   };
@@ -315,8 +315,8 @@ public:
   void dump(ceph::Formatter *f) const override;
   static std::list<ExplicitObjectHitSet> generate_test_instances() {
     std::list<ExplicitObjectHitSet> o;
-    o.push_back(ExplicitObjectHitSet{});
-    o.push_back(ExplicitObjectHitSet{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().insert(hobject_t());
     o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));
     o.back().insert(hobject_t("qwer", "", CEPH_NOSNAP, 456, 1, ""));
@@ -388,8 +388,8 @@ public:
     }
     static std::list<Params> generate_test_instances() {
       std::list<Params> o;
-      o.push_back(Params{});
-      o.push_back(Params{});
+      o.emplace_back();
+      o.emplace_back();
       o.back().fpp_micro = 123456;
       o.back().target_size = 300;
       o.back().seed = 99;
@@ -454,7 +454,7 @@ public:
   void dump(ceph::Formatter *f) const override;
   static std::list<BloomHitSet> generate_test_instances() {
     std::list<BloomHitSet> o;
-    o.push_back(BloomHitSet{});
+    o.emplace_back();
     o.push_back(BloomHitSet(10, .1, 1));
     o.back().insert(hobject_t());
     o.back().insert(hobject_t("asdf", "", CEPH_NOSNAP, 123, 1, ""));

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -109,8 +109,8 @@ void osd_info_t::decode(ceph::buffer::list::const_iterator& bl)
 list<osd_info_t> osd_info_t::generate_test_instances()
 {
   list<osd_info_t> o;
-  o.push_back(osd_info_t{});
-  o.push_back(osd_info_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().last_clean_begin = 1;
   o.back().last_clean_end = 2;
   o.back().up_from = 30;
@@ -193,8 +193,8 @@ void osd_xinfo_t::decode(ceph::buffer::list::const_iterator& bl)
 list<osd_xinfo_t> osd_xinfo_t::generate_test_instances()
 {
   list<osd_xinfo_t> o;
-  o.push_back(osd_xinfo_t{});
-  o.push_back(osd_xinfo_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().down_stamp = utime_t(2, 3);
   o.back().laggy_probability = .123;
   o.back().laggy_interval = 123456;
@@ -1394,7 +1394,7 @@ void OSDMap::Incremental::dump(Formatter *f) const
 auto OSDMap::Incremental::generate_test_instances() -> list<Incremental>
 {
   list<Incremental> o;
-  o.push_back(Incremental{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -348,8 +348,8 @@ struct PGTempMap {
   }
   static std::list<PGTempMap> generate_test_instances() {
     std::list<PGTempMap> o;
-    o.push_back(PGTempMap{});
-    o.push_back(PGTempMap{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().set(pg_t(1, 2), { 3, 4 });
     o.back().set(pg_t(2, 3), { 4, 5 });
     return o;

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -330,8 +330,8 @@ void SnapMapper::object_snaps::dump(ceph::Formatter *f) const
 auto SnapMapper::object_snaps::generate_test_instances() -> std::list<object_snaps>
 {
   std::list<object_snaps> o;
-  o.push_back(object_snaps{});
-  o.push_back(object_snaps{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().oid = hobject_t(sobject_t("name", CEPH_NOSNAP));
   o.back().snaps.insert(1);
   o.back().snaps.insert(2);

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -163,8 +163,8 @@ public:
     }
     static std::list<Mapping> generate_test_instances() {
       std::list<Mapping> o;
-      o.push_back(Mapping{});
-      o.push_back(Mapping{});
+      o.emplace_back();
+      o.emplace_back();
       o.back().snap = 1;
       o.back().hoid = hobject_t(object_t("objname"), "key", 123, 456, 0, "");
       return o;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -242,7 +242,7 @@ void osd_reqid_t::dump(Formatter *f) const
 list<osd_reqid_t> osd_reqid_t::generate_test_instances()
 {
   list<osd_reqid_t> o;
-  o.push_back(osd_reqid_t{});
+  o.emplace_back();
   o.push_back(osd_reqid_t(entity_name_t::CLIENT(123), 1, 45678));
   return o;
 }
@@ -303,7 +303,7 @@ void object_locator_t::dump(Formatter *f) const
 list<object_locator_t> object_locator_t::generate_test_instances()
 {
   list<object_locator_t> o;
-  o.push_back(object_locator_t{});
+  o.emplace_back();
   o.push_back(object_locator_t(123));
   o.push_back(object_locator_t(123, 876));
   o.push_back(object_locator_t(1, "n2"));
@@ -696,9 +696,9 @@ std::list<osd_stat_t> osd_stat_t::generate_test_instances()
 {
   std::list<osd_stat_t> o;
 
-  o.push_back(osd_stat_t{});
+  o.emplace_back();
 
-  o.push_back(osd_stat_t{});
+  o.emplace_back();
   list<store_statfs_t> ll = store_statfs_t::generate_test_instances();
   o.back().statfs = ll.back();
   o.back().hb_peers.push_back(7);
@@ -920,7 +920,7 @@ void pg_t::dump(Formatter *f) const
 list<pg_t> pg_t::generate_test_instances()
 {
   list<pg_t> o;
-  o.push_back(pg_t{});
+  o.emplace_back();
   o.push_back(pg_t(1, 2));
   o.push_back(pg_t(13123, 3));
   o.push_back(pg_t(131223, 4));
@@ -1341,8 +1341,8 @@ void pool_snap_info_t::decode(ceph::buffer::list::const_iterator& bl)
 list<pool_snap_info_t> pool_snap_info_t::generate_test_instances()
 {
   list<pool_snap_info_t> o;
-  o.push_back(pool_snap_info_t{});
-  o.push_back(pool_snap_info_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().snapid = 1;
   o.back().stamp = utime_t(1, 2);
   o.back().name = "foo";
@@ -1562,7 +1562,7 @@ void pool_opts_t::decode(ceph::buffer::list::const_iterator& bl)
 std::list<pool_opts_t> pool_opts_t::generate_test_instances()
 {
   std::list<pool_opts_t> o;
-  o.push_back(pool_opts_t{});
+  o.emplace_back();
   return o;
 }
 
@@ -3641,8 +3641,8 @@ void pg_history_t::dump(Formatter *f) const
 list<pg_history_t> pg_history_t::generate_test_instances()
 {
   list<pg_history_t> o;
-  o.push_back(pg_history_t{});
-  o.push_back(pg_history_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().epoch_created = 1;
   o.back().epoch_pool_created = 1;
   o.back().last_epoch_started = 2;
@@ -3776,8 +3776,8 @@ void pg_info_t::dump(Formatter *f) const
 list<pg_info_t> pg_info_t::generate_test_instances()
 {
   list<pg_info_t> o;
-  o.push_back(pg_info_t{});
-  o.push_back(pg_info_t{});
+  o.emplace_back();
+  o.emplace_back();
   list<pg_history_t> h = pg_history_t::generate_test_instances();
   o.back().history = h.back();
   o.back().pgid = spg_t(pg_t(1, 2), shard_id_t::NO_SHARD);
@@ -3846,7 +3846,7 @@ list<pg_notify_t> pg_notify_t::generate_test_instances()
 {
   list<pg_notify_t> o;
 
-  o.push_back(pg_notify_t{});
+  o.emplace_back();
   o.push_back(pg_notify_t(shard_id_t(3), shard_id_t::NO_SHARD, 1, 1,
 	    pg_info_t(spg_t(pg_t(0,10), shard_id_t(-1))), PastIntervals(),
             PG_FEATURE_CLASSIC_ALL));
@@ -3940,8 +3940,8 @@ std::string PastIntervals::pg_interval_t::fmt_print() const
 auto PastIntervals::pg_interval_t::generate_test_instances() -> list<pg_interval_t>
 {
   list<pg_interval_t> o;
-  o.push_back(pg_interval_t{});
-  o.push_back(pg_interval_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().up.push_back(1);
   o.back().acting.push_back(2);
   o.back().acting.push_back(3);
@@ -5430,10 +5430,10 @@ void pg_log_t::dump(Formatter *f) const
 list<pg_log_t> pg_log_t::generate_test_instances()
 {
   list<pg_log_t> o;
-  o.push_back(pg_log_t{});
+  o.emplace_back();
 
   // this is nonsensical:
-  o.push_back(pg_log_t{});
+  o.emplace_back();
   o.back().head = eversion_t(1,2);
   o.back().tail = eversion_t(3,4);
   for (auto& p : pg_log_entry_t::generate_test_instances()) {
@@ -5579,15 +5579,15 @@ void object_copy_cursor_t::dump(Formatter *f) const
 list<object_copy_cursor_t> object_copy_cursor_t::generate_test_instances()
 {
   list<object_copy_cursor_t> o;
-  o.push_back(object_copy_cursor_t{});
-  o.push_back(object_copy_cursor_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().attr_complete = true;
   o.back().data_offset = 123;
-  o.push_back(object_copy_cursor_t{});
+  o.emplace_back();
   o.back().attr_complete = true;
   o.back().data_complete = true;
   o.back().omap_offset = "foo";
-  o.push_back(object_copy_cursor_t{});
+  o.emplace_back();
   o.back().attr_complete = true;
   o.back().data_complete = true;
   o.back().omap_complete = true;
@@ -5788,7 +5788,7 @@ void pg_create_t::dump(Formatter *f) const
 list<pg_create_t> pg_create_t::generate_test_instances()
 {
   list<pg_create_t> o;
-  o.push_back(pg_create_t{});
+  o.emplace_back();
   o.push_back(pg_create_t(1, pg_t(3, 4), 2));
   return o;
 }
@@ -5831,8 +5831,8 @@ void pg_hit_set_info_t::dump(Formatter *f) const
 list<pg_hit_set_info_t> pg_hit_set_info_t::generate_test_instances()
 {
   list<pg_hit_set_info_t> ls;
-  ls.push_back(pg_hit_set_info_t{});
-  ls.push_back(pg_hit_set_info_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().begin = utime_t(1, 2);
   ls.back().end = utime_t(3, 4);
   return ls;
@@ -5888,8 +5888,8 @@ void pg_hit_set_history_t::dump(Formatter *f) const
 list<pg_hit_set_history_t> pg_hit_set_history_t::generate_test_instances()
 {
   list<pg_hit_set_history_t> ls;
-  ls.push_back(pg_hit_set_history_t{});
-  ls.push_back(pg_hit_set_history_t{});
+  ls.emplace_back();
+  ls.emplace_back();
   ls.back().current_last_update = eversion_t(1, 2);
   ls.back().history.push_back(pg_hit_set_info_t());
   return ls;
@@ -6085,10 +6085,10 @@ void SnapSet::dump(Formatter *f) const
 list<SnapSet> SnapSet::generate_test_instances()
 {
   list<SnapSet> o;
-  o.push_back(SnapSet{});
-  o.push_back(SnapSet{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().seq = 123;
-  o.push_back(SnapSet{});
+  o.emplace_back();
   o.back().seq = 123;
   o.back().clones.push_back(12);
   o.back().clone_size[12] = 12345;
@@ -6194,8 +6194,8 @@ std::string watch_info_t::fmt_print() const
 list<watch_info_t> watch_info_t::generate_test_instances()
 {
   list<watch_info_t> o;
-  o.push_back(watch_info_t{});
-  o.push_back(watch_info_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().cookie = 123;
   o.back().timeout_seconds = 99;
   entity_addr_t ea;
@@ -6248,8 +6248,8 @@ void chunk_info_t::dump(Formatter *f) const
 std::list<chunk_info_t> chunk_info_t::generate_test_instances()
 {
   std::list<chunk_info_t> o;
-  o.push_back(chunk_info_t{});
-  o.push_back(chunk_info_t{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().length = 123;
   o.back().oid = hobject_t(object_t("foo"), "", 123, 456, -1, "");
   o.back().flags = cflag_t::FLAG_DIRTY;
@@ -6797,13 +6797,13 @@ ostream &operator<<(ostream &out, const ObjectRecoveryProgress &prog)
 list<ObjectRecoveryProgress> ObjectRecoveryProgress::generate_test_instances()
 {
   list<ObjectRecoveryProgress> o;
-  o.push_back(ObjectRecoveryProgress{});
+  o.emplace_back();
   o.back().first = false;
   o.back().data_complete = true;
   o.back().omap_complete = true;
   o.back().data_recovered_to = 100;
 
-  o.push_back(ObjectRecoveryProgress{});
+  o.emplace_back();
   o.back().first = true;
   o.back().data_complete = false;
   o.back().omap_complete = false;
@@ -6882,7 +6882,7 @@ void ObjectRecoveryInfo::decode(ceph::buffer::list::const_iterator &bl,
 list<ObjectRecoveryInfo> ObjectRecoveryInfo::generate_test_instances()
 {
   list<ObjectRecoveryInfo> o;
-  o.push_back(ObjectRecoveryInfo{});
+  o.emplace_back();
   o.back().soid = hobject_t(sobject_t("key", CEPH_NOSNAP));
   o.back().version = eversion_t(0,0);
   o.back().size = 100;
@@ -6928,10 +6928,10 @@ std::string ObjectRecoveryInfo::fmt_print() const
 list<PushReplyOp> PushReplyOp::generate_test_instances()
 {
   list<PushReplyOp> o;
-  o.push_back(PushReplyOp{});
-  o.push_back(PushReplyOp{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().soid = hobject_t(sobject_t("asdf", 2));
-  o.push_back(PushReplyOp{});
+  o.emplace_back();
   o.back().soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
   return o;
 }
@@ -7003,11 +7003,11 @@ uint64_t PushReplyOp::cost(CephContext *cct) const
 list<PullOp> PullOp::generate_test_instances()
 {
   list<PullOp> o;
-  o.push_back(PullOp{});
-  o.push_back(PullOp{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().soid = hobject_t(sobject_t("asdf", 2));
   o.back().recovery_info.version = eversion_t(3, 10);
-  o.push_back(PullOp{});
+  o.emplace_back();
   o.back().soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
   o.back().recovery_info.version = eversion_t(0, 0);
   return o;
@@ -7082,11 +7082,11 @@ uint64_t PullOp::cost(CephContext *cct) const
 list<PushOp> PushOp::generate_test_instances()
 {
   list<PushOp> o;
-  o.push_back(PushOp{});
-  o.push_back(PushOp{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().soid = hobject_t(sobject_t("asdf", 2));
   o.back().version = eversion_t(3, 10);
-  o.push_back(PushOp{});
+  o.emplace_back();
   o.back().soid = hobject_t(sobject_t("asdf", CEPH_NOSNAP));
   o.back().version = eversion_t(0, 0);
   return o;
@@ -7259,8 +7259,8 @@ void ScrubMap::dump(Formatter *f) const
 list<ScrubMap> ScrubMap::generate_test_instances()
 {
   list<ScrubMap> o;
-  o.push_back(ScrubMap{});
-  o.push_back(ScrubMap{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().valid_through = eversion_t(1, 2);
   o.back().incr_since = eversion_t(3, 4);
   list<object> obj = object::generate_test_instances();
@@ -7363,10 +7363,10 @@ auto ScrubMap::object::generate_test_instances() -> list<object>
 {
   list<object> o;
 
-  o.push_back(object{});
-  o.push_back(object{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().negative = true;
-  o.push_back(object{});
+  o.emplace_back();
   o.back().size = 123;
   {
     bufferlist foobl;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -204,7 +204,7 @@ struct pg_shard_t {
   }
   static std::list<pg_shard_t> generate_test_instances() {
     std::list<pg_shard_t> o;
-    o.push_back(pg_shard_t{});
+    o.emplace_back();
     o.push_back(pg_shard_t(1));
     o.push_back(pg_shard_t(1, shard_id_t(2)));
     return o;
@@ -619,7 +619,7 @@ struct spg_t {
   }
   static std::list<spg_t> generate_test_instances() {
     std::list<spg_t> o;
-    o.push_back(spg_t{});
+    o.emplace_back();
     o.push_back(spg_t(pg_t(1, 2), shard_id_t(3)));
     return o;
   }
@@ -956,7 +956,7 @@ public:
   }
   static std::list<eversion_t> generate_test_instances() {
     std::list<eversion_t> o;
-    o.push_back(eversion_t{});
+    o.emplace_back();
     o.push_back(eversion_t(1, 2));
     return o;
   }
@@ -1252,8 +1252,8 @@ struct pg_merge_meta_t {
   }
   static std::list<pg_merge_meta_t> generate_test_instances() {
     std::list<pg_merge_meta_t> o;
-    o.push_back(pg_merge_meta_t{});
-    o.push_back(pg_merge_meta_t{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().source_pgid = pg_t(1,2);
     o.back().ready_epoch = 1;
     o.back().last_epoch_started = 2;
@@ -3341,8 +3341,8 @@ struct pg_fast_info_t {
   }
   static std::list<pg_fast_info_t> generate_test_instances() {
     std::list<pg_fast_info_t> o;
-    o.push_back(pg_fast_info_t{});
-    o.push_back(pg_fast_info_t{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().last_update = eversion_t(1, 2);
     o.back().last_complete = eversion_t(3, 4);
     o.back().last_user_version = version_t(5);
@@ -4417,9 +4417,9 @@ struct pg_log_op_return_item_t {
   }
   static std::list<pg_log_op_return_item_t> generate_test_instances() {
     std::list<pg_log_op_return_item_t> o;
-    o.push_back(pg_log_op_return_item_t{});
+    o.emplace_back();
     o.back().rval = 0;
-    o.push_back(pg_log_op_return_item_t{});
+    o.emplace_back();
     o.back().rval = 1;
     o.back().bl.append("asdf");
     return o;
@@ -4969,11 +4969,11 @@ struct pg_missing_item {
   }
   static std::list<pg_missing_item> generate_test_instances() {
     std::list<pg_missing_item> o;
-    o.push_back(pg_missing_item{});
-    o.push_back(pg_missing_item{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().need = eversion_t(1, 2);
     o.back().have = eversion_t(1, 1);
-    o.push_back(pg_missing_item{});
+    o.emplace_back();
     o.back().need = eversion_t(3, 5);
     o.back().have = eversion_t(3, 4);
     o.back().clean_regions.mark_data_region_dirty(4096, 8192);
@@ -5335,14 +5335,14 @@ public:
   }
   static std::list<pg_missing_set> generate_test_instances() {
     std::list<pg_missing_set> o;
-    o.push_back(pg_missing_set{});
+    o.emplace_back();
     o.back().may_include_deletes = true;
-    o.push_back(pg_missing_set{});
+    o.emplace_back();
     o.back().add(
       hobject_t(object_t("foo"), "foo", 123, 456, 0, ""),
       eversion_t(5, 6), eversion_t(5, 1), false);
     o.back().may_include_deletes = true;
-    o.push_back(pg_missing_set{});
+    o.emplace_back();
     o.back().add(
       hobject_t(object_t("foo"), "foo", 123, 456, 0, ""),
       eversion_t(5, 6), eversion_t(5, 1), true);
@@ -5480,18 +5480,18 @@ struct pg_nls_response_template {
   }
   static std::list<pg_nls_response_template> generate_test_instances() {
     std::list<pg_nls_response_template<T>> o;
-    o.push_back(pg_nls_response_template<T>{});
-    o.push_back(pg_nls_response_template<T>{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().handle = hobject_t(object_t("hi"), "key", 1, 2, -1, "");
     o.back().entries.push_back(librados::ListObjectImpl("", "one", ""));
     o.back().entries.push_back(librados::ListObjectImpl("", "two", "twokey"));
     o.back().entries.push_back(librados::ListObjectImpl("", "three", ""));
-    o.push_back(pg_nls_response_template<T>{});
+    o.emplace_back();
     o.back().handle = hobject_t(object_t("hi"), "key", 3, 4, -1, "");
     o.back().entries.push_back(librados::ListObjectImpl("n1", "n1one", ""));
     o.back().entries.push_back(librados::ListObjectImpl("n1", "n1two", "n1twokey"));
     o.back().entries.push_back(librados::ListObjectImpl("n1", "n1three", ""));
-    o.push_back(pg_nls_response_template<T>{});
+    o.emplace_back();
     o.back().handle = hobject_t(object_t("hi"), "key", 5, 6, -1, "");
     o.back().entries.push_back(librados::ListObjectImpl("", "one", ""));
     o.back().entries.push_back(librados::ListObjectImpl("", "two", "twokey"));
@@ -5540,8 +5540,8 @@ struct pg_ls_response_t {
   }
   static std::list<pg_ls_response_t> generate_test_instances() {
     std::list<pg_ls_response_t> o;
-    o.push_back(pg_ls_response_t{});
-    o.push_back(pg_ls_response_t{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().handle = hobject_t(object_t("hi"), "key", 1, 2, -1, "");
     o.back().entries.push_back(std::make_pair(object_t("one"), std::string()));
     o.back().entries.push_back(std::make_pair(object_t("two"), std::string("twokey")));
@@ -6741,8 +6741,8 @@ struct obj_list_watch_response_t {
   static std::list<obj_list_watch_response_t> generate_test_instances() {
     std::list<obj_list_watch_response_t> o;
     entity_addr_t ea;
-    o.push_back(obj_list_watch_response_t{});
-    o.push_back(obj_list_watch_response_t{});
+    o.emplace_back();
+    o.emplace_back();
     std::list<watch_item_t> test_watchers = watch_item_t::generate_test_instances();
     for (auto &e : test_watchers) {
       o.back().entries.push_back(e);
@@ -6801,14 +6801,14 @@ struct clone_info {
   }
   static std::list<clone_info> generate_test_instances() {
     std::list<clone_info> o;
-    o.push_back(clone_info{});
-    o.push_back(clone_info{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().cloneid = 1;
     o.back().snaps.push_back(1);
     o.back().overlap.push_back(std::pair<uint64_t,uint64_t>(0,4096));
     o.back().overlap.push_back(std::pair<uint64_t,uint64_t>(8192,4096));
     o.back().size = 16384;
-    o.push_back(clone_info{});
+    o.emplace_back();
     o.back().cloneid = CEPH_NOSNAP;
     o.back().size = 32768;
     return o;
@@ -6851,8 +6851,8 @@ struct obj_list_snap_response_t {
   }
   static std::list<obj_list_snap_response_t> generate_test_instances() {
     std::list<obj_list_snap_response_t> o;
-    o.push_back(obj_list_snap_response_t{});
-    o.push_back(obj_list_snap_response_t{});
+    o.emplace_back();
+    o.emplace_back();
     clone_info cl;
     cl.cloneid = 1;
     cl.snaps.push_back(1);
@@ -6975,7 +6975,7 @@ struct pool_pg_num_history_t {
   }
   static std::list<pool_pg_num_history_t> generate_test_instances() {
     std::list<pool_pg_num_history_t> ls;
-    ls.push_back(pool_pg_num_history_t{});
+    ls.emplace_back();
     return ls;
   }
   friend std::ostream& operator<<(std::ostream& out, const pool_pg_num_history_t& h) {

--- a/src/rgw/driver/rados/groups.cc
+++ b/src/rgw/driver/rados/groups.cc
@@ -127,7 +127,7 @@ void resource_metadata::dump(ceph::Formatter* f) const
 std::list<resource_metadata> resource_metadata::generate_test_instances()
 {
   std::list<resource_metadata> o;
-  o.push_back(resource_metadata{});
+  o.emplace_back();
   resource_metadata m;
   m.group_id = "id";
   o.push_back(std::move(m));

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -3667,7 +3667,7 @@ list<RGWBucketEntryPoint> RGWBucketEntryPoint::generate_test_instances()
   bp.creation_time = ceph::real_clock::from_ceph_timespec({ceph_le32(2), ceph_le32(3)});
 
   o.push_back(std::move(bp));
-  o.push_back(RGWBucketEntryPoint{});
+  o.emplace_back();
 
   return o;
 }

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -6676,7 +6676,7 @@ list<rgw_data_sync_info> rgw_data_sync_info::generate_test_instances()
   info.state = rgw_data_sync_info::StateBuildingFullSyncMaps;
   info.num_shards = 8;
   o.push_back(std::move(info));
-  o.push_back(rgw_data_sync_info{});
+  o.emplace_back();
   return o;
 }
 
@@ -6688,14 +6688,14 @@ list<rgw_data_sync_marker> rgw_data_sync_marker::generate_test_instances()
   marker.marker = "01234";
   marker.pos = 5;
   o.push_back(std::move(marker));
-  o.push_back(rgw_data_sync_marker{});
+  o.emplace_back();
   return o;
 }
 
 list<rgw_data_sync_status> rgw_data_sync_status::generate_test_instances()
 {
   list<rgw_data_sync_status> o;
-  o.push_back(rgw_data_sync_status{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -93,8 +93,8 @@ void rgw_data_change::decode_json(JSONObj *obj) {
 
 std::list<rgw_data_change> rgw_data_change::generate_test_instances() {
   std::list<rgw_data_change> l;
-  l.push_back(rgw_data_change{});
-  l.push_back(rgw_data_change{});
+  l.emplace_back();
+  l.emplace_back();
   l.back().entity_type = ENTITY_TYPE_BUCKET;
   l.back().key = "bucket_name";
   l.back().timestamp = ceph::real_clock::zero();

--- a/src/rgw/driver/rados/rgw_obj_manifest.cc
+++ b/src/rgw/driver/rados/rgw_obj_manifest.cc
@@ -275,7 +275,7 @@ std::list<RGWObjManifestPart> RGWObjManifestPart::generate_test_instances()
 {
   std::list<RGWObjManifestPart> o;
 
-  o.push_back(RGWObjManifestPart{});
+  o.emplace_back();
 
   RGWObjManifestPart p;
   rgw_bucket b;
@@ -308,7 +308,7 @@ std::list<RGWObjManifest> RGWObjManifest::generate_test_instances()
   }
   m.set_explicit(total_size, objs);
   o.push_back(std::move(m));
-  o.push_back(RGWObjManifest{});
+  o.emplace_back();
   return o;
 }
 
@@ -384,7 +384,7 @@ std::list<RGWObjManifestRule> RGWObjManifestRule::generate_test_instances()
   r.stripe_max_size = 512 * 1024 * 1024;
   r.override_prefix = "override_prefix";
   o.push_back(std::move(r));
-  o.push_back(RGWObjManifestRule{});
+  o.emplace_back();
   return o;
 }
 
@@ -413,7 +413,7 @@ std::list<RGWObjTier> RGWObjTier::generate_test_instances()
   }
   t.is_multipart_upload = true;
   o.push_back(std::move(t));
-  o.push_back(RGWObjTier{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -11583,7 +11583,7 @@ list<objexp_hint_entry> objexp_hint_entry::generate_test_instances()
   it.bucket_id = "1234";
   it.obj_key = rgw_obj_key("obj");
   o.push_back(std::move(it));
-  o.push_back(objexp_hint_entry{});
+  o.emplace_back();
   return o;
 }
 
@@ -11605,7 +11605,7 @@ list<RGWOLHInfo> RGWOLHInfo::generate_test_instances()
   RGWOLHInfo olh;
   olh.removed = false;
   o.push_back(olh);
-  o.push_back(RGWOLHInfo{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -62,8 +62,8 @@ struct RGWUID
   }
   static std::list<RGWUID> generate_test_instances() {
     std::list<RGWUID> o;
-    o.push_back(RGWUID{});
-    o.push_back(RGWUID{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().id = "test:tester";
     return o;
   }

--- a/src/rgw/driver/rados/roles.cc
+++ b/src/rgw/driver/rados/roles.cc
@@ -166,7 +166,7 @@ void resource_metadata::dump(ceph::Formatter* f) const
 std::list<resource_metadata> resource_metadata::generate_test_instances()
 {
   std::list<resource_metadata> o;
-  o.push_back(resource_metadata{});
+  o.emplace_back();
   resource_metadata m;
   m.role_id = "id";
   o.push_back(std::move(m));

--- a/src/rgw/driver/rados/users.cc
+++ b/src/rgw/driver/rados/users.cc
@@ -166,7 +166,7 @@ void resource_metadata::dump(ceph::Formatter* f) const
 std::list<resource_metadata> resource_metadata::generate_test_instances()
 {
   std::list<resource_metadata> o;
-  o.push_back(resource_metadata{});
+  o.emplace_back();
   resource_metadata m;;
   m.user_id = "uid";
   o.push_back(std::move(m));

--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -260,7 +260,7 @@ list<ACLPermission> ACLPermission::generate_test_instances()
   ACLPermission p;
   p.set_permissions(RGW_PERM_WRITE_ACP);
   o.push_back(std::move(p));
-  o.push_back(ACLPermission{});
+  o.emplace_back();
   return o;
 }
 
@@ -314,7 +314,7 @@ list<ACLGrant> ACLGrant::generate_test_instances()
   g1.set_group(ACL_GROUP_AUTHENTICATED_USERS, RGW_PERM_WRITE);
   o.push_back(std::move(g2));
 
-  o.push_back(ACLGrant{});
+  o.emplace_back();
   return o;
 }
 
@@ -322,7 +322,7 @@ list<ACLGranteeType> ACLGranteeType::generate_test_instances()
 {
   list<ACLGranteeType> o;
   o.push_back(ACLGranteeType(ACL_TYPE_CANON_USER));
-  o.push_back(ACLGranteeType{});
+  o.emplace_back();
   return o;
 }
 
@@ -335,7 +335,7 @@ list<RGWAccessControlList> RGWAccessControlList::generate_test_instances()
     acl.add_grant(grant);
   }
   o.push_back(std::move(acl));
-  o.push_back(RGWAccessControlList{});
+  o.emplace_back();
   return o;
 }
 
@@ -346,7 +346,7 @@ list<ACLOwner> ACLOwner::generate_test_instances()
   owner.id = "rgw";
   owner.display_name = "Mr. RGW";
   o.push_back(std::move(owner));
-  o.push_back(ACLOwner{});
+  o.emplace_back();
   return o;
 }
 
@@ -364,7 +364,7 @@ list<RGWAccessControlPolicy> RGWAccessControlPolicy::generate_test_instances()
     o.push_back(std::move(p));
   }
 
-  o.push_back(RGWAccessControlPolicy{});
+  o.emplace_back();
 
   return o;
 }

--- a/src/rgw/rgw_basic_types.cc
+++ b/src/rgw/rgw_basic_types.cc
@@ -84,7 +84,7 @@ list<rgw_bucket> rgw_bucket::generate_test_instances()
   rgw_bucket b;
   init_bucket(&b, "tenant", "name", "pool", ".index_pool", "marker", "123");
   o.push_back(std::move(b));
-  o.push_back(rgw_bucket{});
+  o.emplace_back();
   return o;
 }
 
@@ -128,7 +128,7 @@ list<rgw_user> rgw_user::generate_test_instances()
   rgw_user u("tenant", "user");
 
   o.push_back(u);
-  o.push_back(rgw_user{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -83,7 +83,7 @@ struct rgw_zone_id {
 
   static std::list<rgw_zone_id> generate_test_instances() {
     std::list<rgw_zone_id> o;
-    o.push_back(rgw_zone_id{});
+    o.emplace_back();
     o.push_back(rgw_zone_id("id"));
     return o;
   }

--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -363,7 +363,7 @@ list<ObjectMetaInfo> ObjectMetaInfo::generate_test_instances()
   ObjectMetaInfo m;
   m.size = 1024 * 1024;
   o.push_back(std::move(m));
-  o.push_back(ObjectMetaInfo{});
+  o.emplace_back();
   return o;
 }
 
@@ -392,7 +392,7 @@ list<ObjectCacheInfo> ObjectCacheInfo::generate_test_instances()
   i.rm_xattrs["r3"] = data;
   i.meta.size = 512 * 1024;
   o.push_back(std::move(i));
-  o.push_back(ObjectCacheInfo{});
+  o.emplace_back();
   return o;
 }
 
@@ -410,7 +410,7 @@ void ObjectCacheInfo::dump(Formatter *f) const
 list<RGWCacheNotifyInfo> RGWCacheNotifyInfo::generate_test_instances()
 {
   list<RGWCacheNotifyInfo> o;
-  o.push_back(RGWCacheNotifyInfo{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2072,7 +2072,7 @@ void RGWUserCaps::dump(Formatter *f) const
 list<RGWUserCaps> RGWUserCaps::generate_test_instances()
 {
   list<RGWUserCaps> o;
-  o.push_back(RGWUserCaps{});
+  o.emplace_back();
   RGWUserCaps caps;
   caps.add_cap("read");
   caps.add_cap("write");
@@ -2525,7 +2525,7 @@ list<RGWBucketEnt> RGWBucketEnt::generate_test_instances()
   e.size_rounded = 4096;
   e.count = 1;
   o.push_back(std::move(e));
-  o.push_back(RGWBucketEnt{});
+  o.emplace_back();
   return o;
 }
 
@@ -2546,7 +2546,7 @@ list<rgw_obj> rgw_obj::generate_test_instances()
   rgw_bucket b;
   init_bucket(&b, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
   o.push_back(rgw_obj(b, "object"));
-  o.push_back(rgw_obj{});
+  o.emplace_back();
   return o;
 }
 
@@ -2682,7 +2682,7 @@ list<RGWUserInfo> RGWUserInfo::generate_test_instances()
   i.subusers[u.name] = u;
   o.push_back(std::move(i));
 
-  o.push_back(RGWUserInfo{});
+  o.emplace_back();
   return o;
 }
 
@@ -2975,7 +2975,7 @@ list<RGWSubUser> RGWSubUser::generate_test_instances()
   u.name = "name";
   u.perm_mask = 0xf;
   o.push_back(std::move(u));
-  o.push_back(RGWSubUser{});
+  o.emplace_back();
   return o;
 }
 
@@ -3031,7 +3031,7 @@ list<RGWAccessKey> RGWAccessKey::generate_test_instances()
   k.key = "key";
   k.subuser = "subuser";
   o.push_back(std::move(k));
-  o.push_back(RGWAccessKey{});
+  o.emplace_back();
   return o;
 }
 
@@ -3135,7 +3135,7 @@ void RGWAccountInfo::decode_json(JSONObj* obj)
 std::list<RGWAccountInfo> RGWAccountInfo::generate_test_instances()
 {
   std::list<RGWAccountInfo> o;
-  o.push_back(RGWAccountInfo{});
+  o.emplace_back();
   auto p = RGWAccountInfo{};
   p.id = "account1";
   p.tenant = "tenant1";
@@ -3171,7 +3171,7 @@ void RGWGroupInfo::decode_json(JSONObj* obj)
 std::list<RGWGroupInfo> RGWGroupInfo::generate_test_instances()
 {
   std::list<RGWGroupInfo> o;
-  o.push_back(RGWGroupInfo{});
+  o.emplace_back();
   auto p = RGWGroupInfo{};
   p.id = "id";
   p.tenant = "tenant";

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1602,8 +1602,8 @@ struct multipart_upload_info
 
   static std::list<multipart_upload_info> generate_test_instances() {
     std::list<multipart_upload_info> o;
-    o.push_back(multipart_upload_info{});
-    o.push_back(multipart_upload_info{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().dest_placement.name = "dest_placement";
     o.back().dest_placement.storage_class = "dest_storage_class";
     return o;

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -68,8 +68,8 @@ void RGWCORSRule::erase_origin_if_present(string& origin, bool *rule_empty) {
 list<RGWCORSRule> RGWCORSRule::generate_test_instances()
 {
   list<RGWCORSRule> o;
-  o.push_back(RGWCORSRule{});
-  o.push_back(RGWCORSRule{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().id = "test";
   o.back().max_age = 100;
   o.back().allowed_methods = RGW_CORS_GET | RGW_CORS_PUT;

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -28,7 +28,7 @@ list<obj_version> obj_version::generate_test_instances()
   v.tag = "tag";
 
   o.push_back(std::move(v));
-  o.push_back(obj_version{});
+  o.emplace_back();
   return o;
 }
 
@@ -42,6 +42,6 @@ std::list<RGWBucketEncryptionConfig> RGWBucketEncryptionConfig::generate_test_in
   bc = RGWBucketEncryptionConfig("AES256");
   o.push_back(std::move(bc));
 
-  o.push_back(RGWBucketEncryptionConfig{});
+  o.emplace_back();
   return o;
 }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2676,7 +2676,7 @@ RGWLC::LCWorker::~LCWorker()
 list<RGWLifecycleConfiguration> RGWLifecycleConfiguration::generate_test_instances()
 {
   list<RGWLifecycleConfiguration> o;
-  o.push_back(RGWLifecycleConfiguration{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -703,7 +703,7 @@ list<rgw_log_entry> rgw_log_entry::generate_test_instances()
   e.account_id = "account_id";
   e.role_id = "role_id";
   o.push_back(std::move(e));
-  o.push_back(rgw_log_entry{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -99,8 +99,8 @@ void RGWMetadataLogData::decode_json(JSONObj *obj) {
 
 std::list<RGWMetadataLogData> RGWMetadataLogData::generate_test_instances() {
   std::list<RGWMetadataLogData> l;
-  l.push_back(RGWMetadataLogData{});
-  l.push_back(RGWMetadataLogData{});
+  l.emplace_back();
+  l.emplace_back();
   l.back().read_version = obj_version();
   l.back().read_version.tag = "read_tag";
   l.back().write_version = obj_version();

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -89,7 +89,7 @@ list<RGWUploadPartInfo> RGWUploadPartInfo::generate_test_instances()
   i.size = 10 * 1024 * 1024;
   i.etag = "etag";
   o.push_back(std::move(i));
-  o.push_back(RGWUploadPartInfo{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_obj_types.h
+++ b/src/rgw/rgw_obj_types.h
@@ -90,8 +90,8 @@ struct rgw_obj_index_key { // cls_rgw_obj_key now aliases this type
   void decode_json(JSONObj *obj);
   static std::list<rgw_obj_index_key> generate_test_instances() {
     std::list<rgw_obj_index_key> ls;
-    ls.push_back(rgw_obj_index_key{});
-    ls.push_back(rgw_obj_index_key{});
+    ls.emplace_back();
+    ls.emplace_back();
     ls.back().name = "name";
     ls.back().instance = "instance";
     return ls;

--- a/src/rgw/rgw_object_lock.cc
+++ b/src/rgw/rgw_object_lock.cc
@@ -51,7 +51,7 @@ void ObjectLockRule::dump(Formatter *f) const {
 
 std::list<ObjectLockRule> ObjectLockRule::generate_test_instances() {
   std::list<ObjectLockRule> o;
-  o.push_back(ObjectLockRule{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_oidc_provider.cc
+++ b/src/rgw/rgw_oidc_provider.cc
@@ -38,6 +38,6 @@ std::list<RGWOIDCProviderInfo> RGWOIDCProviderInfo::generate_test_instances()
   p.client_ids = {"a", "b"};
   p.thumbprints = {"c", "d"};
   l.push_back(std::move(p));
-  l.push_back(RGWOIDCProviderInfo{});
+  l.emplace_back();
   return l;
 }

--- a/src/rgw/rgw_placement_types.h
+++ b/src/rgw/rgw_placement_types.h
@@ -96,7 +96,7 @@ struct rgw_placement_rule {
 
   static std::list<rgw_placement_rule> generate_test_instances() {
     std::list<rgw_placement_rule> o;
-    o.push_back(rgw_placement_rule{});
+    o.emplace_back();
     o.push_back(rgw_placement_rule("name", "storage_class"));
     return o;
   }

--- a/src/rgw/rgw_pool_types.h
+++ b/src/rgw/rgw_pool_types.h
@@ -97,7 +97,7 @@ struct rgw_pool {
 
   static std::list<rgw_pool> generate_test_instances() {
     std::list<rgw_pool> o;
-    o.push_back(rgw_pool{});
+    o.emplace_back();
     o.push_back(rgw_pool("pool", "ns"));
     return o;
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1042,8 +1042,8 @@ void RGWQuotaInfo::dump(Formatter *f) const
 std::list<RGWQuotaInfo> RGWQuotaInfo::generate_test_instances()
 {
   std::list<RGWQuotaInfo> o;
-  o.push_back(RGWQuotaInfo{});
-  o.push_back(RGWQuotaInfo{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().enabled = true;
   o.back().check_on_raw = true;
   o.back().max_size = 1024;

--- a/src/rgw/rgw_realm.cc
+++ b/src/rgw/rgw_realm.cc
@@ -86,8 +86,8 @@ int RGWRealm::find_zone(const DoutPrefixProvider *dpp,
 list<RGWRealm> RGWRealm::generate_test_instances()
 {
   list<RGWRealm> o;
-  o.push_back(RGWRealm{});
-  o.push_back(RGWRealm{});
+  o.emplace_back();
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_sync_policy.cc
+++ b/src/rgw/rgw_sync_policy.cc
@@ -792,7 +792,7 @@ void rgw_sync_policy_info::dump(Formatter *f) const
 list<rgw_sync_policy_info> rgw_sync_policy_info::generate_test_instances()
 {
   list<rgw_sync_policy_info> o;
-  o.push_back(rgw_sync_policy_info{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_tag.cc
+++ b/src/rgw/rgw_tag.cc
@@ -72,7 +72,7 @@ std::list<RGWObjTags> RGWObjTags::generate_test_instances()
   r.add_tag("key1","val1");
   r.add_tag("key2","val2");
   o.push_back(std::move(r));
-  o.push_back(RGWObjTags{});
+  o.emplace_back();
   return o;
 }
 

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -71,8 +71,8 @@ static void decode_placement_targets(map<string, RGWZoneGroupPlacementTarget>& t
 list<RGWZone> RGWZone::generate_test_instances()
 {
   list<RGWZone> o;
-  o.push_back(RGWZone{});
-  o.push_back(RGWZone{});
+  o.emplace_back();
+  o.emplace_back();
   return o;
 }
 
@@ -511,8 +511,8 @@ void RGWZonePlacementInfo::dump(Formatter *f) const
 list<RGWZonePlacementInfo> RGWZonePlacementInfo::generate_test_instances()
 {
   list<RGWZonePlacementInfo> o;
-  o.push_back(RGWZonePlacementInfo{});
-  o.push_back(RGWZonePlacementInfo{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().index_pool = rgw_pool("rgw.buckets.index");
   
   o.back().data_extra_pool = rgw_pool("rgw.buckets.non-ec");
@@ -585,7 +585,7 @@ void RGWZoneStorageClasses::dump(Formatter *f) const
 list<RGWZoneStorageClasses> RGWZoneStorageClasses::generate_test_instances()
 {
   list<RGWZoneStorageClasses> o;
-  o.push_back(RGWZoneStorageClasses{});
+  o.emplace_back();
   return o;
 }
 
@@ -672,8 +672,8 @@ void RGWZoneStorageClass::dump(Formatter *f) const
 list<RGWZoneStorageClass> RGWZoneStorageClass::generate_test_instances()
 {
   list<RGWZoneStorageClass> o;
-  o.push_back(RGWZoneStorageClass{});
-  o.push_back(RGWZoneStorageClass{});
+  o.emplace_back();
+  o.emplace_back();
   o.back().data_pool = rgw_pool("pool1");
   o.back().compression_type = "zlib";
   return o;

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -572,7 +572,7 @@ struct RGWZoneGroupTierS3Glacier {
   void decode_json(JSONObj *obj);
   static std::list<RGWZoneGroupTierS3Glacier> generate_test_instances() {
     std::list<RGWZoneGroupTierS3Glacier> o;
-    o.push_back(RGWZoneGroupTierS3Glacier{});
+    o.emplace_back();
     o.back().glacier_restore_days = 2;
     o.back().glacier_restore_tier_type = GlacierRestoreTierType::Expedited;
     return o;
@@ -671,8 +671,8 @@ struct RGWZoneGroupPlacementTier {
   void decode_json(JSONObj *obj);
   static std::list<RGWZoneGroupPlacementTier> generate_test_instances() {
     std::list<RGWZoneGroupPlacementTier> o;
-    o.push_back(RGWZoneGroupPlacementTier{});
-    o.push_back(RGWZoneGroupPlacementTier{});
+    o.emplace_back();
+    o.emplace_back();
     o.back().tier_type = RGWTierType::CLOUD_S3;
     o.back().storage_class = RGW_STORAGE_CLASS_STANDARD;
     o.back().allow_read_through = false;
@@ -730,9 +730,9 @@ struct RGWZoneGroupPlacementTarget {
   void decode_json(JSONObj *obj);
   static std::list<RGWZoneGroupPlacementTarget> generate_test_instances() {
     std::list<RGWZoneGroupPlacementTarget> o;
-    o.push_back(RGWZoneGroupPlacementTarget{});
+    o.emplace_back();
     o.back().storage_classes.insert(RGW_STORAGE_CLASS_STANDARD);
-    o.push_back(RGWZoneGroupPlacementTarget{});
+    o.emplace_back();
     o.back().name = "target";
     o.back().tags.insert("tag1");
     o.back().tags.insert("tag2");


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
