### PR TITLE
tentacle: mgr/dashboard: Dashboard nfs export editor rejects ipv6 addresses

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.html
@@ -41,7 +41,7 @@
                        name="addresses"
                        id="addresses"
                        formControlName="addresses"
-                       placeholder="192.168.0.10, 192.168.1.0/8"
+                       placeholder="e.g. 192.168.0.10, 192.168.1.0/8"
                        [invalid]="!item.controls['addresses'].valid && (item.controls['addresses'].dirty)">
               </cds-text-label>
               <ng-template #addressesError>
@@ -49,8 +49,8 @@
                   <span *ngIf="showError(index, 'addresses', formDir, 'required')"
                         i18n>This field is required.</span>
 
-                  <span *ngIf="showError(index, 'addresses', formDir, 'pattern')">
-                    <ng-container i18n>Must contain one or more comma-separated values</ng-container>
+                  <span *ngIf="showError(index, 'addresses', formDir, 'invalidAddress')">
+                    <ng-container i18n>Must contain one or more comma-separated valid addresses.</ng-container>
                     <br>
                     <ng-container i18n>For example:</ng-container> 192.168.0.10, 192.168.1.0/8
                   </span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form-client/nfs-form-client.component.spec.ts
@@ -68,4 +68,46 @@ describe('NfsFormClientComponent', () => {
     component.removeClient(0);
     expect(component.form.getValue('clients')).toEqual([]);
   });
+
+  describe(`test 'isValidClientAddress'`, () => {
+    it('should return false for empty value', () => {
+      expect(component.isValidClientAddress('')).toBeFalsy();
+      expect(component.isValidClientAddress(null)).toBeFalsy();
+    });
+
+    it('should return false for valid single IPv4 address', () => {
+      expect(component.isValidClientAddress('192.168.1.1')).toBeFalsy();
+    });
+
+    it('should return false for valid IPv6 address', () => {
+      expect(component.isValidClientAddress('2001:db8::1')).toBeFalsy();
+    });
+
+    it('should return false for valid FQDN', () => {
+      expect(component.isValidClientAddress('nfs.example.com')).toBeFalsy();
+    });
+
+    it('should return false for valid IP CIDR range', () => {
+      expect(component.isValidClientAddress('192.168.0.0/24')).toBeFalsy();
+      expect(component.isValidClientAddress('2001:db8::/64')).toBeFalsy();
+    });
+
+    it('should return false for multiple valid addresses separated by comma', () => {
+      const input = '192.168.1.1, 2001:db8::1, nfs.example.com, 10.0.0.0/8';
+      expect(component.isValidClientAddress(input)).toBeFalsy();
+    });
+
+    it('should return true for invalid single address', () => {
+      expect(component.isValidClientAddress('invalid-address')).toBeTruthy();
+    });
+
+    it('should return true for mixed valid and invalid addresses', () => {
+      const input = '192.168.1.1, invalid-address';
+      expect(component.isValidClientAddress(input)).toBeTruthy();
+    });
+
+    it('should return true for URLs with protocols', () => {
+      expect(component.isValidClientAddress('http://nfs.example.com')).toBeTruthy();
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -709,7 +709,9 @@ export class CdValidators {
       return null;
     }
 
-    const urls = value.includes(',') ? value.split(',') : [value];
+    const urls = value.includes(',')
+      ? value.split(',').map((v: string) => v.trim())
+      : [value.trim()];
 
     const invalidUrls = urls.filter(
       (url: string) =>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72733

---

backport of https://github.com/ceph/ceph/pull/65169
parent tracker: https://tracker.ceph.com/issues/72660

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh