### PR TITLE
reef: qa: enable debug mds/client for fs/nfs suite

### DIFF
--- a/qa/suites/fs/nfs/conf
+++ b/qa/suites/fs/nfs/conf
@@ -1,0 +1,1 @@
+./.qa/cephfs/conf


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70031

---

backport of https://github.com/ceph/ceph/pull/54406
parent tracker: https://tracker.ceph.com/issues/63482

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh