### PR TITLE
reef: cephfs: session tracker accounts for killing sessions

### DIFF
--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1098,9 +1098,11 @@ int Session::check_access(CInode *in, unsigned mask,
 
 // track total and per session load
 void SessionMap::hit_session(Session *session) {
-  uint64_t sessions = get_session_count_in_state(Session::STATE_OPEN) +
+  uint64_t sessions = get_session_count_in_state(Session::STATE_OPENING) +
+                      get_session_count_in_state(Session::STATE_OPEN) +
                       get_session_count_in_state(Session::STATE_STALE) +
-                      get_session_count_in_state(Session::STATE_CLOSING);
+                      get_session_count_in_state(Session::STATE_CLOSING) +
+                      get_session_count_in_state(Session::STATE_KILLING);
   ceph_assert(sessions != 0);
 
   double total_load = total_load_avg.hit();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71379

---

backport of https://github.com/ceph/ceph/pull/62631
parent tracker: https://tracker.ceph.com/issues/70770

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh