### PR TITLE
tentacle: mds: include auth credential in session dump

### DIFF
--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -630,6 +630,7 @@ void SessionMapStore::decode_legacy(bufferlist::const_iterator& p)
 void Session::dump(Formatter *f, bool cap_dump) const
 {
   f->dump_int("id", info.inst.name.num());
+  f->dump_object("auth_name", info.auth_name);
   f->dump_object("entity", info.inst);
   f->dump_string("state", get_state_name());
   f->dump_int("num_leases", leases.size());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72278

---

backport of https://github.com/ceph/ceph/pull/64308
parent tracker: https://tracker.ceph.com/issues/71937

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh