### PR TITLE
tentacle: mon/FSCommands: avoid unreachable code triggering compiler warning

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -417,9 +417,10 @@ int FileSystemCommandHandler::set_val(Monitor *mon, FSMap& fsmap, MonOpRequestRe
   const Filesystem* fsp;
   if (std::holds_alternative<Filesystem*>(fsv)) {
     fsp = std::get<Filesystem*>(fsv);
-  } else if (std::holds_alternative<fs_cluster_id_t>(fsv)) {
+  } else {
+    ceph_assert(std::holds_alternative<fs_cluster_id_t>(fsv));
     fsp = &fsmap.get_filesystem(std::get<fs_cluster_id_t>(fsv));
-  } else ceph_assert(0);
+  }
 
   {
     std::string interr;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72149

---

backport of https://github.com/ceph/ceph/pull/63621
parent tracker: https://tracker.ceph.com/issues/70803

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh