### PR TITLE
squid: test-rgw-multisite: create default realm in multisite test script

### DIFF
--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -99,7 +99,7 @@ function init_first_zone {
   secret=$7
 
 # initialize realm
-  x $(rgw_admin $cid) realm create --rgw-realm=$realm
+  x $(rgw_admin $cid) realm create --rgw-realm=$realm --default
 
 # create zonegroup, zone
   x $(rgw_admin $cid) zonegroup create --rgw-zonegroup=$zg --master --default


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72756

---

backport of https://github.com/ceph/ceph/pull/59469
parent tracker: https://tracker.ceph.com/issues/72755

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh