### PR TITLE
squid: qa/suites/fs/upgrade/mds_upgrade_sequence/tasks: set require-osd-release

### DIFF
--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/6-verify.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/6-verify.yaml
@@ -2,4 +2,5 @@ tasks:
 - cephadm.shell:
     host.a:
       - ceph fs dump
+      - ceph osd require-osd-release squid # after the upgrade, this should be bumped up
 - fs.post_upgrade_checks:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70283

---

backport of https://github.com/ceph/ceph/pull/61073
parent tracker: https://tracker.ceph.com/issues/69098

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh