### PR TITLE
squid: qa: use a larger timeout for kernel_untar_build workunit

### DIFF
--- a/qa/suites/fs/workload/tasks/6-workunit/kernel_untar_build.yaml
+++ b/qa/suites/fs/workload/tasks/6-workunit/kernel_untar_build.yaml
@@ -5,6 +5,7 @@ overrides:
         - "mds.dir_split"
 tasks:
 - workunit:
+    timeout: 5h
     clients:
       all:
         - kernel_untar_build.sh


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69369

---

backport of https://github.com/ceph/ceph/pull/60640
parent tracker: https://tracker.ceph.com/issues/68855

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh