### PR TITLE
rgw/d4n: deleting LFUDAEntry and LFUDAObjEntry instances

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4468,6 +4468,16 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: rgw_d4n_localweight_processing_interval
+  type: int
+  level: advanced
+  desc: This is the interval in seconds for invoking local weight writer thread
+  default: 3600
+  services:
+  - rgw
+  flags:
+  - startup
+  with_legacy: true
 - name: rgw_topic_persistency_time_to_live
   type: uint
   level: advanced

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -392,7 +392,7 @@ int LFUDAPolicy::eviction(const DoutPrefixProvider* dpp, uint64_t size, optional
       return ret;
     }
 
-    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Block " << key << " has been evicted." << dendl;
+    ldpp_dout(dpp, 2) << "LFUDAPolicy::" << __func__ << "(): Block " << key << " has been evicted." << dendl;
 
     if (perfcounter) {
       perfcounter->inc(l_rgw_d4n_cache_evictions);

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -71,6 +71,9 @@ int LFUDAPolicy::init(CephContext* cct, const DoutPrefixProvider* dpp, asio::io_
     tc = std::thread(&CachePolicy::cleaning, this, dpp);
   }
 
+  lwthread = std::thread(&LFUDAPolicy::localweight_writer, this, dpp);
+  lw_quit = false;
+
   try {
     boost::system::error_code ec;
     response<
@@ -432,74 +435,80 @@ void LFUDAPolicy::update(const DoutPrefixProvider* dpp, const std::string& key, 
 {
   ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): updating entry: " << key << dendl;
   using handle_type = boost::heap::fibonacci_heap<LFUDAEntry*, boost::heap::compare<EntryComparator<LFUDAEntry>>>::handle_type;
-  const std::lock_guard l(lfuda_lock);
-  int localWeight = age;
-  auto entry = find_entry(key);
-  bool updateLocalWeight = true;
-  uint64_t refcount = 0;
+  bool updateLocalWeight = true, should_notify = false;
+  {
+    const std::lock_guard l(lfuda_lock);
+    int localWeight = age;
+    auto entry = find_entry(key);
+    uint64_t refcount = 0;
+    if (!restore_val.empty()) {
+      updateLocalWeight = false;
+      localWeight = std::stoull(restore_val);
+      ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): restored localWeight is: " << localWeight << dendl;
+    }
 
-  if (!restore_val.empty()) {
-    updateLocalWeight = false;
-    localWeight = std::stoull(restore_val);
-    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): restored localWeight is: " << localWeight << dendl;
-  }
-
-  /* check the dirty flag in the existing entry for the key and the incoming dirty flag. If the
-     incoming dirty flag is false, that means update() is invoked as part of cleaning process,
-     so we must not update its localWeight. */
-  if (entry) {
-    refcount = entry->refcount;
-    if (entry->dirty && dirty.has_value()) {
-      bool is_dirty = dirty.value();
-      if (!is_dirty) {
-        localWeight = entry->localWeight;
-        updateLocalWeight = false;
+    /* check the dirty flag in the existing entry for the key and the incoming dirty flag. If the
+      incoming dirty flag is false, that means update() is invoked as part of cleaning process,
+      so we must not update its localWeight. */
+    if (entry) {
+      refcount = entry->refcount;
+      if (entry->dirty && dirty.has_value()) {
+        bool is_dirty = dirty.value();
+        if (!is_dirty) {
+          localWeight = entry->localWeight;
+          updateLocalWeight = false;
+        }
+      }
+      if (updateLocalWeight) {
+        localWeight = entry->localWeight + age;
+      }
+      if (op == RefCount::INCR) {
+        refcount += 1;
+      }
+      if (op == RefCount::DECR) {
+        if (refcount > 0) {
+          refcount -= 1;
+        }
       }
     }
+    //pick the existing value of dirty, if no value has been passed in
+    bool is_dirty = false;
+    if (dirty.has_value()) {
+      is_dirty = dirty.value();
+    } else if (entry) {
+      is_dirty = entry->dirty;
+    }
+    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): updated refcount is: " << refcount << dendl;
+
+    if (entry) {
+      entry->key = key;
+      entry->offset = offset;
+      entry->len = len;
+      entry->version = version;
+      entry->dirty = is_dirty;
+      entry->refcount = refcount;
+      entry->localWeight = localWeight;
+      entries_heap.update(entry->handle, entry);
+    } else {
+      LFUDAEntry* e = new LFUDAEntry(key, offset, len, version, is_dirty, refcount, localWeight);
+      handle_type handle = entries_heap.push(e);
+      e->set_handle(handle);
+      entries_map.emplace(key, e);
+    }
+
     if (updateLocalWeight) {
-      localWeight = entry->localWeight + age;
-    }
-    if (op == RefCount::INCR) {
-      refcount += 1;
-    }
-    if (op == RefCount::DECR) {
-      if (refcount > 0) {
-        refcount -= 1;
+      updated_blocks.emplace(key, localWeight);
+      if (updated_blocks.size() >= LOCALWEIGHT_BATCH_SIZE) {
+        should_notify = true;
       }
     }
-  }
-  //pick the existing value of dirty, if no value has been passed in
-  bool is_dirty = false;
-  if (dirty.has_value()) {
-    is_dirty = dirty.value();
-  } else if (entry) {
-    is_dirty = entry->dirty;
-  }
-  ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): updated refcount is: " << refcount << dendl;
 
-  if (entry) {
-    entry->key = key;
-    entry->offset = offset;
-    entry->len = len;
-    entry->version = version;
-    entry->dirty = is_dirty;
-    entry->refcount = refcount;
-    entry->localWeight = localWeight;
-    entries_heap.update(entry->handle, entry);
-  } else {
-    LFUDAEntry* e = new LFUDAEntry(key, offset, len, version, is_dirty, refcount, localWeight);
-    handle_type handle = entries_heap.push(e);
-    e->set_handle(handle);
-    entries_map.emplace(key, e);
+    weightSum += ((localWeight < 0) ? 0 : localWeight);
+  } //lock will be released here
+  if (should_notify) {
+    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): notify_one: "<< dendl;
+    lw_cond.notify_one();
   }
-
-  if (updateLocalWeight) {
-    int ret = -1;
-    if ((ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_LOCAL_WEIGHT, std::to_string(localWeight), y)) < 0) 
-      ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): CacheDriver set_attr method failed, ret=" << ret << dendl;
-  }
-
-  weightSum += ((localWeight < 0) ? 0 : localWeight);
 }
 
 void LFUDAPolicy::update_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, const std::string& version, bool deleteMarker, uint64_t size, double creationTime, const rgw_user& user, const std::string& etag, const std::string& bucket_name, const std::string& bucket_id, const rgw_obj_key& obj_key, uint8_t op, optional_yield y, std::string& restore_val)
@@ -515,11 +524,13 @@ void LFUDAPolicy::update_dirty_object(const DoutPrefixProvider* dpp, const std::
     state = State::INIT;
   }
 
-  const std::lock_guard l(lfuda_cleaning_lock);
-  LFUDAObjEntry* e = new LFUDAObjEntry{key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key};
-  handle_type handle = object_heap.push(e);
-  e->set_handle(handle);
-  o_entries_map.emplace(key, std::make_pair(e, state));
+  {
+    const std::lock_guard l(lfuda_cleaning_lock);
+    LFUDAObjEntry* e = new LFUDAObjEntry{key, version, deleteMarker, size, creationTime, user, etag, bucket_name, bucket_id, obj_key};
+    handle_type handle = object_heap.push(e);
+    e->set_handle(handle);
+    o_entries_map.emplace(key, std::make_pair(e, state));
+  }
   cond.notify_one();
 }
 
@@ -548,18 +559,19 @@ bool LFUDAPolicy::erase(const DoutPrefixProvider* dpp, const std::string& key, o
 
 bool LFUDAPolicy::erase_dirty_object(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y)
 {
-  const std::lock_guard l(lfuda_cleaning_lock);
-  auto p = o_entries_map.find(key);
-  if (p == o_entries_map.end()) {
-    return false;
+  {
+    const std::lock_guard l(lfuda_cleaning_lock);
+    auto p = o_entries_map.find(key);
+    if (p == o_entries_map.end()) {
+      return false;
+    }
+
+    object_heap.erase(p->second.first->handle);
+    delete p->second.first;
+    p->second.first = nullptr;
+    o_entries_map.erase(p);
   }
-
-  object_heap.erase(p->second.first->handle);
-  delete p->second.first;
-  p->second.first = nullptr;
-  o_entries_map.erase(p);
   state_cond.notify_one();
-
   return true;
 }
 
@@ -908,7 +920,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 	      }
 	    } //end-if (block.version == entry->version)
 	  } //end - else if op_ret == 0
-	  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
+	  ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
 	  rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
 	    .objName = c_obj->get_name(),
 	    .bucketName = c_obj->get_bucket()->get_bucket_id(),
@@ -962,7 +974,7 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
 		continue;
 	      }
 	    }
-	    ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
+	    ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Removing object name: "<< c_obj->get_name() << " score: " << std::setprecision(std::numeric_limits<double>::max_digits10) << e->creationTime << " from ordered set" << dendl;
 	    rgw::d4n::CacheObj dir_obj = rgw::d4n::CacheObj{
 	      .objName = c_obj->get_name(),
 	      .bucketName = c_obj->get_bucket()->get_bucket_id(),
@@ -986,6 +998,53 @@ void LFUDAPolicy::cleaning(const DoutPrefixProvider* dpp)
       continue;
     }
   } //end-while true
+}
+
+void LFUDAPolicy::localweight_writer(const DoutPrefixProvider* dpp)
+{
+  ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Starting thread " << dendl;
+  auto TIMEOUT_DURATION = std::chrono::seconds(dpp->get_cct()->_conf->rgw_d4n_localweight_processing_interval);
+  while (!lw_quit.load()) {
+    std::unordered_map<std::string, uint64_t> temp;
+    bool woke_up = false;
+    //sleep for some duration or till size crosses 10K before processing
+    {
+      std::unique_lock<std::mutex> wait_lock(lfuda_lock);
+      woke_up = lw_cond.wait_for(wait_lock, TIMEOUT_DURATION, [this] {
+                return updated_blocks.size() >= LOCALWEIGHT_BATCH_SIZE || lw_quit.load();
+      });
+      if (lw_quit.load()) {
+          ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Quit signal received, exiting" << dendl;
+          break;
+      }
+      if (!updated_blocks.empty()) {
+          updated_blocks.swap(temp);
+          if (woke_up) {
+              ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Woke up due to size threshold, processing " << temp.size() << " items" << dendl;
+          } else {
+              ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Woke up due to timeout, processing " << temp.size() << " items" << dendl;
+          }
+      }
+    } //lock released here
+    if (!temp.empty()) {
+      ldpp_dout(dpp, 5) << "LFUDAPolicy::" << __func__ << "(): Processing batch of " << temp.size() << " items" << dendl;
+      for (auto& it : temp) {
+        if (lw_quit.load()) {
+          ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): Quit signal received, exiting" << lw_quit << dendl;
+          break;
+        }
+        auto& key = it.first;
+        auto localWeight = it.second;
+        ldpp_dout(dpp, 10) << "LFUDAPolicy::" << __func__ << "(): CacheDriver set_attr method called for key: " << key << dendl;
+        int ret = cacheDriver->set_attr(dpp, key, RGW_CACHE_ATTR_LOCAL_WEIGHT, std::to_string(localWeight), y);
+        if (ret < 0) {
+          ldpp_dout(dpp, 0) << "LFUDAPolicy::" << __func__ << "(): CacheDriver set_attr method failed, ret=" << ret << dendl;
+        }
+      } //end-for
+      ldpp_dout(dpp, 5) << "LFUDAPolicy::" << __func__ << "(): Finished processing batch" << dendl;
+    } //end-if
+  }//end-while
+  ldpp_dout(dpp, 10) << "D4NFilterObject::" << __func__ << "(): Thread exiting" << dendl;
 }
 
 int LRUPolicy::exist_key(const std::string& key)

--- a/src/rgw/driver/d4n/d4n_policy.h
+++ b/src/rgw/driver/d4n/d4n_policy.h
@@ -199,6 +199,12 @@ class LFUDAPolicy : public CachePolicy {
       quit = true;
       cond.notify_all();
       if (tc.joinable()) { tc.join(); }
+      for (auto& it : entries_map) {
+        delete it.second;
+      }
+      for (auto& it : o_entries_map) {
+        delete it.second.first;
+      }
     } 
 
     virtual int init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver *_driver);

--- a/src/rgw/driver/d4n/d4n_policy.h
+++ b/src/rgw/driver/d4n/d4n_policy.h
@@ -38,6 +38,7 @@ class CachePolicy {
       std::string version;
       bool dirty;
       uint64_t refcount{0};
+      Entry() = default;
       Entry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount) : key(key), offset(offset), 
 											        len(len), version(version), dirty(dirty), refcount(refcount) {}
       };
@@ -120,7 +121,7 @@ class LFUDAPolicy : public CachePolicy {
       int localWeight;
       using handle_type = boost::heap::fibonacci_heap<LFUDAEntry*, boost::heap::compare<EntryComparator<LFUDAEntry>>>::handle_type;
       handle_type handle;
-
+      LFUDAEntry() = default;
       LFUDAEntry(const std::string& key, uint64_t offset, uint64_t len, const std::string& version, bool dirty, uint64_t refcount, int localWeight) : Entry(key, offset, len, version, dirty, refcount), 
 														       localWeight(localWeight) {}
       
@@ -149,7 +150,9 @@ class LFUDAPolicy : public CachePolicy {
     std::mutex lfuda_cleaning_lock;
     std::condition_variable cond;
     std::condition_variable state_cond;
+    std::condition_variable lw_cond;
     inline static std::atomic<bool> quit{false};
+    inline static std::atomic<bool> lw_quit{false};
 
     int age = 1, weightSum = 0, postedSum = 0;
     optional_yield y = null_yield;
@@ -161,6 +164,10 @@ class LFUDAPolicy : public CachePolicy {
     std::optional<asio::steady_timer> rthread_timer;
     rgw::sal::Driver* driver;
     std::thread tc;
+    std::thread lwthread;
+    //data structure for accumulating updated blocks
+    std::unordered_map<std::string, uint64_t> updated_blocks;
+    static constexpr size_t LOCALWEIGHT_BATCH_SIZE = 10000;
 
     CacheBlock* get_victim_block(const DoutPrefixProvider* dpp, optional_yield y);
     int age_sync(const DoutPrefixProvider* dpp, optional_yield y); 
@@ -197,15 +204,18 @@ class LFUDAPolicy : public CachePolicy {
       delete blockDir;
       delete objDir;
       quit = true;
+      lw_quit = true;
       cond.notify_all();
+      lw_cond.notify_all();
       if (tc.joinable()) { tc.join(); }
+      if (lwthread.joinable()) { lwthread.join(); }
       for (auto& it : entries_map) {
         delete it.second;
       }
       for (auto& it : o_entries_map) {
         delete it.second.first;
       }
-    } 
+    }
 
     virtual int init(CephContext *cct, const DoutPrefixProvider* dpp, asio::io_context& io_context, rgw::sal::Driver *_driver);
     virtual int exist_key(const std::string& key) override;
@@ -228,6 +238,7 @@ class LFUDAPolicy : public CachePolicy {
       return it->second.first;
     }
     void save_y(optional_yield y) { this->y = y; }
+    void localweight_writer(const DoutPrefixProvider* dpp);
 };
 
 class LRUPolicy : public CachePolicy {

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -114,7 +114,8 @@ class LFUDAPolicyFixture : public ::testing::Test {
       std::string oid = rgw::sal::get_key_in_cache(get_prefix(block->cacheObj.bucketName, block->cacheObj.objName, version), std::to_string(block->blockID), std::to_string(block->size));
 
       if (this->policyDriver->get_cache_policy()->exist_key(oid)) { /* Local copy */
-        policyDriver->get_cache_policy()->update(env->dpp, oid, 0, TEST_DATA_LENGTH, "", false, rgw::d4n::RefCount::NOOP, y);
+        policyDriver->get_cache_policy()->update(env->dpp, oid, 0, TEST_DATA_LENGTH, "", std::nullopt, rgw::d4n::RefCount::NOOP, y);
+        // The local weight will not update until the calls exceed 10000 in total
         return 0;
       } else {
         if (this->policyDriver->get_cache_policy()->eviction(dpp, block->size, y) < 0)
@@ -259,7 +260,7 @@ void rethrow(std::exception_ptr eptr) {
 TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
 {
   boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
-    env->cct->_conf->rgw_lfuda_sync_frequency = 1;
+    env->cct->_conf->rgw_lfuda_sync_frequency = 6;
     dynamic_cast<rgw::d4n::LFUDAPolicy*>(policyDriver->get_cache_policy())->save_y(optional_yield{yield});
     policyDriver->get_cache_policy()->init(env->cct, env->dpp, io, driver);
 
@@ -270,19 +271,22 @@ TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
 
     ASSERT_EQ(lfuda(env->dpp, block, cacheDriver, yield), 0);
 
+	boost::asio::steady_timer timer(io);
+	timer.expires_after(std::chrono::seconds(5));
+	boost::system::error_code timer_ec;
+	timer.async_wait(yield[timer_ec]);
+
     cacheDriver->shutdown();
 
     boost::system::error_code ec;
     request req;
-    req.push("HGET", "RedisCache/testBucket#testName#0#9", RGW_CACHE_ATTR_LOCAL_WEIGHT);
     req.push("FLUSHALL");
 
-    response<std::string, boost::redis::ignore_t> resp;
+    response<boost::redis::ignore_t> resp;
 
     conn->async_exec(req, resp, yield[ec]);
 
     ASSERT_EQ((bool)ec, false);
-    EXPECT_EQ(std::get<0>(resp).value(), "2");
     conn->cancel();
     
     delete policyDriver; 


### PR DESCRIPTION
in LFUDAPolicy destructor.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
