### PR TITLE
squid: mgr/snap_schedule: fix typo in error message during retention add

### DIFF
--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -545,6 +545,30 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
 
         self.mount_a.run_shell(['rmdir', test_dir[1:]])
 
+    def test_failure_for_duplicate_retention(self):
+        """
+        Test that adding retention for same spec fails for second time.
+        """
+        test_dir = '/' + TestSnapSchedules.TEST_DIRECTORY
+
+        self.mount_a.run_shell(['mkdir', '-p', test_dir[1:]])
+
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1m')
+        self.fs_snap_schedule_cmd('retention', 'add', path=test_dir,
+                                  retention_spec_or_period='m',
+                                  retention_count='50')
+
+        # Adding a duplicate retention spec should fail
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('retention', 'add', path=test_dir,
+                                      retention_spec_or_period='m',
+                                      retention_count='50')
+
+        # remove snapshot schedule
+        self.fs_snap_schedule_cmd('remove', path=test_dir)
+
+        self.mount_a.run_shell(['rmdir', test_dir[1:]])
+
     def test_snap_schedule_all_periods(self):
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/minutes"
         self.mount_a.run_shell(['mkdir', '-p', test_dir])

--- a/src/pybind/mgr/snap_schedule/fs/schedule.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule.py
@@ -364,9 +364,9 @@ class Schedule(object):
             current_retention = json.loads(current)
             for r, v in retention.items():
                 if r in current_retention:
-                    msg = (f'Retention for {r} is already present with value'
-                           f'{current_retention[r]}. Please remove first')
-                    raise ValueError(msg)
+                    msg = (f'Retention for {r} is already present with value '
+                           f'{current_retention[r]}. Please remove it first.')
+                    raise FileExistsError(msg)
             current_retention.update(retention)
             db.execute(cls.UPDATE_RETENTION,
                        (json.dumps(current_retention), path))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71438

---

backport of https://github.com/ceph/ceph/pull/59161
parent tracker: https://tracker.ceph.com/issues/64042

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh