### PR TITLE
Fix uadk build (arm64 only) on debian (conflict with DESTDIR)

### DIFF
--- a/cmake/modules/Builduadk.cmake
+++ b/cmake/modules/Builduadk.cmake
@@ -10,22 +10,22 @@ function(build_uadk)
 
     include(ExternalProject)
     ExternalProject_Add(uadk_ext
-	    UPDATE_COMMAND "" # this disables rebuild on each run
-	    GIT_REPOSITORY "https://github.com/ceph/uadk.git"
-            GIT_CONFIG advice.detachedHead=false
-            GIT_TAG 19f650cae960304e3c674992a4c7d5d56a8f4efa
-            SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
-            BUILD_IN_SOURCE 1
-            CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++
-            CONFIGURE_COMMAND ./autogen.sh COMMAND ${configure_cmd}
-            BUILD_COMMAND make
-	    BUILD_BYPRODUCTS ${UADK_WD_LIBRARY} ${UADK_WD_COMP_LIBRARY} ${UADK_WD_ZIP_LIBRARY}
-            INSTALL_COMMAND make install
-            LOG_CONFIGURE ON
-            LOG_BUILD ON
-            LOG_INSTALL ON
-            LOG_MERGED_STDOUTERR ON
-            LOG_OUTPUT_ON_FAILURE ON)
+        UPDATE_COMMAND "" # this disables rebuild on each run
+        GIT_REPOSITORY "https://github.com/ceph/uadk.git"
+        GIT_CONFIG advice.detachedHead=false
+        GIT_TAG 19f650cae960304e3c674992a4c7d5d56a8f4efa
+        SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
+        BUILD_IN_SOURCE 1
+        CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++
+        CONFIGURE_COMMAND ./autogen.sh COMMAND ${configure_cmd}
+        BUILD_COMMAND make
+        BUILD_BYPRODUCTS ${UADK_WD_LIBRARY} ${UADK_WD_COMP_LIBRARY} ${UADK_WD_ZIP_LIBRARY}
+        INSTALL_COMMAND make install
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON
+        LOG_MERGED_STDOUTERR ON
+        LOG_OUTPUT_ON_FAILURE ON)
 
     ExternalProject_Get_Property(uadk_ext source_dir)
     set(UADK_INCLUDE_DIR ${UADK_INCLUDE_DIR} PARENT_SCOPE)
@@ -40,13 +40,13 @@ function(build_uadk)
     set_target_properties(uadk::uadk PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${UADK_INCLUDE_DIR}
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-	IMPORTED_LOCATION "${UADK_WD_COMP_LIBRARY}")
+        IMPORTED_LOCATION "${UADK_WD_COMP_LIBRARY}")
     set_target_properties(uadk::uadkwd PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${UADK_INCLUDE_DIR}
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-	IMPORTED_LOCATION "${UADK_WD_LIBRARY}")
+        IMPORTED_LOCATION "${UADK_WD_LIBRARY}")
     set_target_properties(uadk::uadkzip PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${UADK_INCLUDE_DIR}
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-	IMPORTED_LOCATION "${UADK_WD_ZIP_LIBRARY}")
+        IMPORTED_LOCATION "${UADK_WD_ZIP_LIBRARY}")
 endfunction()

--- a/cmake/modules/Builduadk.cmake
+++ b/cmake/modules/Builduadk.cmake
@@ -8,6 +8,13 @@ function(build_uadk)
     set(configure_cmd env ./configure --prefix=${UADK_INSTALL_DIR})
     list(APPEND configure_cmd --with-pic --enable-static --disable-shared --with-static_drv)
 
+    # command prefix to unset DESTDIR; otherwise debhelper and
+    # CMake fight about installation directories, and since
+    # everything here stays in the source tree, packaging
+    # is not necessary
+
+    set(UNSET_DESTDIR /usr/bin/env --unset=DESTDIR)
+
     include(ExternalProject)
     ExternalProject_Add(uadk_ext
         UPDATE_COMMAND "" # this disables rebuild on each run
@@ -17,10 +24,10 @@ function(build_uadk)
         SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
         BUILD_IN_SOURCE 1
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++
-        CONFIGURE_COMMAND ./autogen.sh COMMAND ${configure_cmd}
-        BUILD_COMMAND make
+        CONFIGURE_COMMAND ${UNSET_DESTDIR} ./autogen.sh COMMAND ${configure_cmd}
+        BUILD_COMMAND ${UNSET_DESTDIR} make
         BUILD_BYPRODUCTS ${UADK_WD_LIBRARY} ${UADK_WD_COMP_LIBRARY} ${UADK_WD_ZIP_LIBRARY}
-        INSTALL_COMMAND make install
+        INSTALL_COMMAND ${UNSET_DESTDIR} make install
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
