### PR TITLE
ceph-volume: support additional dmcrypt params

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -278,6 +278,18 @@ class Batch(object):
             help='Reuse existing OSD ids',
             type=arg_validators.valid_osd_id
         )
+        parser.add_argument(
+            '--dmcrypt-format-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksFormat options (use the same syntax as the cryptsetup CLI)",
+        )
+        parser.add_argument(
+            '--dmcrypt-open-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksOpen options (use the same syntax as the cryptsetup CLI)",
+        )
         self.args = parser.parse_args(argv)
         if self.args.bluestore:
             self.args.objectstore = 'bluestore'
@@ -379,6 +391,8 @@ class Batch(object):
             'with_tpm',
             'crush_device_class',
             'no_systemd',
+            'dmcrypt_format_opts',
+            'dmcrypt_open_opts',
         ]
         defaults.update({arg: getattr(self.args, arg) for arg in global_args})
         for osd in plan:

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -84,6 +84,14 @@ common_args: Dict[str, Any] = {
         'action': arg_validators.DmcryptAction,
         'help': 'Enable device encryption via dm-crypt',
     },
+    '--dmcrypt-format-opts': {
+        'default': None,
+        'type': Optional[str],
+    },
+    '--dmcrypt-open-opts': {
+        'default': None,
+        'type': Optional[str],
+    },
     '--with-tpm': {
         'dest': 'with_tpm',
         'help': 'Whether encrypted OSDs should be enrolled with TPM.',

--- a/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
@@ -339,7 +339,11 @@ class Migrate(object):
             secret = encryption_utils.get_dmcrypt_key(osd_id, osd_fsid)
             mlogger.info(' preparing dmcrypt for {}, uuid {}'.format(target_lv.lv_path, target_lv.lv_uuid))
             target_path = encryption_utils.prepare_dmcrypt(
-                key=secret, device=target_path, mapping=target_lv.lv_uuid)
+                key=secret,
+                device=target_path,
+                mapping=target_lv.lv_uuid,
+                format_options=self.args.dmcrypt_format_opts,
+                open_options=self.args.dmcrypt_open_opts)
         try:
             # we need to update lvm tags for all the remaining volumes
             # and clear for ones which to be removed
@@ -511,6 +515,18 @@ class Migrate(object):
             action='store_true',
             help='Skip checking OSD systemd unit',
         )
+        parser.add_argument(
+            '--dmcrypt-format-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksFormat options (use the same syntax as the cryptsetup CLI)",
+        )
+        parser.add_argument(
+            '--dmcrypt-open-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksOpen options (use the same syntax as the cryptsetup CLI)",
+        )
         return parser
 
     def main(self):
@@ -602,6 +618,18 @@ class NewVolume(object):
             action='store_true',
             help='Skip checking OSD systemd unit',
         )
+        parser.add_argument(
+            '--dmcrypt-format-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksFormat options (use the same syntax as the cryptsetup CLI)",
+        )
+        parser.add_argument(
+            '--dmcrypt-open-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksOpen options (use the same syntax as the cryptsetup CLI)",
+        )
         return parser
 
     @decorators.needs_root
@@ -617,7 +645,12 @@ class NewVolume(object):
             secret = encryption_utils.get_dmcrypt_key(osd_id, osd_fsid)
             mlogger.info(' preparing dmcrypt for {}, uuid {}'.format(target_lv.lv_path, target_lv.lv_uuid))
             target_path = encryption_utils.prepare_dmcrypt(
-                key=secret, device=target_path, mapping=target_lv.lv_uuid)
+                key=secret,
+                device=target_path,
+                mapping=target_lv.lv_uuid,
+                format_options=self.args.dmcrypt_format_opts,
+                open_options=self.args.dmcrypt_open_opts
+            )
 
         try:
             tag_tracker.update_tags_when_lv_create(self.create_type)

--- a/src/ceph-volume/ceph_volume/objectstore/lvm.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvm.py
@@ -181,7 +181,8 @@ class Lvm(BaseObjectStore):
         # format data device
         encryption_utils.luks_format(
             self.dmcrypt_key,
-            device
+            device,
+            self.args.dmcrypt_format_opts,
         )
 
         if self.with_tpm:
@@ -191,7 +192,8 @@ class Lvm(BaseObjectStore):
             self.dmcrypt_key,
             device,
             uuid,
-            self.with_tpm)
+            self.with_tpm,
+            self.args.dmcrypt_open_opts)
 
         return '/dev/mapper/%s' % uuid
 

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_lvm.py
@@ -10,7 +10,8 @@ from typing import Callable
 class TestLvm:
     @patch('ceph_volume.objectstore.lvm.prepare_utils.create_key', Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
     def setup_method(self, m_create_key):
-        self.lvm = Lvm([])
+        args = Namespace(dmcrypt_format_opts=None, dmcrypt_open_opts=None)
+        self.lvm = Lvm(args)
 
     @patch('ceph_volume.conf.cluster', 'ceph')
     @patch('ceph_volume.api.lvm.get_single_lv')
@@ -28,6 +29,7 @@ class TestLvm:
                                               lv_tags='',
                                               lv_uuid='fake-uuid')
         self.lvm.encrypted = True
+        self.lvm.with_tpm = 0
         self.lvm.dmcrypt_key = 'fake-dmcrypt-key'
         self.lvm.args = args
         self.lvm.objectstore = 'seastore'
@@ -108,6 +110,7 @@ class TestLvm:
                                                            lv_uuid='fake-uuid')
         self.lvm.encrypted = True
         self.lvm.dmcrypt_key = 'fake-dmcrypt-key'
+        self.lvm.with_tpm = 0
         self.lvm.args = args
         self.lvm.objectstore = 'seastore'
         self.lvm.pre_prepare()

--- a/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
@@ -126,6 +126,23 @@ class TestLuksFormat(object):
         assert m_call.call_args[0][0] == expected
 
     @patch('ceph_volume.util.encryption.process.call')
+    def test_luks_format_with_extra_option(self, m_call, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=abcd')
+        expected = [
+            'cryptsetup',
+            '--batch-mode',
+            '--key-size',
+            '512',
+            '--key-file',
+            '-',
+            'luksFormat',
+            '--fake-custom-opt1',
+            '/dev/foo'
+        ]
+        encryption.luks_format('abcd', '/dev/foo', '--fake-custom-opt1')
+        assert m_call.call_args[0][0] == expected
+
+    @patch('ceph_volume.util.encryption.process.call')
     def test_luks_format_command_with_custom_size(self, m_call, conf_ceph_stub):
         conf_ceph_stub('[global]\nfsid=abcd\n[osd]\nosd_dmcrypt_key_size=256')
         expected = [
@@ -177,6 +194,25 @@ class TestLuksOpen(object):
             '/dev/bar'
         ]
         encryption.luks_open('abcd', '/dev/foo', '/dev/bar')
+        assert m_call.call_args[0][0] == expected
+
+    @patch('ceph_volume.util.encryption.bypass_workqueue', return_value=False)
+    @patch('ceph_volume.util.encryption.process.call')
+    def test_luks_format_with_extra_option(self, m_call, m_bypass_workqueue, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=abcd')
+        expected = [
+            'cryptsetup',
+            '--key-size',
+            '512',
+            '--key-file',
+            '-',
+            '--allow-discards',
+            'luksOpen',
+            '--fake-custom-opt1',
+            '/dev/foo',
+            '/dev/bar'
+        ]
+        encryption.luks_open('abcd', '/dev/foo', '/dev/bar', options='--fake-custom-opt1')
         assert m_call.call_args[0][0] == expected
 
     @patch('ceph_volume.util.encryption.bypass_workqueue', return_value=False)


### PR DESCRIPTION
Add support for passing extra options to dmcrypt commands. This makes it possible to provide custom parameters to `cryptsetup luksFormat` and `cryptsetup luksOpen`, using the same syntax as the native cryptsetup CLI.

Fixes: https://tracker.ceph.com/issues/72801
