### PR TITLE
tentacle: mgr/dashboard: expose image summary API

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/_base_controller.py
+++ b/src/pybind/mgr/dashboard/controllers/_base_controller.py
@@ -1,3 +1,4 @@
+import datetime
 import inspect
 import json
 import logging
@@ -279,9 +280,15 @@ class BaseController:
                                                              if version else 'application/xml')
                 return ret.encode('utf8')
             if json_response:
+                # convert datetime obj so json can serialize properly
+                def json_default(obj):
+                    if isinstance(obj, datetime.datetime):
+                        return obj.isoformat().replace("+00:00", "Z")
+                    return str(obj)
+
                 cherrypy.response.headers['Content-Type'] = (version.to_mime_type(subtype='json')
                                                              if version else 'application/json')
-                ret = json.dumps(ret).encode('utf8')
+                ret = json.dumps(ret, default=json_default).encode('utf8')
             return ret
         return inner
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -1558,6 +1558,38 @@ paths:
       summary: Display Rbd Mirroring Summary
       tags:
       - RbdMirroringSummary
+  /api/block/mirroring/{pool_name}/{image_name}/summary:
+    get:
+      parameters:
+      - in: path
+        name: pool_name
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: image_name
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - RbdMirroringSummary
   /api/block/pool/{pool_name}/namespace:
     get:
       parameters:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72798

---

backport of https://github.com/ceph/ceph/pull/65079
parent tracker: https://tracker.ceph.com/issues/72520

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh