### PR TITLE
doc/cephfs: edit troubleshooting.rst

### DIFF
--- a/doc/cephfs/troubleshooting.rst
+++ b/doc/cephfs/troubleshooting.rst
@@ -293,39 +293,58 @@ The following list details potential causes of hung operations:
 Otherwise, you have probably discovered a new bug and should report it to
 the developers!
 
-.. _ceph_fuse_debugging:
+.. BEGIN COMMENTED-OUT CEPH-FUSE SECTION - 2025 Sep 02
 
-ceph-fuse debugging
-===================
+   The following section, down to the text reading "END COMMENTED-OUT CEPH-FUSE
+   SECTION", discusses a feature ("dump_ops_in_flight") that is, as of the
+   Tentacle release, not yet a part of the Ceph ecosystem. At some future time,
+   this feature is expected to be added to Ceph. At that time, this section
+   should be uncommented and updated so that it accurately describes the
+   behavior of "dump_ops_in_flight".
 
-ceph-fuse is an alternative to the CephFS kernel driver that mounts CephFS file
-systems in user space. ceph-fuse supports ``dump_ops_in_flight``. Use the following command to dump in-flight ceph-fuse operations for examination:  
+   See https://github.com/ceph/ceph/pull/65129/files#r2312866526
+
+   See https://tracker.ceph.com/issues/72793
+
+..  .. _ceph_fuse_debugging:
+  
+  ceph-fuse debugging
+  ===================
+
+..  
+  ceph-fuse is an alternative to the CephFS kernel driver that mounts CephFS file
+  systems in user space. ceph-fuse supports ``dump_ops_in_flight``. Use the following command to dump in-flight ceph-fuse operations for examination:  
+  
+  ..
+    .. prompt:: bash #
+  
+    the command goes here - 10 Aug 2025
+  
+  See the :ref:`Mount CephFS using FUSE<cephfs_mount_using_fuse>` documentation.
+
+  END COMMENTED-OUT CEPH-FUSE SECTION - 2025 Sep 02
+
+.. 
+  Debug output
+  ------------
+
 
 ..
+  To get more debugging information from ceph-fuse, list current operations in
+  the foreground while logging to the console (``-d``), enabling client debug
+  (``--debug-client=20``), and enabling prints for each message sent
+  (``--debug-ms=1``).
+  
   .. prompt:: bash #
-
-  the command goes here - 10 Aug 2025
-
-See the :ref:`Mount CephFS using FUSE<cephfs_mount_using_fuse>` documentation.
-
-Debug output
-------------
-
-To get more debugging information from ceph-fuse, list current operations in
-the foreground while logging to the console (``-d``), enabling client debug
-(``--debug-client=20``), and enabling prints for each message sent
-(``--debug-ms=1``).
-
-.. prompt:: bash #
-
-   ceph daemon -d mds.<name> dump_ops_in_flight --debug-client=20 --debug-ms=1
-
-If you suspect a potential monitor issue, enable monitor debugging as well
-(``--debug-monc=20``) by running a command of the following form:
-
-.. prompt:: bash #
-
-   ceph daemon -d mds.<name> dump_ops_in_flight --debug-client=20 --debug-ms=1 --debug-monc=20
+  
+     ceph daemon -d mds.<name> dump_ops_in_flight --debug-client=20 --debug-ms=1
+  
+  If you suspect a potential monitor issue, enable monitor debugging as well
+  (``--debug-monc=20``) by running a command of the following form:
+  
+  .. prompt:: bash #
+  
+     ceph daemon -d mds.<name> dump_ops_in_flight --debug-client=20 --debug-ms=1 --debug-monc=20
 
 .. _kernel_mount_debugging:
 


### PR DESCRIPTION
Comment out the part of the documentation that describes the ceph-fuse operation "dump_ops_in_flight", which, as of September 2025 is not a part of Ceph.

See https://github.com/ceph/ceph/pull/65129/files#r2312866526

See also https://tracker.ceph.com/issues/72793





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
