### PR TITLE
qa/tasks: catch errors for ip netns list

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -98,12 +98,20 @@ def init_log(log_level=logging.INFO):
     global logpath
     logpath = './vstart_runner.log'
 
+    # File handler
     handler = logging.FileHandler(logpath)
     formatter = logging.Formatter(
         fmt=u'%(asctime)s.%(msecs)03d %(levelname)s:%(name)s:%(message)s',
         datefmt='%Y-%m-%dT%H:%M:%S')
     handler.setFormatter(formatter)
     log.addHandler(handler)
+
+    # Stderr handler
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_formatter = logging.Formatter('%(levelname)s: %(message)s')
+    stderr_handler.setFormatter(stderr_formatter)
+    log.addHandler(stderr_handler)
+
     log.setLevel(log_level)
 
 log = None
@@ -135,7 +143,8 @@ def launch_subprocess(args, cwd=None, env=None, shell=True,
                       executable='/bin/bash'):
     return subprocess.Popen(args, cwd=cwd, env=env, shell=shell,
                             executable=executable, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+                            stderr=subprocess.PIPE, stdin=subprocess.PIPE,
+                            bufsize=1,text=True,)
 
 
 # Let's use some sensible defaults


### PR DESCRIPTION
Raised this PR to catch error that is not getting logged as of now in the API tests.
As of now , the root cause is not identified.

## Issue:

The ceph api tests hanging up here, the very last line:

```
2025-09-02 19:17:48,301.301 INFO:__main__:> ip netns list
Build step 'Execute shell' marked build as failure
...
Setting status ... to FAILURE ... message: 'ceph API tests failed'
Finished: FAILURE
```

## Debugging (till now)

~1. Tried adding logs after and before , but no logs came after~
~2. Timeout on the command is also not respected which is of 5 mins, and it goes on for almost 2 hours~
3. Currently, tests running outputting error to stderr, with sudo mode enabled

##  Code flow:

1. ceph api tests calling -> vstart_runner.py -> mount.py (cleanup_stale_netnses_and_bridge(remote))
2. [LocalRemote](https://github.com/ceph/ceph/blob/7da2ef3f81bb581220f3630383e1587c06cca087/qa/tasks/vstart_runner.py#L322) class's object `remote` is passed to the   def cleanup_stale_netnses_and_bridge(remote):
3. cleanup_stale_netnses_and_bridge -> calls remote.run -> [_do run()](https://github.com/ceph/ceph/blob/main/qa/tasks/vstart_runner.py#L512)

