### PR TITLE
tentacle: auth: msgr2 can return incorrect allowed_modes through AuthBadMethodFrame

### DIFF
--- a/src/auth/AuthServer.h
+++ b/src/auth/AuthServer.h
@@ -17,15 +17,22 @@ public:
   AuthServer(CephContext *cct) : auth_registry(cct) {}
   virtual ~AuthServer() {}
 
-  /// Get authentication methods and connection modes for the given peer type
+  /// Get authentication methods for the given peer type
   virtual void get_supported_auth_methods(
     int peer_type,
-    std::vector<uint32_t> *methods,
-    std::vector<uint32_t> *modes = nullptr) {
-    auth_registry.get_supported_methods(peer_type, methods, modes);
+    std::vector<uint32_t> *methods) {
+    auth_registry.get_supported_methods(peer_type, methods, nullptr);
   }
 
-  /// Get support connection modes for the given peer type and auth method
+  /// Get supported connection modes for the given peer type and auth method
+  virtual void get_supported_con_modes(
+    int peer_type,
+    uint32_t auth_method,
+    std::vector<uint32_t> *modes) {
+    auth_registry.get_supported_modes(peer_type, auth_method, modes);
+  }
+
+  /// Choose a connection mode for the given peer type and auth method
   virtual uint32_t pick_con_mode(
     int peer_type,
     uint32_t auth_method,

--- a/src/crimson/auth/AuthServer.h
+++ b/src/crimson/auth/AuthServer.h
@@ -16,10 +16,15 @@ class AuthServer {
 public:
   virtual ~AuthServer() {}
 
-  // Get authentication methods and connection modes for the given peer type
-  virtual std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+  // Get authentication methods for the given peer type
+  virtual std::vector<uint32_t>
   get_supported_auth_methods(int peer_type) = 0;
-  // Get support connection modes for the given peer type and auth method
+  // Get supported connection modes for the given peer type and auth method 
+  virtual std::vector<uint32_t>
+  get_supported_con_modes(
+    int peer_type,
+    uint32_t auth_method) = 0;
+  // Choose a connection mode for the given peer type and auth method
   virtual uint32_t pick_con_mode(
     int peer_type,
     uint32_t auth_method,

--- a/src/crimson/auth/DummyAuth.h
+++ b/src/crimson/auth/DummyAuth.h
@@ -12,9 +12,15 @@ public:
   DummyAuthClientServer() {}
 
   // client
-  std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+  std::vector<uint32_t>
   get_supported_auth_methods(int peer_type) final {
-    return {{CEPH_AUTH_NONE}, {CEPH_AUTH_NONE}};
+    return {CEPH_AUTH_NONE};
+  }
+
+  std::vector<uint32_t>
+  get_supported_con_modes(int peer_type,
+			  uint32_t auth_method) final {
+    return {CEPH_CON_MODE_CRC};
   }
 
   uint32_t pick_con_mode(int peer_type,

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -564,13 +564,21 @@ void Client::ms_handle_reset(crimson::net::ConnectionRef conn, bool /* is_replac
   });
 }
 
-std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+std::vector<uint32_t>
 Client::get_supported_auth_methods(int peer_type)
 {
     std::vector<uint32_t> methods;
+    auth_registry.get_supported_methods(peer_type, &methods, nullptr);
+    return methods;
+}
+
+std::vector<uint32_t>
+Client::get_supported_con_modes(int peer_type,
+				uint32_t auth_method)
+{
     std::vector<uint32_t> modes;
-    auth_registry.get_supported_methods(peer_type, &methods, &modes);
-    return {methods, modes};
+    auth_registry.get_supported_modes(peer_type, auth_method, &modes);
+    return modes;
 }
 
 uint32_t Client::pick_con_mode(int peer_type,

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -119,8 +119,9 @@ public:
   void print(std::ostream&) const;
 private:
   // AuthServer methods
-  std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
-  get_supported_auth_methods(int peer_type) final;
+  std::vector<uint32_t> get_supported_auth_methods(int peer_type) final;
+  std::vector<uint32_t> get_supported_con_modes(int peer_type,
+						uint32_t auth_method) final;
   uint32_t pick_con_mode(int peer_type,
 			 uint32_t auth_method,
 			 const std::vector<uint32_t>& preferred_modes) final;

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1056,8 +1056,11 @@ seastar::future<> ProtocolV2::_auth_bad_method(int r)
 {
   // _auth_bad_method() logic
   ceph_assert(r < 0);
-  auto [allowed_methods, allowed_modes] =
+  auto allowed_methods =
       messenger.get_auth_server()->get_supported_auth_methods(conn.get_peer_type());
+  auto allowed_modes =
+      messenger.get_auth_server()->get_supported_con_modes(conn.get_peer_type(),
+							  auth_meta->auth_method);
   auto bad_method = AuthBadMethodFrame::Encode(
       auth_meta->auth_method, r, allowed_methods, allowed_modes);
   logger().warn("{} WRITE AuthBadMethodFrame: method={}, result={}, "

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2260,7 +2260,9 @@ CtPtr ProtocolV2::_auth_bad_method(int r)
   std::vector<uint32_t> allowed_methods;
   std::vector<uint32_t> allowed_modes;
   messenger->auth_server->get_supported_auth_methods(
-    connection->get_peer_type(), &allowed_methods, &allowed_modes);
+    connection->get_peer_type(), &allowed_methods);
+  messenger->auth_server->get_supported_con_modes(
+    connection->get_peer_type(), auth_meta->auth_method, &allowed_modes);
   ldout(cct, 1) << __func__ << " auth_method " << auth_meta->auth_method
 		<< " r " << cpp_strerror(r)
 		<< ", allowed_methods " << allowed_methods


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72818

---

backport of https://github.com/ceph/ceph/pull/64717
parent tracker: https://tracker.ceph.com/issues/72265

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh