### PR TITLE
tentacle: uadk: remove __DATE__ and __TIME__ from compilation

### DIFF
--- a/cmake/modules/Builduadk.cmake
+++ b/cmake/modules/Builduadk.cmake
@@ -11,9 +11,9 @@ function(build_uadk)
     include(ExternalProject)
     ExternalProject_Add(uadk_ext
 	    UPDATE_COMMAND "" # this disables rebuild on each run
-	    GIT_REPOSITORY "https://github.com/Linaro/uadk.git"
+	    GIT_REPOSITORY "https://github.com/ceph/uadk.git"
             GIT_CONFIG advice.detachedHead=false
-            GIT_TAG 90fb6f227427f568e34337309075ed7a3f71bab9
+            GIT_TAG 19f650cae960304e3c674992a4c7d5d56a8f4efa
             SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
             BUILD_IN_SOURCE 1
             CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72835

---

backport of https://github.com/ceph/ceph/pull/65161
parent tracker: https://tracker.ceph.com/issues/72823

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh