### PR TITLE
tentacle: Fix uadk build (arm64 only) on debian (conflict with DESTDIR)

### DIFF
--- a/cmake/modules/Builduadk.cmake
+++ b/cmake/modules/Builduadk.cmake
@@ -10,22 +10,22 @@ function(build_uadk)
 
     include(ExternalProject)
     ExternalProject_Add(uadk_ext
-	    UPDATE_COMMAND "" # this disables rebuild on each run
-	    GIT_REPOSITORY "https://github.com/ceph/uadk.git"
-            GIT_CONFIG advice.detachedHead=false
-            GIT_TAG 19f650cae960304e3c674992a4c7d5d56a8f4efa
-            SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
-            BUILD_IN_SOURCE 1
-            CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++
-            CONFIGURE_COMMAND ./autogen.sh COMMAND ${configure_cmd}
-            BUILD_COMMAND make
-	    BUILD_BYPRODUCTS ${UADK_WD_LIBRARY} ${UADK_WD_COMP_LIBRARY} ${UADK_WD_ZIP_LIBRARY}
-            INSTALL_COMMAND make install
-            LOG_CONFIGURE ON
-            LOG_BUILD ON
-            LOG_INSTALL ON
-            LOG_MERGED_STDOUTERR ON
-            LOG_OUTPUT_ON_FAILURE ON)
+        UPDATE_COMMAND "" # this disables rebuild on each run
+        GIT_REPOSITORY "https://github.com/ceph/uadk.git"
+        GIT_CONFIG advice.detachedHead=false
+        GIT_TAG 19f650cae960304e3c674992a4c7d5d56a8f4efa
+        SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
+        BUILD_IN_SOURCE 1
+        CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++
+        CONFIGURE_COMMAND ./autogen.sh COMMAND ${configure_cmd}
+        BUILD_COMMAND make
+        BUILD_BYPRODUCTS ${UADK_WD_LIBRARY} ${UADK_WD_COMP_LIBRARY} ${UADK_WD_ZIP_LIBRARY}
+        INSTALL_COMMAND make install
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON
+        LOG_MERGED_STDOUTERR ON
+        LOG_OUTPUT_ON_FAILURE ON)
 
     ExternalProject_Get_Property(uadk_ext source_dir)
     set(UADK_INCLUDE_DIR ${UADK_INCLUDE_DIR} PARENT_SCOPE)
@@ -40,13 +40,13 @@ function(build_uadk)
     set_target_properties(uadk::uadk PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${UADK_INCLUDE_DIR}
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-	IMPORTED_LOCATION "${UADK_WD_COMP_LIBRARY}")
+        IMPORTED_LOCATION "${UADK_WD_COMP_LIBRARY}")
     set_target_properties(uadk::uadkwd PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${UADK_INCLUDE_DIR}
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-	IMPORTED_LOCATION "${UADK_WD_LIBRARY}")
+        IMPORTED_LOCATION "${UADK_WD_LIBRARY}")
     set_target_properties(uadk::uadkzip PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${UADK_INCLUDE_DIR}
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-	IMPORTED_LOCATION "${UADK_WD_ZIP_LIBRARY}")
+        IMPORTED_LOCATION "${UADK_WD_ZIP_LIBRARY}")
 endfunction()

--- a/cmake/modules/Builduadk.cmake
+++ b/cmake/modules/Builduadk.cmake
@@ -8,6 +8,13 @@ function(build_uadk)
     set(configure_cmd env ./configure --prefix=${UADK_INSTALL_DIR})
     list(APPEND configure_cmd --with-pic --enable-static --disable-shared --with-static_drv)
 
+    # command prefix to unset DESTDIR; otherwise debhelper and
+    # CMake fight about installation directories, and since
+    # everything here stays in the source tree, packaging
+    # is not necessary
+
+    set(UNSET_DESTDIR /usr/bin/env --unset=DESTDIR)
+
     include(ExternalProject)
     ExternalProject_Add(uadk_ext
         UPDATE_COMMAND "" # this disables rebuild on each run
@@ -17,10 +24,10 @@ function(build_uadk)
         SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
         BUILD_IN_SOURCE 1
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++
-        CONFIGURE_COMMAND ./autogen.sh COMMAND ${configure_cmd}
-        BUILD_COMMAND make
+        CONFIGURE_COMMAND ${UNSET_DESTDIR} ./autogen.sh COMMAND ${configure_cmd}
+        BUILD_COMMAND ${UNSET_DESTDIR} make
         BUILD_BYPRODUCTS ${UADK_WD_LIBRARY} ${UADK_WD_COMP_LIBRARY} ${UADK_WD_ZIP_LIBRARY}
-        INSTALL_COMMAND make install
+        INSTALL_COMMAND ${UNSET_DESTDIR} make install
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72821

---

backport of https://github.com/ceph/ceph/pull/65316
parent tracker: https://tracker.ceph.com/issues/72722

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh