### PR TITLE
tentacle: make-debs.sh: invoke tar with --no-same-owner

### DIFF
--- a/make-debs.sh
+++ b/make-debs.sh
@@ -50,7 +50,8 @@ test -f "ceph-$vers.tar.bz2" || ./make-dist $vers
 #
 mkdir -p $releasedir
 mv ceph-$vers.tar.bz2 $releasedir/ceph_$vers.orig.tar.bz2
-tar -C $releasedir -jxf $releasedir/ceph_$vers.orig.tar.bz2
+tar -C $releasedir --no-same-owner -jxf $releasedir/ceph_$vers.orig.tar.bz2
+
 #
 # copy the debian directory over and remove -dbg packages
 # because they are large and take time to build


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72833

---

backport of https://github.com/ceph/ceph/pull/65190
parent tracker: https://tracker.ceph.com/issues/72828

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh