### PR TITLE
tentacle: Remove git clean -fdx

### DIFF
--- a/make-debs.sh
+++ b/make-debs.sh
@@ -20,11 +20,6 @@ set -xe
 base=${1:-/tmp/release}
 releasedir=$base/$NAME/WORKDIR
 rm -fr $(dirname $releasedir)
-#
-# remove all files not under git so they are not
-# included in the distribution.
-
-[ -e .git ] && git clean -dxf
 
 # git describe provides a version that is
 # a) human readable


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72831

---

backport of https://github.com/ceph/ceph/pull/65222
parent tracker: https://tracker.ceph.com/issues/72829

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh