### PR TITLE
crimson/os/seastore/BtreeLBAManager: switch to coroutine

### DIFF
--- a/src/crimson/os/seastore/lba/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.cc
@@ -152,7 +152,7 @@ BtreeLBAManager::get_mappings(
     TRACET("{}~0x{:x} got {}", t, laddr, length, ret.back());
   }
 
-  co_return ret;
+  co_return std::move(ret);
 }
 
 BtreeLBAManager::_get_cursors_ret
@@ -176,7 +176,7 @@ BtreeLBAManager::get_cursors(
 
   TRACET("{}~0x{:x} done with {} results, stop at {}",
 	 c.trans, laddr, length, ret.size(), pos);
-  co_return ret;
+  co_return std::move(ret);
 }
 
 BtreeLBAManager::resolve_indirect_cursor_ret
@@ -199,7 +199,7 @@ BtreeLBAManager::resolve_indirect_cursor(
   assert(direct_cursor->get_laddr() <= intermediate_key);
   assert(direct_cursor->get_laddr() + direct_cursor->get_length()
 	 >= intermediate_key + indirect_cursor.get_length());
-  co_return direct_cursor;
+  co_return std::move(direct_cursor);
 }
 
 BtreeLBAManager::get_mapping_ret
@@ -232,7 +232,7 @@ BtreeLBAManager::get_mapping(
   auto mapping = LBAMapping::create_indirect(
     std::move(direct), std::move(cursor));
   TRACET("{} got cursor mapping {}", t, laddr, mapping);
-  co_return mapping;
+  co_return std::move(mapping);
 }
 
 BtreeLBAManager::get_mapping_ret
@@ -351,7 +351,7 @@ BtreeLBAManager::alloc_extents(
     }
 #endif
   }
-  co_return ret;
+  co_return std::move(ret);
 }
 
 BtreeLBAManager::alloc_extent_ret
@@ -421,7 +421,7 @@ BtreeLBAManager::alloc_extents(
   for (auto &cursor : cursors) {
     ret.emplace_back(LBAMapping::create_direct(std::move(cursor)));
   }
-  co_return ret;
+  co_return std::move(ret);
 }
 
 BtreeLBAManager::ref_ret
@@ -699,7 +699,7 @@ BtreeLBAManager::insert_mappings(
     iter = co_await iter.next(c);
   }
 
-  co_return ret;
+  co_return std::move(ret);
 }
 
 static bool is_lba_node(const CachedExtent &e)
@@ -921,13 +921,13 @@ BtreeLBAManager::complete_indirect_lba_mapping(
   assert(mapping.is_viewable());
   assert(mapping.is_indirect());
   if (mapping.is_complete_indirect()) {
-    co_return mapping;
+    co_return std::move(mapping);
   }
   auto c = get_context(t);
   auto btree = co_await get_btree(t);
   auto cursor = co_await resolve_indirect_cursor(c, btree, *mapping.indirect_cursor);
   mapping.direct_cursor = std::move(cursor);
-  co_return mapping;
+  co_return std::move(mapping);
 }
 
 void BtreeLBAManager::register_metrics()
@@ -1175,7 +1175,7 @@ BtreeLBAManager::remap_mappings(
 	remapped_mapping = std::move(mapping);
       });
     });
-  co_return ret;
+  co_return std::move(ret);
 }
 
 }

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -361,6 +361,12 @@ public:
 private:
   Cache &cache;
 
+  base_iertr::future<LBABtree> get_btree(Transaction &t) {
+    return cache.get_root(t).si_then([](RootBlockRef root) {
+      return LBABtree(root);
+    });
+  }
+
   struct {
     uint64_t num_alloc_extents = 0;
     uint64_t num_alloc_extents_iter_nexts = 0;

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -480,18 +480,6 @@ private:
     op_context_t c,
     LBABtree& btree,
     const LBACursor& indirect_cursor);
-
-  resolve_indirect_cursor_ret resolve_indirect_cursor(
-    op_context_t c,
-    const LBACursor& indirect_cursor) {
-    assert(indirect_cursor.is_indirect());
-    return with_btree<LBABtree>(
-      cache,
-      c,
-      [c, &indirect_cursor, this](auto &btree) {
-      return resolve_indirect_cursor(c, btree, indirect_cursor);
-    });
-  }
 };
 using BtreeLBAManagerRef = std::unique_ptr<BtreeLBAManager>;
 

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -161,7 +161,7 @@ public:
     Transaction &t,
     laddr_t begin,
     laddr_t end,
-    scan_mappings_func_t &&f) final;
+    scan_mappings_func_t f) final;
 
   rewrite_extent_ret rewrite_extent(
     Transaction &t,

--- a/src/crimson/os/seastore/lba/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba/btree_lba_manager.h
@@ -84,21 +84,7 @@ public:
   alloc_extent_ret reserve_region(
     Transaction &t,
     laddr_t hint,
-    extent_len_t len) final
-  {
-    std::vector<alloc_mapping_info_t> alloc_infos = {
-      alloc_mapping_info_t::create_zero(len)};
-    return seastar::do_with(
-      std::move(alloc_infos),
-      [&t, hint, this](auto &alloc_infos) {
-      return alloc_contiguous_mappings(
-	t, hint, alloc_infos, alloc_policy_t::linear_search
-      ).si_then([](auto cursors) {
-	assert(cursors.size() == 1);
-	return LBAMapping::create_direct(std::move(cursors.front()));
-      });
-    });
-  }
+    extent_len_t len) final;
 
   clone_mapping_ret clone_mapping(
     Transaction &t,
@@ -122,188 +108,33 @@ public:
     Transaction &t,
     laddr_t hint,
     LogicalChildNode &ext,
-    extent_ref_count_t refcount) final
-  {
-    // The real checksum will be updated upon transaction commit
-    assert(ext.get_last_committed_crc() == 0);
-    assert(!ext.has_laddr());
-    std::vector<alloc_mapping_info_t> alloc_infos = {
-      alloc_mapping_info_t::create_direct(
-	L_ADDR_NULL,
-	ext.get_length(),
-	ext.get_paddr(),
-	refcount,
-	ext.get_last_committed_crc(),
-	ext)};
-    return seastar::do_with(
-      std::move(alloc_infos),
-      [this, &t, hint](auto &alloc_infos) {
-      return alloc_contiguous_mappings(
-	t, hint, alloc_infos, alloc_policy_t::linear_search
-      ).si_then([](auto cursors) {
-	assert(cursors.size() == 1);
-	return LBAMapping::create_direct(std::move(cursors.front()));
-      });
-    });
-  }
+    extent_ref_count_t refcount) final;
 
   alloc_extents_ret alloc_extents(
     Transaction &t,
     laddr_t hint,
     std::vector<LogicalChildNodeRef> extents,
-    extent_ref_count_t refcount) final
-  {
-    std::vector<alloc_mapping_info_t> alloc_infos;
-    assert(!extents.empty());
-    auto has_laddr = extents.front()->has_laddr();
-    for (auto &extent : extents) {
-      assert(extent);
-      assert(extent->has_laddr() == has_laddr);
-      alloc_infos.emplace_back(
-	alloc_mapping_info_t::create_direct(
-	  extent->has_laddr() ? extent->get_laddr() : L_ADDR_NULL,
-	  extent->get_length(),
-	  extent->get_paddr(),
-	  refcount,
-	  extent->get_last_committed_crc(),
-	  *extent));
-    }
-    return seastar::do_with(
-      std::move(alloc_infos),
-      [this, &t, hint, has_laddr](auto &alloc_infos)
-    {
-      if (has_laddr) {
-	return alloc_sparse_mappings(
-	  t, hint, alloc_infos, alloc_policy_t::deterministic)
-#ifndef NDEBUG
-	.si_then([&alloc_infos](std::list<LBACursorRef> cursors) {
-	  assert(alloc_infos.size() == cursors.size());
-	  auto info_p = alloc_infos.begin();
-	  auto cursor_p = cursors.begin();
-	  for (; info_p != alloc_infos.end(); info_p++, cursor_p++) {
-	    auto &cursor = *cursor_p;
-	    assert(cursor->get_laddr() == info_p->key);
-	  }
-	  return alloc_extent_iertr::make_ready_future<
-	    std::list<LBACursorRef>>(std::move(cursors));
-	})
-#endif
-	  ;
-      } else {
-	return alloc_contiguous_mappings(
-	  t, hint, alloc_infos, alloc_policy_t::linear_search);
-      }
-    }).si_then([](std::list<LBACursorRef> cursors) {
-      std::vector<LBAMapping> ret;
-      for (auto &cursor : cursors) {
-	ret.emplace_back(LBAMapping::create_direct(std::move(cursor)));
-      }
-      return ret;
-    });
-  }
+    extent_ref_count_t refcount) final;
 
   ref_ret remove_mapping(
     Transaction &t,
-    laddr_t addr) final {
-    return update_refcount(t, addr, -1
-    ).si_then([this, &t](auto res) {
-      ceph_assert(res.refcount == 0);
-      if (res.addr.is_paddr()) {
-	return ref_iertr::make_ready_future<
-	  ref_update_result_t>(ref_update_result_t{
-	    std::move(res), std::nullopt});
-      }
-      return update_refcount(t, res.key, -1
-      ).si_then([indirect_result=std::move(res)](auto direct_result) mutable {
-	return indirect_result.mapping.refresh(
-	).si_then([direct_result=std::move(direct_result),
-		   indirect_result=std::move(indirect_result)](auto) {
-	  return ref_iertr::make_ready_future<
-	    ref_update_result_t>(ref_update_result_t{
-	      std::move(indirect_result),
-	      std::move(direct_result)});
-	});
-      });
-    });
-  }
+    laddr_t addr) final;
 
   ref_ret remove_indirect_mapping_only(
     Transaction &t,
-    LBAMapping mapping) final {
-    assert(mapping.is_viewable());
-    assert(mapping.is_indirect());
-    return seastar::do_with(
-      std::move(mapping),
-      [&t, this](auto &mapping) {
-      return update_refcount(t, mapping.indirect_cursor.get(), -1
-      ).si_then([](auto res) {
-	return ref_iertr::make_ready_future<
-	  ref_update_result_t>(ref_update_result_t{
-	    std::move(res), std::nullopt});
-      });
-    });
-  }
+    LBAMapping mapping) final;
 
   ref_ret remove_mapping(
     Transaction &t,
-    LBAMapping mapping) final {
-    assert(mapping.is_viewable());
-    assert(mapping.is_complete());
-    return seastar::do_with(
-      std::move(mapping),
-      [&t, this](auto &mapping) {
-      auto &cursor = mapping.get_effective_cursor();
-      return update_refcount(t, &cursor, -1
-      ).si_then([this, &t, &mapping](auto res) {
-	ceph_assert(res.refcount == 0);
-	if (res.addr.is_paddr()) {
-	  assert(!mapping.is_indirect());
-	  return ref_iertr::make_ready_future<
-	    ref_update_result_t>(ref_update_result_t{
-	      std::move(res), std::nullopt});
-	}
-	assert(mapping.is_indirect());
-	auto &cursor = *mapping.direct_cursor;
-	return cursor.refresh().si_then([this, &t, &cursor] {
-	  return update_refcount(t, &cursor, -1);
-	}).si_then([indirect_result=std::move(res)]
-		   (auto direct_result) mutable {
-	  return indirect_result.mapping.refresh(
-	  ).si_then([direct_result=std::move(direct_result),
-		     indirect_result=std::move(indirect_result)](auto) {
-	    return ref_iertr::make_ready_future<
-	      ref_update_result_t>(ref_update_result_t{
-		std::move(indirect_result),
-		std::move(direct_result)});
-	  });
-	});
-      });
-    });
-  }
+    LBAMapping mapping) final;
 
   ref_ret incref_extent(
     Transaction &t,
-    laddr_t addr) final {
-    return update_refcount(t, addr, 1
-    ).si_then([](auto res) {
-      return ref_update_result_t(std::move(res), std::nullopt);
-    });
-  }
+    laddr_t addr) final;
 
   ref_ret incref_extent(
     Transaction &t,
-    LBAMapping mapping) final {
-    assert(mapping.is_viewable());
-    return seastar::do_with(
-      std::move(mapping),
-      [&t, this](auto &mapping) {
-      auto &cursor = mapping.get_effective_cursor();
-      return update_refcount(t, &cursor, 1
-      ).si_then([](auto res) {
-	return ref_update_result_t(std::move(res), std::nullopt);
-      });
-    });
-  }
+    LBAMapping mapping) final;
 
   remap_ret remap_mappings(
     Transaction &t,

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -269,7 +269,7 @@ public:
     Transaction &t,
     laddr_t begin,
     laddr_t end,
-    scan_mappings_func_t &&f) = 0;
+    scan_mappings_func_t f) = 0;
 
   /**
    * rewrite_extent


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
