### PR TITLE
cephfs_mirror: show mirror health warning in ceph -s

### DIFF
--- a/qa/suites/fs/mirror/tasks/mirror.yaml
+++ b/qa/suites/fs/mirror/tasks/mirror.yaml
@@ -1,5 +1,8 @@
 overrides:
   ceph:
+    log-ignorelist:
+      - CEPHFS_MIRROR_FAILURE
+      - CEPHFS_MIRROR_SNAP_SYNC_FAILURE
     conf:
       mgr:
         debug client: 10

--- a/qa/suites/fs/valgrind/mirror/tasks/mirror.yaml
+++ b/qa/suites/fs/valgrind/mirror/tasks/mirror.yaml
@@ -1,5 +1,8 @@
 overrides:
   ceph:
+    log-ignorelist:
+      - CEPHFS_MIRROR_FAILURE
+      - CEPHFS_MIRROR_SNAP_SYNC_FAILURE
     conf:
       mgr:
         debug client: 10

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -1842,3 +1842,58 @@ class TestMirroring(CephFSTestCase):
 
         self.config_set('client.mirror', 'cephfs_mirror_distribute_datasync_threads', 'true')
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_ceph_health_warning_on_init_failure(self):
+        """Test CEPHFS_MIRROR_FAILURE warning in ceph health on init failure"""
+
+        # disable mgr mirroring plugin as it would try to load dir map on
+        # on mirroring enabled for a filesystem (an throw up errors in
+        # the logs)
+        self.disable_mirroring_module()
+
+        # enable mirroring through mon interface -- this should result in the mirror daemon
+        # failing to enable mirroring due to absence of `cephfs_mirror` index object.
+        self.run_ceph_cmd("fs", "mirror", "enable", self.primary_fs_name)
+
+        self.wait_for_health("CEPHFS_MIRROR_FAILURE", 120)
+        self.run_ceph_cmd("fs", "mirror", "disable", self.primary_fs_name)
+
+    def test_ceph_health_warning_on_sync_failure(self):
+        """
+        That making changes to the remote .snap directory shows CEPHFS_MIRROR_SNAP_SYNC_FAILURE
+        warning in ceph health and clears when the failure is resolved.
+        """
+        self.setup_mount_b(mds_perm='rwps')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name,
+                      check_perf_counter=False)
+        dir_name = 'd0'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', check_perf_counter=False)
+
+        # take a snapshot
+        snap_name = "snap_a"
+        expected_snap_count = 1
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+
+        # confirm snapshot synced and status 'idle'
+        with safe_while(sleep=5, tries=30, action='wait for idle state') as proceed:
+            while proceed():
+                try:
+                    self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                                peer_spec, f'/{dir_name}', snap_name, expected_snap_count)
+                    break
+                except:
+                    pass
+
+        # create a directory in the remote fs and check for health warn
+        remote_snap_name = 'snap_b'
+        remote_snap_path = f'{dir_name}/.snap/{remote_snap_name}'
+        self.mount_b.run_shell(['sudo', 'mkdir', remote_snap_path], omit_sudo=False)
+        self.wait_for_health("CEPHFS_MIRROR_SNAP_SYNC_FAILURE", 120)
+
+        # remove the directory in the remote fs and check ceph health clears
+        self.mount_b.run_shell(['sudo', 'rmdir', remote_snap_path], omit_sudo=False)
+        self.wait_for_health_clear(120)
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -3873,3 +3873,61 @@ class TestMirroring(CephFSTestCase):
         self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
         self.assert_snapshot_not_synced(dir_name, snap_name)
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_ceph_health_warning_on_init_failure(self):
+        """Test CEPHFS_MIRROR_FAILURE warning in ceph health on init failure"""
+
+        # disable mgr mirroring plugin as it would try to load dir map on
+        # on mirroring enabled for a filesystem (an throw up errors in
+        # the logs)
+        self.disable_mirroring_module()
+
+        # enable mirroring through mon interface -- this should result in the mirror daemon
+        # failing to enable mirroring due to absence of `cephfs_mirror` index object.
+        self.run_ceph_cmd("fs", "mirror", "enable", self.primary_fs_name)
+
+        try:
+            self.wait_for_health("CEPHFS_MIRROR_FAILURE", 120)
+        finally:
+            self.run_ceph_cmd("fs", "mirror", "disable", self.primary_fs_name)
+
+    def test_ceph_health_warning_on_sync_failure(self):
+        """
+        That making changes to the remote .snap directory shows CEPHFS_MIRROR_SNAP_SYNC_FAILURE
+        warning in ceph health and clears when the failure is resolved.
+        """
+        self.setup_mount_b(mds_perm='rwps')
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        peer_spec = "client.mirror_remote@ceph"
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, peer_spec, self.secondary_fs_name,
+                      check_perf_counter=False)
+        dir_name = 'd0'
+        self.mount_a.run_shell(['mkdir', dir_name])
+        self.add_directory(self.primary_fs_name, self.primary_fs_id, f'/{dir_name}', check_perf_counter=False)
+
+        # take a snapshot
+        snap_name = "snap_a"
+        expected_snap_count = 1
+        self.mount_a.run_shell(['mkdir', f'{dir_name}/.snap/{snap_name}'])
+
+        # confirm snapshot synced and status 'idle'
+        with safe_while(sleep=5, tries=30, action='wait for idle state') as proceed:
+            while proceed():
+                try:
+                    self.check_peer_status_idle(self.primary_fs_name, self.primary_fs_id,
+                                                peer_spec, f'/{dir_name}', snap_name, expected_snap_count)
+                    break
+                except:
+                    pass
+
+        # create a directory in the remote fs and check for health warn
+        remote_snap_name = 'snap_b'
+        remote_snap_path = f'{dir_name}/.snap/{remote_snap_name}'
+        self.mount_b.run_shell(['sudo', 'mkdir', remote_snap_path], omit_sudo=False)
+        try:
+            self.wait_for_health("CEPHFS_MIRROR_SNAP_SYNC_FAILURE", 120)
+        finally:
+            # remove the directory in the remote fs and check ceph health clears
+            self.mount_b.run_shell(['sudo', 'rmdir', remote_snap_path], omit_sudo=False)
+            self.wait_for_health_clear(120)
+            self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -168,3 +168,12 @@ options:
   - cephfs-mirror
   min: 0
   max: 11
+- name: cephfs_mirror_health_tick_interval
+  type: secs
+  level: advanced
+  desc: interval for internal cephfs-mirror background checks
+  long_desc: cephfs-mirror health tick interval in seconds.
+  default: 5
+  services:
+  - cephfs-mirror
+  min: 1

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -13,6 +13,7 @@
 #include "librados.h"
 #include "librados_fwd.hpp"
 #include "rados_types.hpp"
+#include "mgr/DaemonHealthMetric.h"
 
 #include "cls_traits.hpp"
 
@@ -1556,6 +1557,8 @@ inline namespace v14_2_0 {
       const std::map<std::string,std::string>& metadata); ///< static metadata about daemon
     int service_daemon_update_status(
       std::map<std::string,std::string>&& status);
+    int service_daemon_update_health(
+      std::vector<DaemonHealthMetric>&& health_metrics);
 
     int pool_create(const char *name);
     int pool_create(const char *name, uint64_t auid)

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -13,6 +13,7 @@
 #include "librados.h"
 #include "librados_fwd.hpp"
 #include "rados_types.hpp"
+#include "mgr/DaemonHealthMetric.h"
 
 #include "cls_traits.hpp"
 
@@ -1562,6 +1563,8 @@ inline namespace v14_2_0 {
       const std::map<std::string,std::string>& metadata); ///< static metadata about daemon
     int service_daemon_update_status(
       std::map<std::string,std::string>&& status);
+    int service_daemon_update_health(
+      std::vector<DaemonHealthMetric>&& health_metrics);
 
     int pool_create(const char *name);
     int pool_create(const char *name, uint64_t auid)

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -1117,6 +1117,16 @@ int librados::RadosClient::service_daemon_update_status(
   return mgrclient.service_daemon_update_status(std::move(status));
 }
 
+int librados::RadosClient::service_daemon_update_health(
+  std::vector<DaemonHealthMetric>&& health_metrics)
+{
+  if (state != CONNECTED) {
+    return -ENOTCONN;
+  }
+  mgrclient.update_daemon_health(std::move(health_metrics));
+  return 0;
+}
+
 mon_feature_t librados::RadosClient::get_required_monitor_features() const
 {
   return monclient.with_monmap([](const MonMap &monmap) {

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -1116,6 +1116,16 @@ int librados::RadosClient::service_daemon_update_status(
   return mgrclient.service_daemon_update_status(std::move(status));
 }
 
+int librados::RadosClient::service_daemon_update_health(
+  std::vector<DaemonHealthMetric>&& health_metrics)
+{
+  if (state != CONNECTED) {
+    return -ENOTCONN;
+  }
+  mgrclient.update_daemon_health(std::move(health_metrics));
+  return 0;
+}
+
 mon_feature_t librados::RadosClient::get_required_monitor_features() const
 {
   return monclient.with_monmap([](const MonMap &monmap) {

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -188,6 +188,8 @@ public:
     const std::map<std::string,std::string>& metadata); ///< static metadata about daemon
   int service_daemon_update_status(
     std::map<std::string,std::string>&& status);
+  int service_daemon_update_health(
+    std::vector<DaemonHealthMetric>&& health_metrics);
 
   mon_feature_t get_required_monitor_features() const;
 

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -200,6 +200,8 @@ public:
     const std::map<std::string,std::string>& metadata); ///< static metadata about daemon
   int service_daemon_update_status(
     std::map<std::string,std::string>&& status);
+  int service_daemon_update_health(
+    std::vector<DaemonHealthMetric>&& health_metrics);
 
   mon_feature_t get_required_monitor_features() const;
 

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -828,6 +828,15 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_service_update_status)(
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_service_update_status);
 
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_service_update_health)(
+  rados_t cluster,
+  std::vector<DaemonHealthMetric>&& health_metrics)
+{
+  librados::RadosClient *client = (librados::RadosClient *)cluster;
+  return client->service_daemon_update_health(std::move(health_metrics));
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_service_update_health);
+
 static void do_out_buffer(bufferlist& outbl, char **outbuf, size_t *outbuflen)
 {
   if (outbuf) {

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2525,6 +2525,12 @@ int librados::Rados::service_daemon_update_status(
   return client->service_daemon_update_status(std::move(status));
 }
 
+int librados::Rados::service_daemon_update_health(
+  std::vector<DaemonHealthMetric>&& health_metrics)
+{
+  return client->service_daemon_update_health(std::move(health_metrics));
+}
+
 int librados::Rados::pool_create(const char *name)
 {
   string str(name);

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -2530,6 +2530,12 @@ int librados::Rados::service_daemon_update_status(
   return client->service_daemon_update_status(std::move(status));
 }
 
+int librados::Rados::service_daemon_update_health(
+  std::vector<DaemonHealthMetric>&& health_metrics)
+{
+  return client->service_daemon_update_health(std::move(health_metrics));
+}
+
 int librados::Rados::pool_create(const char *name)
 {
   string str(name);

--- a/src/mgr/DaemonHealthMetric.cc
+++ b/src/mgr/DaemonHealthMetric.cc
@@ -17,6 +17,8 @@ void DaemonHealthMetric::dump(ceph::Formatter *f) const {
 std::list<DaemonHealthMetric> DaemonHealthMetric::generate_test_instances() {
   std::list<DaemonHealthMetric> o;
   o.push_back(DaemonHealthMetric(daemon_metric::SLOW_OPS, 1));
+  o.push_back(DaemonHealthMetric(daemon_metric::CEPHFS_MIRROR_FAILURE, 1));
+  o.push_back(DaemonHealthMetric(daemon_metric::CEPHFS_MIRROR_SNAP_SYNC_FAILURE, 1));
   o.push_back(DaemonHealthMetric(daemon_metric::PENDING_CREATING_PGS, 1, 2));
   return o;
 }

--- a/src/mgr/DaemonHealthMetric.h
+++ b/src/mgr/DaemonHealthMetric.h
@@ -14,6 +14,8 @@ namespace ceph { class Formatter; }
 enum class daemon_metric : uint8_t {
   SLOW_OPS,
   PENDING_CREATING_PGS,
+  CEPHFS_MIRROR_FAILURE,
+  CEPHFS_MIRROR_SNAP_SYNC_FAILURE,
   NONE,
 };
 
@@ -21,6 +23,8 @@ static inline const char *daemon_metric_name(daemon_metric t) {
   switch (t) {
   case daemon_metric::SLOW_OPS: return "SLOW_OPS";
   case daemon_metric::PENDING_CREATING_PGS: return "PENDING_CREATING_PGS";
+  case daemon_metric::CEPHFS_MIRROR_FAILURE: return "CEPHFS_MIRROR_FAILURE";
+  case daemon_metric::CEPHFS_MIRROR_SNAP_SYNC_FAILURE: return "CEPHFS_MIRROR_SNAP_SYNC_FAILURE";
   case daemon_metric::NONE: return "NONE";
   default: return "???";
   }

--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -93,6 +93,90 @@ class PendingPGs final : public DaemonHealthMetricCollector {
   vector<DaemonKey> osds;
 };
 
+class CephFSMirrorFailure final : public DaemonHealthMetricCollector {
+  bool _is_relevant(daemon_metric type) const override {
+    return type == daemon_metric::CEPHFS_MIRROR_FAILURE;
+  }
+  health_check_t& _get_check(health_check_map_t& cm) const override {
+    return cm.get_or_add("CEPHFS_MIRROR_FAILURE", HEALTH_WARN, "", 1);
+  }
+  bool _update(const DaemonKey& daemon,
+               const DaemonHealthMetric& metric) override {
+    auto failed_count = metric.get_n1();
+    auto failed_time = metric.get_n2();
+    value.n1 += failed_count;
+    value.n2 = std::max(value.n2, failed_time);
+    if (failed_count || failed_time) {
+      daemons.push_back(daemon);
+      return true;
+    } else {
+      return false;
+    }
+  }
+  void _summarize(health_check_t& check) const override {
+    if (daemons.empty()) {
+      return;
+    }
+    ostringstream ss;
+    if (daemons.size() > 1) {
+      if (daemons.size() > 10) {
+        ss << "daemons " << vector<DaemonKey>(daemons.begin(), daemons.begin()+10) << "..."
+           << " failed";
+      } else {
+        ss << "daemons " << daemons << " failed";
+      }
+    } else {
+      ss <<  daemons.front() << " failed";
+    }
+    check.summary =
+        fmt::format("{} mirroring enable failures, most recently reported at {} sec, {}",
+                    value.n1, value.n2, ss.str());
+  }
+  vector<DaemonKey> daemons;
+};
+
+class CephFSMirrorSnapSyncFailure final : public DaemonHealthMetricCollector {
+  bool _is_relevant(daemon_metric type) const override {
+    return type == daemon_metric::CEPHFS_MIRROR_SNAP_SYNC_FAILURE;
+  }
+  health_check_t& _get_check(health_check_map_t& cm) const override {
+    return cm.get_or_add("CEPHFS_MIRROR_SNAP_SYNC_FAILURE", HEALTH_WARN, "", 1);
+  }
+  bool _update(const DaemonKey& daemon,
+               const DaemonHealthMetric& metric) override {
+    auto failed_count = metric.get_n1();
+    auto failed_time = metric.get_n2();
+    value.n1 += failed_count;
+    value.n2 = std::max(value.n2, failed_time);
+    if (failed_count || failed_time) {
+      daemons.push_back(daemon);
+      return true;
+    } else {
+      return false;
+    }
+  }
+  void _summarize(health_check_t& check) const override {
+    if (daemons.empty()) {
+      return;
+    }
+    ostringstream ss;
+    if (daemons.size() > 1) {
+      if (daemons.size() > 10) {
+        ss << "daemons " << vector<DaemonKey>(daemons.begin(), daemons.begin()+10) << "..."
+           << " failed to sync directory(s)";
+      } else {
+        ss << "daemons " << daemons << " failed to sync directory(s)";
+      }
+    } else {
+      ss <<  daemons.front() << " failed to sync directory(s)";
+    }
+    check.summary =
+        fmt::format("{} mirroring directory sync failures, most recently reported at {} sec, {}",
+                    value.n1, value.n2, ss.str());
+  }
+  vector<DaemonKey> daemons;
+};
+
 } // anonymous namespace
 
 unique_ptr<DaemonHealthMetricCollector>
@@ -103,6 +187,10 @@ DaemonHealthMetricCollector::create(daemon_metric m)
     return std::make_unique<SlowOps>();
   case daemon_metric::PENDING_CREATING_PGS:
     return std::make_unique<PendingPGs>();
+  case daemon_metric::CEPHFS_MIRROR_FAILURE:
+    return std::make_unique<CephFSMirrorFailure>();
+  case daemon_metric::CEPHFS_MIRROR_SNAP_SYNC_FAILURE:
+    return std::make_unique<CephFSMirrorSnapSyncFailure>();
   default:
     return {};
   }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -793,8 +793,9 @@ bool DaemonServer::handle_report(const ref_t<MMgrReport>& m)
         update_task_status(key, *m->task_status);
         daemon->last_service_beacon = now;
       }
-      if (m->get_connection()->peer_is_osd() || m->get_connection()->peer_is_mon()) {
-        // only OSD and MON send health_checks to me now
+      if (m->get_connection()->peer_is_osd() || m->get_connection()->peer_is_mon() ||
+          (m->get_connection()->peer_is_client() && daemon->service_daemon &&
+           daemon->key.type == "cephfs-mirror")) {
         daemon->daemon_health_metrics = std::move(m->daemon_health_metrics);
         dout(10) << "daemon_health_metrics " << daemon->daemon_health_metrics
                  << dendl;
@@ -3236,7 +3237,7 @@ void DaemonServer::send_report()
     });
 
   std::map<daemon_metric, unique_ptr<DaemonHealthMetricCollector>> accumulated;
-  for (auto service : {"osd", "mon"} ) {
+  for (auto service : {"osd", "mon", "cephfs-mirror"} ) {
     auto daemons = daemon_state.get_by_service(service);
     for (const auto& [key,state] : daemons) {
       std::lock_guard l{state->lock};

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -848,8 +848,9 @@ bool DaemonServer::handle_report(const ref_t<MMgrReport>& m)
         update_task_status(key, *m->task_status);
         daemon->last_service_beacon = now;
       }
-      if (m->get_connection()->peer_is_osd() || m->get_connection()->peer_is_mon()) {
-        // only OSD and MON send health_checks to me now
+      if (m->get_connection()->peer_is_osd() || m->get_connection()->peer_is_mon() ||
+          (m->get_connection()->peer_is_client() && daemon->service_daemon &&
+           daemon->key.type == "cephfs-mirror")) {
         daemon->daemon_health_metrics = std::move(m->daemon_health_metrics);
         dout(10) << "daemon_health_metrics " << daemon->daemon_health_metrics
                  << dendl;
@@ -3341,7 +3342,7 @@ void DaemonServer::send_report()
     });
 
   std::map<daemon_metric, unique_ptr<DaemonHealthMetricCollector>> accumulated;
-  for (auto service : {"osd", "mon"} ) {
+  for (auto service : {"osd", "mon", "cephfs-mirror"} ) {
     auto daemons = daemon_state.get_by_service(service);
     for (const auto& [key,state] : daemons) {
       std::lock_guard l{state->lock};

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -38,8 +38,6 @@ namespace mirror {
 
 namespace {
 
-const std::string SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY("mirroring_failed");
-
 class SafeTimerSingleton : public CommonSafeTimer<ceph::mutex> {
 public:
   ceph::mutex timer_lock = ceph::make_mutex("cephfs::mirror::timer_lock");

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -48,9 +48,6 @@ public:
 private:
   inline static const std::string PRIMARY_SNAP_ID_KEY = "primary_snap_id";
 
-  inline static const std::string SERVICE_DAEMON_FAILED_DIR_COUNT_KEY = "failure_count";
-  inline static const std::string SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY = "recovery_count";
-
   using Snapshot = std::pair<std::string, uint64_t>;
 
   // file descriptor "triplet" for synchronizing a snapshot

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -64,9 +64,6 @@ public:
 private:
   inline static const std::string PRIMARY_SNAP_ID_KEY = "primary_snap_id";
 
-  inline static const std::string SERVICE_DAEMON_FAILED_DIR_COUNT_KEY = "failure_count";
-  inline static const std::string SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY = "recovery_count";
-
   using Snapshot = std::pair<std::string, uint64_t>;
 
   // file descriptor "triplet" for synchronizing a snapshot

--- a/src/tools/cephfs_mirror/ServiceDaemon.cc
+++ b/src/tools/cephfs_mirror/ServiceDaemon.cc
@@ -56,6 +56,10 @@ ServiceDaemon::~ServiceDaemon() {
       dout(5) << ": canceling timer task=" << m_timer_ctx << dendl;
       m_timer->cancel_event(m_timer_ctx);
     }
+    if (m_health_timer_ctx != nullptr) {
+      dout(5) << ": canceling health timer task=" << m_health_timer_ctx << dendl;
+      m_timer->cancel_event(m_health_timer_ctx);
+    }
     m_timer->shutdown();
   }
 
@@ -78,6 +82,9 @@ int ServiceDaemon::init() {
   if (r < 0) {
     return r;
   }
+
+  std::scoped_lock timer_lock(m_timer_lock);
+  schedule_health_tick();
   return 0;
 }
 
@@ -221,6 +228,66 @@ void ServiceDaemon::update_status() {
     derr << ": failed to update service daemon status: " << cpp_strerror(r)
          << dendl;
   }
+}
+
+std::vector<DaemonHealthMetric> ServiceDaemon::get_health_metrics() {
+  std::vector<DaemonHealthMetric> health_metrics;
+  {
+    std::scoped_lock locker(m_lock);
+    for (auto &[fscid, filesystem] : m_filesystems) {
+      for (auto &[attr_name, attr_value] : filesystem.fs_attributes) {
+        if (attr_name == SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY) {
+          bool failed = std::get<bool>(attr_value);
+          if (failed) {
+            health_metrics.emplace_back(daemon_metric::CEPHFS_MIRROR_FAILURE,
+                                        failed, ceph_clock_now());
+          }
+        }
+      }
+      for (auto &[peer, attributes] : filesystem.peer_attributes) {
+        uint64_t failed_dir_count = 0;
+        uint64_t recovered_dir_count = 0;
+        for (auto &[attr_name, attr_value] : attributes) {
+          if (attr_name == SERVICE_DAEMON_FAILED_DIR_COUNT_KEY) {
+            failed_dir_count = std::get<uint64_t>(attr_value);
+          } else if (attr_name == SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY) {
+            recovered_dir_count = std::get<uint64_t>(attr_value);
+          }
+        }
+        uint64_t count = failed_dir_count - recovered_dir_count;
+        if (count > 0) {
+          health_metrics.emplace_back(daemon_metric::CEPHFS_MIRROR_SNAP_SYNC_FAILURE,
+                                      count, ceph_clock_now());
+        }
+      }
+    }
+  }
+  return health_metrics;
+}
+
+void ServiceDaemon::schedule_health_tick() {
+  ceph_assert(ceph_mutex_is_locked(m_timer_lock));
+  if (m_health_timer_ctx != nullptr) {
+    return;
+  }
+  m_health_timer_ctx = new LambdaContext([this] {
+    m_health_timer_ctx = nullptr;
+    health_tick();
+  });
+
+  auto interval = m_cct->_conf.get_val<std::chrono::seconds>("cephfs_mirror_health_tick_interval");
+  m_timer->add_event_after(interval, m_health_timer_ctx);
+}
+
+void ServiceDaemon::health_tick() {
+  dout(20) << dendl;
+  int r = m_rados->service_daemon_update_health(get_health_metrics());
+  if (r < 0) {
+    derr << ": failed to update mirror daemon health: " << cpp_strerror(r)
+         << dendl;
+  }
+
+  schedule_health_tick();
 }
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/ServiceDaemon.h
+++ b/src/tools/cephfs_mirror/ServiceDaemon.h
@@ -12,6 +12,10 @@
 namespace cephfs {
 namespace mirror {
 
+const std::string SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY("mirroring_failed");
+const std::string SERVICE_DAEMON_FAILED_DIR_COUNT_KEY = "failure_count";
+const std::string SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY = "recovery_count";
+
 class ServiceDaemon {
 public:
   ServiceDaemon(CephContext *cct, RadosRef rados);
@@ -54,6 +58,8 @@ private:
 
   void schedule_update_status();
   void update_status();
+  std::vector<DaemonHealthMetric> get_health_metrics();
+  void update_health();
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/ServiceDaemon.h
+++ b/src/tools/cephfs_mirror/ServiceDaemon.h
@@ -12,6 +12,10 @@
 namespace cephfs {
 namespace mirror {
 
+const std::string SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY("mirroring_failed");
+const std::string SERVICE_DAEMON_FAILED_DIR_COUNT_KEY = "failure_count";
+const std::string SERVICE_DAEMON_RECOVERED_DIR_COUNT_KEY = "recovery_count";
+
 class ServiceDaemon {
 public:
   ServiceDaemon(CephContext *cct, RadosRef rados);
@@ -51,9 +55,13 @@ private:
   ceph::mutex m_lock = ceph::make_mutex("cephfs::mirror::service_daemon");
   Context *m_timer_ctx = nullptr;
   std::map<fs_cluster_id_t, Filesystem> m_filesystems;
+  Context *m_health_timer_ctx = nullptr;
 
   void schedule_update_status();
   void update_status();
+  std::vector<DaemonHealthMetric> get_health_metrics();
+  void schedule_health_tick();
+  void health_tick();
 };
 
 } // namespace mirror


### PR DESCRIPTION
This PR ensures that cephfs-mirror health warnings are properly surfaced in the cluster status and resolves related performance counter bugs causing CI timeouts.

**Implements Health Reporting**: Adds  `cephfs_mirror_health_tick_interval` to reliably propagate `CEPHFS_MIRROR_FAILURE` and `CEPHFS_MIRROR_SNAP_SYNC_FAILURE` metrics to the manager.

**Adds QA Validation**: Introduces specific tests for both init and sync failures, and updates the suite's log-ignorelist to pass expected cluster warnings.

Fixes: https://tracker.ceph.com/issues/68927






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>