### PR TITLE
tentacle: qa/suites/rados/thrash-old-clients: Add OSD warnings to ignore list

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -38,3 +38,5 @@ overrides:
       - pg degraded
       - PG_BACKFILL_FULL
       - Low space hindering backfill .*? backfill_toofull
+      - OSD_HOST_DOWN
+      - OSD_ROOT_DOWN


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72819

---

backport of https://github.com/ceph/ceph/pull/64603
parent tracker: https://tracker.ceph.com/issues/70972

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh