### PR TITLE
tentacle: cmake: remove _FORTIFY_SOURCE define

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,14 +196,6 @@ endif()
 
 include(CheckCCompilerFlag)
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-  CHECK_C_COMPILER_FLAG("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" HAS_FORTIFY_SOURCE)
-  if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-    if(HAS_FORTIFY_SOURCE)
-      add_definitions(
-        -U_FORTIFY_SOURCE
-        -D_FORTIFY_SOURCE=2)
-    endif()
-  endif()
     CHECK_C_COMPILER_FLAG(-fstack-protector-strong HAS_STACK_PROTECT)
     if (HAS_STACK_PROTECT)
       add_compile_options(-fstack-protector-strong)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72859

---

backport of https://github.com/ceph/ceph/pull/65371
parent tracker: https://tracker.ceph.com/issues/72361

This backport was staged using copy and paste because I have never gotten the backport script to work