### PR TITLE
mds: uninline methods to reduce header dependencies and compile times

### DIFF
--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -23,6 +23,7 @@
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/BackTrace.h"
 #include "common/debug.h"
+#include "common/Formatter.h"
 #include "common/safe_io.h"
 #include "common/version.h"
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -18,7 +18,6 @@
 #include "include/compat.h"
 #include "mdstypes.h"
 
-#include "mon/MonClient.h"
 #include "osdc/Objecter.h"
 #include "MDSRank.h"
 #include "MDSMap.h"

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13,6 +13,7 @@
  */
 
 #include "MDCache.h"
+#include "Mutation.h"
 #include "RetryMessage.h"
 #include "RetryRequest.h"
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -37,8 +37,9 @@
 #include "StrayManager.h"
 #include "OpenFileTable.h"
 #include "MDSContext.h"
-#include "Mutation.h"
 #include "LogSegmentRef.h"
+
+#include <boost/intrusive_ptr.hpp>
 
 class EMetaBlob;
 class MCacheExpire;
@@ -67,6 +68,11 @@ class Migrator;
 class Session;
 
 class ESubtreeMap;
+
+struct MutationImpl;
+struct MDRequestImpl;
+typedef boost::intrusive_ptr<MutationImpl> MutationRef;
+typedef boost::intrusive_ptr<MDRequestImpl> MDRequestRef;
 
 enum {
   l_mdc_first = 3000,

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -16,6 +16,7 @@
 #include "osdc/Journaler.h"
 
 #include <typeinfo>
+#include "common/DecayCounter.h"
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/fair_mutex.h"
@@ -34,6 +35,7 @@
 
 #include "mgr/MgrClient.h"
 
+#include "Beacon.h"
 #include "MDCache.h"
 #include "MDLog.h"
 #include "MDSDaemon.h"
@@ -898,6 +900,15 @@ MDSTableServer *MDSRank::get_table_server(int t)
   }
 }
 
+MDSMap::DaemonState MDSRank::get_want_state() const
+{
+  return beacon.get_want_state();
+}
+
+uint64_t MDSRank::get_global_id() const {
+  return monc->get_global_id();
+}
+
 void MDSRank::suicide()
 {
   if (suicide_hook) {
@@ -941,6 +952,11 @@ void MDSRank::damaged_unlocked()
 {
   std::lock_guard l(mds_lock);
   damaged();
+}
+
+double MDSRank::last_cleared_laggy() const
+{
+  return beacon.last_cleared_laggy();
 }
 
 void MDSRank::handle_write_error(int err)

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -19,19 +19,16 @@
 #include <string_view>
 
 #include "common/admin_socket.h" // for asok_finisher
-#include "common/DecayCounter.h"
 #include "common/LogClient.h"
 #include "common/TrackedOp.h" // for class OpTracker
 
 #include "include/common_fwd.h"
 
-#include "Beacon.h"
 #include "DamageTable.h"
 #include "MDSMap.h"
 #include "SessionMap.h"
 #include "PurgeQueue.h"
 #include "MetricsHandler.h"
-#include "mon/MonClient.h"
 
 // Full .h import instead of forward declaration for PerfCounter, for the
 // benefit of those including this header and using MDSRank::logger
@@ -39,6 +36,7 @@
 
 #include <boost/intrusive_ptr.hpp>
 
+class DecayCounter;
 class MDSContext;
 class MDSMetaRequest;
 class MMDSMap;
@@ -134,6 +132,7 @@ namespace ceph {
 template <class Mutex>
 class CommonSafeTimer;
 
+class Beacon;
 class Locker;
 class MDCache;
 class MDLog;
@@ -209,7 +208,7 @@ class MDSRank {
     Session *get_session(const cref_t<Message> &m);
 
     MDSMap::DaemonState get_state() const { return state; } 
-    MDSMap::DaemonState get_want_state() const { return beacon.get_want_state(); } 
+    MDSMap::DaemonState get_want_state() const;
 
     bool is_creating() const { return state == MDSMap::STATE_CREATING; }
     bool is_starting() const { return state == MDSMap::STATE_STARTING; }
@@ -259,9 +258,7 @@ class MDSRank {
       progress_thread.signal();
     }
 
-    uint64_t get_global_id() const {
-      return monc->get_global_id();
-    }
+    uint64_t get_global_id() const;
 
     // Daemon lifetime functions: these guys break the abstraction
     // and call up into the parent MDSDaemon instance.  It's kind
@@ -308,9 +305,7 @@ class MDSRank {
      */
     void damaged_unlocked();
 
-    double last_cleared_laggy() const {
-      return beacon.last_cleared_laggy();
-    }
+    double last_cleared_laggy() const;
 
     double get_dispatch_queue_max_age(utime_t now) const;
 

--- a/src/mds/MDSRankQuiesce.cc
+++ b/src/mds/MDSRankQuiesce.cc
@@ -12,6 +12,7 @@
 
 #include "MDSRank.h"
 #include "MDCache.h"
+#include "mon/MonClient.h"
 
 #include "QuiesceDbManager.h"
 #include "QuiesceAgent.h"

--- a/src/mds/MDSTableClient.cc
+++ b/src/mds/MDSTableClient.cc
@@ -16,6 +16,7 @@
 #include "MDSMap.h"
 
 #include "MDSContext.h"
+#include "mds_table_types.h"
 #include "RetryMessage.h"
 #include "msg/Messenger.h"
 

--- a/src/mds/MDSTableClient.h
+++ b/src/mds/MDSTableClient.h
@@ -17,8 +17,7 @@
 
 #include "include/buffer.h"
 #include "include/types.h"
-#include "mds_table_types.h"
-#include "mdstypes.h" // for mds_rank_t
+#include "include/cephfs/types.h" // for mds_rank_t
 #include "common/ref.h" // for cref_t
 #include "LogSegmentRef.h"
 

--- a/src/mds/MDSTableServer.cc
+++ b/src/mds/MDSTableServer.cc
@@ -21,12 +21,64 @@
 #include "events/ETableServer.h"
 #include "common/debug.h"
 
+#include "messages/MMDSTableRequest.h"
+
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << rank << ".tableserver(" << get_mdstable_name(table) << ") "
 
 using namespace std;
+
+struct MDSTableServer::notify_info_t {
+  notify_info_t() {}
+  std::set<mds_rank_t> notify_ack_gather;
+  mds_rank_t mds;
+  ref_t<MMDSTableRequest> reply = NULL;
+  MDSContext *onfinish = nullptr;
+};
+
+MDSTableServer::MDSTableServer(MDSRank *m, int tab) :
+    MDSTable(m, get_mdstable_name(tab), false), table(tab) {}
+
+MDSTableServer::~MDSTableServer() = default;
+
+MDSTableServer::MDSTableServer(const MDSTableServer &) = default;
+MDSTableServer &MDSTableServer::operator=(const MDSTableServer &) = default;
+
+void MDSTableServer::_note_prepare(mds_rank_t mds, uint64_t reqid, bool replay) {
+  version++;
+  if (replay)
+    projected_version = version;
+  pending_for_mds[version].mds = mds;
+  pending_for_mds[version].reqid = reqid;
+  pending_for_mds[version].tid = version;
+}
+
+void MDSTableServer::_note_commit(uint64_t tid, bool replay) {
+  version++;
+  if (replay)
+    projected_version = version;
+  pending_for_mds.erase(tid);
+}
+
+void MDSTableServer::_note_rollback(uint64_t tid, bool replay) {
+  version++;
+  if (replay)
+    projected_version = version;
+  pending_for_mds.erase(tid);
+}
+
+void MDSTableServer::_note_server_update(bufferlist& bl, bool replay) {
+  version++;
+  if (replay)
+    projected_version = version;
+}
+
+void MDSTableServer::reset_state() {
+  pending_for_mds.clear();
+  ++version;
+}
 
 void MDSTableServer::handle_request(const cref_t<MMDSTableRequest> &req)
 {
@@ -295,6 +347,16 @@ void MDSTableServer::_do_server_recovery()
     mds->send_message_mds(reply, p);
   }
   recovered = true;
+}
+
+void MDSTableServer::encode_state(bufferlist& bl) const {
+  encode_server_state(bl);
+  encode(pending_for_mds, bl);
+}
+
+void MDSTableServer::decode_state(bufferlist::const_iterator& bl) {
+  decode_server_state(bl);
+  decode(pending_for_mds, bl);
 }
 
 void MDSTableServer::finish_recovery(set<mds_rank_t>& active)

--- a/src/mds/MDSTableServer.h
+++ b/src/mds/MDSTableServer.h
@@ -22,19 +22,21 @@
 #include "mdstypes.h" // for mds_table_pending_t
 #include "mds_table_types.h" // for get_mdstable_name()
 
-#include "messages/MMDSTableRequest.h"
-
 #include "common/ref.h" // for cref_t
 
 class MDSContext;
+class MMDSTableRequest;
 
 class MDSTableServer : public MDSTable {
 public:
   friend class C_ServerRecovery;
 
-  MDSTableServer(MDSRank *m, int tab) :
-    MDSTable(m, get_mdstable_name(tab), false), table(tab) {}
-  ~MDSTableServer() override {}
+  MDSTableServer(MDSRank *m, int tab);
+  ~MDSTableServer();
+
+  // required by DencoderImplFeatureful::copy()
+  MDSTableServer(const MDSTableServer &);
+  MDSTableServer &operator=(const MDSTableServer &);
 
   virtual void handle_query(const cref_t<MMDSTableRequest> &m) = 0;
   virtual void _prepare(const bufferlist &bl, uint64_t reqid, mds_rank_t bymds, bufferlist& out) = 0;
@@ -44,36 +46,12 @@ public:
   virtual void _server_update(bufferlist& bl) { ceph_abort(); }
   virtual bool _notify_prep(version_t tid) { return false; };
 
-  void _note_prepare(mds_rank_t mds, uint64_t reqid, bool replay=false) {
-    version++;
-    if (replay)
-      projected_version = version;
-    pending_for_mds[version].mds = mds;
-    pending_for_mds[version].reqid = reqid;
-    pending_for_mds[version].tid = version;
-  }
-  void _note_commit(uint64_t tid, bool replay=false) {
-    version++;
-    if (replay)
-      projected_version = version;
-    pending_for_mds.erase(tid);
-  }
-  void _note_rollback(uint64_t tid, bool replay=false) {
-    version++;
-    if (replay)
-      projected_version = version;
-    pending_for_mds.erase(tid);
-  }
-  void _note_server_update(bufferlist& bl, bool replay=false) {
-    version++;
-    if (replay)
-      projected_version = version;
-  }
+  void _note_prepare(mds_rank_t mds, uint64_t reqid, bool replay=false);
+  void _note_commit(uint64_t tid, bool replay=false);
+  void _note_rollback(uint64_t tid, bool replay=false);
+  void _note_server_update(bufferlist& bl, bool replay=false);
 
-  void reset_state() override {
-    pending_for_mds.clear();
-    ++version;
-  }
+  void reset_state() override;
 
   void handle_request(const cref_t<MMDSTableRequest> &m);
   void do_server_update(bufferlist& bl);
@@ -81,14 +59,8 @@ public:
   virtual void encode_server_state(bufferlist& bl) const = 0;
   virtual void decode_server_state(bufferlist::const_iterator& bl) = 0;
 
-  void encode_state(bufferlist& bl) const override {
-    encode_server_state(bl);
-    encode(pending_for_mds, bl);
-  }
-  void decode_state(bufferlist::const_iterator& bl) override {
-    decode_server_state(bl);
-    decode(pending_for_mds, bl);
-  }
+  void encode_state(bufferlist& bl) const override;
+  void decode_state(bufferlist::const_iterator& bl) override;
 
   // recovery
   void finish_recovery(std::set<mds_rank_t>& active);
@@ -101,13 +73,7 @@ protected:
   bool recovered = false;
   std::set<mds_rank_t> active_clients;
 private:
-  struct notify_info_t {
-    notify_info_t() {}
-    std::set<mds_rank_t> notify_ack_gather;
-    mds_rank_t mds;
-    ref_t<MMDSTableRequest> reply = NULL;
-    MDSContext *onfinish = nullptr;
-  };
+  struct notify_info_t;
 
   friend class C_Prepare;
   friend class C_Commit;

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -77,6 +77,7 @@ public:
 
   // -- cons --
   Migrator(MDSRank *m, MDCache *c);
+  ~Migrator() noexcept;
 
   static std::string_view get_export_statename(int s) {
     switch (s) {
@@ -118,68 +119,25 @@ public:
   int get_export_queue_size() const { return export_queue.size(); }
   
   // -- status --
-  int is_exporting(CDir *dir) const {
-    auto it = export_state.find(dir);
-    if (it != export_state.end()) return it->second.state;
-    return 0;
-  }
+  int is_exporting(CDir *dir) const;
   bool is_exporting() const { return !export_state.empty(); }
-  int is_importing(dirfrag_t df) const {
-    auto it = import_state.find(df);
-    if (it != import_state.end()) return it->second.state;
-    return 0;
-  }
+  int is_importing(dirfrag_t df) const;
   bool is_importing() const { return !import_state.empty(); }
 
-  bool is_ambiguous_import(dirfrag_t df) const {
-    auto it = import_state.find(df);
-    if (it == import_state.end())
-      return false;
-    if (it->second.state >= IMPORT_LOGGINGSTART &&
-	it->second.state < IMPORT_ABORTING)
-      return true;
-    return false;
-  }
+  bool is_ambiguous_import(dirfrag_t df) const;
 
-  int get_import_state(dirfrag_t df) const {
-    auto it = import_state.find(df);
-    ceph_assert(it != import_state.end());
-    return it->second.state;
-  }
-  int get_import_peer(dirfrag_t df) const {
-    auto it = import_state.find(df);
-    ceph_assert(it != import_state.end());
-    return it->second.peer;
-  }
-
-  int get_export_state(CDir *dir) const {
-    auto it = export_state.find(dir);
-    ceph_assert(it != export_state.end());
-    return it->second.state;
-  }
+  int get_import_state(dirfrag_t df) const;
+  int get_import_peer(dirfrag_t df) const;
+  int get_export_state(CDir *dir) const;
   // this returns true if we are export @dir,
   // and are not waiting for @who to be
   // be warned of ambiguous auth.
   // only returns meaningful results during EXPORT_WARNING state.
-  bool export_has_warned(CDir *dir, mds_rank_t who) {
-    auto it = export_state.find(dir);
-    ceph_assert(it != export_state.end());
-    ceph_assert(it->second.state == EXPORT_WARNING);
-    return (it->second.warning_ack_waiting.count(who) == 0);
-  }
+  bool export_has_warned(CDir *dir, mds_rank_t who);
 
-  bool export_has_notified(CDir *dir, mds_rank_t who) const {
-    auto it = export_state.find(dir);
-    ceph_assert(it != export_state.end());
-    ceph_assert(it->second.state == EXPORT_NOTIFYING);
-    return (it->second.notify_ack_waiting.count(who) == 0);
-  }
+  bool export_has_notified(CDir *dir, mds_rank_t who) const;
 
-  void export_freeze_inc_num_waiters(CDir *dir) {
-    auto it = export_state.find(dir);
-    ceph_assert(it != export_state.end());
-    it->second.num_remote_waiters++;
-  }
+  void export_freeze_inc_num_waiters(CDir *dir);
   void find_stale_export_freeze();
 
   // -- misc --
@@ -270,65 +228,10 @@ protected:
   };
 
   // export fun
-  struct export_state_t {
-    export_state_t() {}
-
-    void set_state(int s) {
-      ceph_assert(s != state);
-      if (state != EXPORT_CANCELLED) {
-	auto& t = state_history.at(state);
-	t.second = double(ceph_clock_now()) - double(t.first);
-      }
-      state = s;
-      state_history[state] = std::pair<utime_t, double>(ceph_clock_now(), 0.0);
-    }
-    utime_t get_start_time(int s) const {
-      ceph_assert(state_history.count(s) > 0);
-      return state_history.at(s).first;
-    }
-    double get_time_spent(int s) const {
-      ceph_assert(state_history.count(s) > 0);
-      const auto& t = state_history.at(s);
-      return s == state ? double(ceph_clock_now()) - double(t.first) : t.second;
-    }
-    double get_freeze_tree_time() const {
-      ceph_assert(state >= EXPORT_DISCOVERING);
-      ceph_assert(state_history.count((int)EXPORT_DISCOVERING) > 0);
-      return double(ceph_clock_now()) - double(state_history.at((int)EXPORT_DISCOVERING).first);
-    };
-
-    int state = EXPORT_CANCELLED;
-    mds_rank_t peer = MDS_RANK_NONE;
-    uint64_t tid = 0;
-    std::set<mds_rank_t> warning_ack_waiting;
-    std::set<mds_rank_t> notify_ack_waiting;
-    std::map<inodeno_t,std::map<client_t,Capability::Import> > peer_imported;
-    MutationRef mut;
-    size_t approx_size = 0;
-    // record the start time and time spent of each export state
-    std::map<int, std::pair<utime_t, double> > state_history;
-    // record the clients whose sessions need to be flushed
-    std::set<client_t> export_client_set;
-    // for freeze tree deadlock detection
-    utime_t last_cum_auth_pins_change;
-    int last_cum_auth_pins = 0;
-    int num_remote_waiters = 0; // number of remote authpin waiters
-    std::shared_ptr<export_base_t> parent;
-  };
+  struct export_state_t;
 
   // import fun
-  struct import_state_t {
-    import_state_t() : mut() {}
-    int state = 0;
-    mds_rank_t peer = 0;
-    uint64_t tid = 0;
-    std::set<mds_rank_t> bystanders;
-    std::list<dirfrag_t> bound_ls;
-    std::list<ScatterLock*> updated_scatterlocks;
-    std::map<client_t,std::pair<Session*,uint64_t> > session_map;
-    std::map<CInode*, std::map<client_t,Capability::Export> > peer_exports;
-    MutationRef mut;
-  };
+  struct import_state_t;
 
   typedef std::map<CDir*, export_state_t>::iterator export_state_iterator;
 

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -19,6 +19,8 @@
 #include "CDentry.h"
 #include "CInode.h"
 #include "CDir.h"
+#include "messages/MClientRequest.h"
+#include "messages/MMDSPeerRequest.h"
 
 using namespace std;
 
@@ -287,6 +289,15 @@ void MutationImpl::_dump_op_descriptor(ostream& stream) const
 }
 
 // MDRequestImpl
+
+MDRequestImpl::Params::Params() = default;
+MDRequestImpl::Params::~Params() noexcept = default;
+
+MDRequestImpl::MDRequestImpl(const Params* params, OpTracker *tracker) :
+  MutationImpl(tracker, params->initiated,
+	       params->reqid, params->attempt, params->peer_to),
+  item_session_request(this), client_request(params->client_req),
+  internal_op(params->internal_op) {}
 
 MDRequestImpl::~MDRequestImpl()
 {

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -36,8 +36,6 @@
 
 #include "common/StackStringStream.h"
 #include "common/TrackedOp.h"
-#include "messages/MClientRequest.h"
-#include "messages/MMDSPeerRequest.h"
 
 class LogSegment;
 class BatchOp;
@@ -51,6 +49,9 @@ class ScatterLock;
 class SimpleLock;
 struct sr_t;
 struct MDLockCache;
+class Message;
+class MClientRequest;
+class MMDSPeerRequest;
 
 struct MutationImpl : public TrackedOp {
 public:
@@ -365,7 +366,8 @@ struct MDRequestImpl : public MutationImpl {
   // ---------------------------------------------------
   struct Params {
     // keep these default values synced to MutationImpl's
-    Params() {}
+    Params();
+    ~Params() noexcept;
     const utime_t& get_recv_stamp() const {
       return initiated;
     }
@@ -391,11 +393,7 @@ struct MDRequestImpl : public MutationImpl {
     int internal_op = -1;
     bool continuous = false;
   };
-  MDRequestImpl(const Params* params, OpTracker *tracker) :
-    MutationImpl(tracker, params->initiated,
-		 params->reqid, params->attempt, params->peer_to),
-    item_session_request(this), client_request(params->client_req),
-    internal_op(params->internal_op) {}
+  MDRequestImpl(const Params* params, OpTracker *tracker);
   ~MDRequestImpl() override;
   
   More* more();

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -15,7 +15,6 @@
 #ifndef PURGE_QUEUE_H_
 #define PURGE_QUEUE_H_
 
-#include "mds/mdstypes.h"
 #include "common/Finisher.h"
 #include "common/snap_types.h" // for class SnapContext
 #include "include/cephfs/types.h" // for mds_rank_t

--- a/src/mds/SnapClient.cc
+++ b/src/mds/SnapClient.cc
@@ -145,6 +145,46 @@ void SnapClient::notify_commit(version_t tid)
   }
 }
 
+void SnapClient::prepare_create(inodeno_t dirino, std::string_view name, utime_t stamp,
+				version_t *pstid, bufferlist *pbl, MDSContext *onfinish) {
+  bufferlist bl;
+  __u32 op = TABLE_OP_CREATE;
+  encode(op, bl);
+  encode(dirino, bl);
+  encode(name, bl);
+  encode(stamp, bl);
+  _prepare(bl, pstid, pbl, onfinish);
+}
+
+void SnapClient::prepare_create_realm(inodeno_t ino, version_t *pstid, bufferlist *pbl, MDSContext *onfinish) {
+  bufferlist bl;
+  __u32 op = TABLE_OP_CREATE;
+  encode(op, bl);
+  encode(ino, bl);
+  _prepare(bl, pstid, pbl, onfinish);
+}
+
+void SnapClient::prepare_destroy(inodeno_t ino, snapid_t snapid, version_t *pstid, bufferlist *pbl, MDSContext *onfinish) {
+  bufferlist bl;
+  __u32 op = TABLE_OP_DESTROY;
+  encode(op, bl);
+  encode(ino, bl);
+  encode(snapid, bl);
+  _prepare(bl, pstid, pbl, onfinish);
+}
+
+void SnapClient::prepare_update(inodeno_t ino, snapid_t snapid, std::string_view name, utime_t stamp,
+				version_t *pstid, MDSContext *onfinish) {
+  bufferlist bl;
+  __u32 op = TABLE_OP_UPDATE;
+  encode(op, bl);
+  encode(ino, bl);
+  encode(snapid, bl);
+  encode(name, bl);
+  encode(stamp, bl);
+  _prepare(bl, pstid, NULL, onfinish);
+}
+
 void SnapClient::refresh(version_t want, MDSContext *onfinish)
 {
   dout(10) << __func__ << " want " << want << dendl;

--- a/src/mds/SnapClient.h
+++ b/src/mds/SnapClient.h
@@ -39,44 +39,14 @@ public:
   void notify_commit(version_t tid) override;
 
   void prepare_create(inodeno_t dirino, std::string_view name, utime_t stamp,
-		      version_t *pstid, bufferlist *pbl, MDSContext *onfinish) {
-    bufferlist bl;
-    __u32 op = TABLE_OP_CREATE;
-    encode(op, bl);
-    encode(dirino, bl);
-    encode(name, bl);
-    encode(stamp, bl);
-    _prepare(bl, pstid, pbl, onfinish);
-  }
+		      version_t *pstid, bufferlist *pbl, MDSContext *onfinish);
 
-  void prepare_create_realm(inodeno_t ino, version_t *pstid, bufferlist *pbl, MDSContext *onfinish) {
-    bufferlist bl;
-    __u32 op = TABLE_OP_CREATE;
-    encode(op, bl);
-    encode(ino, bl);
-    _prepare(bl, pstid, pbl, onfinish);
-  }
+  void prepare_create_realm(inodeno_t ino, version_t *pstid, bufferlist *pbl, MDSContext *onfinish);
 
-  void prepare_destroy(inodeno_t ino, snapid_t snapid, version_t *pstid, bufferlist *pbl, MDSContext *onfinish) {
-    bufferlist bl;
-    __u32 op = TABLE_OP_DESTROY;
-    encode(op, bl);
-    encode(ino, bl);
-    encode(snapid, bl);
-    _prepare(bl, pstid, pbl, onfinish);
-  }
+  void prepare_destroy(inodeno_t ino, snapid_t snapid, version_t *pstid, bufferlist *pbl, MDSContext *onfinish);
 
   void prepare_update(inodeno_t ino, snapid_t snapid, std::string_view name, utime_t stamp,
-		      version_t *pstid, MDSContext *onfinish) {
-    bufferlist bl;
-    __u32 op = TABLE_OP_UPDATE;
-    encode(op, bl);
-    encode(ino, bl);
-    encode(snapid, bl);
-    encode(name, bl);
-    encode(stamp, bl);
-    _prepare(bl, pstid, NULL, onfinish);
-  }
+		      version_t *pstid, MDSContext *onfinish);
 
   version_t get_cached_version() const { return cached_version; }
   void refresh(version_t want, MDSContext *onfinish);

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -15,6 +15,7 @@
 #include "SnapRealm.h"
 #include "CInode.h"
 #include "CDentry.h"
+#include "CDir.h"
 #include "MDCache.h"
 #include "MDSRank.h"
 #include "SnapClient.h"

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -14,6 +14,7 @@
 
 #include "SnapServer.h"
 #include "MDSRank.h"
+#include "snap.h"
 #include "osd/OSDMap.h"
 #include "osdc/Objecter.h"
 
@@ -33,6 +34,12 @@
 #define dout_prefix *_dout << "mds." << rank << ".snap "
 
 using namespace std;
+
+SnapServer::SnapServer(MDSRank *m, MonClient *monc)
+  : MDSTableServer(m, TABLE_SNAP), mon_client(monc) {}
+SnapServer::SnapServer() : MDSTableServer(NULL, TABLE_SNAP) {}
+
+SnapServer::~SnapServer() noexcept = default;
 
 void SnapServer::reset_state()
 {
@@ -69,6 +76,50 @@ void SnapServer::reset_state()
   MDSTableServer::reset_state();
 }
 
+void SnapServer::encode_server_state(bufferlist& bl) const {
+  ENCODE_START(5, 3, bl);
+  encode(last_snap, bl);
+  encode(snaps, bl);
+  encode(need_to_purge, bl);
+  encode(pending_update, bl);
+  encode(pending_destroy, bl);
+  encode(pending_noop, bl);
+  encode(last_created, bl);
+  encode(last_destroyed, bl);
+  encode(snaprealm_v2_since, bl);
+  ENCODE_FINISH(bl);
+}
+
+void SnapServer::decode_server_state(bufferlist::const_iterator& bl) {
+  DECODE_START_LEGACY_COMPAT_LEN(5, 3, 3, bl);
+  decode(last_snap, bl);
+  decode(snaps, bl);
+  decode(need_to_purge, bl);
+  decode(pending_update, bl);
+  if (struct_v >= 2)
+    decode(pending_destroy, bl);
+  else {
+    std::map<version_t, snapid_t> t;
+    decode(t, bl);
+    for (auto& [ver, snapid] : t) {
+      pending_destroy[ver].first = snapid;
+    }
+  }
+  decode(pending_noop, bl);
+  if (struct_v >= 4) {
+    decode(last_created, bl);
+    decode(last_destroyed, bl);
+  } else {
+    last_created = last_snap;
+    last_destroyed = last_snap;
+  }
+  if (struct_v >= 5)
+    decode(snaprealm_v2_since, bl);
+  else
+    snaprealm_v2_since = CEPH_NOSNAP;
+
+  DECODE_FINISH(bl);
+}
 
 // SERVER
 
@@ -362,6 +413,10 @@ void SnapServer::check_osd_map(bool force)
   }
 
   last_checked_osdmap = version;
+}
+
+bool SnapServer::can_allow_multimds_snaps() const {
+  return snaps.empty() || snaps.begin()->first >= snaprealm_v2_since;
 }
 
 void SnapServer::handle_remove_snaps(const cref_t<MRemoveSnaps> &m)

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -16,7 +16,6 @@
 #include "MDSRank.h"
 #include "osd/OSDMap.h"
 #include "osdc/Objecter.h"
-#include "mon/MonClient.h"
 
 #include "include/types.h"
 #include "messages/MMDSTableRequest.h"

--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -20,19 +20,19 @@
 #include <set>
 
 #include "MDSTableServer.h"
-#include "snap.h"
 #include "include/encoding.h"
 #include "include/object.h" // for struct snapid_t
 
 class MDSRank;
 class MRemoveSnaps;
 class MonClient;
+struct SnapInfo;
 
 class SnapServer : public MDSTableServer {
 public:
-  SnapServer(MDSRank *m, MonClient *monc)
-    : MDSTableServer(m, TABLE_SNAP), mon_client(monc) {}
-  SnapServer() : MDSTableServer(NULL, TABLE_SNAP) {}
+  SnapServer(MDSRank *m, MonClient *monc);
+  SnapServer();
+  ~SnapServer() noexcept;
 
   void handle_remove_snaps(const cref_t<MRemoveSnaps> &m);
 
@@ -58,9 +58,7 @@ public:
 
   void check_osd_map(bool force);
 
-  bool can_allow_multimds_snaps() const {
-    return snaps.empty() || snaps.begin()->first >= snaprealm_v2_since;
-  }
+  bool can_allow_multimds_snaps() const;
 
   void encode(bufferlist& bl) const {
     encode_server_state(bl);
@@ -76,49 +74,8 @@ public:
 		    std::map<snapid_t, SnapInfo>& _snaps);
 
 protected:
-  void encode_server_state(bufferlist& bl) const override {
-    ENCODE_START(5, 3, bl);
-    encode(last_snap, bl);
-    encode(snaps, bl);
-    encode(need_to_purge, bl);
-    encode(pending_update, bl);
-    encode(pending_destroy, bl);
-    encode(pending_noop, bl);
-    encode(last_created, bl);
-    encode(last_destroyed, bl);
-    encode(snaprealm_v2_since, bl);
-    ENCODE_FINISH(bl);
-  }
-  void decode_server_state(bufferlist::const_iterator& bl) override {
-    DECODE_START_LEGACY_COMPAT_LEN(5, 3, 3, bl);
-    decode(last_snap, bl);
-    decode(snaps, bl);
-    decode(need_to_purge, bl);
-    decode(pending_update, bl);
-    if (struct_v >= 2)
-      decode(pending_destroy, bl);
-    else {
-      std::map<version_t, snapid_t> t;
-      decode(t, bl);
-      for (auto& [ver, snapid] : t) {
-	pending_destroy[ver].first = snapid;
-      }
-    }
-    decode(pending_noop, bl);
-    if (struct_v >= 4) {
-      decode(last_created, bl);
-      decode(last_destroyed, bl);
-    } else {
-      last_created = last_snap;
-      last_destroyed = last_snap;
-    }
-    if (struct_v >= 5)
-      decode(snaprealm_v2_since, bl);
-    else
-      snaprealm_v2_since = CEPH_NOSNAP;
-
-    DECODE_FINISH(bl);
-  }
+  void encode_server_state(bufferlist& bl) const override;
+  void decode_server_state(bufferlist::const_iterator& bl) override;
 
   // server bits
   void _prepare(const bufferlist &bl, uint64_t reqid, mds_rank_t bymds, bufferlist &out) override;

--- a/src/mds/snap.h
+++ b/src/mds/snap.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <string_view>
 
-#include "mdstypes.h"
 #include "common/snap_types.h"
 #include "include/buffer.h"
 #include "include/object.h" // for snapid_t

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -26,6 +26,7 @@
 #include "mds/CInode.h"
 #include "mds/CDentry.h"
 #include "mds/InoTable.h"
+#include "mds/snap.h" // for struct sr_t
 #include "mds/SnapServer.h"
 #include "cls/cephfs/cls_cephfs_client.h"
 


### PR DESCRIPTION
Another PR split from https://github.com/ceph/ceph/pull/60490

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
