### PR TITLE
seastore: misc cleanups, coroutine conversions

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1192,7 +1192,8 @@ CachedExtentRef Cache::duplicate_for_write(
     // deepcopy the buffer of exist clean extent beacuse it shares
     // buffer with original clean extent.
     auto bp = i->get_bptr();
-    auto nbp = ceph::bufferptr(bp.c_str(), bp.length());
+    auto nbp = ceph::bufferptr(buffer::create_page_aligned(bp.length()));
+    bp.copy_out(0, bp.length(), nbp.c_str());
     i->set_bptr(std::move(nbp));
 
     t.add_mutated_extent(i);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1227,7 +1227,10 @@ public:
       // shallow copy the buffer from original extent
       auto remap_offset = remap_laddr.get_byte_distance<
 	extent_len_t>(original_laddr);
-      auto nbp = ceph::bufferptr(*original_bptr, remap_offset, remap_length);
+
+      auto nbp = ceph::bufferptr(buffer::create_page_aligned(remap_length));
+      original_bptr->copy_out(remap_offset, remap_length, nbp.c_str());
+
       // ExtentPlacementManager::alloc_new_extent will make a new
       // (relative/temp) paddr, so make extent directly
       ext = CachedExtent::make_cached_extent_ref<T>(std::move(nbp));

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1685,11 +1685,6 @@ private:
 
   ExtentPinboardRef pinboard;
 
-  struct query_counters_t {
-    uint64_t access = 0;
-    uint64_t hit = 0;
-  };
-
   btree_cursor_stats_t cursor_stats;
   struct invalid_trans_efforts_t {
     io_stat_t read;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -235,10 +235,10 @@ private:
   // create and append the read-hole to
   // load_ranges_t and bl
   static void create_hole_append_bl(
-      load_ranges_t& ret,
-      ceph::bufferlist& bl,
-      extent_len_t hole_offset,
-      extent_len_t hole_length) {
+    load_ranges_t& ret,
+    ceph::bufferlist& bl,
+    extent_len_t hole_offset,
+    extent_len_t hole_length) {
     ceph::bufferptr hole_ptr = create_extent_ptr_rand(hole_length);
     bl.append(hole_ptr);
     ret.push_back(hole_offset, std::move(hole_ptr));
@@ -248,10 +248,10 @@ private:
   // and append to load_ranges_t
   // returns the iterator containing the inserted read-hole
   auto create_hole_insert_map(
-      load_ranges_t& ret,
-      extent_len_t hole_offset,
-      extent_len_t hole_length,
-      const map_t::const_iterator& next_it) {
+    load_ranges_t& ret,
+    extent_len_t hole_offset,
+    extent_len_t hole_length,
+    const map_t::const_iterator& next_it) {
     assert(!buffer_map.contains(hole_offset));
     ceph::bufferlist bl;
     create_hole_append_bl(ret, bl, hole_offset, hole_length);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -529,6 +529,8 @@ public:
     paddr_t base, const ceph::bufferlist &bl) = 0;
 
   /**
+   * complete_load
+   *
    * Called on dirty CachedExtent implementation after replay.
    * Implementation should perform any reads/in-memory-setup
    * necessary. (for instance, the lba implementation will use this

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -39,19 +39,13 @@ using RBMDevice = random_block_device::RBMDevice;
  *
  * - Commit time
  * After submit_record is done, written_to is increased(this in-memory value)
- * ---written_to represents where the new record will be appended. Note that
- * applied_to is not changed here.
+ * ---written_to represents where the new record will be appended.
  *
  * - Replay time
  * At replay time, CBJournal begins to replay records in CBjournal by reading
  * records from dirty_tail. Then, CBJournal examines whether the records is valid
  * one by one, at which point written_to is recovered
- * if the valid record is founded. Note that applied_to is stored
- * permanently when the apply work---applying the records in CBJournal to RBM---
- * is done by CBJournal (TODO).
- *
- * TODO: apply records from CircularBoundedJournal to RandomBlockManager
- *
+ * if the valid record is founded.
  */
 
 constexpr uint64_t DEFAULT_BLOCK_SIZE = 4096;

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -23,6 +23,8 @@
 #include "crimson/os/seastore/journal/circular_journal_space.h"
 #include "crimson/os/seastore/record_scanner.h"
 
+using namespace std::literals;
+
 namespace crimson::os::seastore::journal {
 
 using RBMDevice = random_block_device::RBMDevice;
@@ -223,6 +225,20 @@ private:
   // the sequence to written records
   CircularJournalSpace cjs;
   RecordSubmitter record_submitter; 
+
+  struct {
+    uint64_t submit_record_count = 0;
+    uint64_t submit_record_size = 0;
+    std::chrono::duration<double> submit_record_latency_total = 0.0s;
+
+    uint64_t submit_record_roll_count = 0;
+    std::chrono::duration<double> submit_record_roll_latency_total = 0.0s;
+
+    uint64_t submit_record_wait_count = 0;
+    std::chrono::duration<double> submit_record_wait_latency_total = 0.0s;
+  } stats;
+  seastar::metrics::metric_group metrics;
+  void register_metrics();
 };
 
 }

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -156,11 +156,6 @@ public:
     cbj_delta_handler_t &&delta_handler,
     journal_seq_t tail);
 
-  submit_record_ertr::future<> do_submit_record(
-    record_t &&record,
-    OrderingHandle &handle,
-    on_submission_func_t &&on_submission);
-
   void try_read_rolled_header(scan_valid_records_cursor &cursor) {
     paddr_t addr = convert_abs_addr_to_paddr(
       get_records_start(),

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -47,9 +47,6 @@ template <> struct fmt::formatter<crimson::os::seastore::op_type_t>
     case op_type_t::READ:
       name = "read";
       break;
-    case op_type_t::WRITE:
-      name = "write";
-      break;
     case op_type_t::GET_ATTR:
       name = "get_attr";
       break;
@@ -158,7 +155,6 @@ void SeaStore::Shard::register_metrics()
   std::pair<op_type_t, sm::label_instance> labels_by_op_type[] = {
     {op_type_t::DO_TRANSACTION,   sm::label_instance("latency", "DO_TRANSACTION")},
     {op_type_t::READ,             sm::label_instance("latency", "READ")},
-    {op_type_t::WRITE,            sm::label_instance("latency", "WRITE")},
     {op_type_t::GET_ATTR,         sm::label_instance("latency", "GET_ATTR")},
     {op_type_t::GET_ATTRS,        sm::label_instance("latency", "GET_ATTRS")},
     {op_type_t::STAT,             sm::label_instance("latency", "STAT")},

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -245,60 +245,6 @@ public:
 
     static void on_error(ceph::os::Transaction &t);
 
-    template <typename F>
-    auto repeat_with_internal_context(
-      CollectionRef ch,
-      ceph::os::Transaction &&t,
-      Transaction::src_t src,
-      const char* tname,
-      op_type_t op_type,
-      F &&f) {
-      // The below repeat_io_num requires MUTATE
-      assert(src == Transaction::src_t::MUTATE);
-      return seastar::do_with(
-        internal_context_t(
-          ch, std::move(t),
-          transaction_manager->create_transaction(
-	    src, tname, t.get_fadvise_flags())),
-        std::forward<F>(f),
-        [this, op_type](auto &ctx, auto &f) {
-        assert(shard_stats.starting_io_num);
-        --(shard_stats.starting_io_num);
-        ++(shard_stats.waiting_collock_io_num);
-
-	return ctx.transaction->get_handle().take_collection_lock(
-	  static_cast<SeastoreCollection&>(*(ctx.ch)).ordering_lock
-	).then([this] {
-	  assert(shard_stats.waiting_collock_io_num);
-	  --(shard_stats.waiting_collock_io_num);
-	  ++(shard_stats.waiting_throttler_io_num);
-
-	  return throttler.get(1);
-	}).then([&, this] {
-	  assert(shard_stats.waiting_throttler_io_num);
-	  --(shard_stats.waiting_throttler_io_num);
-	  ++(shard_stats.processing_inlock_io_num);
-
-	  return repeat_eagain([&, this] {
-	    ++(shard_stats.repeat_io_num);
-
-	    ctx.reset_preserve_handle(*transaction_manager);
-	    return std::invoke(f, ctx);
-	  }).handle_error(
-	    crimson::ct_error::all_same_way([&ctx](auto e) {
-	      on_error(ctx.ext_transaction);
-	      return seastar::now();
-	    })
-	  );
-	}).then([this, op_type, &ctx] {
-	  add_latency_sample(op_type,
-	      std::chrono::steady_clock::now() - ctx.begin_timestamp);
-	}).finally([this] {
-	  throttler.put();
-	});
-      });
-    }
-
     template <typename Ret, typename F>
     auto repeat_with_onode(
       CollectionRef ch,

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -38,7 +38,6 @@ class TransactionManager;
 enum class op_type_t : uint8_t {
     DO_TRANSACTION = 0,
     READ,
-    WRITE,
     GET_ATTR,
     GET_ATTRS,
     STAT,

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -562,79 +562,67 @@ TransactionManager::do_submit_transaction(
 {
   LOG_PREFIX(TransactionManager::do_submit_transaction);
   SUBDEBUGT(seastore_t, "start, entering ool_writes", tref);
-  return trans_intr::make_interruptible(
+  co_await trans_intr::make_interruptible(
     tref.get_handle().enter(write_pipeline.ool_writes_and_lba_updates)
-  ).then_interruptible([this, FNAME, &tref,
-			dispatch_result = std::move(dispatch_result)] {
-    return seastar::do_with(std::move(dispatch_result),
-			    [this, FNAME, &tref](auto &dispatch_result) {
-      SUBTRACET(seastore_t, "write delayed ool extents", tref);
-      return epm->write_delayed_ool_extents(tref, dispatch_result.alloc_map
-      ).handle_error_interruptible(
-        crimson::ct_error::input_output_error::pass_further(),
-        crimson::ct_error::assert_all("invalid error")
-      );
-    });
-  }).si_then([&tref, FNAME, this] {
-    return seastar::do_with(
-      tref.get_valid_pre_alloc_list(),
-      [this, FNAME, &tref](auto &allocated_extents) {
-      return update_lba_mappings(tref, allocated_extents
-      ).si_then([this, FNAME, &tref, &allocated_extents] {
-        auto num_extents = allocated_extents.size();
-        SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
-        return epm->write_preallocated_ool_extents(tref, allocated_extents
-        ).handle_error_interruptible(
-          crimson::ct_error::input_output_error::pass_further(),
-          crimson::ct_error::assert_all("invalid error")
-        );
-      });
-    });
-  }).si_then([this, FNAME, &tref] {
-    SUBTRACET(seastore_t, "entering prepare", tref);
-    return tref.get_handle().enter(write_pipeline.prepare);
-  }).si_then([this, FNAME, &tref, trim_alloc_to=std::move(trim_alloc_to)]() mutable
-	      -> submit_transaction_iertr::future<> {
-    if (trim_alloc_to && *trim_alloc_to != JOURNAL_SEQ_NULL) {
-      SUBTRACET(seastore_t, "trim backref_bufs to {}", tref, *trim_alloc_to);
-      cache->trim_backref_bufs(*trim_alloc_to);
-    }
+  );
 
-    auto record = cache->prepare_record(
+  SUBTRACET(seastore_t, "write delayed ool extents", tref);
+  co_await epm->write_delayed_ool_extents(
+    tref, dispatch_result.alloc_map
+  );
+
+  auto allocated_extents = tref.get_valid_pre_alloc_list();
+  co_await update_lba_mappings(tref, allocated_extents);
+
+  auto num_extents = allocated_extents.size();
+  SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
+  co_await epm->write_preallocated_ool_extents(tref, allocated_extents);
+
+  SUBTRACET(seastore_t, "entering prepare", tref);
+  co_await trans_intr::make_interruptible(
+    tref.get_handle().enter(write_pipeline.prepare)
+  );
+
+  if (trim_alloc_to && *trim_alloc_to != JOURNAL_SEQ_NULL) {
+    SUBTRACET(seastore_t, "trim backref_bufs to {}", tref, *trim_alloc_to);
+    cache->trim_backref_bufs(*trim_alloc_to);
+  }
+
+  auto record = cache->prepare_record(
+    tref,
+    journal->get_trimmer().get_journal_head(),
+    journal->get_trimmer().get_dirty_tail());
+
+  tref.get_handle().maybe_release_collection_lock();
+  if (tref.get_src() == Transaction::src_t::MUTATE) {
+    --(shard_stats.processing_inlock_io_num);
+    ++(shard_stats.processing_postlock_io_num);
+  }
+
+  SUBTRACET(seastore_t, "submitting record", tref);
+  co_await journal->submit_record(
+    std::move(record),
+    tref.get_handle(),
+    tref.get_src(),
+    [this, FNAME, &tref](record_locator_t submit_result) {
+    SUBDEBUGT(seastore_t, "committed with {}", tref, submit_result);
+    auto start_seq = submit_result.write_result.start_seq;
+    journal->get_trimmer().set_journal_head(start_seq);
+    cache->complete_commit(
       tref,
-      journal->get_trimmer().get_journal_head(),
-      journal->get_trimmer().get_dirty_tail());
-
-    tref.get_handle().maybe_release_collection_lock();
-    if (tref.get_src() == Transaction::src_t::MUTATE) {
-      --(shard_stats.processing_inlock_io_num);
-      ++(shard_stats.processing_postlock_io_num);
-    }
-
-    SUBTRACET(seastore_t, "submitting record", tref);
-    return journal->submit_record(
-      std::move(record),
-      tref.get_handle(),
-      tref.get_src(),
-      [this, FNAME, &tref](record_locator_t submit_result)
-    {
-      SUBDEBUGT(seastore_t, "committed with {}", tref, submit_result);
-      auto start_seq = submit_result.write_result.start_seq;
-      journal->get_trimmer().set_journal_head(start_seq);
-      cache->complete_commit(
-          tref,
-          submit_result.record_block_base,
-          start_seq);
-      journal->get_trimmer().update_journal_tails(
-	cache->get_oldest_dirty_from().value_or(start_seq),
-	cache->get_oldest_backref_dirty_from().value_or(start_seq));
-    }).safe_then([&tref] {
-      return tref.get_handle().complete();
+      submit_result.record_block_base,
+      start_seq);
+    journal->get_trimmer().update_journal_tails(
+      cache->get_oldest_dirty_from().value_or(start_seq),
+      cache->get_oldest_backref_dirty_from().value_or(start_seq));
     }).handle_error(
       submit_transaction_iertr::pass_further{},
       crimson::ct_error::assert_all{"Hit error submitting to journal"}
     );
-  });
+
+  co_await trans_intr::make_interruptible(
+    tref.get_handle().complete()
+  );
 }
 
 seastar::future<> TransactionManager::flush(OrderingHandle &handle)

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -14,6 +14,7 @@
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 #include <seastar/core/future.hh>
+#include <seastar/util/defer.hh>
 
 #include "include/ceph_assert.h"
 #include "include/buffer.h"

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -18,6 +18,8 @@
 #include "include/ceph_assert.h"
 #include "include/buffer.h"
 
+#include "crimson/common/coroutine.h"
+
 #include "crimson/osd/exceptions.h"
 
 #include "crimson/os/seastore/logging.h"
@@ -287,74 +289,62 @@ public:
     extent_len_t partial_len,
     lextent_init_func_t<T> maybe_init = [](T&) {})
   {
+    LOG_PREFIX(TransactionManager::read_pin);
     static_assert(is_logical_type(T::TYPE));
     assert(is_aligned(partial_off, get_block_size()));
     assert(is_aligned(partial_len, get_block_size()));
     // must be user-oriented required by maybe_init
     assert(is_user_transaction(t.get_src()));
 
-    return pin.refresh(
-    ).si_then([this, &t](auto npin) {
-      if (npin.is_indirect()) {
-	return lba_manager->complete_indirect_lba_mapping(
-	  t, std::move(npin));
-      } else {
-	return LBAManager::complete_lba_mapping_iertr::make_ready_future<
-	  LBAMapping>(std::move(npin));
+    pin = co_await pin.refresh();
+
+    if (pin.is_indirect()) {
+      pin = co_await lba_manager->complete_indirect_lba_mapping(
+	t, std::move(pin));
+    }
+
+    extent_len_t direct_partial_off = partial_off;
+    bool is_clone = pin.is_clone();
+    std::optional<indirect_info_t> maybe_indirect_info;
+    if (pin.is_indirect()) {
+      auto intermediate_offset = pin.get_intermediate_offset();
+      direct_partial_off = intermediate_offset + partial_off;
+      maybe_indirect_info = indirect_info_t{
+        intermediate_offset, pin.get_length()};
+    }
+
+    SUBDEBUGT(seastore_tm, "{} {} 0x{:x}~0x{:x} direct_off=0x{:x} ...",
+              t, T::TYPE, pin, partial_off, partial_len, direct_partial_off);
+
+
+    // checking the lba child must be atomic with creating
+    // and linking the absent child
+    auto ret = get_extent_if_linked<T>(t, std::move(pin));
+    TCachedExtentRef<T> extent;
+    if (ret.index() == 1) {
+      extent = co_await std::move(std::get<1>(ret));
+      extent = co_await cache->read_extent_maybe_partial(
+	t, std::move(extent), direct_partial_off, partial_len);
+      if (!extent->is_seen_by_users()) {
+	maybe_init(*extent);
+	extent->set_seen_by_users();
       }
-    }).si_then([&t, this, partial_off, partial_len,
-		maybe_init=std::move(maybe_init)](auto npin) mutable {
-
-      extent_len_t direct_partial_off = partial_off;
-      bool is_clone = npin.is_clone();
-      std::optional<indirect_info_t> maybe_indirect_info;
-      if (npin.is_indirect()) {
-	auto intermediate_offset = npin.get_intermediate_offset();
-	direct_partial_off = intermediate_offset + partial_off;
-	maybe_indirect_info = indirect_info_t{
-	  intermediate_offset, npin.get_length()};
-      }
-
-      LOG_PREFIX(TransactionManager::read_pin);
-      SUBDEBUGT(seastore_tm, "{} {} 0x{:x}~0x{:x} direct_off=0x{:x} ...",
-		t, T::TYPE, npin, partial_off, partial_len, direct_partial_off);
-
-      return [this, &t, npin, direct_partial_off, partial_len,
-	      maybe_init=std::move(maybe_init)]() mutable {
-	// checking the lba child must be atomic with creating
-	// and linking the absent child
-	auto ret = get_extent_if_linked<T>(t, std::move(npin));
-	if (ret.index() == 1) {
-	  return std::get<1>(ret
-	  ).si_then([direct_partial_off, partial_len, this, &t](auto extent) {
-	    return cache->read_extent_maybe_partial(
-	      t, std::move(extent), direct_partial_off, partial_len);
-	  }).si_then([maybe_init=std::move(maybe_init)](auto extent) {
-	    if (!extent->is_seen_by_users()) {
-	      maybe_init(*extent);
-	      extent->set_seen_by_users();
-	    }
-	    return std::move(extent);
-	  });
-	} else {
-	  auto &r = std::get<0>(ret);
-	  return this->pin_to_extent<T>(
-	    t, std::move(r.mapping), std::move(r.child_pos),
-	    direct_partial_off, partial_len,
-	    std::move(maybe_init));
-	}
-      }().si_then([FNAME, maybe_indirect_info, is_clone, &t](TCachedExtentRef<T> ext) {
-	if (maybe_indirect_info.has_value()) {
-	  SUBDEBUGT(seastore_tm, "got indirect +0x{:x}~0x{:x} is_clone={} {}",
-		    t, maybe_indirect_info->intermediate_offset,
-		    maybe_indirect_info->length, is_clone, *ext);
-	} else {
-	  SUBDEBUGT(seastore_tm, "got direct is_clone={} {}",
-		    t, is_clone, *ext);
-	}
-	return maybe_indirect_extent_t<T>{ext, maybe_indirect_info, is_clone};
-      });
-    });
+    } else {
+      auto &r = std::get<0>(ret);
+      extent = co_await this->pin_to_extent<T>(
+	t, std::move(r.mapping), std::move(r.child_pos),
+	direct_partial_off, partial_len,
+	std::move(maybe_init));
+    }
+    if (maybe_indirect_info.has_value()) {
+      SUBDEBUGT(seastore_tm, "got indirect +0x{:x}~0x{:x} is_clone={} {}",
+		t, maybe_indirect_info->intermediate_offset,
+		maybe_indirect_info->length, is_clone, *extent);
+    } else {
+      SUBDEBUGT(seastore_tm, "got direct is_clone={} {}",
+		t, is_clone, *extent);
+    }
+    co_return maybe_indirect_extent_t<T>{extent, maybe_indirect_info, is_clone};
   }
 
   template <typename T>

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -198,7 +198,10 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
   }
 
   seastar::future<> tear_down_fut() final {
-    return close();
+    return close(
+    ).then([this] {
+      cbj.reset();
+    });
   }
 
   extent_t generate_extent(size_t blocks) {


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
