### PR TITLE
tentacle: uadk: Build with ceph fork (for FORTIFY_SOURCE fix)

### DIFF
--- a/cmake/modules/Builduadk.cmake
+++ b/cmake/modules/Builduadk.cmake
@@ -20,7 +20,7 @@ function(build_uadk)
         UPDATE_COMMAND "" # this disables rebuild on each run
         GIT_REPOSITORY "https://github.com/ceph/uadk.git"
         GIT_CONFIG advice.detachedHead=false
-        GIT_TAG 19f650cae960304e3c674992a4c7d5d56a8f4efa
+        GIT_TAG 267cf34617cc5d6af63191464db40eefcfb78448
         SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/uadk"
         BUILD_IN_SOURCE 1
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=which g++


### PR DESCRIPTION
See https://github.com/ceph/ceph/pull/65371


(cherry picked from commit c52e361fdd311b54b34a83c4ca0e826e2d360087)
