### PR TITLE
reef: pybind/mgr/dashboard: Use teuthology's actual requirements

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -47,7 +47,15 @@ setup_teuthology() {
     ${TEUTHOLOGY_PYTHON_BIN:-/usr/bin/python3} -m venv venv
     source venv/bin/activate
     pip install -U pip 'setuptools>=12,<60'
-    pip install "git+https://github.com/ceph/teuthology@9e4bf63#egg=teuthology[test]"
+
+    local TEUTH_REF="${TEUTH_REF:-3ae1592c30adc5875a8aeb1f50a30ed9dd04dc04}"
+    git clone https://github.com/ceph/teuthology
+    pushd teuthology
+    git checkout -q "$TEUTH_REF"
+    pip install -r requirements.txt
+    pip install -e '.[test]'
+    popd
+
     pushd $CURR_DIR
     pip install -r requirements.txt -c constraints.txt
     popd


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/65414

(cherry picked from commit 22a87d959bca74478de1e2d9f86859676385491d)