### PR TITLE
osd/scrub: clear m_ec_digest_map between objects

### DIFF
--- a/src/osd/scrubber/scrub_backend.cc
+++ b/src/osd/scrubber/scrub_backend.cc
@@ -881,6 +881,7 @@ std::optional<std::string> ScrubBackend::compare_obj_in_maps(
 {
   // clear per-object data:
   m_current_obj = object_scrub_data_t{};
+  this_chunk->m_ec_digest_map.clear();
 
   stringstream candidates_errors;
   auto auth_res = select_auth_object(ho, candidates_errors);


### PR DESCRIPTION
Fixing a bug introduced by commit 4c61079e931
("calculate EC digest map size only once").

Fixes: https://tracker.ceph.com/issues/72897

