### PR TITLE
crimson/os/seastore/object_data_handler: make sure continuous object data blocks are loaded with a single io request

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -417,9 +417,9 @@ public:
 	      PLACEMENT_HINT_NULL,
 	      NULL_GENERATION,
 	      TRANS_ID_NULL);
-    SUBDEBUG(seastore_cache,
+    SUBDEBUGT(seastore_cache,
 	"{} {}~0x{:x} is absent, add extent and reading range 0x{:x}~0x{:x} ... -- {}",
-	T::TYPE, offset, length, partial_off, partial_len, *ret);
+	t, T::TYPE, offset, length, partial_off, partial_len, *ret);
     add_extent(ret);
     extent_init_func(*ret);
     cache_access_stats_t& access_stats = get_by_ext(
@@ -1598,6 +1598,55 @@ public:
   void boot_done() {
     booting = false;
   }
+
+  template <typename T>
+  struct read_extent_t {
+    TCachedExtentRef<T> extent;
+    const extent_len_t offset = 0;
+    const extent_len_t length = 0;
+  };
+  template <typename T>
+  get_extent_iertr::future<> read_extents_maybe_partial(
+    Transaction &t,
+    std::vector<read_extent_t<T>> &&exts)
+  {
+    LOG_PREFIX(Cache::read_extents_maybe_partial);
+    auto extents = std::move(exts);
+    std::vector<get_extent_iertr::future<>> read_extent_futs;
+    std::vector<read_extent_t<T>> absent_extents;
+    for (auto &ext : extents) {
+      auto &extent = ext.extent;
+      SUBDEBUGT(seastore_cache, "reading extent {} 0x{:x}~0x{:x} ...",
+	       t, *extent, ext.offset, ext.length);
+      assert(is_aligned(ext.offset, get_block_size()));
+      assert(is_aligned(ext.length, get_block_size()));
+      assert(extent->get_paddr().is_absolute());
+      if (extent->is_range_loaded(ext.offset, ext.length)) {
+	// the range of the extent has already been loaded, just do wait_io
+	SUBDEBUG(seastore_cache, "extent loaded");
+	read_extent_futs.emplace_back(
+	  trans_intr::make_interruptible(
+	    extent->wait_io()
+	  ).then_interruptible([] { return get_extent_iertr::now(); }));
+	continue;
+      }
+      if (extent->is_pending_io()) {
+	// the extent is pending on an outstanding io,
+	// fallback to single extent loading
+	read_extent_futs.emplace_back(
+	  read_extent_maybe_partial(t, extent, ext.offset, ext.length
+	  ).discard_result());
+	continue;
+      }
+      assert(extent->state == CachedExtent::extent_state_t::EXIST_CLEAN ||
+	     extent->state == CachedExtent::extent_state_t::CLEAN);
+      absent_extents.emplace_back(ext);
+    }
+    co_await read_absent_extents_maybe_partial(t, std::move(absent_extents));
+    co_await trans_intr::parallel_for_each(
+      read_extent_futs, [](auto &fut) { return std::move(fut); });
+  }
+
 private:
   void touch_extent_fully(
       CachedExtent &ext,
@@ -1972,6 +2021,107 @@ private:
     ).safe_then([](auto extent) {
       return extent->template cast<T>();
     });
+  }
+
+  template <typename T>
+  get_extent_ertr::future<> read_absent_extents_maybe_partial(
+    Transaction &t,
+    std::vector<read_extent_t<T>> &&exts)
+  {
+    LOG_PREFIX(Cache::read_absent_extents_maybe_partial);
+    auto extents = std::move(exts);
+    struct range_to_read_t {
+      paddr_t addr = P_ADDR_NULL;
+      load_range_t range;
+    };
+    std::vector<range_to_read_t> ranges_to_read;
+    std::vector<TCachedExtentRef<T>> extents_read;
+    std::vector<get_extent_iertr::future<>> read_extent_futs;
+    const auto t_src = t.get_src();
+    // get all the ranges of extents that are to be loaded
+    for (auto &ext : extents) {
+      auto &extent = ext.extent;
+      SUBDEBUGT(seastore_cache, "reading extent {} 0x{:x}~0x{:x} ...",
+	       t, *extent, ext.offset, ext.length);
+      assert(extent->state == CachedExtent::extent_state_t::EXIST_CLEAN ||
+	     extent->state == CachedExtent::extent_state_t::CLEAN);
+      extents_read.emplace_back(extent);
+      extent->set_io_wait(extent->state);
+      auto old_length = extent->get_loaded_length();
+      load_ranges_t to_read = extent->load_ranges(ext.offset, ext.length);
+      auto new_length = extent->get_loaded_length();
+      assert(new_length > old_length);
+      pinboard->increase_cached_size(*extent, new_length - old_length, &t_src);
+      for (auto &range : to_read.ranges) {
+	auto range_paddr = extent->get_paddr() + range.offset;
+	ranges_to_read.emplace_back(range_to_read_t{range_paddr, range});
+      }
+    }
+    paddr_t off = P_ADDR_NULL;
+    extent_len_t len = 0;
+    std::vector<ExtentPlacementManager::read_ertr::future<>> futs;
+    std::vector<bufferptr> batch;
+    // load ranges that are successive in the paddr space with
+    // a single readv request
+    for (auto &range : ranges_to_read) {
+      if (off == P_ADDR_NULL) {
+	off = range.addr;
+	len += range.range.ptr.length();
+	batch.emplace_back(std::move(range.range.ptr));
+      } else if (off + len == range.addr) {
+	len += range.range.ptr.length();
+	batch.emplace_back(std::move(range.range.ptr));
+      } else {
+	futs.emplace_back(epm.readv(off, std::move(batch)));
+	len = range.range.ptr.length();
+	off = range.addr;
+	batch.emplace_back(std::move(range.range.ptr));
+      }
+    }
+    if (!batch.empty()) {
+      futs.emplace_back(epm.readv(off, std::move(batch)));
+      len = 0;
+      off = P_ADDR_NULL;
+    }
+
+    // TODO: when_all_succeed should be utilized here, however, it doesn't
+    // 	   actually work with interruptible errorated futures for now.
+    co_await ExtentPlacementManager::read_ertr::parallel_for_each(
+      futs, [](auto &fut) { return std::move(fut);
+    }).handle_error(
+      get_extent_ertr::pass_further{},
+      crimson::ct_error::assert_all{
+	"Cache::read_extent: invalid error"
+      }
+    );
+    for (auto &extent : extents_read) {
+      ceph_assert(extent->state == CachedExtent::extent_state_t::EXIST_CLEAN
+	|| extent->state == CachedExtent::extent_state_t::CLEAN
+	|| !extent->is_valid());
+      if (extent->is_valid()) {
+	if (extent->is_fully_loaded()) {
+	  // crc will be checked against LBA leaf entry for logical extents,
+	  // or check against in-extent crc for physical extents.
+	  if (epm.get_checksum_needed(extent->get_paddr())) {
+	    extent->last_committed_crc = extent->calc_crc32c();
+	  } else {
+	    extent->last_committed_crc = CRC_NULL;
+	  }
+	  // on_clean_read() may change the content,
+	  // call after calc_crc32c()
+	  extent->on_clean_read();
+	  SUBDEBUGT(seastore_cache, "read extent done -- {}", t, *extent);
+	} else {
+	  extent->last_committed_crc = CRC_NULL;
+	  SUBDEBUGT(seastore_cache,
+	    "read extent done (partial) -- {}", t, *extent);
+	}
+      } else {
+	SUBDEBUGT(seastore_cache,
+	  "read extent done (invalidated) -- {}", t, *extent);
+      }
+      extent->complete_io();
+    }
   }
 
   // Extents in cache may contain placeholders

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -155,6 +155,8 @@ public:
     size_t len,
     ceph::bufferptr &out) = 0;
 
+  virtual read_ertr::future<> readv(paddr_t addr, std::vector<bufferptr> vecs) = 0;
+
   read_ertr::future<ceph::bufferptr> read(
     paddr_t addr,
     size_t len

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -519,6 +519,13 @@ public:
     return devices_by_id[addr.get_device_id()]->read(addr, len, out);
   }
 
+  read_ertr::future<> readv(
+    paddr_t addr,
+    std::vector<bufferptr> ptrs) {
+    assert(devices_by_id[addr.get_device_id()] != nullptr);
+    return devices_by_id[addr.get_device_id()]->readv(addr, std::move(ptrs));
+  }
+
   void mark_space_used(paddr_t addr, extent_len_t len) {
     background_process.mark_space_used(addr, len);
   }

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -43,6 +43,21 @@ void ObjectDataBlock::apply_delta(const ceph::bufferlist &bl) {
 
 namespace crimson::os::seastore {
 
+struct guarded_object_data_t {
+  context_t ctx;
+  object_data_t object_data;
+  ~guarded_object_data_t() {
+    if (object_data.must_update()) {
+      ctx.onode.update_object_data(ctx.t, object_data);
+    }
+  }
+};
+
+guarded_object_data_t guard_object_data(context_t ctx)
+{
+  return guarded_object_data_t{ctx, ctx.onode.get_layout().object_data.get()};
+}
+
 template <typename F>
 auto with_object_data(
   ObjectDataHandler::context_t ctx,
@@ -1151,131 +1166,132 @@ ObjectDataHandler::read_ret ObjectDataHandler::read(
   objaddr_t obj_offset,
   extent_len_t len)
 {
-  return seastar::do_with(
-    bufferlist(),
-    [ctx, obj_offset, len](auto &ret) {
-    return with_object_data(
-      ctx,
-      [ctx, obj_offset, len, &ret](const auto &object_data) {
-      LOG_PREFIX(ObjectDataHandler::read);
-      DEBUGT("reading {}~0x{:x}",
-             ctx.t,
-             object_data.get_reserved_data_base(),
-             object_data.get_reserved_data_len());
-      /* Assumption: callers ensure that onode size is <= reserved
-       * size and that len is adjusted here prior to call */
-      ceph_assert(!object_data.is_null());
-      ceph_assert((obj_offset + len) <= object_data.get_reserved_data_len());
-      ceph_assert(len > 0);
-      laddr_offset_t l_start =
-        object_data.get_reserved_data_base() + obj_offset;
-      laddr_offset_t l_end = l_start + len;
-      laddr_t aligned_start = l_start.get_aligned_laddr(
-	ctx.tm.get_block_size());
-      loffset_t aligned_length =
-	  l_end.get_roundup_laddr(ctx.tm.get_block_size()).get_byte_distance<
-	    loffset_t>(aligned_start);
-      return ctx.tm.get_pins(
-        ctx.t,
-	aligned_start,
-	aligned_length
-      ).si_then([FNAME, ctx, l_start, l_end, &ret](auto _pins) {
-        // offset~len falls within reserved region and len > 0
-        ceph_assert(_pins.size() >= 1);
-        ceph_assert(_pins.front().get_key() <= l_start);
-        return seastar::do_with(
-          std::move(_pins),
-          l_start,
-          [FNAME, ctx, l_start, l_end, &ret](auto &pins, auto &l_current) {
-          return trans_intr::do_for_each(
-            pins,
-            [FNAME, ctx, l_start, l_end,
-             &l_current, &ret](auto &pin) -> read_iertr::future<> {
-            auto pin_start = pin.get_key();
-            extent_len_t read_start;
-            extent_len_t read_start_aligned;
-            if (l_current == l_start) { // first pin may skip head
-              ceph_assert(l_current.get_aligned_laddr(
-		ctx.tm.get_block_size()) >= pin_start);
-              read_start = l_current.template
-                get_byte_distance<extent_len_t>(pin_start);
-              read_start_aligned = p2align(read_start, ctx.tm.get_block_size());
-            } else { // non-first pin must match start
-              assert(l_current > l_start);
-              ceph_assert(l_current == pin_start);
-              read_start = 0;
-              read_start_aligned = 0;
-            }
+  LOG_PREFIX(ObjectDataHandler::read);
+  struct read_t : TransactionManager::read_pin_t<ObjectDataBlock> {
+    extent_len_t unaligned_start_offset = 0;
+    extent_len_t unaligned_len = 0;
+    read_t(
+      LBAMapping mapping,
+      extent_len_t aligned_off,
+      extent_len_t aligned_len,
+      extent_len_t unaligned_start_offset,
+      extent_len_t unaligned_len)
+      : read_pin_t(std::move(mapping), aligned_off, aligned_len),
+	unaligned_start_offset(unaligned_start_offset),
+	unaligned_len(unaligned_len) {}
+  };
+  auto ret = bufferlist();
+  auto rpins = std::vector<read_t>();
+  auto guarded_obj_data = guard_object_data(ctx);
+  auto &object_data = guarded_obj_data.object_data;
+  DEBUGT("reading {}~0x{:x}",
+	 ctx.t,
+	 object_data.get_reserved_data_base(),
+	 object_data.get_reserved_data_len());
+  /* Assumption: callers ensure that onode size is <= reserved
+   * size and that len is adjusted here prior to call */
+  ceph_assert(!object_data.is_null());
+  ceph_assert((obj_offset + len) <= object_data.get_reserved_data_len());
+  ceph_assert(len > 0);
+  laddr_offset_t l_start =
+    object_data.get_reserved_data_base() + obj_offset;
+  laddr_offset_t l_end = l_start + len;
+  laddr_t aligned_start = l_start.get_aligned_laddr(
+    ctx.tm.get_block_size());
+  loffset_t aligned_length =
+      l_end.get_roundup_laddr(ctx.tm.get_block_size()).get_byte_distance<
+	loffset_t>(aligned_start);
+  auto _pins = co_await ctx.tm.get_pins(
+    ctx.t,
+    aligned_start,
+    aligned_length);
+  // offset~len falls within reserved region and len > 0
+  ceph_assert(_pins.size() >= 1);
+  ceph_assert(_pins.front().get_key() <= l_start);
+  auto l_current = l_start;
+  for (auto &pin : _pins) {
+    auto pin_start = pin.get_key();
+    extent_len_t read_start;
+    extent_len_t read_start_aligned;
+    if (l_current == l_start) { // first pin may skip head
+      ceph_assert(l_current.get_aligned_laddr(
+	ctx.tm.get_block_size()) >= pin_start);
+      read_start = l_current.template
+	get_byte_distance<extent_len_t>(pin_start);
+      read_start_aligned = p2align(read_start, ctx.tm.get_block_size());
+    } else { // non-first pin must match start
+      assert(l_current > l_start);
+      ceph_assert(l_current == pin_start);
+      read_start = 0;
+      read_start_aligned = 0;
+    }
 
-            ceph_assert(l_current < l_end);
-            auto pin_len = pin.get_length();
-            assert(pin_len > 0);
-            laddr_offset_t pin_end = pin_start + pin_len;
-            assert(l_current < pin_end);
-            laddr_offset_t l_current_end = std::min(pin_end, l_end);
-            extent_len_t read_len =
-              l_current_end.get_byte_distance<extent_len_t>(l_current);
+    ceph_assert(l_current < l_end);
+    auto pin_len = pin.get_length();
+    assert(pin_len > 0);
+    laddr_offset_t pin_end = pin_start + pin_len;
+    assert(l_current < pin_end);
+    laddr_offset_t l_current_end = std::min(pin_end, l_end);
+    extent_len_t read_len =
+      l_current_end.get_byte_distance<extent_len_t>(l_current);
 
-            if (pin.get_val().is_zero()) {
-              DEBUGT("got {}~0x{:x} from zero-pin {}~0x{:x}",
-                ctx.t,
-                l_current,
-                read_len,
-                pin_start,
-                pin_len);
-              ret.append_zero(read_len);
-              l_current = l_current_end;
-              return seastar::now();
-            }
+    if (pin.get_val().is_zero()) {
+      DEBUGT("got {}~0x{:x} from zero-pin {}~0x{:x}",
+	ctx.t,
+	l_current,
+	read_len,
+	pin_start,
+	pin_len);
+      l_current = l_current_end;
+      rpins.emplace_back(pin, 0, 0, 0, read_len);
+      continue;
+    }
 
-            // non-zero pin
-            laddr_t l_current_end_aligned =
-	      l_current_end.get_roundup_laddr(ctx.tm.get_block_size());
-            extent_len_t read_len_aligned =
-              l_current_end_aligned.get_byte_distance<extent_len_t>(pin_start);
-            read_len_aligned -= read_start_aligned;
-            extent_len_t unalign_start_offset = read_start - read_start_aligned;
-            DEBUGT("reading {}~0x{:x} from pin {}~0x{:x}",
-              ctx.t,
-              l_current,
-              read_len,
-              pin_start,
-              pin_len);
-            return ctx.tm.read_pin<ObjectDataBlock>(
-              ctx.t,
-              std::move(pin),
-              read_start_aligned,
-              read_len_aligned
-            ).si_then([&ret, &l_current, l_current_end,
-                       read_start_aligned, read_len_aligned,
-                       unalign_start_offset, read_len](auto maybe_indirect_extent) {
-              auto aligned_bl = maybe_indirect_extent.get_range(
-                  read_start_aligned, read_len_aligned);
-              if (read_len < read_len_aligned) {
-                ceph::bufferlist unaligned_bl;
-                unaligned_bl.substr_of(
-                    aligned_bl, unalign_start_offset, read_len);
-                ret.append(std::move(unaligned_bl));
-              } else {
-                assert(read_len == read_len_aligned);
-                assert(unalign_start_offset == 0);
-                ret.append(std::move(aligned_bl));
-              }
-              l_current = l_current_end;
-              return seastar::now();
-            }).handle_error_interruptible(
-              read_iertr::pass_further{},
-              crimson::ct_error::assert_all{
-                "ObjectDataHandler::read hit invalid error"
-              }
-            );
-          }); // trans_intr::do_for_each()
-        }); // do_with()
-      });
-    }).si_then([&ret] { // with_object_data()
-      return std::move(ret);
-    });
-  }); // do_with()
+    // non-zero pin
+    laddr_t l_current_end_aligned =
+      l_current_end.get_roundup_laddr(ctx.tm.get_block_size());
+    extent_len_t read_len_aligned =
+      l_current_end_aligned.get_byte_distance<extent_len_t>(pin_start);
+    read_len_aligned -= read_start_aligned;
+    extent_len_t unalign_start_offset = read_start - read_start_aligned;
+    DEBUGT("reading {}~0x{:x} from pin {}~0x{:x}",
+      ctx.t,
+      l_current,
+      read_len,
+      pin_start,
+      pin_len);
+    rpins.emplace_back(
+      pin, read_start_aligned, read_len_aligned,
+      unalign_start_offset, read_len);
+    l_current = l_current_end;
+  }
+  co_await ctx.tm.read_pins<ObjectDataBlock>(ctx.t, rpins
+  ).handle_error_interruptible(
+    read_iertr::pass_further{},
+    crimson::ct_error::assert_all{
+      "ObjectDataHandler::read hit invalid error"
+    }
+  );
+  for (auto &pin : rpins) {
+    if (pin.mapping.is_zero_reserved()) {
+      ret.append_zero(pin.unaligned_len);
+      continue;
+    }
+    auto maybe_indirect_extent = pin.get_result();
+    auto aligned_bl = maybe_indirect_extent.get_range(
+	pin.partial_off, pin.partial_len);
+    if (pin.unaligned_len < pin.partial_len) {
+      ceph::bufferlist unaligned_bl;
+      unaligned_bl.substr_of(
+	  aligned_bl, pin.unaligned_start_offset, pin.unaligned_len);
+      ret.append(std::move(unaligned_bl));
+    } else {
+      assert(pin.unaligned_len == pin.partial_len);
+      assert(pin.unaligned_start_offset == 0);
+      ret.append(std::move(aligned_bl));
+    }
+  }
+  co_return std::move(ret);
 }
 
 ObjectDataHandler::fiemap_ret ObjectDataHandler::fiemap(

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -180,6 +180,41 @@ read_ertr::future<> NVMeBlockDevice::read(
     });
 }
 
+read_ertr::future<> NVMeBlockDevice::_readv(
+  uint64_t offset,
+  std::vector<bufferptr> ptrs) {
+  logger().debug(
+      "block: read offset {}, {} buffers",
+      offset,
+      ptrs.size());
+  if (ptrs.size() == 0) {
+    return read_ertr::now();
+  }
+
+  if (is_end_to_end_data_protection()) {
+    return nvme_readv(offset, std::move(ptrs));
+  }
+  std::vector<iovec> iov;
+  size_t length = 0;
+  for (auto &ptr : ptrs) {
+    length += ptr.length();
+    assert((ptr.length() % super.block_size) == 0);
+    iov.emplace_back(ptr.c_str(), ptr.length());
+  }
+  return device.dma_read(offset, std::move(iov)
+  ).handle_exception(
+    [](auto e) -> read_ertr::future<size_t> {
+      logger().error("read: dma_read got error{}", e);
+      return crimson::ct_error::input_output_error::make();
+    }).then([length](auto result) -> read_ertr::future<> {
+      if (result != length) {
+        logger().error("read: dma_read got error with not proper length");
+        return crimson::ct_error::input_output_error::make();
+      }
+      return read_ertr::now();
+    });
+}
+
 write_ertr::future<> NVMeBlockDevice::writev(
   uint64_t offset,
   ceph::bufferlist bl,
@@ -432,6 +467,30 @@ read_ertr::future<> NVMeBlockDevice::nvme_read(
 	ceph_abort();
       }
       return nvme_command_ertr::now();
+    });
+  });
+}
+
+read_ertr::future<> NVMeBlockDevice::nvme_readv(
+  uint64_t offset, std::vector<bufferptr> ptrs) {
+  struct io_t {
+    uint64_t offset = 0;
+    bufferptr ptr;
+  };
+  std::vector<io_t> iov;
+  size_t off = 0;
+  for (auto &ptr : ptrs) {
+    auto len = ptr.length();
+    iov.emplace_back(offset + off, std::move(ptr));
+    off += len;
+  }
+  return seastar::do_with(
+    std::move(iov),
+    [this](auto &iov) {
+    return read_ertr::parallel_for_each(
+      iov,
+      [this](auto &io) {
+      return nvme_read(io.offset, io.ptr.length(), io.ptr.c_str());
     });
   });
 }

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
@@ -228,9 +228,14 @@ public:
   read_ertr::future<> read(
     uint64_t offset,
     bufferptr &bptr) final;
+  read_ertr::future<> _readv(
+    uint64_t offset,
+    std::vector<bufferptr> ptrs) final;
 
   read_ertr::future<> nvme_read(
     uint64_t offset, size_t len, void *buffer_ptr);
+  read_ertr::future<> nvme_readv(
+    uint64_t offset, std::vector<bufferptr> ptrs);
 
   close_ertr::future<> close() override;
 

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -232,6 +232,24 @@ write_ertr::future<> EphemeralRBMDevice::write(
   return write_ertr::now();
 }
 
+read_ertr::future<> EphemeralRBMDevice::_readv(
+  uint64_t offset,
+  std::vector<bufferptr> ptrs) {
+  LOG_PREFIX(EphemeralRBMDevice::_readv);
+  ceph_assert(buf);
+  DEBUG(
+    "EphemeralRBMDevice: read offset {} {} buffers",
+    offset,
+    ptrs.size());
+
+  for (auto &ptr : ptrs) {
+    ptr.copy_in(0, ptr.length(), buf + offset);
+    offset += ptr.length();
+  }
+
+  return read_ertr::now();
+}
+
 read_ertr::future<> EphemeralRBMDevice::read(
   uint64_t offset,
   bufferptr &bptr) {

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -77,9 +77,19 @@ public:
     uint64_t rbm_addr = convert_paddr_to_abs_addr(addr);
     return read(rbm_addr, out);
   }
+  read_ertr::future<> readv(
+    paddr_t addr,
+    std::vector<bufferptr> ptrs) final {
+    uint64_t rbm_addr = convert_paddr_to_abs_addr(addr);
+    return _readv(rbm_addr, std::move(ptrs));
+  }
 protected:
   rbm_superblock_t super;
   rbm_shard_info_t shard_info;
+  virtual read_ertr::future<> _readv(
+    uint64_t offset,
+    std::vector<bufferptr> ptrs) = 0;
+
 public:
   RBMDevice() {}
   virtual ~RBMDevice() = default;
@@ -230,6 +240,9 @@ public:
   read_ertr::future<> read(
     uint64_t offset,
     bufferptr &bptr) override;
+  read_ertr::future<> _readv(
+    uint64_t offset,
+    std::vector<bufferptr> ptrs) override;
 
   close_ertr::future<> close() override;
 

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -167,6 +167,43 @@ static read_ertr::future<> do_read(
   });
 }
 
+static read_ertr::future<> do_readv(
+  device_id_t device_id,
+  seastar::file &device,
+  uint64_t offset,
+  std::vector<bufferptr> ptrs)
+{
+  LOG_PREFIX(block_do_readv);
+  std::vector<iovec> iov;
+  size_t len = 0;
+  for (auto &ptr : ptrs) {
+    iov.emplace_back(ptr.c_str(), ptr.length());
+    len += ptr.length();
+  }
+  TRACE("{} poffset=0x{:x}~0x{:x} {} buffers",
+    device_id_printer_t{device_id}, offset, len, ptrs.size());
+  return device.dma_read(offset, std::move(iov)
+  ).handle_exception(
+    //FIXME: this is a little bit tricky, since seastar::future<T>::handle_exception
+    //	returns seastar::future<T>, to return an crimson::ct_error, we have to create
+    //	a seastar::future<T> holding that crimson::ct_error. This is not necessary
+    //	once seastar::future<T>::handle_exception() returns seastar::futurize_t<T>
+    [FNAME, device_id, offset, len](auto e) -> read_ertr::future<size_t>
+  {
+    ERROR("{} poffset=0x{:x}~0x{:x} got error -- {}",
+          device_id_printer_t{device_id}, offset, len, e);
+    return crimson::ct_error::input_output_error::make();
+  }).then([FNAME, device_id, offset, len](auto result) -> read_ertr::future<> {
+    if (result != len) {
+      ERROR("{} poffset=0x{:x}~0x{:x} read len=0x{:x} inconsistent",
+            device_id_printer_t{device_id}, offset, len, result);
+      return crimson::ct_error::input_output_error::make();
+    }
+    TRACE("{} poffset=0x{:x}~0x{:x} done", device_id_printer_t{device_id}, offset, len);
+    return read_ertr::now();
+  });
+}
+
 write_ertr::future<>
 SegmentStateTracker::write_out(
   device_id_t device_id,
@@ -639,6 +676,58 @@ SegmentManager::release_ertr::future<> BlockSegmentManager::release(
   return tracker->write_out(
       get_device_id(), device,
       shard_info.tracker_offset);
+}
+
+SegmentManager::read_ertr::future<> BlockSegmentManager::readv(
+  paddr_t addr,
+  std::vector<bufferptr> ptrs)
+{
+  LOG_PREFIX(BlockSegmentManager::readv);
+  size_t len = 0;
+  for (auto &ptr : ptrs) {
+    len += ptr.length();
+  }
+  auto& seg_addr = addr.as_seg_paddr();
+  auto id = seg_addr.get_segment_id();
+  auto s_id = id.device_segment_id();
+  auto s_off = seg_addr.get_segment_off();
+  auto p_off = get_offset(addr);
+  DEBUG("{} offset=0x{:x}~0x{:x} poffset=0x{:x} ...", id, s_off, len, p_off);
+
+  assert(addr.get_device_id() == get_device_id());
+
+  if (s_off % superblock.block_size != 0 ||
+      len % superblock.block_size != 0) {
+    ERROR("{} offset=0x{:x}~0x{:x} poffset=0x{:x} invalid read", id, s_off, len, p_off);
+    return crimson::ct_error::invarg::make();
+  }
+
+  if (s_id >= get_num_segments()) {
+    ERROR("{} offset=0x{:x}~0x{:x} poffset=0x{:x} segment-id out of range {}",
+          id, s_off, len, p_off, get_num_segments());
+    return crimson::ct_error::invarg::make();
+  }
+
+  if (s_off + len > superblock.segment_size) {
+    ERROR("{} offset=0x{:x}~0x{:x} poffset=0x{:x} read out of range 0x{:x}",
+          id, s_off, len, p_off, superblock.segment_size);
+    return crimson::ct_error::invarg::make();
+  }
+
+  if (tracker->get(s_id) == segment_state_t::EMPTY) {
+    // XXX: not an error during scanning,
+    // might need refactor to increase the log level
+    DEBUG("{} offset=0x{:x}~0x{:x} poffset=0x{:x} invalid state {}",
+          id, s_off, len, p_off, tracker->get(s_id));
+    return crimson::ct_error::enoent::make();
+  }
+
+  stats.data_read.increment(len);
+  return do_readv(
+    get_device_id(),
+    device,
+    p_off,
+    std::move(ptrs));
 }
 
 SegmentManager::read_ertr::future<> BlockSegmentManager::read(

--- a/src/crimson/os/seastore/segment_manager/block.h
+++ b/src/crimson/os/seastore/segment_manager/block.h
@@ -149,6 +149,9 @@ public:
     size_t len,
     ceph::bufferptr &out) final;
 
+  read_ertr::future<> readv(
+    paddr_t addr, std::vector<bufferptr> vecs) final;
+
   device_type_t get_device_type() const final {
     return superblock.config.spec.dtype;
   }

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -121,6 +121,10 @@ public:
     size_t len,
     ceph::bufferptr &out) final;
 
+  read_ertr::future<> readv(
+    paddr_t addr,
+    std::vector<bufferptr> ptr) final;
+
   size_t get_available_size() const final {
     return config.size;
   }

--- a/src/crimson/os/seastore/segment_manager/zbd.h
+++ b/src/crimson/os/seastore/segment_manager/zbd.h
@@ -151,6 +151,10 @@ namespace crimson::os::seastore::segment_manager::zbd {
       size_t len, 
       ceph::bufferptr &out) final;
 
+    read_ertr::future<> readv(
+      paddr_t addr,
+      std::vector<bufferptr> ptrs) final;
+
     device_type_t get_device_type() const final {
       return device_type_t::ZBD;
     }

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -280,6 +280,166 @@ public:
   }
 
   template <typename T>
+  struct read_pin_t {
+    LBAMapping mapping;
+    const extent_len_t partial_off = 0;
+    const extent_len_t partial_len = 0;
+    read_pin_t(
+      LBAMapping mapping,
+      extent_len_t partial_off,
+      extent_len_t partial_len)
+    : mapping(std::move(mapping)),
+      partial_off(partial_off),
+      partial_len(partial_len) {}
+    maybe_indirect_extent_t<T> get_result() const {
+      bool is_clone = mapping.is_clone();
+      std::optional<indirect_info_t> maybe_indirect_info;
+      if (mapping.is_indirect()) {
+	auto intermediate_offset = mapping.get_intermediate_offset();
+	maybe_indirect_info = indirect_info_t{
+	  intermediate_offset, mapping.get_length()};
+      }
+      return maybe_indirect_extent_t<T>{
+	extent, std::move(maybe_indirect_info), is_clone};
+    }
+  private:
+    TCachedExtentRef<T> extent;
+    std::function<void (T &)> on_read;
+
+    inline extent_len_t maybe_get_direct_partial_off() const {
+      extent_len_t direct_partial_off = partial_off;
+      if (mapping.is_indirect()) {
+	auto intermediate_offset = mapping.get_intermediate_offset();
+	direct_partial_off = intermediate_offset + partial_off;
+      }
+      return direct_partial_off;
+    }
+    Cache::read_extent_t<T> get_read_extent_param(bool full_extent) const {
+      return Cache::read_extent_t<T>{
+	extent,
+	full_extent ? 0 : maybe_get_direct_partial_off(),
+	full_extent ? extent->get_length() : partial_len};
+    }
+    void read_succeeded() {
+      if (on_read) {
+	on_read(*extent);
+      }
+    }
+    friend class TransactionManager;
+  };
+  template <typename T, typename U>
+  requires std::is_base_of_v<read_pin_t<T>, U>
+  base_iertr::future<> read_pins(
+    Transaction &t,
+    std::vector<U> &pins,
+    lextent_init_func_t<T> maybe_init = [](T&) {})
+  {
+    LOG_PREFIX(TransactionManager::read_pins);
+    static_assert(is_logical_type(T::TYPE));
+    co_await trans_intr::parallel_for_each(
+      pins,
+      seastar::coroutine::lambda(
+	[this, &t, FNAME, maybe_init=std::move(maybe_init)](auto &pin)
+	-> get_child_iertr::future<> {
+	assert(is_aligned(pin.partial_off, get_block_size()));
+	assert(is_aligned(pin.partial_len, get_block_size()));
+	// must be user-oriented required by maybe_init
+	assert(is_user_transaction(t.get_src()));
+	if (pin.mapping.is_zero_reserved()) {
+	  co_return;
+	}
+
+	pin.mapping = co_await pin.mapping.refresh();
+	if (pin.mapping.is_indirect()) {
+	  pin.mapping = co_await lba_manager->complete_indirect_lba_mapping(
+	    t, std::move(pin.mapping));
+	}
+	SUBTRACET(seastore_tm, "{} {}~{}",
+	  t, pin.mapping, pin.partial_off, pin.partial_len);
+	auto ret = get_extent_if_linked<T>(t, pin.mapping);
+	if (ret.index() == 1) {
+	  auto extent = co_await std::move(std::get<1>(ret));
+	  pin.extent = std::move(extent);
+	  pin.on_read = [maybe_init=std::move(maybe_init)](auto &extent) {
+	    if (!extent.is_seen_by_users()) {
+	      maybe_init(extent);
+	      extent.set_seen_by_users();
+	    }
+	  };
+	  co_return;
+	} else {
+	  auto &r = std::get<0>(ret);
+	  pin.extent = cache->prepare_absent_extent<T>(
+	    t,
+	    pin.mapping.get_val(),
+	    pin.mapping.get_intermediate_length(),
+	    pin.maybe_get_direct_partial_off(),
+	    pin.partial_len,
+	    [laddr=pin.mapping.get_intermediate_base(),
+	     maybe_init=std::move(maybe_init),
+	     child_pos=std::move(r.child_pos),
+	     &t, this]
+	    (T &extent) mutable {
+	      assert(extent.is_logical());
+	      assert(!extent.has_laddr());
+	      assert(!extent.has_been_invalidated());
+	      child_pos.link_child(&extent);
+	      child_pos.invalidate_retired_placeholder(t, *cache, extent);
+	      extent.set_laddr(laddr);
+	      maybe_init(extent);
+	      extent.set_seen_by_users();
+	    });
+	  pin.on_read = [FNAME, &t, pin=pin.mapping, this](auto &ref) mutable {
+	    if (ref.is_fully_loaded()) {
+	      auto crc = ref.calc_crc32c();
+	      SUBTRACET(
+		seastore_tm,
+		"got extent -- {}, chksum in the lba tree: "
+		"0x{:x}, actual chksum: 0x{:x}",
+		t,
+		ref,
+		pin.get_checksum(),
+		crc);
+	      bool inconsistent = false;
+	      if (full_extent_integrity_check) {
+		inconsistent = (pin.get_checksum() != crc);
+	      } else { // !full_extent_integrity_check: remapped extent may be skipped
+		inconsistent = !(pin.get_checksum() == 0 ||
+				 pin.get_checksum() == crc);
+	      }
+	      if (unlikely(inconsistent)) {
+		SUBERRORT(seastore_tm,
+		  "extent checksum inconsistent, recorded:"
+		  " 0x{:x}, actual: 0x{:x}, {}",
+		  t,
+		  pin.get_checksum(),
+		  crc,
+		  ref);
+		ceph_abort();
+	      }
+	    } else {
+	      assert(!full_extent_integrity_check);
+	    }
+	  };
+	  co_return;
+	}
+      })
+    );
+    std::vector<Cache::read_extent_t<T>> extents;
+    for (auto &pin : pins) {
+      if (pin.mapping.is_zero_reserved()) {
+	continue;
+      }
+      extents.emplace_back(pin.get_read_extent_param(
+	full_extent_integrity_check));
+    }
+    co_await cache->read_extents_maybe_partial(t, std::move(extents));
+    for (auto &pin : pins) {
+      pin.read_succeeded();
+    }
+  }
+
+  template <typename T>
   base_iertr::future<maybe_indirect_extent_t<T>> read_pin(
     Transaction &t,
     LBAMapping pin,

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -895,6 +895,18 @@ TEST_P(object_data_handler_test_t, parallel_partial_read) {
   });
 }
 
+TEST_P(object_data_handler_test_t, aggregate_read) {
+  run_async([this] {
+    auto t = create_mutate_transaction();
+    write(*t, 4096, 4096, 'a');
+    write(*t, 4096 * 10, 65536, 'b');
+    write(*t, 4096 * 12, 12288, 'c');
+    write(*t, 1024 * 1024, 2048, 'd');
+    submit_transaction(std::move(t));
+    read(0, 2048 * 1024);
+  });
+}
+
 INSTANTIATE_TEST_SUITE_P(
   object_data_handler_test,
   object_data_handler_test_t,


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
