### PR TITLE
reef: suites/rados/cephadm: typo in ignore list for still running message

### DIFF
--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -23,7 +23,7 @@ overrides:
     log-ignorelist:
       - OSD_DOWN
       - CEPHADM_FAILED_DAEMON
-      - but is still running
+      - but it is still running
       - PG_DEGRADED
     conf:
       osd:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72920

---

backport of https://github.com/ceph/ceph/pull/64927
parent tracker: https://tracker.ceph.com/issues/72501

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh