### PR TITLE
tentacle: mgr/dashboard: Enable rgw module automatically in the primary and secondary cluster if not enabled during multi-site automation

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -1339,10 +1339,16 @@ class RgwRealm(RESTController):
 
     @allow_empty_body
     # pylint: disable=W0613
-    def list(self):
-        multisite_instance = RgwMultisite()
-        result = multisite_instance.list_realms()
-        return result
+    def list(self, replicable: Optional[bool] = None):
+        if replicable:
+            try:
+                multisite_automation_instance = RgwMultisiteAutomation()
+                return multisite_automation_instance.get_replicable_realms_list()
+            except NoRgwDaemonsException as e:
+                raise DashboardException(e, http_status_code=404, component='rgw')
+        else:
+            multisite_instance = RgwMultisite()
+            return multisite_instance.list_realms()
 
     @allow_empty_body
     # pylint: disable=W0613

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
@@ -14,6 +14,7 @@ import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed, PermissionHelper } from '~/testing/unit-test-helper';
 import { MgrModuleDetailsComponent } from '../mgr-module-details/mgr-module-details.component';
 import { MgrModuleListComponent } from './mgr-module-list.component';
+import { SummaryService } from '~/app/shared/services/summary.service';
 
 describe('MgrModuleListComponent', () => {
   let component: MgrModuleListComponent;
@@ -37,6 +38,8 @@ describe('MgrModuleListComponent', () => {
     fixture = TestBed.createComponent(MgrModuleListComponent);
     component = fixture.componentInstance;
     mgrModuleService = TestBed.inject(MgrModuleService);
+    const summaryService = TestBed.inject(SummaryService);
+    spyOn(summaryService, 'startPolling');
   });
 
   it('should create', () => {
@@ -141,6 +144,7 @@ describe('MgrModuleListComponent', () => {
         always_on: false
       });
       component.updateModuleState();
+      tick(mgrModuleService.REFRESH_INTERVAL);
       tick(mgrModuleService.REFRESH_INTERVAL);
       tick(mgrModuleService.REFRESH_INTERVAL);
       expect(mgrModuleService.enable).toHaveBeenCalledWith('foo');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.html
@@ -8,7 +8,7 @@
                   class="align-items-center"
                   actionName="Enable"
                   (action)="enableRgwModule()">
-      In order to access the import/export/Setup Multi-site Replication feature, the rgw module must be enabled.
+      In order to access the import/export feature, the rgw module must be enabled.
   </cd-alert-panel>
   <cd-alert-panel   *ngIf="restartGatewayMessage"
                     type="warning"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.spec.ts
@@ -5,6 +5,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ToastrModule } from 'ngx-toastr';
 import { PipesModule } from '~/app/shared/pipes/pipes.module';
 import { ModalModule } from 'carbon-components-angular';
+import { SharedModule } from '~/app/shared/shared.module';
 
 describe('RgwMultisiteSyncPolicyDetailsComponent', () => {
   let component: RgwMultisiteSyncPolicyDetailsComponent;
@@ -13,7 +14,13 @@ describe('RgwMultisiteSyncPolicyDetailsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [RgwMultisiteSyncPolicyDetailsComponent],
-      imports: [HttpClientTestingModule, ToastrModule.forRoot(), PipesModule, ModalModule]
+      imports: [
+        HttpClientTestingModule,
+        ToastrModule.forRoot(),
+        PipesModule,
+        ModalModule,
+        SharedModule
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(RgwMultisiteSyncPolicyDetailsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-form/rgw-multisite-sync-policy-form.component.spec.ts
@@ -7,6 +7,7 @@ import { PipesModule } from '~/app/shared/pipes/pipes.module';
 import { ComponentsModule } from '~/app/shared/components/components.module';
 import { RouterTestingModule } from '@angular/router/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA } from '@angular/core';
+import { SharedModule } from '~/app/shared/shared.module';
 
 describe('RgwMultisiteSyncPolicyFormComponent', () => {
   let component: RgwMultisiteSyncPolicyFormComponent;
@@ -21,6 +22,7 @@ describe('RgwMultisiteSyncPolicyFormComponent', () => {
         ToastrModule.forRoot(),
         PipesModule,
         ComponentsModule,
+        SharedModule,
         RouterTestingModule
       ],
       schemas: [NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-wizard/rgw-multisite-wizard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-wizard/rgw-multisite-wizard.component.html
@@ -73,9 +73,9 @@
                   <select class="form-select"
                           id="selectedRealm"
                           formControlName="selectedRealm">
-                  <option *ngFor="let realm of realmsInfo"
-                          [value]="realm.realm">
-                        {{ realm.realm }}
+                  <option *ngFor="let realm of realmList"
+                          [value]="realm">
+                        {{ realm }}
                   </option>
                   </select>
                 </div>
@@ -335,7 +335,8 @@
 
 <ng-template #progressTemplate>
   <cd-progress [value]="executingTask?.progress"
-               [description]="executingTask?.name?.replace('progress/Multisite-Setup:', '')">
+               [description]="executingTask?.name?.replace('progress/Multisite-Setup:', '')?.split('||')[0]?.trim()"
+               [subDescription]="executingTask?.name?.replace('progress/Multisite-Setup:', '')?.split('||')[1]?.trim()">
   </cd-progress>
 </ng-template>
 
@@ -380,6 +381,13 @@
 </ng-template>
 
 <ng-template #reviewTemplate>
+  <cd-alert-panel type="warning"
+                  [showTitle]="false">
+    <span i18n>
+      During the automation process, the RGW module will be enabled on both the source and target clusters, if it is not already enabled.
+      This action may cause a temporary downtime (5-10 seconds) on each cluster.
+    </span>
+  </cd-alert-panel>
   <ng-container [ngSwitch]="multisiteSetupForm.get('configType').value">
     <ng-container *ngSwitchCase="'newRealm'">
       <ng-container *ngTemplateOutlet="newRealmInfo"></ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
@@ -12,6 +12,10 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RgwRealmService } from '~/app/shared/api/rgw-realm.service';
 import { RgwZoneService } from '~/app/shared/api/rgw-zone.service';
 import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
+import { SharedModule } from '~/app/shared/shared.module';
+import { ToastrModule } from 'ngx-toastr';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
 
 describe('RgwOverviewDashboardComponent', () => {
   let component: RgwOverviewDashboardComponent;
@@ -22,6 +26,7 @@ describe('RgwOverviewDashboardComponent', () => {
   let listZonesSpy: jest.SpyInstance;
   let fetchAndTransformBucketsSpy: jest.SpyInstance;
   let totalBucketsAndUsersSpy: jest.SpyInstance;
+  let params: Record<string, any>;
 
   const totalNumObjectsSubject = new BehaviorSubject<number>(290);
   const totalUsedCapacitySubject = new BehaviorSubject<number>(9338880);
@@ -79,9 +84,13 @@ describe('RgwOverviewDashboardComponent', () => {
             averageObjectSize$: averageObjectSizeSubject.asObservable(),
             getTotalBucketsAndUsersLength: jest.fn()
           }
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: { subscribe: (fn: Function) => fn(params) } }
         }
       ],
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule, SharedModule, ToastrModule.forRoot(), CommonModule]
     }).compileComponents();
     fixture = TestBed.createComponent(RgwOverviewDashboardComponent);
     component = fixture.componentInstance;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.spec.ts
@@ -10,6 +10,7 @@ import { MgrModuleListComponent } from '~/app/ceph/cluster/mgr-modules/mgr-modul
 import { ToastrModule } from 'ngx-toastr';
 import { SharedModule } from '../shared.module';
 import { BlockUIService } from 'ng-block-ui';
+import { SummaryService } from '../services/summary.service';
 
 describe('MgrModuleService', () => {
   let service: MgrModuleService;
@@ -88,6 +89,8 @@ describe('MgrModuleService', () => {
       spyOn(notificationService, 'suspendToasties');
       spyOn(blockUIService, 'start');
       spyOn(blockUIService, 'stop');
+      const summaryService = TestBed.inject(SummaryService);
+      spyOn(summaryService, 'startPolling');
     });
 
     it('should enable module', fakeAsync(() => {
@@ -100,6 +103,7 @@ describe('MgrModuleService', () => {
       });
       const selected = component.selection.first();
       service.updateModuleState(selected.name, selected.enabled);
+      tick(service.REFRESH_INTERVAL);
       tick(service.REFRESH_INTERVAL);
       tick(service.REFRESH_INTERVAL);
       expect(service.enable).toHaveBeenCalledWith('foo');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/mgr-module.service.ts
@@ -2,18 +2,23 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BlockUIService } from 'ng-block-ui';
 
-import { Observable, timer as observableTimer } from 'rxjs';
+import { Observable, Subject, timer } from 'rxjs';
 import { NotificationService } from '../services/notification.service';
 import { TableComponent } from '../datatable/table/table.component';
 import { Router } from '@angular/router';
 import { MgrModuleInfo } from '../models/mgr-modules.interface';
 import { NotificationType } from '../enum/notification-type.enum';
+import { delay, retryWhen, switchMap, tap } from 'rxjs/operators';
+import { SummaryService } from '../services/summary.service';
+
+const GLOBAL = 'global';
 
 @Injectable({
   providedIn: 'root'
 })
 export class MgrModuleService {
   private url = 'api/mgr/module';
+  updateCompleted$ = new Subject<void>();
 
   readonly REFRESH_INTERVAL = 2000;
 
@@ -21,7 +26,8 @@ export class MgrModuleService {
     private blockUI: BlockUIService,
     private http: HttpClient,
     private notificationService: NotificationService,
-    private router: Router
+    private router: Router,
+    private summaryService: SummaryService
   ) {}
 
   /**
@@ -85,65 +91,64 @@ export class MgrModuleService {
     table: TableComponent = null,
     navigateTo: string = '',
     notificationText?: string,
-    navigateByUrl?: boolean
+    navigateByUrl?: boolean,
+    reconnectingMessage: string = $localize`Reconnecting, please wait ...`
   ): void {
-    let $obs;
-    const fnWaitUntilReconnected = () => {
-      observableTimer(this.REFRESH_INTERVAL).subscribe(() => {
-        // Trigger an API request to check if the connection is
-        // re-established.
-        this.list().subscribe(
-          () => {
-            // Resume showing the notification toasties.
-            this.notificationService.suspendToasties(false);
-            // Unblock the whole UI.
-            this.blockUI.stop('global');
-            // Reload the data table content.
-            if (table) {
-              table.refreshBtn();
-            }
+    const moduleToggle$ = enabled ? this.disable(module) : this.enable(module);
 
-            if (notificationText) {
-              this.notificationService.show(
-                NotificationType.success,
-                $localize`${notificationText}`
-              );
-            }
-
-            if (!navigateTo) return;
-
-            const navigate = () => this.router.navigate([navigateTo]);
-
-            if (navigateByUrl) {
-              this.router.navigateByUrl('/', { skipLocationChange: true }).then(navigate);
-            } else {
-              navigate();
-            }
-          },
-          () => {
-            fnWaitUntilReconnected();
-          }
-        );
-      });
-    };
-
-    // Note, the Ceph Mgr is always restarted when a module
-    // is enabled/disabled.
-    if (enabled) {
-      $obs = this.disable(module);
-    } else {
-      $obs = this.enable(module);
-    }
-    $obs.subscribe(
-      () => undefined,
-      () => {
-        // Suspend showing the notification toasties.
+    moduleToggle$.subscribe({
+      next: () => {
+        // Module toggle succeeded
+        this.updateCompleted$.next();
+      },
+      error: () => {
+        // Module toggle failed, trigger reconnect flow
         this.notificationService.suspendToasties(true);
-        // Block the whole UI to prevent user interactions until
-        // the connection to the backend is reestablished
-        this.blockUI.start('global', $localize`Reconnecting, please wait ...`);
-        fnWaitUntilReconnected();
+        this.blockUI.start(GLOBAL, reconnectingMessage);
+
+        timer(this.REFRESH_INTERVAL)
+          .pipe(
+            switchMap(() => this.list()),
+            retryWhen((errors) =>
+              errors.pipe(
+                tap(() => {
+                  // Keep retrying until list() succeeds
+                }),
+                delay(this.REFRESH_INTERVAL)
+              )
+            )
+          )
+          .subscribe({
+            next: () => {
+              // Reconnection successful
+              this.notificationService.suspendToasties(false);
+              this.blockUI.stop(GLOBAL);
+
+              if (table) {
+                table.refreshBtn();
+              }
+
+              if (notificationText) {
+                this.notificationService.show(
+                  NotificationType.success,
+                  $localize`${notificationText}`
+                );
+              }
+
+              if (navigateTo) {
+                const navigate = () => this.router.navigate([navigateTo]);
+                if (navigateByUrl) {
+                  this.router.navigateByUrl('/', { skipLocationChange: true }).then(navigate);
+                } else {
+                  navigate();
+                }
+              }
+
+              this.updateCompleted$.next();
+              this.summaryService.startPolling();
+            }
+          });
       }
-    );
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.spec.ts
@@ -2,6 +2,9 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RgwMultisiteService } from './rgw-multisite.service';
+import { BlockUIModule } from 'ng-block-ui';
+import { ToastrModule } from 'ngx-toastr';
+import { SharedModule } from '../shared.module';
 
 const mockSyncPolicyData: any = [
   {
@@ -25,7 +28,12 @@ describe('RgwMultisiteService', () => {
 
   configureTestBed({
     providers: [RgwMultisiteService],
-    imports: [HttpClientTestingModule]
+    imports: [
+      HttpClientTestingModule,
+      BlockUIModule.forRoot(),
+      ToastrModule.forRoot(),
+      SharedModule
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.ts
@@ -2,7 +2,11 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { RgwRealm, RgwZone, RgwZonegroup } from '~/app/ceph/rgw/models/rgw-multisite';
 import { RgwDaemonService } from './rgw-daemon.service';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MgrModuleInfo } from '../models/mgr-modules.interface';
+import { RGW } from '~/app/ceph/rgw/utils/constants';
+import { MgrModuleService } from './mgr-module.service';
 
 @Injectable({
   providedIn: 'root'
@@ -14,7 +18,11 @@ export class RgwMultisiteService {
   private restartGatewayMessageSource = new BehaviorSubject<boolean>(null);
   restartGatewayMessage$ = this.restartGatewayMessageSource.asObservable();
 
-  constructor(private http: HttpClient, public rgwDaemonService: RgwDaemonService) {}
+  constructor(
+    private http: HttpClient,
+    public rgwDaemonService: RgwDaemonService,
+    private mgrModuleService: MgrModuleService
+  ) {}
 
   migrate(realm: RgwRealm, zonegroup: RgwZonegroup, zone: RgwZone, username: string) {
     return this.rgwDaemonService.request((params: HttpParams) => {
@@ -157,5 +165,14 @@ export class RgwMultisiteService {
 
   setRestartGatewayMessage(value: boolean): void {
     this.restartGatewayMessageSource.next(value);
+  }
+
+  getRgwModuleStatus(): Observable<boolean> {
+    return this.mgrModuleService.list().pipe(
+      map((moduleData: MgrModuleInfo[]) => {
+        const rgwModule = moduleData.find((module) => module.name === RGW);
+        return !!rgwModule?.enabled;
+      })
+    );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-realm.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-realm.service.ts
@@ -30,8 +30,14 @@ export class RgwRealmService {
     return this.http.put(`${this.url}/${realm.name}`, requestBody);
   }
 
-  list(): Observable<object> {
-    return this.http.get<object>(`${this.url}`);
+  list(replicable?: boolean): Observable<object> {
+    let params = new HttpParams();
+    if (replicable) {
+      params = params.appendAll({
+        replicable: replicable.toString()
+      });
+    }
+    return this.http.get<object>(`${this.url}`, { params });
   }
 
   get(realm: RgwRealm): Observable<object> {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/progress/progress.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/progress/progress.component.html
@@ -25,6 +25,11 @@
         *ngIf="description">
       {{ description }}
     </h5>
+
+    <p class="text-center text-muted mt-3"
+       *ngIf="subDescription">
+      {{ subDescription }}
+    </p>
   </ng-container>
 
   <div class="w-50 row h-100 d-flex justify-content-center align-items-center mt-4">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/progress/progress.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/progress/progress.component.ts
@@ -13,6 +13,7 @@ export class ProgressComponent {
   @Input() status: string;
   @Input() description: string;
   @Input() subLabel: string;
+  @Input() subDescription: string;
   @Input() completedItems: string;
   @Input() actionName: string;
   @Input() helperText: string;

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -13583,7 +13583,12 @@ paths:
       - RgwMultisite
   /api/rgw/realm:
     get:
-      parameters: []
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: replicable
+        schema:
+          type: string
       responses:
         '200':
           content:

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1345,7 +1345,7 @@ class RgwMultisiteAutomation:
 
         if not selectedRealmName:
             self.create_realm_and_zonegroup(
-                realm_name, zonegroup_name, zone_name, zonegroup_ip_url)
+                realm_name, zonegroup_name, zone_name, zonegroup_ip_url, username)
             self.create_zone_and_user(zone_name, zonegroup_name, username, zone_ip_url)
             self.restart_daemons()
 
@@ -1364,10 +1364,15 @@ class RgwMultisiteAutomation:
             logger.error("Failed to update endpoints: %s", e)
             raise
 
-    def create_realm_and_zonegroup(self, realm: str, zg: str, zone: str, zg_url: str):
+    def create_realm_and_zonegroup(self, realm: str, zg: str, zone: str, zg_url: str,
+                                   username: str):
         try:
             rgw_multisite_instance = RgwMultisite()
-            self.update_progress(f"Creating realm: {realm}, zonegroup: {zg} and zone: {zone}")
+            self.update_progress(
+                f"Initializing multi-site configuration || Creating realm: {realm}, \
+                    zonegroup: {zg}, and zone: {zone} along \
+                        with system user: {username}"
+            )
             rgw_multisite_instance.create_realm(realm_name=realm, default=True)
             rgw_multisite_instance.create_zonegroup(realm_name=realm, zonegroup_name=zg,
                                                     default=True, master=True, endpoints=zg_url)
@@ -1402,7 +1407,10 @@ class RgwMultisiteAutomation:
 
     def restart_daemons(self):
         try:
-            self.update_progress("Restarting RGW daemons and setting credentials")
+            self.update_progress(
+                "Restarting RGW daemons and configuring credentials || Restarts rgw services and \
+                applies access and secret keys on the source cluster"
+            )
             RgwServiceManager().restart_rgw_daemons_and_set_credentials()
             self.progress_done += 1
         except Exception as e:
@@ -1417,7 +1425,11 @@ class RgwMultisiteAutomation:
         try:
             realm_token_info = CephService.get_realm_tokens()
             if fsid and realm_token_info and rep_zone and details_dict:
-                self.update_progress(f"Importing realm token to cluster: {fsid}")
+                self.update_progress(
+                    f"Setting up replication on cluster {fsid} || Enabling RGW module on \
+                        target cluster (if disabled), importing realm \
+                            configuration, and establishing the target zone"
+                )
                 self.import_realm_token_to_cluster(fsid, realm, zg, realm_token_info, username,
                                                    rep_zone, details_dict, selectedRealm)
             else:
@@ -1442,6 +1454,8 @@ class RgwMultisiteAutomation:
             realm_export_token = self._get_realm_export_token(realm_token_info, realm_name)
             cluster_url, cluster_token = self._get_cluster_details(cluster_fsid, cluster_details)
 
+            self._enable_rgw_module(cluster_url=cluster_url, cluster_token=cluster_token)
+
             self._configure_selected_cluster(cluster_url, cluster_token, realm_name,
                                              zonegroup_name, replication_zone_name)
 
@@ -1450,8 +1464,11 @@ class RgwMultisiteAutomation:
                 replication_zone_name)
 
             self.progress_done += 1
-            self.update_progress(f"Checking for user {username} in the selected cluster \
-                                 and setting credentials")
+            self.update_progress(
+                f"Verifying system user and completing replication setup on \
+                    cluster {cluster_fsid} || Ensuring presence of user '{username}' \
+                        and assigning necessary RGW credentials"
+            )
 
             self._verify_user_and_daemons(cluster_url, cluster_token, realm_name,
                                           replication_zone_name, username)
@@ -1462,6 +1479,64 @@ class RgwMultisiteAutomation:
             logger.error("Failed to import realm token to cluster: %s", e)
             self.update_progress("Failed to import realm token to cluster:", 'fail', str(e))
             raise
+
+    def _enable_rgw_module(self, cluster_url, cluster_token):
+        # Enable RGW module if not already enabled
+        mgr_modules_path = 'api/mgr/module'
+        multi_cluster_instance = MultiCluster()
+        # pylint: disable=protected-access
+        mgr_modules_info = multi_cluster_instance._proxy(
+            method='GET',
+            base_url=cluster_url,
+            path=mgr_modules_path,
+            token=cluster_token
+        )
+        logger.debug("mgr modules info in the selected cluster: %s", mgr_modules_info)
+
+        rgw_module = next((mod for mod in mgr_modules_info if mod["name"] == "rgw"), None)
+        rgw_module_status = rgw_module and rgw_module.get('enabled', False)
+
+        if not rgw_module_status:
+            logger.info("RGW module not enabled. Sending request to enable it.")
+            try:
+                # pylint: disable=protected-access
+                multi_cluster_instance._proxy(
+                    method='POST',
+                    base_url=cluster_url,
+                    path='api/mgr/module/rgw/enable',
+                    token=cluster_token
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning("RGW enable request failed (likely due to connection reset).\
+                               Ignoring and retrying later: %s", e)
+
+            max_retries = 10
+            delay = 5
+            retries = 0
+
+            while retries < max_retries:
+                time.sleep(delay)
+                try:
+                    # pylint: disable=protected-access
+                    mgr_modules_info = multi_cluster_instance._proxy(
+                        method='GET',
+                        base_url=cluster_url,
+                        path=mgr_modules_path,
+                        token=cluster_token
+                    )
+                    rgw_module = next((mod for mod in mgr_modules_info if mod["name"] == "rgw"),
+                                      None)
+                    if rgw_module and rgw_module.get('enabled'):
+                        logger.info("RGW module is now enabled after %d retries.", retries)
+                        break
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.warning("Failed to fetch RGW module status on retry %d: %s",
+                                   retries, str(e))
+                retries += 1
+            else:
+                logger.error("RGW module failed to enable after %d retries.", max_retries)
+                raise DashboardException('RGW module failed to enable after maximum retries',
+                                         http_status_code=500, component='rgw')
 
     def _get_realm_export_token(self, realm_token_info, realm_name):
         for realm_token in realm_token_info:
@@ -1587,6 +1662,38 @@ class RgwMultisiteAutomation:
                 self.update_progress("Error checking user in the second cluster", 'fail', str(e))
             logger.info("User %s not found yet, retrying in 5 seconds", username)
             time.sleep(5)
+
+    # For a realm to be replicable it must have a master zone,
+    # valid endpoints and access/secret keys should be set
+    def get_replicable_realms_list(self):
+        replicable_realms = []
+        realms_info = RgwMultisite().list_realms()
+        realm_list = realms_info.get('realms', [])
+        for realm_name in realm_list:  # pylint: disable=R1702
+            try:
+                realm_period = RgwMultisite().get_realm_period(realm_name)
+                master_zone_name = None
+                for zg in realm_period['period_map']['zonegroups']:
+                    if not zg.get('is_master'):
+                        continue
+                    for zone in zg.get('zones', []):
+                        if zone.get('id') == zg.get('master_zone'):
+                            if zone.get('endpoints'):
+                                master_zone_name = zone.get('name')
+                                break
+                if not master_zone_name:
+                    continue
+                zone_info = RgwMultisite().get_zone(master_zone_name)
+                system_key = zone_info.get('system_key', {})
+                access_key = system_key.get('access_key')
+                secret_key = system_key.get('secret_key')
+                if access_key and secret_key:
+                    replicable_realms.append(realm_name)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning("Skipping realm '%s' due to error: %s", realm_name, e)
+                continue
+
+        return replicable_realms
 
 
 class RgwRateLimit:
@@ -1768,6 +1875,19 @@ class RgwMultisite:
         except SubprocessError as error:
             raise DashboardException(error, http_status_code=500, component='rgw')
         return rgw_realm_list
+
+    def get_realm_period(self, realm_name: str):
+        realm_period = {}
+        rgw_realm_period_cmd = ['period', 'get', '--rgw-realm', realm_name]
+        try:
+            exit_code, out, _ = mgr.send_rgwadmin_command(rgw_realm_period_cmd)
+            if exit_code > 0:
+                raise DashboardException('Unable to get realm period',
+                                         http_status_code=500, component='rgw')
+            realm_period = out
+        except SubprocessError as error:
+            raise DashboardException(error, http_status_code=500, component='rgw')
+        return realm_period
 
     def get_realm(self, realm_name: str):
         realm_info = {}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/71903

---

backport of https://github.com/ceph/ceph/pull/62929
parent tracker: https://tracker.ceph.com/issues/71033

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh