### PR TITLE
reef: qa/cephfs: ignore warning that pg is stuck peering for upgrade jobs

### DIFF
--- a/qa/cephfs/overrides/pg_health.yaml
+++ b/qa/cephfs/overrides/pg_health.yaml
@@ -11,3 +11,4 @@ overrides:
       - Degraded data redundancy
       - pg .* is stuck inactive
       - pg .* is .*degraded
+      - pg .* is stuck peering


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/70175

---

backport of https://github.com/ceph/ceph/pull/61876
parent tracker: https://tracker.ceph.com/issues/70023

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh