### PR TITLE
mgr [progress] [autoscaler]: Fix Autoscaler progress completion + progress module refactors

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -140,7 +140,7 @@ The output will resemble the following::
   The system's calculations use whichever of these two ratios (that is, the 
   target ratio and the effective ratio) is greater.
 
-- **BIAS** is used as a multiplier to manually adjust a pool's PG in accordance
+- **BIAS** is the ``pg_autoscale_bias`` and is used as a multiplier to manually adjust a pool's pg_num in accordance
   with prior information about how many PGs a specific pool is expected to
   have.  This is important for pools that primarily store data in omaps vs
   RADOS objects, notably RGW index and CephFS / RBD EC metadata pools. When

--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -42,6 +42,11 @@ class TestProgress(MgrTestCase):
     # and seeing the progress event pop up.
     EVENT_CREATION_PERIOD = 60
 
+    # We will set this in setUp once we have self.mgr_cluster available
+    PG_AUTOSCALER_EVENT_CREATION_PERIOD = None
+    # This is how long we expect to wait at most when a small pool scales up.
+    PG_SCALE_UP_PERIOD = None
+
     WRITE_PERIOD = 30
 
     # Generous period for OSD recovery, should be same order of magnitude
@@ -49,6 +54,9 @@ class TestProgress(MgrTestCase):
     RECOVERY_PERIOD = WRITE_PERIOD * 4
 
     def _get_progress(self):
+        """
+        Get the current progress information from the cluster.
+        """
         out = self.mgr_cluster.mon_manager.raw_cluster_cmd("progress", "json")
         return json.loads(out)
 
@@ -79,9 +87,15 @@ class TestProgress(MgrTestCase):
         return p['completed']
 
     def is_osd_marked_out(self, ev):
+        """
+        Check if the event indicates an OSD has been marked out.
+        """
         return ev['message'].endswith('marked out')
 
     def is_osd_marked_in(self, ev):
+        """
+        Check if the event indicates an OSD has been marked in.
+        """
         return ev['message'].endswith('marked in')
 
     def _get_osd_in_out_events(self, marked='both'):
@@ -129,11 +143,23 @@ class TestProgress(MgrTestCase):
         else:
             return marked_out_count
 
-    def _setup_pool(self, size=None):
+    def _setup_pool(self, **kwargs):
+        """
+        Setup a pool with optional additional pool settings.
+        Args:
+            **kwargs: Additional pool settings like bulk='true', pg_autoscale_bias=4, etc.
+                    These will be passed as 'osd pool set' commands
+        Examples:
+            self._setup_pool()  # Basic pool
+            self._setup_pool(size=3)  # Pool with size 3
+            self._setup_pool(bulk='true', pg_autoscale_bias=4)  # Pool with bulk=true and pg_autoscale_bias=4
+            self._setup_pool(size=2, bulk='true', pg_autoscale_bias=4, min_size=1)  # Combined
+        """
         self.mgr_cluster.mon_manager.create_pool(self.POOL)
-        if size is not None:
+        # Apply additional pool settings
+        for setting, value in kwargs.items():
             self.mgr_cluster.mon_manager.raw_cluster_cmd(
-                'osd', 'pool', 'set', self.POOL, 'size', str(size))
+                'osd', 'pool', 'set', self.POOL, setting, str(value))
 
     def _osd_in_out_completed_events_count(self, marked='both'):
         """
@@ -221,6 +247,9 @@ class TestProgress(MgrTestCase):
 
     @contextmanager    
     def recovery_backfill_disabled(self):
+        """
+        Context manager to disable recovery and backfill temporarily.
+        """
         self.mgr_cluster.mon_manager.raw_cluster_cmd(
             'osd', 'set', 'nobackfill')
         self.mgr_cluster.mon_manager.raw_cluster_cmd(
@@ -230,9 +259,21 @@ class TestProgress(MgrTestCase):
             'osd', 'unset', 'nobackfill')
         self.mgr_cluster.mon_manager.raw_cluster_cmd(
             'osd', 'unset', 'norecover')
-           
+
     def setUp(self):
+        """
+         Set up the test environment every time before a test is run.
+        """
         super(TestProgress, self).setUp()
+        # Speed up the test by reducing the sleep interval of the pg_autoscaler
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            "config", "set", "mgr", "mgr/pg_autoscaler/sleep_interval", "5"
+        )
+        # Set PG_AUTOSCALER_EVENT_CREATION_PERIOD now that self.mgr_cluster is available
+        if self.PG_AUTOSCALER_EVENT_CREATION_PERIOD is None:
+            self.PG_AUTOSCALER_EVENT_CREATION_PERIOD = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                "config", "get", "mgr", "mgr/pg_autoscaler/sleep_interval"
+            ) * 3
         # Ensure we have at least four OSDs
         if self._osd_count() < 4:
             self.skipTest("Not enough OSDS!")
@@ -256,7 +297,12 @@ class TestProgress(MgrTestCase):
                     "--yes-i-really-really-mean-it")
 
         self._load_module("progress")
+        # Clear any existing progress events
         self.mgr_cluster.mon_manager.raw_cluster_cmd('progress', 'clear')
+        # Turn autoscale off globally, since we don't want
+        # any pg-autoscale progress events from being triggered by pool creation.
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'set', 'noautoscale')
 
     def _simulate_failure(self, osd_ids=None):
         """
@@ -286,6 +332,10 @@ class TestProgress(MgrTestCase):
         return ev
 
     def _simulate_back_in(self, osd_ids, initial_event):
+        """
+        Simulate an OSD coming back in, assuming that
+        recovery is still ongoing from a previous out event.
+        """
         for osd_id in osd_ids:
             self.mgr_cluster.mon_manager.raw_cluster_cmd(
                     'osd', 'in', str(osd_id))
@@ -311,11 +361,61 @@ class TestProgress(MgrTestCase):
 
     def _no_events_anywhere(self):
         """
-        Whether there are any live or completed events
+        Check whether there are any live or completed events.
+        Returns True if there are no events anywhere.
         """
         p = self._get_progress()
         total_events = len(p['events']) + len(p['completed'])
         return total_events == 0
+
+    def _pg_autoscaler_events_count(self):
+        """
+        Count the number of on going recovery events that deals with
+        PG autoscaler.
+        """
+        events_in_progress = self._events_in_progress()
+        pg_autoscaler_count = 0
+
+        for ev in events_in_progress:
+            if ev['message'].startswith('PG autoscaler'):
+                pg_autoscaler_count += 1
+
+        return pg_autoscaler_count
+
+    def _get_pg_autoscaler_events(self):
+        """
+        Return the event that deals with PG autoscaler
+        """
+        pg_autoscaler_events = []
+        events_in_progress = self._events_in_progress()
+        for ev in events_in_progress:
+            if ev['message'].startswith('PG autoscaler'):
+                pg_autoscaler_events.append(ev)
+
+        return pg_autoscaler_events
+
+    def _simulate_pg_autoscaler_event(self):
+        """
+        Simulate a PG autoscale event, assuming that
+        noautoscale flag is on.
+
+        Return the JSON representation of the pg_autoscale event.
+        """
+        self._setup_pool(size=3, bulk='true', pg_autoscale_bias=4) # create pool with pg_autoscale_bias 4 and --bulk flag
+        self._write_some_data(self.WRITE_PERIOD)
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'unset', 'noautoscale')
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'set', self.POOL, 'pg_autoscale_mode', 'on')
+        # Wait for a progress event to pop up
+        self.wait_until_equal(lambda: self._pg_autoscaler_events_count(), 1,
+                                  timeout=self.PG_AUTOSCALER_EVENT_CREATION_PERIOD,
+                                  period=1)
+        ev = self._get_pg_autoscaler_events()[0]
+        log.info(json.dumps(ev, indent=1))
+        self.assertIn("PG autoscaler", ev['message'])
+        return ev
+
 
     def _is_quiet(self):
         """
@@ -324,6 +424,8 @@ class TestProgress(MgrTestCase):
         return len(self._get_progress()['events']) == 0
 
     def _is_complete(self, ev_id):
+        """
+        Whether the event with the given ID has completed."""
         progress = self._get_progress()
         live_ids = [ev['id'] for ev in progress['events']]
         complete_ids = [ev['id'] for ev in progress['completed']]
@@ -335,6 +437,11 @@ class TestProgress(MgrTestCase):
             return False
 
     def _is_inprogress_or_complete(self, ev_id):
+        """
+        Whether the event with the given ID is either in progress
+        or complete.  This is useful for waiting on an event that
+        may complete while we're waiting.
+        """
         for ev in self._events_in_progress():
             if ev['id'] == ev_id:
                 return ev['progress'] > 0
@@ -342,6 +449,9 @@ class TestProgress(MgrTestCase):
         return self._is_complete(ev_id)
 
     def tearDown(self):
+        """
+        Clean up the test environment after a test is run.
+        """
         if self.POOL in self.mgr_cluster.mon_manager.pools:
             self.mgr_cluster.mon_manager.remove_pool(self.POOL)
 
@@ -479,7 +589,7 @@ class TestProgress(MgrTestCase):
         """
         pool_size = 3
         self._setup_pool(size=pool_size)
-        self._write_some_data(self.WRITE_PERIOD)        
+        self._write_some_data(self.WRITE_PERIOD)
 
         with self.recovery_backfill_disabled():
             self.mgr_cluster.mon_manager.raw_cluster_cmd(
@@ -494,3 +604,20 @@ class TestProgress(MgrTestCase):
         time.sleep(self.EVENT_CREATION_PERIOD/2)
 
         self.assertEqual(self._osd_in_out_events_count(), 0)
+
+    def test_pg_autoscaler_event(self):
+        """
+        Test PG autoscaler event creation and completion.
+        """
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'config', 'set', 'mgr',
+            'mgr/progress/allow_pg_recovery_event', 'true')
+
+        ev = self._simulate_pg_autoscaler_event()
+
+        # Wait for progress event to ultimately complete
+        self.wait_until_true(lambda: self._is_complete(ev['id']),
+                                 timeout=self.PG_SCALE_UP_PERIOD)
+
+        # There should not be any on going pg_autoscale event
+        self.assertEqual(self._pg_autoscaler_events_count(), 0)

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -496,28 +496,31 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     f.close_section();
   } else if (what == "have_local_config_map") {
     f.dump_bool("have_local_config_map", have_local_config_map);
-  } else if (what == "active_clean_pgs"){
+  } else if (what == "pg_stats_active_clean"){
     without_gil_t no_gil;
     cluster_state.with_pgmap(
         [&](const PGMap &pg_map) {
       no_gil.acquire_gil();
-      f.open_array_section("pg_stats");
+      f.open_array_section("active_clean_pgs");
+      int active_clean_count = 0;
       for (auto &i : pg_map.pg_stat) {
         const auto state = i.second.state;
-	const auto pgid_raw = i.first;
-	const auto pgid = stringify(pgid_raw.m_pool) + "." + stringify(pgid_raw.m_seed);
-	const auto reported_epoch = i.second.reported_epoch;
-	if (state & PG_STATE_ACTIVE && state & PG_STATE_CLEAN) {
-	  f.open_object_section("pg_stat");
-	  f.dump_string("pgid", pgid);
-	  f.dump_string("state", pg_state_string(state));
-	  f.dump_unsigned("reported_epoch", reported_epoch);
-	  f.close_section();
-	}
+	      const auto pgid_raw = i.first;
+	      const auto pgid = stringify(pgid_raw.m_pool) + "." + stringify(pgid_raw.m_seed);
+	      const auto reported_epoch = i.second.reported_epoch;
+	      if (state & PG_STATE_ACTIVE && state & PG_STATE_CLEAN) {
+          active_clean_count++;
+          f.open_object_section("");
+	        f.dump_string("pgid", pgid);
+	        f.dump_string("state", pg_state_string(state));
+	        f.dump_unsigned("reported_epoch", reported_epoch);
+	        f.close_section();
+	      }
       }
       f.close_section();
+      f.dump_unsigned("active_clean_pg_count", active_clean_count);
       const auto num_pg = pg_map.num_pg;
-      f.dump_unsigned("total_num_pgs", num_pg);
+      f.dump_unsigned("total_pg_count", num_pg);
     });
   } else {
     derr << "Python module requested unknown data '" << what << "'" << dendl;

--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -736,16 +736,34 @@ class PgAutoscaler(MgrModule):
         for pool_id in list(self._event):
             ev = self._event[pool_id]
             pool_data = self._get_pool_by_id(pools, pool_id)
-            if (
-                pool_data is None
-                or pool_data["pg_num"] == pool_data["pg_num_target"]
-                or ev.pg_num == ev.pg_num_target
-            ):
-                # pool is gone or we've reached our target
+            if (pool_data is None):
+                # pool is gone
+                self.log.warning("pool %s missing; marking complete", pool_id)
                 self.remote('progress', 'complete', ev.ev_id)
                 del self._event[pool_id]
                 continue
-            ev.update(self, (ev.pg_num - pool_data['pg_num']) / (ev.pg_num - ev.pg_num_target))
+            current = pool_data['pg_num']
+            start = ev.pg_num
+            target = ev.pg_num_target
+            self.log.debug("pool %s; start_pg_num: %d; current_pg_num: %d; -> target_pg_num: %d;",
+                           pool_id, start, current, target)
+            if (current == target):
+                # we've reached our target
+                self.log.debug("pool %s reached target; marking complete", pool_id)
+                self.remote('progress', 'complete', ev.ev_id)
+                del self._event[pool_id]
+                continue
+
+            denominator = (start - target)
+            if denominator == 0:
+               # start == target, we complete the event since nothing to track
+               self.remote('progress', 'complete', ev.ev_id)
+               self._event.pop(pool_id, None)
+               continue
+
+            progress = (start - current) / denominator
+
+            ev.update(self, progress)
 
     def _maybe_adjust(self,
                       osdmap: OSDMap,

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -41,10 +41,13 @@ class Event(object):
         self.id = id
         self._add_to_ceph_s = add_to_ceph_s
 
-    def _refresh(self):
+    def _persist(self) -> None:
+        """
+        Persist the event to the Monitor
+        """
         global _module
         assert _module
-        _module.log.debug('refreshing mgr for %s (%s) at %f' % (self.id, self._message,
+        _module.log.debug('persisting event %s (%s) at %f' % (self.id, self._message,
                                                                 self.progress))
         _module.update_progress_event(
             self.id, self.twoline_progress(6), self.progress, self._add_to_ceph_s)
@@ -194,7 +197,7 @@ class GlobalRecoveryEvent(Event):
         self._progress = 0.0
         self._start_epoch = start_epoch
         self._active_clean_num = active_clean_num
-        self._refresh()
+        self._persist()
 
     def global_event_update_progress(self, log):
         # type: (logging.Logger) -> None
@@ -202,38 +205,40 @@ class GlobalRecoveryEvent(Event):
         global _module
         assert _module
         skipped_pgs = 0
-        active_clean_pgs = _module.get("active_clean_pgs")
-        total_pg_num = active_clean_pgs["total_num_pgs"]
-        new_active_clean_pgs = active_clean_pgs["pg_stats"]
-        new_active_clean_num = len(new_active_clean_pgs)
-        for pg in new_active_clean_pgs:
+        pg_stats_active_clean = _module.get("pg_stats_active_clean")
+        total_pg_num = pg_stats_active_clean["total_pg_count"]
+        active_clean_pgs = pg_stats_active_clean["active_clean_pgs"]
+        active_clean_pg_count = pg_stats_active_clean["active_clean_pg_count"]
+        for pg in active_clean_pgs:
             # Disregard PGs that are not being reported
             # if the states are active+clean. Since it is
             # possible that some pgs might not have any movement
             # even before the start of the event.
             if pg['reported_epoch'] < self._start_epoch:
+                log.debug("Skipping pg {0} since reported_epoch {1} < start_epoch {2}"
+                             .format(pg['pgid'], pg['reported_epoch'], self._start_epoch))
                 skipped_pgs += 1
                 continue
-
-        # Log skipped PGs
-        if skipped_pgs > 0:
-            log.debug("Skipped {0} PGs with reported_epoch < start_epoch {1}"
-                 .format(skipped_pgs, self._start_epoch))
-
-        if self._active_clean_num != new_active_clean_num:
-            # Have this case to know when need to update
-            # the progress
-            try:
-                # Might be that total_pg_num is 0
-                self._progress = float(new_active_clean_num) / (total_pg_num - skipped_pgs)
-            except ZeroDivisionError:
-                self._progress = 0.0
-        else:
-            # No need to update since there is no change
+        start = self._active_clean_num
+        current = active_clean_pg_count
+        total = total_pg_num - skipped_pgs
+        if (current == total):
+            # All active+clean PGs have been recovered
+            self._progress = 1.0
+            self._persist()
             return
 
+        denominator = (start - total)
+        if denominator == 0:
+            # start == target, No need to track anymore
+            self._progress = 1.0
+            self._persist()
+            return
+
+        self._progress = (start - current) / denominator
+
         log.debug("Updated progress to %s", self.summary())
-        self._refresh()
+        self._persist()
 
     @property
     def progress(self):
@@ -252,22 +257,22 @@ class RemoteEvent(Event):
         super().__init__(my_id, message, refs, add_to_ceph_s)
         self._progress = 0.0
         self._failed = False
-        self._refresh()
+        self._persist()
 
     def set_progress(self, progress):
         # type: (float) -> None
         self._progress = progress
-        self._refresh()
+        self._persist()
 
     def set_failed(self, message):
         self._progress = 1.0
         self._failed = True
         self._failure_message = message
-        self._refresh()
+        self._persist()
 
     def set_message(self, message):
         self._message = message
-        self._refresh()
+        self._persist()
 
     @property
     def progress(self):
@@ -300,7 +305,7 @@ class PgRecoveryEvent(Event):
         self._progress = 0.0
 
         self._start_epoch = start_epoch
-        self._refresh()
+        self._persist()
 
     @property
     def which_osds(self):
@@ -391,7 +396,7 @@ class PgRecoveryEvent(Event):
 
         self._progress = min(max(prog, 0.0), 1.0)
 
-        self._refresh()
+        self._persist()
         log.info("Updated progress to %s", self.summary())
 
     @property
@@ -595,23 +600,23 @@ class Module(MgrModule):
         # This function both constructs and updates
         # the global recovery event if one of the
         # PGs is not at active+clean state
-        active_clean_pgs = self.get("active_clean_pgs")
-        total_pg_num = active_clean_pgs["total_num_pgs"]
-        active_clean_num = len(active_clean_pgs["pg_stats"])
+        pg_stats_active_clean = _module.get("pg_stats_active_clean")
+        total_pg_count = pg_stats_active_clean["total_pg_count"]
+        active_clean_pg_count = pg_stats_active_clean["active_clean_pg_count"]
         try:
             # There might be a case where there is no pg_num
-            progress = float(active_clean_num) / total_pg_num
+            progress = float(active_clean_pg_count) / total_pg_count
         except ZeroDivisionError:
             return
         if progress < 1.0:
             self.log.warning(("Starting Global Recovery Event,"
                               "%d pgs not in active + clean state"),
-                              total_pg_num - active_clean_num)
+                              total_pg_count - active_clean_pg_count)
             ev = GlobalRecoveryEvent("Global Recovery Event",
                     refs=[("global", "")],
                     add_to_ceph_s=True,
                     start_epoch=self.get_osdmap().get_epoch(),
-                    active_clean_num=active_clean_num)
+                    active_clean_num=active_clean_pg_count)
             ev.global_event_update_progress(self.log)
             self._events[ev.id] = ev
 

--- a/src/pybind/mgr/progress/test_progress.py
+++ b/src/pybind/mgr/progress/test_progress.py
@@ -16,7 +16,7 @@ class TestPgRecoveryEvent(object):
     def setup_method(self):
         # Creating the class and Mocking 
         # a bunch of attributes for testing
-        module._module = mock.Mock() # just so Event._refresh() works
+        module._module = mock.Mock() # just so Event._persist() works
         self.test_event = module.PgRecoveryEvent(None, None, [module.PgId(1,i) for i in range(3)], [0], 30, False)
 
     def test_pg_update(self):


### PR DESCRIPTION
**Summary**

This PR fixes an issue where the PG Autoscaler progress event could complete incorrectly due to comparing against the wrong target, and includes readability refactors in the progress module along with new test coverage.

**Problem**

The Autoscaler event’s completion check compared:

`pool_data["pg_num"] == pool_data["pg_num_target"]`

However, pool_data["pg_num_target"] is not the current scaling target; it reflects the previously computed value (i.e., what the pool was expected to have already reached). As a result, the comparison could erroneously evaluate true and prematurely complete the Autoscaler progress event.

**Fix**

Use the event’s target recorded at creation time:

`pool_data["pg_num"] == ev.pg_num_target`

This ensures the event only completes when the pool’s pg_num actually reaches the intended target for this scaling action.

**Additional progress-module cleanup**

Rename def _refresh() → def _persist() to better reflect behavior.

Rename variables (e.g., pg_stats_active_clean) to more intuitive names for readability.

Refactor global_event_update_progress() for clearer flow and maintainability.

**Tests**

Add unit tests for the PgAutoscaler event logic in pybind/mgr/progress/test_progress.py to cover correct completion behavior.

Fixes: https://tracker.ceph.com/issues/72857

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
