### PR TITLE
reef: mgr/DaemonState: Minimise time we hold the DaemonStateIndex lock

### DIFF
--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -260,9 +260,12 @@ public:
   template<typename Callback, typename...Args>
   auto with_daemons_by_server(Callback&& cb, Args&&... args) const ->
     decltype(cb(by_server, std::forward<Args>(args)...)) {
-    std::shared_lock l{lock};
-    
-    return std::forward<Callback>(cb)(by_server, std::forward<Args>(args)...);
+    const decltype(by_server) by_server_copy = [&] {
+      // Don't hold the lock any longer than necessary
+      std::shared_lock l{lock};
+      return by_server;
+    }();
+    return std::forward<Callback>(cb)(by_server_copy, std::forward<Args>(args)...);
   }
 
   template<typename Callback, typename...Args>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72852

---

backport of https://github.com/ceph/ceph/pull/64764
parent tracker: https://tracker.ceph.com/issues/72337

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh