### PR TITLE
tentacle: libcephfs_proxy: fix backward compatibility issue

### DIFF
--- a/src/libcephfs_proxy/libcephfsd.c
+++ b/src/libcephfs_proxy/libcephfsd.c
@@ -89,7 +89,7 @@ static int32_t validate_perms(proxy_client_t *client, embedded_perms_t *embed,
 
 	if ((client->neg.v1.enabled & PROXY_FEAT_EMBEDDED_PERMS) == 0) {
 		*embedded = false;
-		return ptr_check(&client->random, embed->ptr, (void **)pperms);
+		return ptr_check(&global_random, embed->ptr, (void **)pperms);
 	}
 
 	perms = ceph_userperm_new(embed->uid, embed->gid, count,

--- a/src/libcephfs_proxy/proxy_async.c
+++ b/src/libcephfs_proxy/proxy_async.c
@@ -18,13 +18,13 @@ static int32_t libcephfsd_cbk_nonblocking_rw(proxy_async_t *async,
 	const struct iovec *iov;
 	int32_t err, count;
 
-	err = ptr_check(&async->random, cbk->ll_nonblocking_rw.v0.info,
+	err = ptr_check(&async->random, cbk->ll_nonblocking_rw.info,
 			(void **)&info);
 	if (err < 0) {
 		return err;
 	}
 
-	info->result = cbk->ll_nonblocking_rw.v0.res;
+	info->result = cbk->ll_nonblocking_rw.res;
 
 	if (!info->write) {
 		iov = info->iov;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72952

---

backport of https://github.com/ceph/ceph/pull/65320
parent tracker: https://tracker.ceph.com/issues/72800

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh