### PR TITLE
squid: monitoring: add user-agent headers to the urllib

### DIFF
--- a/monitoring/ceph-mixin/tests_alerts/validate_rules.py
+++ b/monitoring/ceph-mixin/tests_alerts/validate_rules.py
@@ -84,7 +84,14 @@ class HTMLCache:
         if url in self.cache:
             return self.cache[url]
 
-        req = urllib.request.Request(url)
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Linux x86_64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/139.0.0.0 Safari/537.36"
+            ),
+        }
+        req = urllib.request.Request(url, headers=headers)
         try:
             r = urllib.request.urlopen(req)
         except urllib.error.HTTPError as e:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72965

---

backport of https://github.com/ceph/ceph/pull/65470
parent tracker: https://tracker.ceph.com/issues/72960

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh