### PR TITLE
tentacle: osd: stop scrub_purged_snaps() from ignoring osd_beacon_report_interval

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1882,6 +1882,7 @@ protected:
   // which pgs were scanned for min_lec
   std::vector<pg_t> min_last_epoch_clean_pgs;
   void send_beacon(const ceph::coarse_mono_clock::time_point& now);
+  void maybe_send_beacon();
 
   ceph_tid_t get_tid() {
     return service.get_tid();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72911

---

backport of https://github.com/ceph/ceph/pull/64837
parent tracker: https://tracker.ceph.com/issues/72412

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh