### PR TITLE
squid: RGW: multi object delete op; skip olh update for all deletes but the last one

### DIFF
--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -872,7 +872,9 @@ public:
       int delete_obj(optional_yield y,
 		     const DoutPrefixProvider* dpp,
 		     bool log_op,
-		     const bool force); // if head object missing, do a best effort
+		     const bool force, // if head object missing, do a best effort
+		     const bool skip_olh_obj_update // true for all deletes (except the last one) initiated by a multi-object delete op
+        );
     }; // struct RGWRados::Object::Delete
 
     struct Stat {
@@ -1275,7 +1277,8 @@ public:
 		 const ceph::real_time& expiration_time = ceph::real_time(),
 		 rgw_zone_set *zones_trace = nullptr,
                  bool log_op = true,
-                 const bool force = false); // if head object missing, do a best effort
+                 const bool force = false, // if head object missing, do a best effort
+                 const bool skip_olh_obj_update = false); // true for all deletes (except the last one) initiated by a multi-object delete op
 
   int delete_raw_obj(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, optional_yield y);
 
@@ -1415,7 +1418,7 @@ public:
                           uint64_t olh_epoch, optional_yield y,
 			  uint16_t bilog_flags, bool null_verid,
 			  rgw_zone_set *zones_trace = nullptr,
-			  bool log_op = true, const bool force = false);
+			  bool log_op = true, const bool force = false, const bool skip_olh_obj_update = false);
 
   void check_pending_olh_entries(const DoutPrefixProvider *dpp, std::map<std::string, bufferlist>& pending_entries, std::map<std::string, bufferlist> *rm_pending_entries);
   int remove_olh_pending_entries(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, std::map<std::string, bufferlist>& pending_attrs, optional_yield y);

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2891,7 +2891,7 @@ int RadosObject::RadosDeleteOp::delete_obj(const DoutPrefixProvider* dpp, option
   parent_op.params.parts_accounted_size = params.parts_accounted_size;
   parent_op.params.null_verid = params.null_verid;
 
-  int ret = parent_op.delete_obj(y, dpp, flags & FLAG_LOG_OP, flags & FLAG_FORCE_OP);
+  int ret = parent_op.delete_obj(y, dpp, flags & FLAG_LOG_OP, flags & FLAG_FORCE_OP, flags & FLAG_SKIP_UPDATE_OLH);
   if (ret < 0) {
     return ret;
   }
@@ -2922,7 +2922,7 @@ int RadosObject::delete_object(const DoutPrefixProvider* dpp,
   }
 
   // convert flags to bool params
-  return del_op.delete_obj(y, dpp, flags & FLAG_LOG_OP, flags & FLAG_FORCE_OP);
+  return del_op.delete_obj(y, dpp, flags & FLAG_LOG_OP, flags & FLAG_FORCE_OP, flags & FLAG_SKIP_UPDATE_OLH);
 } // RadosObject::delete_object
 
 int RadosObject::copy_object(const ACLOwner& owner,

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2030,8 +2030,15 @@ class RGWDeleteMultiObj : public RGWOp {
    * set_partial_response to record the outcome.
    */
   void handle_individual_object(const rgw_obj_key& o,
-				optional_yield y,
-                                boost::asio::deadline_timer *formatter_flush_cond);
+                                optional_yield y,
+                                boost::asio::deadline_timer *formatter_flush_cond,
+                                const bool skip_olh_obj_update = false);
+  void handle_versioned_objects(const std::vector<rgw_obj_key>& objects,
+                                uint32_t max_aio, boost::asio::yield_context yield);
+  void handle_non_versioned_objects(const std::vector<rgw_obj_key>& objects,
+                                    uint32_t max_aio, boost::asio::yield_context yield);
+  void handle_objects(const std::vector<rgw_obj_key>& objects,
+                      uint32_t max_aio, boost::asio::yield_context yield);
 
   /**
    * When the request is being executed in a coroutine, performs

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -196,6 +196,7 @@ static constexpr uint32_t FLAG_PREVENT_VERSIONING = 0x0002;
 // if cannot do all elements of op, do as much as possible (e.g.,
 // delete object where head object is missing)
 static constexpr uint32_t FLAG_FORCE_OP = 0x0004;
+static constexpr uint32_t FLAG_SKIP_UPDATE_OLH = 0x0008;
 
 
 // a simple streaming data processing abstraction


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72971

---

backport of https://github.com/ceph/ceph/pull/64800
parent tracker: https://tracker.ceph.com/issues/72375

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh