### PR TITLE
src/cephadm/cephadmlib/daemons: Fix typos in ceph.py and elsewhere

### DIFF
--- a/src/cephadm/cephadmlib/daemons/ceph.py
+++ b/src/cephadm/cephadmlib/daemons/ceph.py
@@ -466,7 +466,7 @@ def get_ceph_mounts_for_type(
                 mounts[selinux_folder] = '/sys/fs/selinux:ro'
             else:
                 logger.error(
-                    f'Cluster direcotry {cluster_dir} does not exist.'
+                    f'Cluster directory {cluster_dir} does not exist.'
                 )
     if daemon_type == 'osd':
         mounts['/'] = '/rootfs'

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/upgrade/upgrade.component.html
@@ -192,7 +192,7 @@
   <div class="w-50"
        *ngIf="!errorMessage; else upgradeInfoError">
     <span class="text-info justify-content-center align-items-center"
-          i18n>Fetching registry informations
+          i18n>Fetching registry information
       <i [ngClass]="[icons.spin, icons.spinner]"></i>
     </span>
   </div>
@@ -216,7 +216,7 @@
   <span class="text-danger justify-content-center align-items-center"
         i18n>
     <i [ngClass]="[icons.danger]"></i>
-    Failed to fetch registry informations
+    Failed to fetch registry information
   </span>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.cs.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.cs.xlf
@@ -11294,7 +11294,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11308,7 +11308,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.de-DE.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.de-DE.xlf
@@ -11717,7 +11717,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11731,7 +11731,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.es-ES.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.es-ES.xlf
@@ -11632,7 +11632,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11646,7 +11646,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.fr-FR.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.fr-FR.xlf
@@ -11632,7 +11632,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11646,7 +11646,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.id-ID.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.id-ID.xlf
@@ -11256,7 +11256,7 @@ set ...'. Pilihan ini harus dikonfigurasi melalui ceph.conf atau CLI.</target>
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11270,7 +11270,7 @@ set ...'. Pilihan ini harus dikonfigurasi melalui ceph.conf atau CLI.</target>
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.it-IT.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.it-IT.xlf
@@ -11632,7 +11632,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11646,7 +11646,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.ja-JP.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.ja-JP.xlf
@@ -11632,7 +11632,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11646,7 +11646,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.ko-KR.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.ko-KR.xlf
@@ -11479,7 +11479,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11493,7 +11493,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.pl-PL.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.pl-PL.xlf
@@ -11255,7 +11255,7 @@ terminal.</target>
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11269,7 +11269,7 @@ terminal.</target>
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.pt-BR.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.pt-BR.xlf
@@ -11632,7 +11632,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11646,7 +11646,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.zh-CN.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.zh-CN.xlf
@@ -11632,7 +11632,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11646,7 +11646,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.zh-TW.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.zh-TW.xlf
@@ -11633,7 +11633,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="516206233d06e9835536cd886aeb1d0c95694cb6" datatype="html">
-        <source>Fetching registry informations <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
+        <source>Fetching registry information <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i [ngClass]=&quot;[icons.spin, icons.spinner]&quot;&gt;"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/span&gt;   &lt;/d"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">194,197</context>
@@ -11647,7 +11647,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="584342c52d131aaac16203e4b55a697d94fb4da5" datatype="html">
-        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry informations </source>
+        <source><x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;     Failed to fetch registry in"/><x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="Failed to fet"/> Failed to fetch registry information </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/upgrade/upgrade.component.html</context>
           <context context-type="linenumber">217,219</context>


### PR DESCRIPTION
src/cephadm/cephadmlib/daemons: Fix typos in ceph.py and Dashboard files.

Pointed out by Eugen Block.
Fixes: https://tracker.ceph.com/issues/64242
Signed-off-by: Anthony D'Atri <anthonyeleven@users.noreply.github.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
