### PR TITLE
tentacle: mon: add config option to change availability score update interval 

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -161,9 +161,11 @@
   users to view the availability score for each pool in a cluster. A pool is considered 
   unavailable if any PG in the pool is not in active state or if there are unfound 
   objects. Otherwise the pool is considered available. The score is updated every 
-  5 seconds. The feature is on by default. A new config option ``enable_availability_tracking``
-  can be used to turn off the feature if required. Another command is added to clear the 
-  availability status for a specific pool, ``ceph osd pool clear-availability-status <pool-name>``. 
+  one second by default. This interval can be changed using the new config option
+  ``pool_availability_update_interval.``. The feature is on by default. A new config option 
+  ``enable_availability_tracking`` can be used to turn off the feature if required. 
+  Another command is added to clear the availability status for a specific pool, 
+  ``ceph osd pool clear-availability-status <pool-name>``. 
   This feature is in tech preview. 
   Related trackers:
    - https://tracker.ceph.com/issues/67777

--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -628,6 +628,7 @@ Miscellaneous
 .. confval:: mon_memory_target
 .. confval:: mon_memory_autotune
 .. confval:: enable_availability_tracking
+.. confval:: pool_availability_update_interval
 
 NVMe-oF Monitor Client
 ======================

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -781,10 +781,19 @@ the Mean Time Between Failures (MTBF) and Mean Time To Recover (MTTR)
 for each pool. The availability score is then calculated by finding 
 the ratio of MTBF to the total time.  
 
-The score is updated every five seconds. This interval is currently 
-not configurable. Any intermittent changes to the pools that 
-occur between this duration but are reset before we recheck the pool 
-status will not be captured by this feature. 
+The score is updated every one second. Transient changes to pools that 
+occur and are reverted between successive updates will not be captured. 
+It is possible to configure this interval with a command of the following 
+form: 
+
+.. prompt:: bash $
+
+   ceph config set mon pool_availability_update_interval 2
+
+This will set the update interval to two seconds. Please note that 
+it is not possible to set this interval less than the config value set
+for ``paxos_propose_interval``. 
+
 
 This feature is on by default. To turn the feature off, e.g. - for an expected 
 downtime, the ``enable_availability_tracking`` config option can be set to ``false``. 

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1420,3 +1420,13 @@ options:
   default: 30
   services:
   - mon
+- name: pool_availability_update_interval
+  type: float
+  level: advanced
+  desc: Update data availability score at this interval. By default the interval 
+    is same as paxos_propose_interval configuration.  
+  default: 1
+  services :
+  - mon
+  flags:
+  - runtime

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -64,6 +64,7 @@ std::vector<std::string> MgrStatMonitor::get_tracked_keys() const noexcept
 {
   return {
     "enable_availability_tracking",
+    "pool_availability_update_interval",
   };
 }
 
@@ -92,6 +93,16 @@ void MgrStatMonitor::handle_conf_change(
                << now << dendl;
     }
     enable_availability_tracking = newval;
+  }
+
+  if (changed.count("pool_availability_update_interval")) {
+      std::scoped_lock l(lock);
+      dout(10) << __func__ << " pool_availability_update_interval config changed from " 
+             << pool_availability_update_interval << " to " 
+             << g_conf().get_val<double>("pool_availability_update_interval")
+             << dendl;
+      
+      pool_availability_update_interval = g_conf().get_val<double>("pool_availability_update_interval"); 
   }
 }
 

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -57,8 +57,10 @@ public:
   void calc_pool_availability();
   bool enable_availability_tracking = g_conf().get_val<bool>("enable_availability_tracking"); ///< tracking availability score feature 
   double pool_availability_update_interval = g_conf().get_val<double>("pool_availability_update_interval");
+  utime_t pool_availability_last_updated = ceph_clock_now(); 
 
   void clear_pool_availability(int64_t poolid);
+  bool should_calc_pool_availability();
 
   void check_sub(Subscription *sub);
   void check_subs();

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -56,7 +56,8 @@ public:
 
   void calc_pool_availability();
   bool enable_availability_tracking = g_conf().get_val<bool>("enable_availability_tracking"); ///< tracking availability score feature 
-  
+  double pool_availability_update_interval = g_conf().get_val<double>("pool_availability_update_interval");
+
   void clear_pool_availability(int64_t poolid);
 
   void check_sub(Subscription *sub);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73013

---

backport of https://github.com/ceph/ceph/pull/65172
parent tracker: https://tracker.ceph.com/issues/72619

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh