### PR TITLE
rbd-mirror: fix group snapshot sync ordering and also properly remove peer UUIDs

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_group.sh
+++ b/qa/workunits/rbd/rbd_mirror_group.sh
@@ -144,9 +144,7 @@ check_group_snap_doesnt_exist ${CLUSTER2} ${POOL}/${group} ${snap}
 # this next extra mirror_group_snapshot should not be needed to remove the snap on the secondary - waiting for fix TODO
 mirror_group_snapshot ${CLUSTER2} ${POOL}/${group}
 mirror_group_snapshot_and_wait_for_sync_complete ${CLUSTER1} ${CLUSTER2} ${POOL}/${group}
-# FIXME: Issues#45 should help uncomment below
-# Context: currently there is a delay in the prune of the regular group snaps.
-#check_group_snap_doesnt_exist ${CLUSTER1} ${POOL}/${group} ${snap}
+check_group_snap_doesnt_exist ${CLUSTER1} ${POOL}/${group} ${snap}
 
 testlog "TEST: stop mirror, create group, start mirror and test replay"
 stop_mirrors ${CLUSTER1}

--- a/qa/workunits/rbd/rbd_mirror_group_simple.sh
+++ b/qa/workunits/rbd/rbd_mirror_group_simple.sh
@@ -1560,8 +1560,7 @@ declare -a test_create_group_with_images_then_mirror_with_regular_snapshots_1=("
 declare -a test_create_group_with_images_then_mirror_with_regular_snapshots_2=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${group0}" "${image_prefix}" 2 'leave_snap')
 declare -a test_create_group_with_images_then_mirror_with_regular_snapshots_3=("${CLUSTER2}" "${CLUSTER1}" "${pool0}" "${group0}" "${image_prefix}" 2 'force_disable')
 
-# TODO scenario 1 is sometimes failing so is disabled - see issue on line 45
-test_create_group_with_images_then_mirror_with_regular_snapshots_scenarios='2 3'
+test_create_group_with_images_then_mirror_with_regular_snapshots_scenarios=3
 
 test_create_group_with_images_then_mirror_with_regular_snapshots()
 {
@@ -1601,8 +1600,6 @@ test_create_group_with_images_then_mirror_with_regular_snapshots()
   if [ "${scenario}" = 'remove_snap' ]; then
     group_snap_remove "${primary_cluster}" "${pool}/${group}" "${snap}"
     check_group_snap_doesnt_exist "${primary_cluster}" "${pool}/${group}" "${snap}"
-    # this next extra mirror_group_snapshot should not be needed - waiting for fix TODO - coding leftover 38
-    mirror_group_snapshot "${primary_cluster}" "${pool}/${group}"
     mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}"/"${group}"
     check_group_snap_doesnt_exist "${secondary_cluster}" "${pool}/${group}" "${snap}"
   else
@@ -1894,12 +1891,8 @@ test_create_group_with_multiple_images_do_io()
 
   group_snap_remove "${primary_cluster}" "${pool}/${group}" "${snap}"
   check_group_snap_doesnt_exist "${primary_cluster}" "${pool}/${group}" "${snap}"
-  # this next extra mirror_group_snapshot should not be needed - waiting for fix TODO - coding leftover 38
-  mirror_group_snapshot "${primary_cluster}" "${pool}/${group}"
   mirror_group_snapshot_and_wait_for_sync_complete "${secondary_cluster}" "${primary_cluster}" "${pool}"/"${group}"
-  # FIXME: Issues#45 should help uncomment below
-  # Context: currently there is a delay in the prune of the regular group snaps.
-  #check_group_snap_doesnt_exist "${secondary_cluster}" "${pool}/${group}" "${snap}"
+  check_group_snap_doesnt_exist "${secondary_cluster}" "${pool}/${group}" "${snap}"
 
   for loop_instance in $(seq 0 $(("${image_count}"-1))); do
       compare_images "${primary_cluster}" "${secondary_cluster}" "${pool}" "${pool}" "${image_prefix}${loop_instance}"

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.cc
@@ -41,8 +41,6 @@ template <typename I>
 void GroupUnlinkPeerRequest<I>::unlink_peer() {
   ldout(m_cct, 10) << "rbd_mirroring_max_mirroring_snapshots = " << m_max_snaps << dendl;
 
-  uint64_t count = 0;
-  auto unlink_snap = m_group_snaps.end();
   // First pass : cleanup snaps that have no peer_uuids or are incomplete
   for (auto peer: *m_mirror_peer_uuids){
     for (auto it = m_group_snaps.begin(); it != m_group_snaps.end(); it++) {
@@ -56,14 +54,15 @@ void GroupUnlinkPeerRequest<I>::unlink_peer() {
 	(ns->mirror_peer_uuids.count(peer) != 0 &&
 	 ns->is_primary() &&
          it->state == cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE)){
-	unlink_snap = it;
-	process_snapshot(*unlink_snap, peer);
+	process_snapshot(*it, peer);
 	return;
       }
     }
   }
 
   for (auto peer: *m_mirror_peer_uuids){
+    uint64_t count = 0;
+    auto unlink_snap = m_group_snaps.end();
     for (auto it = m_group_snaps.begin(); it != m_group_snaps.end(); it++) {
       auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
 	  &it->snapshot_namespace);
@@ -135,17 +134,17 @@ void GroupUnlinkPeerRequest<I>::process_snapshot(cls::rbd::GroupSnapshot group_s
                                                  std::string mirror_peer_uuid) {
   ldout(m_cct, 10) << "snap id: " << group_snap.id << dendl;
   bool found = false;
-  bool has_newer_mirror_snap = false;
 
+  m_has_newer_mirror_snap = false;
   for (auto it = m_group_snaps.begin(); it != m_group_snaps.end(); it++) {
     if (it->id  == group_snap.id) {
       found = true;
     } else if (found) {
       auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-	  &it->snapshot_namespace);
+          &it->snapshot_namespace);
       if (ns != nullptr) {
-	has_newer_mirror_snap = true;
-	break;
+        m_has_newer_mirror_snap = true;
+        break;
       }
     }
   }
@@ -153,11 +152,13 @@ void GroupUnlinkPeerRequest<I>::process_snapshot(cls::rbd::GroupSnapshot group_s
   if (!found) {
     ldout(m_cct, 15) << "missing snapshot: snap_id=" << group_snap.id << dendl;
     finish(-ENOENT);
-    return;  
+    return;
   }
 
-  if (has_newer_mirror_snap) {
-    remove_group_snapshot(group_snap); 
+  const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      group_snap.snapshot_namespace);
+  if (ns.mirror_peer_uuids.empty()) {
+    remove_group_snapshot(group_snap);
   } else {
     remove_peer_uuid(group_snap, mirror_peer_uuid);
   }
@@ -170,9 +171,10 @@ void GroupUnlinkPeerRequest<I>::remove_peer_uuid(
                               std::string mirror_peer_uuid) {
   ldout(m_cct, 10) << dendl;
 
-  auto aio_comp = create_rados_callback<
-    GroupUnlinkPeerRequest<I>,
-    &GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid>(this);
+  auto aio_comp = create_rados_callback(
+      new LambdaContext([this, group_snap](int r) {
+        handle_remove_peer_uuid(r, group_snap);
+      }));
 
   auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
     &group_snap.snapshot_namespace);
@@ -188,7 +190,8 @@ void GroupUnlinkPeerRequest<I>::remove_peer_uuid(
 }
 
 template <typename I>
-void GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid(int r) {
+void GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid(
+    int r, cls::rbd::GroupSnapshot group_snap) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
   if (r < 0) {
@@ -197,7 +200,12 @@ void GroupUnlinkPeerRequest<I>::handle_remove_peer_uuid(int r) {
     finish(r);
     return;
   }
-  list_group_snaps();
+
+  if (m_has_newer_mirror_snap) {
+    remove_group_snapshot(group_snap);
+  } else {
+    list_group_snaps();
+  }
 }
 
 

--- a/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
+++ b/src/librbd/mirror/snapshot/GroupUnlinkPeerRequest.h
@@ -55,6 +55,7 @@ private:
   Context *m_on_finish;
 
   uint64_t m_max_snaps;
+  bool m_has_newer_mirror_snap = false;
   CephContext *m_cct;
 
   std::vector<cls::rbd::GroupSnapshot> m_group_snaps;
@@ -71,7 +72,7 @@ private:
 
   void remove_peer_uuid(cls::rbd::GroupSnapshot group_snap,
                         std::string mirror_peer_uuid);
-  void handle_remove_peer_uuid(int r);
+  void handle_remove_peer_uuid(int r, cls::rbd::GroupSnapshot group_snap);
 
   void remove_group_snapshot(cls::rbd::GroupSnapshot group_snap);
   void handle_remove_group_snapshot(int r);

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -1699,8 +1699,10 @@ void Replayer<I>::prune_mirror_group_snapshots(
       }
     }
     mirror_group_snapshot_unlink_peer(prune_snap->id);
-    // prune all the image snaps of the group snap locally
-    if (prune_all_image_snapshots(prune_snap, locker)) {
+    const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+        prune_snap->snapshot_namespace);
+    if (ns.is_primary() ||
+        prune_all_image_snapshots(prune_snap, locker)) {
       prune_snap = nullptr;
       skip_next_snap_check = false;
       continue;

--- a/src/tools/rbd_mirror/group_replayer/Replayer.cc
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.cc
@@ -345,7 +345,7 @@ void Replayer<I>::validate_image_snaps_sync_complete(
       local_snap.snapshot_namespace);
 
   if (snap_type != cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_MIRROR) {
-    regular_snapshot_complete(local_snap.id, on_finish);
+    user_snapshot_complete(local_snap.id, on_finish);
   } else {
     mirror_snapshot_complete(local_snap.id, on_finish);
   }
@@ -430,14 +430,13 @@ void Replayer<I>::validate_local_group_snapshots() {
         std::unique_lock locker{m_lock};
         m_retry_validate_snap = true;
       }
-      sub_ctx->complete(0);
+      sub_ctx->complete(r);
     });
 
     // validate incomplete non-primary mirror or regular snapshots
     validate_image_snaps_sync_complete(local_snap, ctx);
   }
   gather_ctx->activate();
-
 }
 
 template <typename I>
@@ -478,32 +477,31 @@ void Replayer<I>::handle_load_local_group_snapshots(int r) {
   }
 
   auto last_local_snap = get_latest_mirror_group_snapshot(m_local_group_snaps);
-  if (last_local_snap != nullptr) {
-    auto ns = std::get_if<cls::rbd::GroupSnapshotNamespaceMirror>(
-        &last_local_snap->snapshot_namespace);
-    if (ns->state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
-      if (ns->is_orphan()) {
-        dout(5) << "local group being force promoted" << dendl;
-        handle_replay_complete(&locker, 0, "orphan (force promoting)");
-        return;
-      } else if (m_retry_validate_snap ||
-                 last_local_snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE) {
-        m_retry_validate_snap = false;
-        locker.unlock();
-        schedule_load_group_snapshots();
-        return; // previous snap is syncing, reload local snaps to confirm its completeness.
-      }
-    } else { // primary
-      if (last_local_snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE) {
-        dout(10) << "found incomplete primary group snapshot: "
-                 << last_local_snap->id << dendl;
-        locker.unlock();
-        schedule_load_group_snapshots();
-        return;
-      }
+  if (!last_local_snap) {
+    load_remote_group_snapshots();
+    return;
+  }
+
+  const auto& ns = std::get<cls::rbd::GroupSnapshotNamespaceMirror>(
+      last_local_snap->snapshot_namespace);
+  // handle mirror snapshot states
+  if (ns.state != cls::rbd::MIRROR_SNAPSHOT_STATE_PRIMARY) {
+    if (ns.is_orphan()) {
+      dout(5) << "local group being force promoted" << dendl;
+      handle_replay_complete(&locker, 0, "orphan (force promoting)");
+      return;
+    }
+    if (last_local_snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE) {
+      m_retry_validate_snap = true;
+    }
+  } else {  // primary snapshot
+    if (last_local_snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_COMPLETE) {
       handle_replay_complete(&locker, 0, "local group is primary");
       return;
     }
+    dout(10) << "found incomplete primary group snapshot: "
+             << last_local_snap->id << dendl;
+    m_retry_validate_snap = true;
   }
 
   load_remote_group_snapshots();
@@ -541,6 +539,13 @@ void Replayer<I>::handle_load_remote_group_snapshots(int r) {
     derr << "error listing remote mirror group snapshots: " << cpp_strerror(r)
          << dendl;
     handle_replay_complete(&locker, r, "failed to list remote group snapshots");
+    return;
+  }
+
+  if (m_retry_validate_snap) {
+    m_retry_validate_snap = false;
+    locker.unlock();
+    schedule_load_group_snapshots();
     return;
   }
 
@@ -870,18 +875,18 @@ void Replayer<I>::create_group_snapshot(cls::rbd::GroupSnapshot snap,
       return;
     }
 
-    dout(10) << "found regular snap, snap name: " << snap.name
+    dout(10) << "found user snap, snap name: " << snap.name
              << ", remote group snap id: " << snap.id << dendl;
 
     m_in_flight_op_tracker.start_op();
     auto ctx = new LambdaContext([this, snap](int r) mutable {
       if (r < 0) {
-        dout(10) << "create regular snapshot failed, will be retried later: "
-             << cpp_strerror(r) << dendl;
+        dout(10) << "create user snapshot failed, will be retried later: "
+                 << cpp_strerror(r) << dendl;
       }
       m_in_flight_op_tracker.finish_op();
     });
-    create_regular_snapshot(&snap, ctx);
+    create_user_snapshot(&snap, ctx);
   }
 }
 
@@ -1014,7 +1019,7 @@ void Replayer<I>::mirror_snapshot_complete(
 
   if (itl == m_local_group_snaps.end()) {
     locker.unlock();
-    on_finish->complete(0);
+    on_finish->complete(-EAGAIN);
     return;
   }
 
@@ -1142,16 +1147,55 @@ void Replayer<I>::post_mirror_snapshot_complete(
         if (it == local_snap.snaps.end()) {
           local_image_snap_specs.push_back(snap_spec);
         }
-        continue;
+        break;
       } else {
-        dout(10) << "remote group snap id: " << group_snap_id
-                 << ", local reflected in the image snap: "
-                 << mirror_ns->group_snap_id << dendl;
+        dout(20) << "expecting remote group snap id: " << group_snap_id
+                 << ", but group snap id: " << mirror_ns->group_snap_id
+                 << " is reflecting in the local image: " << image.spec.image_id
+                 << " with image snap id: " << snap_info.id << dendl;
       }
     }
 
     if (!image_snap_complete) {
       set_image_replayer_limits(image.spec.image_id, &remote_snap, &locker);
+    }
+  }
+
+  // Old synced user snap is removed and not yet reflecting locally, wait for it.
+  bool user_snap_found;
+  for (auto local_snap = m_local_group_snaps.begin();
+      local_snap != m_local_group_snaps.end(); ++local_snap) {
+    auto snap_type = cls::rbd::get_group_snap_namespace_type(
+        local_snap->snapshot_namespace);
+    if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
+      user_snap_found = false;
+      for (auto remote_snap = m_remote_group_snaps.begin();
+          remote_snap != m_remote_group_snaps.end(); ++remote_snap) {
+        if (local_snap->id == remote_snap->id) {
+          user_snap_found = true;
+          break;
+        }
+      }
+      if (!user_snap_found) {
+        prune_user_group_snapshots(&locker);
+        locker.unlock();
+        // there is a user group snap removed on remote, so lets wait for it to removed locally
+        on_finish->complete(-EAGAIN);
+        return;
+      }
+    }
+  }
+
+  // User snap is added and not yet turned complete, wait for it.
+  for (auto local_snap = m_local_group_snaps.begin();
+      local_snap != m_local_group_snaps.end(); ++local_snap) {
+    if (local_snap->id == group_snap_id) {
+      break;
+    } else if (local_snap->state == cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE) {
+      locker.unlock();
+      // there is a user group snap waiting sync, so lets wait for it to moved to complete
+      on_finish->complete(-EAGAIN);
+      return;
     }
   }
 
@@ -1180,7 +1224,7 @@ void Replayer<I>::post_mirror_snapshot_complete(
              << dendl;
   } else {
     locker.unlock();
-    on_finish->complete(0);
+    on_finish->complete(-EAGAIN); // try again
   }
 }
 
@@ -1217,7 +1261,7 @@ void Replayer<I>::handle_post_mirror_snapshot_complete(
 }
 
 template <typename I>
-void Replayer<I>::create_regular_snapshot(
+void Replayer<I>::create_user_snapshot(
     cls::rbd::GroupSnapshot *snap,
     Context *on_finish) {
   auto group_snap_id = snap->id;
@@ -1250,7 +1294,7 @@ void Replayer<I>::create_regular_snapshot(
 
   auto comp = create_rados_callback(
       new LambdaContext([this, group_snap_id, on_finish](int r) {
-        handle_create_regular_snapshot(r, group_snap_id, on_finish);
+        handle_create_user_snapshot(r, group_snap_id, on_finish);
       }));
 
   int r = m_local_io_ctx.aio_operate(
@@ -1260,12 +1304,12 @@ void Replayer<I>::create_regular_snapshot(
 }
 
 template <typename I>
-void Replayer<I>::handle_create_regular_snapshot(
+void Replayer<I>::handle_create_user_snapshot(
     int r, const std::string &group_snap_id, Context *on_finish) {
   dout(10) << "group_snap_id=" << group_snap_id << ", r=" << r << dendl;
 
   if (r < 0) {
-    derr << "failed to create regular snapshot: " << group_snap_id
+    derr << "failed to create user snapshot: " << group_snap_id
          << ", error: " << cpp_strerror(r) << dendl;
   }
 
@@ -1273,7 +1317,7 @@ void Replayer<I>::handle_create_regular_snapshot(
 }
 
 template <typename I>
-void Replayer<I>::regular_snapshot_complete(
+void Replayer<I>::user_snapshot_complete(
     const std::string &group_snap_id,
     Context *on_finish) {
   std::unique_lock locker{m_lock};
@@ -1288,7 +1332,7 @@ void Replayer<I>::regular_snapshot_complete(
 
   if (itl == m_local_group_snaps.end()) {
     locker.unlock();
-    on_finish->complete(0);
+    on_finish->complete(-EAGAIN);
     return;
   }
 
@@ -1335,9 +1379,8 @@ void Replayer<I>::regular_snapshot_complete(
           on_finish->complete(r);
         });
 
-      handle_regular_snapshot_image_list(
-        group_snap_id, local_snap, remote_snap,
-        *local_images, cleanup_ctx);
+      handle_user_snapshot_image_list(
+        group_snap_id, local_snap, remote_snap, *local_images, cleanup_ctx);
     });
 
   // initiate image listing
@@ -1345,19 +1388,19 @@ void Replayer<I>::regular_snapshot_complete(
 }
 
 template <typename I>
-void Replayer<I>::handle_regular_snapshot_image_list(
+void Replayer<I>::handle_user_snapshot_image_list(
     const std::string &group_snap_id,
     const cls::rbd::GroupSnapshot &local_snap,
     const cls::rbd::GroupSnapshot &remote_snap,
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     Context *on_finish) {
   dout(10) << group_snap_id << dendl;
-  post_regular_snapshot_complete(group_snap_id, local_snap, remote_snap,
+  post_user_snapshot_complete(group_snap_id, local_snap, remote_snap,
                                  local_images, on_finish);
 }
 
 template <typename I>
-void Replayer<I>::post_regular_snapshot_complete(
+void Replayer<I>::post_user_snapshot_complete(
     const std::string &group_snap_id,
     const cls::rbd::GroupSnapshot &local_snap,
     const cls::rbd::GroupSnapshot &remote_snap,
@@ -1413,6 +1456,7 @@ void Replayer<I>::post_regular_snapshot_complete(
         snap_spec.snap_id = snap_info.id;
 
         local_image_snap_specs.push_back(snap_spec);
+        break;
       }
     }
   }
@@ -1427,7 +1471,7 @@ void Replayer<I>::post_regular_snapshot_complete(
 
     auto comp = create_rados_callback(
         new LambdaContext([this, group_snap_id, on_finish](int r) {
-          handle_post_regular_snapshot_complete(r, group_snap_id, on_finish);
+          handle_post_user_snapshot_complete(r, group_snap_id, on_finish);
         }));
     int r = m_local_io_ctx.aio_operate(
         librbd::util::group_header_name(m_local_group_id), comp, &op);
@@ -1442,12 +1486,12 @@ void Replayer<I>::post_regular_snapshot_complete(
              << dendl;
   } else {
     locker.unlock();
-    on_finish->complete(0);
+    on_finish->complete(-EAGAIN); // try again
   }
 }
 
 template <typename I>
-void Replayer<I>::handle_post_regular_snapshot_complete(
+void Replayer<I>::handle_post_user_snapshot_complete(
     int r, const std::string &group_snap_id, Context *on_finish) {
   dout(10) << group_snap_id << ", r=" << r << dendl;
 
@@ -1563,15 +1607,12 @@ void Replayer<I>::prune_user_group_snapshots(
   int r;
   for (auto local_snap = m_local_group_snaps.begin();
       local_snap != m_local_group_snaps.end(); ++local_snap) {
-    if (local_snap->state != cls::rbd::GROUP_SNAPSHOT_STATE_COMPLETE) {
-      break;
-    }
     auto snap_type = cls::rbd::get_group_snap_namespace_type(
         local_snap->snapshot_namespace);
     if (snap_type == cls::rbd::GROUP_SNAPSHOT_NAMESPACE_TYPE_USER) {
       bool prune_user_snap = true;
       for (auto &remote_snap : m_remote_group_snaps) {
-        if (remote_snap.name == local_snap->name) {
+        if (remote_snap.id == local_snap->id) {
           prune_user_snap = false;
           break;
         }
@@ -1579,13 +1620,13 @@ void Replayer<I>::prune_user_group_snapshots(
       if (!prune_user_snap) {
         continue;
       }
-      dout(10) << "pruning regular group snap in-progress: "
+      dout(10) << "pruning user group snap in-progress: "
                << local_snap->name << ", with id: " << local_snap->id << dendl;
       // prune all the image snaps of the group snap locally
       if (prune_all_image_snapshots(&(*local_snap), locker)) {
         continue;
       }
-      dout(10) << "all image snaps are pruned, finally pruning regular group snap: "
+      dout(10) << "all image snaps are pruned, finally pruning user group snap: "
                << local_snap->id << dendl;
       r = librbd::cls_client::group_snap_remove(&m_local_io_ctx,
              librbd::util::group_header_name(m_local_group_id), local_snap->id);

--- a/src/tools/rbd_mirror/group_replayer/Replayer.h
+++ b/src/tools/rbd_mirror/group_replayer/Replayer.h
@@ -197,28 +197,28 @@ private:
   void handle_post_mirror_snapshot_complete(
     int r, const std::string &group_snap_id, Context *on_finish);
 
-  void create_regular_snapshot(
+  void create_user_snapshot(
     cls::rbd::GroupSnapshot *snap,
     Context *on_finish);
-  void handle_create_regular_snapshot(
+  void handle_create_user_snapshot(
       int r, const std::string &group_snap_id, Context *on_finish);
 
-  void regular_snapshot_complete(
+  void user_snapshot_complete(
     const std::string &group_snap_id,
     Context *on_finish);
-  void handle_regular_snapshot_image_list(
-    const std::string &group_snap_id,
-    const cls::rbd::GroupSnapshot &local_snap,
-    const cls::rbd::GroupSnapshot &remote_snap,
-    const std::vector<cls::rbd::GroupImageStatus>& local_images,
-    Context *on_finish);
-  void post_regular_snapshot_complete(
+  void handle_user_snapshot_image_list(
     const std::string &group_snap_id,
     const cls::rbd::GroupSnapshot &local_snap,
     const cls::rbd::GroupSnapshot &remote_snap,
     const std::vector<cls::rbd::GroupImageStatus>& local_images,
     Context *on_finish);
-  void handle_post_regular_snapshot_complete(
+  void post_user_snapshot_complete(
+    const std::string &group_snap_id,
+    const cls::rbd::GroupSnapshot &local_snap,
+    const cls::rbd::GroupSnapshot &remote_snap,
+    const std::vector<cls::rbd::GroupImageStatus>& local_images,
+    Context *on_finish);
+  void handle_post_user_snapshot_complete(
     int r, const std::string &group_snap_id, Context *on_finish);
 
   void mirror_group_snapshot_unlink_peer(const std::string &snap_id);


### PR DESCRIPTION
- rbd_mirror: order the user group snaps and the mirror group snaps syncing
```
In case of user group snap addition:
* Wait for the user group snap to sync to complete and only then mark
  the mirror group snap to complete
In case of user group snap removal:
* Wait for the user group snap to get pruned and only then mark the
  mirror group snap to complete
  
 Updated tests:
   • test_create_group_with_images_then_mirror_with_regular_snapshots   
       enable scenario 1 as with the recent changes it works, also remove
       additional mirror group snapshot as it is no more required.
```


- librbd/mirror: remove peer UUID of group snapshot before attempting removal
```
Problem:
When the number of snapshots exceeds the configured limit
(rbd_mirroring_max_mirroring_snapshots), the cleanup process remove the last
group snapshot on the primary. If this removal fails partially, the
group snapshot with some or empty image snap may still remain.
  
As a result:
* The snapshot is incorrectly considered for synchronization to the secondary.
* The secondary snapshot can remain forever in the incomplete state, leading
  to stuck of daemon progress.

Solution:
Before attempting to remove the group snapshot:
* Explicitly remove the peer UUID associated with the snapshot.
* This ensures that the snapshot is no longer considered eligible for
  synchronization.
* Even if the actual snapshot deletion fails partially, the snapshot is not
  tried for mirroring, avoiding daemon stalls or inconsistencies.

```


- rbd-mirror: do not prune primary snapshots as part of the secondary daemon

```
Problem:
In a relocate situation there is a demote involved and we have a demote
snapshot both on primary with peer UUID attached and on secondary with peer UUID
attached. Later a promote say on site-b triggered primary demote group snap
removal on site-a which started a image snap removal, so it started a request to
image replayer (idle at that time), but the request didn't yet went
through.

As a next command we had --force promote on site-a but since the request on
site-a for image snap removal is already in place it somehow went through and
removed the image snaps leaving the group snap on site-a primary demote snapshot
partially deleted with peer UUID attached. And now note site-a is again primary.

In the later test, it involved demote on site-b and followed by a resync on it.
But since the primary demote snapshot is lingering in the partially deleted
state and since peer UUID is still attached, there is no way the resync will
go through, leaving the syncing snaps in incomplete state forever.

Note: Any CLI command on new primary site-a cannot delete the partially deleted
snap because there is a peer UUID attached to it.

Solution:
Do not prune any primary snapshot (including primary demote snapshots) as part
of the secondary daemon operations.

It is safe, however, to unlink remote group snapshots (such as non-primary
demote snapshots). Just ensure that primary demote snapshots are not pruned by
the secondary daemon.

Even in scenarios where a relocation back to the initial cluster occurs in the
future, the primary demoted snapshot on the current secondary (which becomes
primary during relocation) will not be synced again — even though it retains
with a peer UUID. This is because the scan_for_unsynced_group_snapshots()
function uses the last local group snapshot ID to locate the corresponding
snapshot on the remote side and continues syncing from that point onward, rather
than starting from the beginning.

However, in the event of a full resync request, this snapshot will be synced.
This is expected behavior and should not pose any issues. This actually
helps in pruning the primary demote snap on primary quickly later.

```

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
