### PR TITLE
osd/SnapMapper: fix SnapMapper::Scrubber shard parsing

### DIFF
--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -56,19 +56,42 @@ const char *SnapMapper::PURGED_SNAP_PREFIX = "PSN_";
   e.g., clean up on deletion).
 
   "SNA_"
-  + ("%lld" % poolid)
-  + "_"
-  + ("%016x" % snapid)
-  + "_"
-  + (".%x" % shard_id)
-  + "_"
+  + ("%lld" % poolid) + "_"
+
+  + ("%016x" % snapid) + "_"
+
+  // shard_id formatting is skipped for shard_id_t::NO_SHARD (See: make_shard_prefix)
+  + (".%x" % shard_id) + "_"
+
   + hobject_t::to_str() ("%llx.%8x.%lx.name...." % pool, hash, snap)
+
   -> SnapMapping::Mapping { snap, hoid }
 
+  -----
+
   "OBJ_" +
+
+  // shard_id formatting is skipped for shard_id_t::NO_SHARD (See: make_shard_prefix)
   + (".%x" % shard_id)
+
   + hobject_t::to_str()
+
    -> SnapMapper::object_snaps { oid, set<snapid_t> }
+
+  -----
+
+  Key formats when shard exists (EC):
+
+  <SNA_><pool>_<snapid>_.<shardid>_<hobject_t::to_str()>
+
+  <OBJ_>_.<shardid>_<hobject_t::to_str()>
+
+  Otherwise, for shard_id_t::NO_SHARD (Replicated):
+
+  <SNA_><pool>_<snapid>_<hobject_t::to_str()>
+
+  <OBJ_>_<hobject_t::to_str()>
+
 
   */
 


### PR DESCRIPTION
From the comment at the beginning of the file
the format for snapshot+obj to obj
should be
SNA_%lld_%llx_.%lx rather than SNA_%lld_%llx.%lx in parse_m

the check for sscanf return value is also incorrect,
it returns the number of input items successfully matched and assigned.

before fix,
we always get shard 255(NO_SHARD)
snap_mapper _parse_m mapping pool 4 snap b shard 255 4:0063648e:::1000000026b.00000000:b
but for erase pool object, it will have shard
snap_mapper _parse_m mapping pool 4 snap b shard 0 4:0063648e:::1000000026b.00000000:b

Fixes: https://tracker.ceph.com/issues/73018

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
