### PR TITLE
crimson/.../store-bench: fix coll_refs index error

### DIFF
--- a/src/crimson/tools/store_bench/store-bench.cc
+++ b/src/crimson/tools/store_bench/store-bench.cc
@@ -26,6 +26,7 @@
 
 #include <random>
 #include <vector>
+#include <unordered_map>
 #include <experimental/random>
 
 #include <boost/program_options/parsers.hpp>
@@ -589,9 +590,6 @@ class RandomWriteWorkload : public StoreBenchWorkload {
   uint64_t get_obj_per_shard() const {
     return size_per_shard / size_per_obj;
   }
-  uint64_t get_obj_per_coll() const {
-    return get_obj_per_shard() / colls_per_shard;
-  }
 public:
   po::options_description get_options() final {
     po::options_description ret{"RandomWriteWorkload"};
@@ -664,7 +662,8 @@ seastar::future<results_t> RandomWriteWorkload::run(
       ghobject_t::NO_GEN);
   };
 
-  std::vector<
+  std::unordered_map<
+    uint64_t,
     std::pair<coll_t, crimson::os::CollectionRef>
     > coll_refs;
   for (uint64_t collidx = 0; collidx < colls_per_shard; ++collidx) {
@@ -673,13 +672,15 @@ seastar::future<results_t> RandomWriteWorkload::run(
    );
    auto ref = co_await local_store.create_new_collection(
      cid);
-   coll_refs.emplace_back(std::make_pair(cid, std::move(ref)));
+   coll_refs.emplace(collidx, std::make_pair(cid, std::move(ref)));
   }
   auto get_coll_id = [&](uint64_t obj_id) {
-    return coll_refs[obj_id % get_obj_per_coll()].first;
+    assert(coll_refs.contains(obj_id % colls_per_shard));
+    return coll_refs.at(obj_id % colls_per_shard).first;
   };
   auto get_coll_ref = [&](uint64_t obj_id) {
-    return coll_refs[obj_id % get_obj_per_coll()].second;
+    assert(coll_refs.contains(obj_id % colls_per_shard));
+    return coll_refs.at(obj_id % colls_per_shard).second;
   };
 
   unsigned running = 0;
@@ -751,7 +752,8 @@ seastar::future<results_t> RandomWriteWorkload::run(
   }
 
   INFO("writes_started {}", writes_started);
-  for (auto &[id, ref]: coll_refs) {
+  for (auto &[_, entry]: coll_refs) {
+    auto &[id, ref] = entry;
     INFO("flushing {}", id);
     co_await local_store.flush(ref);
   }
@@ -791,7 +793,7 @@ int main(int argc, char **argv) {
        "enable debugging")
     ("work-load-type",
      po::value<std::string>(&work_load_type)->required(),
-     "work load type: pg_log or rgw_index")
+     "work load type: pg_log, rgw_index or random_write")
     ("smp", po::value<unsigned>(&smp),
      "number of reactors");
   


### PR DESCRIPTION
Fix issue where coll_refs index could go out of bounds.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
