### PR TITLE
tentacle: mds/MDSMap: Enhance set_min_compat_client to validate iterator range

### DIFF
--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -1327,7 +1327,14 @@ void MDSMap::set_min_compat_client(ceph_release_t version)
   else if (version >= ceph_release_t::jewel)
     bits.push_back(CEPHFS_FEATURE_JEWEL);
 
-  std::sort(bits.begin(), bits.end());
+  if (bits.size() >= 2) {  // Need at least 2 elements to sort
+    auto first = bits.begin();
+    auto last = bits.end();
+    if (first < last) {  // Validate iterator range
+      std::sort(first, last);
+    }
+  }
+
   required_client_features = feature_bitset_t(bits);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72924

---

backport of https://github.com/ceph/ceph/pull/64967
parent tracker: https://tracker.ceph.com/issues/72476

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh