### PR TITLE
tentacle: qa/workunits/rados: remove cache tier test

### DIFF
--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -27,7 +27,6 @@ for f in \
     api_asio api_list \
     api_lock api_lock_pp \
     api_misc api_misc_pp \
-    api_tier_pp \
     api_pool \
     api_snapshots api_snapshots_pp \
     api_stat api_stat_pp \

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -125,16 +125,6 @@ add_executable(ceph_test_rados_api_service_pp
 target_link_libraries(ceph_test_rados_api_service_pp
   librados global ${UNITTEST_LIBS} radostest-cxx)
 
-add_executable(ceph_test_rados_api_tier_pp
-  tier_cxx.cc
-  $<TARGET_OBJECTS:unit-main>)
-target_include_directories(ceph_test_rados_api_tier_pp
-  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
-target_link_libraries(ceph_test_rados_api_tier_pp
-  librados global ${UNITTEST_LIBS} Boost::system radostest-cxx cls_cas_internal
-  cls_cas_client Boost::context)
-
 add_executable(ceph_test_rados_api_snapshots
   snapshots.cc)
 target_link_libraries(ceph_test_rados_api_snapshots
@@ -174,7 +164,6 @@ install(TARGETS
   ceph_test_rados_api_snapshots_pp
   ceph_test_rados_api_stat
   ceph_test_rados_api_stat_pp
-  ceph_test_rados_api_tier_pp
   ceph_test_rados_api_watch_notify
   ceph_test_rados_api_watch_notify_pp
   DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/72996

---

backport of https://github.com/ceph/ceph/pull/64504
parent tracker: https://tracker.ceph.com/issues/71930

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh