### PR TITLE
tentacle: nvmeofgw: cleanup pending map upon monitor restart

### DIFF
--- a/src/mon/NVMeofGwMon.h
+++ b/src/mon/NVMeofGwMon.h
@@ -99,6 +99,7 @@ private:
   epoch_t get_ack_map_epoch(bool gw_created, const NvmeGroupKey& group_key);
   void recreate_gw_epoch();
   void restore_pending_map_info(NVMeofGwMap & tmp_map);
+  void cleanup_pending_map();
 };
 
 #endif /* MON_NVMEGWMONITOR_H_ */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73045

---

backport of https://github.com/ceph/ceph/pull/64863
parent tracker: https://tracker.ceph.com/issues/73043

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh