### PR TITLE
tentacle: nvmeofgw:

### DIFF
--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -321,15 +321,19 @@ void NVMeofGwMap::track_deleting_gws(const NvmeGroupKey& group_key,
   propose_pending = false;
   for (auto& itr: created_gws[group_key]) {
     auto &gw_id = itr.first;
-    if (itr.second.availability == gw_availability_t::GW_DELETING) {
+    if (subs.size() &&
+	 itr.second.availability == gw_availability_t::GW_DELETING) {
       int num_ns = 0;
+      dout(4) << " to delete ? " << gw_id
+          << " subsystems size "<< subs.size() << dendl;
       if ( (num_ns = get_num_namespaces(gw_id, group_key, subs)) == 0) {
         do_delete_gw(gw_id, group_key);
         propose_pending =  true;
       }
-      dout(4) << " to delete ? " << gw_id  << " num_ns " << num_ns
-          << " subsystems size "<< subs.size() << dendl;
-      break; // handle just one GW in "Deleting" state in time.
+      dout(4)  << " num_ns " << num_ns << dendl;
+      if (propose_pending) {
+        break; // handle just one GW in "Deleting" state in time.
+      }
     }
   }
 }

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -426,8 +426,10 @@ bool NVMeofGwMon::preprocess_command(MonOpRequestRef op)
       if (map.created_gws[group_key].size()) {
         time_t seconds_since_1970 = time(NULL);
         uint32_t index = ((seconds_since_1970/60) %
-             map.created_gws[group_key].size()) + 1;
-        f->dump_unsigned("rebalance_ana_group", index);
+             map.created_gws[group_key].size());
+        auto it = map.created_gws[group_key].begin();
+        std::advance(it, index);
+        f->dump_unsigned("rebalance_ana_group", it->second.ana_grp_id + 1);
       }
     }
     f->dump_unsigned("num gws", map.created_gws[group_key].size());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73048

---

backport of https://github.com/ceph/ceph/pull/64245
parent tracker: https://tracker.ceph.com/issues/73047

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh