### PR TITLE
mgr/cephadm: Add check for virtual_interface_networks

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -802,11 +802,11 @@ class CephadmServe:
                         )
                         found = True
                         break
-                if not found and spec.virtual_interface_networks:
+                if not found and ingress_spec.virtual_interface_networks:
                     for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
-                        if subnet in spec.virtual_interface_networks:
+                        if subnet in ingress_spec.virtual_interface_networks:
                             logger.debug(
-                                f'{subnet} found in virtual_interface_networks list {list(spec.virtual_interface_networks)}'
+                                f'{subnet} found in virtual_interface_networks list {list(ingress_spec.virtual_interface_networks)}'
                             )
                             found = True
                             break

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -802,6 +802,14 @@ class CephadmServe:
                         )
                         found = True
                         break
+                if not found and spec.virtual_interface_networks:
+                    for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
+                        if subnet in spec.virtual_interface_networks:
+                            logger.debug(
+                                f'{subnet} found in virtual_interface_networks list {list(spec.virtual_interface_networks)}'
+                            )
+                            found = True
+                            break
                 if not found:
                     self.log.info(
                         f"Filtered out host {host}: Host has no interface available for VIP: {vip}"


### PR DESCRIPTION
Added an additional look up for if a match with the ceph networks is not found it will check the virtual_interface_networks list from the config that will enable matching to those networks, enabling dummy IP usage as described in the docs: https://docs.ceph.com/en/reef/cephadm/services/rgw/#selecting-network-interfaces-for-the-virtual-ip.

Fixes: https://tracker.ceph.com/issues/66874

Config being applied:
```
root@server-03~# cat ./ingress-rgw-ha.yaml 
service_type: ingress
service_id: rgw.cdn
placement:
  label: rgw
spec:
  backend_service: rgw.cdn
  virtual_ip: 192.168.0.80/24                        
  frontend_port: 8080
  monitor_port: 1967
  virtual_interface_networks: ["10.10.0.0/16"]
```

Error logs:
```
Aug 29 14:25:33 server-03.domain.tld ceph-mgr[3581]: [cephadm INFO cephadm.serve] Filtered out host server-03.domain.tld: Host has no interface available for VIP: 192.168.0.80/24
Aug 29 14:25:33 server-03.domain.tld ceph-mgr[3581]: log_channel(cephadm) log [INF] : Filtered out host server-03.domain.tld: Host has no interface available for VIP: 192.168.0.80/24
Aug 29 14:25:33 server-03.domain.tld ceph-mgr[3581]: [cephadm INFO cephadm.serve] Filtered out host server-02.domain.tld: Host has no interface available for VIP: 192.168.0.80/24
Aug 29 14:25:33 server-03.domain.tld ceph-mgr[3581]: log_channel(cephadm) log [INF] : Filtered out host server-02.domain.tld: Host has no interface available for VIP: 192.168.0.80/24
Aug 29 14:25:33 server-03.domain.tld ceph-mgr[3581]: [cephadm INFO cephadm.serve] Filtered out host server-01.domain.tld: Host has no interface available for VIP: 192.168.0.80/24
Aug 29 14:25:33 server-03.domain.tld ceph-mgr[3581]: log_channel(cephadm) log [INF] : Filtered out host server-01.domain.tld: Host has no interface available for VIP: 192.168.0.80/24
```

Logs after change:
```
2025-09-11T15:35:48.876750+0000 mgr.server-01 [INF] 192.168.0.80/24 will be configured on server-02.domain.tld interface vlan1234 (which is in subnet 10.10.0.0/16)
2025-09-11T15:35:48.877018+0000 mgr.server-01 [INF] 192.168.0.80 is in 192.168.0.1/24 on server-01.domain.tld interface vlan1234
2025-09-11T15:35:48.877320+0000 mgr.server-01 [INF] 192.168.0.80/24 will be configured on server-03.domain.tld interface vlan1234 (which is in subnet 10.10.0.0/16)
2025-09-11T15:35:48.889365+0000 mgr.server-01 [INF] Deploying daemon keepalived.rgw.cdn.server-02 on server-02.domain.tld
2025-09-11T15:35:50.890371+0000 mgr.server-01 [INF] 192.168.0.80/24 will be configured on server-03.domain.tld interface vlan1234 (which is in subnet 10.10.0.0/16)
2025-09-11T15:35:50.890638+0000 mgr.server-01 [INF] 192.168.0.80 is in 192.168.0.1/24 on server-01.domain.tld interface vlan1234
2025-09-11T15:35:50.890942+0000 mgr.server-01 [INF] 192.168.0.80/24 will be configured on server-02.domain.tld interface vlan1234 (which is in subnet 10.10.0.0/16)
2025-09-11T15:35:50.891848+0000 mgr.server-01 [INF] Deploying daemon keepalived.rgw.cdn.server-03 on server-03.domain.tld
```


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
