### PR TITLE
squid: doc: Fixes a typo in balancer operations

### DIFF
--- a/doc/rados/operations/balancer.rst
+++ b/doc/rados/operations/balancer.rst
@@ -82,7 +82,7 @@ run a command of the following form:
 
   .. prompt:: bash $
 
-     ceph config set mgr/balancer/upmap_max_deviation   1
+     ceph config set mgr mgr/balancer/upmap_max_deviation   1
 
 This value is reasonable and safe for most clusters.  Note that this is
 an absolute integer number of PGs, not a percentage.


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/64157

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests