### PR TITLE
monitoring: fix "In" OSDs in Cluster-Advanced grafana panel. Also change units from decbytes to bytes wherever used in the panel

### DIFF
--- a/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
@@ -136,7 +136,7 @@ local g = import 'grafonnet/grafana.libsonnet';
 
       $.addStatPanel(
         title='Cluster Capacity',
-        unit='decbytes',
+        unit='bytes',
         datasource='$datasource',
         gridPosition={ x: 6, y: 1, w: 3, h: 3 },
         graphMode='area',
@@ -233,7 +233,6 @@ local g = import 'grafonnet/grafana.libsonnet';
       )
       .addThresholds([
         { color: 'green', value: null },
-        { color: 'red', value: 80 },
       ])
       .addTargets([
         $.addTargetSchema(
@@ -259,7 +258,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           displayValueWithAlias='When Alias Displayed',
           units='none',
           valueHandler='Number Threshold',
-          expr='count(ceph_osd_in{%(matchers)s})' % $.matchers(),
+          expr='sum(ceph_osd_in{%(matchers)s})' % $.matchers(),
           legendFormat='In',
           interval='$interval',
           datasource='$datasource',
@@ -308,6 +307,29 @@ local g = import 'grafonnet/grafana.libsonnet';
           warn=1,
           datasource='$datasource',
         ),
+      ])
+      .addOverrides([
+        { matcher: { id: 'byName', options: 'All' }, properties: [
+          { id: 'color', value: { mode: 'fixed' } },
+        ] },
+        { matcher: { id: 'byName', options: 'Out' }, properties: [
+          {
+            id: 'thresholds',
+            value: { mode: 'absolute', steps: [
+              { color: 'green', value: null },
+              { color: 'red', value: 1 },
+            ] },
+          },
+        ] },
+        { matcher: { id: 'byName', options: 'Down' }, properties: [
+          {
+            id: 'thresholds',
+            value: { mode: 'absolute', steps: [
+              { color: 'green', value: null },
+              { color: 'red', value: 1 },
+            ] },
+          },
+        ] },
       ]),
 
       $.addStatPanel(
@@ -453,7 +475,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         displayName='',
         maxDataPoints=100,
         colorMode='none',
-        unit='decbytes',
+        unit='bytes',
         pluginVersion='9.4.7',
       )
       .addMappings([
@@ -713,7 +735,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         pointSize=5,
         lineWidth=1,
         showPoints='never',
-        unit='decbytes',
+        unit='bytes',
         displayMode='table',
         tooltip={ mode: 'multi', sort: 'desc' },
         interval='$interval',
@@ -755,7 +777,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         pointSize=5,
         lineWidth=1,
         showPoints='never',
-        unit='decbytes',
+        unit='bytes',
         displayMode='table',
         tooltip={ mode: 'multi', sort: 'desc' },
         interval='$interval',

--- a/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
+++ b/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
@@ -290,7 +290,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             }
          },
          "gridPos": {
@@ -505,15 +505,75 @@
                      {
                         "color": "green",
                         "value": null
-                     },
-                     {
-                        "color": "red",
-                        "value": 80
                      }
                   ]
                },
                "unit": "none"
-            }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "All"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Out"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Down"
+                  },
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 1
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               }
+            ]
          },
          "flipCard": false,
          "flipTime": 5,
@@ -571,7 +631,7 @@
                "displayAliasType": "Always",
                "displayType": "Regular",
                "displayValueWithAlias": "When Alias Displayed",
-               "expr": "count(ceph_osd_in{cluster=~\"$cluster\", })",
+               "expr": "sum(ceph_osd_in{cluster=~\"$cluster\", })",
                "format": "time_series",
                "interval": "$interval",
                "intervalFactor": 1,
@@ -913,7 +973,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             }
          },
          "gridPos": {
@@ -1483,7 +1543,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             },
             "overrides": [ ]
          },
@@ -1590,7 +1650,7 @@
                      }
                   ]
                },
-               "unit": "decbytes"
+               "unit": "bytes"
             },
             "overrides": [ ]
          },


### PR DESCRIPTION
fix "In" OSDs in Cluster-Advanced grafana panel. Also change units from decbytes to bytes wherever used in the panel

Fixes: https://tracker.ceph.com/issues/72810

<img width="1912" height="930" alt="Screenshot From 2025-09-17 12-30-49" src="https://github.com/user-attachments/assets/230e9512-a732-4778-87fe-4c42e45c8ec0" />





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
