### PR TITLE
mgr/cephadm: cleaning up old migration logic and improving upgrade handling with certmgr

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -27,7 +27,7 @@ from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from mgr_util import parse_combined_pem_file
 
 from .utils import resolve_ip, SpecialHostLabels
-from .migrations import queue_migrate_nfs_spec, queue_migrate_rgw_spec, queue_migrate_rgw_ssl_spec
+from .migrations import queue_migrate_nfs_spec, queue_migrate_rgw_spec
 
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
@@ -308,12 +308,6 @@ class SpecStore():
                         and j['spec'].get('service_type') == 'rgw'
                 ):
                     queue_migrate_rgw_spec(self.mgr, j)
-
-                if (
-                        (self.mgr.migration_current or 0) < 8
-                        and j['spec'].get('service_type') == 'rgw'
-                ):
-                    queue_migrate_rgw_ssl_spec(self.mgr, j)
 
                 spec = ServiceSpec.from_json(j['spec'])
                 created = str_to_datetime(cast(str, j['created']))

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -446,16 +446,12 @@ class Migrations:
             grafana_cert = self.mgr.get_store(grafana_cert_path)
             grafana_key = self.mgr.get_store(grafana_key_path)
             if grafana_cert:
-                (org, cn) = get_cert_issuer_info(grafana_cert)
-                if org == 'Ceph':
-                    logger.info(f'Migrating {grafana_daemon.name()}/{hostname} cert/key to cert store (as cephadm-signed certs)')
-                    self.mgr.cert_mgr.register_self_signed_cert_key_pair('grafana')
-                    self.mgr.cert_mgr.save_self_signed_cert_key_pair('grafana', CertKeyPair(grafana_cert, grafana_key), host=hostname)
-                else:
+                org, _ = get_cert_issuer_info(grafana_cert)
+                if org != 'Ceph':
                     logger.info(f'Migrating {grafana_daemon.name()}/{hostname} cert/key to cert store (as custom-certs)')
                     grafana_cephadm_signed_certs = False
-                    self.mgr.cert_mgr.save_cert('grafana_ssl_cert', grafana_cert, host=hostname)
-                    self.mgr.cert_mgr.save_key('grafana_ssl_key', grafana_key, host=hostname)
+                    self.mgr.cert_mgr.save_cert('grafana_ssl_cert', grafana_cert, host=hostname, user_made=True, editable=True)
+                    self.mgr.cert_mgr.save_key('grafana_ssl_key', grafana_key, host=hostname, user_made=True, editable=True)
 
         if not grafana_cephadm_signed_certs:
             # Update the spec to specify the right certificate source

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -7,8 +7,7 @@ from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlaceme
 from cephadm.schedule import HostAssignment
 from cephadm.utils import SpecialHostLabels
 import rados
-from mgr_util import parse_combined_pem_file, get_cert_issuer_info
-from cephadm.tlsobject_types import CertKeyPair
+from mgr_util import get_cert_issuer_info
 
 from mgr_module import NFS_POOL_NAME
 from orchestrator import OrchestratorError, DaemonDescription
@@ -16,7 +15,7 @@ from orchestrator import OrchestratorError, DaemonDescription
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
 
-LAST_MIGRATION = 9
+LAST_MIGRATION = 8
 
 logger = logging.getLogger(__name__)
 
@@ -42,9 +41,6 @@ class Migrations:
 
         r = mgr.get_store('rgw_migration_queue')
         self.rgw_migration_queue = json.loads(r) if r else []
-
-        r = mgr.get_store('rgw_ssl_migration_queue')
-        self.rgw_ssl_migration_queue = json.loads(r) if r else []
 
         # for some migrations, we don't need to do anything except for
         # incrementing migration_current.
@@ -125,11 +121,6 @@ class Migrations:
             logger.info('Running migration 7 -> 8')
             if self.migrate_7_8():
                 self.set(8)
-
-        if self.mgr.migration_current == 8:
-            logger.info('Running migration 8 -> 9')
-            if self.migrate_8_9():
-                self.set(9)
 
     def migrate_0_1(self) -> bool:
         """
@@ -478,37 +469,6 @@ class Migrations:
         return True
 
     def migrate_7_8(self) -> bool:
-        logger.info(f'Starting rgw SSL/TLS migration (queue length is {len(self.rgw_ssl_migration_queue)})')
-        for s in self.rgw_ssl_migration_queue:
-
-            svc_spec = s['spec']  # this is the RGWspec
-
-            if 'spec' not in svc_spec:
-                logger.info(f"No SSL/TLS fields migration is needed for rgw spec: {svc_spec}")
-                continue
-
-            cert_field = svc_spec['spec'].get('rgw_frontend_ssl_certificate')
-            if not cert_field:
-                logger.info(f"No SSL/TLS fields migration is needed for rgw spec: {svc_spec}")
-                continue
-
-            cert_str = '\n'.join(cert_field) if isinstance(cert_field, list) else cert_field
-            ssl_cert, ssl_key = parse_combined_pem_file(cert_str)
-            new_spec = svc_spec.copy()
-            new_spec['spec'].update({
-                'rgw_frontend_ssl_certificate': None,
-                'certificate_source': CertificateSource.INLINE.value,
-                'ssl_cert': ssl_cert,
-                'ssl_key': ssl_key,
-            })
-
-            logger.info(f"Migrating {svc_spec} to new RGW SSL/TLS format {new_spec}")
-            self.mgr.spec_store.save(RGWSpec.from_json(new_spec))
-
-        self.rgw_ssl_migration_queue = []
-        return True
-
-    def migrate_8_9(self) -> bool:
         """
         Replace Promtail with Alloy.
 
@@ -586,15 +546,6 @@ def queue_migrate_rgw_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]
     ls.append(spec_dict)
     mgr.set_store('rgw_migration_queue', json.dumps(ls))
     logger.info(f'Queued rgw.{service_id} for migration')
-
-
-def queue_migrate_rgw_ssl_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]) -> None:
-    service_id = spec_dict['spec']['service_id']
-    queued = mgr.get_store('rgw_ssl_migration_queue') or '[]'
-    ls = json.loads(queued)
-    ls.append(spec_dict)
-    mgr.set_store('rgw_ssl_migration_queue', json.dumps(ls))
-    logger.info(f'Queued rgw.{service_id} for TLS migration')
 
 
 def queue_migrate_nfs_spec(mgr: "CephadmOrchestrator", spec_dict: Dict[Any, Any]) -> None:

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -27,9 +27,10 @@ CEPH_TYPES = ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw',
 GATEWAY_TYPES = ['iscsi', 'nfs', 'nvmeof', 'smb']
 MONITORING_STACK_TYPES = ['node-exporter', 'prometheus',
                           'alertmanager', 'grafana', 'loki', 'promtail', 'alloy']
+MGMT_GATEWAY_STACK_TYPES = ['mgmt-gateway', 'oauth2-proxy']
 RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES = ['haproxy', 'nfs']
 
-CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES
+CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES + MGMT_GATEWAY_STACK_TYPES
 
 # these daemon types use the ceph container image
 CEPH_IMAGE_TYPES = CEPH_TYPES + ['iscsi', 'nfs', 'node-proxy']
@@ -37,7 +38,7 @@ CEPH_IMAGE_TYPES = CEPH_TYPES + ['iscsi', 'nfs', 'node-proxy']
 # these daemons do not use the ceph image. There are other daemons
 # that also don't use the ceph image, but we only care about those
 # that are part of the upgrade order here
-NON_CEPH_IMAGE_TYPES = MONITORING_STACK_TYPES + ['nvmeof', 'smb']
+NON_CEPH_IMAGE_TYPES = MONITORING_STACK_TYPES + ['nvmeof', 'smb'] + MGMT_GATEWAY_STACK_TYPES
 
 # Used for _run_cephadm used for check-host etc that don't require an --image parameter
 cephadmNoImage = CephadmNoImage.token


### PR DESCRIPTION
This PR includes four changes aimed at simplifying the cephadm migration logic by leveraging the new `certmgr` capabilities.

1. **Add mgmt-gateway and oauth2-proxy to the upgrade list**

> Ensures these newly introduced services are upgraded alongside other cephadm-managed services.


2. **Fix RGW spec validation for deprecated certificate field**

> The rgw_frontend_ssl_certificate field has been deprecated in favor of ssl_cert and ssl_key. The validation logic has been updated to run after automatic field transformation, ensuring correct validation of RGW specs.


3. **Remove specific SSL RGW migration logic**

> The special-case code for migrating RGW services is no longer needed. certmgr now populates the certstore by reading values directly from the spec during service redeployment as part of the upgrade.


4. **Remove Grafana self-signed certificate migration logic**

> Migration logic for legacy self-signed Grafana certificates has been removed. certmgr now generates fresh certificates during the upgrade, eliminating the need for migration.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>
