### PR TITLE
DNM: test removing 2k levels of dir

### DIFF
--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -2,5 +2,5 @@
 
 # Running as root because the filesystem root directory will be
 # owned by uid 0, and that's where we're writing.
-python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py -k test_create_and_rm_2000_subdir_levels_close_v2
+python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py -k test_create_and_rm_2000_subdir_levels_close_v3
 exit 0

--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -2,5 +2,5 @@
 
 # Running as root because the filesystem root directory will be
 # owned by uid 0, and that's where we're writing.
-python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py -k test_create_and_rm_2000_subdir_levels_close_v3
+python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py -k test_create_and_rm_2000_subdir_levels_close_v4
 exit 0

--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -1,4 +1,6 @@
 #!/bin/sh -ex
 
-python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
+# Running as root because the filesystem root directory will be
+# owned by uid 0, and that's where we're writing.
+python3 -m pytest -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py -k test_create_and_rm_2000_subdir_levels_close_v2
 exit 0

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -228,6 +228,44 @@ def test_create_and_rm_2000_subdir_levels_close_v2(testdir):
             stack.append(_get_subdir_path(dirpath))
             continue
 
+def test_create_and_rm_2000_subdir_levels_close_v3(testdir):
+    '''
+    rmdir() perhaps is the one that is probably consuming most of the time in
+    collecting and releasing caps. in v3 instead we check if dir is empty using
+    readdir() and then remove dir if it is empty; else we add to the stack.
+    '''
+    def _rm_or_enstack_dir(dirpath, stack):
+        dir_is_empty = True
+        dh = cephfs.opendir(dirpath)
+
+        de = cephfs.readdir(dh)
+        while de:
+            if de.d_name not in (b'.', b'..'):
+                dir_is_empty = False
+                break
+            de = cephfs.readdir(dh)
+
+        if dir_is_empty:
+            cephfs.rmdir(dirpath)
+            stack.pop()
+        else:
+            if not de:
+                raise RuntimeError('unexpectedly "de" is None')
+            stack.append(os.path.join(dirpath, de.d_name))
+
+    LEVELS = 2000
+
+    for i in range(1, LEVELS + 1):
+        dirname = f'dir{i}'
+        cephfs.mkdir(dirname, 0o755)
+        cephfs.chdir(dirname)
+    cephfs.chdir('/')
+
+    stack = collections.deque([b'dir1/',])
+    while stack:
+        dirpath = stack[-1]
+        _rm_or_enstack_dir(dirpath, stack)
+
 def test_ceph_mirror_xattr(testdir):
     def gen_mirror_xattr():
         cluster_id = str(uuid.uuid4())

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -171,6 +171,29 @@ def test_xattr(testdir):
     assert_equal(9, ret_val)
     assert_equal("user.big\x00", ret_buff.decode('utf-8'))
 
+def test_create_and_rm_2000_subdir_levels_close(testdir):
+    LEVELS = 2000
+
+    for i in range(1, LEVELS + 1):
+        dirname = f'dir{i}'
+        cephfs.mkdir(dirname, 0o755)
+        cephfs.chdir(dirname)
+    cephfs.chdir('/')
+
+    dirpath = 'dir1/'
+    i = 1
+    stack = collections.deque([dirpath,])
+    while stack:
+        dirpath = stack[-1]
+        try:
+            cephfs.rmdir(dirpath)
+            stack.pop()
+        except libcephfs.ObjectNotEmpty:
+            i += 1
+            dirpath += f'dir{i}/'
+            stack.append(dirpath)
+            continue
+
 def test_ceph_mirror_xattr(testdir):
     def gen_mirror_xattr():
         cluster_id = str(uuid.uuid4())


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)
</details>