### PR TITLE
common: Allow PerfCounters to return a provided service ID

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -975,6 +975,17 @@ void CephContext::_enable_perf_counter()
   }
   _mempool_perf = plb2.create_perf_counters();
   _perf_counters_collection->add(_mempool_perf);
+
+  service_unique_id = _conf.get_val<std::string>("service_unique_id");
+  if (!service_unique_id.empty()) {
+    PerfCountersBuilder plb(this, "service_unique_id", l_service_first,
+			    l_service_last);
+    plb.add_u64(l_service_unique_id, service_unique_id.c_str(),
+		"Unique ID for this service");
+    _service_perf = plb.create_perf_counters();
+    _perf_counters_collection->add(_service_perf);
+    _service_perf->set(l_service_unique_id, 0);
+  }
 }
 
 void CephContext::_disable_perf_counter()
@@ -991,6 +1002,12 @@ void CephContext::_disable_perf_counter()
   _mempool_perf = nullptr;
   _mempool_perf_names.clear();
   _mempool_perf_descriptions.clear();
+
+  if (_service_perf) {
+    _perf_counters_collection->remove(_service_perf);
+    delete _service_perf;
+    _service_perf = nullptr;
+  }
 }
 
 void CephContext::_refresh_perf_values()

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -400,9 +400,19 @@ private:
     l_mempool_items,
     l_mempool_last
   };
+  // This is just how PerfCounters indices work, we have a bunch of
+  // bare enums all over.
+  enum {
+    // Picked by grepping for the current highest value and adding 1000
+    l_service_first = 1001000,
+    l_service_unique_id,
+    l_service_last
+  };
   PerfCounters *_cct_perf = nullptr;
   PerfCounters* _mempool_perf = nullptr;
   std::vector<std::string> _mempool_perf_names, _mempool_perf_descriptions;
+  std::string service_unique_id;
+  PerfCounters* _service_perf = nullptr;
 
   /**
    * Enable the performance counters.

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -715,6 +715,9 @@ int md_config_t::parse_argv(ConfigValues& values,
     else if (ceph_argparse_witharg(args, i, &val, "--client_mountpoint", "-r", (char*)NULL)) {
       set_val_or_die(values, tracker, "client_mountpoint", val.c_str());
     }
+    else if (ceph_argparse_witharg(args, i, &val, "--service_unique_id", (char*)NULL)) {
+      set_val_or_die(values, tracker, "service_unique_id", val.c_str());
+    }
     else {
       int r = parse_option(values, tracker, args, i, NULL, level);
       if (r < 0) {

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6801,3 +6801,20 @@ options:
   level: dev
   default: 0
   desc: When EC writes should generate PDWs (development only) 0=optimal 1=never 2=when possible
+- name: service_unique_id
+  type: str
+  level: advanced
+  desc: Unique string to be returned in PerfCounters
+  fmt_desc: A unique id to be created by orchestration software or the
+    administrator upon initial setup of a service. Enforcing uniqueness
+    is entirely the responsibility of the process used to create and
+    manage the cluster. A unique id will be unique within the scope of
+    the entire cluster across all services if they are chosen to be so.
+  note: If this is empty no uniquifier is provided.
+  tags:
+  - service
+  services:
+  - common
+  flags:
+  - no_mon_update
+  - startup

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -1199,6 +1199,10 @@ int RGWRados::register_to_service_map(const DoutPrefixProvider *dpp, const strin
   metadata["realm_name"] = svc.zone->get_realm().get_name();
   metadata["realm_id"] = svc.zone->get_realm().get_id();
   metadata["id"] = name;
+  auto service_unique_id = cct->_conf.get_val<std::string>("service_unique_id");
+  if (!service_unique_id.empty()) {
+    metadata["service_unique_id"] = std::move(service_unique_id);
+  }
   int ret = rados.service_daemon_register(
     daemon_type,
     stringify(rados.get_instance_id()),


### PR DESCRIPTION
Dashboard has asked for a unique identifier that can be associated with services. This commit provides a component of that functionality. Enforcing uniqueness is beyond the scope of this PR and is the responsibility of cluster setup and orchestration. The scope of uniqueness is a matter of policy and up to the design of cluster setup and orchestration software.
    
We provide the `--service_unique_id` argument that can be passed on the command line when executing a Ceph service that uses `global_init`. If non-empty, a `service_unique_id` section is added to the PerfCounters dump for that service. This section has a single entry whose name is set to the argument of `service_unique_id` and whose value is arbitrary. If unspecified or empty, no `service_unique_id` section is added.