### PR TITLE
tentacle: python-common: enable consistent code formatting with 'black'

### DIFF
--- a/src/python-common/ceph/cephadm/images.py
+++ b/src/python-common/ceph/cephadm/images.py
@@ -19,34 +19,52 @@ def _create_image(image_ref: str, key: str) -> ContainerImage:
     return ContainerImage(
         image_ref,
         f'{_img_prefix}{key}',
-        f'{description} container image'
+        f'{description} container image',
     )
 
 
 class DefaultImages(Enum):
-    PROMETHEUS = _create_image('quay.io/prometheus/prometheus:v2.51.0', 'prometheus')
+    PROMETHEUS = _create_image(
+        'quay.io/prometheus/prometheus:v2.51.0', 'prometheus'
+    )
     LOKI = _create_image('docker.io/grafana/loki:3.0.0', 'loki')
     PROMTAIL = _create_image('docker.io/grafana/promtail:3.0.0', 'promtail')
-    NODE_EXPORTER = _create_image('quay.io/prometheus/node-exporter:v1.7.0', 'node_exporter')
-    ALERTMANAGER = _create_image('quay.io/prometheus/alertmanager:v0.27.0', 'alertmanager')
+    NODE_EXPORTER = _create_image(
+        'quay.io/prometheus/node-exporter:v1.7.0', 'node_exporter'
+    )
+    ALERTMANAGER = _create_image(
+        'quay.io/prometheus/alertmanager:v0.27.0', 'alertmanager'
+    )
     GRAFANA = _create_image('quay.io/ceph/grafana:11.6.0', 'grafana')
     HAPROXY = _create_image('quay.io/ceph/haproxy:2.3', 'haproxy')
     KEEPALIVED = _create_image('quay.io/ceph/keepalived:2.2.4', 'keepalived')
     NVMEOF = _create_image('quay.io/ceph/nvmeof:1.5', 'nvmeof')
-    SNMP_GATEWAY = _create_image('docker.io/maxwo/snmp-notifier:v1.2.1', 'snmp_gateway')
-    ELASTICSEARCH = _create_image('quay.io/omrizeneva/elasticsearch:6.8.23', 'elasticsearch')
-    JAEGER_COLLECTOR = _create_image('quay.io/jaegertracing/jaeger-collector:1.29',
-                                     'jaeger_collector')
-    JAEGER_AGENT = _create_image('quay.io/jaegertracing/jaeger-agent:1.29', 'jaeger_agent')
-    JAEGER_QUERY = _create_image('quay.io/jaegertracing/jaeger-query:1.29', 'jaeger_query')
+    SNMP_GATEWAY = _create_image(
+        'docker.io/maxwo/snmp-notifier:v1.2.1', 'snmp_gateway'
+    )
+    ELASTICSEARCH = _create_image(
+        'quay.io/omrizeneva/elasticsearch:6.8.23', 'elasticsearch'
+    )
+    JAEGER_COLLECTOR = _create_image(
+        'quay.io/jaegertracing/jaeger-collector:1.29', 'jaeger_collector'
+    )
+    JAEGER_AGENT = _create_image(
+        'quay.io/jaegertracing/jaeger-agent:1.29', 'jaeger_agent'
+    )
+    JAEGER_QUERY = _create_image(
+        'quay.io/jaegertracing/jaeger-query:1.29', 'jaeger_query'
+    )
     SAMBA = _create_image(
         'quay.io/samba.org/samba-server:ceph20-centos-amd64', 'samba'
     )
     SAMBA_METRICS = _create_image(
-        'quay.io/samba.org/samba-metrics:ceph20-centos-amd64', 'samba_metrics'
+        'quay.io/samba.org/samba-metrics:ceph20-centos-amd64',
+        'samba_metrics'
     )
     NGINX = _create_image('quay.io/ceph/nginx:sclorg-nginx-126', 'nginx')
-    OAUTH2_PROXY = _create_image('quay.io/oauth2-proxy/oauth2-proxy:v7.6.0', 'oauth2_proxy')
+    OAUTH2_PROXY = _create_image(
+        'quay.io/oauth2-proxy/oauth2-proxy:v7.6.0', 'oauth2_proxy'
+    )
 
     @property
     def image_ref(self) -> str:

--- a/src/python-common/ceph/utils.py
+++ b/src/python-common/ceph/utils.py
@@ -30,7 +30,8 @@ def datetime_to_str(dt: datetime.datetime) -> str:
         ISO 8601 (timezone=UTC).
     """
     return dt.astimezone(tz=datetime.timezone.utc).strftime(
-        '%Y-%m-%dT%H:%M:%S.%fZ')
+        '%Y-%m-%dT%H:%M:%S.%fZ'
+    )
 
 
 def str_to_datetime(string: str) -> datetime.datetime:
@@ -50,7 +51,7 @@ def str_to_datetime(string: str) -> datetime.datetime:
     """
     fmts = [
         '%Y-%m-%dT%H:%M:%S.%f',
-        '%Y-%m-%dT%H:%M:%S.%f%z'
+        '%Y-%m-%dT%H:%M:%S.%f%z',
     ]
 
     # In *all* cases, the 9 digit second precision is too much for
@@ -74,8 +75,11 @@ def str_to_datetime(string: str) -> datetime.datetime:
         except ValueError:
             pass
 
-    raise ValueError("Time data {} does not match one of the formats {}".format(
-        string, str(fmts)))
+    raise ValueError(
+        "Time data {} does not match one of the formats {}".format(
+            string, str(fmts)
+        )
+    )
 
 
 def parse_timedelta(delta: str) -> Optional[datetime.timedelta]:
@@ -101,13 +105,15 @@ def parse_timedelta(delta: str) -> Optional[datetime.timedelta]:
     :return: The `datetime.timedelta` object or `None` in case of
         a parsing error.
     """
-    parts = re.match(r'(?P<seconds>-?\d+)s|'
-                     r'(?P<minutes>-?\d+)m|'
-                     r'(?P<hours>-?\d+)h|'
-                     r'(?P<days>-?\d+)d|'
-                     r'(?P<weeks>-?\d+)w$',
-                     delta,
-                     re.IGNORECASE)
+    parts = re.match(
+        r'(?P<seconds>-?\d+)s|'
+        r'(?P<minutes>-?\d+)m|'
+        r'(?P<hours>-?\d+)h|'
+        r'(?P<days>-?\d+)d|'
+        r'(?P<weeks>-?\d+)w$',
+        delta,
+        re.IGNORECASE,
+    )
     if not parts:
         return None
     parts = parts.groupdict()
@@ -130,17 +136,18 @@ def is_hex(s: str, strict: bool = True) -> bool:
     return True
 
 
-def http_req(hostname: str = '',
-             port: str = '443',
-             method: Optional[str] = None,
-             headers: MutableMapping[str, str] = {},
-             data: Optional[str] = None,
-             endpoint: str = '/',
-             scheme: str = 'https',
-             ssl_verify: bool = False,
-             timeout: Optional[int] = None,
-             ssl_ctx: Optional[Any] = None) -> Tuple[Any, Any, Any]:
-
+def http_req(
+    hostname: str = '',
+    port: str = '443',
+    method: Optional[str] = None,
+    headers: MutableMapping[str, str] = {},
+    data: Optional[str] = None,
+    endpoint: str = '/',
+    scheme: str = 'https',
+    ssl_verify: bool = False,
+    timeout: Optional[int] = None,
+    ssl_ctx: Optional[Any] = None,
+) -> Tuple[Any, Any, Any]:
     if not ssl_ctx:
         ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         if not ssl_verify:

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, rstcheck, mypy, py3
+envlist = lint, rstcheck, mypy, py3, check-black
 skip_missing_interpreters = true
 
 [testenv:py3]
@@ -36,3 +36,21 @@ deps =
     rstcheck
 commands =
     rstcheck --report-level info  README.rst
+
+
+# OPT-IN formatting with 'black'
+#  add your module to the modules list below to use automated formatting
+[black]
+deps = black>=23,<25
+options = -l78 -t py36 --skip-string-normalization
+modules = ceph/cephadm ceph/cryptotools ceph/fs ceph/utils.py
+
+[testenv:check-black]
+deps = {[black]deps}
+commands =
+    black --check -q {[black]options} {[black]modules}
+
+[testenv:format-black]
+deps = {[black]deps}
+commands =
+    black {[black]options} {[black]modules}


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/65155

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
