### PR TITLE
rgw/iam: fix NotEquals handling for multiple values

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -908,7 +908,7 @@ bool Condition::eval(const Environment& env) const {
     return multimap_any(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEquals:
-    return multimap_any(std::not_fn(std::equal_to<std::string>()),
+    return multimap_none(std::equal_to<std::string>(),
      itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringEqualsIgnoreCase:
@@ -916,14 +916,14 @@ bool Condition::eval(const Environment& env) const {
     return multimap_any(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEqualsIgnoreCase:
-    return multimap_any(std::not_fn(ci_equal_to()), itr, isruntime? runtime_vals : vals);
+    return multimap_none(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringLike:
   case TokenID::StringLike:
     return multimap_any(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotLike:
-    return multimap_any(std::not_fn(string_like()), itr, isruntime? runtime_vals : vals);
+    return multimap_none(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringEquals:
     return multimap_all(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
@@ -939,7 +939,7 @@ bool Condition::eval(const Environment& env) const {
     return typed_any(std::equal_to<double>(), as_number, s, vals);
 
   case TokenID::NumericNotEquals:
-    return typed_any(std::not_fn(std::equal_to<double>()),
+    return typed_none(std::equal_to<double>(),
        as_number, s, vals);
 
 
@@ -962,7 +962,7 @@ bool Condition::eval(const Environment& env) const {
     return typed_any(std::equal_to<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateNotEquals:
-    return typed_any(std::not_fn(std::equal_to<ceph::real_time>()),
+    return typed_none(std::equal_to<ceph::real_time>(),
        as_date, s, vals);
   case TokenID::DateLessThan:
     return typed_any(std::less<ceph::real_time>(), as_date, s, vals);
@@ -992,24 +992,8 @@ bool Condition::eval(const Environment& env) const {
     return typed_any(std::equal_to<MaskedIP>(), as_network, s, vals);
 
   case TokenID::NotIpAddress:
-    {
-      auto xc = as_network(s);
-      if (!xc) {
-	return false;
-      }
-
-      for (const string& d : vals) {
-	auto xd = as_network(d);
-	if (!xd) {
-	  continue;
-	}
-
-	if (xc == xd) {
-	  return false;
-	}
-      }
-      return true;
-    }
+    return typed_none(std::equal_to<MaskedIP>(),
+      as_network, s, vals);
 
     // Amazon Resource Names!
     // The ArnEquals and ArnLike condition operators behave identically.
@@ -1018,7 +1002,7 @@ bool Condition::eval(const Environment& env) const {
     return multimap_any(arn_like, itr, isruntime? runtime_vals : vals);
   case TokenID::ArnNotEquals:
   case TokenID::ArnNotLike:
-    return multimap_any(std::not_fn(arn_like), itr, isruntime? runtime_vals : vals);
+    return multimap_none(arn_like, itr, isruntime? runtime_vals : vals);
 
   default:
     return false;

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -905,91 +905,91 @@ bool Condition::eval(const Environment& env) const {
     // String!
   case TokenID::ForAnyValueStringEquals:
   case TokenID::StringEquals:
-    return orrible(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEquals:
-    return orrible(std::not_fn(std::equal_to<std::string>()),
-		   itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(std::equal_to<std::string>()),
+     itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringEqualsIgnoreCase:
   case TokenID::StringEqualsIgnoreCase:
-    return orrible(ci_equal_to(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotEqualsIgnoreCase:
-    return orrible(std::not_fn(ci_equal_to()), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(ci_equal_to()), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAnyValueStringLike:
   case TokenID::StringLike:
-    return orrible(string_like(), itr, isruntime? runtime_vals : vals);
+    return multimap_any(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::StringNotLike:
-    return orrible(std::not_fn(string_like()), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(string_like()), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringEquals:
-    return andible(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(std::equal_to<std::string>(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringLike:
-    return andible(string_like(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(string_like(), itr, isruntime? runtime_vals : vals);
 
   case TokenID::ForAllValuesStringEqualsIgnoreCase:
-    return andible(ci_equal_to(), itr, isruntime? runtime_vals : vals);
+    return multimap_all(ci_equal_to(), itr, isruntime? runtime_vals : vals);
 
     // Numeric
   case TokenID::NumericEquals:
-    return shortible(std::equal_to<double>(), as_number, s, vals);
+    return typed_any(std::equal_to<double>(), as_number, s, vals);
 
   case TokenID::NumericNotEquals:
-    return shortible(std::not_fn(std::equal_to<double>()),
-		     as_number, s, vals);
+    return typed_any(std::not_fn(std::equal_to<double>()),
+       as_number, s, vals);
 
 
   case TokenID::NumericLessThan:
-    return shortible(std::less<double>(), as_number, s, vals);
+    return typed_any(std::less<double>(), as_number, s, vals);
 
 
   case TokenID::NumericLessThanEquals:
-    return shortible(std::less_equal<double>(), as_number, s, vals);
+    return typed_any(std::less_equal<double>(), as_number, s, vals);
 
   case TokenID::NumericGreaterThan:
-    return shortible(std::greater<double>(), as_number, s, vals);
+    return typed_any(std::greater<double>(), as_number, s, vals);
 
   case TokenID::NumericGreaterThanEquals:
-    return shortible(std::greater_equal<double>(), as_number, s, vals);
+    return typed_any(std::greater_equal<double>(), as_number, s,
+       vals);
 
     // Date!
   case TokenID::DateEquals:
-    return shortible(std::equal_to<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::equal_to<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateNotEquals:
-    return shortible(std::not_fn(std::equal_to<ceph::real_time>()),
-		     as_date, s, vals);
-
+    return typed_any(std::not_fn(std::equal_to<ceph::real_time>()),
+       as_date, s, vals);
   case TokenID::DateLessThan:
-    return shortible(std::less<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::less<ceph::real_time>(), as_date, s, vals);
 
 
   case TokenID::DateLessThanEquals:
-    return shortible(std::less_equal<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::less_equal<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateGreaterThan:
-    return shortible(std::greater<ceph::real_time>(), as_date, s, vals);
+    return typed_any(std::greater<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateGreaterThanEquals:
-    return shortible(std::greater_equal<ceph::real_time>(), as_date, s,
+    return typed_any(std::greater_equal<ceph::real_time>(), as_date, s,
 		     vals);
 
     // Bool!
   case TokenID::Bool:
-    return shortible(std::equal_to<bool>(), as_bool, s, vals);
+    return typed_any(std::equal_to<bool>(), as_bool, s, vals);
 
     // Binary!
   case TokenID::BinaryEquals:
-    return shortible(std::equal_to<ceph::bufferlist>(), as_binary, s,
+    return typed_any(std::equal_to<ceph::bufferlist>(), as_binary, s,
 		     vals);
 
     // IP Address!
   case TokenID::IpAddress:
-    return shortible(std::equal_to<MaskedIP>(), as_network, s, vals);
+    return typed_any(std::equal_to<MaskedIP>(), as_network, s, vals);
 
   case TokenID::NotIpAddress:
     {
@@ -1015,10 +1015,10 @@ bool Condition::eval(const Environment& env) const {
     // The ArnEquals and ArnLike condition operators behave identically.
   case TokenID::ArnEquals:
   case TokenID::ArnLike:
-    return orrible(arn_like, itr, isruntime? runtime_vals : vals);
+    return multimap_any(arn_like, itr, isruntime? runtime_vals : vals);
   case TokenID::ArnNotEquals:
   case TokenID::ArnNotLike:
-    return orrible(std::not_fn(arn_like), itr, isruntime? runtime_vals : vals);
+    return multimap_any(std::not_fn(arn_like), itr, isruntime? runtime_vals : vals);
 
   default:
     return false;

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -486,8 +486,8 @@ struct Condition {
   using unordered_multimap_it_pair = std::pair <std::unordered_multimap<std::string,std::string>::const_iterator, std::unordered_multimap<std::string,std::string>::const_iterator>;
 
   template<typename F>
-  static bool andible(F&& f, const unordered_multimap_it_pair& it,
-		      const std::vector<std::string>& v) {
+  static bool multimap_all(F&& f, const unordered_multimap_it_pair& it,
+                           const std::vector<std::string>& v) {
     for (auto itr = it.first; itr != it.second; itr++) {
       bool matched = false;
       for (const auto& d : v) {
@@ -502,8 +502,8 @@ struct Condition {
   }
 
   template<typename F>
-  static bool orrible(F&& f, const unordered_multimap_it_pair& it,
-		      const std::vector<std::string>& v) {
+  static bool multimap_any(F&& f, const unordered_multimap_it_pair& it,
+                           const std::vector<std::string>& v) {
     for (auto itr = it.first; itr != it.second; itr++) {
       for (const auto& d : v) {
         if (f(itr->second, d)) {
@@ -514,9 +514,22 @@ struct Condition {
     return false;
   }
 
+  template<typename F>
+  static bool multimap_none(F&& f, const unordered_multimap_it_pair& it,
+                            const std::vector<std::string>& v) {
+    for (auto itr = it.first; itr != it.second; itr++) {
+      for (const auto& d : v) {
+        if (f(itr->second, d)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   template<typename F, typename X>
-  static bool shortible(F&& f, X& x, const std::string& c,
-			const std::vector<std::string>& v) {
+  static bool typed_any(F&& f, X& x, const std::string& c,
+                        const std::vector<std::string>& v) {
     auto xc = std::forward<X>(x)(c);
     if (!xc) {
       return false;
@@ -533,6 +546,27 @@ struct Condition {
       }
     }
     return false;
+  }
+
+  template<typename F, typename X>
+  static bool typed_none(F&& f, X& x, const std::string& c,
+                         const std::vector<std::string>& v) {
+    auto xc = std::forward<X>(x)(c);
+    if (!xc) {
+      return false;
+    }
+
+    for (const auto& d : v) {
+      auto xd = x(d);
+      if (!xd) {
+        continue;
+      }
+
+      if (f(*xc, *xd)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   template <typename F>


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket （） [73146](https://tracker.ceph.com/issues/73146)
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
