### PR TITLE
tentacle: mgr/dashboard: Allow FQDN in Connect Cluster form -> Cluster API URL

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.ts
@@ -19,9 +19,6 @@ import { NotificationService } from '~/app/shared/services/notification.service'
 export class MultiClusterFormComponent implements OnInit, OnDestroy {
   @Output()
   submitAction = new EventEmitter();
-  readonly endpoints = /^((https?:\/\/)|(www.))(?:([a-zA-Z]+)|(\d+\.\d+.\d+.\d+)):\d{2,5}\/?$/;
-  readonly ipv4Rgx = /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/i;
-  readonly ipv6Rgx = /^(?:[a-f0-9]{1,4}:){7}[a-f0-9]{1,4}$/i;
   clusterApiUrlCmd = 'ceph mgr services';
   remoteClusterForm: CdFormGroup;
   connectionVerified: boolean;
@@ -102,17 +99,7 @@ export class MultiClusterFormComponent implements OnInit, OnDestroy {
       ),
       remoteClusterUrl: new FormControl(null, {
         validators: [
-          CdValidators.custom('endpoint', (value: string) => {
-            if (_.isEmpty(value)) {
-              return false;
-            } else {
-              return (
-                !this.endpoints.test(value) &&
-                !this.ipv4Rgx.test(value) &&
-                !this.ipv6Rgx.test(value)
-              );
-            }
-          }),
+          CdValidators.url,
           CdValidators.custom('hubUrlCheck', (remoteClusterUrl: string) => {
             return this.action === 'connect' && remoteClusterUrl?.includes(this.hubUrl);
           }),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73168

---

backport of https://github.com/ceph/ceph/pull/65566
parent tracker: https://tracker.ceph.com/issues/73077

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh