### PR TITLE
squid: msg/async: Encode message once features are set

### DIFF
--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -105,8 +105,14 @@ protected:
   enum class WriteStatus { NOWRITE, REPLACING, CANWRITE, CLOSED };
   std::atomic<WriteStatus> can_write;
   std::list<Message *> sent;  // the first ceph::buffer::list need to inject seq
+  //struct for outbound msgs
+  struct out_q_entry_t {
+    ceph::buffer::list bl;
+    Message* m {nullptr};
+    bool is_prepared {false};
+  };
   // priority queue for outbound msgs
-  std::map<int, std::list<std::pair<ceph::buffer::list, Message *>>> out_q;
+  std::map<int, std::list<out_q_entry_t>> out_q;
   bool keepalive;
   bool write_in_progress = false;
 
@@ -194,7 +200,7 @@ protected:
   void session_reset();
   void randomize_out_seq();
 
-  Message *_get_next_outgoing(ceph::buffer::list *bl);
+  out_q_entry_t _get_next_outgoing();
 
   void prepare_send_message(uint64_t features, Message *m, ceph::buffer::list &bl);
   ssize_t write_message(Message *m, ceph::buffer::list &bl, bool more);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -431,12 +431,15 @@ void ProtocolV2::send_message(Message *m) {
   // TODO: Currently not all messages supports reencode like MOSDMap, so here
   // only let fast dispatch support messages prepare message
   const bool can_fast_prepare = messenger->ms_can_fast_dispatch(m);
-  if (can_fast_prepare) {
+  bool is_prepared;
+  if (can_fast_prepare && f) {
     prepare_send_message(f, m);
+    is_prepared = can_fast_prepare;
+  } else {
+    is_prepared = false;
   }
 
   std::lock_guard<std::mutex> l(connection->write_lock);
-  bool is_prepared = can_fast_prepare;
   // "features" changes will change the payload encoding
   if (can_fast_prepare && (!can_write || connection->get_features() != f)) {
     // ensure the correctness of message encoding


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/73163

---

backport of https://github.com/ceph/ceph/pull/49619
parent tracker: https://tracker.ceph.com/issues/52657

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh