### PR TITLE
tentacle: build-with-container: add argument groups to organize options

### DIFF
--- a/src/script/build-with-container.py
+++ b/src/script/build-with-container.py
@@ -947,19 +947,15 @@ def parse_cli(build_step_names):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--debug",
+        "--help-build-steps",
         action="store_true",
-        help="Emit debugging level logging and tracebacks",
+        help="Print executable build steps and brief descriptions",
     )
-    parser.add_argument(
-        "--container-engine",
-        help="Select container engine to use (eg. podman, docker)",
+
+    g_basic = parser.add_argument_group(
+        title="Basic options",
     )
-    parser.add_argument(
-        "--cwd",
-        help="Change working directory before executing commands",
-    )
-    parser.add_argument(
+    g_basic.add_argument(
         "--distro",
         "-d",
         choices=DistroKind.aliases().keys(),
@@ -967,52 +963,19 @@ def parse_cli(build_step_names):
         default=str(DistroKind.CENTOS9),
         help="Specify a distro short name",
     )
-    parser.add_argument(
-        "--tag",
-        "-t",
-        help="Specify a container tag. Append to the auto generated tag"
-        " by prefixing the supplied value with the plus (+) character",
+    g_basic.add_argument(
+        "--execute",
+        "-e",
+        dest="steps",
+        action="append",
+        choices=build_step_names,
+        help="Execute the target build step(s)",
     )
-    parser.add_argument(
-        "--base-branch",
-        help="Specify a base branch name",
+    g_basic.add_argument(
+        "--cwd",
+        help="Change working directory before executing commands",
     )
-    parser.add_argument(
-        "--current-branch",
-        help="Manually specify the current branch name",
-    )
-    parser.add_argument(
-        "--image-repo",
-        help="Specify a container image repository",
-    )
-    parser.add_argument(
-        "--image-sources",
-        "-I",
-        type=ImageSource.argument,
-        help="Specify a set of valid image sources. "
-        f"May be a comma separated list of {ImageSource.hint()}",
-    )
-    parser.add_argument(
-        "--base-image",
-        help=(
-            "Supply a custom base image to use instead of the default"
-            " image for the source distro."
-        ),
-    )
-    parser.add_argument(
-        "--homedir",
-        default="/ceph",
-        help="Container image home/build dir",
-    )
-    parser.add_argument(
-        "--dnf-cache-path",
-        help="DNF caching using provided base dir (during build-container build)",
-    )
-    parser.add_argument(
-        "--npm-cache-path",
-        help="NPM caching using provided base dir (during build)",
-    )
-    parser.add_argument(
+    g_basic.add_argument(
         "--build-dir",
         "-b",
         help=(
@@ -1020,7 +983,77 @@ def parse_cli(build_step_names):
             " (the ceph source root)"
         ),
     )
-    parser.add_argument(
+    g_basic.add_argument(
+        "--env-file",
+        type=pathlib.Path,
+        help="Use this environment file when building",
+    )
+
+    g_debug = parser.add_argument_group(
+        title="Debugging options",
+    )
+    g_debug.add_argument(
+        "--debug",
+        action="store_true",
+        help="Emit debugging level logging and tracebacks",
+    )
+    g_debug.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do not execute key commands, print and continue if possible",
+    )
+    g_debug.add_argument(
+        "--no-prereqs",
+        "-P",
+        action="store_true",
+        help="Do not execute any prerequisite steps. Only execute specified steps",
+    )
+
+    g_image = parser.add_argument_group(
+        title="Build image configuration",
+        description=(
+            'These options customize what and how the "Build Image" is'
+            " constructed"
+        ),
+    )
+    g_image.add_argument(
+        "--tag",
+        "-t",
+        help="Specify a container tag. Append to the auto generated tag"
+        " by prefixing the supplied value with the plus (+) character",
+    )
+    g_image.add_argument(
+        "--base-branch",
+        help="Specify a base branch name",
+    )
+    g_image.add_argument(
+        "--current-branch",
+        help="Manually specify the current branch name",
+    )
+    g_image.add_argument(
+        "--image-repo",
+        help="Specify a container image repository",
+    )
+    g_image.add_argument(
+        "--image-sources",
+        "-I",
+        type=ImageSource.argument,
+        help="Specify a set of valid image sources. "
+        f"May be a comma separated list of {ImageSource.hint()}",
+    )
+    g_image.add_argument(
+        "--base-image",
+        help=(
+            "Supply a custom base image to use instead of the default"
+            " image for the source distro."
+        ),
+    )
+    g_image.add_argument(
+        "--homedir",
+        default="/ceph",
+        help="Container image home/build dir",
+    )
+    g_image.add_argument(
         "--build-arg",
         dest="build_args",
         action="append",
@@ -1029,7 +1062,37 @@ def parse_cli(build_step_names):
             " Can be used to override default build image behavior."
         ),
     )
-    parser.add_argument(
+    g_image.add_argument(
+        "--containerfile",
+        default="Dockerfile.build",
+        help="Specify the path to a (build) container file",
+    )
+    g_image.add_argument(
+        "--containerdir",
+        default=".",
+        help="Specify the path to container context dir",
+    )
+
+    g_container = parser.add_argument_group(
+        title="Container options",
+        description="Options to control how the containers are run",
+    )
+    g_container.add_argument(
+        "--container-engine",
+        help="Select container engine to use (eg. podman, docker)",
+    )
+    g_container.add_argument(
+        "--extra",
+        "-x",
+        action="append",
+        help="Specify an extra argument to pass to container command",
+    )
+    g_container.add_argument(
+        "--keep-container",
+        action="store_true",
+        help="Skip removing container after executing command",
+    )
+    g_container.add_argument(
         "--overlay-dir",
         "-l",
         help=(
@@ -1038,52 +1101,46 @@ def parse_cli(build_step_names):
             "use a temporary overlay (discarding writes on container exit)"
         ),
     )
-    parser.add_argument(
+
+    g_caching = parser.add_argument_group(
+        title="Persistent cache options",
+        description=(
+            "Options to control caches that persist after the containers"
+            " have exited"
+        ),
+    )
+    g_caching.add_argument(
+        "--dnf-cache-path",
+        help="DNF caching using provided base dir (during build-container build)",
+    )
+    g_caching.add_argument(
+        "--npm-cache-path",
+        help="NPM caching using provided base dir (during build)",
+    )
+    g_caching.add_argument(
         "--ccache-dir",
         help=(
             "Specify a directory (within the container) to save ccache"
             " output"
         ),
     )
-    parser.add_argument(
-        "--extra",
-        "-x",
-        action="append",
-        help="Specify an extra argument to pass to container command",
+
+    g_pkg = parser.add_argument_group(
+        title="RPM & DEB package build options",
+        description="Options specific to building packages",
     )
-    parser.add_argument(
-        "--keep-container",
-        action="store_true",
-        help="Skip removing container after executing command",
-    )
-    parser.add_argument(
-        "--containerfile",
-        default="Dockerfile.build",
-        help="Specify the path to a (build) container file",
-    )
-    parser.add_argument(
-        "--containerdir",
-        default=".",
-        help="Specify the path to container context dir",
-    )
-    parser.add_argument(
-        "--no-prereqs",
-        "-P",
-        action="store_true",
-        help="Do not execute any prerequisite steps. Only execute specified steps",
-    )
-    parser.add_argument(
+    g_pkg.add_argument(
         "--rpm-no-match-sha",
         dest="srpm_match",
         action="store_const",
-        const='any',
+        const="any",
         help=(
             "Do not try to build RPM packages that match the SHA of the current"
             " git checkout. Use any source RPM available."
             " [DEPRECATED] Use --rpm-match=any"
         ),
     )
-    parser.add_argument(
+    g_pkg.add_argument(
         "--srpm-match",
         dest="srpm_match",
         choices=("any", "versionglob", "auto"),
@@ -1095,39 +1152,17 @@ def parse_cli(build_step_names):
             " 'auto' (the default) uses a version derived from ceph.spec."
         ),
     )
-    parser.add_argument(
+    g_pkg.add_argument(
         "--rpmbuild-arg",
-        '-R',
+        "-R",
         action="append",
         help="Pass this extra argument to rpmbuild",
     )
-    parser.add_argument(
+    g_pkg.add_argument(
         "--ceph-version",
         help="Rather than infer the Ceph version, use this value",
     )
-    parser.add_argument(
-        "--execute",
-        "-e",
-        dest="steps",
-        action="append",
-        choices=build_step_names,
-        help="Execute the target build step(s)",
-    )
-    parser.add_argument(
-        "--env-file",
-        type=pathlib.Path,
-        help="Use this environment file when building",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Do not execute key commands, print and continue if possible",
-    )
-    parser.add_argument(
-        "--help-build-steps",
-        action="store_true",
-        help="Print executable build steps and brief descriptions",
-    )
+
     cli, rest = parser.parse_my_args()
     if cli.help_build_steps:
         print("Executable Build Steps")


### PR DESCRIPTION
Backport of #65514

Use the argparse add_argument_group feature to organize the mass of arguments into more sensible categories. Hopefully, someone reading over the `--help` output can now more easily see options that are useful rather than being overwhelmed by a wall of text.


(cherry picked from commit 71a1be4dd0aea004da56c2f518ee70a281a3f7d3)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
