### PR TITLE
mgr/cephadm: Fix alertmanager TLS and global security handling

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -342,7 +342,7 @@ class AlertmanagerService(CephadmService):
                                      port=dd.ports[0], path='/alerts'))
 
         context = {
-            'security_enabled': security_enabled,
+            'enable_mtls': mgmt_gw_enabled,
             'dashboard_urls': dashboard_urls,
             'webhook_urls': webhook_urls,
             'snmp_gateway_urls': snmp_gateway_urls,

--- a/src/pybind/mgr/cephadm/templates/services/alertmanager/alertmanager.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/alertmanager/alertmanager.yml.j2
@@ -6,13 +6,7 @@ global:
 {% if not secure %}
   http_config:
     tls_config:
-{% if security_enabled %}
-      ca_file: root_cert.pem
-      cert_file: alertmanager.crt
-      key_file: alertmanager.key
-{% else %}
       insecure_skip_verify: true
-{% endif %}
 {% endif %}
 
 route:
@@ -53,6 +47,14 @@ receivers:
   webhook_configs:
 {% for url in dashboard_urls %}
   - url: '{{ url }}/api/prometheus_receiver'
+  {% if enable_mtls %}
+    http_config:
+      tls_config:
+        insecure_skip_verify: false
+        ca_file: root_cert.pem
+        cert_file: alertmanager.crt
+        key_file: alertmanager.key
+  {% endif %}
 {% endfor %}
 {% if snmp_gateway_urls %}
 - name: 'snmp-gateway'

--- a/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
+++ b/src/pybind/mgr/cephadm/tests/services/test_monitoring.py
@@ -196,9 +196,7 @@ class TestMonitoring:
                   resolve_timeout: 5m
                   http_config:
                     tls_config:
-                      ca_file: root_cert.pem
-                      cert_file: alertmanager.crt
-                      key_file: alertmanager.key
+                      insecure_skip_verify: true
 
                 route:
                   receiver: 'default'
@@ -217,6 +215,12 @@ class TestMonitoring:
                 - name: 'ceph-dashboard'
                   webhook_configs:
                   - url: 'https://host_fqdn:29443/internal/dashboard/api/prometheus_receiver'
+                    http_config:
+                      tls_config:
+                        insecure_skip_verify: false
+                        ca_file: root_cert.pem
+                        cert_file: alertmanager.crt
+                        key_file: alertmanager.key
                 """).lstrip()
 
                 web_config = dedent("""
@@ -298,9 +302,7 @@ class TestMonitoring:
                   resolve_timeout: 5m
                   http_config:
                     tls_config:
-                      ca_file: root_cert.pem
-                      cert_file: alertmanager.crt
-                      key_file: alertmanager.key
+                      insecure_skip_verify: true
 
                 route:
                   receiver: 'default'


### PR DESCRIPTION
## TLS Behavior explanation

### Global TLS Configuration

The `secure` parameter controls the global `http_config`:

- **`secure=true`**: No global override; each receiver uses the container's default trust store with full verification.
- **`secure=false`**: Sets `insecure_skip_verify: true`, disabling **both** server certificate and hostname verification for **all** receivers.
  
  **Exception:** The Dashboard receiver can override this with its own `http_config` (see below).

### Dashboard Receiver Per-Webhook Configuration

When  `mgmt-gateway` is enabled (`mTLS` in enforced), the Dashboard receiver uses per-webhook `http_config`:

> - **Re-enables verification:** `insecure_skip_verify: false`
> - **CA configuration:** `ca_file: root_cert.pem` (trust cephadm CA for Dashboard)
> - **Client credentials:** `cert_file` / `key_file` are client credentials and are **only used** if the Dashboard is configured to request/verify client certificates (mTLS).
> 


Fixes: https://tracker.ceph.com/issues/69325


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
