### PR TITLE
ceph-volume: support additional dmcrypt params

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -278,6 +278,18 @@ class Batch(object):
             help='Reuse existing OSD ids',
             type=arg_validators.valid_osd_id
         )
+        parser.add_argument(
+            '--dmcrypt-format-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksFormat options (use the same syntax as the cryptsetup CLI)",
+        )
+        parser.add_argument(
+            '--dmcrypt-open-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksOpen options (use the same syntax as the cryptsetup CLI)",
+        )
         self.args = parser.parse_args(argv)
         if self.args.bluestore:
             self.args.objectstore = 'bluestore'
@@ -378,6 +390,8 @@ class Batch(object):
             'with_tpm',
             'crush_device_class',
             'no_systemd',
+            'dmcrypt_format_opts',
+            'dmcrypt_open_opts',
         ]
         defaults.update({arg: getattr(self.args, arg) for arg in global_args})
         for osd in plan:

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -84,6 +84,14 @@ common_args: Dict[str, Any] = {
         'action': arg_validators.DmcryptAction,
         'help': 'Enable device encryption via dm-crypt',
     },
+    '--dmcrypt-format-opts': {
+        'default': None,
+        'type': str,
+    },
+    '--dmcrypt-open-opts': {
+        'default': None,
+        'type': str,
+    },
     '--with-tpm': {
         'dest': 'with_tpm',
         'help': 'Whether encrypted OSDs should be enrolled with TPM.',

--- a/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
@@ -339,7 +339,11 @@ class Migrate(object):
             secret = encryption_utils.get_dmcrypt_key(osd_id, osd_fsid)
             mlogger.info(' preparing dmcrypt for {}, uuid {}'.format(target_lv.lv_path, target_lv.lv_uuid))
             target_path = encryption_utils.prepare_dmcrypt(
-                key=secret, device=target_path, mapping=target_lv.lv_uuid)
+                key=secret,
+                device=target_path,
+                mapping=target_lv.lv_uuid,
+                format_options=self.args.dmcrypt_format_opts,
+                open_options=self.args.dmcrypt_open_opts)
         try:
             # we need to update lvm tags for all the remaining volumes
             # and clear for ones which to be removed
@@ -511,6 +515,18 @@ class Migrate(object):
             action='store_true',
             help='Skip checking OSD systemd unit',
         )
+        parser.add_argument(
+            '--dmcrypt-format-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksFormat options (use the same syntax as the cryptsetup CLI)",
+        )
+        parser.add_argument(
+            '--dmcrypt-open-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksOpen options (use the same syntax as the cryptsetup CLI)",
+        )
         return parser
 
     def main(self):
@@ -602,6 +618,18 @@ class NewVolume(object):
             action='store_true',
             help='Skip checking OSD systemd unit',
         )
+        parser.add_argument(
+            '--dmcrypt-format-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksFormat options (use the same syntax as the cryptsetup CLI)",
+        )
+        parser.add_argument(
+            '--dmcrypt-open-opts',
+            type=str,
+            default=None,
+            help="Additional cryptsetup luksOpen options (use the same syntax as the cryptsetup CLI)",
+        )
         return parser
 
     @decorators.needs_root
@@ -617,7 +645,12 @@ class NewVolume(object):
             secret = encryption_utils.get_dmcrypt_key(osd_id, osd_fsid)
             mlogger.info(' preparing dmcrypt for {}, uuid {}'.format(target_lv.lv_path, target_lv.lv_uuid))
             target_path = encryption_utils.prepare_dmcrypt(
-                key=secret, device=target_path, mapping=target_lv.lv_uuid)
+                key=secret,
+                device=target_path,
+                mapping=target_lv.lv_uuid,
+                format_options=self.args.dmcrypt_format_opts,
+                open_options=self.args.dmcrypt_open_opts
+            )
 
         try:
             tag_tracker.update_tags_when_lv_create(self.create_type)

--- a/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
@@ -191,7 +191,8 @@ class LvmBlueStore(BlueStore):
         # format data device
         encryption_utils.luks_format(
             self.dmcrypt_key,
-            device
+            device,
+            self.args.dmcrypt_format_opts,
         )
 
         if self.with_tpm:
@@ -201,7 +202,8 @@ class LvmBlueStore(BlueStore):
             self.dmcrypt_key,
             device,
             uuid,
-            self.with_tpm)
+            self.with_tpm,
+            self.args.dmcrypt_open_opts)
 
         return '/dev/mapper/%s' % uuid
 

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_lvmbluestore.py
@@ -1,4 +1,5 @@
 import pytest
+from argparse import Namespace
 from unittest.mock import patch, Mock, MagicMock, call
 from ceph_volume.objectstore.lvmbluestore import LvmBlueStore
 from ceph_volume.api.lvm import Volume
@@ -8,7 +9,8 @@ from ceph_volume.util import system
 class TestLvmBlueStore:
     @patch('ceph_volume.objectstore.lvmbluestore.prepare_utils.create_key', Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
     def setup_method(self, m_create_key):
-        self.lvm_bs = LvmBlueStore([])
+        args = Namespace(dmcrypt_format_opts=None, dmcrypt_open_opts=None)
+        self.lvm_bs = LvmBlueStore(args)
 
     @patch('ceph_volume.conf.cluster', 'ceph')
     @patch('ceph_volume.api.lvm.get_single_lv')
@@ -25,6 +27,7 @@ class TestLvmBlueStore:
                                               lv_tags='',
                                               lv_uuid='fake-uuid')
         self.lvm_bs.encrypted = True
+        self.lvm_bs.with_tpm = 0
         self.lvm_bs.dmcrypt_key = 'fake-dmcrypt-key'
         self.lvm_bs.args = args
         self.lvm_bs.pre_prepare()
@@ -98,6 +101,7 @@ class TestLvmBlueStore:
                                                               lv_uuid='fake-uuid')
         self.lvm_bs.encrypted = True
         self.lvm_bs.dmcrypt_key = 'fake-dmcrypt-key'
+        self.lvm_bs.with_tpm = 0
         self.lvm_bs.args = args
         self.lvm_bs.pre_prepare()
         assert self.lvm_bs.secrets['dmcrypt_key'] == 'fake-dmcrypt-key'

--- a/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
@@ -126,6 +126,23 @@ class TestLuksFormat(object):
         assert m_call.call_args[0][0] == expected
 
     @patch('ceph_volume.util.encryption.process.call')
+    def test_luks_format_with_extra_option(self, m_call, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=abcd')
+        expected = [
+            'cryptsetup',
+            '--batch-mode',
+            '--key-size',
+            '512',
+            '--key-file',
+            '-',
+            'luksFormat',
+            '--fake-custom-opt1',
+            '/dev/foo'
+        ]
+        encryption.luks_format('abcd', '/dev/foo', '--fake-custom-opt1')
+        assert m_call.call_args[0][0] == expected
+
+    @patch('ceph_volume.util.encryption.process.call')
     def test_luks_format_command_with_custom_size(self, m_call, conf_ceph_stub):
         conf_ceph_stub('[global]\nfsid=abcd\n[osd]\nosd_dmcrypt_key_size=256')
         expected = [
@@ -177,6 +194,25 @@ class TestLuksOpen(object):
             '/dev/bar'
         ]
         encryption.luks_open('abcd', '/dev/foo', '/dev/bar')
+        assert m_call.call_args[0][0] == expected
+
+    @patch('ceph_volume.util.encryption.bypass_workqueue', return_value=False)
+    @patch('ceph_volume.util.encryption.process.call')
+    def test_luks_format_with_extra_option(self, m_call, m_bypass_workqueue, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=abcd')
+        expected = [
+            'cryptsetup',
+            '--key-size',
+            '512',
+            '--key-file',
+            '-',
+            '--allow-discards',
+            'luksOpen',
+            '--fake-custom-opt1',
+            '/dev/foo',
+            '/dev/bar'
+        ]
+        encryption.luks_open('abcd', '/dev/foo', '/dev/bar', options='--fake-custom-opt1')
         assert m_call.call_args[0][0] == expected
 
     @patch('ceph_volume.util.encryption.bypass_workqueue', return_value=False)

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -3,13 +3,14 @@ import os
 import logging
 import re
 import json
+import shlex
 from ceph_volume import process, conf, terminal
 from ceph_volume.util import constants, system
 from ceph_volume.util.device import Device
 from .prepare import write_keyring
 from .disk import lsblk, device_family, get_part_entry_type, _dd_read
 from packaging import version
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 mlogger = terminal.MultiLogger(__name__)
@@ -93,23 +94,26 @@ def create_dmcrypt_key() -> str:
     return key
 
 
-def luks_format(key: str, device: str) -> None:
+def luks_format(key: str, device: str, options: Optional[str] = None) -> None:
     """
     Decrypt (open) an encrypted device, previously prepared with cryptsetup
-
     :param key: dmcrypt secret key, will be used for decrypting
     :param device: Absolute path to device
+    :param options: A list of additional cryptsetup args
     """
-    command = [
+    extra_args: List[str] = []
+    base_cmd: List[str] = [
         'cryptsetup',
         '--batch-mode', # do not prompt
-        '--key-size',
-        get_key_size_from_conf(),
-        '--key-file', # misnomer, should be key
-        '-',          # because we indicate stdin for the key here
-        'luksFormat',
-        device,
+        '--key-size', get_key_size_from_conf(),
+        '--key-file', '-',
     ]
+
+    if options is not None:
+        extra_args: List[str] = shlex.split(options)
+
+    command: List[str] = base_cmd + ["luksFormat"] + extra_args + [device]
+
     process.call(command, stdin=key, terminal_verbose=True, show_command=True)
 
 
@@ -182,7 +186,8 @@ def rename_mapper(current: str, new: str) -> None:
 def luks_open(key: str,
               device: str,
               mapping: str,
-              with_tpm: int = 0) -> None:
+              with_tpm: int = 0,
+              options: Optional[str] = None) -> None:
     """
     Decrypt (open) an encrypted device, previously prepared with cryptsetup
 
@@ -192,8 +197,10 @@ def luks_open(key: str,
     :param device: absolute path to device
     :param mapping: mapping name used to correlate device. Usually a UUID
     :param with_tpm: whether to use tpm2 token enrollment.
+    :param options: A list of additional cryptsetup args
     """
     command: List[str] = []
+    extra_args: List[str] = []
     if with_tpm:
         command = ['/usr/lib/systemd/systemd-cryptsetup',
                    'attach',
@@ -204,17 +211,20 @@ def luks_open(key: str,
         if bypass_workqueue(device):
             command[-1] += ',no-read-workqueue,no-write-workqueue'
     else:
-        command = [
-            'cryptsetup',
-            '--key-size',
-            get_key_size_from_conf(),
-            '--key-file',
-            '-',
-            '--allow-discards',  # allow discards (aka TRIM) requests for device
-            'luksOpen',
-            device,
-            mapping,
+        base_cmd: List[str] = [
+            "cryptsetup",
+            "--key-size", str(get_key_size_from_conf()),
+            "--key-file", "-",
+            "--allow-discards",
         ]
+        if options is not None:
+            extra_args = shlex.split(options)
+        command: List[str] = (
+            base_cmd
+            + ["luksOpen"]
+            + extra_args
+            + [device, mapping]
+        )
 
         if bypass_workqueue(device):
             command.extend(['--perf-no_read_workqueue',
@@ -395,7 +405,11 @@ def legacy_encrypted(device):
             break
     return metadata
 
-def prepare_dmcrypt(key, device, mapping):
+def prepare_dmcrypt(key: str,
+                    device: str,
+                    mapping: str,
+                    format_options: Optional[str] = None,
+                    open_options: Optional[str] = None):
     """
     Helper for devices that are encrypted. The operations needed for
     block, db, wal, or data/journal devices are all the same
@@ -405,12 +419,14 @@ def prepare_dmcrypt(key, device, mapping):
     # format data device
     luks_format(
         key,
-        device
+        device,
+        format_options
     )
     luks_open(
         key,
         device,
-        mapping
+        mapping,
+        options=open_options
     )
     return '/dev/mapper/%s' % mapping
 


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
